### PR TITLE
Collect user emails on welcome page

### DIFF
--- a/app/Http/Controllers/WaitingListController.php
+++ b/app/Http/Controllers/WaitingListController.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Request;
+use Session;
+use App\Models\WaitingListUser;
+
+class WaitingListController extends Controller
+{
+
+    /**
+     * Store a users email.
+     *
+     * @param  Request $request
+     * @return Response
+     */
+    public function store(Request $request) {
+        $user = new WaitingListUser;
+        $user->email = Request::input('email');
+        $user->save();
+
+        Session::flash('flash_message', 'Thanks! We\'ll let you know when we lauch.');
+
+        return redirect('/');
+    }
+
+}

--- a/app/Http/Controllers/WaitingListController.php
+++ b/app/Http/Controllers/WaitingListController.php
@@ -2,9 +2,8 @@
 
 namespace App\Http\Controllers;
 
-use Request;
-use Session;
 use App\Models\WaitingListUser;
+use Illuminate\Http\Request;
 
 class WaitingListController extends Controller
 {
@@ -16,13 +15,11 @@ class WaitingListController extends Controller
      * @return Response
      */
     public function store(Request $request) {
-        $user = new WaitingListUser;
-        $user->email = Request::input('email');
-        $user->save();
+        WaitingListUser::create([
+           'email' => $request->input('email')
+        ]);
 
-        Session::flash('flash_message', 'Thanks! We\'ll let you know when we lauch.');
-
-        return redirect('/');
+        return redirect('/')->with('flash_message', 'Thanks! We\'ll let you know when we lauch.');
     }
 
 }

--- a/app/Http/Controllers/WaitingListController.php
+++ b/app/Http/Controllers/WaitingListController.php
@@ -15,7 +15,11 @@ class WaitingListController extends Controller
      * @return Response
      */
     public function store(Request $request) {
-        WaitingListUser::create([
+        $this->validate($request, [
+            'email' => 'required|email'
+        ]);
+
+        WaitingListUser::firstOrCreate([
            'email' => $request->input('email')
         ]);
 

--- a/app/Models/WaitingListUser.php
+++ b/app/Models/WaitingListUser.php
@@ -6,5 +6,5 @@ use Illuminate\Database\Eloquent\Model;
 
 class WaitingListUser extends Model
 {
-    //
+    protected $fillable = ['email'];
 }

--- a/app/Models/WaitingListUser.php
+++ b/app/Models/WaitingListUser.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class WaitingListUser extends Model
+{
+    //
+}

--- a/database/migrations/2017_02_13_172234_create_waiting_list_users_table.php
+++ b/database/migrations/2017_02_13_172234_create_waiting_list_users_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class CreateWaitingListUsersTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('waiting_list_users', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('email');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('waiting_list_users');
+    }
+}

--- a/resources/views/layouts/takeover.blade.php
+++ b/resources/views/layouts/takeover.blade.php
@@ -13,6 +13,10 @@
 </head>
 
 <body class="takeover">
+    @if (Session::has('flash_message'))
+        <div class="alert">{{ Session::get('flash_message') }}</div>
+    @endif
+
     @yield('content')
     <script type="text/javascript" src="https://unpkg.com/jquery@^3.0.0/dist/jquery.min.js"></script>
     <script type="text/javascript" src="https://unpkg.com/@dosomething/forge@^6.7.4/dist/forge.js"></script>

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -19,6 +19,13 @@
                                <li><input type="submit" class="button" value="Submit"></li>
                                <input type="hidden" name="_token" value="{{ csrf_token() }}">
                             </ul>
+                            @if (count($errors) > 0)
+                                <div class="validation-error">
+                                    @foreach ($errors->all() as $error)
+                                        <p>{{ $error }}</p>
+                                    @endforeach
+                                </div>
+                            @endif
                         </form>
                     </div>
                 </div>

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -13,10 +13,13 @@
                     <div class="container__block -centered">
                         <p>We're hard at work making a new <strong>DoSomething.org</strong> experience that is designed to be a platform which better serves the community.</p>
                         <p>Enter your email below to be notified when we launch!</p>
-                        <ul class="form-actions -inline">
-                           <li><input type="text" class="text-field" placeholder="you@gmail.com"></li>
-                           <li><input type="submit" class="button" value="Submit"></li>
-                       </ul>
+                        <form action="waitinglist" method="post">
+                            <ul class="form-actions -inline">
+                               <li><input name="email" type="text" class="text-field" placeholder="you@gmail.com"></li>
+                               <li><input type="submit" class="button" value="Submit"></li>
+                               <input type="hidden" name="_token" value="{{ csrf_token() }}">
+                            </ul>
+                        </form>
                     </div>
                 </div>
             </section>

--- a/routes/web.php
+++ b/routes/web.php
@@ -35,3 +35,8 @@ Route::get('contentful', function () {
 
     return $client->getContentType('campaign');
 });
+
+/**
+ * Temporary route for collecting user emails pre-launch.
+ */
+Route::post('waitinglist', 'WaitingListController@store');


### PR DESCRIPTION
When users click into the new campaigns, we won't have the experience to show them. We want to capture their email, however, to let them know when we do launch. We'll just export the table as a CSV & import into MailChimp later (We don't expect a massive amount of people in this list...)