### PR TITLE
React-ify the reportback block.

### DIFF
--- a/app/Http/Controllers/CampaignController.php
+++ b/app/Http/Controllers/CampaignController.php
@@ -57,9 +57,8 @@ class CampaignController extends Controller
         $campaign = $this->campaignRepository->findBySlug($slug);
         $phoenixNid = data_get($campaign, 'legacy_campaign_id', '1144');
 
-        $response = $this->phoenixLegacy->getAllReportbacks(['campaigns' => $phoenixNid, 'status' => 'promoted']);
-
-        $reportbacks = collect($response['data'])->pluck('reportback_items.data')->flatten(1);
+        $response = $this->phoenixLegacy->getAllReportbacks(['campaigns' => $phoenixNid, 'status' => 'promoted', 'load_user' => true]);
+        $reportbacks = $response['data'];
 
         return view('campaigns.show', ['campaign' => $campaign])
             ->with('state', ['campaign' => $campaign, 'reportbacks' => $reportbacks]);

--- a/resources/assets/components/Flex/index.js
+++ b/resources/assets/components/Flex/index.js
@@ -2,19 +2,20 @@ import React from 'react';
 import classNames from 'classnames';
 import './flex.scss';
 
-export const Flex = (props) => {
+export const Flex = ({children}) => {
   return (
     <div className="flex">
-      {props.children}
+      {children}
     </div>
   );
 };
 
-export const FlexCell = (props) => {
-  const modifiers = props.modifiers.map(className => `-${className}`);
+export const FlexCell = ({modifiers = [], children}) => {
+  modifiers = modifiers.map(className => `-${className}`);
+
   return (
     <div className={classNames('flex__cell', modifiers)}>
-      {props.children}
+      {children}
     </div>
   );
 };

--- a/resources/assets/components/ReportbackBlock.js
+++ b/resources/assets/components/ReportbackBlock.js
@@ -1,0 +1,32 @@
+import React from 'react';
+import Block from './Block';
+import { FlexCell } from './Flex';
+
+const ReportbackItem = (props) => {
+  const image = props.image;
+  const name = props.name;
+  const impact = props.impact;
+
+  return (
+    <Block className="reportback-block">
+      <img src={image} />
+      <div className="padded">
+        <h4>{name}</h4>
+        <p className="footnote">{impact}</p>
+      </div>
+    </Block>
+  );
+};
+
+const ReportbackBlock = (props) => {
+  const items = props.reportbacks.map(reportback => {
+    const image = reportback.reportback_items.data[0].media.uri;
+    const name = reportback.user.first_name;
+
+    return <FlexCell key={reportback.id}><ReportbackItem image={image} name={name} impact={reportback.quantity + ' jeans'} /></FlexCell>;
+  });
+
+  return <FlexCell>{items}</FlexCell>;
+};
+
+export default ReportbackBlock;

--- a/resources/views/campaigns/show.blade.php
+++ b/resources/views/campaigns/show.blade.php
@@ -9,7 +9,7 @@
     </header>
 
     <div id="app">
-        <div class="block-container">
+        <div class="feed-container">
             <div class="flex wrapper">
                 @foreach ($campaign->activity_feed as $block)
                     <div class="flex__cell {{ $block->displayOptions->map(function($c) { return '-'.$c; })->implode(' ') }}">


### PR DESCRIPTION
This pull request adds the reportback block, but rendered on the client! This is important because we'll  need to be able to load more pages of reportbacks as the user scrolls through the feed.

🗂 Updates the Phoenix Legacy API call to load user profile info & _not_ flatten the reportback items. This is a change in behavior from how the legacy gallery works, but makes sense because we don't want a user's name & impact line repeated more than once. (5dc4f45)

💪 Tidies up the `Flex` and `FlexCell` components & sets a default empty array for modifiers prop. This allows us to use a `FlexCell` without a specific width modifier (without errors). (5b22e15)

🔳 Uses the right class name on server-rendered placeholder so it looks right. (ee0a499)

🏞 Adds the "Reportback Block" component! There's also some code to "normalize" the Contentful feed and Phoenix Legacy API call into one state object, which can be cleaned up into a Redux store in another PR. (c12816a)
