### PR TITLE
Add Redux for state management.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -20,7 +20,7 @@ indent_size = 4
 
 [*.json]
 indent_style = space
-indent_size = 4
+indent_size = 2
 
 [*.md]
 trim_trailing_whitespace = false

--- a/app/Http/Controllers/CampaignController.php
+++ b/app/Http/Controllers/CampaignController.php
@@ -61,6 +61,6 @@ class CampaignController extends Controller
         $reportbacks = $response['data'];
 
         return view('campaigns.show', ['campaign' => $campaign])
-            ->with('state', ['campaign' => $campaign, 'reportbacks' => $reportbacks]);
+            ->with('state', ['campaign' => $campaign, 'reportbacks' => ['isFetching' => false, 'data' => $reportbacks]]);
     }
 }

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "react-dom": "^15.4.2",
     "react-redux": "^5.0.2",
     "redux": "^3.6.0",
-    "redux-logger": "^2.8.1"
+    "redux-logger": "^2.8.1",
+    "redux-thunk": "latest"
   },
   "devDependencies": {
     "@dosomething/webpack-config": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,10 @@
     "lodash": "^4.17.4",
     "marked": "^0.3.6",
     "react": "^15.4.2",
-    "react-dom": "^15.4.2"
+    "react-dom": "^15.4.2",
+    "react-redux": "^5.0.2",
+    "redux": "^3.6.0",
+    "redux-logger": "^2.8.1"
   },
   "devDependencies": {
     "@dosomething/webpack-config": "^1.1.1",
@@ -30,6 +33,9 @@
     "babel-preset-react": "^6.22.0",
     "dotenv": "^4.0.0",
     "modernizr": "^3.3.1",
+    "redux-devtools": "^3.3.2",
+    "redux-devtools-dock-monitor": "^1.1.1",
+    "redux-devtools-log-monitor": "^1.2.0",
     "webpack": "^1.11.0",
     "webpack-dev-server": "^1.11.0"
   }

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "react-redux": "^5.0.2",
     "redux": "^3.6.0",
     "redux-logger": "^2.8.1",
-    "redux-thunk": "latest"
+    "redux-thunk": "^2.2.0"
   },
   "devDependencies": {
     "@dosomething/webpack-config": "^1.1.1",

--- a/resources/assets/actions.js
+++ b/resources/assets/actions.js
@@ -1,11 +1,35 @@
+import { Phoenix } from '@dosomething/gateway';
+
 /*
- * Actions:
+ * Actions names: import these constants to dispatch an event
+ * without having hardcoded strings all about.
  */
-export const LOAD_MORE_REPORTBACKS = 'LOAD_MORE_REPORTBACKS';
+export const REQUESTED_REPORTBACKS = 'REQUESTED_REPORTBACKS';
+export const RECEIVED_REPORTBACKS = 'RECEIVED_REPORTBACKS';
 
 /**
- * Action Creators:
+ * Action Creators: these functions create actions, which describe changes
+ * to the state tree (either as a result of application logic or user input).
  */
-export function loadMoreReportbacks() {
-  return { type: LOAD_MORE_REPORTBACKS };
+
+// Action: reportback fetch initiated.
+export function requestingReportbacks(node) {
+  return { type: REQUESTED_REPORTBACKS, node };
+}
+
+// Action: new reportback data received.
+export function receivedReportbacks(node, page, data) {
+  return { type: RECEIVED_REPORTBACKS, node, page, data};
+}
+
+// An async action creator to fetch another page of reportbacks.
+export function fetchReportbacks(node, page) {
+  return dispatch => {
+    dispatch(requestingReportbacks(node));
+
+    return (new Phoenix).getAllReportbacks({ campaigns: node, page })
+      .then(json => {
+        dispatch(receivedReportbacks(node, page, json.data))
+      })
+  }
 }

--- a/resources/assets/actions.js
+++ b/resources/assets/actions.js
@@ -1,0 +1,11 @@
+/*
+ * Actions:
+ */
+export const LOAD_MORE_REPORTBACKS = 'LOAD_MORE_REPORTBACKS';
+
+/**
+ * Action Creators:
+ */
+export function loadMoreReportbacks() {
+  return { type: LOAD_MORE_REPORTBACKS };
+}

--- a/resources/assets/actions.js
+++ b/resources/assets/actions.js
@@ -1,7 +1,7 @@
 import { Phoenix } from '@dosomething/gateway';
 
 /*
- * Actions names: import these constants to dispatch an event
+ * Action names: import these constants to dispatch an event
  * without having hardcoded strings all about.
  */
 export const REQUESTED_REPORTBACKS = 'REQUESTED_REPORTBACKS';

--- a/resources/assets/app.js
+++ b/resources/assets/app.js
@@ -21,22 +21,29 @@ import ReactDom from 'react-dom';
 import { Provider } from 'react-redux'
 
 import { createStore, applyMiddleware, compose } from 'redux'
-import createLogger from 'redux-logger'
+import thunk from 'redux-thunk';
 import rootReducer from './reducers'
 import ActionFeed from './containers/ActionFeed';
 
 ready(() => {
   const appContainer = document.getElementById('app');
-  const loggerMiddleware = createLogger();
   const preloadedState = window.STATE || {};
 
+  // Log actions to the console in development.
+  const middleware = [thunk];
+  if (process.env.NODE_ENV === `development`) {
+    const createLogger = require(`redux-logger`);
+    middleware.push(createLogger());
+  }
+
+  // If React DevTools are available, use instrumented compose function.
   const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose;
 
   const store = createStore(
     rootReducer,
     preloadedState,
     composeEnhancers(
-      applyMiddleware(loggerMiddleware)
+      applyMiddleware(...middleware)
     )
   );
 

--- a/resources/assets/app.js
+++ b/resources/assets/app.js
@@ -14,16 +14,34 @@ import { ready } from './helpers';
 import './components/construction.scss';
 import './components/container.scss';
 import './components/header.scss';
-import Feed from './components/Feed';
 
 import React from 'react';
 import ReactDom from 'react-dom';
 
+import { Provider } from 'react-redux'
+
+import { createStore, applyMiddleware, compose } from 'redux'
+import createLogger from 'redux-logger'
+import rootReducer from './reducers'
+import ActionFeed from './containers/ActionFeed';
+
 ready(() => {
   const appContainer = document.getElementById('app');
+  const loggerMiddleware = createLogger();
+  const preloadedState = window.STATE || {};
+
+  const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose;
+
+  const store = createStore(
+    rootReducer,
+    preloadedState,
+    composeEnhancers(
+      applyMiddleware(loggerMiddleware)
+    )
+  );
 
   if (appContainer) {
-    ReactDom.render(<Feed state={window.STATE}/>, appContainer);
+    ReactDom.render(<Provider store={store}><ActionFeed /></Provider>, appContainer);
   }
 });
 

--- a/resources/assets/app.js
+++ b/resources/assets/app.js
@@ -25,6 +25,11 @@ import thunk from 'redux-thunk';
 import rootReducer from './reducers'
 import ActionFeed from './containers/ActionFeed';
 
+// Make action available to demonstrate loading more reportbacks.
+// @TODO: Expose this in the UI!
+import { fetchReportbacks } from './actions';
+window.actions = { fetchReportbacks };
+
 ready(() => {
   const appContainer = document.getElementById('app');
   const preloadedState = window.STATE || {};

--- a/resources/assets/app.js
+++ b/resources/assets/app.js
@@ -19,11 +19,9 @@ import React from 'react';
 import ReactDom from 'react-dom';
 
 import { Provider } from 'react-redux'
-
-import { createStore, applyMiddleware, compose } from 'redux'
-import thunk from 'redux-thunk';
-import rootReducer from './reducers'
 import ActionFeed from './containers/ActionFeed';
+import rootReducer from './reducers'
+import configureStore from './store';
 
 // Make action available to demonstrate loading more reportbacks.
 // @TODO: Expose this in the UI!
@@ -32,25 +30,7 @@ window.actions = { fetchReportbacks };
 
 ready(() => {
   const appContainer = document.getElementById('app');
-  const preloadedState = window.STATE || {};
-
-  // Log actions to the console in development.
-  const middleware = [thunk];
-  if (process.env.NODE_ENV === `development`) {
-    const createLogger = require(`redux-logger`);
-    middleware.push(createLogger());
-  }
-
-  // If React DevTools are available, use instrumented compose function.
-  const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose;
-
-  const store = createStore(
-    rootReducer,
-    preloadedState,
-    composeEnhancers(
-      applyMiddleware(...middleware)
-    )
-  );
+  const store = configureStore(rootReducer, window.STATE);
 
   if (appContainer) {
     ReactDom.render(<Provider store={store}><ActionFeed /></Provider>, appContainer);

--- a/resources/assets/components/Feed/index.js
+++ b/resources/assets/components/Feed/index.js
@@ -46,7 +46,10 @@ class Feed extends React.Component {
 
         const count = block.fields.additionalContent.count || 3;
         for (let i = 0; i < count; i++) {
-          block.reportbacks.push(reportbacks.shift());
+          let reportback = reportbacks.data.shift();
+          if (reportback) {
+            block.reportbacks.push(reportback);
+          }
         }
       }
 

--- a/resources/assets/components/Feed/index.js
+++ b/resources/assets/components/Feed/index.js
@@ -31,8 +31,8 @@ class Feed extends React.Component {
    * @returns {XML}
    */
   render() {
-    let feed = this.props.state.campaign.activityFeed;
-    let reportbacks = this.props.state.reportbacks;
+    let feed = this.props.campaign.activityFeed;
+    let reportbacks = this.props.reportbacks;
 
     // @TODO: This should be moved into a separate data normalization layer.
     feed.map((block) => {

--- a/resources/assets/containers/ActionFeed.js
+++ b/resources/assets/containers/ActionFeed.js
@@ -1,0 +1,24 @@
+import React from 'react';
+import { connect } from 'react-redux'
+import { toggleTodo } from '../actions'
+import Feed from '../components/Feed'
+
+const mapStateToProps = (state) => {
+  return {
+    campaign: state.campaign,
+    reportbacks: state.reportbacks,
+  };
+};
+
+const mapDispatchToProps = (dispatch, ownProps) => {
+  return {
+    // ...
+  }
+};
+
+const ActivityFeed = connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(Feed);
+
+export default ActivityFeed;

--- a/resources/assets/reducers.js
+++ b/resources/assets/reducers.js
@@ -1,14 +1,28 @@
 import { combineReducers } from 'redux';
-import { LOAD_MORE_REPORTBACKS, loadMoreReportbacks } from './actions';
+import { REQUESTED_REPORTBACKS, RECEIVED_REPORTBACKS } from './actions';
 
+/**
+ * Campaign reducer:
+ */
 const campaign = (state = {}, action) => {
   return state;
 };
 
+/**
+ * Reportback reducer:
+ */
 const reportbacks = (state = {}, action) => {
   switch (action.type) {
-    case LOAD_MORE_REPORTBACKS:
-      return state;
+    case REQUESTED_REPORTBACKS:
+      return Object.assign({}, state, {
+        isFetching: true
+      });
+
+    case RECEIVED_REPORTBACKS:
+      return Object.assign({}, state, {
+        isFetching: false,
+        data: state.data.concat(action.data),
+      });
 
     default:
       return state;

--- a/resources/assets/reducers.js
+++ b/resources/assets/reducers.js
@@ -1,0 +1,20 @@
+import { combineReducers } from 'redux';
+import { LOAD_MORE_REPORTBACKS, loadMoreReportbacks } from './actions';
+
+const campaign = (state = {}, action) => {
+  return state;
+};
+
+const reportbacks = (state = {}, action) => {
+  switch (action.type) {
+    case LOAD_MORE_REPORTBACKS:
+      return state;
+
+    default:
+      return state;
+  }
+};
+
+const rootReducer = combineReducers({campaign, reportbacks});
+
+export default rootReducer;

--- a/resources/assets/store.js
+++ b/resources/assets/store.js
@@ -1,0 +1,22 @@
+import { createStore, applyMiddleware, compose } from 'redux'
+import thunk from 'redux-thunk';
+
+export default function(rootReducer, preloadedState = {}) {
+  // Log actions to the console in development.
+  const middleware = [thunk];
+  if (process.env.NODE_ENV === `development`) {
+    const createLogger = require(`redux-logger`);
+    middleware.push(createLogger());
+  }
+
+  // If React DevTools are available, use instrumented compose function.
+  const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose;
+
+  return createStore(
+    rootReducer,
+    preloadedState,
+    composeEnhancers(
+      applyMiddleware(...middleware)
+    )
+  );
+};


### PR DESCRIPTION
## Changes
This pull request adds [Redux](http://redux.js.org) for sane state management. 🔮 

There aren't any user-facing changes in this PR, but it adds the basic structure for us to build new features (like loading in more reportbacks or reacting to photos) without things getting out of control.

You can trigger a demo by selecting the root React element in [React Dev Tools](https://github.com/facebook/react-devtools) (which sets the `$r` variable) and then manually dispatching a the `fetchReportbacks` action on the store.

If running a development build, you'll be able to see the actions reflected in the console (or you can install [Redux Dev Tools](https://github.com/zalmoxisus/redux-devtools-extension) and you'll be able to see the actions dispatched on the review app):

![screen shot 2017-02-22 at 3 30 54 pm](https://cloud.githubusercontent.com/assets/583202/23230974/f051f3c0-f913-11e6-844e-5555770e6a1d.png)

⚛️