### PR TITLE
Adding new Media Uploader component

### DIFF
--- a/resources/assets/components/MediaUploader/index.js
+++ b/resources/assets/components/MediaUploader/index.js
@@ -1,0 +1,74 @@
+import React from 'react';
+import { processFile } from '../../helpers';
+import './media-uploader.scss';
+
+class MediaUploader extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.handleChange = this.handleChange.bind(this);
+
+    this.state = {
+      file: null,
+      filePreviewUrl: null
+    };
+  }
+
+  handleChange(event) {
+    event.preventDefault();
+
+    this.readFile(event.target.files[0]);
+  }
+
+  readFile(file) {
+    let fileReader = new FileReader;
+    let blob;
+
+    fileReader.readAsArrayBuffer(file);
+
+    fileReader.onloadend = () => {
+      try {
+        blob = processFile(fileReader.result);
+
+        this.setState({
+          file: blob,
+          filePreviewUrl: URL.createObjectURL(blob)
+        });
+      }
+      catch(error) {
+        // @todo: need a nice way to handle this, display message?
+        console.log(error);
+      }
+    }
+  }
+
+  render() {
+    let { filePreviewUrl } = this.state;
+    let content = null;
+
+    if (filePreviewUrl) {
+      content = (<img src={filePreviewUrl} />);
+    } else {
+      content = (<span>{this.props.label}</span>);
+    }
+
+    return (
+      <div className="media-uploader">
+        <label htmlFor="media-uploader">
+          {content}
+          <input type="file" id="media-uploader" name="media-uploader" onChange={this.handleChange} />
+        </label>
+      </div>
+    );
+  }
+}
+
+MediaUploader.propTypes = {
+  label: React.PropTypes.string
+};
+
+MediaUploader.defaultProps = {
+  label: 'Upload Media'
+};
+
+export default MediaUploader;

--- a/resources/assets/components/MediaUploader/media-uploader.scss
+++ b/resources/assets/components/MediaUploader/media-uploader.scss
@@ -1,0 +1,22 @@
+@import '~@dosomething/forge/scss/toolkit';
+
+.media-uploader {
+  background-color: #eee;
+  color: $med-gray;
+  height: 300px;
+  width: 300px;
+
+  label {
+    cursor: pointer;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    text-align: center;
+    height: 100%;
+    width: 100%;
+  }
+
+  input {
+    @include visually-hidden();
+  }
+}

--- a/resources/assets/components/MediaUploader/media-uploader.scss
+++ b/resources/assets/components/MediaUploader/media-uploader.scss
@@ -3,16 +3,14 @@
 .media-uploader {
   background-color: #eee;
   color: $med-gray;
-  height: 300px;
-  width: 300px;
 
   label {
     cursor: pointer;
     display: flex;
     flex-direction: column;
+    height: 100%;
     justify-content: center;
     text-align: center;
-    height: 100%;
     width: 100%;
   }
 

--- a/resources/assets/helpers.js
+++ b/resources/assets/helpers.js
@@ -1,4 +1,5 @@
 import marked from 'marked';
+import get from 'lodash/get';
 
 /**
  * Wait until the DOM is ready.
@@ -61,31 +62,17 @@ export function processFile(file) {
  * @todo Eventually deal with other file types.
  */
 function getFileType(file) {
-  let type = '';
   let dv = new DataView(file, 0, 5);
   let byte1 = dv.getUint8(0, true);
   let byte2 = dv.getUint8(1, true);
   let hex = byte1.toString(16) + byte2.toString(16);
 
-  switch(hex) {
-    case '8950':
-        type = 'image/png';
-        break;
-    case '4749':
-        type = 'image/gif';
-        break;
-    case '424d':
-        type = 'image/bmp';
-        break;
-    case 'ffd8':
-        type = 'image/jpeg';
-        break;
-    default:
-        type = null;
-        break;
-  };
-
-  return type;
+  return get({
+    '8950': 'image/png',
+    '4749': 'image/gif',
+    '424d': 'image/bmp',
+    'ffd8': 'image/jpeg'
+  }, hex, null);
 }
 
 /**

--- a/resources/assets/helpers.js
+++ b/resources/assets/helpers.js
@@ -29,3 +29,125 @@ export function markdown(source) {
     __html: marked(source, options),
   }
 }
+
+/**
+ * Process file (provided as an ArrayBuffer) depending
+ * on its type.
+ *
+ * @param  {ArrayBuffer} file
+ * @return {Blob}
+ * @todo Eventually deal with other file types.
+ */
+export function processFile(file) {
+  let fileType = getFileType(file);
+  let dataView = new DataView(file);
+
+  if (fileType === 'image/png') {
+    return new Blob([dataView], { type: fileType });
+  }
+
+  if (fileType === 'image/jpeg') {
+    return stripExifData(file, dataView);
+  }
+
+  throw 'Unsupported file type.';
+}
+
+/**
+ * Get the type for a specified file.
+ *
+ * @param  {ArrayBuffer} file
+ * @return {String|null}
+ * @todo Eventually deal with other file types.
+ */
+function getFileType(file) {
+  let type = '';
+  let dv = new DataView(file, 0, 5);
+  let byte1 = dv.getUint8(0, true);
+  let byte2 = dv.getUint8(1, true);
+  let hex = byte1.toString(16) + byte2.toString(16);
+
+  switch(hex) {
+    case '8950':
+        type = 'image/png';
+        break;
+    case '4749':
+        type = 'image/gif';
+        break;
+    case '424d':
+        type = 'image/bmp';
+        break;
+    case 'ffd8':
+        type = 'image/jpeg';
+        break;
+    default:
+        type = null;
+        break;
+  };
+
+  return type;
+}
+
+/**
+ * Remove EXIF data on specified file if present.
+ *
+ * @param  {ArrayBuffer} image
+ * @param  {DataView} dataView
+ * @return {Blob}
+ */
+function stripExifData(image, dataView = null) {
+  if (! dataView) {
+    let dataView = new DataView(image);
+  }
+
+  let offset = 0;
+  let recess = 0;
+  let pieces = [];
+  let i = 0;
+
+  offset += 2;
+  var app1 = dataView.getUint16(offset);
+  offset += 2;
+
+  // This loop does the acutal reading of the data and creates
+  // an array with only the pieces we want.
+  while (offset < dataView.byteLength) {
+    if (app1 === 0xffe1) {
+      pieces[i] = {
+        recess : recess,
+        offset : offset - 2
+      };
+
+      recess = offset + dataView.getUint16(offset);
+
+      i++;
+    }
+    else if (app1 === 0xffda) {
+      break;
+    }
+
+    offset += dataView.getUint16(offset);
+    app1 = dataView.getUint16(offset);
+    offset += 2;
+  }
+
+  // If the file had EXIF data and it was removed, create a
+  // file blob using the new array of file data.
+  if (pieces.length > 0) {
+    var newPieces = [];
+
+    pieces.forEach(function(v) {
+      newPieces.push(image.slice(v.recess, v.offset));
+    }, this);
+
+    newPieces.push(image.slice(recess));
+
+    return new Blob(newPieces, {type: 'image/jpeg'});
+  }
+
+  // If no EXIF data existed on the file, then nothing was done to it.
+  // We can just create a blob with the original data.
+  else {
+    return new Blob([dataView], {type: 'image/jpeg'});
+  }
+}


### PR DESCRIPTION
This PR adds a new `MediaUploader` component, that should be able to technically handle a variety of media, but for the time being is meant to only really deal with JPEG and PNG, and will throw a basic error if other file types are uploaded. When a file is successfully uploaded it is placed inside the media uploader container for previewing. See below:

![mediauploader](https://d3uepj124s5rcx.cloudfront.net/items/3x2R3z3a0A09343p0C0R/Screen%20Recording%202017-02-27%20at%2003.38%20PM.gif?v=1c000d9b)

The `MediaUploader` component accepts a `label` prop for overriding the text label shown, otherwise it resorts to using a default:

```javascript
<MediaUploader label="Send us your photo" />
```

The MediaUploader also does a bit of processing to remove EXIF data _only_ from JPEG files (since EXIF data only exists on JPEG, TIFF and RAW files, so no need to worry about PNG).

### Next Steps

This is the first component needed for the Reportback Uploader. The next steps will be to create a Reportback Uploader component and import this Media Uploader component inside of it.
