### PR TITLE
Allow multiple instances of the same block in feed.

### DIFF
--- a/resources/assets/components/Feed/index.js
+++ b/resources/assets/components/Feed/index.js
@@ -15,14 +15,14 @@ class Feed extends React.Component {
    * @param block
    * @returns {XML}
    */
-  renderFeedItem(block) {
+  renderFeedItem(block, index) {
     const BlockComponent = get({
       'campaign_update': CampaignUpdateBlock,
       'join_cta': CallToActionBlock,
       'reportbacks': ReportbackBlock,
     }, block.type, PlaceholderBlock);
 
-    return <FlexCell key={block.id} width={block.fields.displayOptions}><BlockComponent {...block} /></FlexCell>;
+    return <FlexCell key={block.id + '-' + index} width={block.fields.displayOptions}><BlockComponent {...block} /></FlexCell>;
   }
 
   /**
@@ -60,7 +60,7 @@ class Feed extends React.Component {
       <div className="feed-container">
         <div className="wrapper">
           <Flex>
-            {feed.map((block) => this.renderFeedItem(block))}
+            {feed.map((block, index) => this.renderFeedItem(block, index))}
           </Flex>
         </div>
       </div>


### PR DESCRIPTION
#### Changes
This change allows multiple instances of the same block to exist within the feed – so we can have a preset "Reportbacks (Full Row)" block that just gets inserted as many times as needed, rather than having to create a new one each time.

![screen recording 2017-03-01 at 01 49 pm](https://cloud.githubusercontent.com/assets/583202/23475628/2cc4d99a-fe86-11e6-9831-4b9ef6de84c0.gif)
