### PR TITLE
Reportback uploader component

### DIFF
--- a/resources/assets/components/Feed/index.js
+++ b/resources/assets/components/Feed/index.js
@@ -6,6 +6,7 @@ import CampaignUpdateBlock from '../CampaignUpdateBlock';
 import PlaceholderBlock from '../PlaceholderBlock';
 import ReportbackBlock from "../ReportbackBlock";
 import { Flex, FlexCell } from '../Flex';
+import ReportbackUploader from '../ReportbackUploader';
 import './feed.scss';
 
 class Feed extends React.Component {
@@ -61,6 +62,9 @@ class Feed extends React.Component {
         <div className="wrapper">
           <Flex>
             {feed.map((block, index) => this.renderFeedItem(block, index))}
+            <FlexCell key="reportback_uploader">
+              <ReportbackUploader/>
+            </FlexCell>
           </Flex>
         </div>
       </div>

--- a/resources/assets/components/MediaUploader/index.js
+++ b/resources/assets/components/MediaUploader/index.js
@@ -7,11 +7,6 @@ class MediaUploader extends React.Component {
     super(props);
 
     this.handleChange = this.handleChange.bind(this);
-
-    this.state = {
-      file: null,
-      filePreviewUrl: null
-    };
   }
 
   handleChange(event) {
@@ -30,7 +25,7 @@ class MediaUploader extends React.Component {
       try {
         blob = processFile(fileReader.result);
 
-        this.setState({
+        this.props.setMediaState({
           file: blob,
           filePreviewUrl: URL.createObjectURL(blob)
         });
@@ -43,7 +38,7 @@ class MediaUploader extends React.Component {
   }
 
   render() {
-    let { filePreviewUrl } = this.state;
+    let { filePreviewUrl } = this.props.media;
     let content = null;
 
     if (filePreviewUrl) {

--- a/resources/assets/components/MediaUploader/index.js
+++ b/resources/assets/components/MediaUploader/index.js
@@ -25,7 +25,7 @@ class MediaUploader extends React.Component {
       try {
         blob = processFile(fileReader.result);
 
-        this.props.setMediaState({
+        this.props.onChange({
           file: blob,
           filePreviewUrl: URL.createObjectURL(blob)
         });
@@ -61,7 +61,7 @@ class MediaUploader extends React.Component {
 MediaUploader.propTypes = {
   label: React.PropTypes.string,
   media: React.PropTypes.object,
-  setMediaState: React.PropTypes.func
+  onChange: React.PropTypes.func
 };
 
 MediaUploader.defaultProps = {

--- a/resources/assets/components/MediaUploader/index.js
+++ b/resources/assets/components/MediaUploader/index.js
@@ -59,11 +59,17 @@ class MediaUploader extends React.Component {
 }
 
 MediaUploader.propTypes = {
-  label: React.PropTypes.string
+  label: React.PropTypes.string,
+  media: React.PropTypes.object,
+  setMediaState: React.PropTypes.func
 };
 
 MediaUploader.defaultProps = {
-  label: 'Upload Media'
+  label: 'Upload Media',
+  media: {
+    file: null,
+    filePreviewUrl: null,
+  }
 };
 
 export default MediaUploader;

--- a/resources/assets/components/ReportbackUploader/index.js
+++ b/resources/assets/components/ReportbackUploader/index.js
@@ -9,7 +9,7 @@ class ReportbackUploader extends React.Component {
     super();
 
     this.storeReportback = this.storeReportback.bind(this);
-    this.setMediaState = this.setMediaState.bind(this);
+    this.onChange = this.onChange.bind(this);
 
     this.state = {
       media: this.defaultMediaState(),
@@ -26,7 +26,7 @@ class ReportbackUploader extends React.Component {
     }
   };
 
-  setMediaState(media) {
+  onChange(media) {
     this.setState({ media })
   }
 
@@ -55,7 +55,7 @@ class ReportbackUploader extends React.Component {
         <div className="reportback-uploader">
           <h2 className="heading">Upload your photos</h2>
           <form className="reportback-form" onSubmit={this.storeReportback} ref={(form) => this.form = form}>
-            <MediaUploader label="Send us your photo" media={this.state.media} setMediaState={this.setMediaState} />
+            <MediaUploader label="Send us your photo" media={this.state.media} onChange={this.onChange} />
 
             <div className="wrapper">
               <div className="form-item">

--- a/resources/assets/components/ReportbackUploader/index.js
+++ b/resources/assets/components/ReportbackUploader/index.js
@@ -9,48 +9,44 @@ class ReportbackUploader extends React.Component {
     super();
 
     this.storeReportback = this.storeReportback.bind(this);
+    this.setMediaState = this.setMediaState.bind(this);
 
     this.state = {
-      media: {
-        file: null,
-        filePreviewUrl: null
-      },
+      media: this.defaultMediaState(),
       caption: null,
       impact: null,
       why_participated: null
     };
   }
 
-  setMediaState(data) {
-    console.log('setMediaState');
-    console.log(data.filePreviewUrl);
+  defaultMediaState() {
+    return {
+      file: null,
+      filePreviewUrl: null
+    }
+  };
 
-    // this.setState({
-    //   media: {
-    //     file: data.file,
-    //     filePreviewUrl: data.filePreviewUrl
-    //   }
-    // });
+  setMediaState(media) {
+    this.setState({ media })
   }
 
   storeReportback(event) {
     event.preventDefault();
 
-    console.log('storeReportback');
+    const reportback = {
+      photo: this.state.media,
+      caption: this.caption.value,
+      impact: this.impact.value,
+      why_participated: this.why_participated.value
+    };
 
-    // const reportback = {
-    //   photo: this.mediaUploader.state.file,
-    //   caption: this.caption.value,
-    //   impact: this.impact.value,
-    //   why_participated: this.why_participated.value
-    // };
-
-    // console.log(reportback);
-    // console.log(this.mediaUploader);
+    console.log(reportback);
 
     // @TODO: only reset form AFTER successful RB submission.
-    // this.form.reset();
-    // this.mediaUploader.setDefaultState();
+    this.form.reset();
+    this.setState({
+      media: this.defaultMediaState()
+    });
   }
 
   render() {
@@ -87,6 +83,3 @@ class ReportbackUploader extends React.Component {
 }
 
 export default ReportbackUploader;
-
-// <MediaUploader label="Send us your photo" media={this.state.photo} onChange={} />
-// <MediaUploader label="Send us your photo" ref={(component) => this.mediaUploader = component} />

--- a/resources/assets/components/ReportbackUploader/index.js
+++ b/resources/assets/components/ReportbackUploader/index.js
@@ -1,0 +1,92 @@
+import React from 'react';
+import Block from '../Block';
+import { Flex } from '../Flex';
+import MediaUploader from '../MediaUploader';
+import './reportback-uploader.scss';
+
+class ReportbackUploader extends React.Component {
+  constructor() {
+    super();
+
+    this.storeReportback = this.storeReportback.bind(this);
+
+    this.state = {
+      media: {
+        file: null,
+        filePreviewUrl: null
+      },
+      caption: null,
+      impact: null,
+      why_participated: null
+    };
+  }
+
+  setMediaState(data) {
+    console.log('setMediaState');
+    console.log(data.filePreviewUrl);
+
+    // this.setState({
+    //   media: {
+    //     file: data.file,
+    //     filePreviewUrl: data.filePreviewUrl
+    //   }
+    // });
+  }
+
+  storeReportback(event) {
+    event.preventDefault();
+
+    console.log('storeReportback');
+
+    // const reportback = {
+    //   photo: this.mediaUploader.state.file,
+    //   caption: this.caption.value,
+    //   impact: this.impact.value,
+    //   why_participated: this.why_participated.value
+    // };
+
+    // console.log(reportback);
+    // console.log(this.mediaUploader);
+
+    // @TODO: only reset form AFTER successful RB submission.
+    // this.form.reset();
+    // this.mediaUploader.setDefaultState();
+  }
+
+  render() {
+    return (
+      <Block>
+        <div className="reportback-uploader">
+          <h2 className="heading">Upload your photos</h2>
+          <form className="reportback-form" onSubmit={this.storeReportback} ref={(form) => this.form = form}>
+            <MediaUploader label="Send us your photo" media={this.state.media} setMediaState={this.setMediaState} />
+
+            <div className="wrapper">
+              <div className="form-item">
+                <label className="field-label" htmlFor="caption">Add a caption to your photo.</label>
+                <input className="text-field" id="caption" name="caption" type="text" placeholder="Give it your best shot" ref={(input) => this.caption = input} />
+              </div>
+
+              <div>
+                <label className="field-label" htmlFor="impact">How many jeans are in this photo?</label>
+                <input className="text-field" id="impact" name="impact" type="text" placeholder="Enter # here -- like '300' or '5'" ref={(input) => this.impact = input} />
+              </div>
+            </div>
+
+            <div className="form-item">
+              <label className="field-label" htmlFor="why_participated">Why is this campaign important to you?</label>
+              <textarea className="text-field" id="why_participated" name="why_participated" placeholder="No need to write an essay, but we'd love to see why this matters to you!" ref={(input) => this.why_participated = input}></textarea>
+            </div>
+
+            <button className="button" type="submit">Submit a new photo</button>
+          </form>
+        </div>
+      </Block>
+    );
+  }
+}
+
+export default ReportbackUploader;
+
+// <MediaUploader label="Send us your photo" media={this.state.photo} onChange={} />
+// <MediaUploader label="Send us your photo" ref={(component) => this.mediaUploader = component} />

--- a/resources/assets/components/ReportbackUploader/reportback-uploader.scss
+++ b/resources/assets/components/ReportbackUploader/reportback-uploader.scss
@@ -1,0 +1,39 @@
+@import '~@dosomething/forge/scss/toolkit';
+
+$media-uploader-size: 300;
+
+.reportback-uploader {
+  .heading {
+    background-color: $black;
+    color: $white;
+    font-size: $font-medium;
+    margin: -($base-spacing / 2);
+    padding: $base-spacing / 2;
+  }
+
+  .button {
+    display: block;
+    margin: 0 auto;
+  }
+}
+
+.reportback-form {
+  .media-uploader {
+    float: left;
+    height: 300px;
+    margin: $base-spacing 0;
+    width: 300px;
+  }
+
+  .wrapper {
+    float: left;
+    padding-left: $base-spacing / 2;
+    width: calc(100% - 300px);
+  }
+
+  .form-item {
+    margin-top: $base-spacing;
+    clear: both;
+  }
+}
+

--- a/resources/assets/components/ReportbackUploader/reportback-uploader.scss
+++ b/resources/assets/components/ReportbackUploader/reportback-uploader.scss
@@ -1,7 +1,5 @@
 @import '~@dosomething/forge/scss/toolkit';
 
-$media-uploader-size: 300;
-
 .reportback-uploader {
   .heading {
     background-color: $black;

--- a/resources/assets/components/ReportbackUploader/reportback-uploader.scss
+++ b/resources/assets/components/ReportbackUploader/reportback-uploader.scss
@@ -19,16 +19,21 @@ $media-uploader-size: 300;
 
 .reportback-form {
   .media-uploader {
-    float: left;
     height: 300px;
-    margin: $base-spacing 0;
+    margin: $base-spacing auto;
     width: 300px;
+
+    @include media($medium) {
+      float: left;
+    }
   }
 
   .wrapper {
-    float: left;
-    padding-left: $base-spacing / 2;
-    width: calc(100% - 300px);
+    @include media($medium) {
+      float: left;
+      padding-left: $base-spacing / 2;
+      width: calc(100% - 300px);
+    }
   }
 
   .form-item {

--- a/resources/assets/containers/ActionFeed.js
+++ b/resources/assets/containers/ActionFeed.js
@@ -7,6 +7,7 @@ const mapStateToProps = (state) => {
   return {
     campaign: state.campaign,
     reportbacks: state.reportbacks,
+    submission: state.submission,
   };
 };
 

--- a/resources/assets/reducers.js
+++ b/resources/assets/reducers.js
@@ -29,6 +29,13 @@ const reportbacks = (state = {}, action) => {
   }
 };
 
-const rootReducer = combineReducers({campaign, reportbacks});
+/**
+ * Events reducer:
+ */
+const submission = (state = {}, action) => {
+  return state;
+};
+
+const rootReducer = combineReducers({campaign, submission, reportbacks});
 
 export default rootReducer;


### PR DESCRIPTION
This PR add the `ReportbackUploader` component which currently includes the Reportback form and will also include the upcoming Reportback Submissions gallery. It incorporates the use of the `MediaUploader` component for uploading files as well as the required form inputs.

It also sets up a new property called `submission` in the Redux store in preparation for receiving submissions via the RB Uploader.

Currently, it allows you to add a photo and accompanying text input in the fields and submit the reportback but only outputs the submitted data to the console. The next steps will include actually submitting the reportback data to Phoenix-Ashes and then updating the Redux store if the submission was successful.

The styles for the Reportback Uploader are pretty basic for the time being since the designs are not finalized yet, but it's responsive (enough).

Refs #46
