### PR TITLE
Login prompt for reactions

### DIFF
--- a/app/helpers.php
+++ b/app/helpers.php
@@ -26,7 +26,7 @@ function scriptifyCurrentUser()
     return scriptify([
         'authenticated' => $authenticated,
         'northstarId' => $authenticated ? Auth::user()->northstar_id : null,
-    ], 'user');
+    ], 'USER');
 }
 
 /**

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -20,6 +20,15 @@ function scriptify($json = [], $store = 'STATE')
     return new HtmlString('<script type="text/javascript">window.'.$store.' = '.json_encode($json).'</script>');
 }
 
+function scriptifyCurrentUser()
+{
+    $authenticated = Auth::check();
+    return scriptify([
+        'authenticated' => $authenticated,
+        'northstarId' => $authenticated ? Auth::user()->northstar_id : null,
+    ], 'user');
+}
+
 /**
  * Get an item from the cache, or store the default value.
  *

--- a/resources/assets/components/ReportbackBlock/index.js
+++ b/resources/assets/components/ReportbackBlock/index.js
@@ -8,10 +8,10 @@ class ReportbackReaction extends React.Component {
   constructor(props) {
     super(props);
 
-    this.onReact = this.onReact.bind(this);
+    this.onClick = this.onClick.bind(this);
     this.phoenix = new Phoenix();
 
-    // This user might the current user or the Drupal API User
+    // This user might be the current user or the Drupal API User
     const currentUser = this.props.reactions.current_user;
     const userReaction = currentUser ? currentUser.reacted : false;
 
@@ -24,8 +24,8 @@ class ReportbackReaction extends React.Component {
     }
   }
 
-  onReact() {
-    if (!window.USER.authenticated) {
+  onClick() {
+    if (!window.AUTH.authenticated) {
       window.location.href = '/login';
       return;
     }
@@ -56,7 +56,7 @@ class ReportbackReaction extends React.Component {
 
   render() {
     return (
-      <Reaction active={this.state.active} total={this.state.total} onClick={this.onReact}></Reaction>
+      <Reaction active={this.state.active} total={this.state.total} onClick={this.onClick}></Reaction>
     );
   }
 }

--- a/resources/assets/components/ReportbackBlock/index.js
+++ b/resources/assets/components/ReportbackBlock/index.js
@@ -11,16 +11,25 @@ class ReportbackReaction extends React.Component {
     this.onReact = this.onReact.bind(this);
     this.phoenix = new Phoenix();
 
+    // This user might the current user or the Drupal API User
     const currentUser = this.props.reactions.current_user;
+    const userReaction = currentUser ? currentUser.reacted : false;
+
+    const reacted = window.USER.authenticated ? userReaction : false;
 
     this.state = {
-      active: currentUser ? currentUser.reacted : false,
+      active: reacted,
       total: this.props.reactions.term.total,
       reactionId: currentUser ? currentUser.kudos_id : '',
     }
   }
 
   onReact() {
+    if (!window.USER.authenticated) {
+      window.location.href = '/login';
+      return;
+    }
+
     const newReactionState = !this.state.active;
 
     this.setState({

--- a/resources/views/layouts/master.blade.php
+++ b/resources/views/layouts/master.blade.php
@@ -48,6 +48,7 @@
 <script type="text/javascript" src="{{ asset('dist/app.js') }}"></script>
 
 {{ isset($state) ? scriptify($state) : scriptify() }}
+{{ scriptifyCurrentUser() }}
 </body>
 
 </html>


### PR DESCRIPTION
This PR makes it so, If an unauthenticated user tries to react on a reportback, they are taken to the Northstar login page.

There is an annoying complication / workaround I had to do in the JS you'll see commented below, other than that everything is pretty straightforward. Also I added the Northstar ID, even though it's not used now we will need it later for event tracking. 