### PR TITLE
Render embeds into campaign update blocks.

### DIFF
--- a/app/Http/Controllers/EmbedController.php
+++ b/app/Http/Controllers/EmbedController.php
@@ -30,9 +30,10 @@ class EmbedController extends Controller
                 'icon' => $info->providerIcon,
             ],
             'title' => $info->title,
+            'description' => $info->description,
             'url' => $info->url,
             'image' => $info->image,
-            'code' => $info->code,
+            'code' => $info->type === 'video' ? $info->code : null,
         ];
     }
 

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "react-redux": "^5.0.2",
     "redux": "^3.6.0",
     "redux-logger": "^2.8.1",
-    "redux-thunk": "^2.2.0"
+    "redux-thunk": "^2.2.0",
+    "whatwg-fetch": "^2.0.3"
   },
   "devDependencies": {
     "@dosomething/webpack-config": "^1.1.1",

--- a/resources/assets/app.js
+++ b/resources/assets/app.js
@@ -10,6 +10,9 @@
 
 import { ready } from './helpers';
 
+// WHATWG Fetch Polyfill
+import 'whatwg-fetch';
+
 // Components
 import './components/construction.scss';
 import './components/container.scss';

--- a/resources/assets/components/CampaignUpdateBlock/index.js
+++ b/resources/assets/components/CampaignUpdateBlock/index.js
@@ -7,7 +7,7 @@ import DEFAULT_AVATAR from './default-avatar.png';
 import './campaign-update.scss';
 
 const Byline = ({author, jobTitle = 'DoSomething.org Staff', avatar = DEFAULT_AVATAR}) => (
-  <Figure size="small" alignment="left" verticalAlignment="center" image={avatar}>
+  <Figure size="small" alignment="left" verticalAlignment="center" image={avatar} imageClassName="avatar">
     <strong>{author}</strong><br/>
     <p className="footnote">{jobTitle}</p>
   </Figure>

--- a/resources/assets/components/CampaignUpdateBlock/index.js
+++ b/resources/assets/components/CampaignUpdateBlock/index.js
@@ -3,6 +3,7 @@ import classnames from 'classnames';
 import { markdown } from '../../helpers';
 import Block from '../Block';
 import Figure from '../Figure';
+import Embed from '../Embed';
 import DEFAULT_AVATAR from './default-avatar.png';
 import './campaign-update.scss';
 
@@ -14,7 +15,7 @@ const Byline = ({author, jobTitle = 'DoSomething.org Staff', avatar = DEFAULT_AV
 );
 
 const CampaignUpdateBlock = (props) => {
-  const { title, content, additionalContent } = props.fields;
+  const { title, content, link, additionalContent } = props.fields;
   let { author, jobTitle, avatar } = additionalContent;
 
   const contentHtml = markdown(content);
@@ -25,6 +26,7 @@ const CampaignUpdateBlock = (props) => {
       { isTweet ? null : <h2>{title}</h2> }
       <div className={classnames('campaign-update__content', {'-tweet': isTweet})}
            dangerouslySetInnerHTML={contentHtml} />
+      { link ? <Embed url={link} /> : null }
       { author ? <Byline author={author} jobTitle={jobTitle} avatar={avatar} />: null}
     </Block>
   );

--- a/resources/assets/components/Embed/embed.scss
+++ b/resources/assets/components/Embed/embed.scss
@@ -1,0 +1,26 @@
+@import '~@dosomething/forge/scss/toolkit';
+
+.embed {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  margin: 0 auto $base-spacing;
+  overflow: hidden;
+  min-height: 100px;
+  transition: box-shadow 1s;
+
+  a {
+    color: $black;
+    text-decoration: none;
+    font-weight: $weight-normal;
+  }
+}
+
+.embed.-loaded {
+  display: block;
+  box-shadow: $box-shadow;
+}
+
+.embed__preview {
+  padding: $base-spacing / 2;
+}

--- a/resources/assets/components/Embed/index.js
+++ b/resources/assets/components/Embed/index.js
@@ -25,7 +25,7 @@ class Embed extends React.Component {
       embed = <div className="media-video" dangerouslySetInnerHTML={{__html: this.state.code }} />;
     } else if (this.state.title && this.state.url && this.state.image) {
       embed = (
-        <a href={this.state.url}>
+        <a href={this.state.url} target="_blank">
           <Figure className="embed__preview" image={this.state.image} alignment="left" size="large">
             <h3>{ this.state.title }</h3>
             <p>{ this.state.description }</p>

--- a/resources/assets/components/Embed/index.js
+++ b/resources/assets/components/Embed/index.js
@@ -28,7 +28,7 @@ class Embed extends React.Component {
         <a href={this.state.url} target="_blank">
           <Figure className="embed__preview" image={this.state.image} alignment="left" size="large">
             <h3>{ this.state.title }</h3>
-            <p>{ this.state.description }</p>
+            { this.state.description ? <p>{ this.state.description }</p> : null }
             <p className="footnote">{ this.state.provider.name }</p>
           </Figure>
         </a>

--- a/resources/assets/components/Embed/index.js
+++ b/resources/assets/components/Embed/index.js
@@ -1,0 +1,50 @@
+import React from 'react';
+import classnames from 'classnames';
+import Figure from '../Figure';
+import { Phoenix } from '@dosomething/gateway';
+import './embed.scss';
+
+class Embed extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {};
+    this.phoenix = new Phoenix;
+  }
+
+  componentDidMount() {
+    this.phoenix.get('embed', { url: this.props.url })
+      .then(json => this.setState(json));
+  }
+
+  render() {
+    let embed = <div className="spinner"/>;
+
+    // If an <iframe> code snippet is provided, use that. Otherwise, build preview card.
+    if (this.state.code) {
+      embed = <div className="media-video" dangerouslySetInnerHTML={{__html: this.state.code }} />;
+    } else if (this.state.title && this.state.url && this.state.image) {
+      embed = (
+        <a href={this.state.url}>
+          <Figure className="embed__preview" image={this.state.image} alignment="left" size="large">
+            <h3>{ this.state.title }</h3>
+            <p>{ this.state.description }</p>
+            <p className="footnote">{ this.state.provider.name }</p>
+          </Figure>
+        </a>
+      );
+    }
+
+    return (
+      <div className={classnames('embed', {'-loaded': this.state.title})}>
+        {embed}
+      </div>
+    );
+  }
+}
+
+Embed.propTypes = {
+  url: React.PropTypes.string.isRequired,
+};
+
+export default Embed;

--- a/resources/assets/components/Figure/figure.scss
+++ b/resources/assets/components/Figure/figure.scss
@@ -1,3 +1,11 @@
-.figure.-small img {
+.figure.-small > .figure__media {
   width: 50px;
+
+  img { width: 100% }
+}
+
+.figure.-large > .figure__media {
+  width: 200px;
+
+  img { width: 100% }
 }

--- a/resources/assets/components/Figure/index.js
+++ b/resources/assets/components/Figure/index.js
@@ -3,10 +3,10 @@ import classnames from 'classnames';
 import { modifiers } from '../../helpers';
 import './figure.scss';
 
-const Figure = ({alignment, verticalAlignment, size, image, alt, children}) => (
-  <article className={classnames('figure', modifiers(alignment, verticalAlignment, size))}>
+const Figure = ({alignment, verticalAlignment, size, image, className, imageClassName, alt, children}) => (
+  <article className={classnames('figure', className, modifiers(alignment, verticalAlignment, size))}>
     <div className="figure__media">
-      <img className="avatar" alt={alt} src={image} />
+      <img className={imageClassName} alt={alt} src={image} />
     </div>
     <div className="figure__body">
       {children}
@@ -17,7 +17,7 @@ const Figure = ({alignment, verticalAlignment, size, image, alt, children}) => (
 Figure.propTypes = {
   alignment: React.PropTypes.oneOf(['left', 'right']),
   verticalAlignment: React.PropTypes.oneOf(['center']),
-  size: React.PropTypes.oneOf(['small', 'medium']),
+  size: React.PropTypes.oneOf(['small', 'medium', 'large']),
   image: React.PropTypes.string.isRequired,
   alt: React.PropTypes.string,
 };


### PR DESCRIPTION
#### Changes
This pull request adds support for rendering the newly-added "Link" field on Campaign Update blocks. This will allow campaign leads to display videos or article links in updates.

Check it out on [the review app](https://phoenix-next-pr-56.herokuapp.com/campaigns/teens-for-jeans) for a preview! 👀