### PR TITLE
Updating structure of reducers for Redux pattern.

### DIFF
--- a/resources/assets/actions.js
+++ b/resources/assets/actions.js
@@ -6,6 +6,7 @@ import { Phoenix } from '@dosomething/gateway';
  */
 export const REQUESTED_REPORTBACKS = 'REQUESTED_REPORTBACKS';
 export const RECEIVED_REPORTBACKS = 'RECEIVED_REPORTBACKS';
+export const STORED_REPORTBACK_SUBMISSION = 'STORED_REPORTBACK_SUBMISSION';
 
 /**
  * Action Creators: these functions create actions, which describe changes
@@ -20,6 +21,10 @@ export function requestingReportbacks(node) {
 // Action: new reportback data received.
 export function receivedReportbacks(node, page, data) {
   return { type: RECEIVED_REPORTBACKS, node, page, data};
+}
+
+export function storeReportbackSubmission() {
+  return { type: STORED_REPORTBACK_SUBMISSION };
 }
 
 // An async action creator to fetch another page of reportbacks.

--- a/resources/assets/containers/ActionFeed.js
+++ b/resources/assets/containers/ActionFeed.js
@@ -7,7 +7,7 @@ const mapStateToProps = (state) => {
   return {
     campaign: state.campaign,
     reportbacks: state.reportbacks,
-    submission: state.submission,
+    submissions: state.submissions,
   };
 };
 

--- a/resources/assets/reducers/campaign.js
+++ b/resources/assets/reducers/campaign.js
@@ -1,0 +1,8 @@
+/**
+ * Campaign reducer:
+ */
+const campaign = (state = {}, action) => {
+  return state;
+}
+
+export default campaign;

--- a/resources/assets/reducers/index.js
+++ b/resources/assets/reducers/index.js
@@ -1,0 +1,12 @@
+import { combineReducers } from 'redux';
+import campaign from './campaign';
+import reportbacks from './reportbacks';
+import submissions from './submissions';
+
+const rootReducer = combineReducers({
+  campaign,
+  reportbacks,
+  submissions
+});
+
+export default rootReducer;

--- a/resources/assets/reducers/reportbacks.js
+++ b/resources/assets/reducers/reportbacks.js
@@ -1,12 +1,4 @@
-import { combineReducers } from 'redux';
-import { REQUESTED_REPORTBACKS, RECEIVED_REPORTBACKS } from './actions';
-
-/**
- * Campaign reducer:
- */
-const campaign = (state = {}, action) => {
-  return state;
-};
+import { REQUESTED_REPORTBACKS, RECEIVED_REPORTBACKS } from '../actions';
 
 /**
  * Reportback reducer:
@@ -27,15 +19,6 @@ const reportbacks = (state = {}, action) => {
     default:
       return state;
   }
-};
+}
 
-/**
- * Events reducer:
- */
-const submission = (state = {}, action) => {
-  return state;
-};
-
-const rootReducer = combineReducers({campaign, submission, reportbacks});
-
-export default rootReducer;
+export default reportbacks;

--- a/resources/assets/reducers/submissions.js
+++ b/resources/assets/reducers/submissions.js
@@ -1,0 +1,16 @@
+import { STORED_REPORTBACK_SUBMISSION } from '../actions';
+
+/**
+ * Submissions reducer:
+ */
+const submissions = (state = {}, action) => {
+  switch (action.type) {
+    case STORED_REPORTBACK_SUBMISSION:
+      return state;
+
+    default:
+      return state;
+  }
+}
+
+export default submissions;


### PR DESCRIPTION
This PR splits up the reducers into their own corresponding files within a new `/reducers` directory, and includes an `index.js` file that collects them all to be combined to provide the exportable `rootReducer` to make things more manageable.

