### PR TITLE
State tweaks for the win

### DIFF
--- a/app/Http/Controllers/CampaignController.php
+++ b/app/Http/Controllers/CampaignController.php
@@ -42,6 +42,7 @@ class CampaignController extends Controller
      */
     public function index()
     {
+        dd(Auth::user());
         $campaigns = $this->campaignRepository->getAll();
 
         return view('campaigns.index', ['campaigns' => $campaigns]);
@@ -69,6 +70,6 @@ class CampaignController extends Controller
         $reportbacks = $response['data'];
 
         return view('campaigns.show', ['campaign' => $campaign])
-            ->with('state', ['campaign' => $campaign, 'reportbacks' => ['isFetching' => false, 'data' => $reportbacks], 'submissions' => ['isStoring' => false]]);
+            ->with('state', ['campaign' => $campaign, 'reportbacks' => ['data' => $reportbacks]]);
     }
 }

--- a/app/Http/Controllers/CampaignController.php
+++ b/app/Http/Controllers/CampaignController.php
@@ -42,7 +42,6 @@ class CampaignController extends Controller
      */
     public function index()
     {
-        dd(Auth::user());
         $campaigns = $this->campaignRepository->getAll();
 
         return view('campaigns.index', ['campaigns' => $campaigns]);

--- a/resources/assets/reducers/submissions.js
+++ b/resources/assets/reducers/submissions.js
@@ -17,7 +17,7 @@ const submissions = (state = {}, action) => {
 
     case ADD_TO_SUBMISSIONS_LIST:
       return Object.assign({}, state, {
-        data: [...state, action.reportback]
+        data: [...state.data, action.reportback]
       })
 
     default:

--- a/resources/assets/store.js
+++ b/resources/assets/store.js
@@ -1,7 +1,19 @@
 import { createStore, combineReducers, applyMiddleware, compose } from 'redux'
 import thunk from 'redux-thunk';
+import merge from 'lodash/merge';
 
 export default function(reducers, preloadedState = {}) {
+  const initialState = {
+    reportbacks: {
+      isFetching: false,
+      data: [],
+    },
+    submissions: {
+      isStoring: false,
+      data: [],
+    }
+  };
+
   // Log actions to the console in development.
   const middleware = [thunk];
   if (process.env.NODE_ENV === `development`) {
@@ -14,7 +26,7 @@ export default function(reducers, preloadedState = {}) {
 
   return createStore(
     combineReducers(reducers),
-    preloadedState,
+    merge(initialState, preloadedState),
     composeEnhancers(
       applyMiddleware(...middleware)
     )


### PR DESCRIPTION
In this PR, @DFurnes and I did some pair-programmingz to help setup a suitable initial state for the main `store` of the app, so it doesn't have to be setup elsewhere (like coming from the `CampaignController` like it was doing before), and just accepts overrides to update the base state on first load if state data is passed in.

It also fixes how the submissions reducer updates the state for submissions which was previously incorrect.