### PR TITLE
First pass at the static block.

### DIFF
--- a/resources/assets/components/Feed/index.js
+++ b/resources/assets/components/Feed/index.js
@@ -4,6 +4,7 @@ import { get } from 'lodash';
 import CallToActionBlock from '../CallToActionBlock';
 import CampaignUpdateBlock from '../CampaignUpdateBlock';
 import PlaceholderBlock from '../PlaceholderBlock';
+import StaticBlock from '../StaticBlock';
 import { Flex, FlexCell } from '../Flex';
 import ReportbackContainer from '../../containers/ReportbackContainer';
 import ReportbackUploaderContainer from '../../containers/ReportbackUploaderContainer';
@@ -20,6 +21,7 @@ class Feed extends React.Component {
       'campaign_update': CampaignUpdateBlock,
       'join_cta': CallToActionBlock,
       'reportbacks': ReportbackContainer,
+      'static': StaticBlock,
     }, block.type, PlaceholderBlock);
 
     return <FlexCell key={block.id + '-' + index} width={block.fields.displayOptions}><BlockComponent {...block} /></FlexCell>;

--- a/resources/assets/components/StaticBlock/index.js
+++ b/resources/assets/components/StaticBlock/index.js
@@ -1,0 +1,18 @@
+import React from 'react';
+import Block from '../Block';
+import Markdown from '../Markdown';
+import './static-block.scss';
+
+const StaticBlock = (props) => {
+  const source = props.fields.additionalContent.source;
+
+  return (
+    <Block>
+      <h4 className="static-block__title">{props.fields.title}</h4>
+      <Markdown>{props.fields.content}</Markdown>
+      { source ? <div className="static-block__citation"><p className="footnote">Source: {source}</p></div> : null }
+    </Block>
+  );
+};
+
+export default StaticBlock;

--- a/resources/assets/components/StaticBlock/static-block.scss
+++ b/resources/assets/components/StaticBlock/static-block.scss
@@ -1,0 +1,22 @@
+@import '~@dosomething/forge/scss/toolkit';
+
+.static-block__title {
+  color: #fff;
+  background-color: #e8273e; // red, the color of desire ♬
+  text-transform: uppercase;
+  margin: (- $base-spacing / 2) (- $base-spacing / 2) $base-spacing;
+  padding: $base-spacing / 2;
+}
+
+.static-block__citation {
+  margin-top: $base-spacing;
+
+  &::before {
+    content: '';
+    display: block;
+    width: 50%;
+    height: 2px;
+    background-color: $med-gray;
+    margin-bottom: $base-spacing / 2;
+  }
+}


### PR DESCRIPTION
#### Changes
This pull request includes a first pass at the "static block", which displays a title, markdown content, and an optional "source" at the bottom. For now, I did some negative margin hackery & hard-coded that wonderful red from the mocks – it'll makes sense to clean that up once we have a clearer creative direction in mind next week. 😄

<img width="807" alt="screen shot 2017-03-14 at 5 14 10 pm" src="https://cloud.githubusercontent.com/assets/583202/23922679/ad9c3efc-08d9-11e7-9e17-a1e1353629e8.png">

🦊