### PR TITLE
Only allow one "width" for a block.

### DIFF
--- a/resources/assets/components/Feed/index.js
+++ b/resources/assets/components/Feed/index.js
@@ -24,7 +24,7 @@ class Feed extends React.Component {
       'static': StaticBlock,
     }, block.type, PlaceholderBlock);
 
-    return <FlexCell key={block.id + '-' + index} width={block.fields.displayOptions}><BlockComponent {...block} /></FlexCell>;
+    return <FlexCell key={block.id + '-' + index} width={block.fields.displayOptions[0]}><BlockComponent {...block} /></FlexCell>;
   }
 
   /**
@@ -37,7 +37,7 @@ class Feed extends React.Component {
       <Flex>
         {this.props.blocks.map((block, index) => this.renderFeedItem(block, index))}
         {this.props.revealer}
-        <FlexCell key="reportback_uploader">
+        <FlexCell key="reportback_uploader" width="full">
           <ReportbackUploaderContainer/>
         </FlexCell>
       </Flex>

--- a/resources/assets/components/Flex/index.js
+++ b/resources/assets/components/Flex/index.js
@@ -20,6 +20,6 @@ export const FlexCell = ({width = [], children}) => {
 };
 
 FlexCell.propTypes = {
-  width: React.PropTypes.arrayOf(React.PropTypes.oneOf(['full', 'one-third', 'two-thirds']))
+  width: React.PropTypes.oneOf(['full', 'one-third', 'two-thirds']),
 };
 

--- a/resources/assets/components/Revealer/index.js
+++ b/resources/assets/components/Revealer/index.js
@@ -5,7 +5,7 @@ import './revealer.scss';
 
 const Revealer = (props) => {
   return (
-    <FlexCell width={["full"]}>
+    <FlexCell width="full">
       <div className="revealer">
         <h1>{props.callToAction}</h1>
         <a className="button" onClick={props.onReveal}>{props.title}</a>


### PR DESCRIPTION
## Changes
This fixes a weird lil' display issue in Safari, and limits the `width` prop on the flex cell to one value because it doesn't really make sense for something to be more than one width, does it?!

#### Before:
![screen shot 2017-03-16 at 12 27 29 pm](https://cloud.githubusercontent.com/assets/583202/24007097/0166b9c0-0a44-11e7-9ec4-9a4ca702cdbd.png)

#### After:
![screen shot 2017-03-16 at 12 27 12 pm](https://cloud.githubusercontent.com/assets/583202/24007103/04284566-0a44-11e7-941e-92ef9061e009.png)

🐞 