### PR TITLE
CTA block updates

### DIFF
--- a/resources/assets/components/CallToActionBlock/cta.scss
+++ b/resources/assets/components/CallToActionBlock/cta.scss
@@ -1,8 +1,66 @@
 @import '~@dosomething/forge/scss/toolkit';
 
 .cta {
-  width: 100%;
-  margin: 12px;
   border: 0;
   border-radius: $sm-border-radius;
+  margin: 12px;
+  width: 100%;
+
+  &.has-photo {
+    @include media($medium) {
+      display: flex;
+
+      .cta__content, .cta__photo {
+        flex: 0 0 50%;
+      }
+    }
+
+    .cta__photo {
+      background-size: cover;
+      background-position: center center;
+      display: none;
+
+      @include media($medium) {
+        display: block;
+      }
+    }
+
+  }
+}
+
+.cta__block {
+  @include media($medium) {
+    .has-photo & {
+      margin: $base-spacing auto;
+      width: 90%;
+    }
+  }
+}
+
+.cta__title {
+  font-size: $font-medium;
+  font-weight: $weight-sbold;
+}
+
+.cta__message {
+  font-size: $font-regular;
+  font-weight: $weight-normal;
+}
+
+.cta__impact {
+  color: $purple;
+  font-weight: $weight-bold;
+
+  span {
+    display: block;
+    line-height: 1.2;
+  }
+}
+
+.cta__impact-prefix {
+  text-transform: uppercase;
+}
+
+.cta__impact-number {
+  font-size: $font-hero;
 }

--- a/resources/assets/components/CallToActionBlock/index.js
+++ b/resources/assets/components/CallToActionBlock/index.js
@@ -1,21 +1,51 @@
 import React from 'react';
+import classnames from 'classnames';
+import { contentfulImageUrl } from '../../helpers';
 import './cta.scss';
 
 const CallToActionBlock = (props) => {
+  const additionalContent = props.fields.additionalContent || {};
+
   //TODO: This should probably be editable in contentful
-  const cta = props.signups.thisCampaign ? 'Reportback' : 'Get Involved';
+  const buttonText = props.signups.thisCampaign ? 'Reportback' : 'Get Involved';
 
   //TODO: This should take you to the action page if you're signed up
   const onClick = () => props.clickedSignUp(props.campaign.legacyCampaignId);
 
+  const backgroundImageStyle = {
+    backgroundImage: `url(${contentfulImageUrl(props.campaign.coverImage.url, '400', '400', 'fill')})`,
+  };
+
+  const impactContent = () => {
+    if (additionalContent.impactNumber) {
+      return (
+        <div className="cta__block cta__impact">
+          {additionalContent.impactPrefix ? <span className="cta__impact-prefix">{additionalContent.impactPrefix}</span> : null}
+          {additionalContent.impactNumber ? <span className="cta__impact-number">{additionalContent.impactNumber}</span> : null}
+          {additionalContent.impactMessage ? <span className="cta__impact-message">{additionalContent.impactMessage}</span> : null}
+        </div>
+      );
+    }
+
+    return null;
+  }
+
   return (
-    <div className="cta">
-      <div className="cta__block">
-        <p className="cta__message">{ props.fields.title }</p>
+    <div className={classnames('cta', {'has-photo': additionalContent.hasPhoto})}>
+
+      <div className="cta__content">
+        { !props.fields.content ? <div className="cta__block"><p className="cta__title">{props.fields.title}</p></div> : null }
+
+        {impactContent()}
+
+        { props.fields.content ? <div className="cta__block"><p className="cta__message">{props.fields.content}</p></div> : null }
+
+        <div className="cta__block">
+          <a className="button" onClick={onClick}>{ buttonText }</a>
+        </div>
       </div>
-      <div className="cta__block">
-        <a className="button" onClick={onClick}>{ cta }</a>
-      </div>
+
+      { additionalContent.hasPhoto ? <div className="cta__photo" style={backgroundImageStyle}></div> : null }
     </div>
   );
 };

--- a/resources/assets/components/CallToActionBlock/index.js
+++ b/resources/assets/components/CallToActionBlock/index.js
@@ -16,18 +16,16 @@ const CallToActionBlock = (props) => {
     backgroundImage: `url(${contentfulImageUrl(props.campaign.coverImage.url, '400', '400', 'fill')})`,
   };
 
-  const impactContent = () => {
-    if (additionalContent.impactNumber) {
-      return (
-        <div className="cta__block cta__impact">
-          {additionalContent.impactPrefix ? <span className="cta__impact-prefix">{additionalContent.impactPrefix}</span> : null}
-          {additionalContent.impactNumber ? <span className="cta__impact-number">{additionalContent.impactNumber}</span> : null}
-          {additionalContent.impactMessage ? <span className="cta__impact-message">{additionalContent.impactMessage}</span> : null}
-        </div>
-      );
-    }
+  let impactContent = null;
 
-    return null;
+  if (additionalContent.impactNumber) {
+    impactContent = (
+      <div className="cta__block cta__impact">
+        {additionalContent.impactPrefix ? <span className="cta__impact-prefix">{additionalContent.impactPrefix}</span> : null}
+        {additionalContent.impactNumber ? <span className="cta__impact-number">{additionalContent.impactNumber}</span> : null}
+        {additionalContent.impactMessage ? <span className="cta__impact-message">{additionalContent.impactMessage}</span> : null}
+      </div>
+    );
   }
 
   return (
@@ -36,7 +34,7 @@ const CallToActionBlock = (props) => {
       <div className="cta__content">
         { !props.fields.content ? <div className="cta__block"><p className="cta__title">{props.fields.title}</p></div> : null }
 
-        {impactContent()}
+        {impactContent}
 
         { props.fields.content ? <div className="cta__block"><p className="cta__message">{props.fields.content}</p></div> : null }
 

--- a/resources/assets/components/ContentfulImage/index.js
+++ b/resources/assets/components/ContentfulImage/index.js
@@ -1,0 +1,16 @@
+import React from 'react';
+import { contentfulImageUrl } from '../../helpers';
+
+const ContentfulImage = ({ url, width = null, height = null, fit = 'fill', description = 'something' }) => (
+  <img alt={description ? description : null} src={contentfulImageUrl(url, width, height, fit)} />
+);
+
+ContentfulImage.propTypes = {
+  url: React.PropTypes.string.isRequired,
+  width: React.PropTypes.string,
+  height: React.PropTypes.string,
+  fit: React.PropTypes.string,
+  description: React.PropTypes.string,
+};
+
+export default ContentfulImage;

--- a/resources/assets/helpers.js
+++ b/resources/assets/helpers.js
@@ -2,6 +2,33 @@ import marked from 'marked';
 import get from 'lodash/get';
 
 /**
+ * Generate a Contentful Image URL with added url parameters.
+ *
+ * @param  {String} url
+ * @param  {String} width
+ * @param  {String} height
+ * @param  {String} fit
+ * @return {String}
+ */
+export function contentfulImageUrl(url, width = null, height = null, fit = null) {
+  let params = [];
+
+  if (width) {
+    params.push(`w=${width}`);
+  }
+
+  if (height) {
+    params.push(`h=${height}`);
+  }
+
+  if (fit) {
+    params.push(`fit=${fit}`);
+  }
+
+  return params.length ? `${url}?${params.join('&')}` : url;
+}
+
+/**
  * Wait until the DOM is ready.
  *
  * @param {Function} fn


### PR DESCRIPTION
This PR does a few updates to the `CallToActionBlock` so it can accommodate more variations based on the content entered in Contentful by the Campaign Lead:

![image](https://cloud.githubusercontent.com/assets/105849/24116298/b5d30266-0d7c-11e7-86fc-be744037a094.png)

One thing to note, I originally coded the component to use the new `ContentfulImage` component that inserts an `<img />` tag with proper link to a modified version of the cover image for the campaign using URL params. However, I ended up deciding that for the `CallToActionBlock` component, it would work better (responsively for small/medium/large screens) if the image was added as a custom `style` attribute. I ended up leaving the new `ContentfulImage` component because it could come in handy in the future 🔮 

Reference: https://trello.com/c/uJEgoIBB/272-5-as-a-developer-i-want-to-build-the-three-cta-blocks-that-have-been-selected-for-the-v1-launch-so-that-we-can-prompt-people-to-