### PR TITLE
Bug fix to address users that have signed up for a campaign but not reported back yet.

### DIFF
--- a/resources/assets/actions/reportback.js
+++ b/resources/assets/actions/reportback.js
@@ -113,9 +113,13 @@ export function fetchUserReportbacks(userId, campaignId) {
         dispatch(receivedUserReportbacks());
 
         if (json.data.length) {
-          let reportbackItems = json.data.shift().reportback.reportback_items.data;
+          let reportback = json.data.shift().reportback;
 
-          reportbackItems.forEach(reportbackItem => {
+          if (!reportback) {
+            return;
+          }
+
+          reportback.reportback_items.data.forEach(reportbackItem => {
             dispatch(addToSubmissionsList(reportbackItem));
           });
         }

--- a/resources/assets/reducers/submissions.js
+++ b/resources/assets/reducers/submissions.js
@@ -29,7 +29,7 @@ const submissions = (state = {}, action) => {
       return {...state, isStoring: false};
 
     case ADD_TO_SUBMISSIONS_LIST:
-      return {...state, data: [...state.data, action.reportback].reverse()}
+      return {...state, data: [action.reportback, ...state.data]}
 
     default:
       return state;


### PR DESCRIPTION
This PR provides a quick fix for a bug where the `reportbacks` property on the `/signups` response might be `null` if the user signed up but had not reported back yet on the campaign. This would result in an error, since the property would be `null` instead of an array to loop through:

![image](https://cloud.githubusercontent.com/assets/105849/24270100/2671ec20-0fea-11e7-962a-4d1c832d18cb.png)

(Screenshot photo credit curtesy of @DFurnes)

This also addresses the submission list reversing issue mentioned [here](https://github.com/DoSomething/phoenix-next/pull/96#pullrequestreview-28760899).