### PR TITLE
Collapse Redux logger for easier reading.

### DIFF
--- a/resources/assets/store.js
+++ b/resources/assets/store.js
@@ -55,7 +55,7 @@ export default function(reducers, preloadedState = {}) {
   const middleware = [thunk];
   if (process.env.NODE_ENV === `development`) {
     const createLogger = require(`redux-logger`);
-    middleware.push(createLogger());
+    middleware.push(createLogger({collapsed: true}));
   }
 
   // If React DevTools are available, use instrumented compose function.


### PR DESCRIPTION
## Changes
This collapses the Redux log statement so they aren't so noisy. 🔇

#### Before
![screen shot 2017-03-24 at 11 35 16 am](https://cloud.githubusercontent.com/assets/583202/24301463/09f48228-1086-11e7-853a-93463e0a74ad.png)

#### After
![screen shot 2017-03-24 at 11 35 36 am](https://cloud.githubusercontent.com/assets/583202/24301467/0c84e0f0-1086-11e7-9276-dd7e69317880.png)

