### PR TITLE
Adds Facebook meta tags

### DIFF
--- a/resources/views/layouts/master.blade.php
+++ b/resources/views/layouts/master.blade.php
@@ -11,6 +11,10 @@
     <link rel="icon" type="image/ico" href="/favicon.ico?v1">
     <link rel="stylesheet" href="https://unpkg.com/@dosomething/forge@^6.7.4/dist/forge.css" media="screen, projection" type="text/css">
     <link rel="stylesheet" href="{{ asset('dist/app.css') }}" media="screen, projection" type="text/css">
+
+    @if(isset($campaign))
+        @include('partials.social')
+    @endif
 </head>
 
 <body>

--- a/resources/views/partials/social.blade.php
+++ b/resources/views/partials/social.blade.php
@@ -1,0 +1,10 @@
+<meta property="og:title" content="{{ $campaign->title }}" />
+<meta property="og:type"  content="article" />
+<meta property="og:description" content="{{ $campaign->callToAction }}" />
+
+{{-- Exposing the URL in our current setup causes funky side effects because of redirect rules
+     and Facebook seems capable of working without it. --}}
+{{-- <meta property="og:url" content="https://dosomething.org/campaigns/{{ $campaign->slug }}" /> --}}
+
+{{-- Contentful outputs "//" which Facebook cannot parse --}}
+<meta property="og:image" content="http:{{ $campaign->coverImage->getFile()->getUrl() }}" />


### PR DESCRIPTION
This PR adds some meta tags so Facebook can crawl our campaign pages 

![screen shot 2017-03-27 at 4 35 50 pm](https://cloud.githubusercontent.com/assets/897368/24377119/3183747e-130c-11e7-883e-3d037fb4718e.png)
