### PR TITLE
Adds share component

### DIFF
--- a/resources/assets/actions/index.js
+++ b/resources/assets/actions/index.js
@@ -35,3 +35,9 @@ export const SIGNUP_FOUND = 'SIGNUP_FOUND';
 export const SIGNUP_PENDING = 'SIGNUP_PENDING';
 export const SIGNUP_NOT_FOUND = 'SIGNUP_NOT_FOUND';
 export * from './signup';
+
+// Social Action Names & Creatirs
+export const REQUESTED_FACEBOOK_SHARE = 'REQUESTED_FACEBOOK_SHARE';
+export const FACEBOOK_SHARE_COMPLETED = 'FACEBOOK_SHARE_COMPLETED';
+export const FACEBOOK_SHARE_CANCELLED = 'FACEBOOK_SHARE_CANCELLED';
+export * from './share';

--- a/resources/assets/actions/share.js
+++ b/resources/assets/actions/share.js
@@ -1,0 +1,38 @@
+import {
+  REQUESTED_FACEBOOK_SHARE,
+  FACEBOOK_SHARE_COMPLETED,
+  FACEBOOK_SHARE_CANCELLED,
+} from '../actions';
+
+// Action: present the user with the share dialog.
+export function requestedFacebookShare() {
+  return { type: REQUESTED_FACEBOOK_SHARE };
+}
+
+// Action: user sucessfully shared.
+export function facebookShareCompleted() {
+  return { type: FACEBOOK_SHARE_COMPLETED };
+}
+
+// Action: user closed the Facebook share dialog.
+export function facebookShareCancelled() {
+  return { type: FACEBOOK_SHARE_CANCELLED };
+}
+
+// Action: user clicked a share button.
+export function clickedShare() {
+  return dispatch => {
+    dispatch(requestedFacebookShare());
+
+    FB.ui({
+      method: 'share',
+      href: window.location.href,
+    }, (response) => {
+      if (response) {
+        dispatch(facebookShareCompleted());
+      } else {
+        dispatch(facebookShareCancelled());
+      }
+    });
+  }
+}

--- a/resources/assets/analytics.js
+++ b/resources/assets/analytics.js
@@ -63,7 +63,6 @@ function stateChanged(action, state) {
   const transformation = transformState(action, state);
 
   analyze('action', transformation);
-  console.log(transformation);
 }
 
 /**

--- a/resources/assets/components/CampaignUpdateBlock/index.js
+++ b/resources/assets/components/CampaignUpdateBlock/index.js
@@ -7,6 +7,9 @@ import Embed from '../Embed';
 import DEFAULT_AVATAR from './default-avatar.png';
 import './campaign-update.scss';
 
+// TEMP - purley for demo purposes till it has an official home.
+import Share from '../../containers/ShareContainer';
+
 const Byline = ({author, jobTitle = 'DoSomething.org Staff', avatar = DEFAULT_AVATAR}) => (
   <Figure size="small" alignment="left" verticalAlignment="center" image={avatar} imageClassName="avatar">
     <strong>{author}</strong><br/>
@@ -28,6 +31,7 @@ const CampaignUpdateBlock = (props) => {
       </Markdown>
       { link ? <Embed url={link} /> : null }
       { author ? <Byline author={author} jobTitle={jobTitle} avatar={avatar} />: null}
+      <Share />
     </Block>
   );
 };

--- a/resources/assets/components/CampaignUpdateBlock/index.js
+++ b/resources/assets/components/CampaignUpdateBlock/index.js
@@ -8,7 +8,7 @@ import DEFAULT_AVATAR from './default-avatar.png';
 import './campaign-update.scss';
 
 // TEMP - purley for demo purposes till it has an official home.
-import Share from '../../containers/ShareContainer';
+import ShareContainer from '../../containers/ShareContainer';
 
 const Byline = ({author, jobTitle = 'DoSomething.org Staff', avatar = DEFAULT_AVATAR}) => (
   <Figure size="small" alignment="left" verticalAlignment="center" image={avatar} imageClassName="avatar">
@@ -31,7 +31,7 @@ const CampaignUpdateBlock = (props) => {
       </Markdown>
       { link ? <Embed url={link} /> : null }
       { author ? <Byline author={author} jobTitle={jobTitle} avatar={avatar} />: null}
-      <Share />
+      <ShareContainer />
     </Block>
   );
 };

--- a/resources/assets/components/Reaction/index.js
+++ b/resources/assets/components/Reaction/index.js
@@ -19,4 +19,4 @@ const Reaction = (props) => {
   );
 };
 
-module.exports = Reaction;
+export default Reaction;

--- a/resources/assets/components/Share/index.js
+++ b/resources/assets/components/Share/index.js
@@ -1,0 +1,18 @@
+import React from 'react';
+import classnames from 'classnames';
+
+import './share.scss';
+
+const Share = ({ variant, clickedShare }) => {
+  const className = classnames('button share', {'-blue': variant === 'blue'});
+
+  return (
+    <a className={className} onClick={clickedShare}>share</a>
+  );
+};
+
+Share.defaultProps = {
+  variant: 'white',
+}
+
+export default Share;

--- a/resources/assets/components/Share/share.scss
+++ b/resources/assets/components/Share/share.scss
@@ -1,0 +1,5 @@
+@import '~@dosomething/forge/scss/toolkit';
+
+.share {
+  // padding: 400%
+}

--- a/resources/assets/containers/ShareContainer.js
+++ b/resources/assets/containers/ShareContainer.js
@@ -1,0 +1,21 @@
+import { connect } from 'react-redux';
+import Share from '../components/Share';
+import { clickedShare } from '../actions';
+
+const mapStateToProps = (state) => {
+  return {
+    social: status.user,
+    user: state.user,
+  };
+};
+
+/**
+ * Provide pre-bound functions that allow the component to dispatch
+ * actions to the Redux store as props for this component.
+ */
+const actionCreators = {
+  clickedShare,
+};
+
+// Export the container component.
+export default connect(mapStateToProps, actionCreators)(Share);

--- a/resources/assets/containers/ShareContainer.js
+++ b/resources/assets/containers/ShareContainer.js
@@ -4,7 +4,7 @@ import { clickedShare } from '../actions';
 
 const mapStateToProps = (state) => {
   return {
-    social: status.user,
+    share: status.share,
     user: state.user,
   };
 };

--- a/resources/assets/reducers/index.js
+++ b/resources/assets/reducers/index.js
@@ -4,3 +4,4 @@ export submissions from './submissions';
 export blocks from './blocks';
 export user from './user';
 export signups from './signups';
+export share from './share';

--- a/resources/assets/reducers/share.js
+++ b/resources/assets/reducers/share.js
@@ -1,0 +1,26 @@
+import {
+  REQUESTED_FACEBOOK_SHARE,
+  FACEBOOK_SHARE_COMPLETED,
+  FACEBOOK_SHARE_CANCELLED,
+} from '../actions';
+
+/**
+ * Share reducer:
+ */
+const share = (state = {}, action) => {
+  switch (action.type) {
+    case REQUESTED_FACEBOOK_SHARE:
+      return {...state, status: 'pending'};
+
+    case FACEBOOK_SHARE_COMPLETED:
+      return {...state, status: 'complete'};
+
+    case FACEBOOK_SHARE_CANCELLED:
+      return {...state, status: 'cancelled'};
+
+    default:
+      return state;
+  }
+}
+
+export default share;

--- a/resources/assets/store.js
+++ b/resources/assets/store.js
@@ -31,6 +31,9 @@ const initialState = {
   user: {
     id: null,
   },
+  share: {
+    status: null,
+  },
 };
 
 export default function(reducers, preloadedState = {}) {

--- a/resources/views/layouts/master.blade.php
+++ b/resources/views/layouts/master.blade.php
@@ -18,6 +18,7 @@
 </head>
 
 <body>
+    <div id="fb-root"></div>
     <div class="chrome">
         <div class="wrapper">
             <div class="navigation -floating -white">

--- a/resources/views/partials/social.blade.php
+++ b/resources/views/partials/social.blade.php
@@ -10,3 +10,23 @@
 <meta property="og:image" content="{{ $shareFields['coverImage'] }}" />
 
 <meta property="fb:app_id" content="{{ $shareFields['facebookAppId'] }}" />
+
+{{-- This is a non-blocking script --}}
+<script>
+  window.fbAsyncInit = function() {
+    FB.init({
+      appId: '{{ $shareFields['facebookAppId'] }}',
+      xfbml: true,
+      version: 'v2.8'
+    });
+    FB.AppEvents.logPageView();
+  };
+
+  (function(d, s, id){
+     var js, fjs = d.getElementsByTagName(s)[0];
+     if (d.getElementById(id)) {return;}
+     js = d.createElement(s); js.id = id;
+     js.src = "//connect.facebook.net/en_US/sdk.js";
+     fjs.parentNode.insertBefore(js, fjs);
+   }(document, 'script', 'facebook-jssdk'));
+</script>


### PR DESCRIPTION
Sharing PR! 

This PR adds a few things

- Facebook SDK. This loads async & doesn't block the page from rendering. Seems better than trying to hack it a nonofficial way, also gives us potential to leverage the FB api down the road.
- Adds some "sharing" actions & reducers. This could have all fit in 1 component neatly, but I wanted everything to be tracked when people try to share.
- Temp. adds the share button in the update component. This will obviously move somewhere else in the final design (or stay, who knows!)

This pr does NOT

- Style the button. Next up!
- Add user id's to the share url (Suggestion by Matt). I can play around with that and add it in the next PR if it works!