### PR TITLE
Adds some share button styling

### DIFF
--- a/resources/assets/components/Share/index.js
+++ b/resources/assets/components/Share/index.js
@@ -9,7 +9,7 @@ const Share = ({ variant, clickedShare }) => {
   return (
     <a className={className} onClick={clickedShare}>
       share on
-      <a className="social-icon -facebook"><span>Facebook</span></a>
+      <i className="social-icon -facebook"><span>Facebook</span></i>
     </a>
   );
 };

--- a/resources/assets/components/Share/index.js
+++ b/resources/assets/components/Share/index.js
@@ -4,15 +4,18 @@ import classnames from 'classnames';
 import './share.scss';
 
 const Share = ({ variant, clickedShare }) => {
-  const className = classnames('button share', {'-blue': variant === 'blue'});
+  const className = classnames('button share', {'-black': variant === 'black'});
 
   return (
-    <a className={className} onClick={clickedShare}>share</a>
+    <a className={className} onClick={clickedShare}>
+      share on
+      <a className="social-icon -facebook"><span>Facebook</span></a>
+    </a>
   );
 };
 
 Share.defaultProps = {
-  variant: 'white',
+  variant: 'black',
 }
 
 export default Share;

--- a/resources/assets/components/Share/share.scss
+++ b/resources/assets/components/Share/share.scss
@@ -1,5 +1,25 @@
 @import '~@dosomething/forge/scss/toolkit';
 
 .share {
-  // padding: 400%
+  color: $white;
+
+  &.-black {
+    color: $black;
+    background: $white;
+    border: 1px solid $black;
+
+    &:hover {
+      background: $light-gray;
+    }
+  }
+
+  .social-icon {
+    color: inherit;
+
+    &:after {
+      font-size: 22px;
+      font-weight: 800;
+      margin-left: 4px;
+    }
+  }
 }


### PR DESCRIPTION
Adds some style tweaks to the share button so it resembles the mockup more, added the black/white variation.

Quick Note:

Forge docs specify icons should use this markup

```html
<a className="social-icon"...
```

But React gives a warning about having an anchor within an anchor, so that's why I used the `<i>` instead. I think it should be fine