### PR TITLE
JS Event queue

### DIFF
--- a/resources/assets/actions/event.js
+++ b/resources/assets/actions/event.js
@@ -15,7 +15,7 @@ import {
 
 // Action: remove completed event from storage.
 export function completedEvent(index) {
-  return { type: COMPLETED_EVENT, index };
+  return { type: COMPLETED_EVENT, index, deviceId: getDeviceId() };
 }
 
 // Action: run through all of the events in the queue.
@@ -24,15 +24,11 @@ export function startQueue() {
     const queue = storageGet(getDeviceId(), EVENT_STORAGE_KEY);
 
     queue.forEach((event, index) => {
-      //TODO: Check if action is valid
-      dispatch(event.action);
+      // Check if the event is over 30 min old.
+      if (isTimestampValid(event.createdAt, (30 * 60 * 1000))) dispatch(event.action);
+
       dispatch(completedEvent(index));
     });
-
-    // Get events
-    // If still valid
-    // Dispatch action
-    // Dispatch completed event
   }
 }
 

--- a/resources/assets/actions/event.js
+++ b/resources/assets/actions/event.js
@@ -1,12 +1,17 @@
 import {
+  QUEUE_EVENT,
+  COMPLETED_EVENT,
+} from '../actions';
+
+import {
   getDeviceId,
   isTimestampValid,
 } from '../helpers';
 
 import {
-  QUEUE_EVENT,
-  COMPLETED_EVENT,
-} from '../actions';
+  get as storageGet,
+  EVENT_STORAGE_KEY,
+} from '../storageHelpers';
 
 // Action: remove completed event from storage.
 export function completedEvent(index) {
@@ -15,7 +20,15 @@ export function completedEvent(index) {
 
 // Action: run through all of the events in the queue.
 export function startQueue() {
-  return (dispatch, getState) => {
+  return dispatch => {
+    const queue = storageGet(getDeviceId(), EVENT_STORAGE_KEY);
+
+    queue.forEach((event, index) => {
+      //TODO: Check if action is valid
+      dispatch(event.action);
+      dispatch(completedEvent(index));
+    });
+
     // Get events
     // If still valid
     // Dispatch action
@@ -25,14 +38,10 @@ export function startQueue() {
 
 // Action: add an event to the queue.
 export function queueEvent(action) {
-  const params = [...arguments];
-  params.shift();
-
   return {
     type: QUEUE_EVENT,
     deviceId: getDeviceId(),
     createdAt: Date.now(),
-    action,
-    params,
+    action: action,
   }
 }

--- a/resources/assets/actions/event.js
+++ b/resources/assets/actions/event.js
@@ -1,11 +1,26 @@
 import {
+  getDeviceId,
+  isTimestampValid,
+} from '../helpers';
+
+import {
   QUEUE_EVENT,
-  RUN_QUEUE,
+  COMPLETED_EVENT,
 } from '../actions';
 
+// Action: remove completed event from storage.
+export function completedEvent(index) {
+  return { type: COMPLETED_EVENT, index };
+}
+
 // Action: run through all of the events in the queue.
-export function runQueue() {
-  return { type: RUN_QUEUE };
+export function startQueue() {
+  return (dispatch, getState) => {
+    // Get events
+    // If still valid
+    // Dispatch action
+    // Dispatch completed event
+  }
 }
 
 // Action: add an event to the queue.
@@ -15,6 +30,8 @@ export function queueEvent(action) {
 
   return {
     type: QUEUE_EVENT,
+    deviceId: getDeviceId(),
+    createdAt: Date.now(),
     action,
     params,
   }

--- a/resources/assets/actions/event.js
+++ b/resources/assets/actions/event.js
@@ -1,0 +1,21 @@
+import {
+  QUEUE_EVENT,
+  RUN_QUEUE,
+} from '../actions';
+
+// Action: run through all of the events in the queue.
+export function runQueue() {
+  return { type: RUN_QUEUE };
+}
+
+// Action: add an event to the queue.
+export function queueEvent(action) {
+  const params = [...arguments];
+  params.shift();
+
+  return {
+    type: QUEUE_EVENT,
+    action,
+    params,
+  }
+}

--- a/resources/assets/actions/event.js
+++ b/resources/assets/actions/event.js
@@ -11,7 +11,7 @@ import {
 } from '../helpers';
 
 import {
-  get as storageGet,
+  getArray,
   EVENT_STORAGE_KEY,
 } from '../storageHelpers';
 
@@ -23,7 +23,7 @@ export function completedEvent(index) {
 // Action: run through all of the events in the queue.
 export function startQueue() {
   return dispatch => {
-    const queue = storageGet(getDeviceId(), EVENT_STORAGE_KEY);
+    const queue = getArray(getDeviceId(), EVENT_STORAGE_KEY);
 
     queue.forEach((event, index) => {
       // Check if the event is over 30 min old before dispatching.

--- a/resources/assets/actions/event.js
+++ b/resources/assets/actions/event.js
@@ -33,7 +33,7 @@ export function startQueue() {
         const args = event.action.args || [];
 
         // If the creator was found, dispatch the action.
-        if (action) dispatch(action.call(action.prototype, ...args));
+        if (action) dispatch(action(...args));
       }
 
       // Always remove the event from storge.
@@ -43,10 +43,7 @@ export function startQueue() {
 }
 
 // Action: add an event to the queue.
-export function queueEvent(actionCreatorName) {
-  const args = [...arguments];
-  args.shift();
-
+export function queueEvent(actionCreatorName, ...args) {
   return {
     type: QUEUE_EVENT,
     deviceId: getDeviceId(),

--- a/resources/assets/actions/index.js
+++ b/resources/assets/actions/index.js
@@ -45,5 +45,5 @@ export * from './share';
 
 // Event Queue Names & Creators
 export const QUEUE_EVENT = 'QUEUE_EVENT';
-export const RUN_QUEUE = 'RUN_QUEUE';
+export const COMPLETED_EVENT = 'COMPLETED_EVENT';
 export * from './event';

--- a/resources/assets/actions/index.js
+++ b/resources/assets/actions/index.js
@@ -37,8 +37,13 @@ export const SIGNUP_PENDING = 'SIGNUP_PENDING';
 export const SIGNUP_NOT_FOUND = 'SIGNUP_NOT_FOUND';
 export * from './signup';
 
-// Social Action Names & Creatirs
+// Social Action Names & Creators
 export const REQUESTED_FACEBOOK_SHARE = 'REQUESTED_FACEBOOK_SHARE';
 export const FACEBOOK_SHARE_COMPLETED = 'FACEBOOK_SHARE_COMPLETED';
 export const FACEBOOK_SHARE_CANCELLED = 'FACEBOOK_SHARE_CANCELLED';
 export * from './share';
+
+// Event Queue Names & Creators
+export const QUEUE_EVENT = 'QUEUE_EVENT';
+export const RUN_QUEUE = 'RUN_QUEUE';
+export * from './event';

--- a/resources/assets/components/Feed/index.js
+++ b/resources/assets/components/Feed/index.js
@@ -24,6 +24,10 @@ class Feed extends React.Component {
 
     // Load the first page of reportbacks.
     this.props.fetchReportbacks();
+
+    // TEMP - for testing
+    this.props.queueEvent({type: 'TEST', boop: 'bop'});
+    this.props.startQueue();
   }
 
   /**

--- a/resources/assets/components/Feed/index.js
+++ b/resources/assets/components/Feed/index.js
@@ -25,8 +25,7 @@ class Feed extends React.Component {
     // Load the first page of reportbacks.
     this.props.fetchReportbacks();
 
-    // TEMP - for testing
-    this.props.queueEvent({type: 'TEST', boop: 'bop'});
+    // Loop through the event queue
     this.props.startQueue();
   }
 
@@ -55,12 +54,13 @@ class Feed extends React.Component {
    */
   render() {
     const { blocks, signedUp, hasNewSignup, hasPendingSignup, isAuthenticated } = this.props;
+    const affiliated = signedUp && isAuthenticated;
 
-    const viewMoreOrSignup = signedUp ? this.props.clickedViewMore : () => this.props.clickedSignUp(this.props.legacyCampaignId);
-    const revealer = <Revealer title={signedUp ? 'view more' : 'sign up'}
-                               callToAction={signedUp ? '' : this.props.callToAction}
+    const viewMoreOrSignup = affiliated ? this.props.clickedViewMore : () => this.props.clickedSignUp(this.props.legacyCampaignId);
+    const revealer = <Revealer title={affiliated ? 'view more' : 'sign up'}
+                               callToAction={affiliated ? '' : this.props.callToAction}
                                isLoading={hasPendingSignup}
-                               onReveal={() => ensureAuth(isAuthenticated) && viewMoreOrSignup()} />;
+                               onReveal={() => viewMoreOrSignup()} />;
 
     return (
       <Flex>

--- a/resources/assets/components/Feed/index.js
+++ b/resources/assets/components/Feed/index.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import { get } from 'lodash';
-import { ensureAuth } from '../../helpers';
 
 import Affirmation from '../Affirmation';
 import CallToActionContainer from '../../containers/CallToActionContainer';
@@ -39,13 +38,13 @@ const renderFeedItem = (block, index) => {
  *
  * @returns {XML}
  */
-const Feed = ({ blocks, callToAction, signedUp, hasNewSignup, hasPendingSignup, isAuthenticated, canLoadMorePages, clickedViewMore, clickedSignUp }) => {
-  const viewMoreOrSignup = signedUp ? clickedViewMore : clickedSignUp;
+const Feed = ({ blocks, callToAction, campaignId, signedUp, hasNewSignup, hasPendingSignup, isAuthenticated, canLoadMorePages, clickedViewMore, clickedSignUp }) => {
+  const viewMoreOrSignup = signedUp ? clickedViewMore : () => clickedSignUp(campaignId);
   const revealer = <Revealer title={signedUp ? 'view more' : 'sign up'}
                              callToAction={signedUp ? '' : callToAction}
                              isLoading={hasPendingSignup}
                              isVisible={(isAuthenticated && !signedUp) || canLoadMorePages}
-                             onReveal={() => ensureAuth(isAuthenticated) && viewMoreOrSignup()} />;
+                             onReveal={() => viewMoreOrSignup()} />;
 
   return (
     <Flex>

--- a/resources/assets/containers/FeedContainer.js
+++ b/resources/assets/containers/FeedContainer.js
@@ -5,8 +5,6 @@ import {
   clickedSignUp,
   checkForSignup,
   fetchReportbacks,
-
-  queueEvent,
   startQueue,
 } from '../actions';
 
@@ -107,9 +105,6 @@ const actionCreators = {
   clickedSignUp,
   checkForSignup,
   fetchReportbacks,
-
-  //TEMP - for testing
-  queueEvent,
   startQueue,
 };
 

--- a/resources/assets/containers/FeedContainer.js
+++ b/resources/assets/containers/FeedContainer.js
@@ -5,6 +5,9 @@ import {
   clickedSignUp,
   checkForSignup,
   fetchReportbacks,
+
+  queueEvent,
+  startQueue,
 } from '../actions';
 
 const BLOCKS_PER_ROW = 3;
@@ -104,6 +107,10 @@ const actionCreators = {
   clickedSignUp,
   checkForSignup,
   fetchReportbacks,
+
+  //TEMP - for testing
+  queueEvent,
+  startQueue,
 };
 
 // Export the container component.

--- a/resources/assets/containers/FeedContainer.js
+++ b/resources/assets/containers/FeedContainer.js
@@ -15,6 +15,7 @@ const mapStateToProps = (state) => {
   return {
     blocks: getBlocksWithReportbacks(getVisibleBlocks(state), state),
     canLoadMorePages: getBlockOffset(state) < getMaximumOffset(state),
+    campaignId: state.campaign.legacyCampaignId,
     callToAction: state.campaign.callToAction,
     submissions: state.submissions,
     signedUp: state.signups.data.includes(state.campaign.legacyCampaignId),

--- a/resources/assets/helpers.js
+++ b/resources/assets/helpers.js
@@ -32,21 +32,6 @@ export function contentfulImageUrl(url, width = null, height = null, fit = null)
 }
 
 /**
- * Ensure a user is authenticated. If not, redirect them
- * to log in via the OpenID Connect flow.
- * @param isAuthenticated
- * @returns {boolean}
- */
-export function ensureAuth(isAuthenticated) {
-  if (! isAuthenticated) {
-    window.location.href = '/login';
-    return false;
-  }
-
-  return true;
-}
-
-/**
  * Wait until the DOM is ready.
  *
  * @param {Function} fn

--- a/resources/assets/helpers.js
+++ b/resources/assets/helpers.js
@@ -222,6 +222,20 @@ export function createDeviceId() {
   localStorage.setItem(DEVICE_ID, generateUniqueId());
 }
 
+/**
+ * Get the unique identifier of this device.
+ * If it doesn't have one, create it.
+ *
+ * @return {String}
+ */
+export function getDeviceId() {
+  const id = localStorage.getItem(DEVICE_ID);
+  if (id) return id;
+
+  createDeviceId()
+  return getDeviceId();
+}
+
 const SESSION_ID = 'SESSION_ID';
 const SESSION_LAST_UPDATED_AT = 'SESSION_LAST_UPDATED_AT';
 
@@ -249,6 +263,17 @@ export function generateSessionid() {
 }
 
 /**
+ * Check if the given timestamp is still valid.
+ *
+ * @param  {int}  timestamp  Timestamp in milliseconds
+ * @param  {int}  maxTime    Expire time in milliseconds
+ * @return {Boolean}         Whether the timestamp is valid
+ */
+export function isTimestampValid(timestmap, maxTime) {
+  return (timestmap + maxTime) > Date.now();
+}
+
+/**
  * Check if the given session id is still valid.
  *
  * @return {Boolean}
@@ -258,6 +283,6 @@ export function isSessionValid() {
 
   if (!session.id || !session.lastUpdatedAt) return false;
 
-  // Check if the timestamp is 15 min old
-  return (session.lastUpdatedAt + (15 * 60 * 1000)) > Date.now();
+  // Check if the timestamp is 15 min old.
+  return isTimestampValid(session.lastUpdatedAt, (15 * 60 * 1000));
 }

--- a/resources/assets/reducers/events.js
+++ b/resources/assets/reducers/events.js
@@ -16,6 +16,11 @@ const events = (state = {}, action) => {
   switch (action.type) {
     case QUEUE_EVENT:
       storageAppend(action.deviceId, EVENT_STORAGE_KEY, action);
+
+      if (action.redirectToLogin) {
+        window.location.href = '/login';
+      }
+
       return state;
 
     case COMPLETED_EVENT:

--- a/resources/assets/reducers/events.js
+++ b/resources/assets/reducers/events.js
@@ -27,10 +27,6 @@ const events = (state = {}, action) => {
       storageSplice(action.deviceId, EVENT_STORAGE_KEY, action.index);
       return state;
 
-    case 'TEST':
-      console.log('EYYYYY');
-      return state;
-
     default:
       return state;
   }

--- a/resources/assets/reducers/events.js
+++ b/resources/assets/reducers/events.js
@@ -15,14 +15,14 @@ import {
 const events = (state = {}, action) => {
   switch (action.type) {
     case QUEUE_EVENT:
-      storageAppend(action.deviceId, EVENT_STORAGE_KEY, {
-        action: action.action,
-        params: action.params,
-      });
-
+      storageAppend(action.deviceId, EVENT_STORAGE_KEY, action);
       return state;
 
     case COMPLETED_EVENT:
+      return state;
+
+    case 'TEST':
+      console.log('EYYYYY');
       return state;
 
     default:

--- a/resources/assets/reducers/events.js
+++ b/resources/assets/reducers/events.js
@@ -1,0 +1,22 @@
+import {
+  QUEUE_EVENT,
+  RUN_QUEUE,
+} from '../actions';
+
+/**
+ * Events reducer:
+ */
+const events = (state = {}, action) => {
+  switch (action.type) {
+    case QUEUE_EVENT:
+      return state;
+
+    case RUN_QUEUE:
+      return state;
+
+    default:
+      return state;
+  }
+}
+
+export default events;

--- a/resources/assets/reducers/events.js
+++ b/resources/assets/reducers/events.js
@@ -5,7 +5,7 @@ import {
 
 import {
   append as storageAppend,
-  get as storageGet,
+  splice as storageSplice,
   EVENT_STORAGE_KEY,
 } from '../storageHelpers';
 
@@ -19,6 +19,7 @@ const events = (state = {}, action) => {
       return state;
 
     case COMPLETED_EVENT:
+      storageSplice(action.deviceId, EVENT_STORAGE_KEY, action.index);
       return state;
 
     case 'TEST':

--- a/resources/assets/reducers/events.js
+++ b/resources/assets/reducers/events.js
@@ -1,7 +1,13 @@
 import {
   QUEUE_EVENT,
-  RUN_QUEUE,
+  COMPLETED_EVENT,
 } from '../actions';
+
+import {
+  append as storageAppend,
+  get as storageGet,
+  EVENT_STORAGE_KEY,
+} from '../storageHelpers';
 
 /**
  * Events reducer:
@@ -9,9 +15,14 @@ import {
 const events = (state = {}, action) => {
   switch (action.type) {
     case QUEUE_EVENT:
+      storageAppend(action.deviceId, EVENT_STORAGE_KEY, {
+        action: action.action,
+        params: action.params,
+      });
+
       return state;
 
-    case RUN_QUEUE:
+    case COMPLETED_EVENT:
       return state;
 
     default:

--- a/resources/assets/reducers/index.js
+++ b/resources/assets/reducers/index.js
@@ -5,3 +5,4 @@ export blocks from './blocks';
 export user from './user';
 export signups from './signups';
 export share from './share';
+export events from './events';

--- a/resources/assets/storageHelpers.js
+++ b/resources/assets/storageHelpers.js
@@ -1,7 +1,7 @@
 export const SIGNUP_STORAGE_KEY = 'signups';
 export const EVENT_STORAGE_KEY  = 'events';
 
-import { getDeviceId } './helpers';
+import { getDeviceId } from './helpers';
 
 function key(id, type) {
   return `${id}-${type}`;

--- a/resources/assets/storageHelpers.js
+++ b/resources/assets/storageHelpers.js
@@ -43,6 +43,18 @@ export function remove(id, type) {
 }
 
 /**
+ * Get the array in local storage for the given
+ * unique id and data type or an empty array.
+ *
+ * @param  {string} id   Unique id
+ * @param  {string} type Data type
+ * @return {array}
+ */
+export function getArray(id, type) {
+  return get(id, type) || [];
+}
+
+/**
  * Append data to an array in local storage
  * for the given unique id and data type.
  *
@@ -51,12 +63,25 @@ export function remove(id, type) {
  * @param {mixed}  data Data to write
  */
 export function append(id, type, data) {
-  const array = get(id, type) || [];
+  const array = getArray(id, type);
   array.push(data);
   set(id, type, array);
 }
 
-// TODO: Removed from array helper?
+/**
+ * Remove a specific index from an array
+ * in local storage for the given unique
+ * id and data type.
+ *
+ * @param  {string} id    Unique id
+ * @param  {string} type  Data type
+ * @param  {int}    index Index to delete
+ */
+export function splice(id, type, index) {
+  const array = getArray(id, type);
+  array.splice(index, 1);
+  set(id, type, array);
+}
 
 /**
  * Load the state that was last written to storage.

--- a/resources/assets/storageHelpers.js
+++ b/resources/assets/storageHelpers.js
@@ -1,4 +1,7 @@
 export const SIGNUP_STORAGE_KEY = 'signups';
+export const EVENT_STORAGE_KEY  = 'events';
+
+import { getDeviceId } './helpers';
 
 function key(id, type) {
   return `${id}-${type}`;
@@ -53,6 +56,8 @@ export function append(id, type, data) {
   set(id, type, array);
 }
 
+// TODO: Removed from array helper?
+
 /**
  * Load the state that was last written to storage.
  *
@@ -62,9 +67,14 @@ export function append(id, type, data) {
  */
 export function loadStorage(initialState, preloadedState) {
   const userId = preloadedState.user.id;
-  if (! userId) return;
+  if (userId) {
+    initialState.signups.data = get(userId, SIGNUP_STORAGE_KEY) || [];
+  }
 
-  initialState.signups.data = get(userId, SIGNUP_STORAGE_KEY) || [];
+  const deviceId = getDeviceId();
+  if (deviceId) {
+    initialState.events.queue = get(deviceId, EVENT_STORAGE_KEY) || [];
+  }
 
   return initialState;
 }

--- a/resources/assets/store.js
+++ b/resources/assets/store.js
@@ -42,6 +42,9 @@ const initialState = {
   share: {
     status: null,
   },
+  events: {
+    queue: [],
+  }
 };
 
 /**


### PR DESCRIPTION
This PR adds an event queue for actions that need to run post authentication. For example, being signed up for a campaign. This is important because we don't want users clicking sign up, making an account, and being asked to sign up again.