### PR TITLE
More efficient pagination & hide "view more" button when at end of feed.

### DIFF
--- a/resources/assets/actions/feed.js
+++ b/resources/assets/actions/feed.js
@@ -1,4 +1,5 @@
 import { FEED_INCREMENT_PAGE, fetchReportbacks } from '../actions';
+import { totalBlocksInFeed, totalReportbackBlocksInFeed, getBlockOffset } from '../selectors/feed';
 
 /**
  * Action Creators: these functions create actions, which describe changes
@@ -10,12 +11,28 @@ export function displayNextPage() {
   return {type: FEED_INCREMENT_PAGE };
 }
 
-// Action: user clicked the "view more" button.
+// Async Action: user clicked the "view more" button.
 export function clickedViewMore() {
-  return (dispatch, getState) => {
-    // @TODO: Only dispatch if we _need_ more reportbacks.
-    dispatch(fetchReportbacks());
-
+  return dispatch => {
     dispatch(displayNextPage());
+    dispatch(conditionallyFetchReportbacks());
+  }
+}
+
+// Async Action: determine if the feed needs to fetch more photos.
+export function conditionallyFetchReportbacks() {
+  return (dispatch, getState) => {
+    const state = getState();
+
+    // The number of needed reportbacks are the number of reportback blocks in the
+    // community feed + any additional offset that hasn't been filled by blocks.
+    const overflowReportbackBlocks = Math.max(0, getBlockOffset(state) - totalBlocksInFeed(state));
+    const neededReportbacks = totalReportbackBlocksInFeed(state) + overflowReportbackBlocks;
+
+    // Dispatch an HTTP request if we don't have enough reportbacks in the store.
+    if (state.reportbacks.ids.length < neededReportbacks) {
+      console.log(`Loading more reportbacks. We have ${state.reportbacks.ids.length} and need ${neededReportbacks}.`);
+      dispatch(fetchReportbacks());
+    }
   }
 }

--- a/resources/assets/actions/reportback.js
+++ b/resources/assets/actions/reportback.js
@@ -26,8 +26,8 @@ export function requestedReportbacks(node) {
 }
 
 // Action: new reportback data received.
-export function receivedReportbacks(page, { reportbacks, reportbackItems, reactions }) {
-  return { type: RECEIVED_REPORTBACKS, page, reportbacks, reportbackItems, reactions };
+export function receivedReportbacks({ reportbacks, reportbackItems, reactions }, page, total) {
+  return { type: RECEIVED_REPORTBACKS, reportbacks, reportbackItems, reactions, page, total };
 }
 
 // Action: toggled a reaction
@@ -179,7 +179,7 @@ export function fetchReportbacks() {
 
     (new Phoenix).get('reportbacks', { campaigns: node, page }).then(json => {
       const normalizedData = normalizeReportbacksResponse(json.data);
-      dispatch(receivedReportbacks(json.meta.pagination.current_page, normalizedData))
+      dispatch(receivedReportbacks(normalizedData, json.meta.pagination.current_page, json.meta.pagination.total))
     })
   }
 }

--- a/resources/assets/components/App.js
+++ b/resources/assets/components/App.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Provider } from 'react-redux';
 import * as reducers from '../reducers'
-import configureStore from '../store';
+import { configureStore, initializeStore } from '../store';
 
 import { Router, Route, useRouterHistory } from 'react-router';
 import createBrowserHistory from 'history/lib/createBrowserHistory';
@@ -26,7 +26,7 @@ observe(history, store);
 const App = (props) => (
   <Provider store={store}>
     <Router history={history}>
-      <Route component={Chrome}>
+      <Route component={Chrome} onEnter={initializeStore(store)}>
         <Route path="/" component={FeedContainer}/>
         <Route path="/pages/:page" component={ContentPageContainer}/>
         <Route path='*' component={NotFound} />

--- a/resources/assets/components/Feed/index.js
+++ b/resources/assets/components/Feed/index.js
@@ -39,11 +39,12 @@ const renderFeedItem = (block, index) => {
  *
  * @returns {XML}
  */
-const Feed = ({ blocks, callToAction, signedUp, hasNewSignup, hasPendingSignup, isAuthenticated, clickedViewMore, clickedSignUp }) => {
+const Feed = ({ blocks, callToAction, signedUp, hasNewSignup, hasPendingSignup, isAuthenticated, canLoadMorePages, clickedViewMore, clickedSignUp }) => {
   const viewMoreOrSignup = signedUp ? clickedViewMore : clickedSignUp;
   const revealer = <Revealer title={signedUp ? 'view more' : 'sign up'}
                              callToAction={signedUp ? '' : callToAction}
                              isLoading={hasPendingSignup}
+                             isVisible={(isAuthenticated && !signedUp) || canLoadMorePages}
                              onReveal={() => ensureAuth(isAuthenticated) && viewMoreOrSignup()} />;
 
   return (

--- a/resources/assets/components/Feed/index.js
+++ b/resources/assets/components/Feed/index.js
@@ -12,64 +12,51 @@ import Revealer from '../Revealer';
 import StaticBlock from '../StaticBlock';
 import { Flex, FlexCell } from '../Flex';
 
-class Feed extends React.Component {
-  /**
-   * Perform actions immediately after mounting component.
-   */
-  componentDidMount() {
-    // If we don't already have a signup, check.
-    if (! this.props.signedUp) {
-      this.props.checkForSignup(this.props.legacyCampaignId);
-    }
+/**
+ * Render a single feed item.
+ *
+ * @param block
+ * @param index
+ * @returns {XML}
+ */
+const renderFeedItem = (block, index) => {
+  const BlockComponent = get({
+    'campaign_update': CampaignUpdateBlock,
+    'join_cta': CallToActionContainer,
+    'reportbacks': ReportbackBlock,
+    'static': StaticBlock,
+  }, block.fields.type, PlaceholderBlock);
 
-    // Load the first page of reportbacks.
-    this.props.fetchReportbacks();
-  }
+  return (
+    <FlexCell key={block.id + '-' + index} width={block.fields.displayOptions[0]}>
+      <BlockComponent {...block} />
+    </FlexCell>
+  );
+};
 
-  /**
-   * Render a single feed item.
-   *
-   * @param block
-   * @param index
-   * @returns {XML}
-   */
-  renderFeedItem(block, index) {
-    const BlockComponent = get({
-      'campaign_update': CampaignUpdateBlock,
-      'join_cta': CallToActionContainer,
-      'reportbacks': ReportbackBlock,
-      'static': StaticBlock,
-    }, block.fields.type, PlaceholderBlock);
+/**
+ * Render the feed.
+ *
+ * @returns {XML}
+ */
+const Feed = ({ blocks, callToAction, signedUp, hasNewSignup, hasPendingSignup, isAuthenticated, clickedViewMore, clickedSignUp }) => {
+  const viewMoreOrSignup = signedUp ? clickedViewMore : clickedSignUp;
+  const revealer = <Revealer title={signedUp ? 'view more' : 'sign up'}
+                             callToAction={signedUp ? '' : callToAction}
+                             isLoading={hasPendingSignup}
+                             onReveal={() => ensureAuth(isAuthenticated) && viewMoreOrSignup()} />;
 
-    return <FlexCell key={block.id + '-' + index} width={block.fields.displayOptions[0]}><BlockComponent {...block} /></FlexCell>;
-  }
-
-  /**
-   * Render the feed.
-   *
-   * @returns {XML}
-   */
-  render() {
-    const { blocks, signedUp, hasNewSignup, hasPendingSignup, isAuthenticated } = this.props;
-
-    const viewMoreOrSignup = signedUp ? this.props.clickedViewMore : () => this.props.clickedSignUp(this.props.legacyCampaignId);
-    const revealer = <Revealer title={signedUp ? 'view more' : 'sign up'}
-                               callToAction={signedUp ? '' : this.props.callToAction}
-                               isLoading={hasPendingSignup}
-                               onReveal={() => ensureAuth(isAuthenticated) && viewMoreOrSignup()} />;
-
-    return (
-      <Flex>
-        {hasNewSignup ? <Affirmation /> : null}
-        {blocks.map((block, index) => this.renderFeedItem(block, index))}
-        {revealer}
-        <FlexCell key="reportback_uploader" width="full">
-          <ReportbackUploaderContainer/>
-        </FlexCell>
-      </Flex>
-    );
-  }
-}
+  return (
+    <Flex>
+      {hasNewSignup ? <Affirmation /> : null}
+      {blocks.map(renderFeedItem)}
+      {revealer}
+      <FlexCell key="reportback_uploader" width="full">
+        <ReportbackUploaderContainer/>
+      </FlexCell>
+    </Flex>
+  );
+};
 
 Feed.defaultProps = {
   blocks: [],

--- a/resources/assets/components/ReportbackBlock/index.js
+++ b/resources/assets/components/ReportbackBlock/index.js
@@ -2,12 +2,13 @@ import React from 'react';
 import Block from '../Block';
 import { FlexCell } from '../Flex';
 import ReportbackItemContainer from '../../containers/ReportbackItemContainer';
+import { mapDisplayToPoints } from '../../selectors/feed';
 import './reportback-block.scss';
 
 const ReportbackBlock = props => {
   let items = [];
 
-  for (let i = 0; i < props.fields.additionalContent.count; i++) {
+  for (let i = 0; i < mapDisplayToPoints(props.fields.displayOptions); i++) {
     const id = props.reportbacks[i];
 
     items.push(
@@ -18,7 +19,6 @@ const ReportbackBlock = props => {
       </FlexCell>
     );
   }
-
 
   return <FlexCell>{items}</FlexCell>;
 };

--- a/resources/assets/components/Revealer/index.js
+++ b/resources/assets/components/Revealer/index.js
@@ -5,6 +5,10 @@ import classnames from 'classnames';
 import './revealer.scss';
 
 const Revealer = (props) => {
+  if (! props.isVisible) {
+    return null;
+  }
+
   return (
     <FlexCell width="full">
       <div className="revealer">
@@ -19,6 +23,7 @@ Revealer.defaultProps = {
   callToAction: '',
   title: 'view more',
   onReveal: () => {},
+  isVisible: true,
 };
 
 export default Revealer;

--- a/resources/assets/containers/FeedContainer.js
+++ b/resources/assets/containers/FeedContainer.js
@@ -3,12 +3,27 @@ import Feed from '../components/Feed';
 import {
   clickedViewMore,
   clickedSignUp,
-  checkForSignup,
-  fetchReportbacks,
 } from '../actions';
 
 const BLOCKS_PER_ROW = 3;
 const ROWS_PER_PAGE = 3;
+
+/**
+ * Return a new reportback block.
+ *
+ * @returns {Object}
+ */
+const reportbackBlock = () => {
+  return {
+      id: 'dynamic',
+      type: 'customBlock',
+      fields: {
+        type: 'reportbacks',
+        displayOptions: ['one-third'],
+        additionalContent: { count: 1 }
+      }
+    };
+};
 
 /**
  * Map the given display option to a numeric point value.
@@ -43,19 +58,10 @@ const filterVisibleBlocks = (blocks, offset) => {
   });
 
   // If we weren't able to fill enough rows with blocks, add
-  // enough additional rows of reportbacks.
+  // additional reportback blocks until we hit the target.
   while (totalPoints < pointTarget) {
-    // @TODO: There's gotta be a better way of doing this.
-    filteredBlocks.push({
-      id: String(Math.ceil(Math.random() * 100000)),
-      type: 'customBlock',
-      fields: {
-        type: 'reportbacks',
-        displayOptions: ['full'],
-        additionalContent: { count: BLOCKS_PER_ROW }
-      }
-    });
-    totalPoints += BLOCKS_PER_ROW;
+    filteredBlocks.push(reportbackBlock());
+    totalPoints++;
   }
 
   return filteredBlocks;
@@ -68,7 +74,8 @@ const filterVisibleBlocks = (blocks, offset) => {
  */
 const appendReportbacks = (reportbacks, blocks) => {
   let reportbackIndex = 0;
-  return blocks.map(block => {
+
+  const appendedBlocks = blocks.map(block => {
     if (block.fields.type !== 'reportbacks') return block;
 
     // Attach some unique reportback IDs to each block.
@@ -77,6 +84,12 @@ const appendReportbacks = (reportbacks, blocks) => {
 
     return block;
   });
+
+  if (reportbackIndex > reportbacks.length) {
+    // @TODO: We need to dispatch an action here?
+  }
+
+  return appendedBlocks;
 };
 
 /**
@@ -85,7 +98,6 @@ const appendReportbacks = (reportbacks, blocks) => {
 const mapStateToProps = (state) => {
   return {
     blocks: appendReportbacks(state.reportbacks.ids, filterVisibleBlocks(state.campaign.activityFeed, state.blocks.offset)),
-    legacyCampaignId: state.campaign.legacyCampaignId,
     callToAction: state.campaign.callToAction,
     submissions: state.submissions,
     signedUp: state.signups.data.includes(state.campaign.legacyCampaignId),
@@ -102,8 +114,6 @@ const mapStateToProps = (state) => {
 const actionCreators = {
   clickedViewMore,
   clickedSignUp,
-  checkForSignup,
-  fetchReportbacks,
 };
 
 // Export the container component.

--- a/resources/assets/containers/FeedContainer.js
+++ b/resources/assets/containers/FeedContainer.js
@@ -1,14 +1,20 @@
 import { connect } from 'react-redux';
 import Feed from '../components/Feed';
 import { clickedViewMore, clickedSignUp } from '../actions';
-import { getBlocksWithReportbacks, getVisibleBlocks } from '../selectors/feed';
+import {
+  getBlocksWithReportbacks,
+  getVisibleBlocks,
+  getBlockOffset,
+  getMaximumOffset
+} from '../selectors/feed';
 
 /**
  * Provide state from the Redux store as props for this component.
  */
 const mapStateToProps = (state) => {
   return {
-    blocks: getBlocksWithReportbacks(getVisibleBlocks(state), state.reportbacks.ids),
+    blocks: getBlocksWithReportbacks(getVisibleBlocks(state), state),
+    canLoadMorePages: getBlockOffset(state) < getMaximumOffset(state),
     callToAction: state.campaign.callToAction,
     submissions: state.submissions,
     signedUp: state.signups.data.includes(state.campaign.legacyCampaignId),

--- a/resources/assets/containers/FeedContainer.js
+++ b/resources/assets/containers/FeedContainer.js
@@ -1,103 +1,14 @@
 import { connect } from 'react-redux';
 import Feed from '../components/Feed';
-import {
-  clickedViewMore,
-  clickedSignUp,
-} from '../actions';
-
-const BLOCKS_PER_ROW = 3;
-const ROWS_PER_PAGE = 3;
-
-/**
- * Return a new reportback block.
- *
- * @returns {Object}
- */
-const reportbackBlock = () => {
-  return {
-      id: 'dynamic',
-      type: 'customBlock',
-      fields: {
-        type: 'reportbacks',
-        displayOptions: ['one-third'],
-        additionalContent: { count: 1 }
-      }
-    };
-};
-
-/**
- * Map the given display option to a numeric point value.
- *
- * @param {Array} displayOption
- * @return int
- */
-const mapDisplayToPoints = (displayOption) => {
-  switch (displayOption[0]) {
-    case 'one-third': return 1;
-    case 'two-thirds': return 2;
-    case 'full': return 3;
-    default: return 0;
-  }
-};
-
-/**
- * Filter the blocks based on the page offset.
- *
- * @param blocks
- * @param offset
- */
-const filterVisibleBlocks = (blocks, offset) => {
-  const rowTarget = offset * ROWS_PER_PAGE;
-  const pointTarget = rowTarget * BLOCKS_PER_ROW;
-  let totalPoints = 0;
-
-  // Filter out blocks that don't fit within offset.
-  const filteredBlocks = blocks.filter(block => {
-    totalPoints += mapDisplayToPoints(block.fields.displayOptions);
-    return totalPoints < pointTarget;
-  });
-
-  // If we weren't able to fill enough rows with blocks, add
-  // additional reportback blocks until we hit the target.
-  while (totalPoints < pointTarget) {
-    filteredBlocks.push(reportbackBlock());
-    totalPoints++;
-  }
-
-  return filteredBlocks;
-};
-
-/**
- * Append reportback IDs to the reportback blocks.
- * @param reportbacks
- * @param blocks
- */
-const appendReportbacks = (reportbacks, blocks) => {
-  let reportbackIndex = 0;
-
-  const appendedBlocks = blocks.map(block => {
-    if (block.fields.type !== 'reportbacks') return block;
-
-    // Attach some unique reportback IDs to each block.
-    const count = block.fields.additionalContent.count || 3;
-    block.reportbacks = reportbacks.slice(reportbackIndex, reportbackIndex += count);
-
-    return block;
-  });
-
-  if (reportbackIndex > reportbacks.length) {
-    // @TODO: We need to dispatch an action here?
-  }
-
-  return appendedBlocks;
-};
+import { clickedViewMore, clickedSignUp } from '../actions';
+import { getBlocksWithReportbacks, getVisibleBlocks } from '../selectors/feed';
 
 /**
  * Provide state from the Redux store as props for this component.
  */
 const mapStateToProps = (state) => {
   return {
-    blocks: appendReportbacks(state.reportbacks.ids, filterVisibleBlocks(state.campaign.activityFeed, state.blocks.offset)),
+    blocks: getBlocksWithReportbacks(getVisibleBlocks(state), state.reportbacks.ids),
     callToAction: state.campaign.callToAction,
     submissions: state.submissions,
     signedUp: state.signups.data.includes(state.campaign.legacyCampaignId),

--- a/resources/assets/reducers/reportbacks.js
+++ b/resources/assets/reducers/reportbacks.js
@@ -23,6 +23,7 @@ const reportbacks = (state = {}, action) => {
         ...state,
         isFetching: false,
         page: action.page + 1,
+        total: action.total,
         ids: state.ids.concat(Object.keys(action.reportbacks)),
         entities: merge(state.entities, action.reportbacks),
         itemEntities: merge(state.itemEntities, action.reportbackItems),

--- a/resources/assets/selectors/feed.js
+++ b/resources/assets/selectors/feed.js
@@ -1,0 +1,108 @@
+const BLOCKS_PER_ROW = 3;
+const ROWS_PER_PAGE = 3;
+
+/**
+ * Map the given display option to a numeric point value.
+ *
+ * @param {Array} displayOption
+ * @return int
+ */
+export function mapDisplayToPoints(displayOption) {
+  switch (displayOption[0]) {
+    case 'one-third': return 1;
+    case 'two-thirds': return 2;
+    case 'full': return 3;
+    default: return 0;
+  }
+}
+
+/**
+ * Get the blocks from the application state.
+ * @param state
+ */
+export const getBlocks = (state) => state.campaign.activityFeed;
+
+/**
+ * Get the number of blocks that are visible in the feed.
+ * @param state
+ * @returns {number}
+ */
+export const getBlockOffset = (state) => state.blocks.offset * BLOCKS_PER_ROW * ROWS_PER_PAGE;
+
+/**
+ * Calculate the total number of "blocks" in the feed.
+ * @param state
+ * @returns {*}
+ */
+export function totalBlocksInFeed(state) {
+  return getBlocks(state)
+    .reduce((total, block) => {
+      return total + mapDisplayToPoints(block.fields.displayOptions)
+    }, 0);
+}
+
+/**
+ * Calculate the total number of reportback "blocks" in the feed.
+ * @param state
+ * @returns {*}
+ */
+export function totalReportbackBlocksInFeed(state) {
+  return getBlocks(state)
+    .filter(block => block.fields.type === 'reportbacks')
+    .reduce((total, block) => {
+      return total + mapDisplayToPoints(block.fields.displayOptions);
+    }, 0);
+}
+
+/**
+ * Filter the blocks based on the page offset.
+ *
+ * @param state
+ */
+export function getVisibleBlocks(state) {
+  const blockOffset = getBlockOffset(state);
+  let totalPoints = 0;
+
+  // Filter out blocks that don't fit within offset.
+  const filteredBlocks = getBlocks(state).filter(block => {
+    totalPoints += mapDisplayToPoints(block.fields.displayOptions);
+    return totalPoints < blockOffset;
+  });
+
+  // If we weren't able to fill enough rows with blocks, add
+  // additional reportback blocks until we hit the target.
+  while (totalPoints < blockOffset) {
+    filteredBlocks.push({
+      id: 'dynamic',
+      type: 'customBlock',
+      fields: {
+        type: 'reportbacks',
+        displayOptions: ['one-third'],
+        additionalContent: { count: 1 }
+      }
+    });
+    totalPoints++;
+  }
+
+  return filteredBlocks;
+}
+
+/**
+ * Append reportback IDs to the reportback blocks.
+ *
+ * @param blocks
+ * @param reportbacks
+ */
+export function getBlocksWithReportbacks(blocks, reportbacks) {
+  let reportbackIndex = 0;
+
+  return blocks.map(block => {
+    if (block.fields.type !== 'reportbacks') return block;
+
+    // Attach some unique reportback IDs to each block.
+    const count = mapDisplayToPoints(block.fields.displayOptions);
+    block.reportbacks = reportbacks.slice(reportbackIndex, reportbackIndex += count);
+
+    return block;
+  });
+}

--- a/resources/assets/selectors/feed.js
+++ b/resources/assets/selectors/feed.js
@@ -30,6 +30,13 @@ export const getBlocks = (state) => state.campaign.activityFeed;
 export const getBlockOffset = (state) => state.blocks.offset * BLOCKS_PER_ROW * ROWS_PER_PAGE;
 
 /**
+ * Get the number of blocks that are visible in the feed.
+ * @param state
+ * @returns {number}
+ */
+export const getMaximumOffset = (state) => totalBlocksInFeed(state) + (state.reportbacks.total - totalReportbackBlocksInFeed(state));
+
+/**
  * Calculate the total number of "blocks" in the feed.
  * @param state
  * @returns {*}
@@ -71,7 +78,7 @@ export function getVisibleBlocks(state) {
 
   // If we weren't able to fill enough rows with blocks, add
   // additional reportback blocks until we hit the target.
-  while (totalPoints < blockOffset) {
+  while (totalPoints < blockOffset && totalPoints < getMaximumOffset(state)) {
     filteredBlocks.push({
       id: 'dynamic',
       type: 'customBlock',
@@ -91,9 +98,10 @@ export function getVisibleBlocks(state) {
  * Append reportback IDs to the reportback blocks.
  *
  * @param blocks
- * @param reportbacks
+ * @param state
  */
-export function getBlocksWithReportbacks(blocks, reportbacks) {
+export function getBlocksWithReportbacks(blocks, state) {
+  const reportbacks = state.reportbacks.ids;
   let reportbackIndex = 0;
 
   return blocks.map(block => {

--- a/resources/assets/store.js
+++ b/resources/assets/store.js
@@ -1,6 +1,7 @@
 import { createStore, combineReducers, applyMiddleware, compose } from 'redux'
 import thunk from 'redux-thunk';
 import merge from 'lodash/merge';
+import { checkForSignup, fetchReportbacks } from './actions';
 import { observerMiddleware } from './analytics';
 
 /**
@@ -48,7 +49,7 @@ const initialState = {
  * @param preloadedState
  * @returns {Store<S>}
  */
-export default function(reducers, preloadedState = {}) {
+export function configureStore(reducers, preloadedState = {}) {
   const middleware = [thunk, observerMiddleware];
 
   // Log actions to the console in development & track state changes.
@@ -65,4 +66,28 @@ export default function(reducers, preloadedState = {}) {
     merge(initialState, preloadedState),
     composeEnhancers(applyMiddleware(...middleware))
   );
-};
+}
+
+/**
+ * Dispatch any actions to lazy-load application state. This
+ * is done exactly once on initial page load.
+ *
+ * @param {Store<S>} store
+ */
+export function initializeStore(store) {
+  return (nextState, replace, callback) => {
+    const state = store.getState();
+
+    // If we don't already have a signup cached in local storage, check.
+    if (! state.signups.data.includes(state.campaign.legacyCampaignId)) {
+      store.dispatch(checkForSignup(state.campaign.legacyCampaignId));
+    }
+
+    // Fetch the first page of reportbacks for the feed.
+    store.dispatch(fetchReportbacks());
+
+    callback();
+  }
+}
+
+

--- a/resources/assets/store.js
+++ b/resources/assets/store.js
@@ -18,6 +18,7 @@ const initialState = {
   },
   reportbacks: {
     isFetching: false,
+    total: 0,
     page: 1,
     ids: [],
     entities: {},


### PR DESCRIPTION
#### Changes
__This pull request wraps up the "infinite" reportback gallery (for now).__ It will now only makes requests to load more reportbacks when there are empty "slots" in the feed, and will hide the "view more" button when the user reaches the end of the feed.

The calculations needed to render the feed happen in a new "selectors" directory. Right now this is just symbolic, but we can probably use something like [reselect](https://github.com/reactjs/reselect) to make this extra zippy in the future.

I've added an `initializeStore` export from the store which gets fired on a `onEnter` transition hook to the router. This gives us a convenient place that to dispatch actions that need to happen on application load (since we can't ensure that a user will always start on the community feed).