### PR TITLE
Adds authentication+queue to reactions

### DIFF
--- a/resources/assets/actions/reportback.js
+++ b/resources/assets/actions/reportback.js
@@ -13,7 +13,8 @@ import {
   ADD_SUBMISSION_ITEM_TO_LIST,
   REQUESTED_USER_SUBMISSIONS,
   REQUESTED_USER_SUBMISSIONS_FAILED,
-  RECEIVED_USER_SUBMISSIONS
+  RECEIVED_USER_SUBMISSIONS,
+  queueEvent
 } from '../actions';
 
 /**
@@ -90,7 +91,13 @@ export function addSubmissionItemToList(reportbackItem) {
 
 // Async Action: user reacted to a photo.
 export function toggleReactionOn(reportbackItemId, termId) {
-  return dispatch => {
+  return (dispatch, getState) => {
+    // If the user is not logged in, handle this action later.
+    if (! getState().user.id) {
+      dispatch(queueEvent('toggleReactionOn', reportbackItemId, termId));
+      return;
+    }
+
     dispatch(reactionChanged(reportbackItemId, true));
 
     (new Phoenix).post('reactions', {

--- a/resources/assets/actions/signup.js
+++ b/resources/assets/actions/signup.js
@@ -70,7 +70,7 @@ export function checkForSignup(campaignId) {
 // Async Action: send signup to phoenix.
 export function clickedSignUp(campaignId) {
   return (dispatch, getState) => {
-    // If the user is logged in, handle this action later.
+    // If the user is not logged in, handle this action later.
     if (! getState().user.id) {
       dispatch(queueEvent('clickedSignUp', campaignId));
       return;

--- a/resources/assets/components/ReportbackItem/index.js
+++ b/resources/assets/components/ReportbackItem/index.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import { Figure, BaseFigure } from '../Figure';
 import Reaction from '../Reaction';
-import { ensureAuth } from '../../helpers';
 import './reportback-item.scss';
 
 const ReportbackItem = ({
@@ -30,7 +29,7 @@ const ReportbackItem = ({
 
   const reactionElement = reaction && !isFetching ? (
     <Reaction active={reaction.reacted} total={reaction.total}
-              onToggleOn={() => ensureAuth(isAuthenticated) && toggleReactionOn(id, reaction.termId)}
+              onToggleOn={() => toggleReactionOn(id, reaction.termId)}
               onToggleOff={() => toggleReactionOff(id, reaction.id)} />
   ) : null;
 

--- a/resources/assets/reducers/reportbacks.js
+++ b/resources/assets/reducers/reportbacks.js
@@ -30,6 +30,8 @@ const reportbacks = (state = {}, action) => {
       };
 
     case REACTION_CHANGED:
+      if (!state.itemEntities[action.reportbackItemId]) return state;
+
       return update(state, {
         itemEntities: {
           [action.reportbackItemId]: {


### PR DESCRIPTION
This PR requires users to authenticate if they try to react, and will post the reaction upon returning to the page. Followup of this PR: https://github.com/DoSomething/phoenix-next/pull/113

