### PR TITLE
Add the action page.

### DIFF
--- a/resources/assets/components/ActionPage/index.js
+++ b/resources/assets/components/ActionPage/index.js
@@ -1,18 +1,9 @@
-/**
- * Render a single feed item.
- *
- * @param block
- * @param index
- * @returns {XML}
- */
 import React from 'react';
-import { ensureAuth } from '../../helpers';
-
-import Revealer from '../Revealer';
-import { Flex, FlexCell } from '../Flex';
-import ReportbackUploaderContainer from '../../containers/ReportbackUploaderContainer';
 import Block from '../Block';
 import Markdown from '../Markdown';
+import ReportbackUploaderContainer from '../../containers/ReportbackUploaderContainer';
+import Revealer from '../Revealer';
+import { Flex, FlexCell } from '../Flex';
 
 /**
  * Render the feed.

--- a/resources/assets/components/ActionPage/index.js
+++ b/resources/assets/components/ActionPage/index.js
@@ -1,0 +1,45 @@
+/**
+ * Render a single feed item.
+ *
+ * @param block
+ * @param index
+ * @returns {XML}
+ */
+import React from 'react';
+import { ensureAuth } from '../../helpers';
+
+import Revealer from '../Revealer';
+import { Flex, FlexCell } from '../Flex';
+import Block from '../Block';
+import Markdown from '../Markdown';
+
+/**
+ * Render the feed.
+ *
+ * @returns {XML}
+ */
+const ActionPage = ({ steps, callToAction, signedUp, hasPendingSignup, isAuthenticated, clickedSignUp }) => {
+  if (! signedUp) {
+    steps = steps.slice(0, 2);
+  }
+
+  const revealer = <Revealer title="sign up" callToAction={callToAction}
+                             isLoading={hasPendingSignup}
+                             onReveal={() => clickedSignUp()} />;
+
+  return (
+    <Flex>
+      {steps.map((step, key) => (
+        <FlexCell width="full" key={key}>
+          <Block>
+            <h2>{step.title}</h2>
+            <Markdown>{step.content}</Markdown>
+          </Block>
+        </FlexCell>
+      ))}
+      {isAuthenticated && signedUp ? null : revealer}
+    </Flex>
+  );
+};
+
+export default ActionPage;

--- a/resources/assets/components/ActionPage/index.js
+++ b/resources/assets/components/ActionPage/index.js
@@ -10,6 +10,7 @@ import { ensureAuth } from '../../helpers';
 
 import Revealer from '../Revealer';
 import { Flex, FlexCell } from '../Flex';
+import ReportbackUploaderContainer from '../../containers/ReportbackUploaderContainer';
 import Block from '../Block';
 import Markdown from '../Markdown';
 
@@ -27,6 +28,12 @@ const ActionPage = ({ steps, callToAction, signedUp, hasPendingSignup, isAuthent
                              isLoading={hasPendingSignup}
                              onReveal={() => clickedSignUp()} />;
 
+  const uploader = (
+    <FlexCell key="reportback_uploader" width="full">
+      <ReportbackUploaderContainer/>
+    </FlexCell>
+  );
+
   return (
     <Flex>
       {steps.map((step, key) => (
@@ -38,6 +45,7 @@ const ActionPage = ({ steps, callToAction, signedUp, hasPendingSignup, isAuthent
         </FlexCell>
       ))}
       {isAuthenticated && signedUp ? null : revealer}
+      {isAuthenticated && signedUp ? uploader : null}
     </Flex>
   );
 };

--- a/resources/assets/components/App.js
+++ b/resources/assets/components/App.js
@@ -7,7 +7,7 @@ import { Router, Route, useRouterHistory } from 'react-router';
 import createBrowserHistory from 'history/lib/createBrowserHistory';
 import { syncHistoryWithStore, routerReducer } from 'react-router-redux';
 
-import Chrome from './Chrome';
+import ChromeContainer from '../containers/ChromeContainer';
 import FeedContainer from '../containers/FeedContainer';
 import ContentPageContainer from '../containers/ContentPageContainer';
 import NotFound from './NotFound';
@@ -26,7 +26,7 @@ observe(history, store);
 const App = (props) => (
   <Provider store={store}>
     <Router history={history}>
-      <Route component={Chrome} onEnter={initializeStore(store)}>
+      <Route component={ChromeContainer} onEnter={initializeStore(store)}>
         <Route path="/" component={FeedContainer}/>
         <Route path="/pages/:page" component={ContentPageContainer}/>
         <Route path='*' component={NotFound} />

--- a/resources/assets/components/App.js
+++ b/resources/assets/components/App.js
@@ -9,6 +9,7 @@ import { syncHistoryWithStore, routerReducer } from 'react-router-redux';
 
 import ChromeContainer from '../containers/ChromeContainer';
 import FeedContainer from '../containers/FeedContainer';
+import ActionPageContainer from '../containers/ActionPageContainer';
 import ContentPageContainer from '../containers/ContentPageContainer';
 import NotFound from './NotFound';
 
@@ -28,6 +29,7 @@ const App = (props) => (
     <Router history={history}>
       <Route component={ChromeContainer} onEnter={initializeStore(store)}>
         <Route path="/" component={FeedContainer}/>
+        <Route path="/action" component={ActionPageContainer}/>
         <Route path="/pages/:page" component={ContentPageContainer}/>
         <Route path='*' component={NotFound} />
       </Route>

--- a/resources/assets/components/Chrome.js
+++ b/resources/assets/components/Chrome.js
@@ -1,11 +1,13 @@
 import React from 'react';
 import FeedEnclosure from './FeedEnclosure';
 import NavigationContainer from '../containers/NavigationContainer';
+import Affirmation from './Affirmation';
 
 const Chrome = (props) => (
   <div>
     <NavigationContainer />
     <FeedEnclosure>
+      {props.hasNewSignup ? <Affirmation /> : null}
       {props.children}
     </FeedEnclosure>
   </div>

--- a/resources/assets/components/Feed/index.js
+++ b/resources/assets/components/Feed/index.js
@@ -51,9 +51,6 @@ const Feed = ({ blocks, callToAction, campaignId, signedUp, hasNewSignup, hasPen
       {hasNewSignup ? <Affirmation /> : null}
       {blocks.map(renderFeedItem)}
       {revealer}
-      <FlexCell key="reportback_uploader" width="full">
-        <ReportbackUploaderContainer/>
-      </FlexCell>
     </Flex>
   );
 };

--- a/resources/assets/containers/ActionPageContainer.js
+++ b/resources/assets/containers/ActionPageContainer.js
@@ -1,0 +1,56 @@
+import { connect } from 'react-redux';
+import ActionPage from '../components/ActionPage';
+import { clickedSignUp } from '../actions';
+import { lipsum } from '../helpers';
+
+// @TODO Pull in real content from Contentful.
+let steps = [
+  {
+    title: 'Step 1: Know It',
+    content: `Lorem ipsum labore tempora aut possimus possimus animi eaque voluptatem iste dicta placeat
+    aperiam porro dolor beatae dignissimos animi voluptatem illum ut sint labore voluptatibus blanditiis 
+    doloribus fugit temporibus delectus nemo qui molestiae dolor rem architecto veritatis explicabo qui 
+    sequi et ipsam et rerum quis cupiditate occaecati vel debitis accusantium error in aut quia ut 
+    laborum non explicabo aspernatur vel omnis et`,
+  },
+  {
+    title: 'Step 2: Plan It',
+    content: `Lorem ipsum iste dicta expedita sit et accusamus sunt omnis assumenda molestias et et voluptas
+    quidem molestiae dolor aut distinctio quod nemo minima distinctio ut et doloremque distinctio iste rem
+    accusamus et vel sint quia aut omnis magnam delectus et recusandae occaecati tempore ut mollitia est
+    aut eligendi culpa dolores ut in quibusdam quia tenetur eaque sit optio.`,
+  },
+  {
+    title: 'Step 3: Do It',
+    content: `Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean eget augue tristique, condimentum
+    neque non, iaculis diam. Cras varius enim at ex egestas dignissim. Nullam consequat massa eu lobortis
+    faucibus. Fusce eu ullamcorper magna, ac porttitor libero. Nunc vitae fringilla est. Vivamus erat risus,
+    aliquam sed gravida vitae, hendrerit et orci. Vivamus libero ligula, imperdiet eu lacus ac, blandit aliquam
+    est. Sed ultricies id velit vel vehicula. Curabitur ac turpis lobortis, imperdiet mauris non, tristique
+    libero. Fusce molestie turpis nisl, sit amet posuere magna placerat nec.`,
+  },
+];
+
+/**
+ * Provide state from the Redux store as props for this component.
+ */
+const mapStateToProps = (state) => {
+  return {
+    steps: steps,
+    callToAction: state.campaign.callToAction,
+    signedUp: state.signups.data.includes(state.campaign.legacyCampaignId),
+    hasPendingSignup: state.signups.isPending,
+    isAuthenticated: state.user.id !== null,
+  };
+};
+
+/**
+ * Provide pre-bound functions that allow the component to dispatch
+ * actions to the Redux store as props for this component.
+ */
+const actionCreators = {
+  clickedSignUp,
+};
+
+// Export the container component.
+export default connect(mapStateToProps, actionCreators)(ActionPage);

--- a/resources/assets/containers/ChromeContainer.js
+++ b/resources/assets/containers/ChromeContainer.js
@@ -1,0 +1,23 @@
+import { connect } from 'react-redux';
+import Chrome from '../components/Chrome';
+
+/**
+ * Provide state from the Redux store as props for this component.
+ */
+const mapStateToProps = (state, props) => {
+  return {
+    children: props.children,
+    hasNewSignup: state.signups.thisSession,
+  };
+};
+
+/**
+ * Provide pre-bound functions that allow the component to dispatch
+ * actions to the Redux store as props for this component.
+ */
+const actionCreators = {
+  // ...
+};
+
+// Export the container component.
+export default connect(mapStateToProps, actionCreators)(Chrome);

--- a/resources/assets/containers/FeedContainer.js
+++ b/resources/assets/containers/FeedContainer.js
@@ -17,7 +17,6 @@ const mapStateToProps = (state) => {
     canLoadMorePages: getBlockOffset(state) < getMaximumOffset(state),
     campaignId: state.campaign.legacyCampaignId,
     callToAction: state.campaign.callToAction,
-    submissions: state.submissions,
     signedUp: state.signups.data.includes(state.campaign.legacyCampaignId),
     hasNewSignup: state.signups.thisSession,
     hasPendingSignup: state.signups.isPending,

--- a/resources/assets/containers/NavigationContainer.js
+++ b/resources/assets/containers/NavigationContainer.js
@@ -17,6 +17,7 @@ const NavigationContainer = (props) => {
   return (
     <Navigation>
       <NavigationLink to="/">Feed</NavigationLink>
+      <NavigationLink to="/action">Action</NavigationLink>
       { additionalPages }
     </Navigation>
   );

--- a/resources/assets/containers/NavigationContainer.js
+++ b/resources/assets/containers/NavigationContainer.js
@@ -16,7 +16,7 @@ const NavigationContainer = (props) => {
 
   return (
     <Navigation>
-      <NavigationLink to="/">Feed</NavigationLink>
+      <NavigationLink to="/">Community</NavigationLink>
       <NavigationLink to="/action">Action</NavigationLink>
       { additionalPages }
     </Navigation>


### PR DESCRIPTION
#### Changes
__This pull request adds the action page!__ This involved extracting the Affirmation component to the Chrome so it'd stay between pages, adding the new action page & container (with functioning revealer & some fake placeholder content), and moving the reportback uploader to the new page.

Check it out [on the review branch](https://phoenix-next-pr-117.herokuapp.com/campaigns/teens-for-jeans).

🍹