### PR TITLE
Provide local URLs to uploaded files to send in API POST requests.

### DIFF
--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -6,6 +6,7 @@ use Exception;
 use Illuminate\Auth\AuthenticationException;
 use Illuminate\Foundation\Exceptions\Handler as ExceptionHandler;
 use Illuminate\Validation\ValidationException;
+use App\Exceptions\InvalidFileUploadException;
 
 class Handler extends ExceptionHandler
 {
@@ -86,6 +87,9 @@ class Handler extends ExceptionHandler
         }
         elseif ($exception instanceof AuthenticationException) {
             $code = 401;
+        }
+        elseif ($exception instanceof InvalidFileUploadException) {
+            $code = $exception->getStatusCode();
         }
         else {
             $code = 500;

--- a/app/Exceptions/InvalidFileUploadException.php
+++ b/app/Exceptions/InvalidFileUploadException.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Exceptions;
+
+use Symfony\Component\HttpKernel\Exception\HttpException;
+
+class InvalidFileUploadException extends HttpException
+{
+    /**
+     * Make a new Invalid File Upload exception.
+     */
+    public function __construct()
+    {
+        parent::__construct(400, 'There were issues uploading the provided file.');
+    }
+}

--- a/app/Http/Controllers/ReportbackController.php
+++ b/app/Http/Controllers/ReportbackController.php
@@ -5,7 +5,6 @@ namespace App\Http\Controllers;
 use App\Exceptions\InvalidFileUploadException;
 use App\Services\PhoenixLegacy;
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\File;
 
 class ReportbackController extends Controller
 {

--- a/app/Services/PhoenixLegacy.php
+++ b/app/Services/PhoenixLegacy.php
@@ -37,15 +37,7 @@ class PhoenixLegacy extends RestApiClient
     {
         $path = 'v1/signups';
 
-        // Avoid caching when requesting signups for sepcific user and campaign.
-        // @Temporary?
-        if (isset($query['campaigns']) && isset($query['users'])) {
-            return $this->get($path, $query);
-        }
-
-        return remember(make_cache_key('legacy-'.$path, $query), $this->cacheExpiration, function() use ($path, $query) {
-            return $this->get($path, $query);
-        });
+        return $this->get($path, $query);
     }
 
     /**
@@ -132,11 +124,10 @@ class PhoenixLegacy extends RestApiClient
     {
         return $this->post('v1/campaigns/'.$campaign_id.'/reportback', [
             'uid' => $user_id,
+            'file_url' => $contents['file_url'],
+            'caption' => $contents['caption'],
             'quantity' => $contents['quantity'],
             'why_participated' => $contents['why_participated'],
-            'file' => $contents['file'],
-            'filename' => $contents['filename'],
-            'caption' => $contents['caption'],
             'source' => $contents['source'],
         ]);
     }

--- a/config/filesystems.php
+++ b/config/filesystems.php
@@ -54,6 +54,11 @@ return [
             'visibility' => 'public',
         ],
 
+        'uploads' => [
+            'driver' => 'local',
+            'root' => public_path('uploads'),
+        ],
+
         's3' => [
             'driver' => 's3',
             'key' => 'your-key',


### PR DESCRIPTION
This PR switches up posting Reportbacks to use the `file_url` to provide a URI for a file instead of sending the file as a DataURI. 

The issue was when converting the images to a DataURI to send in the API request to Phoenix-Ashes, the DataURI would be created properly, but JSON values have a string character limit and if the image was not "ant-sized" then the string would get cut off. The resulting image DataURI Phoenix-Ashes would get would thus be broken.

The current solution is to store the uploaded file in a `/uploads/images` directory on Phoenix-Next that is publicly accessible. In the API request we then send the URL to this file for Phoenix-Ashes to upload it itself and store it on its end. Once a response is received, then the locally stored file is deleted.

This PR also removed the caching of signups, so we can receive and up-to-date representation of user submissions.
