### PR TITLE
Removing extra affirmation

### DIFF
--- a/resources/assets/components/Feed/index.js
+++ b/resources/assets/components/Feed/index.js
@@ -1,7 +1,5 @@
 import React from 'react';
 import { get } from 'lodash';
-
-import Affirmation from '../Affirmation';
 import CallToActionContainer from '../../containers/CallToActionContainer';
 import CampaignUpdateBlock from '../CampaignUpdateBlock';
 import PlaceholderBlock from '../PlaceholderBlock';
@@ -38,8 +36,10 @@ const renderFeedItem = (block, index) => {
  *
  * @returns {XML}
  */
-const Feed = ({ blocks, callToAction, campaignId, signedUp, hasNewSignup, hasPendingSignup, isAuthenticated, canLoadMorePages, clickedViewMore, clickedSignUp }) => {
-  const viewMoreOrSignup = signedUp ? clickedViewMore : () => clickedSignUp(campaignId);
+
+const Feed = ({ blocks, callToAction, campaignId, signedUp, hasPendingSignup, isAuthenticated, canLoadMorePages, clickedViewMore, clickedSignUp }) => {
+  const viewMoreOrSignup = signedUp ? clickedViewMore : () => clickedSignUp(campaignId, mergeMetadata(Feed.defaultMetadata));
+
   const revealer = <Revealer title={signedUp ? 'view more' : 'sign up'}
                              callToAction={signedUp ? '' : callToAction}
                              isLoading={hasPendingSignup}
@@ -48,7 +48,6 @@ const Feed = ({ blocks, callToAction, campaignId, signedUp, hasNewSignup, hasPen
 
   return (
     <Flex>
-      {hasNewSignup ? <Affirmation /> : null}
       {blocks.map(renderFeedItem)}
       {revealer}
     </Flex>

--- a/resources/assets/components/Feed/index.js
+++ b/resources/assets/components/Feed/index.js
@@ -1,11 +1,6 @@
 import React from 'react';
 import { get } from 'lodash';
-<<<<<<< HEAD
-=======
 import { mergeMetadata } from '../../helpers/analytics';
-
-import Affirmation from '../Affirmation';
->>>>>>> 44055be6646ea5dd37c69bfa4f8f34cadf7b8597
 import CallToActionContainer from '../../containers/CallToActionContainer';
 import CampaignUpdateBlock from '../CampaignUpdateBlock';
 import PlaceholderBlock from '../PlaceholderBlock';


### PR DESCRIPTION
When we moved the affirmation from the Feed to the Chrome we accidentally left it in the Feed (see [here](https://dosomething.slack.com/archives/C3ASB4204/p1491324454860194) for commits)

![screen shot 2017-04-05 at 11 16 56 am](https://cloud.githubusercontent.com/assets/897368/24712864/0afad15c-19f2-11e7-901c-c2edb39d3a0d.png)

Easy fix!