### PR TITLE
Quick fix for a bug breaking the submissions gallery.

### DIFF
--- a/resources/assets/components/ReportbackItem/index.js
+++ b/resources/assets/components/ReportbackItem/index.js
@@ -8,9 +8,9 @@ function getMetadataFromProps(props) {
   return {
     itemId: props.id,
     quantity: props.quantity,
-    totalReactions: props.reaction.total,
-    reportbackId: props.reportback.id,
-    reportbackUser: props.reportback.user,
+    totalReactions: props.reaction ? props.reaction.total : null,
+    reportbackId: props.reportback ? props.reportback.id : null,
+    reportbackUser: props.reportback ? props.reportback.user : null,
   };
 }
 


### PR DESCRIPTION
This PR fixes a bug that is currently breaking the submissions gallery. The analytics related code tries to retrieve data from Reportback Items, however the RB items in the submission gallery do not contain reactions or parent reportback information. This just adds a fallback in case that data is not present.

Fixes #125 