### PR TITLE
Action after signup

### DIFF
--- a/resources/assets/actions/index.js
+++ b/resources/assets/actions/index.js
@@ -35,6 +35,7 @@ export const SIGNUP_CREATED = 'SIGNUP_CREATED';
 export const SIGNUP_FOUND = 'SIGNUP_FOUND';
 export const SIGNUP_PENDING = 'SIGNUP_PENDING';
 export const SIGNUP_NOT_FOUND = 'SIGNUP_NOT_FOUND';
+export const HIDE_AFFIRMATION = 'HIDE_AFFIRMATION';
 export * from './signup';
 
 // Social Action Names & Creators
@@ -73,4 +74,5 @@ export const ANALYTICS_ACTIONS = [
   LOCATION_CHANGE,
   QUEUE_EVENT,
   COMPLETED_EVENT,
+  HIDE_AFFIRMATION,
 ];

--- a/resources/assets/actions/signup.js
+++ b/resources/assets/actions/signup.js
@@ -1,9 +1,11 @@
 import { Phoenix } from '@dosomething/gateway';
+import { get as historyGet } from '../history';
 import {
   SIGNUP_CREATED,
   SIGNUP_FOUND,
   SIGNUP_NOT_FOUND,
   SIGNUP_PENDING,
+  HIDE_AFFIRMATION,
   queueEvent,
   trackEvent,
 } from '../actions';
@@ -12,6 +14,11 @@ import {
  * Action Creators: these functions create actions, which describe changes
  * to the state tree (either as a result of application logic or user input).
  */
+
+// Action: hide the signup affirmation
+export function hideAffirmation() {
+  return { type: HIDE_AFFIRMATION };
+}
 
 // Action: a new signup was created for a campaign.
 export function signupCreated(campaignId) {
@@ -23,6 +30,9 @@ export function signupCreated(campaignId) {
       campaignId,
       userId: user.id,
     });
+
+    // Take users to the action page after sign up.
+    historyGet().push('/action');
   }
 }
 

--- a/resources/assets/components/Affirmation/affirmation.scss
+++ b/resources/assets/components/Affirmation/affirmation.scss
@@ -70,6 +70,7 @@
     line-height: 18px;
 
     &:hover {
+      cursor: pointer;
       text-decoration: none;
     }
   }

--- a/resources/assets/components/Affirmation/affirmation.scss
+++ b/resources/assets/components/Affirmation/affirmation.scss
@@ -7,10 +7,6 @@
   color: $white;
   position: relative;
 
-  .wrapper {
-    @extend .feed-wrapper;
-  }
-
   .affirmation__section {
     margin-bottom: $base-spacing;
     width: 100%;

--- a/resources/assets/components/Affirmation/affirmation.scss
+++ b/resources/assets/components/Affirmation/affirmation.scss
@@ -7,9 +7,8 @@
   color: $white;
   position: relative;
 
-  .affirmation__container {
-    max-width: 720px;
-    margin: auto;
+  .wrapper {
+    @extend .feed-wrapper;
   }
 
   .affirmation__section {

--- a/resources/assets/components/Affirmation/index.js
+++ b/resources/assets/components/Affirmation/index.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { FlexCell } from '../Flex';
 import Highlight from '../Highlight';
 import { Figure } from '../Figure';
+import { Wrapper } from '../Wrapper';
 import ShareContainer from '../../containers/ShareContainer';
 import { EMPTY_IMAGE } from '../../helpers';
 import './affirmation.scss';
@@ -12,7 +13,7 @@ const Affirmation = (props) => {
   return (
     <FlexCell width="full">
       <div className="affirmation">
-        <div className="wrapper">
+        <Wrapper width="feed">
           <div className="affirmation__section affirmation__section-heading">
             <Highlight>{ props.header }</Highlight>
           </div>
@@ -31,7 +32,7 @@ const Affirmation = (props) => {
               <ShareContainer variant="blue" parentSource="affirmation" />
             </div>
           </div>
-        </div>
+        </Wrapper>
         <a className="affirmation__exit" href="#" onClick={props.hideAffirmation}>&times;</a>
       </div>
     </FlexCell>

--- a/resources/assets/components/Affirmation/index.js
+++ b/resources/assets/components/Affirmation/index.js
@@ -6,52 +6,82 @@ import ShareContainer from '../../containers/ShareContainer';
 import { EMPTY_IMAGE } from '../../helpers';
 import './affirmation.scss';
 
-class Affirmation extends React.Component {
-  constructor(props) {
-    super(props);
+// class Affirmation extends React.Component {
+//   constructor(props) {
+//     super(props);
+//
+//     this.onClick = this.onClick.bind(this);
+//
+//     this.state = {
+//       open: true,
+//     }
+//   }
+//
+//   onClick() {
+//     this.setState({ open: false });
+//   }
+//
+//   render() {
+//     if (!this.state.open) return null;
+//
+    // return (
+    //   <FlexCell width="full">
+    //     <div className="affirmation">
+    //       <div className="wrapper">
+    //         <div className="affirmation__section affirmation__section-heading">
+    //           <Highlight>{ this.props.header }</Highlight>
+    //         </div>
+    //         <div className="affirmation__section affirmation__section-quote">
+    //           <Figure image={this.props.photo} alt={this.props.author} alignment="left">
+    //             <p>{ this.props.quote }</p>
+    //             <span>- { this.props.author }</span>
+    //           </Figure>
+    //         </div>
+    //         <div className="affirmation__section affirmation__section-share">
+    //           <div className="affirmation__block">
+    //             <h3>{ this.props.ctaHeader }</h3>
+    //             <p>{ this.props.ctaDescription }</p>
+    //           </div>
+    //           <div className="affirmation__block">
+    //             <ShareContainer variant="blue" />
+    //           </div>
+    //         </div>
+    //       </div>
+    //       <a className="affirmation__exit" href="#" onClick={this.onClick}>&times;</a>
+    //     </div>
+    //   </FlexCell>
+    // );
+//   }
+// }
 
-    this.onClick = this.onClick.bind(this);
-
-    this.state = {
-      open: true,
-    }
-  }
-
-  onClick() {
-    this.setState({ open: false });
-  }
-
-  render() {
-    if (!this.state.open) return null;
-
-    return (
-      <FlexCell width="full">
-        <div className="affirmation">
-          <div className="affirmation__container">
-            <div className="affirmation__section affirmation__section-heading">
-              <Highlight>{ this.props.header }</Highlight>
+const Affirmation = (props) => {
+  return (
+    <FlexCell width="full">
+      <div className="affirmation">
+        <div className="wrapper">
+          <div className="affirmation__section affirmation__section-heading">
+            <Highlight>{ props.header }</Highlight>
+          </div>
+          <div className="affirmation__section affirmation__section-quote">
+            <Figure image={props.photo} alt={props.author} alignment="left">
+              <p>{ props.quote }</p>
+              <span>- { props.author }</span>
+            </Figure>
+          </div>
+          <div className="affirmation__section affirmation__section-share">
+            <div className="affirmation__block">
+              <h3>{ props.ctaHeader }</h3>
+              <p>{ props.ctaDescription }</p>
             </div>
-            <div className="affirmation__section affirmation__section-quote">
-              <Figure image={this.props.photo} alt={this.props.author} alignment="left">
-                <p>{ this.props.quote }</p>
-                <span>- { this.props.author }</span>
-              </Figure>
-            </div>
-            <div className="affirmation__section affirmation__section-share">
-              <div className="affirmation__block">
-                <h3>{ this.props.ctaHeader }</h3>
-                <p>{ this.props.ctaDescription }</p>
-              </div>
-              <div className="affirmation__block">
-                <ShareContainer variant="blue" />
-              </div>
+            <div className="affirmation__block">
+              <ShareContainer variant="blue" />
             </div>
           </div>
-          <a className="affirmation__exit" href="#" onClick={this.onClick}>&times;</a>
         </div>
-      </FlexCell>
-    );
-  }
+        <a className="affirmation__exit" href="#" onClick={props.hideAffirmation}>&times;</a>
+      </div>
+    </FlexCell>
+  );
 }
 
 //TODO: Replace these default strings with content from Contentful

--- a/resources/assets/components/App.js
+++ b/resources/assets/components/App.js
@@ -3,9 +3,9 @@ import { Provider } from 'react-redux';
 import * as reducers from '../reducers'
 import { configureStore, initializeStore } from '../store';
 
-import { Router, Route, useRouterHistory } from 'react-router';
-import createBrowserHistory from 'history/lib/createBrowserHistory';
-import { syncHistoryWithStore, routerReducer } from 'react-router-redux';
+import { Router, Route } from 'react-router';
+import { routerReducer } from 'react-router-redux';
+import { init as historyInit } from '../history';
 
 import ChromeContainer from '../containers/ChromeContainer';
 import FeedContainer from '../containers/FeedContainer';
@@ -15,12 +15,8 @@ import NotFound from './NotFound';
 
 import observe from '../middleware/analytics';
 
-// Set the application "base name" to /campaigns/:slug so all pages are relative to that.
-const basename = window.location.pathname.split('/').slice(0, 3).join('/');
-
 const store = configureStore({...reducers, routing: routerReducer}, window.STATE);
-const routerHistory = useRouterHistory(createBrowserHistory);
-const history = syncHistoryWithStore(routerHistory({basename}), store);
+const history = historyInit(store);
 
 observe(history, store);
 

--- a/resources/assets/components/Chrome.js
+++ b/resources/assets/components/Chrome.js
@@ -6,6 +6,7 @@ import AffirmationContainer from '../containers/AffirmationContainer';
 const Chrome = (props) => (
   <div>
     <AffirmationContainer />
+    <NavigationContainer />
     <FeedEnclosure>
       {props.children}
     </FeedEnclosure>

--- a/resources/assets/components/Chrome.js
+++ b/resources/assets/components/Chrome.js
@@ -1,13 +1,12 @@
 import React from 'react';
 import FeedEnclosure from './FeedEnclosure';
 import NavigationContainer from '../containers/NavigationContainer';
-import Affirmation from './Affirmation';
+import AffirmationContainer from '../containers/AffirmationContainer';
 
 const Chrome = (props) => (
   <div>
-    <NavigationContainer />
+    <AffirmationContainer />
     <FeedEnclosure>
-      {props.hasNewSignup ? <Affirmation /> : null}
       {props.children}
     </FeedEnclosure>
   </div>

--- a/resources/assets/components/FeedEnclosure/feed-enclosure.scss
+++ b/resources/assets/components/FeedEnclosure/feed-enclosure.scss
@@ -1,4 +1,4 @@
-@import '~@dosomething/forge/scss/toolkit';
+@import '../../scss/next-toolbox.scss';
 
 .feed-enclosure {
   background: rgb(32, 38, 52);
@@ -8,8 +8,5 @@
 }
 
 .feed-enclosure > .wrapper {
-  @include media($tablet) {
-    @include span(12 no-gutters);
-    @include push(2);
-  }
+  @extend .feed-wrapper;
 }

--- a/resources/assets/components/FeedEnclosure/feed-enclosure.scss
+++ b/resources/assets/components/FeedEnclosure/feed-enclosure.scss
@@ -1,12 +1,8 @@
-@import '../../scss/next-toolbox.scss';
+@import '~@dosomething/forge/scss/toolkit';
 
 .feed-enclosure {
   background: rgb(32, 38, 52);
   padding: ($base-spacing / 2) 0;
 
   @include clearfix;
-}
-
-.feed-enclosure > .wrapper {
-  @extend .feed-wrapper;
 }

--- a/resources/assets/components/FeedEnclosure/index.js
+++ b/resources/assets/components/FeedEnclosure/index.js
@@ -1,11 +1,12 @@
 import React from 'react';
+import { Wrapper } from '../Wrapper';
 import './feed-enclosure.scss';
 
 const FeedEnclosure = ({children}) => (
   <div className="feed-enclosure">
-    <div className="wrapper">
-      {children}
-    </div>
+    <Wrapper width="feed">
+      { children }
+    </Wrapper>
   </div>
 );
 

--- a/resources/assets/components/Navigation/index.js
+++ b/resources/assets/components/Navigation/index.js
@@ -1,13 +1,12 @@
 import React from 'react';
 import { Link } from 'react-router';
+import FeedEnclosure from '../FeedEnclosure';
 import './navigation.scss';
 
 export const Navigation = ({children}) => (
-  <div className="feed-enclosure">
-    <div className="wrapper">
-      { children }
-    </div>
-  </div>
+  <FeedEnclosure>
+    { children }
+  </FeedEnclosure>
 );
 
 export const NavigationLink = props => (

--- a/resources/assets/components/Wrapper/index.js
+++ b/resources/assets/components/Wrapper/index.js
@@ -1,0 +1,16 @@
+import React from 'react';
+import classNames from 'classnames';
+import { modifiers } from '../../helpers';
+import './wrapper.scss';
+
+export const Wrapper = ({width = '', children}) => {
+  return (
+    <div className={classNames('wrapper', modifiers(width))}>
+      {children}
+    </div>
+  );
+};
+
+Wrapper.propTypes = {
+  width: React.PropTypes.oneOf(['default', 'feed']),
+};

--- a/resources/assets/components/Wrapper/wrapper.scss
+++ b/resources/assets/components/Wrapper/wrapper.scss
@@ -1,0 +1,8 @@
+@import '~@dosomething/forge/scss/toolkit';
+
+.wrapper.-feed {
+  @include media($tablet) {
+    @include span(12 no-gutters);
+    @include push(2);
+  }
+}

--- a/resources/assets/containers/AffirmationContainer.js
+++ b/resources/assets/containers/AffirmationContainer.js
@@ -1,0 +1,23 @@
+import { connect } from 'react-redux';
+import Affirmation from '../components/Affirmation';
+import { hideAffirmation } from '../actions';
+
+/**
+ * Provide state from the Redux store as props for this component.
+ */
+const mapStateToProps = (state) => {
+  return {
+    showAffirmation: state.signups.showAffirmation,
+  };
+};
+
+/**
+ * Provide pre-bound functions that allow the component to dispatch
+ * actions to the Redux store as props for this component.
+ */
+const actionCreators = {
+  hideAffirmation,
+};
+
+// Export the container component.
+export default connect(mapStateToProps, actionCreators)(Affirmation);

--- a/resources/assets/history.js
+++ b/resources/assets/history.js
@@ -1,0 +1,29 @@
+import { useRouterHistory } from 'react-router';
+import createBrowserHistory from 'history/lib/createBrowserHistory';
+import { syncHistoryWithStore } from 'react-router-redux';
+
+let history = null;
+
+/**
+ * Get the history object for this app
+ * @return {History}
+ */
+export function get() {
+  return history;
+}
+
+/**
+ *  Initialize the history.
+ *
+ * @param  {Object} store
+ * @return {History}
+ */
+export function init(store) {
+  // Set the application "base name" to /campaigns/:slug so all pages are relative to that.
+  const basename = window.location.pathname.split('/').slice(0, 3).join('/');
+
+  const routerHistory = useRouterHistory(createBrowserHistory);
+  history = syncHistoryWithStore(routerHistory({basename}), store);
+
+  return history;
+}

--- a/resources/assets/reducers/signups.js
+++ b/resources/assets/reducers/signups.js
@@ -3,6 +3,7 @@ import {
   SIGNUP_FOUND,
   SIGNUP_PENDING,
   SIGNUP_NOT_FOUND,
+  HIDE_AFFIRMATION,
 } from '../actions';
 
 import {
@@ -26,6 +27,7 @@ const signupReducer = (state = {}, action) => {
         data: signups,
         isPending: false,
         thisSession: true,
+        showAffirmation: true,
       };
 
     case SIGNUP_FOUND:
@@ -43,6 +45,9 @@ const signupReducer = (state = {}, action) => {
 
     case SIGNUP_NOT_FOUND:
       return { ...state, isPending: false };
+
+    case HIDE_AFFIRMATION:
+      return { ...state, showAffirmation: false };
 
     default:
       return state;

--- a/resources/assets/scss/next-toolbox.scss
+++ b/resources/assets/scss/next-toolbox.scss
@@ -17,3 +17,10 @@ $light-background-color: #F6F6F6;
 $dark-background-color: #000000;
 
 $half-spacing: $base-spacing / 2;
+
+.feed-wrapper {
+  @include media($tablet) {
+    @include span(12 no-gutters);
+    @include push(2);
+  }
+}

--- a/resources/assets/scss/next-toolbox.scss
+++ b/resources/assets/scss/next-toolbox.scss
@@ -17,10 +17,3 @@ $light-background-color: #F6F6F6;
 $dark-background-color: #000000;
 
 $half-spacing: $base-spacing / 2;
-
-.feed-wrapper {
-  @include media($tablet) {
-    @include span(12 no-gutters);
-    @include push(2);
-  }
-}

--- a/resources/assets/store.js
+++ b/resources/assets/store.js
@@ -36,7 +36,7 @@ const initialState = {
     data: [],
     thisCampaign: false,
     thisSession: false,
-    showAffirmation: true,
+    showAffirmation: false,
     pending: false,
   },
   user: {

--- a/resources/assets/store.js
+++ b/resources/assets/store.js
@@ -36,6 +36,7 @@ const initialState = {
     data: [],
     thisCampaign: false,
     thisSession: false,
+    showAffirmation: false,
     pending: false,
   },
   user: {

--- a/resources/assets/store.js
+++ b/resources/assets/store.js
@@ -36,7 +36,7 @@ const initialState = {
     data: [],
     thisCampaign: false,
     thisSession: false,
-    showAffirmation: false,
+    showAffirmation: true,
     pending: false,
   },
   user: {


### PR DESCRIPTION
This PR does a few things!

1) After you signup, you're taken to the action page. To do this I had to make some changes to how the `History` object is used + exposed in our app.

2) I moved the `Affirmation` component to its correct position on the page and gave it a container so we could automatically track when people close it, and the state of it in general.

3) I needed to re-use the `.wrapper` class that's inside the `.feed-enclosure`. I abstracted the class out so multiple components could use it, if anyone has any thoughts / suggestions please throw em out!