### PR TITLE
Preventing infinite authentication loop

### DIFF
--- a/resources/assets/reducers/events.js
+++ b/resources/assets/reducers/events.js
@@ -17,7 +17,7 @@ const events = (state = {}, action) => {
     case QUEUE_EVENT:
       storageAppend(action.deviceId, EVENT_STORAGE_KEY, action);
 
-      if (action.redirectToLogin) {
+      if (action.requiresAuth) {
         window.location.href = '/login';
       }
 


### PR DESCRIPTION
Currently, if a user tries to back out of authenticating after clicking signup, they'll be sent right back to Northstar. This is because the event queue isn't handling whether they actually logged in or not. This PR fixes that!

Bug:
![loop](https://cloud.githubusercontent.com/assets/897368/24806371/9fa2d11a-1b82-11e7-9e39-a83565fbe3a0.gif)

Fix:
![fixedd](https://cloud.githubusercontent.com/assets/897368/24806426/d6df3a7e-1b82-11e7-9606-2b57a60175ef.gif)