### PR TITLE
Fix issue where last visible block is accidentally filtered.

### DIFF
--- a/resources/assets/selectors/feed.js
+++ b/resources/assets/selectors/feed.js
@@ -73,7 +73,7 @@ export function getVisibleBlocks(state) {
   // Filter out blocks that don't fit within offset.
   const filteredBlocks = getBlocks(state).filter(block => {
     totalPoints += mapDisplayToPoints(block.fields.displayOptions);
-    return totalPoints < blockOffset;
+    return totalPoints <= blockOffset;
   });
 
   // If we weren't able to fill enough rows with blocks, add


### PR DESCRIPTION
#### Changes
Fixes an issue where the last block would be filtered if it fit "perfectly" into the feed. 🔢

![screen shot 2017-04-07 at 2 51 02 pm](https://cloud.githubusercontent.com/assets/583202/24814999/a5c4839e-1ba1-11e7-8a55-f7e232fbbabd.png)