### PR TITLE
Add titles to Campaign Update blocks... and a bit more styling!

### DIFF
--- a/resources/assets/app.js
+++ b/resources/assets/app.js
@@ -16,6 +16,7 @@ import { ready } from './helpers';
 import 'whatwg-fetch';
 
 // Style Components
+import './scss/chrome.scss';
 import './scss/construction.scss';
 import './scss/container.scss';
 import './scss/header.scss';

--- a/resources/assets/components/Block/block.scss
+++ b/resources/assets/components/Block/block.scss
@@ -1,11 +1,19 @@
-@import '~@dosomething/forge/scss/toolkit';
+@import '../../scss/next-toolbox';
 
 .block {
   width: 100%;
   background: #fff;
   margin: $base-spacing / 2;
   padding: $base-spacing / 2;
-  box-shadow: $box-shadow;
-  border-radius: $sm-border-radius;
+  border: 1px solid $primary-border-color;
+  border-radius: $lg-border-radius;
   overflow: hidden;
+}
+
+.block__title {
+  color: $black;
+  background-color: $primary-color;
+  text-transform: uppercase;
+  margin: (- $base-spacing / 2) (- $base-spacing / 2) $base-spacing;
+  padding: $base-spacing / 2;
 }

--- a/resources/assets/components/Block/index.js
+++ b/resources/assets/components/Block/index.js
@@ -2,12 +2,18 @@ import React from 'react';
 import classNames from 'classnames';
 import './block.scss';
 
-const Block = (props) => {
-  return (
-    <div className={classNames('block', props.className)}>
-      {props.children}
-    </div>
-  );
+export const BlockTitle = ({ children }) => (
+  <h4 className="block__title">{children}</h4>
+);
+
+BlockTitle.PropTypes = {
+  children: React.PropTypes.string,
 };
+
+export const Block = (props) => (
+  <div className={classNames('block', props.className)}>
+    {props.children}
+  </div>
+);
 
 export default Block;

--- a/resources/assets/components/CallToActionBlock/cta.scss
+++ b/resources/assets/components/CallToActionBlock/cta.scss
@@ -1,8 +1,10 @@
-@import '~@dosomething/forge/scss/toolkit';
+@import '../../scss/next-toolbox';
 
 .cta {
-  border: 0;
-  border-radius: $sm-border-radius;
+  color: $white;
+  background: $black;
+  border: 1px solid $primary-border-color;
+  border-radius: $lg-border-radius;
   margin: 12px;
   width: 100%;
 
@@ -48,7 +50,8 @@
 }
 
 .cta__impact {
-  color: $purple;
+  color: $white;
+  text-transform: uppercase;
   font-weight: $weight-bold;
 
   span {

--- a/resources/assets/components/CampaignUpdateBlock/index.js
+++ b/resources/assets/components/CampaignUpdateBlock/index.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import classnames from 'classnames';
 import Markdown from '../Markdown';
-import Block from '../Block';
+import { Block, BlockTitle } from '../Block';
 import Figure from '../Figure';
 import Embed from '../Embed';
 import DEFAULT_AVATAR from './default-avatar.png';
@@ -22,6 +22,7 @@ const CampaignUpdateBlock = (props) => {
 
   return (
     <Block>
+      <BlockTitle>Campaign Update</BlockTitle>
       { isTweet ? null : <h2>{title}</h2> }
       <Markdown className={classnames('campaign-update__content', {'-tweet': isTweet})}>
         {content}

--- a/resources/assets/components/FeedEnclosure/feed-enclosure.scss
+++ b/resources/assets/components/FeedEnclosure/feed-enclosure.scss
@@ -1,7 +1,7 @@
 @import '../../scss/next-toolbox';
 
 .feed-enclosure {
-  padding: ($base-spacing / 2) 0;
-
   @include clearfix;
+
+  margin: $base-spacing 0;
 }

--- a/resources/assets/components/FeedEnclosure/feed-enclosure.scss
+++ b/resources/assets/components/FeedEnclosure/feed-enclosure.scss
@@ -1,7 +1,6 @@
-@import '~@dosomething/forge/scss/toolkit';
+@import '../../scss/next-toolbox';
 
 .feed-enclosure {
-  background: rgb(32, 38, 52);
   padding: ($base-spacing / 2) 0;
 
   @include clearfix;

--- a/resources/assets/components/Navigation/navigation.scss
+++ b/resources/assets/components/Navigation/navigation.scss
@@ -1,7 +1,8 @@
-@import '~@dosomething/forge/scss/toolkit';
+@import '../../scss/next-toolbox';
 
 .nav-link {
-  color: #fff;
+  color: #9b9b9b;
+  text-transform: uppercase;
   margin: 0 $base-spacing / 2;
 
   &:hover {
@@ -12,5 +13,6 @@
 }
 
 .nav-link.is-active {
-  border-bottom: 4px solid #fff;
+  color: $black;
+  border-bottom: 4px solid $black;
 }

--- a/resources/assets/components/ReportbackItem/reportback-item.scss
+++ b/resources/assets/components/ReportbackItem/reportback-item.scss
@@ -1,7 +1,7 @@
 @import '~@dosomething/forge/scss/toolkit';
 
 .reportback-item > .figure__media {
-  background-color: $off-white;
+  background-color: $med-gray;
 
   & > img {
     width: 480px; // HACK: Expand smaller images to fit in card.

--- a/resources/assets/components/Revealer/revealer.scss
+++ b/resources/assets/components/Revealer/revealer.scss
@@ -1,4 +1,4 @@
-@import '~@dosomething/forge/scss/toolkit';
+@import '../../scss/next-toolbox';
 
 .revealer {
   text-align: center;
@@ -15,7 +15,7 @@
   &::before {
     content: '';
     display: block;
-    background: linear-gradient(to bottom, rgba(150, 150, 150, 0), rgba(0, 0, 0, 0.6));
+    background: linear-gradient(to bottom, rgba($light-background-color, 0), rgba($light-background-color, 1));
     width: 100%;
     height: 300px;
     left: 0;

--- a/resources/assets/components/StaticBlock/index.js
+++ b/resources/assets/components/StaticBlock/index.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import Block from '../Block';
+import { Block, BlockTitle } from '../Block';
 import Markdown from '../Markdown';
 import './static-block.scss';
 
@@ -8,7 +8,7 @@ const StaticBlock = (props) => {
 
   return (
     <Block>
-      <h4 className="static-block__title">{props.fields.title}</h4>
+      <BlockTitle>{ props.fields.title }</BlockTitle>
       <Markdown>{props.fields.content}</Markdown>
       { source ? <div className="static-block__citation"><p className="footnote">Source: {source}</p></div> : null }
     </Block>

--- a/resources/assets/components/StaticBlock/static-block.scss
+++ b/resources/assets/components/StaticBlock/static-block.scss
@@ -1,13 +1,5 @@
 @import '~@dosomething/forge/scss/toolkit';
 
-.static-block__title {
-  color: #fff;
-  background-color: #e8273e; // red, the color of desire ♬
-  text-transform: uppercase;
-  margin: (- $base-spacing / 2) (- $base-spacing / 2) $base-spacing;
-  padding: $base-spacing / 2;
-}
-
 .static-block__citation {
   margin-top: $base-spacing;
 

--- a/resources/assets/scss/chrome.scss
+++ b/resources/assets/scss/chrome.scss
@@ -1,0 +1,5 @@
+@import './next-toolbox';
+
+.chrome > .wrapper {
+  background: $light-background-color;
+}

--- a/resources/assets/scss/next-toolbox.scss
+++ b/resources/assets/scss/next-toolbox.scss
@@ -6,14 +6,21 @@
 // but this can be moved to Forge when we're confident with
 // the variables.
 
-$primary-color: #E8263E;
+
+// overridden colors
+$black: #202020;
+$light-gray: #dcdcdc;
+
+// semantic colors
+$primary-color: #f9dd27;
 
 $primary-text-color: #000000;
 $secondary-text-color: #A3A3A3;
 
-$primary-border-color: #DCDCDC;
+$primary-border-color: $light-gray;
 
 $light-background-color: #F6F6F6;
 $dark-background-color: #000000;
 
+// spacing
 $half-spacing: $base-spacing / 2;


### PR DESCRIPTION
#### Changes
I started this pull request just intending to add titles to the Campaign Update blocks and got a little carried away! This is totally not pixel-perfect, but gets the site looking much closer to the mocks so we'll look real nice for today's demo. 🎨

![screen shot 2017-04-07 at 3 27 40 pm](https://cloud.githubusercontent.com/assets/583202/24816441/bfd4514c-1ba6-11e7-9680-f4a666ec8ecd.png)
