### PR TITLE
Adds signup errors

### DIFF
--- a/resources/assets/actions/index.js
+++ b/resources/assets/actions/index.js
@@ -46,7 +46,7 @@ export * from './share';
 
 // Notification Action Names & Creators
 export const ADD_NOTIFICATION = 'ADD_NOTIFICATION';
-export const CLOSE_NOTIFICATION = 'CLOSE_NOTIFICATION';
+export const REMOVE_NOTIFICATION = 'REMOVE_NOTIFICATION';
 export * from './notifications';
 
 // Event Queue Names & Creators
@@ -81,5 +81,5 @@ export const ANALYTICS_ACTIONS = [
   COMPLETED_EVENT,
   HIDE_AFFIRMATION,
   ADD_NOTIFICATION,
-  CLOSE_NOTIFICATION,
+  REMOVE_NOTIFICATION,
 ];

--- a/resources/assets/actions/index.js
+++ b/resources/assets/actions/index.js
@@ -44,6 +44,11 @@ export const FACEBOOK_SHARE_COMPLETED = 'FACEBOOK_SHARE_COMPLETED';
 export const FACEBOOK_SHARE_CANCELLED = 'FACEBOOK_SHARE_CANCELLED';
 export * from './share';
 
+// Notification Action Names & Creators
+export const ADD_NOTIFICATION = 'ADD_NOTIFICATION';
+export const CLOSE_NOTIFICATION = 'CLOSE_NOTIFICATION';
+export * from './notifications';
+
 // Event Queue Names & Creators
 export const QUEUE_EVENT = 'QUEUE_EVENT';
 export const COMPLETED_EVENT = 'COMPLETED_EVENT';
@@ -75,4 +80,6 @@ export const ANALYTICS_ACTIONS = [
   QUEUE_EVENT,
   COMPLETED_EVENT,
   HIDE_AFFIRMATION,
+  ADD_NOTIFICATION,
+  CLOSE_NOTIFICATION,
 ];

--- a/resources/assets/actions/notifications.js
+++ b/resources/assets/actions/notifications.js
@@ -1,0 +1,16 @@
+import { ADD_NOTIFICATION, CLOSE_NOTIFICATION } from '../actions';
+
+/**
+ * Action Creators: these functions create actions, which describe changes
+ * to the state tree (either as a result of application logic or user input).
+ */
+
+// Action: add a notification
+export function addNotification(style, message) {
+  return { type: ADD_NOTIFICATION, style, message };
+}
+
+// Action: close a notification
+export function closeNotification(index) {
+  return { type: CLOSE_NOTIFICATION, index };
+}

--- a/resources/assets/actions/notifications.js
+++ b/resources/assets/actions/notifications.js
@@ -1,4 +1,4 @@
-import { ADD_NOTIFICATION, CLOSE_NOTIFICATION } from '../actions';
+import { ADD_NOTIFICATION, REMOVE_NOTIFICATION } from '../actions';
 
 /**
  * Action Creators: these functions create actions, which describe changes
@@ -11,6 +11,6 @@ export function addNotification(style, message) {
 }
 
 // Action: close a notification
-export function closeNotification(index) {
-  return { type: CLOSE_NOTIFICATION, index };
+export function removeNotification(index) {
+  return { type: REMOVE_NOTIFICATION, index };
 }

--- a/resources/assets/actions/signup.js
+++ b/resources/assets/actions/signup.js
@@ -8,6 +8,7 @@ import {
   HIDE_AFFIRMATION,
   queueEvent,
   trackEvent,
+  addNotification,
 } from '../actions';
 
 /**
@@ -93,8 +94,8 @@ export function clickedSignUp(campaignId, metadata) {
     dispatch(signupPending());
 
     (new Phoenix).post('signups', { campaignId }).then(response => {
-      // TODO: Handle a bad signup response...
-      if (! response) return;
+      // Handle a bad signup response...
+      if (! response) dispatch(addNotification('error', 'Agh, looks like we had an error. Try again in a few minutes!'));
       // If Drupal denied our signup request, check if we already had a signup.
       else if (response[0] === false) dispatch(checkForSignup(campaignId));
       // Otherwise, mark the signup as a success.

--- a/resources/assets/components/Chrome.js
+++ b/resources/assets/components/Chrome.js
@@ -3,9 +3,11 @@ import FeedEnclosure from './FeedEnclosure';
 import LedeBanner from './LedeBanner';
 import NavigationContainer from '../containers/NavigationContainer';
 import AffirmationContainer from '../containers/AffirmationContainer';
+import NotificationContainer from '../containers/NotificationContainer';
 
 const Chrome = (props) => (
   <div>
+    <NotificationContainer />
     <LedeBanner title={props.title} subtitle={props.subtitle} blurb={props.blurb} coverImage={props.coverImage} />
     <AffirmationContainer />
     <NavigationContainer />

--- a/resources/assets/components/Notification/index.js
+++ b/resources/assets/components/Notification/index.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import classNames from 'classnames';
 import './notification.scss';
 
 const Notification = ({ message, style, close }) => (
@@ -14,7 +13,6 @@ const Notification = ({ message, style, close }) => (
 Notification.defaultProps = {
   message: null,
   style: 'error',
-  key: null,
   close: () => {},
 };
 
@@ -24,7 +22,7 @@ export const NotificationList = ({ notifications, closeNotification }) => (
       <Notification
         key={index}
         message={message}
-        type={style}
+        style={style}
         close={() => closeNotification(index)} />
     ))}
   </div>
@@ -32,7 +30,6 @@ export const NotificationList = ({ notifications, closeNotification }) => (
 
 NotificationList.defaultProps = {
   notifications: [],
-  closeNotification: () => {},
 }
 
 export default NotificationList;

--- a/resources/assets/components/Notification/index.js
+++ b/resources/assets/components/Notification/index.js
@@ -1,29 +1,28 @@
 import React from 'react';
 import './notification.scss';
 
-const Notification = ({ message, style, close }) => (
+const Notification = ({ message, style, remove }) => (
   <div className={`notification -${style}`}>
     <div className='notification__content'>
       <p>{ message }</p>
     </div>
-    <span className='notification__close' onClick={ close }>&times;</span>
+    <span className='notification__close' onClick={ remove }>&times;</span>
   </div>
 );
 
 Notification.defaultProps = {
   message: null,
   style: 'error',
-  close: () => {},
 };
 
-export const NotificationList = ({ notifications, closeNotification }) => (
+export const NotificationList = ({ notifications, removeNotification }) => (
   <div className='notification-list'>
     {notifications.map(({ message, style }, index) => (
       <Notification
         key={index}
         message={message}
         style={style}
-        close={() => closeNotification(index)} />
+        close={() => removeNotification(index)} />
     ))}
   </div>
 );

--- a/resources/assets/components/Notification/index.js
+++ b/resources/assets/components/Notification/index.js
@@ -22,7 +22,7 @@ export const NotificationList = ({ notifications, removeNotification }) => (
         key={index}
         message={message}
         style={style}
-        close={() => removeNotification(index)} />
+        remove={() => removeNotification(index)} />
     ))}
   </div>
 );

--- a/resources/assets/components/Notification/index.js
+++ b/resources/assets/components/Notification/index.js
@@ -1,0 +1,38 @@
+import React from 'react';
+import classNames from 'classnames';
+import './notification.scss';
+
+const Notification = ({ message, style, close }) => (
+  <div className={`notification -${style}`}>
+    <div className='notification__content'>
+      <p>{ message }</p>
+    </div>
+    <span className='notification__close' onClick={ close }>&times;</span>
+  </div>
+);
+
+Notification.defaultProps = {
+  message: null,
+  style: 'error',
+  key: null,
+  close: () => {},
+};
+
+export const NotificationList = ({ notifications, closeNotification }) => (
+  <div className='notification-list'>
+    {notifications.map(({ message, style }, index) => (
+      <Notification
+        key={index}
+        message={message}
+        type={style}
+        close={() => closeNotification(index)} />
+    ))}
+  </div>
+);
+
+NotificationList.defaultProps = {
+  notifications: [],
+  closeNotification: () => {},
+}
+
+export default NotificationList;

--- a/resources/assets/components/Notification/notification.scss
+++ b/resources/assets/components/Notification/notification.scss
@@ -10,7 +10,6 @@
   .notification {
     position: relative;
     width: 100%;
-    background: $white; // For debugging, just a default.
 
     &.-error {
       color: $white;

--- a/resources/assets/components/Notification/notification.scss
+++ b/resources/assets/components/Notification/notification.scss
@@ -1,0 +1,40 @@
+@import '../../scss/next-toolbox.scss';
+
+.notification-list {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  z-index: 100;
+
+  .notification {
+    position: relative;
+    width: 100%;
+    background: $white; // For debugging, just a default.
+
+    &.-error {
+      color: $white;
+      background: $error-color;
+    }
+
+    .notification__content {
+      padding: $base-spacing;
+
+      p {
+        color: inherit;
+      }
+    }
+
+    .notification__close {
+      position: absolute;
+      top: $base-spacing / 2;
+      right: $base-spacing / 2;
+      font-size: 32px;
+      color: inherit;
+
+      &:hover {
+        cursor: pointer;
+      }
+    }
+  }
+}

--- a/resources/assets/containers/ChromeContainer.js
+++ b/resources/assets/containers/ChromeContainer.js
@@ -5,8 +5,6 @@ import Chrome from '../components/Chrome';
  * Provide state from the Redux store as props for this component.
  */
 const mapStateToProps = (state, props) => {
-  console.log(state);
-  // console.log(props);
   return {
     children: props.children,
     hasNewSignup: state.signups.thisSession,

--- a/resources/assets/containers/NotificationContainer.js
+++ b/resources/assets/containers/NotificationContainer.js
@@ -1,0 +1,20 @@
+import { connect } from 'react-redux';
+import NotificationList from '../components/Notification';
+import { closeNotification } from '../actions';
+
+const mapStateToProps = (state) => {
+  return {
+    notifications: state.notifications.items,
+  };
+};
+
+/**
+ * Provide pre-bound functions that allow the component to dispatch
+ * actions to the Redux store as props for this component.
+ */
+const actionCreators = {
+  closeNotification,
+};
+
+// Export the container component.
+export default connect(mapStateToProps, actionCreators)(NotificationList);

--- a/resources/assets/containers/NotificationContainer.js
+++ b/resources/assets/containers/NotificationContainer.js
@@ -1,6 +1,6 @@
 import { connect } from 'react-redux';
 import NotificationList from '../components/Notification';
-import { closeNotification } from '../actions';
+import { removeNotification } from '../actions';
 
 const mapStateToProps = (state) => {
   return {
@@ -13,7 +13,7 @@ const mapStateToProps = (state) => {
  * actions to the Redux store as props for this component.
  */
 const actionCreators = {
-  closeNotification,
+  removeNotification,
 };
 
 // Export the container component.

--- a/resources/assets/reducers/index.js
+++ b/resources/assets/reducers/index.js
@@ -6,3 +6,4 @@ export user from './user';
 export signups from './signups';
 export share from './share';
 export events from './events';
+export notifications from './notifications';

--- a/resources/assets/reducers/notifications.js
+++ b/resources/assets/reducers/notifications.js
@@ -1,4 +1,4 @@
-import { ADD_NOTIFICATION, CLOSE_NOTIFICATION } from '../actions';
+import { ADD_NOTIFICATION, REMOVE_NOTIFICATION } from '../actions';
 
 /**
  * Notifications reducer:
@@ -19,7 +19,7 @@ const notifications = (state = {}, action) => {
         ],
       };
 
-    case CLOSE_NOTIFICATION:
+    case REMOVE_NOTIFICATION:
       const index = action.index;
 
       return {

--- a/resources/assets/reducers/notifications.js
+++ b/resources/assets/reducers/notifications.js
@@ -1,0 +1,38 @@
+import { ADD_NOTIFICATION, CLOSE_NOTIFICATION } from '../actions';
+
+/**
+ * Notifications reducer:
+ */
+const notifications = (state = {}, action) => {
+  switch (action.type) {
+    case ADD_NOTIFICATION:
+      const notification = {
+        style: action.style,
+        message: action.message,
+      };
+
+      return {
+        ...state,
+        items: [
+          ...state.items,
+          notification,
+        ],
+      };
+
+    case CLOSE_NOTIFICATION:
+      const index = action.index;
+
+      return {
+        ...state,
+        items: [
+          ...state.items.slice(0, index),
+          ...state.items.slice(index + 1)
+        ],
+      };
+
+    default:
+      return state;
+  }
+}
+
+export default notifications;

--- a/resources/assets/store.js
+++ b/resources/assets/store.js
@@ -47,6 +47,9 @@ const initialState = {
   },
   events: {
     queue: [],
+  },
+  notifications: {
+    items: [],
   }
 };
 


### PR DESCRIPTION
![error](https://cloud.githubusercontent.com/assets/897368/24874420/91f975e2-1df2-11e7-8970-f8c5c148ce47.gif)

![many-errors](https://cloud.githubusercontent.com/assets/897368/24874617/483effac-1df3-11e7-877d-70588499e973.gif)

This PR displays errors on the top of the page when you fail to signup. It has an underlying "notification" system which lets you push notifications to the user. (Currently, these are just errors, but flexible enough for future expansion). 

Also I've hard coded the error string for now, @ngjo can we confirm what the error text should be?

