### PR TITLE
More lil' fixes.

### DIFF
--- a/resources/assets/components/Feed/feed.scss
+++ b/resources/assets/components/Feed/feed.scss
@@ -1,0 +1,4 @@
+.feed {
+  // Ensure the revealer doesn't overflow if feed is empty.
+  min-height: 300px;
+}

--- a/resources/assets/components/Feed/index.js
+++ b/resources/assets/components/Feed/index.js
@@ -9,6 +9,7 @@ import ReportbackUploaderContainer from '../../containers/ReportbackUploaderCont
 import Revealer from '../Revealer';
 import StaticBlock from '../StaticBlock';
 import { Flex, FlexCell } from '../Flex';
+import './feed.scss';
 
 /**
  * Render a single feed item.
@@ -46,10 +47,12 @@ const Feed = ({ blocks, callToAction, campaignId, signedUp, hasPendingSignup, is
                              onReveal={() => viewMoreOrSignup()} />;
 
   return (
-    <Flex>
-      {blocks.map(renderFeedItem)}
+    <div>
+      <Flex className="feed">
+        {blocks.map(renderFeedItem)}
+      </Flex>
       {revealer}
-    </Flex>
+    </div>
   );
 };
 

--- a/resources/assets/components/Feed/index.js
+++ b/resources/assets/components/Feed/index.js
@@ -5,7 +5,6 @@ import CallToActionContainer from '../../containers/CallToActionContainer';
 import CampaignUpdateBlock from '../CampaignUpdateBlock';
 import PlaceholderBlock from '../PlaceholderBlock';
 import ReportbackBlock from '../ReportbackBlock';
-import ReportbackUploaderContainer from '../../containers/ReportbackUploaderContainer';
 import Revealer from '../Revealer';
 import StaticBlock from '../StaticBlock';
 import { Flex, FlexCell } from '../Flex';

--- a/resources/assets/components/Flex/index.js
+++ b/resources/assets/components/Flex/index.js
@@ -1,19 +1,17 @@
 import React from 'react';
-import classNames from 'classnames';
+import classnames from 'classnames';
 import { modifiers } from '../../helpers';
 import './flex.scss';
 
-export const Flex = ({children}) => {
-  return (
-    <div className="flex">
-      {children}
-    </div>
-  );
-};
+export const Flex = ({className = null, children}) => (
+  <div className={classnames('flex', className)}>
+    {children}
+  </div>
+);
 
 export const FlexCell = ({width = [], children}) => {
   return (
-    <div className={classNames('flex__cell', modifiers(width))}>
+    <div className={classnames('flex__cell', modifiers(width))}>
       {children}
     </div>
   );

--- a/resources/assets/components/Revealer/revealer.scss
+++ b/resources/assets/components/Revealer/revealer.scss
@@ -8,8 +8,9 @@
   position: relative;
 
   h1 {
-    color: $white;
-    margin-bottom: 8px;
+    color: $black;
+    font-size: type-scale(1);
+    margin-bottom: $base-spacing;
   }
 
   &::before {


### PR DESCRIPTION
#### Changes
A few more little fixes that I noticed after we set up [Sincerely Us](https://next.dosomething.org/campaigns/sincerely-us):

🏳️ Fixes white text in CTA (we flagged in sprint planning, but didn't see a card).

🔲 Adds a `min-height` to feed so the revealer doesn't look [real broke](https://cloud.githubusercontent.com/assets/583202/24882664/dea777e6-1e0f-11e7-8ce5-88a4b09f29f3.png) when there aren't blocks.


![screen shot 2017-04-10 at 5 07 16 pm](https://cloud.githubusercontent.com/assets/583202/24882747/2e7f3f42-1e10-11e7-8b93-14ab1e88ebba.png)