### PR TITLE
Cleanup and update to add hashing for React keys.

### DIFF
--- a/resources/assets/components/ReportbackUploader/index.js
+++ b/resources/assets/components/ReportbackUploader/index.js
@@ -4,6 +4,7 @@ import { Flex } from '../Flex';
 import MediaUploader from '../MediaUploader';
 import Gallery from '../Gallery';
 import ReportbackItem from '../ReportbackItem';
+import { makeHash } from '../../helpers';
 import './reportback-uploader.scss';
 
 class ReportbackUploader extends React.Component {
@@ -109,7 +110,8 @@ class ReportbackUploader extends React.Component {
           </form>
         </div>
           <Gallery isFetching={this.props.submissions.isFetching} type="triad">
-            {this.props.submissions.items.map((submission, index) => <ReportbackItem key={Date.now() + index} {...submission} url={submission.media.uri || submission.media.filePreviewUrl} reaction={null} />)}
+            {/* @TODO: Need to normalize data for uploaded RBs vs API retrieved RBs earlier in process if possible... */}
+            {this.props.submissions.items.map((submission, index) => <ReportbackItem key={makeHash((submission.media.uri || submission.media.filePreviewUrl).slice(-20))} {...submission} url={submission.media.uri || submission.media.filePreviewUrl} reaction={null} />)}
           </Gallery>
       </Block>
     );

--- a/resources/assets/components/ReportbackUploader/index.js
+++ b/resources/assets/components/ReportbackUploader/index.js
@@ -111,7 +111,7 @@ class ReportbackUploader extends React.Component {
         </div>
           <Gallery isFetching={this.props.submissions.isFetching} type="triad">
             {/* @TODO: Need to normalize data for uploaded RBs vs API retrieved RBs earlier in process if possible... */}
-            {this.props.submissions.items.map((submission, index) => <ReportbackItem key={makeHash((submission.media.uri || submission.media.filePreviewUrl).slice(-20))} {...submission} url={submission.media.uri || submission.media.filePreviewUrl} reaction={null} />)}
+            {this.props.submissions.items.map((submission, index) => <ReportbackItem key={makeHash(submission.media.uri || submission.media.filePreviewUrl)} {...submission} url={submission.media.uri || submission.media.filePreviewUrl} reaction={null} />)}
           </Gallery>
       </Block>
     );

--- a/resources/assets/helpers/index.js
+++ b/resources/assets/helpers/index.js
@@ -237,3 +237,26 @@ export function convertNumberToWord(number) {
     default: throw new Error('Number out of range');
   }
 }
+
+/**
+ * Make a hash from a specified string.
+ * @see  http://werxltd.com/wp/2010/05/13/javascript-implementation-of-javas-string-hashcode-method/
+ *
+ * @param  {String} string
+ * @return {String}
+ */
+export function makeHash(string) {
+  let hash = 0;
+
+  if (!string.length) {
+    return hash;
+  }
+
+  string.split('').forEach((char, index) => {
+    char = string.charCodeAt(index);
+    hash = ((hash << 5) - hash) + char;
+    hash = hash & hash;
+  });
+
+  return Math.abs(hash);
+}

--- a/resources/views/partials/navigation.blade.php
+++ b/resources/views/partials/navigation.blade.php
@@ -21,7 +21,7 @@
                 @if (Auth::user())
                     <a id="js-account-toggle" class="navigation__dropdown-toggle">My Profile</a>
                     <ul>
-                        <li><a href="{{ config('services.phoenix-legacy.url') . 'northstar/' . Auth::user()->northstar_id }}">Profile</a></li>
+                        <li><a href="{{ config('services.phoenix-legacy.url') . '/northstar/' . Auth::user()->northstar_id }}">Profile</a></li>
                         <li><a href="{{ url('logout') }}" class="secondary-nav-item" id="link--logout">Log Out</a></li>
                     </ul>
                 @else


### PR DESCRIPTION
This PR tries out adding a `makeHash()` helper method to turn provided strings into hashes. Did a little _post-work_ playing around with this because I didn't like the solution in place on RB Submission Gallery with how the keys were being assigned. It was actually not a useful method at all since on each re-render the key would end up being different based on how it was produced, which defeats the purpose of said React `key`s.

So this approach attempts to grab a string common and unique among both types of RBs (prior API requested submissions and new uploaded submission), takes the string, chops off a piece and makes a hash from it. The new key is the same after each re-render which will help React optimize how it renders the submissions gallery.

I'm still not super keen on the long prop name passed and use of the `||` for both the `key` and `url` props... but it works nicely otherwise and left a comment to ideally normalize this data elsewhere if possible :)

This PR also fixes a missing `/` for the profile link the Navigation template!