### PR TITLE
Updates for new routing rules & cache issues.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ Homestead.json
 Homestead.yaml
 .env
 .DS_Store
+
+npm-debug.log

--- a/app/Http/Controllers/CampaignController.php
+++ b/app/Http/Controllers/CampaignController.php
@@ -48,6 +48,16 @@ class CampaignController extends Controller
     }
 
     /**
+     * Handle redirects from global paths.
+     *
+     * @return \Illuminate\Http\Response
+     */
+    public function redirect($path)
+    {
+        return redirect('campaigns/us/' . $path);
+    }
+
+    /**
      * Display the specified resource.
      *
      * @param  int  $slug

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "redux-devtools-dock-monitor": "^1.1.1",
     "redux-devtools-log-monitor": "^1.2.0",
     "webpack": "^1.11.0",
-    "webpack-dev-server": "^1.11.0"
+    "webpack-dev-server": "^1.11.0",
+    "webpack-manifest-plugin": "^1.1.0"
   }
 }

--- a/resources/assets/history.js
+++ b/resources/assets/history.js
@@ -19,8 +19,8 @@ export function get() {
  * @return {History}
  */
 export function init(store) {
-  // Set the application "base name" to /campaigns/:slug so all pages are relative to that.
-  const basename = window.location.pathname.split('/').slice(0, 3).join('/');
+  // Set the application "base name" to /us/campaigns/:slug so all pages are relative to that.
+  const basename = window.location.pathname.split('/').slice(0, 4).join('/');
 
   const routerHistory = useRouterHistory(createBrowserHistory);
   history = syncHistoryWithStore(routerHistory({basename}), store);

--- a/resources/views/layouts/master.blade.php
+++ b/resources/views/layouts/master.blade.php
@@ -10,7 +10,7 @@
 
     <link rel="icon" type="image/ico" href="/favicon.ico?v1">
     <link rel="stylesheet" href="https://unpkg.com/@dosomething/forge@^6.7.4/dist/forge.css" media="screen, projection" type="text/css">
-    <link rel="stylesheet" href="{{ asset('dist/app.css') }}" media="screen, projection" type="text/css">
+    <link rel="stylesheet" href="{{ elixir('app.css', 'dist') }}" media="screen, projection" type="text/css">
 
     @if(isset($shareFields))
         @include('partials.social')
@@ -30,7 +30,7 @@
     @include('partials.analytics')
     {{ isset($state) ? scriptify($state) : scriptify() }}
 
-    <script type="text/javascript" src="{{ asset('dist/app.js') }}"></script>
+    <script type="text/javascript" src="{{ elixir('app.js', 'dist') }}"></script>
 </body>
 
 </html>

--- a/routes/web.php
+++ b/routes/web.php
@@ -18,8 +18,10 @@ $router->get('logout', 'AuthController@getLogout');
 
 // Campaigns
 $router->get('campaigns', 'CampaignController@index');
-$router->get('campaigns/{slug}/{clientRoute?}', 'CampaignController@show')
+$router->get('campaigns/us/{slug}/{clientRoute?}', 'CampaignController@show')
     ->where('clientRoute', '.*');
+$router->get('campaigns/{path}', 'CampaignController@redirect')
+    ->where('path', '.*');
 
 // Waiting List: for collecting user emails pre-launch.
 $router->post('waitinglist', 'WaitingListController@store');

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,5 +1,7 @@
 var webpack = require('webpack');
 var dotenv = require('dotenv').config();
+var ManifestPlugin = require('webpack-manifest-plugin');
+var ExtractTextPlugin = require('extract-text-webpack-plugin');
 var configurator = require('@dosomething/webpack-config');
 
 var config = configurator({
@@ -9,6 +11,7 @@ var config = configurator({
 });
 
 // Override output path.
+config.output.filename = '[name]-[hash].js';
 config.output.path = './public/dist';
 
 // Expose Service URLs
@@ -24,5 +27,14 @@ config.plugins.push(
     }
   })
 );
+
+// Add revision hash to extracted CSS files.
+config.plugins = config.plugins.filter(plugin => ! plugin instanceof ExtractTextPlugin);
+config.plugins.push(new ExtractTextPlugin('[name]-[hash].css'));
+
+config.plugins.push(new ManifestPlugin({
+  fileName: 'rev-manifest.json',
+}));
+
 
 module.exports = config;


### PR DESCRIPTION
#### Changes

This pull request includes some changes for the updated Fastly routing rules.

🌐 Hosts campaigns at `/us/campaigns/{slug}`, since that allows us to seamlessly host this "within" the existing Drupal app. Also updates the client-side router to expect the extra prefix.

↪️ Adds a convenience redirect from `/campaigns/{path}` to `/us/campaigns/{path}`.

📜 Adds a hash to file names (e.g. `app-cad3da13eaff74eca3e4.js`) based on their contents, and creates an asset manifest so that Laravel can output the correct paths in our views. This should fix issues where Fastly is still serving old assets after a deploy.

References DoSomething/devops#240.