### PR TITLE
Adding signups total

### DIFF
--- a/app/Http/Controllers/SignupController.php
+++ b/app/Http/Controllers/SignupController.php
@@ -38,7 +38,7 @@ class SignupController extends Controller
      */
     public function total($campaignId)
     {
-        return response()->json($this->phoenixLegacy->getAllSignups(['campaign' => $campaignId]));
+        return response()->json($this->phoenixLegacy->getAllSignupsCached(['campaign' => $campaignId]));
     }
 
     /**

--- a/app/Http/Controllers/SignupController.php
+++ b/app/Http/Controllers/SignupController.php
@@ -38,7 +38,8 @@ class SignupController extends Controller
      */
     public function total($campaignId)
     {
-        return response()->json($this->phoenixLegacy->getAllSignupsCached(['campaign' => $campaignId]));
+        // Count = 1 is a hack to make the API actually return something. Don't ask.
+        return response()->json($this->phoenixLegacy->getAllSignupsCached(['campaign' => $campaignId, 'count' => 1]));
     }
 
     /**

--- a/app/Http/Controllers/SignupController.php
+++ b/app/Http/Controllers/SignupController.php
@@ -31,6 +31,17 @@ class SignupController extends Controller
     }
 
     /**
+     * Get the total signups for this campaign.
+     *
+     * @param  int $campaignId
+     * @return \Illuminate\Http\Response
+     */
+    public function total($campaignId)
+    {
+        return response()->json($this->phoenixLegacy->getAllSignups(['campaign' => $campaignId]));
+    }
+
+    /**
      * Store a newly created resource in storage.
      *
      * @param  \Illuminate\Http\Request  $request

--- a/app/Services/PhoenixLegacy.php
+++ b/app/Services/PhoenixLegacy.php
@@ -37,7 +37,13 @@ class PhoenixLegacy extends RestApiClient
     {
         $path = 'v1/signups';
 
-        return $this->get($path, $query);
+        // Use a lower expiration on this.
+        $customCacheExpiration = 10;
+        $cacheKey = 'legacy-' . $path . '-' . implode($query);
+
+        return remember(make_cache_key($cacheKey), $customCacheExpiration, function() use ($path, $query) {
+            return $this->get($path, $query);
+        });
     }
 
     /**

--- a/app/Services/PhoenixLegacy.php
+++ b/app/Services/PhoenixLegacy.php
@@ -37,6 +37,20 @@ class PhoenixLegacy extends RestApiClient
     {
         $path = 'v1/signups';
 
+        return $this->get($path, $query);
+    }
+
+    /**
+     * Get a cached index of (optionally filtered) campaign signups from Phoenix.
+     * @see: https://github.com/DoSomething/phoenix/wiki/API#retrieve-a-signup-collection
+     *
+     * @param array $query - query string, for filtering results
+     * @return array - JSON response
+     */
+    public function getAllSignupsCached(array $query = [])
+    {
+        $path = 'v1/signups';
+
         // Use a lower expiration on this.
         $customCacheExpiration = 10;
         $cacheKey = 'legacy-' . $path . '-' . implode($query);

--- a/resources/assets/actions/index.js
+++ b/resources/assets/actions/index.js
@@ -36,6 +36,7 @@ export const SIGNUP_FOUND = 'SIGNUP_FOUND';
 export const SIGNUP_PENDING = 'SIGNUP_PENDING';
 export const SIGNUP_NOT_FOUND = 'SIGNUP_NOT_FOUND';
 export const HIDE_AFFIRMATION = 'HIDE_AFFIRMATION';
+export const SET_TOTAL_SIGNUPS = 'SET_TOTAL_SIGNUPS';
 export * from './signup';
 
 // Social Action Names & Creators

--- a/resources/assets/actions/signup.js
+++ b/resources/assets/actions/signup.js
@@ -92,7 +92,6 @@ export function getTotalSignups(campaignId) {
       campaigns: campaignId
     }).then(response => {
       if (!response || !response.meta || !response.meta.pagination) {
-        dispatch(addNotification('error'));
         throw new Error('no signup metadata found');
       }
 

--- a/resources/assets/actions/signup.js
+++ b/resources/assets/actions/signup.js
@@ -69,7 +69,6 @@ export function checkForSignup(campaignId) {
       user: getState().user.id,
     }).then(response => {
       if (!response || !response.data || !response.data[0]) {
-        dispatch(addNotification('error'));
         throw new Error('no signup found');
       }
 

--- a/resources/assets/components/Notification/index.js
+++ b/resources/assets/components/Notification/index.js
@@ -11,7 +11,7 @@ const Notification = ({ message, style, remove }) => (
 );
 
 Notification.defaultProps = {
-  message: null,
+  message: 'Agh, looks like we had an error. Try again in a few minutes!',
   style: 'error',
 };
 

--- a/resources/assets/reducers/signups.js
+++ b/resources/assets/reducers/signups.js
@@ -4,6 +4,7 @@ import {
   SIGNUP_PENDING,
   SIGNUP_NOT_FOUND,
   HIDE_AFFIRMATION,
+  SET_TOTAL_SIGNUPS,
 } from '../actions';
 
 import {
@@ -28,6 +29,7 @@ const signupReducer = (state = {}, action) => {
         isPending: false,
         thisSession: true,
         showAffirmation: true,
+        total: state.total + 1,
       };
 
     case SIGNUP_FOUND:
@@ -48,6 +50,9 @@ const signupReducer = (state = {}, action) => {
 
     case HIDE_AFFIRMATION:
       return { ...state, showAffirmation: false };
+
+    case SET_TOTAL_SIGNUPS:
+      return { ...state, total: action.total };
 
     default:
       return state;

--- a/resources/assets/store.js
+++ b/resources/assets/store.js
@@ -1,7 +1,7 @@
 import { createStore, combineReducers, applyMiddleware, compose } from 'redux'
 import thunk from 'redux-thunk';
 import merge from 'lodash/merge';
-import { checkForSignup, fetchReportbacks, startQueue } from './actions';
+import { checkForSignup, fetchReportbacks, startQueue, getTotalSignups } from './actions';
 import { observerMiddleware } from './middleware/analytics';
 import { loadStorage } from './helpers/storage';
 
@@ -38,6 +38,7 @@ const initialState = {
     thisSession: false,
     showAffirmation: false,
     pending: false,
+    total: 0,
   },
   user: {
     id: null,
@@ -97,6 +98,9 @@ export function initializeStore(store) {
     if (! state.signups.data.includes(state.campaign.legacyCampaignId)) {
       store.dispatch(checkForSignup(state.campaign.legacyCampaignId));
     }
+
+    // Check for total signups
+    store.dispatch(getTotalSignups(state.campaign.legacyCampaignId));
 
     // Fetch the first page of reportbacks for the feed.
     store.dispatch(fetchReportbacks());

--- a/routes/web.php
+++ b/routes/web.php
@@ -41,6 +41,7 @@ $router->delete('reactions/{id}', 'ReactionController@delete');
 $router->resource('reportbacks', 'ReportbackController', ['except' => ['create', 'edit', 'destroy']]);
 
 // Signups
+$router->get('signups/total/${campaignId}', 'SignupController@total');
 $router->resource('signups', 'SignupController', ['except' => ['create', 'edit', 'destroy']]);
 
 // Activity

--- a/routes/web.php
+++ b/routes/web.php
@@ -41,7 +41,7 @@ $router->delete('reactions/{id}', 'ReactionController@delete');
 $router->resource('reportbacks', 'ReportbackController', ['except' => ['create', 'edit', 'destroy']]);
 
 // Signups
-$router->get('signups/total/${campaignId}', 'SignupController@total');
+$router->get('signups/total/{campaignId}', 'SignupController@total');
 $router->resource('signups', 'SignupController', ['except' => ['create', 'edit', 'destroy']]);
 
 // Activity


### PR DESCRIPTION
Still WIP - The caching had unintended consequences, need to make a separate index function that caches the response & leave the original untouched

This PR grabs the total signups from phoenix-ashes and adds it to the client store. Additionally it adds some caching on the sign ups index since it tends to take a few seconds to load. This PR also accounts for updating the total when a user signs up.

This pr _does not_ display anywhere, only visible in the dev console

![screen shot 2017-04-11 at 11 30 54 am](https://cloud.githubusercontent.com/assets/897368/24917188/5c38dbc4-1eaa-11e7-9d33-366a2cca9d30.png)

(Note the number change below)

![screen shot 2017-04-11 at 11 37 54 am](https://cloud.githubusercontent.com/assets/897368/24917481/5866a796-1eab-11e7-9d49-ae79bd07eb99.png)
