### PR TITLE
Prefix assets and Next-specific routes.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /node_modules
 /public/dist
+/public/next/assets
 /public/storage
 /vendor
 /.idea

--- a/config/services.php
+++ b/config/services.php
@@ -49,7 +49,7 @@ return [
             'client_id' => env('NORTHSTAR_AUTHORIZATION_ID'),
             'client_secret' => env('NORTHSTAR_AUTHORIZATION_SECRET'),
             'scope' => ['user', 'openid', 'role:staff', 'role:admin'],
-            'redirect_uri' => 'login',
+            'redirect_uri' => 'next/login',
         ],
     ],
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "start": "npm run clean && npm run modernizr && NODE_ENV=development webpack",
     "build": "npm run clean && npm run modernizr && NODE_ENV=production webpack",
     "clean": "rm -rf public/dist",
-    "modernizr": "modernizr -c node_modules/@dosomething/forge/modernizr.json -d public/dist/modernizr.js",
+    "modernizr": "modernizr -c node_modules/@dosomething/forge/modernizr.json -d public/next/assets/modernizr.js",
     "heroku-postbuild": "sh bootstrap/setup.sh"
   },
   "babel": {

--- a/resources/assets/actions/reportback.js
+++ b/resources/assets/actions/reportback.js
@@ -101,7 +101,7 @@ export function toggleReactionOn(reportbackItemId, termId, metadata) {
 
     dispatch(reactionChanged(reportbackItemId, true));
 
-    (new Phoenix).post('reactions', {
+    (new Phoenix).post('next/reactions', {
       reportback_item_id: reportbackItemId,
       term_id: termId,
     }).then(json => {
@@ -120,7 +120,7 @@ export function toggleReactionOff(reportbackItemId, reactionId, metadata) {
   return dispatch => {
     dispatch(reactionChanged(reportbackItemId, false));
 
-    (new Phoenix).delete(`reactions/${reactionId}`)
+    (new Phoenix).delete(`next/reactions/${reactionId}`)
       .then(json => {
         dispatch(reactionComplete(reportbackItemId, null));
         dispatch(trackEvent('reaction toggled off', metadata));
@@ -134,7 +134,7 @@ export function submitReportback(reportback) {
   return dispatch => {
     dispatch(storeReportback(reportback));
 
-    const url = `${window.location.origin}/reportbacks`;
+    const url = `${window.location.origin}/next/reportbacks`;
 
     const token = document.querySelector('meta[name="csrf-token"]');
 
@@ -178,7 +178,7 @@ export function fetchUserReportbacks(userId, campaignId) {
   return dispatch => {
     dispatch(requestingUserReportbacks());
 
-    return (new Phoenix).get('signups', { campaigns: campaignId, users: userId })
+    return (new Phoenix).get('next/signups', { campaigns: campaignId, users: userId })
       .then(json => {
         dispatch(receivedUserReportbacks());
 
@@ -206,7 +206,7 @@ export function fetchReportbacks() {
 
     dispatch(requestedReportbacks(node));
 
-    (new Phoenix).get('reportbacks', { campaigns: node, page }).then(json => {
+    (new Phoenix).get('next/reportbacks', { campaigns: node, page }).then(json => {
       const normalizedData = normalizeReportbacksResponse(json.data);
       dispatch(receivedReportbacks(normalizedData, json.meta.pagination.current_page, json.meta.pagination.total))
     })

--- a/resources/assets/actions/signup.js
+++ b/resources/assets/actions/signup.js
@@ -63,7 +63,7 @@ export function signupPending() {
 // Async Action: check if user already signed up for the campaign
 export function checkForSignup(campaignId) {
   return (dispatch, getState) => {
-    (new Phoenix).get('signups', {
+    (new Phoenix).get('next/signups', {
       campaigns: campaignId,
       user: getState().user.id,
     }).then(response => {
@@ -93,7 +93,7 @@ export function clickedSignUp(campaignId, metadata) {
 
     dispatch(signupPending());
 
-    (new Phoenix).post('signups', { campaignId }).then(response => {
+    (new Phoenix).post('next/signups', { campaignId }).then(response => {
       // Handle a bad signup response...
       if (! response) dispatch(addNotification('error', 'Agh, looks like we had an error. Try again in a few minutes!'));
       // If Drupal denied our signup request, check if we already had a signup.

--- a/resources/assets/components/Embed/index.js
+++ b/resources/assets/components/Embed/index.js
@@ -13,7 +13,7 @@ class Embed extends React.Component {
   }
 
   componentDidMount() {
-    this.phoenix.get('embed', { url: this.props.url })
+    this.phoenix.get('next/embed', { url: this.props.url })
       .then(json => this.setState(json));
   }
 

--- a/resources/views/layouts/master.blade.php
+++ b/resources/views/layouts/master.blade.php
@@ -10,7 +10,7 @@
 
     <link rel="icon" type="image/ico" href="/favicon.ico?v1">
     <link rel="stylesheet" href="https://unpkg.com/@dosomething/forge@^6.7.4/dist/forge.css" media="screen, projection" type="text/css">
-    <link rel="stylesheet" href="{{ elixir('app.css', 'dist') }}" media="screen, projection" type="text/css">
+    <link rel="stylesheet" href="{{ elixir('app.css', 'next/assets') }}" media="screen, projection" type="text/css">
 
     @if(isset($shareFields))
         @include('partials.social')
@@ -30,7 +30,7 @@
     @include('partials.analytics')
     {{ isset($state) ? scriptify($state) : scriptify() }}
 
-    <script type="text/javascript" src="{{ elixir('app.js', 'dist') }}"></script>
+    <script type="text/javascript" src="{{ elixir('app.js', 'next/assets') }}"></script>
 </body>
 
 </html>

--- a/resources/views/layouts/takeover.blade.php
+++ b/resources/views/layouts/takeover.blade.php
@@ -9,7 +9,7 @@
 
     <link rel="icon" type="image/ico" href="/favicon.ico?v1">
     <link rel="stylesheet" href="https://unpkg.com/@dosomething/forge@^6.7.4/dist/forge.css" media="screen, projection" type="text/css">
-    <link rel="stylesheet" href="{{ elixir('app.css', 'dist') }}" media="screen, projection" type="text/css">
+    <link rel="stylesheet" href="{{ elixir('app.css', 'next/assets') }}" media="screen, projection" type="text/css">
 </head>
 
 <body class="takeover">
@@ -20,7 +20,7 @@
     @yield('content')
     <script type="text/javascript" src="https://unpkg.com/jquery@^3.0.0/dist/jquery.min.js"></script>
     <script type="text/javascript" src="https://unpkg.com/@dosomething/forge@^6.7.4/dist/forge.js"></script>
-    <script type="text/javascript" src="{{ elixir('app.js', 'dist') }}"></script>
+    <script type="text/javascript" src="{{ elixir('app.js', 'next/assets') }}"></script>
 </body>
 
 </html>

--- a/resources/views/partials/navigation.blade.php
+++ b/resources/views/partials/navigation.blade.php
@@ -22,10 +22,10 @@
                     <a id="js-account-toggle" class="navigation__dropdown-toggle">My Profile</a>
                     <ul>
                         <li><a href="{{ config('services.phoenix-legacy.url') . '/northstar/' . Auth::user()->northstar_id }}">Profile</a></li>
-                        <li><a href="{{ url('logout') }}" class="secondary-nav-item" id="link--logout">Log Out</a></li>
+                        <li><a href="{{ url('next/logout') }}" class="secondary-nav-item" id="link--logout">Log Out</a></li>
                     </ul>
                 @else
-                    <a href="{{ url('login') }}">Log In</a>
+                    <a href="{{ url('next/login') }}">Log In</a>
                 @endif
             </li>
         </ul>

--- a/routes/web.php
+++ b/routes/web.php
@@ -13,8 +13,8 @@ $router->get('/', function () {
 });
 
 // Authentication
-$router->get('login', 'AuthController@getLogin');
-$router->get('logout', 'AuthController@getLogout');
+$router->get('next/login', 'AuthController@getLogin');
+$router->get('next/logout', 'AuthController@getLogout');
 
 // Campaigns
 $router->get('campaigns', 'CampaignController@index');
@@ -27,7 +27,7 @@ $router->get('campaigns/{path}', 'CampaignController@redirect')
 $router->post('waitinglist', 'WaitingListController@store');
 
 // Embeds
-$router->get('embed', 'EmbedController@index');
+$router->get('next/embed', 'EmbedController@index');
 
 
 /**
@@ -36,14 +36,14 @@ $router->get('embed', 'EmbedController@index');
  */
 
 // Reactions
-$router->post('reactions', 'ReactionController@store');
-$router->delete('reactions/{id}', 'ReactionController@delete');
+$router->post('next/reactions', 'ReactionController@store');
+$router->delete('next/reactions/{id}', 'ReactionController@delete');
 
 // Reportbacks
-$router->resource('reportbacks', 'ReportbackController', ['except' => ['create', 'edit', 'destroy']]);
+$router->resource('next/reportbacks', 'ReportbackController', ['except' => ['create', 'edit', 'destroy']]);
 
 // Signups
-$router->resource('signups', 'SignupController', ['except' => ['create', 'edit', 'destroy']]);
+$router->resource('next/signups', 'SignupController', ['except' => ['create', 'edit', 'destroy']]);
 
 // Activity
-$router->get('activity/{campaignId}', 'ActivityController@show');
+$router->get('next/activity/{campaignId}', 'ActivityController@show');

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -12,7 +12,7 @@ var config = configurator({
 
 // Override output path.
 config.output.filename = '[name]-[hash].js';
-config.output.path = './public/dist';
+config.output.path = './public/next/assets';
 
 // Expose Service URLs
 config.plugins.push(


### PR DESCRIPTION
#### Changes
This pull request prefixes our asset directory and API endpoints with `next/` so it'll be easy to access them when viewing the site through the `www.dosomething.org/...` strangler pass-thru, without having to add a specific routing rule for each Next-specific URL.

🕸