### PR TITLE
Set `thisCampaign` on signups storage load

### DIFF
--- a/resources/assets/helpers/storage.js
+++ b/resources/assets/helpers/storage.js
@@ -96,7 +96,7 @@ export function loadStorage(initialState, preloadedState) {
     const signups = get(userId, SIGNUP_STORAGE_KEY) || [];
     initialState.signups.data = signups;
 
-    if (signups.includes(initialState.campaign.legacyCampaignId)) initialState.signups.thisCampaign = true;
+    if (signups.includes(preloadedState.campaign.legacyCampaignId)) initialState.signups.thisCampaign = true;
   }
 
   const deviceId = getDeviceId();

--- a/resources/assets/helpers/storage.js
+++ b/resources/assets/helpers/storage.js
@@ -93,7 +93,10 @@ export function splice(id, type, index) {
 export function loadStorage(initialState, preloadedState) {
   const userId = preloadedState.user.id;
   if (userId) {
-    initialState.signups.data = get(userId, SIGNUP_STORAGE_KEY) || [];
+    const signups = get(userId, SIGNUP_STORAGE_KEY) || [];
+    initialState.signups.data = signups;
+
+    if (signups.includes(initialState.campaign.legacyCampaignId)) initialState.signups.thisCampaign = true;
   }
 
   const deviceId = getDeviceId();


### PR DESCRIPTION
`thisCampaign` is false when the store is initiated, even if the signup is cached. this is blocking @weerd 