### PR TITLE
Lazy load the action page step backgrounds.

### DIFF
--- a/resources/assets/components/ActionPage/actionPage.scss
+++ b/resources/assets/components/ActionPage/actionPage.scss
@@ -17,14 +17,24 @@
   }
 
   .action-step__header {
+    position: relative;
     width: 100%;
-    background-size: cover;
-    background-position: center center;
+    background: $dark-gray;
     text-align: center;
     text-transform: uppercase;
     padding: $base-spacing;
+    overflow: hidden;
+
+    img {
+      width: 100%;
+      position: absolute;
+      top: 50%; left: 0;
+      transform: translateY(-50%);
+      filter: grayscale(100%);
+    }
 
     span {
+      position: relative;
       color: $primary-color;
       font-size: $font-regular;
       font-weight: $weight-bold;
@@ -32,6 +42,7 @@
     }
 
     h1 {
+      position: relative;
       color: $white;
       font-size: $font-hero;
       font-weight: $weight-bold;

--- a/resources/assets/components/ActionPage/index.js
+++ b/resources/assets/components/ActionPage/index.js
@@ -2,13 +2,15 @@ import React from 'react';
 import Markdown from '../Markdown';
 import ReportbackUploaderContainer from '../../containers/ReportbackUploaderContainer';
 import Revealer from '../Revealer';
+import LazyImage from '../LazyImage';
 import { Flex, FlexCell } from '../Flex';
 import { convertNumberToWord } from '../../helpers';
 import './actionPage.scss';
 
 const Stepheader = ({ title, step, background }) => (
   <FlexCell width="full">
-    <div className="action-step__header" style={{ backgroundImage: background }}>
+    <div className="action-step__header">
+      <LazyImage src={background} />
       <span>step { convertNumberToWord(step) }</span>
       <h1>{ title }</h1>
     </div>
@@ -23,8 +25,7 @@ const renderPhoto = (photo, index) => (
 
 const renderStep = (step, index) => {
   const title = step.title;
-  const background = `url('${step.background}')`;
-
+  const background = step.background;
   const stepWidth = step.displayOptions[0];
   const photoWidth = stepWidth === 'full' ? 'full' : 'one-third';
 

--- a/resources/assets/components/Markdown/index.js
+++ b/resources/assets/components/Markdown/index.js
@@ -1,9 +1,10 @@
 import React from 'react';
+import classnames from 'classnames';
 import { markdown } from "../../helpers";
 import './markdown.scss';
 
 const Markdown = ({className = 'markdown', children}) => (
-  <div className={className} dangerouslySetInnerHTML={markdown(children)} />
+  <div className={classnames('markdown', 'with-lists', className)} dangerouslySetInnerHTML={markdown(children)} />
 );
 
 Markdown.propTypes = {

--- a/resources/assets/components/Markdown/markdown.scss
+++ b/resources/assets/components/Markdown/markdown.scss
@@ -1,12 +1,19 @@
 @import '../../scss/next-toolbox.scss';
 
 .markdown {
-  blockquote {
-    position: relative;
-    margin: $base-spacing / 2 0;
+  // Code blocks can be used for pre-formatted text.
+  code {
+    font-family: $font-proxima-nova;
+    font-size: $font-regular;
+    display: block;
+  }
 
-    p {
-      margin-left: $base-spacing / 2;
+  pre, blockquote {
+    position: relative;
+    margin: $base-spacing 0;
+
+    p, ul, code {
+      margin-left: $base-spacing;
     }
 
     &:before {


### PR DESCRIPTION
#### Changes
Noticed this while working on slow coffee shop wi-fi. This pull request updates step backgrounds to lazy-load, applies a CSS3 grayscale filter for the fun of it, and sets a gray background until then (or if a background wasn't provided).

![screen shot 2017-04-11 at 4 10 25 pm](https://cloud.githubusercontent.com/assets/583202/24928888/036cb6b4-1ed2-11e7-8d2f-b3b5f959cbb5.png)

There's also a few updates to improve rendering of action page content:

![screen shot 2017-04-11 at 4 31 54 pm](https://cloud.githubusercontent.com/assets/583202/24929566/659b93da-1ed4-11e7-849d-b5c3b0c2e908.png)
