### PR TITLE
Redirect to action page if already signed up.

### DIFF
--- a/resources/assets/actions/signup.js
+++ b/resources/assets/actions/signup.js
@@ -111,8 +111,11 @@ export function clickedSignUp(campaignId, metadata) {
       return;
     }
 
-    // Make sure we don't already have a signup cached before making the request.
-    if (getState().signups.data.includes(campaignId)) return;
+    // If we already have a signup, just go to the action page.
+    if (getState().signups.data.includes(campaignId)) {
+      historyGet().push('/action');
+      return;
+    };
 
     dispatch(signupPending());
 


### PR DESCRIPTION
#### Changes
This sends the user to the action page if they click a CTA block when already signed up.

🉑 