### PR TITLE
Fix links to not depend on trailing slash in the env

### DIFF
--- a/app/helpers.php
+++ b/app/helpers.php
@@ -170,3 +170,19 @@ function getShareFields($campaign, $shareOverrides)
         'quote' => $shareOverrides ? $shareOverrides->quote : null,
     ];
 }
+
+/**
+ * Generate a link to Phoenix Ashes.
+ *
+ * @param  String $path path/to/something
+ * @return String
+ */
+function phoenixLink($path)
+{
+    $base = config('services.phoenix-legacy.url');
+    if (substr($base, -1) !== '/') {
+        $base .= '/';
+    }
+
+    return $base . $path;
+}

--- a/resources/views/partials/footer.blade.php
+++ b/resources/views/partials/footer.blade.php
@@ -25,12 +25,12 @@
     <div class="footer__column -links">
         <h4 class="js-toggle-collapsed is-collapsed is-toggleable">Who We Are</h4>
         <ul>
-          <li><a href="{{ config('services.phoenix-legacy.url') . 'us/about/who-we-are' }}">What is DoSomething.org?</a></li>
-          <li><a href="{{ config('services.phoenix-legacy.url') . 'us/about/our-people' }}">Our Team</a></li>
-          <li><a href="{{ config('services.phoenix-legacy.url') . 'us/about/sexy-financials' }}">Sexy Financials</a></li>
+          <li><a href="{{ phoenixLink('us/about/who-we-are') }}">What is DoSomething.org?</a></li>
+          <li><a href="{{ phoenixLink('us/about/our-people') }}">Our Team</a></li>
+          <li><a href="{{ phoenixLink('us/about/sexy-financials') }}">Sexy Financials</a></li>
           <li><a href="http://xyzfactor.org/">XYZ Factor</a></li>
           <li><a href="https://app.dosomething.org/">Mobile App</a></li>
-          <li><a href="{{ config('services.phoenix-legacy.url') . 'us/about/our-press' }}">Press</a></li>
+          <li><a href="{{ phoenixLink('us/about/our-press') }}">Press</a></li>
           <li><a href="https://blog.dosomething.org/">Blog</a></li>
          </ul>
     </div>
@@ -38,26 +38,26 @@
         <h4 class="js-toggle-collapsed is-collapsed is-toggleable">Our Friends</h4>
         <ul>
           <li><a href="http://www.tmiagency.org">TMI Agency</a></li>
-          <li><a href="{{ config('services.phoenix-legacy.url') . 'us/about/our-partners' }}">Partners</a></li>
-          <li><a href="{{ config('services.phoenix-legacy.url') . 'us/about/old-people' }}">Old People</a></li>
-          <li><a href="{{ config('services.phoenix-legacy.url') . 'us/about/hotline-list' }}">Crisis Hotlines</a></li>
+          <li><a href="{{ phoenixLink('us/about/our-partners') }}">Partners</a></li>
+          <li><a href="{{ phoenixLink('us/about/old-people') }}">Old People</a></li>
+          <li><a href="{{ phoenixLink('us/about/hotline-list') }}">Crisis Hotlines</a></li>
         </ul>
     </div>
     <div class="footer__column -links">
         <h4 class="js-toggle-collapsed is-collapsed is-toggleable">Get Involved</h4>
         <ul>
-          <li><a href="{{ config('services.phoenix-legacy.url') . 'us/about/easy-scholarships' }}">Scholarships</a></li>
-          <li><a href="{{ config('services.phoenix-legacy.url') . 'us/about/join-our-team' }}">Jobs</a></li>
-          <li><a href="{{ config('services.phoenix-legacy.url') . 'us/about/internships' }}">Internships</a></li>
-          <li><a href="{{ config('services.phoenix-legacy.url') . 'us/about/donate' }}">Donate</a></li>
+          <li><a href="{{ phoenixLink('us/about/easy-scholarships') }}">Scholarships</a></li>
+          <li><a href="{{ phoenixLink('us/about/join-our-team') }}">Jobs</a></li>
+          <li><a href="{{ phoenixLink('us/about/internships') }}">Internships</a></li>
+          <li><a href="{{ phoenixLink('us/about/donate') }}">Donate</a></li>
           <li><a href="https://help.dosomething.org/hc/en-us">Help Center</a></li>
         </ul>
     </div>
   </div>
   <div class="footer__subfooter">
     <ul>
-      <li><a href="{{ config('services.phoenix-legacy.url') . 'us/about/terms-service' }}">Terms of Service</a></li>
-      <li><a href="{{ config('services.phoenix-legacy.url') . 'us/about/privacy-policy' }}">Privacy Policy.</a></li>
+      <li><a href="{{ phoenixLink('us/about/terms-service') }}">Terms of Service</a></li>
+      <li><a href="{{ phoenixLink('us/about/privacy-policy') }}">Privacy Policy.</a></li>
     </ul>
   </div>
 </footer>

--- a/resources/views/partials/navigation.blade.php
+++ b/resources/views/partials/navigation.blade.php
@@ -21,7 +21,7 @@
                 @if (Auth::user())
                     <a id="js-account-toggle" class="navigation__dropdown-toggle">My Profile</a>
                     <ul>
-                        <li><a href="{{ phoenixLink('/northstar/' . Auth::user()->northstar_id) }}">Profile</a></li>
+                        <li><a href="{{ phoenixLink('northstar/' . Auth::user()->northstar_id) }}">Profile</a></li>
                         <li><a href="{{ route('logout') }}" class="secondary-nav-item" id="link--logout">Log Out</a></li>
                     </ul>
                 @else

--- a/resources/views/partials/navigation.blade.php
+++ b/resources/views/partials/navigation.blade.php
@@ -4,13 +4,13 @@
     <div class="navigation__menu">
         <ul class="navigation__primary">
             <li>
-                <a href="{{ config('services.phoenix-legacy.url') . 'us/campaigns' }}">
+                <a href="{{ phoenixLink('us/campaigns') }}">
                     <strong class="navigation__title">Explore Campaigns</strong>
                     <span class="navigation__subtitle">Find ways to take action both online and off.</span>
                 </a>
             </li>
             <li>
-                <a href="{{ config('services.phoenix-legacy.url') . 'us/about/who-we-are' }}">
+                <a href="{{ phoenixLink('us/about/who-we-are') }}">
                     <strong class="navigation__title">What is DoSomething.org?</strong>
                     <span class="navigation__subtitle">A global movement for good.</span>
                 </a>
@@ -21,7 +21,7 @@
                 @if (Auth::user())
                     <a id="js-account-toggle" class="navigation__dropdown-toggle">My Profile</a>
                     <ul>
-                        <li><a href="{{ config('services.phoenix-legacy.url') . '/northstar/' . Auth::user()->northstar_id }}">Profile</a></li>
+                        <li><a href="{{ phoenixLink('/northstar/' . Auth::user()->northstar_id) }}">Profile</a></li>
                         <li><a href="{{ url('next/logout') }}" class="secondary-nav-item" id="link--logout">Log Out</a></li>
                     </ul>
                 @else


### PR DESCRIPTION
If your env file doesn't have a trailing slash, it shouldn't break all of the links surrounding the page