### PR TITLE
Update lede title to more closely match the mocks.

### DIFF
--- a/resources/assets/components/Dashboard/index.js
+++ b/resources/assets/components/Dashboard/index.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import { Flex, FlexCell } from '../Flex';
 import ShareContainer from '../../containers/ShareContainer';
-import Markdown from '../Markdown';
 import { getDaysBetween } from '../../helpers';
 import './dashboard.scss';
 

--- a/resources/assets/components/LedeBanner/lede-banner.scss
+++ b/resources/assets/components/LedeBanner/lede-banner.scss
@@ -77,6 +77,7 @@
   border-bottom: 8px solid $primary-color;
   font-family: $secondary-font-family;
   font-size: 50px;
+  font-weight: normal;
   letter-spacing: 4px;
   line-height: 1.1;
   margin-bottom: 0;
@@ -85,10 +86,6 @@
 
   @include media($medium) {
     font-size: 65px;
-  }
-
-  @include media($larger) {
-    font-size: 85px;
   }
 }
 


### PR DESCRIPTION
Currently the lede title is taking up [an awful lot of space](https://cloud.githubusercontent.com/assets/583202/24974432/23c58b66-1f90-11e7-9a15-f06b2c3f1e3f.png). This pull request adjusts the styles a little bit to make it [more closely match the mocks](https://cloud.githubusercontent.com/assets/583202/24974433/25737144-1f90-11e7-87c2-085253330752.png) and also removes an unused import in the dashboard.

🎨