### PR TITLE
Fixes issue rendering empty Markdown blocks.

### DIFF
--- a/resources/assets/components/Markdown/index.js
+++ b/resources/assets/components/Markdown/index.js
@@ -8,7 +8,7 @@ const Markdown = ({className = 'markdown', children}) => (
 );
 
 Markdown.propTypes = {
-  children: React.PropTypes.string.isRequired,
+  children: React.PropTypes.string,
   className: React.PropTypes.string,
 };
 

--- a/resources/assets/helpers/index.js
+++ b/resources/assets/helpers/index.js
@@ -65,7 +65,7 @@ export function ready(fn) {
  * @param {String} source - Markdown source
  * @returns {{__html}} - Prepared object for React's dangerouslySetInnerHtml
  */
-export function markdown(source) {
+export function markdown(source = '') {
   // Markdown options <https://github.com/chjj/marked#options-1>
   const options = {
     sanitize: true


### PR DESCRIPTION
#### Changes
This pull request fixes an issue where empty Markdown blocks would cause Marked to throw an exception, stopping rendering of the page.

```
[Error] TypeError: undefined is not an object (evaluating 'src.replace')
Please report this to https://github.com/chjj/marked.
	marked (app-d95247492c83c0bc7a4f.js:23437)
	markdown (app-d95247492c83c0bc7a4f.js:21983)
	Markdown (app-d95247492c83c0bc7a4f.js:39912:173)
        …
```

📄 ‼️ 