### PR TITLE
Prevent exception if 'source' JSON field is not set.

### DIFF
--- a/resources/assets/components/StaticBlock/index.js
+++ b/resources/assets/components/StaticBlock/index.js
@@ -4,7 +4,7 @@ import Markdown from '../Markdown';
 import './static-block.scss';
 
 const StaticBlock = (props) => {
-  const source = props.fields.additionalContent.source;
+  const { source } = props.fields.additionalContent;
 
   return (
     <Block>


### PR DESCRIPTION
#### Changes
This pull request fixes an issue where static blocks would explode if the `source` JSON field wasn't set. Switching to using destructuring to grab that value handles the optional field gracefully.

ℹ️