### PR TITLE
Fix error reading pagination when no reportbacks exist for campaign.

### DIFF
--- a/resources/assets/actions/reportback.js
+++ b/resources/assets/actions/reportback.js
@@ -1,6 +1,7 @@
 import { Phoenix } from '@dosomething/gateway';
 import { normalizeReportbacksResponse } from "../normalizers";
 import has from 'lodash/has';
+import get from 'lodash/get';
 import {
   REQUESTED_REPORTBACKS,
   RECEIVED_REPORTBACKS,
@@ -208,7 +209,10 @@ export function fetchReportbacks() {
 
     (new Phoenix).get('next/reportbacks', { campaigns: node, page }).then(json => {
       const normalizedData = normalizeReportbacksResponse(json.data);
-      dispatch(receivedReportbacks(normalizedData, json.meta.pagination.current_page, json.meta.pagination.total))
+      const currentPage =  get(json, 'meta.pagination.current_page', 1);
+      const total =  get(json, 'meta.pagination.current_page', 0);
+
+      dispatch(receivedReportbacks(normalizedData, currentPage, total))
     })
   }
 }

--- a/resources/assets/actions/reportback.js
+++ b/resources/assets/actions/reportback.js
@@ -209,8 +209,8 @@ export function fetchReportbacks() {
 
     (new Phoenix).get('next/reportbacks', { campaigns: node, page }).then(json => {
       const normalizedData = normalizeReportbacksResponse(json.data);
-      const currentPage =  get(json, 'meta.pagination.current_page', 1);
-      const total =  get(json, 'meta.pagination.current_page', 0);
+      const currentPage = get(json, 'meta.pagination.current_page', 1);
+      const total = get(json, 'meta.pagination.total', 0);
 
       dispatch(receivedReportbacks(normalizedData, currentPage, total))
     })


### PR DESCRIPTION
#### Changes
Phoenix Ashes [doesn't return a `meta.pagination` object](https://cloud.githubusercontent.com/assets/583202/25008075/9395d234-2030-11e7-931a-f60d7433920b.png) if there aren't any results for a query, which means we were throwing an exception when trying to read that in the response. This pull request uses Lodash's [`get`](https://lodash.com/docs/#get) helper to gracefully fail if that property isn't defined.

📟 