### PR TITLE
Fixes "history" dependency issue with Wercker builds.

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "classnames": "^2.2.5",
     "dom-delegate": "^2.0.3",
     "dosomething-modal": "^0.3.0",
+    "history": "^3.0.0",
     "lodash": "^4.17.4",
     "marked": "^0.3.6",
     "react": "^15.4.2",

--- a/resources/assets/init.js
+++ b/resources/assets/init.js
@@ -14,10 +14,7 @@ import ReactDom from 'react-dom';
 import { ready } from './helpers';
 import { configureStore } from './store';
 import * as reducers from './reducers'
-import { useRouterHistory } from 'react-router';
-import createBrowserHistory from 'history/lib/createBrowserHistory';
-import { syncHistoryWithStore, routerReducer } from 'react-router-redux';
-import observe from './middleware/analytics';
+import { routerReducer } from 'react-router-redux';
 
 // WHATWG Fetch Polyfill
 import 'whatwg-fetch';


### PR DESCRIPTION
#### Changes
This pull request seems to fix issues with the [`history`](https://www.npmjs.com/package/history) package not being required properly in Wercker builds by explicitly adding it to our `package.json`. I think there's another underlying issue here, but this should at least unblock production testing.

Closes #168.

📚