### PR TITLE
Cleaning up styles and output for the campaign content pages.

### DIFF
--- a/resources/assets/components/CallToActionBlock/cta.scss
+++ b/resources/assets/components/CallToActionBlock/cta.scss
@@ -8,6 +8,12 @@
   margin: 12px;
   width: 100%;
 
+  &.-transparent {
+    background-color: transparent;
+    border: 0 none;
+    color: $off-black;
+  }
+
   &.has-photo {
     @include media($medium) {
       display: flex;
@@ -26,44 +32,51 @@
         display: block;
       }
     }
-
   }
-}
 
-.cta__block {
-  @include media($medium) {
-    .has-photo & {
-      margin: $base-spacing auto;
-      width: 90%;
+  .cta__block {
+    @include media($medium) {
+      width: auto;
+      margin-left: inherit;
+
+      .has-photo & {
+        margin: $base-spacing auto;
+        width: 90%;
+      }
     }
   }
-}
 
-.cta__title {
-  font-size: $font-medium;
-  font-weight: $weight-sbold;
-}
-
-.cta__message {
-  font-size: $font-regular;
-  font-weight: $weight-normal;
-}
-
-.cta__impact {
-  color: $white;
-  text-transform: uppercase;
-  font-weight: $weight-bold;
-
-  span {
-    display: block;
-    line-height: 1.2;
+  .cta__title {
+    font-size: $font-medium;
+    font-weight: $weight-sbold;
   }
-}
 
-.cta__impact-prefix {
-  text-transform: uppercase;
-}
+  .cta__message {
+    color: $white;
+    font-size: $font-regular;
+    font-weight: $weight-normal;
 
-.cta__impact-number {
-  font-size: $font-hero;
+    p + p {
+      margin-top: $half-spacing;
+    }
+  }
+
+  .cta__impact {
+    color: $white;
+    text-transform: uppercase;
+    font-weight: $weight-bold;
+
+    span {
+      display: block;
+      line-height: 1.2;
+    }
+  }
+
+  .cta__impact-prefix {
+    text-transform: uppercase;
+  }
+
+  .cta__impact-number {
+    font-size: $font-hero;
+  }
 }

--- a/resources/assets/components/CallToActionBlock/index.js
+++ b/resources/assets/components/CallToActionBlock/index.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import classnames from 'classnames';
-import { contentfulImageUrl } from '../../helpers';
+import Markdown from '../Markdown';
+import { contentfulImageUrl, modifiers } from '../../helpers';
 import { mergeMetadata } from '../../helpers/analytics';
 import './cta.scss';
 
@@ -22,12 +23,12 @@ const renderBackgroundImageStyle = (imageUrl) => (
   { backgroundImage: `url(${contentfulImageUrl(imageUrl, '400', '400', 'fill')})` }
 );
 
-const CallToActionBlock = ({ isAffiliated, fields, imageUrl, legacyCampaignId, clickedSignUp }) => {
+const CallToActionBlock = ({ isAffiliated, fields, imageUrl, legacyCampaignId, clickedSignUp, modifierClasses = [] }) => {
   const { title, content, additionalContent } = fields;
   const hasPhoto = additionalContent ? additionalContent.hasPhoto : false;
 
   // @TODO: This should probably be editable in contentful...
-  const buttonText = isAffiliated ? 'Join Us' : 'Get Involved';
+  const buttonText = isAffiliated ? 'Join Us' : 'Make Cards';
 
   const metadata = mergeMetadata(CallToActionBlock.defaultMetadata, {
     hasPhoto: hasPhoto,
@@ -38,13 +39,13 @@ const CallToActionBlock = ({ isAffiliated, fields, imageUrl, legacyCampaignId, c
   const handleOnClickButton = () => clickedSignUp(legacyCampaignId, metadata);
 
   return (
-    <div className={classnames('cta', {'has-photo': hasPhoto})}>
+    <div className={classnames('cta', modifiers(modifierClasses), {'has-photo': hasPhoto})}>
       <div className="cta__content">
         { !content ? <div className="cta__block"><p className="cta__title">{title}</p></div> : null }
 
         { additionalContent ? renderImpactContent(additionalContent) : null}
 
-        { content ? <div className="cta__block"><p className="cta__message">{content}</p></div> : null }
+        { content ? <div className="cta__block"><Markdown className="cta__message">{content}</Markdown></div> : null }
 
         <div className="cta__block">
           <a className="button" onClick={handleOnClickButton}>{buttonText}</a>
@@ -61,5 +62,3 @@ CallToActionBlock.defaultMetadata = {
 }
 
 export default CallToActionBlock;
-
-

--- a/resources/assets/components/ContentPage/content-page.scss
+++ b/resources/assets/components/ContentPage/content-page.scss
@@ -44,12 +44,4 @@
     clear: both;
     margin: 0;
   }
-
-  // @TODO: Upcoming PR with work specifically on CTA will address having some classes to
-  // allow for transparent vs filled-in CTAs @_@
-  > .cta {
-    background-color: transparent;
-    border: 0 none;
-    color: $off-black;
-  }
 }

--- a/resources/assets/components/ContentPage/index.js
+++ b/resources/assets/components/ContentPage/index.js
@@ -10,7 +10,7 @@ const ContentPage = ({ pages, route }) => {
   const page = pages.find(page => page.fields.slug === route.page);
 
   // @TODO: temporary variables until these CTAs are no longer hardcoded.
-  const ctaText1 = 'Help us send letters of support to every mosque in the US.\nJoin hundreds of members members making cards!';
+  const ctaText1 = 'Help us send letters of support to every mosque in the US.\n\n__Join hundreds of members members making cards!__';
   const ctaText2 = 'Help us send letters of support to every mosque in the United States.';
 
   return (
@@ -25,7 +25,7 @@ const ContentPage = ({ pages, route }) => {
         <CallToActionContainer fields={ {title: 'something', content: ctaText1} } />
       </div>
 
-      <CallToActionContainer fields={ {title: ctaText2} } />
+      <CallToActionContainer fields={ {title: ctaText2} } modifierClasses="transparent" />
     </div>
   );
 };

--- a/resources/assets/components/ContentPage/index.js
+++ b/resources/assets/components/ContentPage/index.js
@@ -22,7 +22,7 @@ const ContentPage = ({ pages, route }) => {
         </article>
       </div>
       <div className="secondary">
-        <CallToActionContainer fields={ {title: 'something', content: ctaText1} } />
+        <CallToActionContainer fields={ {content: ctaText1} } />
       </div>
 
       <CallToActionContainer fields={ {title: ctaText2} } modifierClasses="transparent" />

--- a/resources/assets/components/Markdown/index.js
+++ b/resources/assets/components/Markdown/index.js
@@ -3,7 +3,7 @@ import classnames from 'classnames';
 import { markdown } from "../../helpers";
 import './markdown.scss';
 
-const Markdown = ({className = 'markdown', children}) => (
+const Markdown = ({className = null, children}) => (
   <div className={classnames('markdown', 'with-lists', className)} dangerouslySetInnerHTML={markdown(children)} />
 );
 


### PR DESCRIPTION
This PR does some additional tweaks, responsive fixes, etc to wrap up the Campaign content pages for now, with the two hardcoded CTAs.

Refs https://trello.com/c/eCW7M75Z/394-3-as-a-developer-i-want-to-be-able-to-add-cta-blocks-to-the-faq-and-scholarship-pages-so-that-i-can-push-users-to-affiliate-or-t