### PR TITLE
Removes min-height from action page photos

### DIFF
--- a/resources/assets/components/ActionPage/actionPage.scss
+++ b/resources/assets/components/ActionPage/actionPage.scss
@@ -62,7 +62,7 @@
       padding: $base-spacing / 2;
 
       img {
-        min-height: 200px;
+/*         min-height: 200px; */
       }
     }
   }

--- a/resources/assets/components/ActionPage/actionPage.scss
+++ b/resources/assets/components/ActionPage/actionPage.scss
@@ -60,10 +60,7 @@
 
     .action-step__photo {
       padding: $base-spacing / 2;
-
-      img {
-/*         min-height: 200px; */
-      }
+      // TODO: We'll want to make these square at some point, and get a proper overflow for the action step photos.
     }
   }
 


### PR DESCRIPTION
This PR just removes min-height from action steps photos. 

This is the easiest way to handle the image stretching on mobile and desktop sizes. Later on, we should make these into squares with proper overflows and such.