### PR TITLE
Some style/layout fixes

### DIFF
--- a/resources/assets/components/ActionPage/actionPage.scss
+++ b/resources/assets/components/ActionPage/actionPage.scss
@@ -12,7 +12,7 @@
     }
   }
 
-  &.-hide {
+  &.-truncate {
     overflow-y: hidden;
     max-height: 600px;
 

--- a/resources/assets/components/ActionPage/actionPage.scss
+++ b/resources/assets/components/ActionPage/actionPage.scss
@@ -12,6 +12,15 @@
     }
   }
 
+  &.-hide {
+    overflow-y: hidden;
+    max-height: 600px;
+
+    @include media($medium) {
+      max-height: 400px;
+    }
+  }
+
   h1, h2, h3, p {
     color: $black;
     font-family: $primary-font-family;

--- a/resources/assets/components/ActionPage/index.js
+++ b/resources/assets/components/ActionPage/index.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import classnames from 'classnames';
 import Markdown from '../Markdown';
 import ReportbackUploaderContainer from '../../containers/ReportbackUploaderContainer';
 import Revealer from '../Revealer';
@@ -28,10 +29,11 @@ const renderStep = (step, index) => {
   const background = step.background;
   const stepWidth = step.displayOptions[0];
   const photoWidth = stepWidth === 'full' ? 'full' : 'one-third';
+  const shouldHide = step.hide;
 
   return (
     <FlexCell width="full" key={index}>
-      <div className="action-step">
+      <div className={classnames('action-step', {'-hide': shouldHide})}>
         <Flex>
           <Stepheader title={title} step={index + 1} background={background} />
           <FlexCell width="two-thirds">
@@ -56,6 +58,7 @@ const renderStep = (step, index) => {
 const ActionPage = ({ steps, callToAction, campaignId, signedUp, hasPendingSignup, isAuthenticated, clickedSignUp }) => {
   if (! signedUp) {
     steps = steps.slice(0, 2);
+    steps[steps.length - 1].hide = true;
   }
 
   const revealer = <Revealer title="sign up" callToAction={callToAction}

--- a/resources/assets/components/ActionPage/index.js
+++ b/resources/assets/components/ActionPage/index.js
@@ -29,11 +29,11 @@ const renderStep = (step, index) => {
   const background = step.background;
   const stepWidth = step.displayOptions[0];
   const photoWidth = stepWidth === 'full' ? 'full' : 'one-third';
-  const shouldHide = step.hide;
+  const shouldTruncate = step.truncate;
 
   return (
     <FlexCell width="full" key={index}>
-      <div className={classnames('action-step', {'-hide': shouldHide})}>
+      <div className={classnames('action-step', {'-truncate': shouldTruncate})}>
         <Flex>
           <Stepheader title={title} step={index + 1} background={background} />
           <FlexCell width="two-thirds">
@@ -58,7 +58,10 @@ const renderStep = (step, index) => {
 const ActionPage = ({ steps, callToAction, campaignId, signedUp, hasPendingSignup, isAuthenticated, clickedSignUp }) => {
   if (! signedUp) {
     steps = steps.slice(0, 2);
-    steps[steps.length - 1].hide = true;
+
+    if (steps[steps.length - 1]) {
+      steps[steps.length - 1].truncate = true;
+    }
   }
 
   const revealer = <Revealer title="sign up" callToAction={callToAction}

--- a/resources/assets/components/Affirmation/affirmation.scss
+++ b/resources/assets/components/Affirmation/affirmation.scss
@@ -24,9 +24,13 @@
     h1 {
       letter-spacing: 1.1px;
       font-family: $secondary-font-family;
-      font-size: $font-gigantic; // TODO: This needs to be the 65px one
+      font-size: $font-hero;
       font-weight: $weight-normal;
       color: $white;
+
+      @include media($medium) {
+        font-size: $font-gigantic;
+      }
     }
   }
 

--- a/resources/assets/components/Affirmation/index.js
+++ b/resources/assets/components/Affirmation/index.js
@@ -41,7 +41,7 @@ const Affirmation = (props) => {
 
 //TODO: Replace these default strings with content from Contentful
 Affirmation.defaultProps = {
-  header: '🙌 THANKS FOR JOINING! 🙌',
+  header: 'THANKS FOR JOINING!',
   quote: `You doing this means so much to my community. Thank you so much for doing this simple action. Ramadan is a special time for us and this just makes it even more special.`,
   author: 'Usra, Maryland',
   photo: 'https://static.dosomething.org/img/sincerely-us-member-quote.jpg',

--- a/resources/assets/containers/ActionPageContainer.js
+++ b/resources/assets/containers/ActionPageContainer.js
@@ -11,7 +11,7 @@ const mapStateToProps = (state) => {
     steps: state.campaign.actionSteps,
     campaignId: state.campaign.legacyCampaignId,
     callToAction: state.campaign.callToAction,
-    signedUp: state.signups.data.includes(state.campaign.legacyCampaignId),
+    signedUp: state.signups.thisCampaign,
     hasPendingSignup: state.signups.isPending,
     isAuthenticated: state.user.id !== null,
   };

--- a/resources/assets/selectors/feed.js
+++ b/resources/assets/selectors/feed.js
@@ -1,5 +1,5 @@
 const BLOCKS_PER_ROW = 3;
-const ROWS_PER_PAGE = 3;
+const ROWS_PER_PAGE = 5;
 
 /**
  * Map the given display option to a numeric point value.


### PR DESCRIPTION
## Increases the length of the community tab to 5 rows

![screen shot 2017-04-13 at 1 32 23 pm](https://cloud.githubusercontent.com/assets/897368/25016368/abc122e2-204d-11e7-92c3-b00a03a9ad9d.png)

## Cuts the action page step off sooner

![screen shot 2017-04-13 at 1 27 07 pm](https://cloud.githubusercontent.com/assets/897368/25016246/2cb9c472-204d-11e7-9a31-6814f041ebeb.png)
![screen shot 2017-04-13 at 1 26 59 pm](https://cloud.githubusercontent.com/assets/897368/25016247/2cbb5e54-204d-11e7-82af-d1970afb072a.png)

## Fixes the affirmation header on mobile

![screen shot 2017-04-13 at 1 26 18 pm](https://cloud.githubusercontent.com/assets/897368/25016337/8cbf7d62-204d-11e7-879c-cf3b9d2a6546.png)
