### PR TITLE
Adding missing step to trigger restarting php

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -53,4 +53,5 @@ end
 after "deploy:update", "deploy:cleanup"
 after "deploy:symlink", "deploy:link_folders"
 after "deploy:link_folders", "deploy:artisan_migrate"
+after "deploy:artisan_migrate", "deploy:artisan_cache_clear"
 after "deploy:artisan_cache_clear", "deploy:restart_php"


### PR DESCRIPTION
Capistrano was missing the step to run artisan cache clear to trigger restarting PHP. This PR adds that step in.