### PR TITLE
Reportback uploader validation messages

### DIFF
--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -85,6 +85,8 @@ class Handler extends ExceptionHandler
         }
         elseif ($exception instanceof ValidationException) {
             $code = 422;
+
+            $fields = $exception->validator->errors()->all();
         }
         elseif ($exception instanceof AuthenticationException) {
             $code = 401;
@@ -101,6 +103,11 @@ class Handler extends ExceptionHandler
                 'message' => $hideErrorDetails ? self::PRODUCTION_ERROR_MESSAGE : $exception->getMessage(),
             ],
         ];
+
+        // Add fields messages if available.
+        if (isset($fields)) {
+            $response['error']['fields'] = $fields;
+        }
 
         // Debug mode info.
         if (config('app.debug')) {

--- a/app/Http/Controllers/ReportbackController.php
+++ b/app/Http/Controllers/ReportbackController.php
@@ -40,9 +40,9 @@ class ReportbackController extends Controller
     public function store(Request $request)
     {
         $this->validate($request, [
-            'media' => 'required',
+            'media' => 'required|file|image',
             'caption' => 'required',
-            'impact' => 'required',
+            'impact' => 'required|numeric',
             'whyParticipated' => 'required',
         ]);
 

--- a/resources/assets/actions/reportback.js
+++ b/resources/assets/actions/reportback.js
@@ -52,9 +52,12 @@ export function storeReportback(reportback) {
   };
 }
 
-// Action: storeing new user submitted reportback failed.
-export function storeReportbackFailed(reportback) {
-  return { type: STORE_REPORTBACK_FAILED };
+// Action: storing new user submitted reportback failed.
+export function storeReportbackFailed(error) {
+  return {
+    type: STORE_REPORTBACK_FAILED,
+    error
+  };
 }
 
 // Action: storing new user submitted reportback was successful.
@@ -152,8 +155,9 @@ export function submitReportback(reportback) {
     })
       .then(response => {
         if (response.status >= 300) {
-          dispatch(storeReportbackFailed());
-          // @TODO: implement showing validation error.
+          response.json().then(json => {
+            dispatch(storeReportbackFailed(json));
+          });
         }
         else {
           dispatch(storeReportbackSuccessful());

--- a/resources/assets/components/FormMessage/form-message.scss
+++ b/resources/assets/components/FormMessage/form-message.scss
@@ -1,0 +1,21 @@
+@import '../../scss/next-toolbox.scss';
+
+.form-message {
+  margin-top: $base-spacing;
+
+  &.-error {
+    color: red;
+
+    & h3 {
+      color: red;
+    }
+  }
+
+  &.-success {
+    color: green;
+
+    & h3 {
+      color: green;
+    }
+  }
+}

--- a/resources/assets/components/FormMessage/index.js
+++ b/resources/assets/components/FormMessage/index.js
@@ -30,11 +30,15 @@ const FormMessage = ({ messaging }) => {
     modifierClasses = 'error';
 
     // Validation Error
+    // @TODO: maybe use a switch statement here, or maybe not refer
+    // to the error code, and instead just check if the fields list
+    // has items. Something to debate in the future.
     if (messaging.error.code === 422) {
-      message = renderErrorMessage(messaging.error);
+      message = renderValidationMessage(messaging.error);
     }
-
-    message = renderMessage(messaging.error.message);
+    else {
+      message = renderMessage(messaging.error.message);
+    }
   }
 
   // Success

--- a/resources/assets/components/FormMessage/index.js
+++ b/resources/assets/components/FormMessage/index.js
@@ -1,0 +1,54 @@
+import React from 'react';
+import classnames from 'classnames';
+import { has } from 'lodash';
+import { modifiers } from '../../helpers';
+
+import './form-message.scss';
+
+const renderMessage = (message) => {
+  return <p>{message}</p>;
+}
+
+const renderValidationMessage = (error) => {
+  return (
+    <div>
+      <h3>Hmm, there were some issues with your submission.</h3>
+      <ul className="list -compacted">
+        {error.fields.map((field, index) => {
+          return <li key={index}>{field}</li>;
+        })}
+      </ul>
+    </div>
+  );
+}
+
+const FormMessage = ({ messaging }) => {
+  let message, modifierClasses;
+
+  // Error
+  if (has(messaging, 'error')) {
+    modifierClasses = 'error';
+
+    // Validation Error
+    if (messaging.error.code === 422) {
+      message = renderErrorMessage(messaging.error);
+    }
+
+    message = renderMessage(messaging.error.message);
+  }
+
+  // Success
+  if (has(messaging, 'success')) {
+    modifierClasses = 'success';
+
+    message = renderMessage(messaging.success.message);
+  }
+
+  if (message) {
+    return <div className={classnames('form-message', modifiers(modifierClasses))}>{message}</div>;
+  }
+
+  return null;
+};
+
+export default FormMessage;

--- a/resources/assets/components/ReportbackUploader/index.js
+++ b/resources/assets/components/ReportbackUploader/index.js
@@ -4,6 +4,7 @@ import { Flex } from '../Flex';
 import MediaUploader from '../MediaUploader';
 import Gallery from '../Gallery';
 import ReportbackItem from '../ReportbackItem';
+import FormMessage from '../FormMessage';
 import { makeHash } from '../../helpers';
 import './reportback-uploader.scss';
 
@@ -11,8 +12,8 @@ class ReportbackUploader extends React.Component {
   constructor(props) {
     super(props);
 
-    this.onSubmit = this.onSubmit.bind(this);
-    this.onChange = this.onChange.bind(this);
+    this.handleOnSubmitForm = this.handleOnSubmitForm.bind(this);
+    this.handleOnFileUpload = this.handleOnFileUpload.bind(this);
 
     this.state = {
       media: this.defaultMediaState(),
@@ -35,11 +36,11 @@ class ReportbackUploader extends React.Component {
     this.props.fetchUserReportbacks(this.props.userId, this.props.legacyCampaignId);
   }
 
-  onChange(media) {
+  handleOnFileUpload(media) {
     this.setState({ media })
   }
 
-  onSubmit(event) {
+  handleOnSubmitForm(event) {
     event.preventDefault();
 
     const reportback = {
@@ -51,9 +52,9 @@ class ReportbackUploader extends React.Component {
       status: 'pending',
     };
 
-    let fileType = reportback.media.file.type;
+    let fileType = reportback.media.file ? reportback.media.file.type : null;
 
-    reportback.media.type = fileType.substring(0, fileType.indexOf('/'));
+    reportback.media.type = fileType ? fileType.substring(0, fileType.indexOf('/')) : null;
 
     this.props.submitReportback(this.setFormData(reportback));
 
@@ -69,7 +70,7 @@ class ReportbackUploader extends React.Component {
 
     Object.keys(reportback).map((item) => {
       if (item === 'media') {
-        formData.append(item, reportback[item].file);
+        formData.append(item, (reportback[item].file || ''));
       }
       else {
         formData.append(item, reportback[item]);
@@ -86,8 +87,11 @@ class ReportbackUploader extends React.Component {
       <Block>
         <div className="reportback-uploader">
           <h2 className="heading">Upload your photos</h2>
-          <form className="reportback-form" onSubmit={this.onSubmit} ref={(form) => this.form = form}>
-            <MediaUploader label="Send us your photo" media={this.state.media} onChange={this.onChange} />
+
+          { this.props.submissions.messaging ? <FormMessage messaging={this.props.submissions.messaging} /> : null }
+
+          <form className="reportback-form" onSubmit={this.handleOnSubmitForm} ref={(form) => this.form = form}>
+            <MediaUploader label="Send us your photo" media={this.state.media} onChange={this.handleOnFileUpload} />
 
             <div className="wrapper">
               <div className="form-item">

--- a/resources/assets/reducers/submissions.js
+++ b/resources/assets/reducers/submissions.js
@@ -53,7 +53,3 @@ const submissions = (state = {}, action) => {
 }
 
 export default submissions;
-
-// console.log('Reducing...');
-//       console.log(action);
-//       return {...state, errors: action.error, isFetching: false};

--- a/resources/assets/reducers/submissions.js
+++ b/resources/assets/reducers/submissions.js
@@ -3,6 +3,7 @@ import {
   REQUESTED_USER_SUBMISSIONS_FAILED,
   RECEIVED_USER_SUBMISSIONS,
   STORE_REPORTBACK_PENDING,
+  STORE_REPORTBACK_FAILED,
   STORE_REPORTBACK_SUCCESSFUL,
   ADD_SUBMISSION_METADATA,
   ADD_SUBMISSION_ITEM_TO_LIST
@@ -25,6 +26,9 @@ const submissions = (state = {}, action) => {
 
     case STORE_REPORTBACK_PENDING:
       return {...state, isStoring: true};
+
+    case STORE_REPORTBACK_FAILED:
+      return {...state, messaging: action.error};
 
     case STORE_REPORTBACK_SUCCESSFUL:
       return {...state, isStoring: false};
@@ -49,3 +53,7 @@ const submissions = (state = {}, action) => {
 }
 
 export default submissions;
+
+// console.log('Reducing...');
+//       console.log(action);
+//       return {...state, errors: action.error, isFetching: false};

--- a/resources/assets/store.js
+++ b/resources/assets/store.js
@@ -31,6 +31,7 @@ const initialState = {
     isFetching: false,
     isStoring: false,
     items: [],
+    messaging: null,
   },
   signups: {
     data: [],


### PR DESCRIPTION
This PR adds form validation errors displaying inside the Reportback Uploader form so a user can understand what is wrong if an error occurs when submitting a reportback. It sets up a system for showcasing messaging of different kinds in the form using a `FormMessage` component, so we can show other info (submission was fine but something happened on the receiving server) or show a success message.

For the next upcoming PR I'll be adding the success message and also persisting the field data in the form if an error occurs so that the user can amend what they entered. Currently, if there are errors all the fields will be wiped, but this is expected... for now.