### PR TITLE
Temporarily disbale CSRF protection on two routes.

### DIFF
--- a/app/Http/Middleware/VerifyCsrfToken.php
+++ b/app/Http/Middleware/VerifyCsrfToken.php
@@ -12,6 +12,7 @@ class VerifyCsrfToken extends BaseVerifier
      * @var array
      */
     protected $except = [
-        //
+        'next/reportbacks',
+        'next/signups',
     ];
 }


### PR DESCRIPTION
#### Changes
This pull request temporarily disables CSRF protection for the `next/reportback` and `next/signup` routes, since we've seen strange errors where that's preventing users from reporting back.