### PR TITLE
Switching reportback endpoint for store

### DIFF
--- a/app/Http/Controllers/ReportbackItemsController.php
+++ b/app/Http/Controllers/ReportbackItemsController.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Services\PhoenixLegacy;
+use Illuminate\Http\Request;
+
+class ReportbackItemsController extends Controller
+{
+    /**
+     * ReportbackController constructor.
+     *
+     * @todo once Rogue is ready, this will all change to request
+     * Reportbacks from Rogue instead of PhoenixLegacy.
+     */
+    public function __construct(PhoenixLegacy $phoenixLegacy)
+    {
+        $this->phoenixLegacy = $phoenixLegacy;
+    }
+
+    /**
+     * Display a listing of the resource.
+     *
+     * @return \Illuminate\Http\Response
+     */
+    public function index(Request $request)
+    {
+        return response()->json($this->phoenixLegacy->getAllReportbackItems($request->query()));
+    }
+}

--- a/app/Services/PhoenixLegacy.php
+++ b/app/Services/PhoenixLegacy.php
@@ -95,7 +95,7 @@ class PhoenixLegacy extends RestApiClient
 
     /**
      * Get an index of (optionally filtered) campaign reportbacks from Phoenix.
-     * @see: https://github.com/DoSomething/phoenix/wiki/API#retrieve-a-reportback-collection
+     * @see: https://github.com/DoSomething/phoenix/blob/dev/documentation/endpoints/reportbacks.md#retrieve-all-reportbacks
      *
      * @param array|string $query - query string, for filtering results
      * @return array - JSON response
@@ -103,6 +103,24 @@ class PhoenixLegacy extends RestApiClient
     public function getAllReportbacks(array $query = [])
     {
         $path = 'v1/reportbacks';
+        $query['load_user'] = true;
+        if (auth()->id()) {
+            $query['as_user'] = auth()->id();
+        }
+
+        return $this->get($path, $query);
+    }
+
+    /**
+     * Get an index of (optionally filtered) campaign reportback items from Phoenix.
+     * @see: https://github.com/DoSomething/phoenix/blob/dev/documentation/endpoints/reportback-items.md#retrieve-all-reportback-items
+     *
+     * @param array|string $query - query string, for filtering results
+     * @return array - JSON response
+     */
+    public function getAllReportbackItems(array $query = [])
+    {
+        $path = 'v1/reportback-items';
         $query['load_user'] = true;
         if (auth()->id()) {
             $query['as_user'] = auth()->id();

--- a/resources/assets/actions/reportback.js
+++ b/resources/assets/actions/reportback.js
@@ -1,5 +1,5 @@
 import { Phoenix } from '@dosomething/gateway';
-import { normalizeReportbacksResponse } from "../normalizers";
+import { normalizeReportbackItemResponse } from "../normalizers";
 import has from 'lodash/has';
 import get from 'lodash/get';
 import {
@@ -211,8 +211,8 @@ export function fetchReportbacks() {
 
     dispatch(requestedReportbacks(node));
 
-    (new Phoenix).get('next/reportbacks', { campaigns: node, page }).then(json => {
-      const normalizedData = normalizeReportbacksResponse(json.data);
+    (new Phoenix).get('next/reportbackItems', { campaigns: node, page }).then(json => {
+      const normalizedData = normalizeReportbackItemResponse(json.data);
       const currentPage = get(json, 'meta.pagination.current_page', 1);
       const total = get(json, 'meta.pagination.total', 0);
 

--- a/resources/assets/normalizers.js
+++ b/resources/assets/normalizers.js
@@ -29,3 +29,48 @@ export function normalizeReportbacksResponse(data) {
 
   return {reportbacks, reportbackItems};
 }
+
+/**
+ * Create normalized entities from the reportback item response.
+ * @param  {Object} data
+ * @return {Object}
+ */
+export function normalizeReportbackItemResponse(data) {
+  let reportbacks = {};
+  let reportbackItems = {};
+
+  data.forEach((reportbackItem) => {
+    const kudos = reportbackItem.kudos.data[0];
+    const currentUser = kudos ? kudos.current_user : false;
+
+    reportbackItem.reaction = {
+      id: currentUser ? currentUser.kudos_id : null,
+      reacted: !!(currentUser && currentUser.kudos_id),
+      total: kudos ? kudos.term.total : 0,
+      termId: kudos ? kudos.term.id : '1274', // This is a hardcoded default because phoenix-ashes is bugged.
+    }
+
+    const reportback = reportbackItem.reportback;
+    let existingReportback = reportbacks[reportback.id];
+
+    if (! existingReportback) {
+      existingReportback = reportback;
+      reportbacks[reportback.id] = existingReportback;
+    }
+
+    if (! existingReportback.reportback_items) {
+      existingReportback.reportback_items = []; // Underscore naming b/c of old data format.
+    }
+
+    existingReportback.reportback_items.push(reportbackItem.id);
+
+    if (! existingReportback.user) {
+      existingReportback.user = reportbackItem.user;
+    }
+
+    delete reportbackItem.campaign;
+    reportbackItems[reportbackItem.id] = reportbackItem;
+  });
+
+  return { reportbacks, reportbackItems };
+}

--- a/routes/web.php
+++ b/routes/web.php
@@ -41,6 +41,7 @@ $router->delete('next/reactions/{id}', 'ReactionController@delete');
 
 // Reportbacks
 $router->resource('next/reportbacks', 'ReportbackController', ['except' => ['create', 'edit', 'destroy']]);
+$router->resource('next/reportbackItems', 'ReportbackItemsController', ['only' => ['index']]);
 
 // Signups
 $router->get('next/signups/total/{campaignId}', 'SignupController@total');


### PR DESCRIPTION
Due to issues with the reportback endpoint, we're making a hotfix to use the reportback items endpoint instead. This PR accepts the data from that endpoint and normalizes it into the original format, so we _shouldn't_ have any problems with needing to recode components. 

I also left the old normalizer in the code just in case we fix the ashes bug