### PR TITLE
Fixes issues with Webpack build.

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "scripts": {
     "start": "npm run clean && npm run modernizr && NODE_ENV=development webpack",
     "build": "npm run clean && npm run modernizr && NODE_ENV=production webpack",
-    "clean": "rm -rf public/dist",
+    "clean": "rm -rf public/next/assets",
     "modernizr": "modernizr -c node_modules/@dosomething/forge/modernizr.json -d public/next/assets/modernizr.js",
     "heroku-postbuild": "sh bootstrap/setup.sh"
   },

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -29,7 +29,7 @@ config.plugins.push(
 );
 
 // Add revision hash to extracted CSS files.
-config.plugins = config.plugins.filter(plugin => ! plugin instanceof ExtractTextPlugin);
+config.plugins = config.plugins.filter(plugin => !(plugin instanceof ExtractTextPlugin));
 config.plugins.push(new ExtractTextPlugin('[name]-[hash].css'));
 
 config.plugins.push(new ManifestPlugin({


### PR DESCRIPTION
#### Changes
This pull request fixes two issues with the Webpack build:

💣 It now properly clears `next/assets` when beginning a build (rather than the old `dist` path). This means we won't end up with bajillions of copies of the built assets on our dev machines.

🎞 Fixes an issue where we were accidentally removing all Webpack plugins before adding the "patched" version of `ExtractTextPlugin` (see #147), and shipping debug builds to production. (This drops our script payload from 2MB to 400kb, phew!)

💻 🔜 🏁 