### PR TITLE
Reportback uploader messaging updates

### DIFF
--- a/resources/assets/actions/reportback.js
+++ b/resources/assets/actions/reportback.js
@@ -61,7 +61,7 @@ export function storeReportbackFailed(error) {
 }
 
 // Action: storing new user submitted reportback was successful.
-export function storeReportbackSuccessful(reportback) {
+export function storeReportbackSuccessful() {
   return { type: STORE_REPORTBACK_SUCCESSFUL };
 }
 

--- a/resources/assets/components/ReportbackUploader/index.js
+++ b/resources/assets/components/ReportbackUploader/index.js
@@ -34,35 +34,8 @@ class ReportbackUploader extends React.Component {
   };
 
   componentDidMount() {
-    // console.log(this.form);
     this.props.fetchUserReportbacks(this.props.userId, this.props.legacyCampaignId);
   }
-
-  shouldComponentUpdate(nextProps, nextState) {
-    if (has(nextProps.submissions.messaging, 'error')) {
-      console.log('shouldComponentUpdate...');
-      // console.log(nextProps);
-      // console.log(nextState);
-
-      this.form.reset();
-
-      return true;
-    }
-
-    return false;
-  }
-
-  // componentWillMount() {
-  //   if (has(this.submissions.messaging, 'success')) {
-  //     console.log('we have A success message');
-  //     this.setState({
-  //       media: this.defaultMediaState()
-  //     });
-  //   }
-  //   // else {
-  //   //   console.log('we have NO success message');
-  //   // }
-  // }
 
   handleOnFileUpload(media) {
     this.setState({ media })
@@ -85,6 +58,14 @@ class ReportbackUploader extends React.Component {
     reportback.media.type = fileType ? fileType.substring(0, fileType.indexOf('/')) : null;
 
     this.props.submitReportback(this.setFormData(reportback));
+
+    // @TODO: only reset form AFTER successful RB submission.
+    // We'll make this a lot better once we switch to storing all the state
+    // in the Redux store @_@
+    this.form.reset();
+    this.setState({
+      media: this.defaultMediaState()
+    });
   }
 
   setFormData(reportback) {
@@ -106,12 +87,6 @@ class ReportbackUploader extends React.Component {
 
   render() {
     const submissions = this.props.submissions;
-    // console.log(submissions);
-    // console.log(this.form);
-
-    // if (has(submissions.messaging, 'success')) {
-    //   this.form.reset();
-    // }
 
     return (
       <Block>

--- a/resources/assets/components/ReportbackUploader/index.js
+++ b/resources/assets/components/ReportbackUploader/index.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { has } from 'lodash';
 import Block from '../Block';
 import { Flex } from '../Flex';
 import MediaUploader from '../MediaUploader';
@@ -33,8 +34,35 @@ class ReportbackUploader extends React.Component {
   };
 
   componentDidMount() {
+    // console.log(this.form);
     this.props.fetchUserReportbacks(this.props.userId, this.props.legacyCampaignId);
   }
+
+  shouldComponentUpdate(nextProps, nextState) {
+    if (has(nextProps.submissions.messaging, 'error')) {
+      console.log('shouldComponentUpdate...');
+      // console.log(nextProps);
+      // console.log(nextState);
+
+      this.form.reset();
+
+      return true;
+    }
+
+    return false;
+  }
+
+  // componentWillMount() {
+  //   if (has(this.submissions.messaging, 'success')) {
+  //     console.log('we have A success message');
+  //     this.setState({
+  //       media: this.defaultMediaState()
+  //     });
+  //   }
+  //   // else {
+  //   //   console.log('we have NO success message');
+  //   // }
+  // }
 
   handleOnFileUpload(media) {
     this.setState({ media })
@@ -57,12 +85,6 @@ class ReportbackUploader extends React.Component {
     reportback.media.type = fileType ? fileType.substring(0, fileType.indexOf('/')) : null;
 
     this.props.submitReportback(this.setFormData(reportback));
-
-    // @TODO: only reset form AFTER successful RB submission.
-    this.form.reset();
-    this.setState({
-      media: this.defaultMediaState()
-    });
   }
 
   setFormData(reportback) {
@@ -83,12 +105,20 @@ class ReportbackUploader extends React.Component {
   }
 
   render() {
+    const submissions = this.props.submissions;
+    // console.log(submissions);
+    // console.log(this.form);
+
+    // if (has(submissions.messaging, 'success')) {
+    //   this.form.reset();
+    // }
+
     return (
       <Block>
         <div className="reportback-uploader">
           <h2 className="heading">Upload your photos</h2>
 
-          { this.props.submissions.messaging ? <FormMessage messaging={this.props.submissions.messaging} /> : null }
+          { submissions.messaging ? <FormMessage messaging={submissions.messaging} /> : null }
 
           <form className="reportback-form" onSubmit={this.handleOnSubmitForm} ref={(form) => this.form = form}>
             <MediaUploader label="Send us your photo" media={this.state.media} onChange={this.handleOnFileUpload} />
@@ -110,12 +140,12 @@ class ReportbackUploader extends React.Component {
               <textarea className="text-field" id="why_participated" name="why_participated" placeholder="No need to write an essay, but we'd love to see why this matters to you!" ref={(input) => this.why_participated = input}></textarea>
             </div>
 
-            <button className="button" type="submit">Submit a new photo</button>
+            <button className="button" type="submit" disabled={submissions.isStoring ? true : false }>Submit a new photo</button>
           </form>
         </div>
-          <Gallery isFetching={this.props.submissions.isFetching} type="triad">
+          <Gallery isFetching={submissions.isFetching} type="triad">
             {/* @TODO: Need to normalize data for uploaded RBs vs API retrieved RBs earlier in process if possible... */}
-            {this.props.submissions.items.map((submission, index) => <ReportbackItem key={makeHash(submission.media.uri || submission.media.filePreviewUrl)} {...submission} url={submission.media.uri || submission.media.filePreviewUrl} reaction={null} />)}
+            {submissions.items.map((submission, index) => <ReportbackItem key={makeHash(submission.media.uri || submission.media.filePreviewUrl)} {...submission} url={submission.media.uri || submission.media.filePreviewUrl} reaction={null} />)}
           </Gallery>
       </Block>
     );

--- a/resources/assets/reducers/submissions.js
+++ b/resources/assets/reducers/submissions.js
@@ -25,11 +25,7 @@ const submissions = (state = {}, action) => {
       return {...state, isFetching: false};
 
     case STORE_REPORTBACK_PENDING:
-      return {
-        ...state,
-        // messaging: null,
-        isStoring: true
-      };
+      return {...state, isStoring: true};
 
     case STORE_REPORTBACK_FAILED:
       return {

--- a/resources/assets/reducers/submissions.js
+++ b/resources/assets/reducers/submissions.js
@@ -25,13 +25,27 @@ const submissions = (state = {}, action) => {
       return {...state, isFetching: false};
 
     case STORE_REPORTBACK_PENDING:
-      return {...state, isStoring: true};
+      return {
+        ...state,
+        // messaging: null,
+        isStoring: true
+      };
 
     case STORE_REPORTBACK_FAILED:
-      return {...state, messaging: action.error};
+      return {
+        ...state,
+        messaging: action.error,
+        isStoring: false
+      };
 
     case STORE_REPORTBACK_SUCCESSFUL:
-      return {...state, isStoring: false};
+      return {
+        ...state,
+        messaging: {
+          success: { message: 'Thanks! We got your photo and you\'re entered to win the scholarship!' }
+        },
+        isStoring: false
+      };
 
     case ADD_SUBMISSION_METADATA:
       return {


### PR DESCRIPTION
Hokay! This PR adds success messaging, disables the submit button while the uploader is "thinking" 🤔 

We're holding off on resetting the form only after successful submit, once we move the RB Uploader state to the Redux store. It was proving a bit hairy to reset the form since there's some state change updates and React gets mad if that's done in the wrong place.