### PR TITLE
Assorted fixes to the embed component.

### DIFF
--- a/resources/assets/components/Embed/embed.scss
+++ b/resources/assets/components/Embed/embed.scss
@@ -1,4 +1,4 @@
-@import '~@dosomething/forge/scss/toolkit';
+@import '../../scss/next-toolbox';
 
 .embed {
   display: flex;
@@ -7,7 +7,6 @@
   margin: 0 auto $base-spacing;
   overflow: hidden;
   min-height: 100px;
-  transition: box-shadow 1s;
 
   a {
     color: $black;
@@ -18,7 +17,12 @@
 
 .embed.-loaded {
   display: block;
-  box-shadow: $box-shadow;
+  border: 1px solid $primary-border-color;
+  border-radius: $lg-border-radius;
+
+  &:hover {
+    background: $light-background-color;
+  }
 }
 
 .embed__preview {

--- a/resources/assets/components/Embed/index.js
+++ b/resources/assets/components/Embed/index.js
@@ -23,10 +23,10 @@ class Embed extends React.Component {
     // If an <iframe> code snippet is provided, use that. Otherwise, build preview card.
     if (this.state.code) {
       embed = <div className="media-video" dangerouslySetInnerHTML={{__html: this.state.code }} />;
-    } else if (this.state.title && this.state.url && this.state.image) {
+    } else if (this.state.title && this.state.url) {
       embed = (
         <a href={this.state.url} target="_blank">
-          <Figure className="embed__preview" image={this.state.image} alignment="left" size="large">
+          <Figure className="embed__preview" image={this.state.image || this.state.provider.icon} alignment="left-collapse" size="large">
             <h3>{ this.state.title }</h3>
             { this.state.description ? <p>{ this.state.description }</p> : null }
             <p className="footnote">{ this.state.provider.name }</p>

--- a/resources/assets/components/Figure/figure.scss
+++ b/resources/assets/components/Figure/figure.scss
@@ -1,3 +1,5 @@
+@import '../../scss/next-toolbox';
+
 .figure.-small > .figure__media {
   width: 50px;
 
@@ -8,4 +10,20 @@
   width: 200px;
 
   img { width: 100% }
+}
+
+.figure.-left-collapse {
+  text-align: left;
+
+  @include media($tablet) {
+    > .figure__media {
+      float: left;
+      margin-right: gutter();
+      margin-bottom: 0;
+    }
+
+    > .figure__body {
+      overflow: hidden;
+    }
+  }
 }

--- a/resources/assets/components/Figure/index.js
+++ b/resources/assets/components/Figure/index.js
@@ -12,7 +12,7 @@ export const BaseFigure = ({alignment, verticalAlignment, media, size, className
 );
 
 BaseFigure.propTypes = {
-  alignment: React.PropTypes.oneOf(['left', 'right']),
+  alignment: React.PropTypes.oneOf(['left', 'right', 'left-collapse']),
   verticalAlignment: React.PropTypes.oneOf(['center']),
   size: React.PropTypes.oneOf(['small', 'medium', 'large']),
   media: React.PropTypes.element,

--- a/resources/assets/normalizers.js
+++ b/resources/assets/normalizers.js
@@ -48,7 +48,7 @@ export function normalizeReportbackItemResponse(data) {
       reacted: !!(currentUser && currentUser.kudos_id),
       total: kudos ? kudos.term.total : 0,
       termId: kudos ? kudos.term.id : '1274', // This is a hardcoded default because phoenix-ashes is bugged.
-    }
+    };
 
     const reportback = reportbackItem.reportback;
     let existingReportback = reportbacks[reportback.id];


### PR DESCRIPTION
#### Changes
__This pull request includes some little fixes to the embed component.__ It fixes a bug where URLs without preview images wouldn't render (by removing that requirement and using provider icon as a fallback), updates styles to match the latest mocks (no drop shadow), and improves appearance on mobile devices by collapsing to a single column.

<img width="624" alt="screen shot 2017-04-14 at 5 36 52 pm" src="https://cloud.githubusercontent.com/assets/583202/25056801/4322750a-2139-11e7-8650-5354ae75eb1b.png">
