### PR TITLE
Run linter on Wercker builds.

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -8,6 +8,9 @@ module.exports = {
     // in development builds.
     'no-console': 'off',
 
+    // For now, only warn on missing alt tags.
+    'jsx-a11y/img-has-alt': 'warn',
+
     // Require space before "!" unary operator to conform to
     // our PHP code style:
     'space-unary-ops': ['error', {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "history": "^3.0.0",
     "lodash": "^4.17.4",
     "marked": "^0.3.6",
+    "prop-types": "^15.5.8",
     "react": "^15.4.2",
     "react-dom": "^15.4.2",
     "react-redux": "^5.0.2",
@@ -36,9 +37,9 @@
     "whatwg-fetch": "^2.0.3"
   },
   "devDependencies": {
+    "@dosomething/babel-config": "^1.0",
     "@dosomething/eslint-config": "^2.0.0",
     "@dosomething/webpack-config": "^2.0.0",
-    "@dosomething/babel-config": "^1.0",
     "babel-eslint": "^7.2.2",
     "dotenv": "^4.0.0",
     "modernizr": "^3.3.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "scripts": {
-    "lint": "eslint resources/assets/**/*.js",
+    "lint": "eslint --ext .js resources/assets",
     "start": "npm run clean && NODE_ENV=development webpack --watch",
     "build:dev": "npm run clean && NODE_ENV=development webpack",
     "build": "npm run clean && NODE_ENV=production webpack",

--- a/resources/assets/components/ActionPage/index.js
+++ b/resources/assets/components/ActionPage/index.js
@@ -1,15 +1,16 @@
 import React from 'react';
 import classnames from 'classnames';
+import { cloneDeep } from 'lodash';
+
+import LazyImage from '../LazyImage';
 import Markdown from '../Markdown';
 import ReportbackUploaderContainer from '../../containers/ReportbackUploaderContainer';
 import Revealer from '../Revealer';
-import LazyImage from '../LazyImage';
 import { Flex, FlexCell } from '../Flex';
 import { convertNumberToWord } from '../../helpers';
-import cloneDeep from 'lodash/cloneDeep';
 import './actionPage.scss';
 
-const Stepheader = ({ title, step, background }) => (
+const StepHeader = ({ title, step, background }) => (
   <FlexCell width="full">
     <div className="action-step__header">
       <LazyImage src={background} />
@@ -19,12 +20,32 @@ const Stepheader = ({ title, step, background }) => (
   </FlexCell>
 );
 
+StepHeader.propTypes = {
+  title: React.PropTypes.string.isRequired,
+  step: React.PropTypes.number.isRequired,
+  background: React.PropTypes.string.isRequired,
+};
+
+/**
+ * Render a photo on the action page.
+ *
+ * @param step
+ * @param index
+ * @returns {XML}
+ */
 const renderPhoto = (photo, index) => (
   <div className="action-step__photo" key={index}>
     <img src={photo} />
   </div>
 );
 
+/**
+ * Render a single step on the action page.
+ *
+ * @param step
+ * @param index
+ * @returns {XML}
+ */
 const renderStep = (step, index) => {
   const title = step.title;
   const background = step.background;
@@ -34,9 +55,9 @@ const renderStep = (step, index) => {
 
   return (
     <FlexCell width="full" key={index}>
-      <div className={classnames('action-step', {'-truncate': shouldTruncate})}>
+      <div className={classnames('action-step', { '-truncate': shouldTruncate })}>
         <Flex>
-          <Stepheader title={title} step={index + 1} background={background} />
+          <StepHeader title={title} step={index + 1} background={background} />
           <FlexCell width="two-thirds">
             <Markdown>{ step.content }</Markdown>
           </FlexCell>
@@ -48,17 +69,22 @@ const renderStep = (step, index) => {
         </Flex>
       </div>
     </FlexCell>
-  )
-}
+  );
+};
 
 /**
  * Render the feed.
  *
  * @returns {XML}
  */
-const ActionPage = ({ steps, callToAction, campaignId, signedUp, hasPendingSignup, isAuthenticated, clickedSignUp }) => {
-  let actionSteps = cloneDeep(steps);
+const ActionPage = (props) => {
+  const {
+    steps, callToAction, campaignId, isAuthenticated,
+    signedUp, hasPendingSignup, clickedSignUp,
+  } = props;
 
+  // Truncate steps if user isn't signed up.
+  let actionSteps = cloneDeep(steps);
   if (! signedUp) {
     actionSteps = actionSteps.slice(0, 2);
 
@@ -67,13 +93,18 @@ const ActionPage = ({ steps, callToAction, campaignId, signedUp, hasPendingSignu
     }
   }
 
-  const revealer = <Revealer title='join us' callToAction={callToAction}
-                             isLoading={hasPendingSignup}
-                             onReveal={() => clickedSignUp(campaignId, ActionPage.defaultMetadata)} />;
+  const revealer = (
+    <Revealer
+      title="Join Us"
+      callToAction={callToAction}
+      isLoading={hasPendingSignup}
+      onReveal={() => clickedSignUp(campaignId, ActionPage.defaultMetadata)}
+    />
+  );
 
   const uploader = (
     <FlexCell key="reportback_uploader" width="full">
-      <ReportbackUploaderContainer/>
+      <ReportbackUploaderContainer />
     </FlexCell>
   );
 
@@ -86,7 +117,23 @@ const ActionPage = ({ steps, callToAction, campaignId, signedUp, hasPendingSignu
   );
 };
 
+ActionPage.propTypes = {
+  steps: React.PropTypes.arrayOf(React.PropTypes.shape({
+    title: React.PropTypes.string.isRequired,
+    content: React.PropTypes.string.isRequired,
+    background: React.PropTypes.string.isRequired,
+    photos: React.PropTypes.array,
+  })),
+  callToAction: React.PropTypes.string.isRequired,
+  campaignId: React.PropTypes.string.isRequired,
+  hasPendingSignup: React.PropTypes.bool.isRequired,
+  isAuthenticated: React.PropTypes.bool.isRequired,
+  signedUp: React.PropTypes.bool.isRequired,
+  clickedSignUp: React.PropTypes.func.isRequired,
+};
+
 ActionPage.defaultMetadata = {
+  steps: [],
   source: 'action page',
 };
 

--- a/resources/assets/components/ActionPage/index.js
+++ b/resources/assets/components/ActionPage/index.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import classnames from 'classnames';
 import { cloneDeep } from 'lodash';
@@ -21,9 +22,9 @@ const StepHeader = ({ title, step, background }) => (
 );
 
 StepHeader.propTypes = {
-  title: React.PropTypes.string.isRequired,
-  step: React.PropTypes.number.isRequired,
-  background: React.PropTypes.string.isRequired,
+  title: PropTypes.string.isRequired,
+  step: PropTypes.number.isRequired,
+  background: PropTypes.string.isRequired,
 };
 
 /**
@@ -118,18 +119,18 @@ const ActionPage = (props) => {
 };
 
 ActionPage.propTypes = {
-  steps: React.PropTypes.arrayOf(React.PropTypes.shape({
-    title: React.PropTypes.string.isRequired,
-    content: React.PropTypes.string.isRequired,
-    background: React.PropTypes.string.isRequired,
-    photos: React.PropTypes.array,
+  steps: PropTypes.arrayOf(PropTypes.shape({
+    title: PropTypes.string.isRequired,
+    content: PropTypes.string.isRequired,
+    background: PropTypes.string.isRequired,
+    photos: PropTypes.array,
   })),
-  callToAction: React.PropTypes.string.isRequired,
-  campaignId: React.PropTypes.string.isRequired,
-  hasPendingSignup: React.PropTypes.bool.isRequired,
-  isAuthenticated: React.PropTypes.bool.isRequired,
-  signedUp: React.PropTypes.bool.isRequired,
-  clickedSignUp: React.PropTypes.func.isRequired,
+  callToAction: PropTypes.string.isRequired,
+  campaignId: PropTypes.string.isRequired,
+  hasPendingSignup: PropTypes.bool.isRequired,
+  isAuthenticated: PropTypes.bool.isRequired,
+  signedUp: PropTypes.bool.isRequired,
+  clickedSignUp: PropTypes.func.isRequired,
 };
 
 ActionPage.defaultMetadata = {

--- a/resources/assets/components/Affirmation/index.js
+++ b/resources/assets/components/Affirmation/index.js
@@ -4,7 +4,6 @@ import Highlight from '../Highlight';
 import { Figure } from '../Figure';
 import { Wrapper } from '../Wrapper';
 import ShareContainer from '../../containers/ShareContainer';
-import { EMPTY_IMAGE } from '../../helpers';
 import './affirmation.scss';
 
 const Affirmation = (props) => {
@@ -33,16 +32,27 @@ const Affirmation = (props) => {
             </div>
           </div>
         </Wrapper>
-        <a className="affirmation__exit" href="#" onClick={props.hideAffirmation}>&times;</a>
+        <button className="affirmation__exit" onClick={props.hideAffirmation}>&times;</button>
       </div>
     </FlexCell>
   );
-}
+};
 
-//TODO: Replace these default strings with content from Contentful
+Affirmation.propTypes = {
+  header: React.PropTypes.string.isRequired,
+  photo: React.PropTypes.string,
+  author: React.PropTypes.string,
+  quote: React.PropTypes.string,
+  ctaHeader: React.PropTypes.string,
+  ctaDescription: React.PropTypes.string,
+  showAffirmation: React.PropTypes.func.isRequired,
+  hideAffirmation: React.PropTypes.func.isRequired,
+};
+
+// @TODO: Replace these default strings with content from Contentful
 Affirmation.defaultProps = {
   header: 'THANKS FOR JOINING!',
-  quote: `You doing this means so much to my community. Thank you so much for doing this simple action. Ramadan is a special time for us and this just makes it even more special.`,
+  quote: 'You doing this means so much to my community. Thank you so much for doing this simple action. Ramadan is a special time for us and this just makes it even more special.',
   author: 'Usra, Maryland',
   photo: 'https://static.dosomething.org/img/sincerely-us-member-quote.jpg',
   ctaHeader: 'Rally your friends!',

--- a/resources/assets/components/Affirmation/index.js
+++ b/resources/assets/components/Affirmation/index.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { FlexCell } from '../Flex';
 import Highlight from '../Highlight';
 import { Figure } from '../Figure';
-import { Wrapper } from '../Wrapper';
+import Wrapper from '../Wrapper';
 import ShareContainer from '../../containers/ShareContainer';
 import './affirmation.scss';
 

--- a/resources/assets/components/Affirmation/index.js
+++ b/resources/assets/components/Affirmation/index.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import { FlexCell } from '../Flex';
 import Highlight from '../Highlight';
@@ -39,14 +40,14 @@ const Affirmation = (props) => {
 };
 
 Affirmation.propTypes = {
-  header: React.PropTypes.string.isRequired,
-  photo: React.PropTypes.string,
-  author: React.PropTypes.string,
-  quote: React.PropTypes.string,
-  ctaHeader: React.PropTypes.string,
-  ctaDescription: React.PropTypes.string,
-  showAffirmation: React.PropTypes.bool.isRequired, // @TODO: This is confusingly named!
-  hideAffirmation: React.PropTypes.func.isRequired,
+  header: PropTypes.string.isRequired,
+  photo: PropTypes.string,
+  author: PropTypes.string,
+  quote: PropTypes.string,
+  ctaHeader: PropTypes.string,
+  ctaDescription: PropTypes.string,
+  showAffirmation: PropTypes.bool.isRequired, // @TODO: This is confusingly named!
+  hideAffirmation: PropTypes.func.isRequired,
 };
 
 // @TODO: Replace these default strings with content from Contentful

--- a/resources/assets/components/App.js
+++ b/resources/assets/components/App.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import { Provider } from 'react-redux';
 import { Router, Route } from 'react-router';
@@ -24,8 +25,8 @@ const App = ({ store, history }) => (
 );
 
 App.propTypes = {
-  store: React.PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
-  history: React.PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
+  store: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
+  history: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
 };
 
 export default App;

--- a/resources/assets/components/Block/index.js
+++ b/resources/assets/components/Block/index.js
@@ -6,11 +6,11 @@ export const BlockTitle = ({ children }) => (
   <h4 className="block__title">{children}</h4>
 );
 
-BlockTitle.PropTypes = {
-  children: React.PropTypes.string,
+BlockTitle.propTypes = {
+  children: React.PropTypes.string.isRequired,
 };
 
-const Block = (props) => (
+const Block = props => (
   <div className={classNames('block', props.className)}>
     {props.children}
   </div>
@@ -18,6 +18,11 @@ const Block = (props) => (
 
 Block.propTypes = {
   className: React.PropTypes.string,
+  children: React.PropTypes.node.isRequired,
+};
+
+Block.defaultProps = {
+  className: null,
 };
 
 export default Block;

--- a/resources/assets/components/Block/index.js
+++ b/resources/assets/components/Block/index.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import classNames from 'classnames';
 import './block.scss';
@@ -7,7 +8,7 @@ export const BlockTitle = ({ children }) => (
 );
 
 BlockTitle.propTypes = {
-  children: React.PropTypes.string.isRequired,
+  children: PropTypes.string.isRequired,
 };
 
 const Block = props => (
@@ -17,8 +18,8 @@ const Block = props => (
 );
 
 Block.propTypes = {
-  className: React.PropTypes.string,
-  children: React.PropTypes.node.isRequired,
+  className: PropTypes.string,
+  children: PropTypes.node.isRequired,
 };
 
 Block.defaultProps = {

--- a/resources/assets/components/CallToActionBlock/index.js
+++ b/resources/assets/components/CallToActionBlock/index.js
@@ -19,11 +19,12 @@ const renderImpactContent = (data) => {
   return null;
 };
 
-const renderBackgroundImageStyle = (imageUrl) => (
+const renderBackgroundImageStyle = imageUrl => (
   { backgroundImage: `url(${contentfulImageUrl(imageUrl, '400', '400', 'fill')})` }
 );
 
-const CallToActionBlock = ({ isAffiliated, fields, imageUrl, legacyCampaignId, clickedSignUp, modifierClasses = [] }) => {
+const CallToActionBlock = (props) => {
+  const { isAffiliated, fields, imageUrl, campaignId, clickedSignUp, modifierClasses } = props;
   const { title, content, additionalContent } = fields;
   const hasPhoto = additionalContent ? additionalContent.hasPhoto : false;
 
@@ -31,34 +32,48 @@ const CallToActionBlock = ({ isAffiliated, fields, imageUrl, legacyCampaignId, c
   const buttonText = isAffiliated ? 'Make Cards' : 'Join Us';
 
   const metadata = mergeMetadata(CallToActionBlock.defaultMetadata, {
-    hasPhoto: hasPhoto,
+    hasPhoto,
     hasImpact: additionalContent !== 'undefined',
     hasContent: typeof content !== 'undefined',
   });
 
-  const handleOnClickButton = () => clickedSignUp(legacyCampaignId, metadata);
+  const handleOnClickButton = () => clickedSignUp(campaignId, metadata);
 
   return (
-    <div className={classnames('cta', modifiers(modifierClasses), {'has-photo': hasPhoto})}>
+    <div className={classnames('cta', modifiers(modifierClasses), { 'has-photo': hasPhoto })}>
       <div className="cta__content">
-        { !content ? <div className="cta__block"><p className="cta__title">{title}</p></div> : null }
+        { ! content ? <div className="cta__block"><p className="cta__title">{title}</p></div> : null }
 
         { additionalContent ? renderImpactContent(additionalContent) : null}
 
         { content ? <div className="cta__block"><Markdown className="cta__message">{content}</Markdown></div> : null }
 
         <div className="cta__block">
-          <a className="button" onClick={handleOnClickButton}>{buttonText}</a>
+          <button className="button" onClick={handleOnClickButton}>{buttonText}</button>
         </div>
       </div>
 
-      { hasPhoto ? <div className="cta__photo" style={renderBackgroundImageStyle(imageUrl)}></div> : null }
+      { hasPhoto ? <div className="cta__photo" style={renderBackgroundImageStyle(imageUrl)} /> : null }
     </div>
   );
 };
 
+CallToActionBlock.propTypes = {
+  isAffiliated: React.PropTypes.bool,
+  fields: React.PropTypes.shape({
+    title: React.PropTypes.string,
+    content: React.PropTypes.string,
+    additionalContent: React.PropTypes.instanceOf(Object),
+  }),
+  imageUrl: React.PropTypes.string.isRequired,
+  campaignId: React.PropTypes.string.isRequired,
+  clickedSignUp: React.PropTypes.func.isRequired,
+  modifierClasses: React.PropTypes.arrayOf(React.PropTypes.string),
+};
+
 CallToActionBlock.defaultMetadata = {
   source: 'call to action block',
-}
+  modifierClasses: [],
+};
 
 export default CallToActionBlock;

--- a/resources/assets/components/CallToActionBlock/index.js
+++ b/resources/assets/components/CallToActionBlock/index.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import classnames from 'classnames';
 import Markdown from '../Markdown';
@@ -59,16 +60,16 @@ const CallToActionBlock = (props) => {
 };
 
 CallToActionBlock.propTypes = {
-  isAffiliated: React.PropTypes.bool,
-  fields: React.PropTypes.shape({
-    title: React.PropTypes.string,
-    content: React.PropTypes.string,
-    additionalContent: React.PropTypes.instanceOf(Object),
+  isAffiliated: PropTypes.bool,
+  fields: PropTypes.shape({
+    title: PropTypes.string,
+    content: PropTypes.string,
+    additionalContent: PropTypes.instanceOf(Object),
   }),
-  imageUrl: React.PropTypes.string.isRequired,
-  campaignId: React.PropTypes.string.isRequired,
-  clickedSignUp: React.PropTypes.func.isRequired,
-  modifierClasses: React.PropTypes.string, // @TODO: Should this be an array?
+  imageUrl: PropTypes.string.isRequired,
+  campaignId: PropTypes.string.isRequired,
+  clickedSignUp: PropTypes.func.isRequired,
+  modifierClasses: PropTypes.string, // @TODO: Should this be an array?
 };
 
 CallToActionBlock.defaultMetadata = {

--- a/resources/assets/components/CampaignUpdateBlock/index.js
+++ b/resources/assets/components/CampaignUpdateBlock/index.js
@@ -50,8 +50,8 @@ CampaignUpdateBlock.propTypes = {
     content: React.PropTypes.string,
     additionalContent: React.PropTypes.shape({
       author: React.PropTypes.string.isRequired,
-      jobTitle: React.PropTypes.string.isRequired,
-      avatar: React.PropTypes.string.isRequired,
+      jobTitle: React.PropTypes.string,
+      avatar: React.PropTypes.string,
     }),
   }).isRequired,
 };

--- a/resources/assets/components/CampaignUpdateBlock/index.js
+++ b/resources/assets/components/CampaignUpdateBlock/index.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import classnames from 'classnames';
 import Markdown from '../Markdown';
@@ -8,16 +9,16 @@ import DEFAULT_AVATAR from './default-avatar.png';
 import './campaign-update.scss';
 
 const Byline = ({ author, jobTitle, avatar }) => (
-  <Figure size="small" alignment="left" verticalAlignment="center" image={avatar} imageClassName="avatar">
+  <Figure size="small" alignment="left" verticalAlignment="center" image={avatar} alt={`picture of ${author}`} imageClassName="avatar">
     <strong>{author}</strong><br />
     <p className="footnote">{jobTitle}</p>
   </Figure>
 );
 
 Byline.propTypes = {
-  author: React.PropTypes.string.isRequired,
-  jobTitle: React.PropTypes.string,
-  avatar: React.PropTypes.string,
+  author: PropTypes.string.isRequired,
+  jobTitle: PropTypes.string,
+  avatar: PropTypes.string,
 };
 
 Byline.defaultProps = {
@@ -45,13 +46,13 @@ const CampaignUpdateBlock = (props) => {
 };
 
 CampaignUpdateBlock.propTypes = {
-  fields: React.PropTypes.shape({
-    title: React.PropTypes.string,
-    content: React.PropTypes.string,
-    additionalContent: React.PropTypes.shape({
-      author: React.PropTypes.string.isRequired,
-      jobTitle: React.PropTypes.string,
-      avatar: React.PropTypes.string,
+  fields: PropTypes.shape({
+    title: PropTypes.string,
+    content: PropTypes.string,
+    additionalContent: PropTypes.shape({
+      author: PropTypes.string.isRequired,
+      jobTitle: PropTypes.string,
+      avatar: PropTypes.string,
     }),
   }).isRequired,
 };

--- a/resources/assets/components/CampaignUpdateBlock/index.js
+++ b/resources/assets/components/CampaignUpdateBlock/index.js
@@ -2,21 +2,32 @@ import React from 'react';
 import classnames from 'classnames';
 import Markdown from '../Markdown';
 import Block, { BlockTitle } from '../Block';
-import Figure from '../Figure';
+import { Figure } from '../Figure';
 import Embed from '../Embed';
 import DEFAULT_AVATAR from './default-avatar.png';
 import './campaign-update.scss';
 
-const Byline = ({author, jobTitle = 'DoSomething.org Staff', avatar = DEFAULT_AVATAR}) => (
+const Byline = ({ author, jobTitle, avatar }) => (
   <Figure size="small" alignment="left" verticalAlignment="center" image={avatar} imageClassName="avatar">
-    <strong>{author}</strong><br/>
+    <strong>{author}</strong><br />
     <p className="footnote">{jobTitle}</p>
   </Figure>
 );
 
+Byline.propTypes = {
+  author: React.PropTypes.string.isRequired,
+  jobTitle: React.PropTypes.string,
+  avatar: React.PropTypes.string,
+};
+
+Byline.defaultProps = {
+  jobTitle: 'DoSomething.org Staff',
+  avatar: DEFAULT_AVATAR,
+};
+
 const CampaignUpdateBlock = (props) => {
   const { title, content, link, additionalContent } = props.fields;
-  let { author, jobTitle, avatar } = additionalContent;
+  const { author, jobTitle, avatar } = additionalContent;
 
   const isTweet = content.length < 144;
 
@@ -28,9 +39,21 @@ const CampaignUpdateBlock = (props) => {
         {content}
       </Markdown>
       { link ? <Embed url={link} /> : null }
-      { author ? <Byline author={author} jobTitle={jobTitle} avatar={avatar} />: null}
+      { author ? <Byline author={author} jobTitle={jobTitle} avatar={avatar} /> : null}
     </Block>
   );
+};
+
+CampaignUpdateBlock.propTypes = {
+  fields: React.PropTypes.shape({
+    title: React.PropTypes.string,
+    content: React.PropTypes.string,
+    additionalContent: React.PropTypes.shape({
+      author: React.PropTypes.string.isRequired,
+      jobTitle: React.PropTypes.string.isRequired,
+      avatar: React.PropTypes.string.isRequired,
+    }),
+  }).isRequired,
 };
 
 export default CampaignUpdateBlock;

--- a/resources/assets/components/Chrome.js
+++ b/resources/assets/components/Chrome.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import Dashboard from './Dashboard';
 import Debugger from './Debugger';
@@ -37,29 +38,29 @@ const Chrome = props => (
 );
 
 Chrome.propTypes = {
-  isAffiliated: React.PropTypes.bool,
-  title: React.PropTypes.string.isRequired,
-  subtitle: React.PropTypes.string.isRequired,
-  blurb: React.PropTypes.string.isRequired,
-  coverImage: React.PropTypes.shape({
-    description: React.PropTypes.string,
-    url: React.PropTypes.string,
+  isAffiliated: PropTypes.bool,
+  title: PropTypes.string.isRequired,
+  subtitle: PropTypes.string.isRequired,
+  blurb: PropTypes.string.isRequired,
+  coverImage: PropTypes.shape({
+    description: PropTypes.string,
+    url: PropTypes.string,
   }).isRequired,
-  legacyCampaignId: React.PropTypes.string.isRequired,
-  clickedSignUp: React.PropTypes.func.isRequired,
-  totalCampaignSignups: React.PropTypes.number.isRequired,
-  dashboard: React.PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
-  endDate: React.PropTypes.shape({
-    date: React.PropTypes.string,
-    timezone: React.PropTypes.string,
-    timezone_type: React.PropTypes.number,
+  legacyCampaignId: PropTypes.string.isRequired,
+  clickedSignUp: PropTypes.func.isRequired,
+  totalCampaignSignups: PropTypes.number.isRequired,
+  dashboard: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
+  endDate: PropTypes.shape({
+    date: PropTypes.string,
+    timezone: PropTypes.string,
+    timezone_type: PropTypes.number,
   }).isRequired,
-  children: React.PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
-  user: React.PropTypes.shape({
-    id: React.PropTypes.string,
-    role: React.PropTypes.string,
+  children: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
+  user: PropTypes.shape({
+    id: PropTypes.string,
+    role: PropTypes.string,
   }).isRequired,
-  signups: React.PropTypes.array.isRequired, // eslint-disable-line react/forbid-prop-types
+  signups: PropTypes.array.isRequired, // eslint-disable-line react/forbid-prop-types
 };
 
 Chrome.defaultProps = {

--- a/resources/assets/components/ContentPage/index.js
+++ b/resources/assets/components/ContentPage/index.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import Markdown from '../Markdown';
 import CallToActionContainer from '../../containers/CallToActionContainer';
@@ -29,14 +30,14 @@ const ContentPage = ({ pages, route }) => {
 };
 
 ContentPage.propTypes = {
-  pages: React.PropTypes.arrayOf(React.PropTypes.shape({
-    fields: React.PropTypes.shape({
-      title: React.PropTypes.string.isRequired,
-      slug: React.PropTypes.string.isRequired,
-      content: React.PropTypes.string.isRequired,
+  pages: PropTypes.arrayOf(PropTypes.shape({
+    fields: PropTypes.shape({
+      title: PropTypes.string.isRequired,
+      slug: PropTypes.string.isRequired,
+      content: PropTypes.string.isRequired,
     }),
   })),
-  route: React.PropTypes.instanceOf(Object).isRequired,
+  route: PropTypes.instanceOf(Object).isRequired,
 };
 
 ContentPage.defaultProps = {

--- a/resources/assets/components/ContentfulImage/index.js
+++ b/resources/assets/components/ContentfulImage/index.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import { contentfulImageUrl } from '../../helpers';
 
@@ -6,10 +7,10 @@ const ContentfulImage = ({ url, width, height, fit }) => (
 );
 
 ContentfulImage.propTypes = {
-  url: React.PropTypes.string.isRequired,
-  width: React.PropTypes.string,
-  height: React.PropTypes.string,
-  fit: React.PropTypes.string,
+  url: PropTypes.string.isRequired,
+  width: PropTypes.string,
+  height: PropTypes.string,
+  fit: PropTypes.string,
 };
 
 ContentfulImage.defaultProps = {

--- a/resources/assets/components/Dashboard/index.js
+++ b/resources/assets/components/Dashboard/index.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import { Flex, FlexCell } from '../Flex';
 import ShareContainer from '../../containers/ShareContainer';
@@ -54,18 +55,18 @@ const Dashboard = (props) => {
 };
 
 Dashboard.propTypes = {
-  totalCampaignSignups: React.PropTypes.number.isRequired,
-  endDate: React.PropTypes.shape({
-    date: React.PropTypes.string,
+  totalCampaignSignups: PropTypes.number.isRequired,
+  endDate: PropTypes.shape({
+    date: PropTypes.string,
   }).isRequired,
-  content: React.PropTypes.shape({
-    fields: React.PropTypes.shape({
-      firstValue: React.PropTypes.string.isRequired,
-      firstDescription: React.PropTypes.string.isRequired,
-      secondValue: React.PropTypes.string.isRequired,
-      secondDescription: React.PropTypes.string.isRequired,
-      shareHeader: React.PropTypes.string.isRequired,
-      shareCopy: React.PropTypes.string.isRequired,
+  content: PropTypes.shape({
+    fields: PropTypes.shape({
+      firstValue: PropTypes.string.isRequired,
+      firstDescription: PropTypes.string.isRequired,
+      secondValue: PropTypes.string.isRequired,
+      secondDescription: PropTypes.string.isRequired,
+      shareHeader: PropTypes.string.isRequired,
+      shareCopy: PropTypes.string.isRequired,
     }),
   }),
 };

--- a/resources/assets/components/Debugger/index.js
+++ b/resources/assets/components/Debugger/index.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import { Flex, FlexCell } from '../Flex';
 import {
@@ -38,10 +39,10 @@ const Debugger = (props) => {
 };
 
 Debugger.propTypes = {
-  signups: React.PropTypes.arrayOf(React.PropTypes.string),
-  user: React.PropTypes.shape({
-    id: React.PropTypes.string,
-    role: React.PropTypes.string,
+  signups: PropTypes.arrayOf(PropTypes.string),
+  user: PropTypes.shape({
+    id: PropTypes.string,
+    role: PropTypes.string,
   }).isRequired,
 };
 

--- a/resources/assets/components/Embed/index.js
+++ b/resources/assets/components/Embed/index.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import classnames from 'classnames';
 import { Phoenix } from '@dosomething/gateway';
@@ -27,7 +28,7 @@ class Embed extends React.Component {
     } else if (this.state.title && this.state.url) {
       embed = (
         <a href={this.state.url} target="_blank" rel="noopener noreferrer">
-          <Figure className="embed__preview" image={this.state.image || this.state.provider.icon} alignment="left-collapse" size="large">
+          <Figure className="embed__preview" image={this.state.image || this.state.provider.icon} alt={this.state.provider.name} alignment="left-collapse" size="large">
             <h3>{ this.state.title }</h3>
             { this.state.description ? <p>{ this.state.description }</p> : null }
             <p className="footnote">{ this.state.provider.name }</p>
@@ -45,7 +46,7 @@ class Embed extends React.Component {
 }
 
 Embed.propTypes = {
-  url: React.PropTypes.string.isRequired,
+  url: PropTypes.string.isRequired,
 };
 
 export default Embed;

--- a/resources/assets/components/Feed/index.js
+++ b/resources/assets/components/Feed/index.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import { get } from 'lodash';
 import { mergeMetadata } from '../../helpers/analytics';
@@ -64,20 +65,20 @@ const Feed = (props) => {
 };
 
 Feed.propTypes = {
-  blocks: React.PropTypes.arrayOf(React.PropType.shape({
-    id: React.PropTypes.string.isRequired,
-    type: React.PropTypes.string.isRequired,
-    content: React.PropTypes.string,
-    additionalContent: React.PropTypes.instanceOf(Object).isRequired,
+  blocks: PropTypes.arrayOf(PropTypes.shape({
+    id: PropTypes.string.isRequired,
+    type: PropTypes.string.isRequired,
+    content: PropTypes.string,
+    additionalContent: PropTypes.instanceOf(Object),
   })),
-  callToAction: React.PropTypes.string.isRequired,
-  campaignId: React.PropTypes.string.isRequired,
-  signedUp: React.PropTypes.bool.isRequired,
-  hasPendingSignup: React.PropTypes.bool.isRequired,
-  isAuthenticated: React.PropTypes.bool.isRequired,
-  canLoadMorePages: React.PropTypes.bool.isRequired,
-  clickedViewMore: React.PropTypes.func.isRequired,
-  clickedSignUp: React.PropTypes.func.isRequired,
+  callToAction: PropTypes.string.isRequired,
+  campaignId: PropTypes.string.isRequired,
+  signedUp: PropTypes.bool.isRequired,
+  hasPendingSignup: PropTypes.bool.isRequired,
+  isAuthenticated: PropTypes.bool.isRequired,
+  canLoadMorePages: PropTypes.bool.isRequired,
+  clickedViewMore: PropTypes.func.isRequired,
+  clickedSignUp: PropTypes.func.isRequired,
 };
 
 Feed.defaultProps = {

--- a/resources/assets/components/FeedEnclosure/index.js
+++ b/resources/assets/components/FeedEnclosure/index.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Wrapper } from '../Wrapper';
+import Wrapper from '../Wrapper';
 import './feed-enclosure.scss';
 
 const FeedEnclosure = ({children}) => (

--- a/resources/assets/components/FeedEnclosure/index.js
+++ b/resources/assets/components/FeedEnclosure/index.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import Wrapper from '../Wrapper';
 import './feed-enclosure.scss';
@@ -11,7 +12,7 @@ const FeedEnclosure = ({ children }) => (
 );
 
 FeedEnclosure.propTypes = {
-  children: React.PropTypes.node,
+  children: PropTypes.node,
 };
 
 FeedEnclosure.defaultProps = {

--- a/resources/assets/components/Figure/index.js
+++ b/resources/assets/components/Figure/index.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import classnames from 'classnames';
 import LazyImage from '../LazyImage';
@@ -12,12 +13,12 @@ export const BaseFigure = ({ alignment, verticalAlignment, media, size, classNam
 );
 
 BaseFigure.propTypes = {
-  className: React.PropTypes.string,
-  children: React.PropTypes.node,
-  alignment: React.PropTypes.oneOf(['left', 'right', 'left-collapse']),
-  verticalAlignment: React.PropTypes.oneOf(['center']),
-  size: React.PropTypes.oneOf(['small', 'medium', 'large']),
-  media: React.PropTypes.node.isRequired,
+  className: PropTypes.string,
+  children: PropTypes.node,
+  alignment: PropTypes.oneOf(['left', 'right', 'left-collapse']),
+  verticalAlignment: PropTypes.oneOf(['center']),
+  size: PropTypes.oneOf(['small', 'medium', 'large']),
+  media: PropTypes.node,
 };
 
 BaseFigure.defaultProps = {
@@ -26,6 +27,7 @@ BaseFigure.defaultProps = {
   children: null,
   verticalAlignment: null,
   size: null,
+  media: null,
 };
 
 export const Figure = (props) => {
@@ -35,9 +37,9 @@ export const Figure = (props) => {
 };
 
 Figure.propTypes = {
-  imageClassName: React.PropTypes.string,
-  image: React.PropTypes.string,
-  alt: React.PropTypes.string.isRequired,
+  imageClassName: PropTypes.string,
+  image: PropTypes.string,
+  alt: PropTypes.string.isRequired,
 };
 
 Figure.defaultProps = {

--- a/resources/assets/components/Flex/index.js
+++ b/resources/assets/components/Flex/index.js
@@ -3,20 +3,35 @@ import classnames from 'classnames';
 import { modifiers } from '../../helpers';
 import './flex.scss';
 
-export const Flex = ({className = null, children}) => (
+export const Flex = ({ className = null, children }) => (
   <div className={classnames('flex', className)}>
     {children}
   </div>
 );
 
-export const FlexCell = ({width = [], children}) => {
-  return (
-    <div className={classnames('flex__cell', modifiers(width))}>
-      {children}
-    </div>
-  );
+Flex.propTypes = {
+  className: React.PropTypes.string,
+  children: React.PropTypes.oneOfType([
+    React.PropTypes.object,
+    React.PropTypes.array,
+  ]).isRequired,
 };
+
+Flex.defaultProps = {
+  className: null,
+};
+
+export const FlexCell = ({ width = [], children }) => (
+  <div className={classnames('flex__cell', modifiers(width))}>
+    {children}
+  </div>
+);
 
 FlexCell.propTypes = {
   width: React.PropTypes.oneOf(['full', 'one-third', 'two-thirds']),
+  children: React.PropTypes.node.isRequired,
+};
+
+FlexCell.defaultProps = {
+  width: [],
 };

--- a/resources/assets/components/Flex/index.js
+++ b/resources/assets/components/Flex/index.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import classnames from 'classnames';
 import { modifiers } from '../../helpers';
@@ -10,10 +11,10 @@ export const Flex = ({ className = null, children }) => (
 );
 
 Flex.propTypes = {
-  className: React.PropTypes.string,
-  children: React.PropTypes.oneOfType([
-    React.PropTypes.object,
-    React.PropTypes.array,
+  className: PropTypes.string,
+  children: PropTypes.oneOfType([
+    PropTypes.object,
+    PropTypes.array,
   ]).isRequired,
 };
 
@@ -28,10 +29,10 @@ export const FlexCell = ({ width = [], children }) => (
 );
 
 FlexCell.propTypes = {
-  width: React.PropTypes.oneOf(['full', 'one-third', 'two-thirds']),
-  children: React.PropTypes.node.isRequired,
+  width: PropTypes.oneOf(['full', 'one-third', 'two-thirds']),
+  children: PropTypes.node.isRequired,
 };
 
 FlexCell.defaultProps = {
-  width: [],
+  width: null,
 };

--- a/resources/assets/components/FormMessage/index.js
+++ b/resources/assets/components/FormMessage/index.js
@@ -1,29 +1,28 @@
 import React from 'react';
 import classnames from 'classnames';
 import { has } from 'lodash';
-import { modifiers } from '../../helpers';
+import { makeHash, modifiers } from '../../helpers';
 
 import './form-message.scss';
 
-const renderMessage = (message) => {
-  return <p>{message}</p>;
-}
+const renderMessage = message => (
+  <p>{message}</p>
+);
 
-const renderValidationMessage = (error) => {
-  return (
-    <div>
-      <h3>Hmm, there were some issues with your submission.</h3>
-      <ul className="list -compacted">
-        {error.fields.map((field, index) => {
-          return <li key={index}>{field}</li>;
-        })}
-      </ul>
-    </div>
-  );
-}
+const renderValidationMessage = error => (
+  <div>
+    <h3>Hmm, there were some issues with your submission.</h3>
+    <ul className="list -compacted">
+      {error.fields.map(field => (
+        <li key={makeHash(field)}>{field}</li>
+      ))}
+    </ul>
+  </div>
+);
 
 const FormMessage = ({ messaging }) => {
-  let message, modifierClasses;
+  let message;
+  let modifierClasses;
 
   // Error
   if (has(messaging, 'error')) {
@@ -35,8 +34,7 @@ const FormMessage = ({ messaging }) => {
     // has items. Something to debate in the future.
     if (messaging.error.code === 422) {
       message = renderValidationMessage(messaging.error);
-    }
-    else {
+    } else {
       message = renderMessage(messaging.error.message);
     }
   }
@@ -53,6 +51,10 @@ const FormMessage = ({ messaging }) => {
   }
 
   return null;
+};
+
+FormMessage.propTypes = {
+  messaging: React.PropTypes.objectOf(React.PropTypes.object),
 };
 
 export default FormMessage;

--- a/resources/assets/components/FormMessage/index.js
+++ b/resources/assets/components/FormMessage/index.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import classnames from 'classnames';
 import { has } from 'lodash';
@@ -54,7 +55,7 @@ const FormMessage = ({ messaging }) => {
 };
 
 FormMessage.propTypes = {
-  messaging: React.PropTypes.objectOf(React.PropTypes.object),
+  messaging: PropTypes.objectOf(PropTypes.object),
 };
 
 export default FormMessage;

--- a/resources/assets/components/Gallery/index.js
+++ b/resources/assets/components/Gallery/index.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import classnames from 'classnames';
 import { modifiers } from '../../helpers';
@@ -13,9 +14,9 @@ const Gallery = ({ isFetching, type = null, children }) => {
 };
 
 Gallery.propTypes = {
-  children: React.PropTypes.arrayOf(React.PropTypes.element),
-  isFetching: React.PropTypes.bool,
-  type: React.PropTypes.oneOf(['triad', 'quartet']),
+  children: PropTypes.arrayOf(PropTypes.element),
+  isFetching: PropTypes.bool,
+  type: PropTypes.oneOf(['triad', 'quartet']),
 };
 
 Gallery.defaultProps = {

--- a/resources/assets/components/Gallery/index.js
+++ b/resources/assets/components/Gallery/index.js
@@ -2,21 +2,24 @@ import React from 'react';
 import classnames from 'classnames';
 import { modifiers } from '../../helpers';
 
-const renderGalleryItem = (child, index) => {
-  return <li key={`submission-${index}`} className="">{child}</li>;
-};
+const renderGalleryItem = (child, index) => <li key={`submission-${index}`} className="">{child}</li>;
 
-const Gallery = ({isFetching, type = null, children}) => {
+const Gallery = ({ isFetching, type = null, children }) => {
   if (isFetching) {
     return <div>loading…</div>;
   }
 
   return children.length ? <ul className={classnames('gallery', modifiers(type))}>{children.map(renderGalleryItem)}</ul> : null;
-}
+};
 
 Gallery.propTypes = {
   children: React.PropTypes.arrayOf(React.PropTypes.element),
+  isFetching: React.PropTypes.bool,
   type: React.PropTypes.oneOf(['triad', 'quartet']),
+};
+
+Gallery.defaultProps = {
+  isFetching: false,
 };
 
 export default Gallery;

--- a/resources/assets/components/Highlight/index.js
+++ b/resources/assets/components/Highlight/index.js
@@ -1,10 +1,11 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import './highlight.scss';
 
 const Highlight = ({ children }) => <h1 className="highlight">{ children }</h1>;
 
 Highlight.propTypes = {
-  children: React.PropTypes.string.isRequired,
+  children: PropTypes.string.isRequired,
 };
 
 export default Highlight;

--- a/resources/assets/components/Highlight/index.js
+++ b/resources/assets/components/Highlight/index.js
@@ -1,4 +1,10 @@
 import React from 'react';
 import './highlight.scss';
 
-export default ({ children }) => <h1 className="highlight">{ children }</h1>;
+const Highlight = ({ children }) => <h1 className="highlight">{ children }</h1>;
+
+Highlight.propTypes = {
+  children: React.PropTypes.string.isRequired,
+};
+
+export default Highlight;

--- a/resources/assets/components/LazyImage/index.js
+++ b/resources/assets/components/LazyImage/index.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 /* global Image */
 
 import React from 'react';
@@ -38,7 +39,7 @@ class LazyImage extends React.Component {
 }
 
 LazyImage.propTypes = {
-  src: React.PropTypes.string.isRequired,
+  src: PropTypes.string.isRequired,
 };
 
 export default LazyImage;

--- a/resources/assets/components/LazyImage/index.js
+++ b/resources/assets/components/LazyImage/index.js
@@ -1,3 +1,5 @@
+/* global Image */
+
 import React from 'react';
 import { EMPTY_IMAGE } from '../../helpers';
 
@@ -5,7 +7,7 @@ class LazyImage extends React.Component {
   constructor(props) {
     super(props);
 
-    this.state = {loaded: false};
+    this.state = { loaded: false };
   }
 
   /**
@@ -25,14 +27,18 @@ class LazyImage extends React.Component {
    * @returns {XML}
    */
   render() {
-    return <img {...this.props}
-                src={this.state.loaded && this.props.src ? this.props.src : EMPTY_IMAGE}
-                style={{transition: 'opacity 0.5s', opacity: this.state.loaded ? 1 : 0}} />;
+    return (
+      <img
+        {...this.props}
+        src={this.state.loaded && this.props.src ? this.props.src : EMPTY_IMAGE}
+        style={{ transition: 'opacity 0.5s', opacity: this.state.loaded ? 1 : 0 }}
+      />
+    );
   }
 }
 
 LazyImage.propTypes = {
-  src: React.PropTypes.string,
+  src: React.PropTypes.string.isRequired,
 };
 
 export default LazyImage;

--- a/resources/assets/components/LedeBanner/index.js
+++ b/resources/assets/components/LedeBanner/index.js
@@ -4,16 +4,24 @@ import { contentfulImageUrl } from '../../helpers';
 
 import './lede-banner.scss';
 
-const LedeBanner = ({title, subtitle, blurb, coverImage, isAffiliated, legacyCampaignId, clickedSignUp}) => {
+const LedeBanner = ({
+    title,
+    subtitle,
+    blurb,
+    coverImage,
+    isAffiliated,
+    legacyCampaignId,
+    clickedSignUp,
+  }) => {
   const backgroundImageStyle = {
     backgroundImage: `url(${contentfulImageUrl(coverImage.url, '800', '600', 'fill')})`,
   };
 
-  const onClick = () => clickedSignUp(legacyCampaignId, {source: 'lede banner'});
+  const onClick = () => clickedSignUp(legacyCampaignId, { source: 'lede banner' });
 
   return (
     <header role="banner" className="lede-banner">
-      <div className="lede-banner__image" style={backgroundImageStyle}></div>
+      <div className="lede-banner__image" style={backgroundImageStyle} />
       <div className="lede-banner__content">
         <div className="wrapper">
           <div className="lede-banner__headline">
@@ -27,7 +35,20 @@ const LedeBanner = ({title, subtitle, blurb, coverImage, isAffiliated, legacyCam
         </div>
       </div>
     </header>
-  )
+  );
+};
+
+LedeBanner.propTypes = {
+  blurb: React.PropTypes.string.isRequired,
+  clickedSignUp: React.PropTypes.func.isRequired,
+  coverImage: React.PropTypes.shape({
+    description: React.PropTypes.string,
+    url: React.PropTypes.string,
+  }).isRequired,
+  isAffiliated: React.PropTypes.bool.isRequired,
+  legacyCampaignId: React.PropTypes.string.isRequired,
+  subtitle: React.PropTypes.string.isRequired,
+  title: React.PropTypes.string.isRequired,
 };
 
 export default LedeBanner;

--- a/resources/assets/components/LedeBanner/index.js
+++ b/resources/assets/components/LedeBanner/index.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import Markdown from '../Markdown';
 import { contentfulImageUrl } from '../../helpers';
@@ -39,16 +40,16 @@ const LedeBanner = ({
 };
 
 LedeBanner.propTypes = {
-  blurb: React.PropTypes.string.isRequired,
-  clickedSignUp: React.PropTypes.func.isRequired,
-  coverImage: React.PropTypes.shape({
-    description: React.PropTypes.string,
-    url: React.PropTypes.string,
+  blurb: PropTypes.string.isRequired,
+  clickedSignUp: PropTypes.func.isRequired,
+  coverImage: PropTypes.shape({
+    description: PropTypes.string,
+    url: PropTypes.string,
   }).isRequired,
-  isAffiliated: React.PropTypes.bool.isRequired,
-  legacyCampaignId: React.PropTypes.string.isRequired,
-  subtitle: React.PropTypes.string.isRequired,
-  title: React.PropTypes.string.isRequired,
+  isAffiliated: PropTypes.bool.isRequired,
+  legacyCampaignId: PropTypes.string.isRequired,
+  subtitle: PropTypes.string.isRequired,
+  title: PropTypes.string.isRequired,
 };
 
 export default LedeBanner;

--- a/resources/assets/components/Markdown/index.js
+++ b/resources/assets/components/Markdown/index.js
@@ -5,7 +5,7 @@ import { markdown } from '../../helpers';
 import './markdown.scss';
 
 const Markdown = ({ className = null, children }) => (
-  <div className={classnames('markdown', 'with-lists', className)} dangerouslySetInnerHTML={markdown(children)} />
+  <div className={classnames('markdown', 'with-lists', className)} dangerouslySetInnerHTML={markdown(children)} /> // eslint-disable-line react/no-danger
 );
 
 Markdown.propTypes = {

--- a/resources/assets/components/Markdown/index.js
+++ b/resources/assets/components/Markdown/index.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import classnames from 'classnames';
 import { markdown } from '../../helpers';
@@ -9,8 +10,8 @@ const Markdown = ({ className = null, children }) => (
 );
 
 Markdown.propTypes = {
-  children: React.PropTypes.string.isRequired,
-  className: React.PropTypes.string,
+  children: PropTypes.string.isRequired,
+  className: PropTypes.string,
 };
 
 Markdown.defaultProps = {

--- a/resources/assets/components/Markdown/index.js
+++ b/resources/assets/components/Markdown/index.js
@@ -1,15 +1,20 @@
 import React from 'react';
 import classnames from 'classnames';
-import { markdown } from "../../helpers";
+import { markdown } from '../../helpers';
+
 import './markdown.scss';
 
-const Markdown = ({className = null, children}) => (
+const Markdown = ({ className = null, children }) => (
   <div className={classnames('markdown', 'with-lists', className)} dangerouslySetInnerHTML={markdown(children)} />
 );
 
 Markdown.propTypes = {
-  children: React.PropTypes.string,
+  children: React.PropTypes.string.isRequired,
   className: React.PropTypes.string,
+};
+
+Markdown.defaultProps = {
+  className: null,
 };
 
 export default Markdown;

--- a/resources/assets/components/MediaUploader/index.js
+++ b/resources/assets/components/MediaUploader/index.js
@@ -62,7 +62,7 @@ class MediaUploader extends React.Component {
 
 MediaUploader.propTypes = {
   label: React.PropTypes.string,
-  media: React.PropTypes.scope({
+  media: React.PropTypes.shape({
     file: React.PropTypes.instanceOf(Blob),
     filePreviewUrl: React.PropTypes.string,
   }),

--- a/resources/assets/components/MediaUploader/index.js
+++ b/resources/assets/components/MediaUploader/index.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 /* global FileReader, URL, Blob */
 
 import React from 'react';
@@ -61,12 +62,12 @@ class MediaUploader extends React.Component {
 }
 
 MediaUploader.propTypes = {
-  label: React.PropTypes.string,
-  media: React.PropTypes.shape({
-    file: React.PropTypes.instanceOf(Blob),
-    filePreviewUrl: React.PropTypes.string,
+  label: PropTypes.string,
+  media: PropTypes.shape({
+    file: PropTypes.instanceOf(Blob),
+    filePreviewUrl: PropTypes.string,
   }),
-  onChange: React.PropTypes.func.isRequired,
+  onChange: PropTypes.func.isRequired,
 };
 
 MediaUploader.defaultProps = {

--- a/resources/assets/components/MediaUploader/index.js
+++ b/resources/assets/components/MediaUploader/index.js
@@ -1,3 +1,5 @@
+/* global FileReader, URL, Blob */
+
 import React from 'react';
 import classnames from 'classnames';
 import { processFile } from '../../helpers';
@@ -17,7 +19,7 @@ class MediaUploader extends React.Component {
   }
 
   readFile(file) {
-    let fileReader = new FileReader;
+    const fileReader = new FileReader();
     let blob;
 
     fileReader.readAsArrayBuffer(file);
@@ -28,22 +30,21 @@ class MediaUploader extends React.Component {
 
         this.props.onChange({
           file: blob,
-          filePreviewUrl: URL.createObjectURL(blob)
+          filePreviewUrl: URL.createObjectURL(blob),
         });
-      }
-      catch(error) {
+      } catch (error) {
         // @todo: need a nice way to handle this, display message?
         console.log(error);
       }
-    }
+    };
   }
 
   render() {
-    let { filePreviewUrl } = this.props.media;
+    const { filePreviewUrl } = this.props.media;
     let content = null;
 
     if (filePreviewUrl) {
-      content = (<img src={filePreviewUrl} />);
+      content = (<img src={filePreviewUrl} alt="uploaded file" />);
     } else {
       content = (<span>{this.props.label}</span>);
     }
@@ -61,8 +62,11 @@ class MediaUploader extends React.Component {
 
 MediaUploader.propTypes = {
   label: React.PropTypes.string,
-  media: React.PropTypes.object,
-  onChange: React.PropTypes.func
+  media: React.PropTypes.scope({
+    file: React.PropTypes.instanceOf(Blob),
+    filePreviewUrl: React.PropTypes.string,
+  }),
+  onChange: React.PropTypes.func.isRequired,
 };
 
 MediaUploader.defaultProps = {
@@ -70,7 +74,7 @@ MediaUploader.defaultProps = {
   media: {
     file: null,
     filePreviewUrl: null,
-  }
+  },
 };
 
 export default MediaUploader;

--- a/resources/assets/components/Navigation/index.js
+++ b/resources/assets/components/Navigation/index.js
@@ -1,15 +1,20 @@
 import React from 'react';
 import { Link } from 'react-router';
 import FeedEnclosure from '../FeedEnclosure';
+
 import './navigation.scss';
 
-export const Navigation = ({children}) => (
+export const Navigation = ({ children }) => (
   <FeedEnclosure>
     <div className="nav">
       { children }
     </div>
   </FeedEnclosure>
 );
+
+Navigation.propTypes = {
+  children: React.PropTypes.node.isRequired,
+};
 
 export const NavigationLink = props => (
   <Link {...props} className="nav-link" activeClassName="is-active" />

--- a/resources/assets/components/Navigation/index.js
+++ b/resources/assets/components/Navigation/index.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import { Link } from 'react-router';
 import FeedEnclosure from '../FeedEnclosure';
@@ -13,7 +14,7 @@ export const Navigation = ({ children }) => (
 );
 
 Navigation.propTypes = {
-  children: React.PropTypes.node.isRequired,
+  children: PropTypes.node.isRequired,
 };
 
 export const NavigationLink = props => (

--- a/resources/assets/components/Notification/index.js
+++ b/resources/assets/components/Notification/index.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import { makeHash } from '../../helpers';
 
@@ -13,9 +14,9 @@ const Notification = ({ message, style, remove }) => (
 );
 
 Notification.propTypes = {
-  message: React.PropTypes.string,
-  style: React.PropTypes.string,
-  remove: React.PropTypes.func.isRequired,
+  message: PropTypes.string,
+  style: PropTypes.string,
+  remove: PropTypes.func.isRequired,
 };
 
 Notification.defaultProps = {
@@ -37,8 +38,8 @@ const NotificationList = ({ notifications, removeNotification }) => (
 );
 
 NotificationList.propTypes = {
-  notifications: React.PropTypes.arrayOf(React.PropTypes.object),
-  removeNotification: React.PropTypes.func.isRequired,
+  notifications: PropTypes.arrayOf(PropTypes.object),
+  removeNotification: PropTypes.func.isRequired,
 };
 
 NotificationList.defaultProps = {

--- a/resources/assets/components/Notification/index.js
+++ b/resources/assets/components/Notification/index.js
@@ -1,14 +1,22 @@
 import React from 'react';
+import { makeHash } from '../../helpers';
+
 import './notification.scss';
 
 const Notification = ({ message, style, remove }) => (
   <div className={`notification -${style}`}>
-    <div className='notification__content'>
+    <div className="notification__content">
       <p>{ message }</p>
     </div>
-    <span className='notification__close' onClick={ remove }>&times;</span>
+    <button className="notification__close" onClick={remove}>&times;</button>
   </div>
 );
+
+Notification.propTypes = {
+  message: React.PropTypes.string,
+  style: React.PropTypes.string,
+  remove: React.PropTypes.func.isRequired,
+};
 
 Notification.defaultProps = {
   message: 'Agh, looks like we had an error. Try again in a few minutes!',
@@ -16,19 +24,25 @@ Notification.defaultProps = {
 };
 
 const NotificationList = ({ notifications, removeNotification }) => (
-  <div className='notification-list'>
+  <div className="notification-list">
     {notifications.map(({ message, style }, index) => (
       <Notification
-        key={index}
+        key={makeHash(message)}
         message={message}
         style={style}
-        remove={() => removeNotification(index)} />
+        remove={() => removeNotification(index)}
+      />
     ))}
   </div>
 );
 
+NotificationList.propTypes = {
+  notifications: React.PropTypes.arrayOf(React.PropTypes.object),
+  removeNotification: React.PropTypes.func.isRequired,
+};
+
 NotificationList.defaultProps = {
   notifications: [],
-}
+};
 
 export default NotificationList;

--- a/resources/assets/components/Notification/notification.scss
+++ b/resources/assets/components/Notification/notification.scss
@@ -25,11 +25,17 @@
     }
 
     .notification__close {
-      position: absolute;
-      top: $half-spacing;
-      right: $half-spacing;
-      font-size: 32px;
+      background-color: transparent;
+      border: 0 none;
       color: inherit;
+      font-size: 32px;
+      position: absolute;
+      right: $half-spacing;
+      top: $half-spacing;
+
+      &:focus {
+        outline: transparent 0 none;
+      }
 
       &:hover {
         cursor: pointer;

--- a/resources/assets/components/PlaceholderBlock/index.js
+++ b/resources/assets/components/PlaceholderBlock/index.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import Block from '../Block/index';
 import './placeholder.scss';
@@ -9,8 +10,8 @@ const PlaceholderBlock = props => (
 );
 
 PlaceholderBlock.propTypes = {
-  fields: React.PropTypes.shape({
-    title: React.PropTypes.string.isRequired,
+  fields: PropTypes.shape({
+    title: PropTypes.string.isRequired,
   }).isRequired,
 };
 

--- a/resources/assets/components/PlaceholderBlock/index.js
+++ b/resources/assets/components/PlaceholderBlock/index.js
@@ -2,12 +2,16 @@ import React from 'react';
 import Block from '../Block/index';
 import './placeholder.scss';
 
-const PlaceholderBlock = (props) => {
-  return (
-    <Block className="placeholder">
-      {props.fields.title}
-    </Block>
-  );
+const PlaceholderBlock = props => (
+  <Block className="placeholder">
+    {props.fields.title}
+  </Block>
+);
+
+PlaceholderBlock.propTypes = {
+  fields: React.PropTypes.shape({
+    title: React.PropTypes.string.isRequired,
+  }).isRequired,
 };
 
 export default PlaceholderBlock;

--- a/resources/assets/components/Reaction/index.js
+++ b/resources/assets/components/Reaction/index.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import classnames from 'classnames';
 import { BaseFigure } from '../Figure';
@@ -23,10 +24,10 @@ const Reaction = (props) => {
 };
 
 Reaction.propTypes = {
-  active: React.PropTypes.bool,
-  onToggleOff: React.PropTypes.func.isRequired,
-  onToggleOn: React.PropTypes.func.isRequired,
-  total: React.PropTypes.number,
+  active: PropTypes.bool,
+  onToggleOff: PropTypes.func.isRequired,
+  onToggleOn: PropTypes.func.isRequired,
+  total: PropTypes.number,
 };
 
 Reaction.defaultProps = {

--- a/resources/assets/components/Reaction/index.js
+++ b/resources/assets/components/Reaction/index.js
@@ -1,22 +1,37 @@
 import React from 'react';
-import './reaction.scss';
-import { BaseFigure } from '../Figure';
 import classnames from 'classnames';
+import { BaseFigure } from '../Figure';
+import './reaction.scss';
+
+// @TODO: review the structure of the reaction button below, not ideal that it is an article tag
+// with a button tag, enclosing another article tag!?
 
 const Reaction = (props) => {
-  const active = props.active || false;
-  const total = props.total || 0;
+  const active = props.active;
+  const total = props.total;
 
-  const onToggle = !active ? props.onToggleOn : props.onToggleOff;
-  const reactionButton = <div className={classnames('reaction__button', {'-reacted' : active})} />;
+  const onToggle = ! active ? props.onToggleOn : props.onToggleOff;
+  const reactionButton = <div className={classnames('reaction__button', { '-reacted': active })} />;
 
   return (
-    <div className="reaction" onClick={onToggle}>
+    <button className="reaction" onClick={onToggle}>
       <BaseFigure media={reactionButton} alignment="left">
         <span className="reaction__meta">{total}</span>
       </BaseFigure>
-    </div>
+    </button>
   );
+};
+
+Reaction.propTypes = {
+  active: React.PropTypes.bool,
+  onToggleOff: React.PropTypes.func.isRequired,
+  onToggleOn: React.PropTypes.func.isRequired,
+  total: React.PropTypes.number,
+};
+
+Reaction.defaultProps = {
+  active: false,
+  total: 0,
 };
 
 export default Reaction;

--- a/resources/assets/components/Reaction/reaction.scss
+++ b/resources/assets/components/Reaction/reaction.scss
@@ -1,7 +1,13 @@
 @import '~@dosomething/forge/scss/toolkit';
 
 .reaction {
+  background-color: transparent;
+  border: 0 none;
   float: right;
+
+  &:focus {
+    outline: transparent 0 none;
+  }
 
   .reaction__button {
     display: inline-block;

--- a/resources/assets/components/ReportbackBlock/index.js
+++ b/resources/assets/components/ReportbackBlock/index.js
@@ -5,10 +5,10 @@ import ReportbackItemContainer from '../../containers/ReportbackItemContainer';
 import { mapDisplayToPoints } from '../../selectors/feed';
 import './reportback-block.scss';
 
-const ReportbackBlock = props => {
-  let items = [];
+const ReportbackBlock = (props) => {
+  const items = [];
 
-  for (let i = 0; i < mapDisplayToPoints(props.fields.displayOptions); i++) {
+  for (let i = 0; i < mapDisplayToPoints(props.fields.displayOptions); i += 1) {
     const id = props.reportbacks[i];
 
     items.push(
@@ -16,11 +16,18 @@ const ReportbackBlock = props => {
         <Block className="reportback-block">
           <ReportbackItemContainer id={id} />
         </Block>
-      </FlexCell>
+      </FlexCell>,
     );
   }
 
   return <FlexCell>{items}</FlexCell>;
+};
+
+ReportbackBlock.propTypes = {
+  fields: React.PropTypes.shape({
+    displayOptions: React.PropTypes.array,
+  }).isRequired,
+  reportbacks: React.PropTypes.arrayOf(React.PropTypes.string).isRequired,
 };
 
 export default ReportbackBlock;

--- a/resources/assets/components/ReportbackBlock/index.js
+++ b/resources/assets/components/ReportbackBlock/index.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import Block from '../Block';
 import { FlexCell } from '../Flex';
@@ -24,10 +25,10 @@ const ReportbackBlock = (props) => {
 };
 
 ReportbackBlock.propTypes = {
-  fields: React.PropTypes.shape({
-    displayOptions: React.PropTypes.array,
+  fields: PropTypes.shape({
+    displayOptions: PropTypes.array,
   }).isRequired,
-  reportbacks: React.PropTypes.arrayOf(React.PropTypes.string).isRequired,
+  reportbacks: PropTypes.arrayOf(PropTypes.string).isRequired,
 };
 
 export default ReportbackBlock;

--- a/resources/assets/components/ReportbackItem/index.js
+++ b/resources/assets/components/ReportbackItem/index.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import { Figure, BaseFigure } from '../Figure';
 import Reaction from '../Reaction';
@@ -40,7 +41,7 @@ const ReportbackItem = (props) => {
 
   if (isFetching) {
     return (
-      <Figure className="reportback-item" image="">
+      <Figure className="reportback-item" image="" alt="Loading...">
         <BaseFigure media={reactionElement} alignment="right" className="padded">
           <h4>Loading…</h4>
           <p className="footnote">…</p>
@@ -51,7 +52,7 @@ const ReportbackItem = (props) => {
 
   // TODO: Don't hardcode cards
   return (
-    <Figure className="reportback-item" image={url}>
+    <Figure className="reportback-item" image={url} alt={`${firstName}'s photo`}>
       <BaseFigure media={reactionElement} alignment="right" className="padded">
         {firstName ? <h4>{firstName}</h4> : null }
         {quantity ? <p className="footnote">{quantity} cards</p> : null }
@@ -62,20 +63,20 @@ const ReportbackItem = (props) => {
 };
 
 ReportbackItem.propTypes = {
-  id: React.PropTypes.string,
-  caption: React.PropTypes.string,
-  firstName: React.PropTypes.string,
-  isFetching: React.PropTypes.bool,
-  quantity: React.PropTypes.number,
-  reaction: React.PropTypes.shape({
-    id: React.PropTypes.string,
-    reacted: React.PropTypes.bool,
-    termId: React.PropTypes.string,
-    total: React.PropTypes.number,
+  id: PropTypes.string,
+  caption: PropTypes.string,
+  firstName: PropTypes.string,
+  isFetching: PropTypes.bool,
+  quantity: PropTypes.number,
+  reaction: PropTypes.shape({
+    id: PropTypes.string,
+    reacted: PropTypes.bool,
+    termId: PropTypes.string,
+    total: PropTypes.number,
   }),
-  toggleReactionOff: React.PropTypes.func,
-  toggleReactionOn: React.PropTypes.func,
-  url: React.PropTypes.string,
+  toggleReactionOff: PropTypes.func,
+  toggleReactionOn: PropTypes.func,
+  url: PropTypes.string,
 };
 
 ReportbackItem.defaultProps = {

--- a/resources/assets/components/ReportbackItem/index.js
+++ b/resources/assets/components/ReportbackItem/index.js
@@ -73,8 +73,8 @@ ReportbackItem.propTypes = {
     termId: React.PropTypes.string,
     total: React.PropTypes.number,
   }),
-  toggleReactionOff: React.PropTypes.func.isRequired,
-  toggleReactionOn: React.PropTypes.func.isRequired,
+  toggleReactionOff: React.PropTypes.func,
+  toggleReactionOn: React.PropTypes.func,
   url: React.PropTypes.string,
 };
 
@@ -86,6 +86,8 @@ ReportbackItem.defaultProps = {
   quantity: undefined,
   reaction: null,
   url: undefined,
+  toggleReactionOff: () => {},
+  toggleReactionOn: () => {},
 };
 
 ReportbackItem.defaultMetadata = {

--- a/resources/assets/components/ReportbackItem/index.js
+++ b/resources/assets/components/ReportbackItem/index.js
@@ -23,10 +23,20 @@ const ReportbackItem = (props) => {
     firstName,
     reaction = null,
     isFetching = false,
-    isAuthenticated,
     toggleReactionOn,
-    toggleReactionOff
+    toggleReactionOff,
   } = props;
+
+  const metadata = mergeMetadata(ReportbackItem.defaultMetadata, getMetadataFromProps(props));
+
+  const reactionElement = reaction ? (
+    <Reaction
+      active={reaction.reacted}
+      total={reaction.total}
+      onToggleOn={() => toggleReactionOn(id, reaction.termId, metadata)}
+      onToggleOff={() => toggleReactionOff(id, reaction.id, metadata)}
+    />
+  ) : null;
 
   if (isFetching) {
     return (
@@ -39,27 +49,47 @@ const ReportbackItem = (props) => {
     );
   }
 
-  const metadata = mergeMetadata(ReportbackItem.defaultMetadata, getMetadataFromProps(props));
-
-  const reactionElement = reaction ? (
-    <Reaction active={reaction.reacted} total={reaction.total}
-              onToggleOn={() => toggleReactionOn(id, reaction.termId, metadata)}
-              onToggleOff={() => toggleReactionOff(id, reaction.id, metadata)} />
-  ) : null;
   // TODO: Don't hardcode cards
   return (
     <Figure className="reportback-item" image={url}>
       <BaseFigure media={reactionElement} alignment="right" className="padded">
         {firstName ? <h4>{firstName}</h4> : null }
         {quantity ? <p className="footnote">{quantity} cards</p> : null }
-        {caption ?  <p>{caption}</p> : null }
+        {caption ? <p>{caption}</p> : null }
       </BaseFigure>
     </Figure>
   );
 };
 
+ReportbackItem.propTypes = {
+  id: React.PropTypes.string,
+  caption: React.PropTypes.string,
+  firstName: React.PropTypes.string,
+  isFetching: React.PropTypes.bool,
+  quantity: React.PropTypes.number,
+  reaction: React.PropTypes.shape({
+    id: React.PropTypes.string,
+    reacted: React.PropTypes.bool,
+    termId: React.PropTypes.string,
+    total: React.PropTypes.number,
+  }),
+  toggleReactionOff: React.PropTypes.func.isRequired,
+  toggleReactionOn: React.PropTypes.func.isRequired,
+  url: React.PropTypes.string,
+};
+
+ReportbackItem.defaultProps = {
+  id: undefined,
+  caption: undefined,
+  firstName: undefined,
+  isFetching: false,
+  quantity: undefined,
+  reaction: null,
+  url: undefined,
+};
+
 ReportbackItem.defaultMetadata = {
   source: 'reportback item',
-}
+};
 
 export default ReportbackItem;

--- a/resources/assets/components/ReportbackItem/index.js
+++ b/resources/assets/components/ReportbackItem/index.js
@@ -79,6 +79,10 @@ ReportbackItem.propTypes = {
   url: PropTypes.string,
 };
 
+// @TODO: The following props needed to be defined as undefined likely due to how we are
+// implementing this component as a lazy loaded item. The props could not be set as required which
+// thus meant we needed default props. However, setting the default props as null would cause the
+// app to crash. Something to look into...
 ReportbackItem.defaultProps = {
   id: undefined,
   caption: undefined,

--- a/resources/assets/components/ReportbackUploader/index.js
+++ b/resources/assets/components/ReportbackUploader/index.js
@@ -1,7 +1,7 @@
+/* global FormData */
+
 import React from 'react';
-import { has } from 'lodash';
 import Block from '../Block';
-import { Flex } from '../Flex';
 import MediaUploader from '../MediaUploader';
 import Gallery from '../Gallery';
 import ReportbackItem from '../ReportbackItem';
@@ -10,35 +10,59 @@ import { makeHash } from '../../helpers';
 import './reportback-uploader.scss';
 
 class ReportbackUploader extends React.Component {
+  static renderReportbackItem(submission) {
+    // @TODO: Normalize data for uploaded RBs vs API retrieved RBs if possible...
+    const key = makeHash(submission.media.uri || submission.media.filePreviewUrl);
+    const url = submission.media.uri || submission.media.filePreviewUrl;
+
+    return <ReportbackItem key={key} {...submission} url={url} reaction={null} />;
+  }
+
+  static setFormData(container) {
+    const reportback = container;
+    const formData = new FormData();
+
+    Object.keys(reportback).forEach((item) => {
+      if (item === 'media') {
+        formData.append(item, (reportback[item].file || ''));
+      } else {
+        formData.append(item, reportback[item]);
+      }
+    });
+
+    reportback.formData = formData;
+
+    return reportback;
+  }
+
   constructor(props) {
     super(props);
 
     this.handleOnSubmitForm = this.handleOnSubmitForm.bind(this);
     this.handleOnFileUpload = this.handleOnFileUpload.bind(this);
 
-    this.state = {
-      media: this.defaultMediaState(),
-      caption: null,
-      impact: null,
-      why_participated: null
-    };
-  }
 
-  defaultMediaState() {
-    return {
+    this.defaultMediaState = {
       file: null,
       filePreviewUrl: null,
       type: null,
-      uri: null
-    }
-  };
+      uri: null,
+    };
+
+    this.state = {
+      media: this.defaultMediaState,
+      caption: null,
+      impact: null,
+      why_participated: null,
+    };
+  }
 
   componentDidMount() {
     this.props.fetchUserReportbacks(this.props.userId, this.props.legacyCampaignId);
   }
 
   handleOnFileUpload(media) {
-    this.setState({ media })
+    this.setState({ media });
   }
 
   handleOnSubmitForm(event) {
@@ -53,36 +77,19 @@ class ReportbackUploader extends React.Component {
       status: 'pending',
     };
 
-    let fileType = reportback.media.file ? reportback.media.file.type : null;
+    const fileType = reportback.media.file ? reportback.media.file.type : null;
 
     reportback.media.type = fileType ? fileType.substring(0, fileType.indexOf('/')) : null;
 
-    this.props.submitReportback(this.setFormData(reportback));
+    this.props.submitReportback(ReportbackUploader.setFormData(reportback));
 
     // @TODO: only reset form AFTER successful RB submission.
     // We'll make this a lot better once we switch to storing all the state
     // in the Redux store @_@
     this.form.reset();
     this.setState({
-      media: this.defaultMediaState()
+      media: this.defaultMediaState,
     });
-  }
-
-  setFormData(reportback) {
-    let formData = new FormData;
-
-    Object.keys(reportback).map((item) => {
-      if (item === 'media') {
-        formData.append(item, (reportback[item].file || ''));
-      }
-      else {
-        formData.append(item, reportback[item]);
-      }
-    });
-
-    reportback['formData'] = formData;
-
-    return reportback;
   }
 
   render() {
@@ -95,36 +102,49 @@ class ReportbackUploader extends React.Component {
 
           { submissions.messaging ? <FormMessage messaging={submissions.messaging} /> : null }
 
-          <form className="reportback-form" onSubmit={this.handleOnSubmitForm} ref={(form) => this.form = form}>
+          <form className="reportback-form" onSubmit={this.handleOnSubmitForm} ref={form => (this.form = form)}>
             <MediaUploader label="Add your photo here" media={this.state.media} onChange={this.handleOnFileUpload} />
 
             <div className="wrapper">
               <div className="form-item">
                 <label className="field-label" htmlFor="caption">Add a caption to your photo.</label>
-                <input className="text-field" id="caption" name="caption" type="text" placeholder="60 characters or less" ref={(input) => this.caption = input} />
+                <input className="text-field" id="caption" name="caption" type="text" placeholder="60 characters or less" ref={input => (this.caption = input)} />
               </div>
 
               <div>
                 <label className="field-label" htmlFor="impact">How many cards are in this photo?</label>
-                <input className="text-field" id="impact" name="impact" type="text" placeholder="Enter # here -- like '300' or '5'" ref={(input) => this.impact = input} />
+                <input className="text-field" id="impact" name="impact" type="text" placeholder="Enter # here -- like '300' or '5'" ref={input => (this.impact = input)} />
               </div>
             </div>
 
             <div className="form-item">
               <label className="field-label" htmlFor="why_participated">Why is this campaign important to you?</label>
-              <textarea className="text-field" id="why_participated" name="why_participated" placeholder="No need to write an essay, but we'd love to see why this matters to you!" ref={(input) => this.why_participated = input}></textarea>
+              <textarea className="text-field" id="why_participated" name="why_participated" placeholder="No need to write an essay, but we'd love to see why this matters to you!" ref={input => (this.why_participated = input)} />
             </div>
 
-            <button className="button" type="submit" disabled={submissions.isStoring ? true : false }>Submit a new photo</button>
+            <button className="button" type="submit" disabled={submissions.isStoring}>Submit a new photo</button>
           </form>
         </div>
-          <Gallery isFetching={submissions.isFetching} type="triad">
-            {/* @TODO: Need to normalize data for uploaded RBs vs API retrieved RBs earlier in process if possible... */}
-            {submissions.items.map((submission, index) => <ReportbackItem key={makeHash(submission.media.uri || submission.media.filePreviewUrl)} {...submission} url={submission.media.uri || submission.media.filePreviewUrl} reaction={null} />)}
-          </Gallery>
+        <Gallery isFetching={submissions.isFetching} type="triad">
+          {submissions.items.map(submission => ReportbackUploader.renderReportbackItem(submission))}
+        </Gallery>
       </Block>
     );
   }
 }
+
+ReportbackUploader.propTypes = {
+  fetchUserReportbacks: React.PropTypes.func.isRequired,
+  legacyCampaignId: React.PropTypes.string.isRequired,
+  submissions: React.PropTypes.shape({
+    isFetching: React.PropTypes.bool,
+    isStoring: React.PropTypes.bool,
+    items: React.PropTypes.array,
+    messaging: React.PropTypes.object,
+    reportback: React.PropTypes.object,
+  }).isRequired,
+  submitReportback: React.PropTypes.func.isRequired,
+  userId: React.PropTypes.string.isRequired,
+};
 
 export default ReportbackUploader;

--- a/resources/assets/components/ReportbackUploader/index.js
+++ b/resources/assets/components/ReportbackUploader/index.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 /* global FormData */
 
 import React from 'react';
@@ -134,17 +135,17 @@ class ReportbackUploader extends React.Component {
 }
 
 ReportbackUploader.propTypes = {
-  fetchUserReportbacks: React.PropTypes.func.isRequired,
-  legacyCampaignId: React.PropTypes.string.isRequired,
-  submissions: React.PropTypes.shape({
-    isFetching: React.PropTypes.bool,
-    isStoring: React.PropTypes.bool,
-    items: React.PropTypes.array,
-    messaging: React.PropTypes.object,
-    reportback: React.PropTypes.object,
+  fetchUserReportbacks: PropTypes.func.isRequired,
+  legacyCampaignId: PropTypes.string.isRequired,
+  submissions: PropTypes.shape({
+    isFetching: PropTypes.bool,
+    isStoring: PropTypes.bool,
+    items: PropTypes.array,
+    messaging: PropTypes.object,
+    reportback: PropTypes.object,
   }).isRequired,
-  submitReportback: React.PropTypes.func.isRequired,
-  userId: React.PropTypes.string.isRequired,
+  submitReportback: PropTypes.func.isRequired,
+  userId: PropTypes.string.isRequired,
 };
 
 export default ReportbackUploader;

--- a/resources/assets/components/Revealer/index.js
+++ b/resources/assets/components/Revealer/index.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import classnames from 'classnames';
 import { FlexCell } from '../Flex';
@@ -20,11 +21,11 @@ const Revealer = (props) => {
 };
 
 Revealer.propTypes = {
-  callToAction: React.PropTypes.string,
-  isLoading: React.PropTypes.bool,
-  isVisible: React.PropTypes.bool,
-  onReveal: React.PropTypes.func,
-  title: React.PropTypes.string,
+  callToAction: PropTypes.string,
+  isLoading: PropTypes.bool,
+  isVisible: PropTypes.bool,
+  onReveal: PropTypes.func,
+  title: PropTypes.string,
 };
 
 Revealer.defaultProps = {

--- a/resources/assets/components/Revealer/index.js
+++ b/resources/assets/components/Revealer/index.js
@@ -1,6 +1,6 @@
 import React from 'react';
-import { FlexCell } from '../Flex';
 import classnames from 'classnames';
+import { FlexCell } from '../Flex';
 
 import './revealer.scss';
 
@@ -13,17 +13,26 @@ const Revealer = (props) => {
     <FlexCell width="full">
       <div className="revealer">
         <h1>{props.callToAction}</h1>
-        <button disabled={props.isLoading} className={classnames('button', {'is-loading': props.isLoading})} onClick={props.onReveal}>{props.title}</button>
+        <button disabled={props.isLoading} className={classnames('button', { 'is-loading': props.isLoading })} onClick={props.onReveal}>{props.title}</button>
       </div>
     </FlexCell>
   );
 };
 
+Revealer.propTypes = {
+  callToAction: React.PropTypes.string,
+  isLoading: React.PropTypes.bool,
+  isVisible: React.PropTypes.bool,
+  onReveal: React.PropTypes.func,
+  title: React.PropTypes.string,
+};
+
 Revealer.defaultProps = {
   callToAction: '',
-  title: 'view more',
-  onReveal: () => {},
+  isLoading: false,
   isVisible: true,
+  onReveal: () => {},
+  title: 'view more',
 };
 
 export default Revealer;

--- a/resources/assets/components/Share/index.js
+++ b/resources/assets/components/Share/index.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import classnames from 'classnames';
 import { mergeMetadata } from '../../helpers/analytics';
@@ -20,9 +21,9 @@ const Share = ({ variant, clickedShare, parentSource }) => {
 };
 
 Share.propTypes = {
-  clickedShare: React.PropTypes.func,
-  parentSource: React.PropTypes.string,
-  variant: React.PropTypes.string,
+  clickedShare: PropTypes.func,
+  parentSource: PropTypes.string,
+  variant: PropTypes.string,
 };
 
 Share.defaultProps = {

--- a/resources/assets/components/Share/index.js
+++ b/resources/assets/components/Share/index.js
@@ -5,7 +5,7 @@ import { mergeMetadata } from '../../helpers/analytics';
 import './share.scss';
 
 const Share = ({ variant, clickedShare, parentSource }) => {
-  const className = classnames('button share', {'-black': variant === 'black'});
+  const className = classnames('button share', { '-black': variant === 'black' });
 
   const metadata = mergeMetadata(Share.defaultMetadata, {
     parentSource,
@@ -13,22 +13,27 @@ const Share = ({ variant, clickedShare, parentSource }) => {
   });
 
   return (
-    <a className={className} onClick={() => clickedShare(metadata)}>
-      share on
-      <i className="social-icon -facebook"><span>Facebook</span></i>
-    </a>
+    <button className={className} onClick={() => clickedShare(metadata)}>
+      share on <i className="social-icon -facebook"><span>Facebook</span></i>
+    </button>
   );
+};
+
+Share.propTypes = {
+  clickedShare: React.PropTypes.func,
+  parentSource: React.PropTypes.string,
+  variant: React.PropTypes.string,
 };
 
 Share.defaultProps = {
   variant: 'black',
   clickedShare: () => {},
   parentSource: null,
-}
+};
 
 Share.defaultMetadata = {
   source: 'share button',
   platform: 'facebook',
-}
+};
 
 export default Share;

--- a/resources/assets/components/StaticBlock/index.js
+++ b/resources/assets/components/StaticBlock/index.js
@@ -15,4 +15,12 @@ const StaticBlock = (props) => {
   );
 };
 
+StaticBlock.propTypes = {
+  fields: React.PropTypes.shape({
+    title: React.PropTypes.string,
+    content: React.PropTypes.string,
+    additionalContent: React.PropTypes.object,
+  }).isRequired,
+};
+
 export default StaticBlock;

--- a/resources/assets/components/StaticBlock/index.js
+++ b/resources/assets/components/StaticBlock/index.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import Block, { BlockTitle } from '../Block';
 import Markdown from '../Markdown';
@@ -16,10 +17,10 @@ const StaticBlock = (props) => {
 };
 
 StaticBlock.propTypes = {
-  fields: React.PropTypes.shape({
-    title: React.PropTypes.string,
-    content: React.PropTypes.string,
-    additionalContent: React.PropTypes.object,
+  fields: PropTypes.shape({
+    title: PropTypes.string,
+    content: PropTypes.string,
+    additionalContent: PropTypes.object,
   }).isRequired,
 };
 

--- a/resources/assets/components/Wrapper/index.js
+++ b/resources/assets/components/Wrapper/index.js
@@ -10,7 +10,7 @@ const Wrapper = ({ width = '', children }) => (
 );
 
 Wrapper.propTypes = {
-  children: React.PropTypes.arrayOf(React.PropTypes.element).isRequired,
+  children: React.PropTypes.element.isRequired,
   width: React.PropTypes.oneOf(['default', 'feed']),
 };
 

--- a/resources/assets/components/Wrapper/index.js
+++ b/resources/assets/components/Wrapper/index.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import classNames from 'classnames';
 import { modifiers } from '../../helpers';
@@ -10,8 +11,8 @@ const Wrapper = ({ width = '', children }) => (
 );
 
 Wrapper.propTypes = {
-  children: React.PropTypes.element.isRequired,
-  width: React.PropTypes.oneOf(['default', 'feed']),
+  children: PropTypes.element.isRequired,
+  width: PropTypes.oneOf(['default', 'feed']),
 };
 
 Wrapper.defaultProps = {

--- a/resources/assets/components/Wrapper/index.js
+++ b/resources/assets/components/Wrapper/index.js
@@ -3,14 +3,19 @@ import classNames from 'classnames';
 import { modifiers } from '../../helpers';
 import './wrapper.scss';
 
-export const Wrapper = ({width = '', children}) => {
-  return (
-    <div className={classNames('wrapper', modifiers(width))}>
-      {children}
-    </div>
-  );
-};
+const Wrapper = ({ width = '', children }) => (
+  <div className={classNames('wrapper', modifiers(width))}>
+    { children }
+  </div>
+);
 
 Wrapper.propTypes = {
+  children: React.PropTypes.arrayOf(React.PropTypes.element).isRequired,
   width: React.PropTypes.oneOf(['default', 'feed']),
 };
+
+Wrapper.defaultProps = {
+  width: '',
+};
+
+export default Wrapper;

--- a/resources/assets/containers/CallToActionContainer.js
+++ b/resources/assets/containers/CallToActionContainer.js
@@ -8,7 +8,7 @@ import { clickedSignUp } from '../actions';
 const mapStateToProps = state => ({
   isAffiliated: state.signups.thisCampaign,
   imageUrl: state.campaign.coverImage.url,
-  legacyCampaignId: state.campaign.legacyCampaignId,
+  campaignId: state.campaign.legacyCampaignId,
 });
 
 /**

--- a/resources/assets/containers/NavigationContainer.js
+++ b/resources/assets/containers/NavigationContainer.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
 import { Navigation, NavigationLink } from '../components/Navigation';
@@ -24,7 +25,7 @@ const NavigationContainer = ({ pages }) => {
 };
 
 NavigationContainer.propTypes = {
-  pages: React.PropTypes.array,  // eslint-disable-line react/forbid-prop-types
+  pages: PropTypes.array,  // eslint-disable-line react/forbid-prop-types
 };
 
 NavigationContainer.defaultProps = {

--- a/resources/assets/history.js
+++ b/resources/assets/history.js
@@ -1,3 +1,5 @@
+/* global window */
+
 import { useRouterHistory } from 'react-router';
 import createBrowserHistory from 'history/lib/createBrowserHistory';
 import { syncHistoryWithStore } from 'react-router-redux';
@@ -23,7 +25,7 @@ export function init(store) {
   const basename = window.location.pathname.split('/').slice(0, 4).join('/');
 
   const routerHistory = useRouterHistory(createBrowserHistory);
-  history = syncHistoryWithStore(routerHistory({basename}), store);
+  history = syncHistoryWithStore(routerHistory({ basename }), store);
 
   return history;
 }

--- a/resources/assets/init.js
+++ b/resources/assets/init.js
@@ -1,3 +1,5 @@
+/* global window, document */
+
 /*
  |--------------------------------------------------------------------------
  | Phoenix Next
@@ -9,15 +11,15 @@
  |
  */
 
-import React from 'react';
-import ReactDom from 'react-dom';
-import { ready } from './helpers';
-import { configureStore } from './store';
-import * as reducers from './reducers'
-import { routerReducer } from 'react-router-redux';
-
 // WHATWG Fetch Polyfill
 import 'whatwg-fetch';
+
+import React from 'react';
+import ReactDom from 'react-dom';
+import { routerReducer } from 'react-router-redux';
+import { ready } from './helpers';
+import { configureStore } from './store';
+import * as reducers from './reducers';
 
 // Style Components
 import './scss/base.scss';
@@ -35,7 +37,7 @@ import { init as navigationInit } from './helpers/navigation';
 import { init as historyInit } from './history';
 
 // Configure store & history.
-const store = configureStore({...reducers, routing: routerReducer}, window.STATE);
+const store = configureStore({ ...reducers, routing: routerReducer }, window.STATE);
 const history = historyInit(store);
 
 ready(() => {

--- a/resources/assets/normalizers.js
+++ b/resources/assets/normalizers.js
@@ -4,30 +4,34 @@
  * @param data
  */
 export function normalizeReportbacksResponse(data) {
-  let reportbacks = {};
-  let reportbackItems = {};
+  const reportbacks = {};
+  const reportbackItems = {};
 
-  data.forEach((reportback) => {
-    reportback.reportback_items = reportback.reportback_items.data.map((item) => {
-      const currentUser = item.kudos.data[0] ? item.kudos.data[0].current_user : false;
+  data.forEach((reportbackRecord) => {
+    const reportback = reportbackRecord;
 
-      item.reaction = {
+    reportback.reportback_items = reportback.reportback_items.data.map((reprotbackItemRecord) => {
+      const reportbackItem = reprotbackItemRecord;
+      const reactions = reportbackItem.kudos.data;
+      const currentUser = reactions[0] ? reactions[0].current_user : false;
+
+      reportbackItem.reaction = {
         id: currentUser ? currentUser.kudos_id : null,
-        reacted: !!(currentUser && currentUser.kudos_id),
-        total: item.kudos.data[0] ? item.kudos.data[0].term.total : 0,
-        termId: item.kudos.data[0] ? item.kudos.data[0].term.id : '1274', // This is a hardcoded default because phoenix-ashes is bugged.
+        reacted: !! (currentUser && currentUser.kudos_id),
+        total: reportbackItem.kudos.data[0] ? reportbackItem.kudos.data[0].term.total : 0,
+        termId: reportbackItem.kudos.data[0] ? reportbackItem.kudos.data[0].term.id : '1274', // This is a hardcoded default because phoenix-ashes is bugged.
       };
-      delete item.kudos;
+      delete reportbackItem.kudos;
 
-      reportbackItems[item.id] = item;
-      return item.id;
+      reportbackItems[reportbackItem.id] = reportbackItem;
+      return reportbackItem.id;
     });
 
     delete reportback.campaign;
     reportbacks[reportback.id] = reportback;
   });
 
-  return {reportbacks, reportbackItems};
+  return { reportbacks, reportbackItems };
 }
 
 /**
@@ -36,16 +40,17 @@ export function normalizeReportbacksResponse(data) {
  * @return {Object}
  */
 export function normalizeReportbackItemResponse(data) {
-  let reportbacks = {};
-  let reportbackItems = {};
+  const reportbacks = {};
+  const reportbackItems = {};
 
-  data.forEach((reportbackItem) => {
+  data.forEach((reprotbackItemRecord) => {
+    const reportbackItem = reprotbackItemRecord;
     const kudos = reportbackItem.kudos.data[0];
     const currentUser = kudos ? kudos.current_user : false;
 
     reportbackItem.reaction = {
       id: currentUser ? currentUser.kudos_id : null,
-      reacted: !!(currentUser && currentUser.kudos_id),
+      reacted: !! (currentUser && currentUser.kudos_id),
       total: kudos ? kudos.term.total : 0,
       termId: kudos ? kudos.term.id : '1274', // This is a hardcoded default because phoenix-ashes is bugged.
     };

--- a/resources/assets/store.js
+++ b/resources/assets/store.js
@@ -1,4 +1,4 @@
-import { createStore, combineReducers, applyMiddleware, compose } from 'redux'
+import { createStore, combineReducers, applyMiddleware, compose } from 'redux';
 import thunk from 'redux-thunk';
 import merge from 'lodash/merge';
 import { checkForSignup, fetchReportbacks, startQueue, getTotalSignups } from './actions';
@@ -38,7 +38,7 @@ const initialState = {
     thisCampaign: false,
     thisSession: false,
     showAffirmation: false,
-    pending: false,
+    isPending: false,
     total: 0,
   },
   user: {
@@ -53,7 +53,7 @@ const initialState = {
   },
   notifications: {
     items: [],
-  }
+  },
 };
 
 /**
@@ -69,20 +69,20 @@ export function configureStore(reducers, preloadedState = {}) {
 
   // Log actions to the console in development & track state changes.
   if (process.env.NODE_ENV !== 'production') {
-    const createLogger = require(`redux-logger`);
-    middleware.push(createLogger({collapsed: true}));
+    const createLogger = require('redux-logger'); // eslint-disable-line global-require
+    middleware.push(createLogger({ collapsed: true }));
   }
 
   // If React DevTools are available, use instrumented compose function.
-  const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose;
+  const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose; // eslint-disable-line
 
-  //TODO: Let's just merge all 3 states at once
+  // @TODO: Let's just merge all 3 states at once
   const transformedState = loadStorage(initialState, preloadedState);
 
   return createStore(
     combineReducers(reducers),
     merge(transformedState, preloadedState),
-    composeEnhancers(applyMiddleware(...middleware))
+    composeEnhancers(applyMiddleware(...middleware)),
   );
 }
 
@@ -114,5 +114,5 @@ export function initializeStore(store) {
     start(store);
 
     callback();
-  }
+  };
 }

--- a/wercker.yml
+++ b/wercker.yml
@@ -17,6 +17,9 @@ build:
             npm config set cache $WERCKER_CACHE_DIR/wercker/npm
             npm install
       - script:
+          name: check code style
+          code: npm run lint
+      - script:
           name: build front-end assets
           code: npm run build
 


### PR DESCRIPTION
#### Changes
This pull request adds a linting step that will fail Wercker builds if there are style problems. It also fixes a ton more style issues (womp womp) that we found when fixing the lint command syntax.

This also updates `React.PropTypes` to reference the `prop-types` package instead via the [code mod](https://github.com/reactjs/react-codemod#react-proptypes-to-prop-types).

✏️ 💯 