### PR TITLE
Fix for non-square images popping out of container.

### DIFF
--- a/resources/assets/components/MediaUploader/media-uploader.scss
+++ b/resources/assets/components/MediaUploader/media-uploader.scss
@@ -15,6 +15,7 @@
     flex-direction: column;
     height: 100%;
     justify-content: center;
+    overflow: hidden;
     text-align: center;
     width: 100%;
 
@@ -26,6 +27,10 @@
       height: 50px;
       margin-bottom: 10px;
       width: 50px;
+    }
+
+    img {
+      max-height: 100%;
     }
   }
 


### PR DESCRIPTION
This PR fixes the bug in the RB uploader which allowed unconventionally sized images (ie: not perfect squares :trollface:) to overflow out of its container.

Before:
![screen shot 2017-04-21 at 3 27 47 pm](https://cloud.githubusercontent.com/assets/105849/25293606/a32d9e82-26a9-11e7-9ab5-475754ada16d.png)

After:
![screen shot 2017-04-21 at 3 28 11 pm](https://cloud.githubusercontent.com/assets/105849/25293616/a95bfe20-26a9-11e7-8d81-51da5e279077.png)

