### PR TITLE
Re-enable CSRF middleware on all routes.

### DIFF
--- a/app/Http/Middleware/VerifyCsrfToken.php
+++ b/app/Http/Middleware/VerifyCsrfToken.php
@@ -12,7 +12,6 @@ class VerifyCsrfToken extends BaseVerifier
      * @var array
      */
     protected $except = [
-        'next/reportbacks',
-        'next/signups',
+        // ...
     ];
 }

--- a/resources/assets/normalizers.js
+++ b/resources/assets/normalizers.js
@@ -43,8 +43,8 @@ export function normalizeReportbackItemResponse(data) {
   const reportbacks = {};
   const reportbackItems = {};
 
-  data.forEach((reprotbackItemRecord) => {
-    const reportbackItem = reprotbackItemRecord;
+  data.forEach((reportbackItemRecord) => {
+    const reportbackItem = reportbackItemRecord;
     const kudos = reportbackItem.kudos.data[0];
     const currentUser = kudos ? kudos.current_user : false;
 


### PR DESCRIPTION
We haven't had any login CSRF token errors since we fixed the session issue in #207... let's try re-enabling this for those two routes. ✌️ 🔀

References #188.