### PR TITLE
By default, use Jest's watch mode for running tests.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "private": true,
   "scripts": {
-    "test": "npm run jest",
-    "jest": "NODE_ENV=test && node --harmony ./node_modules/jest/bin/jest.js",
+    "test": "NODE_ENV=test && node --harmony ./node_modules/jest/bin/jest.js --watch",
+    "test:ci": "NODE_ENV=test && node --harmony ./node_modules/jest/bin/jest.js",
     "lint": "eslint --ext .js resources/assets",
     "start": "npm run clean && NODE_ENV=development webpack --watch",
     "build:dev": "npm run clean && NODE_ENV=development webpack",

--- a/wercker.yml
+++ b/wercker.yml
@@ -26,7 +26,7 @@ build:
           code: npm run lint
       - script:
           name: test javascript code
-          code: npm run jest
+          code: npm run test:ci
       - script:
           name: build front-end assets
           code: npm run build


### PR DESCRIPTION
### Changes
Jest has a pretty wonderful interactive "watch" mode which run tests only on changed files (either based on the current git diff or by watching for changes as you make them). Let's give it a go!

![screen shot 2017-04-27 at 3 05 14 pm](https://cloud.githubusercontent.com/assets/583202/25499908/0f54319c-2b5b-11e7-9bbf-cc24f2f79a38.png)
