### PR TITLE
Allow setting custom nouns for the impact item.

### DIFF
--- a/resources/assets/components/ReportbackItem/index.js
+++ b/resources/assets/components/ReportbackItem/index.js
@@ -16,17 +16,8 @@ function getMetadataFromProps(props) {
 }
 
 const ReportbackItem = (props) => {
-  const {
-    id,
-    url,
-    quantity,
-    caption,
-    firstName,
-    reaction = null,
-    isFetching = false,
-    toggleReactionOn,
-    toggleReactionOff,
-  } = props;
+  const { id, url, quantity, noun, caption, firstName, reaction = null,
+    isFetching = false, toggleReactionOn, toggleReactionOff } = props;
 
   const metadata = mergeMetadata(ReportbackItem.defaultMetadata, getMetadataFromProps(props));
 
@@ -50,12 +41,11 @@ const ReportbackItem = (props) => {
     );
   }
 
-  // TODO: Don't hardcode cards
   return (
     <Figure className="reportback-item" image={url} alt={`${firstName}'s photo`}>
       <BaseFigure media={reactionElement} alignment="right" className="padded">
         {firstName ? <h4>{firstName}</h4> : null }
-        {quantity ? <p className="footnote">{quantity} cards</p> : null }
+        {quantity ? <p className="footnote">{quantity} {noun}</p> : null }
         {caption ? <p>{caption}</p> : null }
       </BaseFigure>
     </Figure>
@@ -67,6 +57,7 @@ ReportbackItem.propTypes = {
   caption: PropTypes.string,
   firstName: PropTypes.string,
   isFetching: PropTypes.bool,
+  noun: PropTypes.string,
   quantity: PropTypes.number,
   reaction: PropTypes.shape({
     id: PropTypes.string,
@@ -88,6 +79,7 @@ ReportbackItem.defaultProps = {
   caption: undefined,
   firstName: undefined,
   isFetching: false,
+  noun: 'items',
   quantity: undefined,
   reaction: null,
   url: undefined,

--- a/resources/assets/components/ReportbackItem/index.js
+++ b/resources/assets/components/ReportbackItem/index.js
@@ -3,6 +3,7 @@ import React from 'react';
 import { Figure, BaseFigure } from '../Figure';
 import Reaction from '../Reaction';
 import { mergeMetadata } from '../../helpers/analytics';
+import { pluralize } from '../../helpers';
 import './reportback-item.scss';
 
 function getMetadataFromProps(props) {
@@ -45,7 +46,7 @@ const ReportbackItem = (props) => {
     <Figure className="reportback-item" image={url} alt={`${firstName}'s photo`}>
       <BaseFigure media={reactionElement} alignment="right" className="padded">
         {firstName ? <h4>{firstName}</h4> : null }
-        {quantity ? <p className="footnote">{quantity} {noun}</p> : null }
+        {quantity ? <p className="footnote">{quantity} {pluralize(quantity, noun.singular, noun.plural)}</p> : null }
         {caption ? <p>{caption}</p> : null }
       </BaseFigure>
     </Figure>
@@ -57,7 +58,10 @@ ReportbackItem.propTypes = {
   caption: PropTypes.string,
   firstName: PropTypes.string,
   isFetching: PropTypes.bool,
-  noun: PropTypes.string,
+  noun: PropTypes.shape({
+    singular: PropTypes.string,
+    plural: PropTypes.string,
+  }),
   quantity: PropTypes.number,
   reaction: PropTypes.shape({
     id: PropTypes.string,
@@ -79,7 +83,10 @@ ReportbackItem.defaultProps = {
   caption: undefined,
   firstName: undefined,
   isFetching: false,
-  noun: 'items',
+  noun: {
+    singular: 'item',
+    plural: 'items',
+  },
   quantity: undefined,
   reaction: null,
   url: undefined,

--- a/resources/assets/components/ReportbackUploader/index.js
+++ b/resources/assets/components/ReportbackUploader/index.js
@@ -113,7 +113,7 @@ class ReportbackUploader extends React.Component {
               </div>
 
               <div>
-                <label className="field-label" htmlFor="impact">How many cards are in this photo?</label>
+                <label className="field-label" htmlFor="impact">How many {this.props.noun} are in this photo?</label>
                 <input className="text-field" id="impact" name="impact" type="text" placeholder="Enter # here -- like '300' or '5'" ref={input => (this.impact = input)} />
               </div>
             </div>
@@ -146,6 +146,11 @@ ReportbackUploader.propTypes = {
   }).isRequired,
   submitReportback: PropTypes.func.isRequired,
   userId: PropTypes.string.isRequired,
+  noun: PropTypes.string,
+};
+
+ReportbackUploader.defaultProps = {
+  noun: 'items',
 };
 
 export default ReportbackUploader;

--- a/resources/assets/components/ReportbackUploader/index.js
+++ b/resources/assets/components/ReportbackUploader/index.js
@@ -113,7 +113,7 @@ class ReportbackUploader extends React.Component {
               </div>
 
               <div>
-                <label className="field-label" htmlFor="impact">How many {this.props.noun} are in this photo?</label>
+                <label className="field-label" htmlFor="impact">How many {this.props.noun.plural} are in this photo?</label>
                 <input className="text-field" id="impact" name="impact" type="text" placeholder="Enter # here -- like '300' or '5'" ref={input => (this.impact = input)} />
               </div>
             </div>
@@ -146,11 +146,17 @@ ReportbackUploader.propTypes = {
   }).isRequired,
   submitReportback: PropTypes.func.isRequired,
   userId: PropTypes.string.isRequired,
-  noun: PropTypes.string,
+  noun: PropTypes.shape({
+    singular: PropTypes.string,
+    plural: PropTypes.string,
+  }),
 };
 
 ReportbackUploader.defaultProps = {
-  noun: 'items',
+  noun: {
+    singular: 'item',
+    plural: 'items',
+  },
 };
 
 export default ReportbackUploader;

--- a/resources/assets/containers/ReportbackItemContainer.js
+++ b/resources/assets/containers/ReportbackItemContainer.js
@@ -1,4 +1,5 @@
 import { connect } from 'react-redux';
+import { get } from 'lodash';
 import ReportbackItem from '../components/ReportbackItem';
 import {
   toggleReactionOn,
@@ -20,6 +21,7 @@ const mapStateToProps = (state, props) => {
     id: reportbackItem.id,
     url: reportbackItem.media.uri,
     quantity: reportback.quantity,
+    noun: get(state.campaign.additionalContent, 'noun.plural'),
     firstName: reportback.user.first_name,
     reaction: reportbackItem.reaction,
     caption: reportbackItem.caption,

--- a/resources/assets/containers/ReportbackItemContainer.js
+++ b/resources/assets/containers/ReportbackItemContainer.js
@@ -21,7 +21,7 @@ const mapStateToProps = (state, props) => {
     id: reportbackItem.id,
     url: reportbackItem.media.uri,
     quantity: reportback.quantity,
-    noun: get(state.campaign.additionalContent, 'noun.plural'),
+    noun: get(state.campaign.additionalContent, 'noun'),
     firstName: reportback.user.first_name,
     reaction: reportbackItem.reaction,
     caption: reportbackItem.caption,

--- a/resources/assets/containers/ReportbackUploaderContainer.js
+++ b/resources/assets/containers/ReportbackUploaderContainer.js
@@ -1,4 +1,5 @@
 import { connect } from 'react-redux';
+import { get } from 'lodash';
 import ReportbackUploader from '../components/ReportbackUploader';
 import { submitReportback, addToSubmissionsList, fetchUserReportbacks } from '../actions';
 
@@ -9,6 +10,7 @@ const mapStateToProps = state => ({
   campaignId: state.campaign.id,
   legacyCampaignId: state.campaign.legacyCampaignId,
   submissions: state.submissions,
+  noun: get(state.campaign.additionalContent, 'noun.plural'),
   userId: state.user.id,
 });
 

--- a/resources/assets/containers/ReportbackUploaderContainer.js
+++ b/resources/assets/containers/ReportbackUploaderContainer.js
@@ -10,7 +10,7 @@ const mapStateToProps = state => ({
   campaignId: state.campaign.id,
   legacyCampaignId: state.campaign.legacyCampaignId,
   submissions: state.submissions,
-  noun: get(state.campaign.additionalContent, 'noun.plural'),
+  noun: get(state.campaign.additionalContent, 'noun'),
   userId: state.user.id,
 });
 

--- a/resources/assets/helpers/index.js
+++ b/resources/assets/helpers/index.js
@@ -91,6 +91,17 @@ export function modifiers(...names) {
 }
 
 /**
+ * Pluralize a noun.
+ *
+ * @param {Number} quantity
+ * @param {String} singular
+ * @param {String} plural
+ */
+export function pluralize(quantity, singular, plural) {
+  return quantity === 1 ? singular : plural;
+}
+
+/**
  * Get the type for a specified file.
  *
  * @param  {ArrayBuffer} file

--- a/resources/assets/helpers/test.js
+++ b/resources/assets/helpers/test.js
@@ -2,6 +2,7 @@ import {
   makeHash,
   modifiers,
   contentfulImageUrl,
+  pluralize,
 } from './index';
 
 /**
@@ -54,4 +55,13 @@ test('prefix a series of class names', () => {
 
 test('prefix a series of class names, ignoring undefined or null values', () => {
   expect(modifiers('danger', undefined, 'will', null, 'robinson')).toEqual(expect.arrayContaining(['-danger', '-will', '-robinson']));
+});
+
+/**
+ * Test pluralize()
+ */
+test('pluralizes words', () => {
+  expect(pluralize(0, 'item', 'items')).toEqual('items');
+  expect(pluralize(1, 'item', 'items')).toEqual('item');
+  expect(pluralize(2, 'item', 'items')).toEqual('items');
 });


### PR DESCRIPTION
#### Changes
This pull request allows campaign leads to customize the "impact noun" (for example, "cards" or "jeans") using the Additional Content JSON field in Contentful. If not set, it will default to "items".

Check it out on [Mirror Messages](https://phoenix-next-stage-pr-234.herokuapp.com/us/campaigns/mirror-messages). Closes #230.