### PR TITLE
Update to allow for more custom CTAs on content pages.

### DIFF
--- a/resources/assets/components/CallToActionBlock/index.js
+++ b/resources/assets/components/CallToActionBlock/index.js
@@ -25,12 +25,13 @@ const renderBackgroundImageStyle = imageUrl => (
 );
 
 const CallToActionBlock = (props) => {
-  const { isAffiliated, fields, imageUrl, campaignId, clickedSignUp, modifierClasses } = props;
+  const { isAffiliated, fields, imageUrl, campaignId, clickedSignUp, modifierClasses,
+    noun, verb } = props;
   const { title, content, additionalContent } = fields;
+
   const hasPhoto = additionalContent ? additionalContent.hasPhoto : false;
 
-  // @TODO: This should probably be editable in contentful...
-  const buttonText = isAffiliated ? 'Make Cards' : 'Join Us';
+  const buttonText = isAffiliated ? `${verb.plural} ${noun.plural}` : 'Join Us';
 
   const metadata = mergeMetadata(CallToActionBlock.defaultMetadata, {
     hasPhoto,
@@ -60,20 +61,33 @@ const CallToActionBlock = (props) => {
 };
 
 CallToActionBlock.propTypes = {
-  isAffiliated: PropTypes.bool,
+  campaignId: PropTypes.string.isRequired,
+  clickedSignUp: PropTypes.func.isRequired,
   fields: PropTypes.shape({
     title: PropTypes.string,
     content: PropTypes.string,
     additionalContent: PropTypes.instanceOf(Object),
   }),
   imageUrl: PropTypes.string.isRequired,
-  campaignId: PropTypes.string.isRequired,
-  clickedSignUp: PropTypes.func.isRequired,
+  isAffiliated: PropTypes.bool,
   modifierClasses: PropTypes.oneOfType([PropTypes.array, PropTypes.string]),
+  noun: PropTypes.shape({
+    singular: PropTypes.string,
+    plural: PropTypes.string,
+  }),
+  verb: PropTypes.shape({
+    singular: PropTypes.string,
+    plural: PropTypes.string,
+  }),
 };
 
 CallToActionBlock.defaultProps = {
+  fields: {
+    title: 'Ready to start?',
+  },
   modifierClasses: [],
+  noun: { singular: 'item', plural: 'items' },
+  verb: { singular: 'make an', plural: 'make' },
 };
 
 CallToActionBlock.defaultMetadata = {

--- a/resources/assets/components/ContentPage/index.js
+++ b/resources/assets/components/ContentPage/index.js
@@ -5,12 +5,8 @@ import CallToActionContainer from '../../containers/CallToActionContainer';
 
 import './content-page.scss';
 
-const ContentPage = ({ pages, route }) => {
+const ContentPage = ({ pages, route, tagline, noun, verb }) => {
   const page = pages.find(item => item.fields.slug === route.page);
-
-  // @TODO: temporary variables until these CTAs are no longer hardcoded.
-  const ctaText1 = { content: 'Help us send letters of support to every mosque in the US.\n\n__Join hundreds of members members making cards!__' };
-  const ctaText2 = { content: 'Help us send letters of support to every mosque in the United States.' };
 
   return (
     <div className="content-page">
@@ -21,10 +17,10 @@ const ContentPage = ({ pages, route }) => {
         </article>
       </div>
       <div className="secondary">
-        <CallToActionContainer fields={ctaText1} />
+        <CallToActionContainer fields={{ content: `${tagline}\n\n__Join hundreds of members and ${verb.plural} ${noun.plural}!__` }} />
       </div>
 
-      <CallToActionContainer fields={ctaText2} modifierClasses="transparent" />
+      <CallToActionContainer fields={{ title: tagline }} modifierClasses="transparent" />
     </div>
   );
 };
@@ -37,11 +33,23 @@ ContentPage.propTypes = {
       content: PropTypes.string.isRequired,
     }),
   })),
+  noun: PropTypes.shape({
+    singular: PropTypes.string,
+    plural: PropTypes.string,
+  }),
   route: PropTypes.instanceOf(Object).isRequired,
+  tagline: PropTypes.string,
+  verb: PropTypes.shape({
+    singular: PropTypes.string,
+    plural: PropTypes.string,
+  }),
 };
 
 ContentPage.defaultProps = {
   pages: [],
+  noun: { singular: 'item', plural: 'items' },
+  tagline: 'Ready to start?',
+  verb: { singular: 'make an', plural: 'make' },
 };
 
 export default ContentPage;

--- a/resources/assets/containers/CallToActionContainer.js
+++ b/resources/assets/containers/CallToActionContainer.js
@@ -1,4 +1,5 @@
 import { connect } from 'react-redux';
+import { get } from 'lodash';
 import CallToActionBlock from '../components/CallToActionBlock';
 import { clickedSignUp } from '../actions';
 
@@ -9,6 +10,8 @@ const mapStateToProps = state => ({
   isAffiliated: state.signups.thisCampaign,
   imageUrl: state.campaign.coverImage.url,
   campaignId: state.campaign.legacyCampaignId,
+  noun: get(state.campaign.additionalContent, 'noun'),
+  verb: get(state.campaign.additionalContent, 'verb'),
 });
 
 /**

--- a/resources/assets/containers/ContentPageContainer.js
+++ b/resources/assets/containers/ContentPageContainer.js
@@ -1,4 +1,5 @@
 import { connect } from 'react-redux';
+import { get } from 'lodash';
 import ContentPage from '../components/ContentPage';
 
 /**
@@ -7,6 +8,9 @@ import ContentPage from '../components/ContentPage';
 const mapStateToProps = (state, ownProps) => ({
   pages: state.campaign.pages,
   route: ownProps.params,
+  noun: get(state.campaign.additionalContent, 'noun'),
+  verb: get(state.campaign.additionalContent, 'verb'),
+  tagline: get(state.campaign.additionalContent, 'tagline'),
 });
 
 // Export the container component.


### PR DESCRIPTION
This PR makes an update to allow having slightly more customized CTAs on the content pages for a campaign. It tries to be smart enough to handle a few scenarios, but to customize it we need to pass a custom JSON object for the campaign via Contentful as follows:

```
{
  "tagline": "Help us send letters of support to every mosque in the United States.",
  "verb": {
    "singular": "make a",
    "plural": "make"
    },
  "noun": {
    "singular": "card",
    "plural": "cards"
  }
}
```