### PR TITLE
Default to a first name of Doer.

### DIFF
--- a/resources/assets/components/ReportbackItem/__snapshots__/test.js.snap
+++ b/resources/assets/components/ReportbackItem/__snapshots__/test.js.snap
@@ -1,0 +1,60 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Reportback Item basic snapshot test 1`] = `
+<Figure
+  alt="A Doer's photo"
+  className="reportback-item"
+  image={null}
+  imageClassName={null}
+>
+  <BaseFigure
+    alignment="right"
+    className="padded"
+    media={null}
+    size={null}
+    verticalAlignment={null}
+  >
+    <h4>
+      A Doer
+    </h4>
+  </BaseFigure>
+</Figure>
+`;
+
+exports[`Reportback Item snapshot test 1`] = `
+<Figure
+  alt="Luke Skywalker's photo"
+  className="reportback-item"
+  image="https://static1.comicvine.com/uploads/original/11118/111184078/5124660-6531264806-22292.jpg"
+  imageClassName={null}
+>
+  <BaseFigure
+    alignment="right"
+    className="padded"
+    media={
+      <Reaction
+        active={true}
+        onToggleOff={[Function]}
+        onToggleOn={[Function]}
+        total={30}
+      />
+    }
+    size={null}
+    verticalAlignment={null}
+  >
+    <h4>
+      Luke Skywalker
+    </h4>
+    <p
+      className="footnote"
+    >
+      20
+       
+      lightsabers
+    </p>
+    <p>
+      Some awesmome caption
+    </p>
+  </BaseFigure>
+</Figure>
+`;

--- a/resources/assets/components/ReportbackItem/index.js
+++ b/resources/assets/components/ReportbackItem/index.js
@@ -17,10 +17,8 @@ function getMetadataFromProps(props) {
 }
 
 const ReportbackItem = (props) => {
-  const { id, url, quantity, noun, caption, reaction = null, isFetching = false,
+  const { id, url, quantity, noun, caption, firstName, reaction = null, isFetching = false,
     basicDisplay = false, toggleReactionOn, toggleReactionOff } = props;
-
-  const firstName = props.firstName || 'A Doer';
 
   const metadata = mergeMetadata(ReportbackItem.defaultMetadata, getMetadataFromProps(props));
 
@@ -85,7 +83,7 @@ ReportbackItem.defaultProps = {
   id: undefined,
   basicDisplay: false,
   caption: undefined,
-  firstName: undefined,
+  firstName: 'A Doer',
   isFetching: false,
   noun: {
     singular: 'item',

--- a/resources/assets/components/ReportbackItem/index.js
+++ b/resources/assets/components/ReportbackItem/index.js
@@ -17,8 +17,10 @@ function getMetadataFromProps(props) {
 }
 
 const ReportbackItem = (props) => {
-  const { id, url, quantity, noun, caption, firstName, reaction = null,
-    isFetching = false, toggleReactionOn, toggleReactionOff } = props;
+  const { id, url, quantity, noun, caption, reaction = null, isFetching = false,
+    basicDisplay = false, toggleReactionOn, toggleReactionOff } = props;
+
+  const firstName = props.firstName || 'A Doer';
 
   const metadata = mergeMetadata(ReportbackItem.defaultMetadata, getMetadataFromProps(props));
 
@@ -45,8 +47,8 @@ const ReportbackItem = (props) => {
   return (
     <Figure className="reportback-item" image={url} alt={`${firstName}'s photo`}>
       <BaseFigure media={reactionElement} alignment="right" className="padded">
-        {firstName ? <h4>{firstName}</h4> : null }
-        {quantity ? <p className="footnote">{quantity} {pluralize(quantity, noun.singular, noun.plural)}</p> : null }
+        {! basicDisplay && firstName ? <h4>{firstName}</h4> : null }
+        {! basicDisplay && quantity ? <p className="footnote">{quantity} {pluralize(quantity, noun.singular, noun.plural)}</p> : null }
         {caption ? <p>{caption}</p> : null }
       </BaseFigure>
     </Figure>
@@ -55,6 +57,7 @@ const ReportbackItem = (props) => {
 
 ReportbackItem.propTypes = {
   id: PropTypes.string,
+  basicDisplay: PropTypes.bool,
   caption: PropTypes.string,
   firstName: PropTypes.string,
   isFetching: PropTypes.bool,
@@ -80,6 +83,7 @@ ReportbackItem.propTypes = {
 // app to crash. Something to look into...
 ReportbackItem.defaultProps = {
   id: undefined,
+  basicDisplay: false,
   caption: undefined,
   firstName: undefined,
   isFetching: false,

--- a/resources/assets/components/ReportbackItem/test.js
+++ b/resources/assets/components/ReportbackItem/test.js
@@ -4,7 +4,7 @@ import { shallowToJson } from 'enzyme-to-json';
 import ReportbackItem from './index';
 
 test('Reportback Item basic snapshot test', () => {
-  const component = shallow(<ReportbackItem/>);
+  const component = shallow(<ReportbackItem />);
   const tree = shallowToJson(component);
   expect(tree).toMatchSnapshot();
 });
@@ -15,11 +15,11 @@ test('Reportback Item snapshot test', () => {
       id="09251952"
       caption="Some awesmome caption"
       firstName="Luke Skywalker"
-      noun={{ singular: 'lightsaber', plural: 'lightsabers'}}
+      noun={{ singular: 'lightsaber', plural: 'lightsabers' }}
       quantity={20}
       url="https://static1.comicvine.com/uploads/original/11118/111184078/5124660-6531264806-22292.jpg"
       reaction={{ id: '456', reacted: true, termId: '789', total: 30 }}
-    />
+    />,
   );
   const tree = shallowToJson(component);
   expect(tree).toMatchSnapshot();

--- a/resources/assets/components/ReportbackItem/test.js
+++ b/resources/assets/components/ReportbackItem/test.js
@@ -1,0 +1,26 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { shallowToJson } from 'enzyme-to-json';
+import ReportbackItem from './index';
+
+test('Reportback Item basic snapshot test', () => {
+  const component = shallow(<ReportbackItem/>);
+  const tree = shallowToJson(component);
+  expect(tree).toMatchSnapshot();
+});
+
+test('Reportback Item snapshot test', () => {
+  const component = shallow(
+    <ReportbackItem
+      id="09251952"
+      caption="Some awesmome caption"
+      firstName="Luke Skywalker"
+      noun={{ singular: 'lightsaber', plural: 'lightsabers'}}
+      quantity={20}
+      url="https://static1.comicvine.com/uploads/original/11118/111184078/5124660-6531264806-22292.jpg"
+      reaction={{ id: '456', reacted: true, termId: '789', total: 30 }}
+    />
+  );
+  const tree = shallowToJson(component);
+  expect(tree).toMatchSnapshot();
+});

--- a/resources/assets/components/ReportbackUploader/index.js
+++ b/resources/assets/components/ReportbackUploader/index.js
@@ -16,7 +16,7 @@ class ReportbackUploader extends React.Component {
     const key = makeHash(submission.media.uri || submission.media.filePreviewUrl);
     const url = submission.media.uri || submission.media.filePreviewUrl;
 
-    return <ReportbackItem key={key} {...submission} url={url} reaction={null} />;
+    return <ReportbackItem key={key} {...submission} url={url} reaction={null} basicDisplay />;
   }
 
   static setFormData(container) {


### PR DESCRIPTION
This PR lets us default to a first name of **A Doer** if no first name is available when rendering out Reportback Items. It was a little tricky because in the submission gallery, we prefer not to display any name, even if a default is provided. Since both reportback item blocks in the feed and submission gallery use the same RB Item component, I added a new `basicDisplay` boolean prop that can be passed to make sure only a very basic display of the RB item is rendered.

Refs https://trello.com/c/ehcE3Vay/606-1-as-a-developer-i-want-the-user-name-to-default-doer-if-the-account-has-no-name