### PR TITLE
Update for how the Byline is imported.

### DIFF
--- a/resources/assets/components/CompetitionBlock/index.js
+++ b/resources/assets/components/CompetitionBlock/index.js
@@ -5,7 +5,7 @@ import classnames from 'classnames';
 import Markdown from '../Markdown';
 import Block, { BlockTitle } from '../Block';
 import { Flex, FlexCell } from '../Flex';
-import { Byline } from '../Byline';
+import Byline from '../Byline';
 import LazyImage from '../LazyImage';
 import './competitionBlock.scss';
 


### PR DESCRIPTION
This PR provides a quick fix. Now that the `Byline` is its own component, we import it without the need for using destructuring since it's the default export. It was throwing a bunch of errors otherwise 😬 