### PR TITLE
Hot fixing the flex cell for competitions

### DIFF
--- a/resources/assets/components/CompetitionBlock/competitionBlock.scss
+++ b/resources/assets/components/CompetitionBlock/competitionBlock.scss
@@ -6,6 +6,10 @@
   @include media($medium) {
     flex-direction: row;
   }
+  
+  > .flex__cell {
+    flex: 0 0 auto;  
+  }
 
   .competition-block__content {
     &.is-confirmation > .markdown {


### PR DESCRIPTION
See this issue for details of the bug: https://github.com/DoSomething/phoenix-next/issues/248

TLDR: Competitions block is shrunk on IOS

This PR is a shitty hotfix I found by playing around in the inspector. The actual flex cell value is `0 0 100%;` which seems to work fine everywhere else. @DFurnes & @weerd can you weigh in here with any thoughts / ideas?