### PR TITLE
Update to fix up styles for the competition block.

### DIFF
--- a/resources/assets/components/CompetitionBlock/competitionBlock.scss
+++ b/resources/assets/components/CompetitionBlock/competitionBlock.scss
@@ -1,32 +1,30 @@
 @import '../../scss/next-toolbox';
 
 .competition-block {
-  flex-direction: column-reverse;
-
-  @include media($medium) {
-    flex-direction: row;
-  }
-  
-  > .flex__cell {
-    flex: 0 0 auto;  
+  .button {
+    clear: both;
+    margin-top: $base-spacing;
   }
 
-  .competition-block__content {
-    &.is-confirmation > .markdown {
-      margin-bottom: $base-spacing;
-    }
-
-    button {
-      margin: $base-spacing 0;
+  .markdown {
+    @include media($large) {
+      float: left;
+      padding-right: $base-spacing;
+      width: 66.6666666666666%;
     }
   }
 
-  .competition-block__photo {
-    margin-bottom: $half-spacing;
+  > .figure {
+    margin-top: $base-spacing;
+  }
+}
 
-    @include media($medium) {
-      margin-bottom: 0;
-      margin-left: $half-spacing;
-    }
+.competition-block__photo {
+  margin-top: $half-spacing;
+
+  @include media($large) {
+    float: right;
+    margin-top: 0;
+    width: 33.3333333333333%;
   }
 }

--- a/resources/assets/components/CompetitionBlock/index.js
+++ b/resources/assets/components/CompetitionBlock/index.js
@@ -4,7 +4,6 @@ import classnames from 'classnames';
 
 import Markdown from '../Markdown';
 import Block, { BlockTitle } from '../Block';
-import { Flex, FlexCell } from '../Flex';
 import Byline from '../Byline';
 import LazyImage from '../LazyImage';
 import './competitionBlock.scss';
@@ -32,7 +31,7 @@ const CompetitionBlock = (props) => {
     checkForCompetition(campaignId, campaignRunId);
   }
 
-  const button = showConfirmation ? null : (
+  const renderButton = showConfirmation ? null : (
     <button
       disabled={hasPendingJoin}
       className={classnames('button', { 'is-loading': hasPendingJoin })}
@@ -40,23 +39,23 @@ const CompetitionBlock = (props) => {
     >join competition</button>
   );
 
+  const renderPhoto = photo && ! showConfirmation ? (
+    <div className="competition-block__photo">
+      <LazyImage alt="competition" src={photo} />
+    </div>
+  ) : null;
+
   return (
     <Block>
       <BlockTitle>Go above and beyond!</BlockTitle>
-      <Flex className="competition-block">
-        <FlexCell width="two-thirds">
-          <div className={classnames('competition-block__content', { 'is-confirmation': showConfirmation })}>
-            <Markdown className={classnames('', { 'is-success': showConfirmation })}>{ showConfirmation ? DEFAULT_CONFIRMATION : content }</Markdown>
-            { button }
-            <Byline {...byline} />
-          </div>
-        </FlexCell>
-        <FlexCell width="one-third">
-          <div className="competition-block__photo">
-            { photo ? <LazyImage alt="competition" src={photo} /> : null }
-          </div>
-        </FlexCell>
-      </Flex>
+      <div className={classnames('competition-block', { 'is-confirmation': showConfirmation })}>
+        <div className="clearfix">
+          <Markdown className={classnames('', { 'is-success': showConfirmation })}>{ showConfirmation ? DEFAULT_CONFIRMATION : content }</Markdown>
+          { renderPhoto }
+        </div>
+        { renderButton }
+        <Byline {...byline} />
+      </div>
     </Block>
   );
 };

--- a/resources/assets/components/CompetitionBlock/index.js
+++ b/resources/assets/components/CompetitionBlock/index.js
@@ -31,7 +31,7 @@ const CompetitionBlock = (props) => {
     checkForCompetition(campaignId, campaignRunId);
   }
 
-  const renderButton = showConfirmation ? null : (
+  const button = showConfirmation ? null : (
     <button
       disabled={hasPendingJoin}
       className={classnames('button', { 'is-loading': hasPendingJoin })}
@@ -39,7 +39,7 @@ const CompetitionBlock = (props) => {
     >join competition</button>
   );
 
-  const renderPhoto = photo && ! showConfirmation ? (
+  const competitionPhoto = photo && ! showConfirmation ? (
     <div className="competition-block__photo">
       <LazyImage alt="competition" src={photo} />
     </div>
@@ -51,9 +51,9 @@ const CompetitionBlock = (props) => {
       <div className={classnames('competition-block', { 'is-confirmation': showConfirmation })}>
         <div className="clearfix">
           <Markdown className={classnames('', { 'is-success': showConfirmation })}>{ showConfirmation ? DEFAULT_CONFIRMATION : content }</Markdown>
-          { renderPhoto }
+          { competitionPhoto }
         </div>
-        { renderButton }
+        { button }
         <Byline {...byline} />
       </div>
     </Block>

--- a/resources/assets/components/Markdown/markdown.scss
+++ b/resources/assets/components/Markdown/markdown.scss
@@ -6,6 +6,7 @@
     color: inherit;
   }
 
+  // Overriding rules in Forge, we'll eventually address this better.
   h1 + p,
   h2 + p,
   h3 + p,
@@ -14,7 +15,11 @@
   h6 + p,
   p + p,
   p + ul,
-  p + ol {
+  p + ol,
+  ul + p,
+  ol + p,
+  ul + ul,
+  ol + ol, {
     margin-top: $half-spacing;
   }
 

--- a/resources/assets/components/Markdown/markdown.scss
+++ b/resources/assets/components/Markdown/markdown.scss
@@ -6,6 +6,18 @@
     color: inherit;
   }
 
+  h1 + p,
+  h2 + p,
+  h3 + p,
+  h4 + p,
+  h5 + p,
+  h6 + p,
+  p + p,
+  p + ul,
+  p + ol {
+    margin-top: $half-spacing;
+  }
+
   &.is-success {
     color: $success-color;
   }

--- a/resources/assets/components/Markdown/markdown.scss
+++ b/resources/assets/components/Markdown/markdown.scss
@@ -17,9 +17,11 @@
   p + ul,
   p + ol,
   ul + p,
-  ol + p,
   ul + ul,
-  ol + ol, {
+  ul + ol,
+  ol + p,
+  ol + ol,
+  ol + ul {
     margin-top: $half-spacing;
   }
 


### PR DESCRIPTION
This PR make a few markup and style fixes for the competition block and removes the use of flexbox which was a bit of overkill for what the content holds. Updates also include responsive fixes.

![image](https://d2ppvlu71ri8gs.cloudfront.net/items/2I0N462v0f2l2y0W1L2e/Screen%20Recording%202017-05-10%20at%2005.54%20PM.gif?v=b15fe169)