### PR TITLE
Adding experiments to analytics data

### DIFF
--- a/resources/assets/helpers/analytics.js
+++ b/resources/assets/helpers/analytics.js
@@ -24,6 +24,11 @@ export function getSession() {
  * @return {Object}        Object to send
  */
 export function transformState(action, state) {
+  const experiments = {
+    tests: Object.keys(state.experiments),
+    variants: Object.keys(state.experiments).reduce((acc, key) => [...acc, key], []),
+  };
+
   const transformation = {
     feed: {
       page: state.blocks.offset,
@@ -40,6 +45,7 @@ export function transformState(action, state) {
       session: getSession(),
       ...state.user,
     },
+    experiments,
     action,
   };
 

--- a/resources/assets/helpers/analytics.js
+++ b/resources/assets/helpers/analytics.js
@@ -24,10 +24,9 @@ export function getSession() {
  * @return {Object}        Object to send
  */
 export function transformState(action, state) {
-  const experimentKeys = state.experiments ? Object.keys(state.experiments) : [];
   const experiments = {
-    tests: experimentKeys,
-    variants: experimentKeys.reduce((acc, key) => [...acc, state.experiments[key]], []),
+    tests: state.experiments ? Object.keys(state.experiments) : [],
+    variants: state.experiments ? Object.values(state.experiments) : [],
   };
 
   const transformation = {

--- a/resources/assets/helpers/analytics.js
+++ b/resources/assets/helpers/analytics.js
@@ -24,9 +24,10 @@ export function getSession() {
  * @return {Object}        Object to send
  */
 export function transformState(action, state) {
+  const experimentKeys = state.experiments ? Object.keys(state.experiments) : [];
   const experiments = {
-    tests: Object.keys(state.experiments),
-    variants: Object.keys(state.experiments).reduce((acc, key) => [...acc, key], []),
+    tests: experimentKeys,
+    variants: experimentKeys.reduce((acc, key) => [...acc, key], []),
   };
 
   const transformation = {

--- a/resources/assets/helpers/analytics.js
+++ b/resources/assets/helpers/analytics.js
@@ -27,7 +27,7 @@ export function transformState(action, state) {
   const experimentKeys = state.experiments ? Object.keys(state.experiments) : [];
   const experiments = {
     tests: experimentKeys,
-    variants: experimentKeys.reduce((acc, key) => [...acc, key], []),
+    variants: experimentKeys.reduce((acc, key) => [...acc, state.experiments[key]], []),
   };
 
   const transformation = {


### PR DESCRIPTION
This pr adds experiments to the analytics data we send off to Keen

_Why are you transforming the data this way?_

From a Keen.IO perspective, we'll be able to query using the [in](https://keen.io/docs/api/#filters) operator. This way we can ask questions such as "What was the conversion rate for people in this variant A" or "What was the conversion rate for people in A and B".  I don't expect we'll ever need the `tests` array, but its there if we do.