### PR TITLE
Adding browser size to the Keen payload

### DIFF
--- a/resources/assets/helpers/analytics.js
+++ b/resources/assets/helpers/analytics.js
@@ -24,6 +24,11 @@ export function getSession() {
  * @return {Object}        Object to send
  */
 export function transformState(action, state) {
+  const experiments = {
+    tests: Object.keys(state.experiments),
+    variants: Object.keys(state.experiments).reduce((acc, key) => [...acc, key], []),
+  };
+
   const transformation = {
     feed: {
       page: state.blocks.offset,
@@ -40,6 +45,7 @@ export function transformState(action, state) {
       session: getSession(),
       ...state.user,
     },
+    experiments,
     action,
   };
 

--- a/resources/assets/helpers/analytics.js
+++ b/resources/assets/helpers/analytics.js
@@ -24,10 +24,9 @@ export function getSession() {
  * @return {Object}        Object to send
  */
 export function transformState(action, state) {
-  const experimentKeys = state.experiments ? Object.keys(state.experiments) : [];
   const experiments = {
-    tests: experimentKeys,
-    variants: experimentKeys.reduce((acc, key) => [...acc, state.experiments[key]], []),
+    tests: state.experiments ? Object.keys(state.experiments) : [],
+    variants: state.experiments ? Object.values(state.experiments) : [],
   };
 
   const transformation = {

--- a/resources/assets/helpers/analytics.js
+++ b/resources/assets/helpers/analytics.js
@@ -24,9 +24,10 @@ export function getSession() {
  * @return {Object}        Object to send
  */
 export function transformState(action, state) {
+  const experimentKeys = state.experiments ? Object.keys(state.experiments) : [];
   const experiments = {
-    tests: Object.keys(state.experiments),
-    variants: Object.keys(state.experiments).reduce((acc, key) => [...acc, key], []),
+    tests: experimentKeys,
+    variants: experimentKeys.reduce((acc, key) => [...acc, key], []),
   };
 
   const transformation = {

--- a/resources/assets/helpers/analytics.js
+++ b/resources/assets/helpers/analytics.js
@@ -27,7 +27,7 @@ export function transformState(action, state) {
   const experimentKeys = state.experiments ? Object.keys(state.experiments) : [];
   const experiments = {
     tests: experimentKeys,
-    variants: experimentKeys.reduce((acc, key) => [...acc, key], []),
+    variants: experimentKeys.reduce((acc, key) => [...acc, state.experiments[key]], []),
   };
 
   const transformation = {

--- a/resources/assets/helpers/analytics.js
+++ b/resources/assets/helpers/analytics.js
@@ -1,7 +1,7 @@
 /* global document, location, localStorage */
 
 import { analyze } from '@dosomething/analytics';
-import { generateUniqueId, isTimestampValid } from '../helpers';
+import { generateUniqueId, isTimestampValid, getFormattedScreenSize } from '../helpers';
 
 const DEVICE_ID = 'DEVICE_ID';
 const SESSION_ID = 'SESSION_ID';
@@ -24,11 +24,6 @@ export function getSession() {
  * @return {Object}        Object to send
  */
 export function transformState(action, state) {
-  const experiments = {
-    tests: state.experiments ? Object.keys(state.experiments) : [],
-    variants: state.experiments ? Object.values(state.experiments) : [],
-  };
-
   const transformation = {
     feed: {
       page: state.blocks.offset,
@@ -45,7 +40,13 @@ export function transformState(action, state) {
       session: getSession(),
       ...state.user,
     },
-    experiments,
+    experiments: {
+      tests: state.experiments ? Object.keys(state.experiments) : [],
+      variants: state.experiments ? Object.values(state.experiments) : [],
+    },
+    _browser: { // Just in case we ever need a store item named "browser", prefixing with _
+      size: getFormattedScreenSize(),
+    },
     action,
   };
 

--- a/resources/assets/helpers/index.js
+++ b/resources/assets/helpers/index.js
@@ -292,3 +292,29 @@ export function getDaysBetween(dateOne, dateTwo) {
 
   return Math.round(Math.abs((dateOne.getTime() - dateTwo.getTime()) / oneDay));
 }
+
+/**
+ * Get a formatted name (small, medium, large)
+ * of the current display size.
+ *
+ * @param  {int} width - Defaults to the screen width
+ * @return {String}
+ */
+export function getFormattedScreenSize(screenWidth = window.innerWidth) {
+  const breakpoints = [
+    {
+      name: 'small',
+      test: width => width <= 759,
+    },
+    {
+      name: 'medium',
+      test: width => width >= 760 && width <= 959,
+    },
+    {
+      name: 'large',
+      test: width => width >= 960,
+    },
+  ];
+
+  return breakpoints.find(breakpoint => breakpoint.test(screenWidth)).name;
+}


### PR DESCRIPTION
- Adds a helper method to get the current screen size
- Adds this data to the payload

<img width="226" alt="screen shot 2017-05-16 at 1 13 30 pm" src="https://cloud.githubusercontent.com/assets/897368/26119545/8fa171ae-3a3b-11e7-8e71-15390040eab2.png">
<img width="170" alt="screen shot 2017-05-16 at 1 13 12 pm" src="https://cloud.githubusercontent.com/assets/897368/26119544/8f9f26ce-3a3b-11e7-888b-487792efb243.png">
<img width="186" alt="screen shot 2017-05-16 at 1 13 07 pm" src="https://cloud.githubusercontent.com/assets/897368/26119546/8fa7531c-3a3b-11e7-8264-f423d584597c.png">

