### PR TITLE
Updating how we setup experiments to hopefully make things easier.

### DIFF
--- a/app/Http/Controllers/CampaignController.php
+++ b/app/Http/Controllers/CampaignController.php
@@ -66,15 +66,6 @@ class CampaignController extends Controller
      */
     public function show($slug)
     {
-        $experiments = [];
-
-        if (config('services.sixpack.enabled')) {
-            $sixpack = app(Sixpack::class);
-            $experiments = [
-                'competitions_prompt_style' => $sixpack->participate('competitions_prompt_style', ['default_block', 'colorful_block'])->getAlternative(),
-            ];
-        }
-
         $campaign = $this->campaignRepository->findBySlug($slug);
         $shareFields = getShareFields($campaign, $campaign->socialOverrides);
 
@@ -83,7 +74,7 @@ class CampaignController extends Controller
             'shareFields' => $shareFields,
         ])->with('state', [
             'campaign' => $campaign,
-            'experiments' => $experiments,
+            'experiments' => get_experiment_alternatives_selection(),
             'share' => $shareFields,
             'user' => [
                 'id' => auth()->id(),

--- a/app/Http/Controllers/CampaignController.php
+++ b/app/Http/Controllers/CampaignController.php
@@ -5,7 +5,6 @@ namespace App\Http\Controllers;
 use Auth;
 use App\Services\PhoenixLegacy;
 use App\Repositories\CampaignRepository;
-use SeatGeek\Sixpack\Session\Base as Sixpack;
 
 class CampaignController extends Controller
 {

--- a/app/Providers/SixpackServiceProvider.php
+++ b/app/Providers/SixpackServiceProvider.php
@@ -24,7 +24,7 @@ class SixpackServiceProvider extends ServiceProvider
      */
     public function register()
     {
-        $this->app->bind(Sixpack::class, function ($app) {
+        $this->app->singleton(Sixpack::class, function ($app) {
             return new Sixpack([
                 'baseUrl' => config('services.sixpack.url'),
                 'cookiePrefix' => config('services.sixpack.prefix'),

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -128,7 +128,7 @@ function get_experiment_alternatives_selection()
 
     $experiments = get_experiments();
 
-    return collect($experiments)->map(function($alternatives, $name) use ($sixpack) {
+    return collect($experiments)->map(function ($alternatives, $name) use ($sixpack) {
         return $data[$name] = $sixpack->participate($name, array_values($alternatives))->getAlternative();
     })->toArray();
 }

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -6,6 +6,7 @@ use Contentful\Delivery\Asset;
 use App\Services\PhoenixLegacy;
 use Illuminate\Support\HtmlString;
 use Contentful\Delivery\DynamicEntry;
+use Illuminate\Support\Facades\Storage;
 use SeatGeek\Sixpack\Session\Base as Sixpack;
 
 /**
@@ -95,21 +96,19 @@ function markdown($source)
 }
 
 /**
- * Get all Sixpack experiments from experiments definition file.
+ * Get all Sixpack experiments from specified experiments definition file.
  *
  * @return array
  */
-function get_experiments()
+function get_experiments($file = 'experiments.json')
 {
-    try {
-        $experiments = file_get_contents(resource_path('assets/experiments.json'));
+    $filePath = 'assets/'.$file;
 
-        if (! $experiments) {
-            return [];
-        }
-    } catch (\Exception $error) {
+    if (! Storage::disk('resources')->exists($filePath)) {
         return [];
     }
+
+    $experiments = Storage::disk('resources')->get($filePath);
 
     return json_decode($experiments, true);
 }

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -6,6 +6,7 @@ use Contentful\Delivery\Asset;
 use App\Services\PhoenixLegacy;
 use Illuminate\Support\HtmlString;
 use Contentful\Delivery\DynamicEntry;
+use SeatGeek\Sixpack\Session\Base as Sixpack;
 
 /**
  * App helper functions.
@@ -91,6 +92,46 @@ function markdown($source)
     $markup = $parsedown->setMarkupEscaped(true)->text($source);
 
     return new HtmlString($markup);
+}
+
+/**
+ * Get all Sixpack experiments from experiments definition file.
+ *
+ * @return array
+ */
+function get_experiments()
+{
+    try {
+        $experiments = file_get_contents(resource_path('assets/experiments.json'));
+
+        if (! $experiments) {
+            return [];
+        }
+    } catch (\Exception $error) {
+        return [];
+    }
+
+    return json_decode($experiments, true);
+}
+
+/**
+ * Get selection of alternatives for all Sixpack experiments for the current client.
+ *
+ * @return array
+ */
+function get_experiment_alternatives_selection()
+{
+    if (! config('services.sixpack.enabled')) {
+        return [];
+    }
+
+    $sixpack = app(Sixpack::class);
+
+    $experiments = get_experiments();
+
+    return collect($experiments)->map(function($alternatives, $name) use ($sixpack) {
+        return $data[$name] = $sixpack->participate($name, array_values($alternatives))->getAlternative();
+    })->toArray();
 }
 
 /**

--- a/config/filesystems.php
+++ b/config/filesystems.php
@@ -59,6 +59,11 @@ return [
             'root' => public_path('next/uploads'),
         ],
 
+        'resources' => [
+            'driver' => 'local',
+            'root' => resource_path(),
+        ],
+
         's3' => [
             'driver' => 's3',
             'key' => 'your-key',

--- a/resources/assets/experiments.json
+++ b/resources/assets/experiments.json
@@ -1,0 +1,10 @@
+{
+  "competitions_prompt_style": {
+    "a": "default_block",
+    "b": "colorful_block"
+  },
+  "lede_banner_number_of_buttons": {
+    "a": "one_button",
+    "b": "two_buttons"
+  }
+}


### PR DESCRIPTION
This PR updates how we implement Sixpack A/B tests within Phoenix-Next. To begin with, instead of having to specify experiments (name and list of alternatives) within the `CampaignController`, we can just update a JSON file. We can then call a function `get_experiment_alternatives_selection()` which will create (if not already created in Sixpack) and participate the current client in the experiment, as well as return an array of all the selected alternatives the current client has been assigned to.

```javascript
// experiments.json example experiments definitions
{
  "competitions_prompt_style": {
    "a": "default_block",
    "b": "colorful_block"
  },
  "lede_banner_number_of_buttons": {
    "a": "one_button",
    "b": "two_buttons",
    "c": "three_buttons"
  }
}
```
The return value from calling the `get_experiment_alternatives_selection()` function:

```php
// experiments and selected alternatives for current client
[
  "competitions_prompt_style" => "default_block"
  "lede_banner_number_of_buttons" => "two_buttons"
]
```

The selected alternative array above is what gets passed to the redux store, which contains the same established structure:

![image](https://cloud.githubusercontent.com/assets/105849/26128919/1916b2e4-3a5c-11e7-8e53-ed665eb5ba98.png)
