### PR TITLE
adding app init component

### DIFF
--- a/resources/assets/actions/analytics.js
+++ b/resources/assets/actions/analytics.js
@@ -1,6 +1,11 @@
 /* eslint import/prefer-default-export: "off" */
 import { analyze } from '@dosomething/analytics';
+import { APPLICATION_INIT } from './';
 import { transformState } from '../helpers/analytics';
+
+export function appInit() {
+  return { type: APPLICATION_INIT };
+}
 
 // Action: Track a custom event
 export function trackEvent(collection, metadata) {

--- a/resources/assets/actions/index.js
+++ b/resources/assets/actions/index.js
@@ -62,9 +62,11 @@ export const COMPLETED_EVENT = 'COMPLETED_EVENT';
 export * from './event';
 
 // Analytics Action Names & Creators
+export const APPLICATION_INIT = 'APPLICATION_INIT';
 export * from './analytics';
 
 export const ANALYTICS_ACTIONS = [
+  APPLICATION_INIT,
   REQUESTED_REPORTBACKS,
   REACTION_CHANGED,
   REACTION_COMPLETE,

--- a/resources/assets/components/AppInit.js
+++ b/resources/assets/components/AppInit.js
@@ -1,0 +1,12 @@
+import { connect } from 'react-redux';
+import { appInit } from '../actions';
+
+const mapStateToProps = () => ({});
+const actionCreators = { appInit };
+
+const AppInit = (props) => {
+  props.appInit();
+  return null;
+};
+
+export default connect(mapStateToProps, actionCreators)(AppInit);

--- a/resources/assets/components/Chrome.js
+++ b/resources/assets/components/Chrome.js
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import AppInit from './AppInit';
 import Dashboard from './Dashboard';
 import Debugger from './Debugger';
 import FeedEnclosure from './FeedEnclosure';
@@ -10,6 +11,7 @@ import NotificationContainer from '../containers/NotificationContainer';
 
 const Chrome = props => (
   <div>
+    <AppInit />
     <NotificationContainer />
     <LedeBanner
       isAffiliated={props.isAffiliated}

--- a/resources/assets/middleware/analytics.js
+++ b/resources/assets/middleware/analytics.js
@@ -43,7 +43,7 @@ export const observerMiddleware = store => next => (action) => {
  * @param  {Object} store   Instance of a React Redux store
  * @return {Function}
  */
-export function start(store) {
+export function start() {
   // Setup session
   createDeviceId();
 
@@ -63,7 +63,4 @@ export function start(store) {
     pageview(path);
   });
   pageview(window.location.pathname);
-
-  // Track state changes for Keen.io
-  stateChanged({ type: 'APPLICATION_INIT' }, store.getState());
 }


### PR DESCRIPTION
Unfortunately, another unexpected problem from the react router upgrade, we hit a snag here where the routing information is not in the store when the app boots up, so our APP_INIT data is currently returning blank paths.

This PR is literally a hack to get around this, I don't like it at all but had no better ideas.