### PR TITLE
Sixpacking first experiments

### DIFF
--- a/app/Http/Controllers/SignupController.php
+++ b/app/Http/Controllers/SignupController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers;
 
 use Illuminate\Http\Request;
 use App\Services\PhoenixLegacy;
+use SeatGeek\Sixpack\Session\Base as Sixpack;
 
 class SignupController extends Controller
 {
@@ -53,6 +54,10 @@ class SignupController extends Controller
         $this->validate($request, [
             'campaignId' => 'required',
         ]);
+
+        // @TEST 2017-05-17 lede_banner_number_of_buttons
+        $sixpack = app(Sixpack::class);
+        $sixpack->convert('lede_banner_number_of_buttons');
 
         return $this->phoenixLegacy->storeSignup(
             auth()->id(),

--- a/app/Http/Controllers/UserContestController.php
+++ b/app/Http/Controllers/UserContestController.php
@@ -63,6 +63,7 @@ class UserContestController extends Controller
             'legacyCampaignRunId' => 'required',
         ]);
 
+        // @TEST 2017-05-17 competitions_prompt_style
         $sixpack = app(Sixpack::class);
         $sixpack->convert('competitions_prompt_style');
 

--- a/resources/assets/components/Chrome.js
+++ b/resources/assets/components/Chrome.js
@@ -44,34 +44,46 @@ const Chrome = props => (
 );
 
 Chrome.propTypes = {
-  isAffiliated: PropTypes.bool,
-  title: PropTypes.string.isRequired,
-  subtitle: PropTypes.string.isRequired,
   blurb: PropTypes.string.isRequired,
+  clickedSignUp: PropTypes.func.isRequired,
+  children: PropTypes.node.isRequired,
+  competitions: PropTypes.array.isRequired, // eslint-disable-line react/forbid-prop-types
   coverImage: PropTypes.shape({
     description: PropTypes.string,
     url: PropTypes.string,
   }).isRequired,
-  legacyCampaignId: PropTypes.string.isRequired,
-  clickedSignUp: PropTypes.func.isRequired,
-  totalCampaignSignups: PropTypes.number.isRequired,
   dashboard: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
   endDate: PropTypes.shape({
     date: PropTypes.string,
     timezone: PropTypes.string,
     timezone_type: PropTypes.number,
   }).isRequired,
-  children: PropTypes.node.isRequired,
+  experiments: PropTypes.object, // eslint-disable-line react/forbid-prop-types
+  legacyCampaignId: PropTypes.string.isRequired,
+  noun: PropTypes.shape({
+    singular: PropTypes.string,
+    plural: PropTypes.string,
+  }),
+  isAffiliated: PropTypes.bool,
+  signups: PropTypes.array.isRequired, // eslint-disable-line react/forbid-prop-types
+  subtitle: PropTypes.string.isRequired,
+  title: PropTypes.string.isRequired,
+  totalCampaignSignups: PropTypes.number.isRequired,
   user: PropTypes.shape({
     id: PropTypes.string,
     role: PropTypes.string,
   }).isRequired,
-  signups: PropTypes.array.isRequired, // eslint-disable-line react/forbid-prop-types
-  competitions: PropTypes.array.isRequired, // eslint-disable-line react/forbid-prop-types
+  verb: PropTypes.shape({
+    singular: PropTypes.string,
+    plural: PropTypes.string,
+  }),
 };
 
 Chrome.defaultProps = {
+  experiments: null,
   isAffiliated: false,
+  noun: { singular: 'this', plural: 'this' },
+  verb: { singular: 'do', plural: 'do' },
 };
 
 export default Chrome;

--- a/resources/assets/components/Chrome.js
+++ b/resources/assets/components/Chrome.js
@@ -21,6 +21,9 @@ const Chrome = props => (
       coverImage={props.coverImage}
       legacyCampaignId={props.legacyCampaignId}
       clickedSignUp={props.clickedSignUp}
+      noun={props.noun}
+      verb={props.verb}
+      experiments={props.experiments}
     />
     <Dashboard
       totalCampaignSignups={props.totalCampaignSignups}

--- a/resources/assets/components/Chrome.js
+++ b/resources/assets/components/Chrome.js
@@ -82,8 +82,8 @@ Chrome.propTypes = {
 Chrome.defaultProps = {
   experiments: null,
   isAffiliated: false,
-  noun: { singular: 'this', plural: 'this' },
-  verb: { singular: 'do', plural: 'do' },
+  noun: { singular: 'action', plural: 'action' },
+  verb: { singular: 'take', plural: 'take' },
 };
 
 export default Chrome;

--- a/resources/assets/components/CompetitionBlock/competitionBlock.scss
+++ b/resources/assets/components/CompetitionBlock/competitionBlock.scss
@@ -29,15 +29,18 @@
   }
 }
 
+// @TEST 2017-05-17 competitions_prompt_style
 .block {
   &.-colorful {
-    background-color: $purple;
+    background-color: $primary-color;
     border-radius: 4px;
-  }
-}
 
-.competition-block {
-  .-colorful & {
-    color: $white;
+    .block__title {
+      @include visually_hidden();
+    }
+
+    .avatar {
+      border: 3px solid $white;
+    }
   }
 }

--- a/resources/assets/components/CompetitionBlock/index.js
+++ b/resources/assets/components/CompetitionBlock/index.js
@@ -20,7 +20,7 @@ const CompetitionBlock = (props) => {
   const { content, photo, byline, joinCompetition, hasJoinedCompetition,
     hasPendingJoin, showConfirmation, campaignId, campaignRunId, checkForCompetition } = props;
 
-  // @TEST: Sixpack Experiments
+  // @TEST 2017-05-17 competitions_prompt_style
   const experiments = props.experiments;
   const experimentAlternative = get(experiments, 'competitions_prompt_style', null);
   const experimentClasses = [];

--- a/resources/assets/components/ContentPage/index.js
+++ b/resources/assets/components/ContentPage/index.js
@@ -47,9 +47,9 @@ ContentPage.propTypes = {
 
 ContentPage.defaultProps = {
   pages: [],
-  noun: { singular: 'item', plural: 'items' },
+  noun: { singular: 'action', plural: 'action' },
   tagline: 'Ready to start?',
-  verb: { singular: 'make an', plural: 'make' },
+  verb: { singular: 'take', plural: 'take' },
 };
 
 export default ContentPage;

--- a/resources/assets/components/LedeBanner/index.js
+++ b/resources/assets/components/LedeBanner/index.js
@@ -22,7 +22,7 @@ const LedeBanner = ({
     backgroundImage: `url(${contentfulImageUrl(coverImage.url, '800', '600', 'fill')})`,
   };
 
-  const onClick = (message) => clickedSignUp(legacyCampaignId, message);
+  const onClick = message => clickedSignUp(legacyCampaignId, message);
 
   // @TEST 2017-05-17 lede_banner_number_of_buttons
   const submissionActions = () => {
@@ -31,14 +31,14 @@ const LedeBanner = ({
     if (buttonCount === 'two_buttons') {
       return (
         <ul className="button-group">
-          <li><button className="button" onClick={() => onClick({ source: `lede banner|text: Support the cause` })}>Support the cause</button></li>
+          <li><button className="button" onClick={() => onClick({ source: 'lede banner|text: Support the cause' })}>Support the cause</button></li>
           <li><button className="button" onClick={() => onClick({ source: `lede banner|text: ${verb.plural} ${noun.plural}` })}>{verb.plural} {noun.plural}</button></li>
         </ul>
       );
     }
 
     return (
-      <button className="button" onClick={() => onClick({ source: `lede banner|text: Join us` })}>Join us</button>
+      <button className="button" onClick={() => onClick({ source: 'lede banner|text: Join us' })}>Join us</button>
     );
   };
 
@@ -81,6 +81,12 @@ LedeBanner.propTypes = {
     singular: PropTypes.string,
     plural: PropTypes.string,
   }),
+};
+
+LedeBanner.defaultProps = {
+  experiments: null,
+  noun: { singular: 'this', plural: 'this' },
+  verb: { singular: 'do', plural: 'do' },
 };
 
 export default LedeBanner;

--- a/resources/assets/components/LedeBanner/index.js
+++ b/resources/assets/components/LedeBanner/index.js
@@ -32,7 +32,7 @@ const LedeBanner = ({
       return (
         <ul className="button-group">
           <li><button className="button" onClick={() => onClick({ source: 'lede banner|text: Support the cause' })}>Support the cause</button></li>
-          <li><button className="button" onClick={() => onClick({ source: `lede banner|text: ${verb.plural} ${noun.plural}` })}>{verb.plural} {noun.plural}</button></li>
+          <li><button className="button" onClick={() => onClick({ source: 'lede banner|text: Custom noun & verb' })}>{verb.plural} {noun.plural}</button></li>
         </ul>
       );
     }

--- a/resources/assets/components/LedeBanner/index.js
+++ b/resources/assets/components/LedeBanner/index.js
@@ -85,8 +85,8 @@ LedeBanner.propTypes = {
 
 LedeBanner.defaultProps = {
   experiments: null,
-  noun: { singular: 'this', plural: 'this' },
-  verb: { singular: 'do', plural: 'do' },
+  noun: { singular: 'action', plural: 'action' },
+  verb: { singular: 'take', plural: 'take' },
 };
 
 export default LedeBanner;

--- a/resources/assets/components/LedeBanner/index.js
+++ b/resources/assets/components/LedeBanner/index.js
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import { get } from 'lodash';
 import Markdown from '../Markdown';
 import { contentfulImageUrl } from '../../helpers';
 
@@ -13,12 +14,33 @@ const LedeBanner = ({
     isAffiliated,
     legacyCampaignId,
     clickedSignUp,
+    noun,
+    verb,
+    experiments,
   }) => {
   const backgroundImageStyle = {
     backgroundImage: `url(${contentfulImageUrl(coverImage.url, '800', '600', 'fill')})`,
   };
 
-  const onClick = () => clickedSignUp(legacyCampaignId, { source: 'lede banner' });
+  const onClick = (message) => clickedSignUp(legacyCampaignId, message);
+
+  // @TEST 2017-05-17 lede_banner_number_of_buttons
+  const submissionActions = () => {
+    const buttonCount = get(experiments, 'lede_banner_number_of_buttons', null);
+
+    if (buttonCount === 'two_buttons') {
+      return (
+        <ul className="button-group">
+          <li><button className="button" onClick={() => onClick({ source: `lede banner|text: Support the cause` })}>Support the cause</button></li>
+          <li><button className="button" onClick={() => onClick({ source: `lede banner|text: ${verb.plural} ${noun.plural}` })}>{verb.plural} {noun.plural}</button></li>
+        </ul>
+      );
+    }
+
+    return (
+      <button className="button" onClick={() => onClick({ source: `lede banner|text: Join us` })}>Join us</button>
+    );
+  };
 
   return (
     <header role="banner" className="lede-banner">
@@ -32,7 +54,7 @@ const LedeBanner = ({
 
           <Markdown className="lede-banner__blurb">{blurb}</Markdown>
 
-          { isAffiliated ? null : <button className="button" onClick={onClick}>Join us</button> }
+          { isAffiliated ? null : submissionActions() }
         </div>
       </div>
     </header>
@@ -46,10 +68,19 @@ LedeBanner.propTypes = {
     description: PropTypes.string,
     url: PropTypes.string,
   }).isRequired,
+  experiments: PropTypes.object, // eslint-disable-line react/forbid-prop-types
   isAffiliated: PropTypes.bool.isRequired,
   legacyCampaignId: PropTypes.string.isRequired,
+  noun: PropTypes.shape({
+    singular: PropTypes.string,
+    plural: PropTypes.string,
+  }),
   subtitle: PropTypes.string.isRequired,
   title: PropTypes.string.isRequired,
+  verb: PropTypes.shape({
+    singular: PropTypes.string,
+    plural: PropTypes.string,
+  }),
 };
 
 export default LedeBanner;

--- a/resources/assets/components/LedeBanner/lede-banner.scss
+++ b/resources/assets/components/LedeBanner/lede-banner.scss
@@ -16,16 +16,43 @@
       width: 50%;
     }
   }
+
+  // @TEST 2017-05-17 lede_banner_number_of_buttons
+  .button-group {
+    @include clearfix;
+
+    li {
+      &:last-child {
+        margin-top: $base-spacing;
+      }
+
+      @include media($medium) {
+        .button {
+          width: 100%;
+        }
+      }
+
+      @media (min-width: 1260px) {
+        float: left;
+        width: 50%;
+
+        &:first-child {
+          padding-right: $half-spacing;
+        }
+
+        &:last-child {
+          margin-top: 0;
+          padding-left: $half-spacing;
+        }
+      }
+    }
+  }
 }
 
 .lede-banner__content {
   @include media($medium) {
     flex: 1;
     min-height: 500px;
-  }
-
-  @include media($large) {
-    @include post(2);
   }
 
   & > .wrapper {
@@ -44,10 +71,6 @@
 
   @include media($medium) {
     flex: 1;
-  }
-
-  @include media($large) {
-    @include prefix(2);
   }
 }
 

--- a/resources/assets/containers/ChromeContainer.js
+++ b/resources/assets/containers/ChromeContainer.js
@@ -1,5 +1,6 @@
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router-dom';
+import { get } from 'lodash';
 import Chrome from '../components/Chrome';
 import { clickedSignUp } from '../actions';
 
@@ -20,6 +21,9 @@ const mapStateToProps = (state, props) => ({
   user: state.user,
   signups: state.signups.data,
   competitions: state.competitions.data,
+  noun: get(state.campaign.additionalContent, 'noun'),
+  verb: get(state.campaign.additionalContent, 'verb'),
+  experiments: state.experiments,
 });
 
 /**


### PR DESCRIPTION
This PR adds Sixpack experiments for the LedeBanner and the Competition Prompt.

Experiment alternative that has 2 buttons in the lede banner:
![image](https://cloud.githubusercontent.com/assets/105849/26176434/2371c918-3b24-11e7-8e3f-24f61c113b1e.png)

Experiment alternative that updates the style of the competition prompt:
<img width="802" alt="screen shot 2017-05-17 at 4 36 42 pm" src="https://cloud.githubusercontent.com/assets/105849/26176390/fa29fa12-3b23-11e7-86b9-a42c7a1e3f3b.png">

Some of the setup for these experiments isn't ideal, but we're working to find solutions to make adding these tests easier in the future.