### PR TITLE
adding babel polyfill

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@dosomething/analytics": "^2.0.2",
     "@dosomething/forge": "^6.7.4",
     "@dosomething/gateway": "^1.0.1",
+    "babel-polyfill": "^6.23.0",
     "classnames": "^2.2.5",
     "dom-delegate": "^2.0.3",
     "dosomething-modal": "^0.3.0",

--- a/resources/assets/init.js
+++ b/resources/assets/init.js
@@ -13,6 +13,7 @@
 
 // WHATWG Fetch Polyfill
 import 'whatwg-fetch';
+import 'babel-polyfill';
 
 import React from 'react';
 import ReactDom from 'react-dom';


### PR DESCRIPTION
Older browsers are crashing because of our `Object.values` usage. This polyfill will let us continue using Dave Magic ™️ without crashing!