### PR TITLE
Only track campaign id

### DIFF
--- a/resources/assets/helpers/analytics.js
+++ b/resources/assets/helpers/analytics.js
@@ -29,7 +29,9 @@ export function transformState(action, state) {
     feed: {
       page: state.blocks.offset,
     },
-    campaign: state.campaign,
+    campaign: {
+      legacyCampaignId: state.campaign.legacyCampaignId,
+    },
     signups: state.signups,
     submissions: state.submissions,
     user: {


### PR DESCRIPTION
While we're breaking the data structure, let's just get rid of all that campaign content which is cluttering up the schema.

![screen shot 2017-05-19 at 2 23 27 pm](https://cloud.githubusercontent.com/assets/897368/26261501/67bdab74-3c9f-11e7-8f52-825116c1e295.png)
