### PR TITLE
Fetch env vars on demand

### DIFF
--- a/app/Http/Controllers/CampaignController.php
+++ b/app/Http/Controllers/CampaignController.php
@@ -57,10 +57,12 @@ class CampaignController extends Controller
     {
         $campaign = $this->campaignRepository->findBySlug($slug);
         $shareFields = getShareFields($campaign, $campaign->socialOverrides);
+        $env = getClientEnvironmentVars();
 
         return view('campaigns.show', [
             'campaign' => $campaign,
             'shareFields' => $shareFields,
+            'env' => $env,
         ])->with('state', [
             'campaign' => $campaign,
             'experiments' => get_experiment_alternatives_selection(),

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -270,7 +270,8 @@ function phoenixLink($path)
  *
  * @return array
  */
-function getClientEnvironmentVars() {
+function getClientEnvironmentVars()
+{
     return [
         'KEEN_PROJECT_ID' => config('services.analytics.keen_id'),
         'KEEN_WRITE_KEY' => config('services.analytics.keen_key'),

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -264,3 +264,15 @@ function phoenixLink($path)
 
     return $base . $path;
 }
+
+/**
+ * Get the env vars which are safe for client usage.
+ *
+ * @return array
+ */
+function getClientEnvironmentVars() {
+    return [
+        'KEEN_PROJECT_ID' => config('services.analytics.keen_id'),
+        'KEEN_WRITE_KEY' => config('services.analytics.keen_key'),
+    ];
+}

--- a/config/services.php
+++ b/config/services.php
@@ -17,6 +17,7 @@ return [
     'analytics' => [
         'google_id' => env('GOOGLE_ANALYTICS_ID'),
         'keen_id' => env('KEEN_PROJECT_ID'),
+        'keen_key' => env('KEEN_WRITE_KEY'),
         'facebook_id' => env('FACEBOOK_APP_ID'),
     ],
 

--- a/resources/assets/middleware/analytics.js
+++ b/resources/assets/middleware/analytics.js
@@ -47,7 +47,7 @@ export function start() {
   checkSession();
 
   // Initialize Analytics
-  const env = window.env || {};
+  const env = window.ENV || {};
   init('track', true, env.KEEN_PROJECT_ID ? {
     projectId: env.KEEN_PROJECT_ID,
     writeKey: env.KEEN_WRITE_KEY,

--- a/resources/assets/middleware/analytics.js
+++ b/resources/assets/middleware/analytics.js
@@ -47,9 +47,10 @@ export function start() {
   checkSession();
 
   // Initialize Analytics
-  init('track', true, services.KEEN_PROJECT_ID ? {
-    projectId: services.KEEN_PROJECT_ID,
-    writeKey: services.KEEN_WRITE_KEY,
+  const env = window.env || {};
+  init('track', true, env.KEEN_PROJECT_ID ? {
+    projectId: env.KEEN_PROJECT_ID,
+    writeKey: env.KEEN_WRITE_KEY,
   } : null);
 
   // Track page changes for Google Analytics

--- a/resources/assets/middleware/analytics.js
+++ b/resources/assets/middleware/analytics.js
@@ -1,4 +1,4 @@
-/* global window, services */
+/* global window */
 
 import { init, pageview } from '@dosomething/analytics';
 import { ANALYTICS_ACTIONS } from '../actions';

--- a/resources/views/layouts/master.blade.php
+++ b/resources/views/layouts/master.blade.php
@@ -29,7 +29,7 @@
 
     @include('partials.analytics')
     {{ isset($state) ? scriptify($state) : scriptify() }}
-    {{ isset($env) ? scriptify($env, 'env') : scriptify() }}
+    {{ isset($env) ? scriptify($env, 'ENV') : scriptify() }}
 
     <script type="text/javascript" src="{{ elixir('app.js', 'next/assets') }}"></script>
 </body>

--- a/resources/views/layouts/master.blade.php
+++ b/resources/views/layouts/master.blade.php
@@ -29,6 +29,7 @@
 
     @include('partials.analytics')
     {{ isset($state) ? scriptify($state) : scriptify() }}
+    {{ isset($env) ? scriptify($env) : scriptify() }}
 
     <script type="text/javascript" src="{{ elixir('app.js', 'next/assets') }}"></script>
 </body>

--- a/resources/views/layouts/master.blade.php
+++ b/resources/views/layouts/master.blade.php
@@ -29,7 +29,7 @@
 
     @include('partials.analytics')
     {{ isset($state) ? scriptify($state) : scriptify() }}
-    {{ isset($env) ? scriptify($env) : scriptify() }}
+    {{ isset($env) ? scriptify($env, 'env') : scriptify() }}
 
     <script type="text/javascript" src="{{ elixir('app.js', 'next/assets') }}"></script>
 </body>


### PR DESCRIPTION
We're seeing problems getting new env vars to populate in the webpack build, so this can act as a workaround for now

Here are some successful Keen requests 

![screen shot 2017-05-23 at 12 56 29 pm](https://cloud.githubusercontent.com/assets/897368/26365972/46e4b508-3fb7-11e7-8345-904f91ad906e.png)
![screen shot 2017-05-23 at 12 56 24 pm](https://cloud.githubusercontent.com/assets/897368/26365973/46ed9bfa-3fb7-11e7-9fb1-dec7c547229c.png)
