### PR TITLE
Updating NPM version

### DIFF
--- a/wercker.yml
+++ b/wercker.yml
@@ -14,7 +14,7 @@ build:
           sudo apt-get install -y nodejs
       - script:
           name: update npm
-          code: npm install -g npm@3.x-latest
+          code: npm install -g npm@4.6.1
       - script:
           name: npm install
           code: |-


### PR DESCRIPTION
```
npm ERR! Linux 4.8.11-coreos-r2
npm ERR! argv "/usr/bin/nodejs" "/usr/bin/npm" "install" "-g" "npm@3.x-latest"
npm ERR! node v6.10.3
npm ERR! npm  v3.10.10
npm ERR! code ETARGET

npm ERR! notarget No compatible version found: npm@3.x-latest
npm ERR! notarget Valid install targets:
```