### PR TITLE
Update to remove signup requirement for experiment conversion.

### DIFF
--- a/resources/assets/actions/experiments.js
+++ b/resources/assets/actions/experiments.js
@@ -3,16 +3,10 @@ import {
   ADD_TO_EXPERIMENTS_STORE,
   UPDATE_EXPERIMENTS_STORE,
   CONVERT_EXPERIMENT,
-  queueEvent,
 } from '../actions';
 
 export function convertExperiment(name) {
-  return (dispatch, getState) => {
-    if (! getState().user.id) {
-      dispatch(queueEvent('convertExperiment', name));
-      return;
-    }
-
+  return (dispatch) => {
     dispatch({
       type: CONVERT_EXPERIMENT,
       name,


### PR DESCRIPTION
This PR provides a quick update to remove the the post-signup requirement to convert on any Sixpack experiments.