### PR TITLE
Show a 404 when a user goes to a bad "custom page" slug.

### DIFF
--- a/resources/assets/components/ContentPage/content-page.scss
+++ b/resources/assets/components/ContentPage/content-page.scss
@@ -1,10 +1,9 @@
 @import '../../scss/next-toolbox';
 
 .content-page {
-  padding: 0 $half-spacing;
-
   @include clearfix;
-  padding-top: $half-spacing;
+
+  padding: $half-spacing;
   font-family: $primary-font-family;
   font-size: $font-regular;
   line-height: 1.4;
@@ -20,14 +19,13 @@
   }
 
   .secondary {
-    margin: 0 0 $base-spacing;
-
-    @include visually-hidden();
+    display: none;
 
     @include media($large) {
-      @include visually-restored();
+      display: block;
       float: right;
       padding-left: $half-spacing;
+      margin: 0 0 $base-spacing;
       width: 33.3333333333333%
     }
   }

--- a/resources/assets/components/ContentPage/index.js
+++ b/resources/assets/components/ContentPage/index.js
@@ -57,11 +57,17 @@ Page.defaultProps = {
 
 const ContentPage = (props) => {
   const { pages, route, tagline, noun, verb } = props;
+  const ctaContent = `${tagline}\n\n__Join hundreds of members and ${verb.plural} ${noun.plural}!__`;
+
+  // Load the page by the slug, or return a 404 page.
   const page = pages.find(item => item.fields.slug === route.page);
+  if (! page) {
+    const copy = 'That page could not be found. Try choosing from the links above!';
+    return <Page header="Not Found" markdown={copy} ctaTitle={tagline} ctaContent={ctaContent} />;
+  }
 
   const header = page.fields.title;
   const markdown = page.fields.content;
-  const ctaContent = `${tagline}\n\n__Join hundreds of members and ${verb.plural} ${noun.plural}!__`;
 
   if (route.page.includes('scholarship')) {
     return (


### PR DESCRIPTION
### Changes
This is a quick fix for when users go to a slug that doesn't exist, like `/campaigns/sincerely-us/pages/skooolershooops` or something very silly. I'd like to refactor how we handle this in the future to move it back into the router, but this way we give people a better experience than a blown-up page.

I also fixed the padding between the content page and footer, since it was real cozy.