### PR TITLE
Reportback uploader quantity label renaming

### DIFF
--- a/resources/assets/components/ReportbackUploader/index.js
+++ b/resources/assets/components/ReportbackUploader/index.js
@@ -113,7 +113,7 @@ class ReportbackUploader extends React.Component {
               </div>
 
               <div>
-                <label className="field-label" htmlFor="impact">Total number of cards made.</label>
+                <label className="field-label" htmlFor="impact">Total number of {this.props.noun.plural} made?</label>
                 <input className="text-field" id="impact" name="impact" type="text" placeholder="Enter # here -- like '300' or '5'" ref={input => (this.impact = input)} />
               </div>
             </div>

--- a/resources/assets/components/ReportbackUploader/index.js
+++ b/resources/assets/components/ReportbackUploader/index.js
@@ -113,7 +113,7 @@ class ReportbackUploader extends React.Component {
               </div>
 
               <div>
-                <label className="field-label" htmlFor="impact">How many {this.props.noun.plural} are in this photo?</label>
+                <label className="field-label" htmlFor="impact">Total number of cards made.</label>
                 <input className="text-field" id="impact" name="impact" type="text" placeholder="Enter # here -- like '300' or '5'" ref={input => (this.impact = input)} />
               </div>
             </div>


### PR DESCRIPTION
We changed "How many cards are in the photo?" to "Total number of cards made." because there was some confusion from competitors looking at the leaderboard (leaderboard shows most recent quantity, not a sum of the submitted RB quantities). 

Small caveat - 'made' is hardcoded into that field so when we have other campaigns with a different 'verb' action, we'll need to revisit this. This shouldn't be a big problem for the next two campaigns we're launching.