### PR TITLE
Removing unused var that I forgot to remove after an update.

### DIFF
--- a/resources/assets/components/Navigation/TabbedNavigation.js
+++ b/resources/assets/components/Navigation/TabbedNavigation.js
@@ -1,4 +1,4 @@
-/* global window, document */
+/* global window */
 
 import PropTypes from 'prop-types';
 import React from 'react';


### PR DESCRIPTION
When I switched to using `ref` for setting the `this.node` property, I forgot to cleanup the eslint rule for `document` usage @_@ This is causing an error on Phoenix-Next Thor from deploying properly.