### PR TITLE
Fixes for some quirky behavior with the sticky nav.

### DIFF
--- a/resources/assets/components/Navigation/TabbedNavigation.js
+++ b/resources/assets/components/Navigation/TabbedNavigation.js
@@ -30,6 +30,8 @@ class TabbedNavigation extends React.Component {
    * React lifecycle method called after render() method runs.
    */
   componentDidMount() {
+    this.updateState();
+
     window.addEventListener('scroll', this.onScroll, false);
   }
 

--- a/resources/assets/components/Navigation/tabbed-navigation.scss
+++ b/resources/assets/components/Navigation/tabbed-navigation.scss
@@ -9,7 +9,6 @@
   @include media($tablet) {
     position: sticky;
     top: 0;
-    transition: background-color 0.2s linear;
     z-index: 100;
   }
 

--- a/resources/assets/components/ScrollConcierge/index.js
+++ b/resources/assets/components/ScrollConcierge/index.js
@@ -62,7 +62,7 @@ class ScrollConcierge extends React.Component {
     // Wait for headline font to load so we don't scroll to
     // the wrong place when the page reflows & offset changes.
     font.load().then(() => {
-      const VISUAL_OFFSET = 100;
+      const VISUAL_OFFSET = 95;
 
       // Wait until the page has finished layout, then scroll.
       waitForLayout(() => scrollTo(this.node.offsetTop - VISUAL_OFFSET));


### PR DESCRIPTION
This PR adds a few quick adjustments to the sticky nav so it works better and doesn't leave any visual bugs, or _seemingly_ visual bugs. I removed the transition animation for the background color since it seemed like a bug if you were scrolled a bit down and switched to the action page or community page and you see a slight flash of content behind the nav as the page repaints and the background color transitions in.

This also updates the visual offset on the Scroll Concierge™ so it'll scroll to a better location that triggers the sticky nav 😄 