### PR TITLE
Allow linking directly to specific campaign updates.

### DIFF
--- a/app.json
+++ b/app.json
@@ -3,7 +3,7 @@
   "description": ":sparkles:",
   "env": {
     "APP_ENV": "local",
-    "APP_DEBUG": "true",
+    "APP_DEBUG": "false",
     "NPM_CONFIG_PRODUCTION": "false",
     "APP_KEY": {
       "required": true

--- a/resources/assets/components/App.js
+++ b/resources/assets/components/App.js
@@ -10,6 +10,7 @@ import ChromeContainer from '../containers/ChromeContainer';
 import Experience from '../components/Experience';
 import FeedContainer from '../containers/FeedContainer';
 import ActionPageContainer from '../containers/ActionPageContainer';
+import { BlockContainer } from './Block';
 import ContentPageContainer from '../containers/ContentPageContainer';
 import PitchContainer from '../containers/PitchContainer';
 import ExperimentContainer from '../containers/ExperimentContainer';
@@ -60,6 +61,7 @@ const App = ({ store, history }) => {
           <Route path={paths.community} exact component={PitchTest} />
           <Route path={paths.action} component={chrome(ActionPageContainer)} />
           <Route path={`${paths.pages}:page`} component={chrome(ContentPageContainer)} />
+          <Route path={`${paths.blocks}:id`} component={chrome(BlockContainer)} />
           {/* * */}
 
           {/* Custom user experiences */}

--- a/resources/assets/components/Block/Block.js
+++ b/resources/assets/components/Block/Block.js
@@ -9,7 +9,7 @@ import CallToActionContainer from '../../containers/CallToActionContainer';
 const Block = ({ json }) => {
   switch (json.fields.type) {
     case 'campaign_update':
-      return <CampaignUpdateBlock fields={json.fields} />;
+      return <CampaignUpdateBlock id={json.id} fields={json.fields} />;
 
     case 'join_cta':
       return <CallToActionContainer />;

--- a/resources/assets/components/Block/Block.js
+++ b/resources/assets/components/Block/Block.js
@@ -1,0 +1,37 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import CampaignUpdateBlock from '../CampaignUpdateBlock';
+import PlaceholderBlock from '../PlaceholderBlock';
+import ReportbackBlock from '../ReportbackBlock';
+import StaticBlock from '../StaticBlock';
+import CallToActionContainer from '../../containers/CallToActionContainer';
+
+const Block = ({ json }) => {
+  switch (json.fields.type) {
+    case 'campaign_update':
+      return <CampaignUpdateBlock fields={json.fields} />;
+
+    case 'join_cta':
+      return <CallToActionContainer />;
+
+    case 'reportbacks':
+      return <ReportbackBlock fields={json.fields} reportbacks={json.reportbacks} />;
+
+    case 'static':
+      return <StaticBlock fields={json.fields} />;
+
+    default:
+      return <PlaceholderBlock />;
+  }
+};
+
+Block.propTypes = {
+  // @TODO: Validate the shape of this JSON object with prop types.
+  json: PropTypes.object, // eslint-disable-line react/forbid-prop-types
+};
+
+Block.defaultProps = {
+  json: { fields: { type: null } },
+};
+
+export default Block;

--- a/resources/assets/components/Block/BlockContainer.js
+++ b/resources/assets/components/Block/BlockContainer.js
@@ -1,0 +1,16 @@
+import { connect } from 'react-redux';
+import { find } from 'lodash';
+import Block from './Block';
+
+/**
+ * Provide state from the Redux store as props for this component.
+ */
+const mapStateToProps = (state, ownProps) => {
+  const { id } = ownProps.match.params;
+  const json = find(state.campaign.activityFeed, { id });
+
+  return { json };
+};
+
+// Export the container component.
+export default connect(mapStateToProps)(Block);

--- a/resources/assets/components/Block/BlockWrapper.js
+++ b/resources/assets/components/Block/BlockWrapper.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import classNames from 'classnames';
+import classnames from 'classnames';
 import { Link } from 'react-router-dom';
 import './block-wrapper.scss';
 
@@ -21,10 +21,10 @@ BlockTitle.defaultProps = {
 };
 
 const BlockWrapper = props => (
-  <div className={classNames('block-wrapper', props.className)}>
+  <article className={classnames('block-wrapper', props.className)}>
     { props.title ? <BlockTitle title={props.title} id={props.id} /> : null }
     {props.children}
-  </div>
+  </article>
 );
 
 BlockWrapper.propTypes = {

--- a/resources/assets/components/Block/BlockWrapper.js
+++ b/resources/assets/components/Block/BlockWrapper.js
@@ -1,0 +1,37 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import classNames from 'classnames';
+import './block-wrapper.scss';
+
+const BlockTitle = (props) => {
+  return <h4 className="block-wrapper__title">{props.title}</h4>;
+};
+
+BlockTitle.propTypes = {
+  title: PropTypes.string,
+};
+
+BlockTitle.defaultProps = {
+  title: null,
+};
+
+const BlockWrapper = props => (
+  <div className={classNames('block-wrapper', props.className)}>
+    { props.title ? <BlockTitle title={props.title} /> : null }
+    {props.children}
+  </div>
+);
+
+BlockWrapper.propTypes = {
+  className: PropTypes.string,
+  title: PropTypes.string,
+  children: PropTypes.node.isRequired,
+};
+
+BlockWrapper.defaultProps = {
+  className: null,
+  title: null,
+  id: null,
+};
+
+export default BlockWrapper;

--- a/resources/assets/components/Block/BlockWrapper.js
+++ b/resources/assets/components/Block/BlockWrapper.js
@@ -1,23 +1,28 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
+import { Link } from 'react-router-dom';
 import './block-wrapper.scss';
 
 const BlockTitle = (props) => {
-  return <h4 className="block-wrapper__title">{props.title}</h4>;
+  const title = props.id ? <Link to={`/blocks/${props.id}`}>{props.title}</Link> : props.title;
+
+  return <h4 className="block-wrapper__title">{title}</h4>;
 };
 
 BlockTitle.propTypes = {
   title: PropTypes.string,
+  id: PropTypes.string,
 };
 
 BlockTitle.defaultProps = {
   title: null,
+  id: null,
 };
 
 const BlockWrapper = props => (
   <div className={classNames('block-wrapper', props.className)}>
-    { props.title ? <BlockTitle title={props.title} /> : null }
+    { props.title ? <BlockTitle title={props.title} id={props.id} /> : null }
     {props.children}
   </div>
 );
@@ -25,6 +30,7 @@ const BlockWrapper = props => (
 BlockWrapper.propTypes = {
   className: PropTypes.string,
   title: PropTypes.string,
+  id: PropTypes.string,
   children: PropTypes.node.isRequired,
 };
 

--- a/resources/assets/components/Block/block-wrapper.scss
+++ b/resources/assets/components/Block/block-wrapper.scss
@@ -23,3 +23,12 @@
   margin: (- $half-spacing) (- $half-spacing) $base-spacing;
   padding: $half-spacing;
 }
+
+.block-wrapper__title a {
+  color: $black;
+}
+
+.block-wrapper__title a:hover {
+  color: rgba($black, 0.75);
+  text-decoration: none;
+}

--- a/resources/assets/components/Block/block-wrapper.scss
+++ b/resources/assets/components/Block/block-wrapper.scss
@@ -1,6 +1,6 @@
 @import '../../scss/next-toolbox';
 
-.block {
+.block-wrapper {
   @extend %block;
   margin: $half-spacing;
   overflow: hidden;
@@ -15,7 +15,7 @@
   }
 }
 
-.block__title {
+.block-wrapper__title {
   color: $black;
   font-family: $primary-font-family;
   background-color: $primary-color;

--- a/resources/assets/components/Block/index.js
+++ b/resources/assets/components/Block/index.js
@@ -1,29 +1,11 @@
-import PropTypes from 'prop-types';
-import React from 'react';
-import classNames from 'classnames';
-import './block.scss';
+// The <BlockWrapper> can be used to give the "block" visual
+// treatment (and optional title bar) to any type of block.
+export BlockWrapper from './BlockWrapper';
 
-export const BlockTitle = ({ children }) => (
-  <h4 className="block__title">{children}</h4>
-);
+// The <BlockContainer> can match a route to a particular
+// block from the campaign feed in the Redux store.
+export BlockContainer from './BlockContainer';
 
-BlockTitle.propTypes = {
-  children: PropTypes.string.isRequired,
-};
-
-const Block = props => (
-  <div className={classNames('block', props.className)}>
-    {props.children}
-  </div>
-);
-
-Block.propTypes = {
-  className: PropTypes.string,
-  children: PropTypes.node.isRequired,
-};
-
-Block.defaultProps = {
-  className: null,
-};
-
-export default Block;
+// The <Block> component accepts a JSON blob from the Contentful
+// content type & renders the appropriate component.
+export default from './Block';

--- a/resources/assets/components/CampaignUpdateBlock/__snapshots__/test.js.snap
+++ b/resources/assets/components/CampaignUpdateBlock/__snapshots__/test.js.snap
@@ -1,12 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Campaign Update Block with additional content as tweet snapshot test 1`] = `
-<Block
+<BlockWrapper
   className={null}
+  id={null}
+  title="Campaign Update"
 >
-  <BlockTitle>
-    Campaign Update
-  </BlockTitle>
   <Markdown
     className="campaign-update__content -tweet"
   >
@@ -17,16 +16,15 @@ exports[`Campaign Update Block with additional content as tweet snapshot test 1`
     avatar={Object {}}
     jobTitle="DoSomething.org Staff"
   />
-</Block>
+</BlockWrapper>
 `;
 
 exports[`Campaign Update Block with additional content snapshot test 1`] = `
-<Block
+<BlockWrapper
   className={null}
+  id={null}
+  title="Campaign Update"
 >
-  <BlockTitle>
-    Campaign Update
-  </BlockTitle>
   <h2>
     Heyo!
   </h2>
@@ -40,16 +38,15 @@ exports[`Campaign Update Block with additional content snapshot test 1`] = `
     avatar={Object {}}
     jobTitle="DoSomething.org Staff"
   />
-</Block>
+</BlockWrapper>
 `;
 
 exports[`Campaign Update Block with no additional content snapshot test 1`] = `
-<Block
+<BlockWrapper
   className={null}
+  id={null}
+  title="Campaign Update"
 >
-  <BlockTitle>
-    Campaign Update
-  </BlockTitle>
   <h2>
     Heyo!
   </h2>
@@ -58,5 +55,5 @@ exports[`Campaign Update Block with no additional content snapshot test 1`] = `
   >
     Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec id elit non mi porta gravida at eget metus. Vestibulum id ligula porta felis euismod semper. Vestibulum id ligula porta felis euismod semper. Morbi leo risus, porta ac consectetur ac, vestibulum at eros.
   </Markdown>
-</Block>
+</BlockWrapper>
 `;

--- a/resources/assets/components/CampaignUpdateBlock/index.js
+++ b/resources/assets/components/CampaignUpdateBlock/index.js
@@ -13,7 +13,7 @@ const CampaignUpdateBlock = (props) => {
   const isTweet = content.length < 144;
 
   return (
-    <BlockWrapper title="Campaign Update">
+    <BlockWrapper title="Campaign Update" id={props.id}>
       { isTweet ? null : <h2>{title}</h2> }
 
       <Markdown className={classnames('campaign-update__content', { '-tweet': isTweet })}>
@@ -34,6 +34,7 @@ const CampaignUpdateBlock = (props) => {
 };
 
 CampaignUpdateBlock.propTypes = {
+  id: PropTypes.string.isRequired,
   fields: PropTypes.shape({
     title: PropTypes.string,
     content: PropTypes.string,

--- a/resources/assets/components/CampaignUpdateBlock/index.js
+++ b/resources/assets/components/CampaignUpdateBlock/index.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import Markdown from '../Markdown';
-import Block, { BlockTitle } from '../Block';
+import { BlockWrapper } from '../Block';
 import Embed from '../Embed';
 import Byline from '../Byline';
 import './campaign-update.scss';
@@ -13,9 +13,7 @@ const CampaignUpdateBlock = (props) => {
   const isTweet = content.length < 144;
 
   return (
-    <Block>
-      <BlockTitle>Campaign Update</BlockTitle>
-
+    <BlockWrapper title="Campaign Update">
       { isTweet ? null : <h2>{title}</h2> }
 
       <Markdown className={classnames('campaign-update__content', { '-tweet': isTweet })}>
@@ -31,7 +29,7 @@ const CampaignUpdateBlock = (props) => {
           avatar={additionalContent.avatar}
         />
         : null }
-    </Block>
+    </BlockWrapper>
   );
 };
 

--- a/resources/assets/components/CompetitionBlock/index.js
+++ b/resources/assets/components/CompetitionBlock/index.js
@@ -11,7 +11,7 @@ import './competitionBlock.scss';
 const DEFAULT_CONFIRMATION = `
 # You're signed up!
 
-You should recieve an email shortly with more instructions.
+You should receive an email shortly with more instructions.
 You can keep working on the campaign for now. I'm so excited to have you onboard!
 `;
 

--- a/resources/assets/components/CompetitionBlock/index.js
+++ b/resources/assets/components/CompetitionBlock/index.js
@@ -3,7 +3,7 @@ import React from 'react';
 import classnames from 'classnames';
 
 import Markdown from '../Markdown';
-import Block, { BlockTitle } from '../Block';
+import { BlockWrapper } from '../Block';
 import Byline from '../Byline';
 import LazyImage from '../LazyImage';
 import './competitionBlock.scss';
@@ -56,17 +56,16 @@ const CompetitionBlock = (props) => {
   ) : null;
 
   return (
-    <Block className={classnames('-default')}>
-      <BlockTitle>Go above and beyond!</BlockTitle>
+    <BlockWrapper title="Go above and beyond!" className="-default">
       <div className={classnames('competition-block', { 'is-confirmation': showConfirmation })}>
         <div className="clearfix">
-          <Markdown className={classnames('', { 'is-success': showConfirmation })}>{ showConfirmation ? DEFAULT_CONFIRMATION : content }</Markdown>
+          <Markdown className={classnames({ 'is-success': showConfirmation })}>{ showConfirmation ? DEFAULT_CONFIRMATION : content }</Markdown>
           { competitionPhoto }
         </div>
         { button }
         <Byline {...byline} />
       </div>
-    </Block>
+    </BlockWrapper>
   );
 };
 

--- a/resources/assets/components/Feed/index.js
+++ b/resources/assets/components/Feed/index.js
@@ -1,10 +1,3 @@
-/**
- * Render a single feed item.
- *
- * @param block
- * @param index
- * @returns {XML}
- */
 import PropTypes from 'prop-types';
 import React from 'react';
 import { mergeMetadata } from '../../helpers/analytics';
@@ -13,6 +6,13 @@ import { Flex, FlexCell } from '../Flex';
 import './feed.scss';
 import Block from '../Block';
 
+/**
+ * Render a single feed item.
+ *
+ * @param block
+ * @param index
+ * @returns {XML}
+ */
 const renderFeedItem = (block, index) => (
   <FlexCell key={`${block.id}-${index}`} width={block.fields.displayOptions[0]}>
     <Block json={block} />

--- a/resources/assets/components/Feed/index.js
+++ b/resources/assets/components/Feed/index.js
@@ -1,16 +1,3 @@
-import PropTypes from 'prop-types';
-import React from 'react';
-import { get } from 'lodash';
-import { mergeMetadata } from '../../helpers/analytics';
-import CallToActionContainer from '../../containers/CallToActionContainer';
-import CampaignUpdateBlock from '../CampaignUpdateBlock';
-import PlaceholderBlock from '../PlaceholderBlock';
-import ReportbackBlock from '../ReportbackBlock';
-import Revealer from '../Revealer';
-import StaticBlock from '../StaticBlock';
-import { Flex, FlexCell } from '../Flex';
-import './feed.scss';
-
 /**
  * Render a single feed item.
  *
@@ -18,20 +5,19 @@ import './feed.scss';
  * @param index
  * @returns {XML}
  */
-const renderFeedItem = (block, index) => {
-  const BlockComponent = get({
-    'campaign_update': CampaignUpdateBlock,  // eslint-disable-line quote-props
-    'join_cta': CallToActionContainer, // eslint-disable-line quote-props
-    'reportbacks': ReportbackBlock, // eslint-disable-line quote-props
-    'static': StaticBlock, // eslint-disable-line quote-props
-  }, block.fields.type, PlaceholderBlock);
+import PropTypes from 'prop-types';
+import React from 'react';
+import { mergeMetadata } from '../../helpers/analytics';
+import Revealer from '../Revealer';
+import { Flex, FlexCell } from '../Flex';
+import './feed.scss';
+import Block from '../Block';
 
-  return (
-    <FlexCell key={`${block.id}-${index}`} width={block.fields.displayOptions[0]}>
-      <BlockComponent {...block} />
-    </FlexCell>
-  );
-};
+const renderFeedItem = (block, index) => (
+  <FlexCell key={`${block.id}-${index}`} width={block.fields.displayOptions[0]}>
+    <Block json={block} />
+  </FlexCell>
+);
 
 /**
  * Render the feed.

--- a/resources/assets/components/Navigation/tabbed-navigation.scss
+++ b/resources/assets/components/Navigation/tabbed-navigation.scss
@@ -56,6 +56,7 @@
     display: inline-block;
     margin: 10px $half-spacing;
     text-transform: uppercase;
+    border-bottom: 4px solid transparent;
 
     &:hover {
       color: $off-black;

--- a/resources/assets/components/Navigation/tabbed-navigation.scss
+++ b/resources/assets/components/Navigation/tabbed-navigation.scss
@@ -53,7 +53,6 @@
 
   .nav-link {
     color: #9B9B9B;
-    color: #9B9B9B;
     display: inline-block;
     margin: 10px $half-spacing;
     text-transform: uppercase;

--- a/resources/assets/components/PlaceholderBlock/index.js
+++ b/resources/assets/components/PlaceholderBlock/index.js
@@ -1,18 +1,24 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import Block from '../Block/index';
+import { BlockWrapper } from '../Block';
 import './placeholder.scss';
 
 const PlaceholderBlock = props => (
-  <Block className="placeholder">
+  <BlockWrapper className="placeholder">
     {props.fields.title}
-  </Block>
+  </BlockWrapper>
 );
 
 PlaceholderBlock.propTypes = {
   fields: PropTypes.shape({
-    title: PropTypes.string.isRequired,
+    title: PropTypes.string,
   }).isRequired,
+};
+
+PlaceholderBlock.defaultProps = {
+  fields: {
+    title: 'Loading...',
+  },
 };
 
 export default PlaceholderBlock;

--- a/resources/assets/components/PlaceholderBlock/index.js
+++ b/resources/assets/components/PlaceholderBlock/index.js
@@ -17,7 +17,7 @@ PlaceholderBlock.propTypes = {
 
 PlaceholderBlock.defaultProps = {
   fields: {
-    title: 'Loading...',
+    title: 'Not found :(',
   },
 };
 

--- a/resources/assets/components/PlaceholderBlock/placeholder.scss
+++ b/resources/assets/components/PlaceholderBlock/placeholder.scss
@@ -5,5 +5,10 @@
   justify-content: center;
   align-items: center;
   color: $light-gray;
+  width: 100%;
   min-height: 200px;
+}
+
+.placeholder.-full {
+  min-height: 100vh;
 }

--- a/resources/assets/components/ReportbackBlock/index.js
+++ b/resources/assets/components/ReportbackBlock/index.js
@@ -1,6 +1,6 @@
-import PropTypes from 'prop-types';
 import React from 'react';
-import Block from '../Block';
+import PropTypes from 'prop-types';
+import BlockWrapper from '../Block/BlockWrapper';
 import { FlexCell } from '../Flex';
 import ReportbackItemContainer from '../../containers/ReportbackItemContainer';
 import { mapDisplayToPoints } from '../../selectors/feed';
@@ -14,9 +14,9 @@ const ReportbackBlock = (props) => {
 
     items.push(
       <FlexCell key={id || `null-${i}`}>
-        <Block className="reportback-block">
+        <BlockWrapper className="reportback-block">
           <ReportbackItemContainer id={id} />
-        </Block>
+        </BlockWrapper>
       </FlexCell>,
     );
   }

--- a/resources/assets/components/ReportbackBlock/reportback-block.scss
+++ b/resources/assets/components/ReportbackBlock/reportback-block.scss
@@ -1,3 +1,3 @@
-.reportback-block {
+.block.reportback-block {
   padding: 0;
 }

--- a/resources/assets/components/ReportbackUploader/index.js
+++ b/resources/assets/components/ReportbackUploader/index.js
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 /* global FormData */
 
 import React from 'react';
-import Block from '../Block';
+import { BlockWrapper } from '../Block';
 import MediaUploader from '../MediaUploader';
 import Gallery from '../Gallery';
 import ReportbackItem from '../ReportbackItem';
@@ -97,7 +97,7 @@ class ReportbackUploader extends React.Component {
     const submissions = this.props.submissions;
 
     return (
-      <Block>
+      <BlockWrapper>
         <div className="reportback-uploader">
           <h2 className="heading">Upload your photos</h2>
 
@@ -129,7 +129,7 @@ class ReportbackUploader extends React.Component {
         <Gallery isFetching={submissions.isFetching} type="triad">
           {submissions.items.map(submission => ReportbackUploader.renderReportbackItem(submission))}
         </Gallery>
-      </Block>
+      </BlockWrapper>
     );
   }
 }

--- a/resources/assets/components/StaticBlock/index.js
+++ b/resources/assets/components/StaticBlock/index.js
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import Block, { BlockTitle } from '../Block';
+import BlockWrapper from '../Block/BlockWrapper';
 import Markdown from '../Markdown';
 import './static-block.scss';
 
@@ -8,11 +8,10 @@ const StaticBlock = (props) => {
   const { source } = props.fields.additionalContent;
 
   return (
-    <Block>
-      <BlockTitle>{ props.fields.title }</BlockTitle>
+    <BlockWrapper title={props.fields.title}>
       <Markdown>{props.fields.content}</Markdown>
       { source ? <div className="static-block__citation"><p className="footnote">{source}</p></div> : null }
-    </Block>
+    </BlockWrapper>
   );
 };
 

--- a/resources/assets/helpers/navigation.js
+++ b/resources/assets/helpers/navigation.js
@@ -5,6 +5,7 @@ import { findKey } from 'lodash';
 export const paths = {
   community: '/',
   action: '/action',
+  blocks: '/blocks/',
   pages: '/pages/',
   background: '/background',
 };

--- a/resources/views/campaigns/show.blade.php
+++ b/resources/views/campaigns/show.blade.php
@@ -5,13 +5,11 @@
     <div id="app">
         <div class="feed-enclosure">
             <div class="flex wrapper">
-                @foreach ($campaign->activity_feed as $block)
-                    <div class="flex__cell {{ $block->displayOptions->map(function($c) { return '-'.$c; })->implode(' ') }}">
-                        <div class="block placeholder">
-                            Loading…
+                    <div class="flex__cell">
+                        <div class="placeholder -full">
+                            <div class="spinner"></div>
                         </div>
                     </div>
-                @endforeach
             </div>
         </div>
     </div>


### PR DESCRIPTION
### What does this PR do?
This pull request refactors how blocks are rendered & adds a `/blocks/:id` page for block permalinks.

📦 I extracted the logic to determine which block to use into the `Block` component (which just accepts a Contentful JSON blob) so we can more easily display blocks outside of the feed. This made it much easier to display a block outside of the feed, and makes things more readable to boot.

⁉️ I tried out putting a handful of block related components in the `/components/Block` directory (including the container), and then just exporting a "table of contents" from the index (following along with some of the other recent organizational ideas.) Give it a [peek](https://github.com/DoSomething/phoenix-next/tree/cb20eeeef12c5c1524f8f744d9a7df118fc98376/resources/assets/components/Block).

🔗 And finally, I added a `/blocks/:id` route and little permalinks (click the "Campaign Update" title to get the link for any update) so that we can easily link to any specific campaign updates. I'm pushing this up now to get a MVP shipped, but the plan is to have any block be linkable & to display 'em in a modal. Here's an example: [`/us/campaigns/sincerely-us/blocks/1SLj7iLgp6QWs4Ma2USWMm`](https://phoenix-next-stage-pr-310.herokuapp.com/us/campaigns/sincerely-us/blocks/1SLj7iLgp6QWs4Ma2USWMm).

### Any background context you want to provide?
🍃

### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.