### PR TITLE
Build Forge assets locally rather than using CDN.

### DIFF
--- a/resources/assets/scss/base.scss
+++ b/resources/assets/scss/base.scss
@@ -1,5 +1,9 @@
 @import 'next-toolbox';
 
+// Import Forge so we get our base styles.
+$forge-path: "../../../node_modules/@dosomething/forge/assets/";
+@import '~@dosomething/forge/scss/forge';
+
 body, html {
   font-family: $primary-font-family;
   line-height: 1.4;

--- a/resources/views/layouts/master.blade.php
+++ b/resources/views/layouts/master.blade.php
@@ -9,7 +9,6 @@
     <title>DoSomething.org</title>
 
     <link rel="icon" type="image/ico" href="/favicon.ico?v1">
-    <link rel="stylesheet" href="https://unpkg.com/@dosomething/forge@^6.7.4/dist/forge.css" media="screen, projection" type="text/css">
     <link rel="stylesheet" href="{{ elixir('app.css', 'next/assets') }}" media="screen, projection" type="text/css">
 
     @if(isset($shareFields))

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -17,7 +17,7 @@ module.exports = configure({
 
   module: {
     loaders: [
-      { enforce: 'pre', test: /\.js$/, use: 'eslint-loader', exclude: /node_modules/ }
+      { enforce: 'pre', test: /\.js$/, use: 'eslint-loader', exclude: /node_modules/ },
     ],
   },
 


### PR DESCRIPTION
### What does this PR do?
We're seeing some unexpected issues serving CSS to Safari from [unpkg](https://unpkg.com). To sidestep that, I've added Forge to the local build process for this application. In the future, it could be interesting to see if we want to host our own CDN for assets used between apps.

### Any background context you want to provide?
The unpkg version is being sent without a `Content-Type` header, which I imagine might be the issue. It's showing up in the "Other" tab in Safari's network inspector:

![screen shot 2017-06-27 at 4 39 32 pm](https://user-images.githubusercontent.com/583202/27608955-39867232-5b57-11e7-942d-91693c273109.png)


### What are the relevant tickets/cards?
[Trello Card](https://trello.com/c/4op2THja/715-🐛-as-dave-the-only-soul-who-uses-safari-i-want-the-top-nav-to-show-up-correctly-🐛)

### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.