### PR TITLE
Only redirect signups to action page if the campaign is open

### DIFF
--- a/resources/assets/actions/signup.js
+++ b/resources/assets/actions/signup.js
@@ -1,5 +1,6 @@
 import { Phoenix } from '@dosomething/gateway';
 import { push } from 'react-router-redux';
+import { isCampaignClosed } from '../helpers';
 import {
   SIGNUP_CREATED,
   SIGNUP_FOUND,
@@ -128,8 +129,11 @@ export function clickedSignUp(campaignId, metadata) {
         // If Drupal denied our signup request, check if we already had a signup.
         dispatch(checkForSignup(campaignId));
       } else {
-        // Otherwise, mark the signup as a success & take user to the action page.
-        dispatch(push('/action'));
+        // Otherwise, mark the signup as a success and
+        // take user to the action page if campaign is open.
+        if (! isCampaignClosed(getState().campaign.endDate.date)) {
+          dispatch(push('/action'));
+        }
 
         dispatch(signupCreated(campaignId));
 


### PR DESCRIPTION
### What does this PR do?
In order to ship the action page changes, we should also make sure people who are signing up on a closed campaign are not taken to the action page post signup. This change ensures they still get the modal experience, but the redirect is dependent on campaign status.


### Any background context you want to provide?
We need to close Sincerely Us like now