### PR TITLE
Fixing a couple bugs quickly.

### DIFF
--- a/resources/assets/components/ActionPage/StepHeader.js
+++ b/resources/assets/components/ActionPage/StepHeader.js
@@ -8,7 +8,7 @@ import { convertNumberToWord } from '../../helpers';
 const StepHeader = ({ title, step, background }) => (
   <FlexCell width="full">
     <div className="action-step__header">
-      <LazyImage src={background} />
+      { background ? <LazyImage src={background} /> : null }
       <span>step { convertNumberToWord(step) }</span>
       <h1>{ title }</h1>
     </div>
@@ -18,7 +18,11 @@ const StepHeader = ({ title, step, background }) => (
 StepHeader.propTypes = {
   title: PropTypes.string.isRequired,
   step: PropTypes.number.isRequired,
-  background: PropTypes.string.isRequired,
+  background: PropTypes.string,
+};
+
+StepHeader.defaultProps = {
+  background: null,
 };
 
 export default StepHeader;

--- a/resources/assets/components/ReportbackUploader/ReportbackUploaderContainer.js
+++ b/resources/assets/components/ReportbackUploader/ReportbackUploaderContainer.js
@@ -1,7 +1,7 @@
 import { connect } from 'react-redux';
 import { get } from 'lodash';
 import ReportbackUploader from './ReportbackUploader';
-import { submitReportback, addToSubmissionsList, fetchUserReportbacks } from '../../actions';
+import { submitReportback, addSubmissionItemToList, fetchUserReportbacks } from '../../actions';
 
 /**
  * Provide state from the Redux store as props for this component.
@@ -21,7 +21,7 @@ const mapStateToProps = state => ({
  */
 const actionCreators = {
   submitReportback,
-  addToSubmissionsList,
+  addSubmissionItemToList,
   fetchUserReportbacks,
 };
 


### PR DESCRIPTION
### What does this PR do?
This PR fixes two quick bugs I ran into. 

First, now that the RB uploader can be added as a step on the action page, the component should not make the background required.

Second, the `addToSubmissionsList` action was renamed, but the `ReportbackUploaderContainer` did not update the references to the new name of `addSubmissionItemToList`.


