### PR TITLE
Reportback Submission gallery separation from RB Uploader Component

### DIFF
--- a/resources/assets/components/ActionPage/ActionStepsWrapper.js
+++ b/resources/assets/components/ActionPage/ActionStepsWrapper.js
@@ -8,15 +8,22 @@ import { Flex, FlexCell } from '../Flex';
 import { makeHash } from '../../helpers';
 import CompetitionContainer from '../../containers/CompetitionContainer';
 import { ReportbackUploaderContainer } from '../ReportbackUploader';
+import { SubmissionGalleryContainer } from '../Gallery';
 import { clickedSignUp as clickedSignUpAction } from '../../actions';
 
 const ActionStepsWrapper = (props) => {
-  const { callToAction, campaignId, hasPendingSignup,
-    isSignedUp, isAuthenticated, clickedSignUp, actionSteps } = props;
+  const { actionSteps, callToAction, campaignId, clickedSignUp,
+    hasPendingSignup, isAuthenticated, isSignedUp  } = props;
 
-  const uploader = (
+  const photoUploader = (
     <FlexCell key="reportback_uploader" width="full">
       <ReportbackUploaderContainer />
+    </FlexCell>
+  );
+
+  const submissionGallery = (
+    <FlexCell key="submission_gallery" width="full">
+      <SubmissionGalleryContainer />
     </FlexCell>
   );
 
@@ -31,10 +38,13 @@ const ActionStepsWrapper = (props) => {
     />
   );
 
-  const revealerOrUploader = isSignedUp ? uploader : actionRevealer;
+  const revealerOrUploader = isSignedUp ? photoUploader : actionRevealer;
+
+  const renderSubmissionGallery = isSignedUp ? submissionGallery : null;
 
   let stepIndex = 0;
-  let appendUploader = true; // TODO: Remove this after content updates.
+  let appendPhotoUploader = true; // TODO: Remove this after contentful updates.
+  let appendSubmissionGallery = true; // TODO: Remove this after contentful updates.
 
   const stepComponents = actionSteps.map((step) => {
     const title = step.title;
@@ -56,8 +66,14 @@ const ActionStepsWrapper = (props) => {
         );
 
       case 'photo-uploader':
-        appendUploader = false; // TODO: Remove this flag after content updates post deploy.
+        appendPhotoUploader = false; // TODO: Remove this flag after contentful updates post deploy.
+
         return revealerOrUploader;
+
+      case 'submission-gallery':
+        appendSubmissionGallery = false; // TODO: Remove this flag after contentful updates post deploy.
+
+        return renderSubmissionGallery;
 
       default:
         stepIndex += 1;
@@ -76,8 +92,12 @@ const ActionStepsWrapper = (props) => {
     }
   });
 
-  if (appendUploader) {
+  if (appendPhotoUploader) {
     stepComponents.push(revealerOrUploader);
+  }
+
+  if (appendSubmissionGallery) {
+    stepComponents.push(renderSubmissionGallery);
   }
 
   return (

--- a/resources/assets/components/ActionPage/ActionStepsWrapper.js
+++ b/resources/assets/components/ActionPage/ActionStepsWrapper.js
@@ -13,7 +13,7 @@ import { clickedSignUp as clickedSignUpAction } from '../../actions';
 
 const ActionStepsWrapper = (props) => {
   const { actionSteps, callToAction, campaignId, clickedSignUp,
-    hasPendingSignup, isAuthenticated, isSignedUp  } = props;
+    hasPendingSignup, isAuthenticated, isSignedUp } = props;
 
   const photoUploader = (
     <FlexCell key="reportback_uploader" width="full">
@@ -66,12 +66,14 @@ const ActionStepsWrapper = (props) => {
         );
 
       case 'photo-uploader':
-        appendPhotoUploader = false; // TODO: Remove this flag after contentful updates post deploy.
+        // TODO: Remove this flag after contentful updates post deploy.
+        appendPhotoUploader = false;
 
         return revealerOrUploader;
 
       case 'submission-gallery':
-        appendSubmissionGallery = false; // TODO: Remove this flag after contentful updates post deploy.
+        // TODO: Remove this flag after contentful updates post deploy.
+        appendSubmissionGallery = false;
 
         return renderSubmissionGallery;
 

--- a/resources/assets/components/Gallery/Gallery.js
+++ b/resources/assets/components/Gallery/Gallery.js
@@ -1,0 +1,17 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import classnames from 'classnames';
+import { modifiers } from '../../helpers';
+
+const renderGalleryItem = (child, index) => <li key={`submission-${index}`}>{child}</li>;
+
+const Gallery = ({ type = null, children }) => (
+  children.length ? <ul className={classnames('gallery', modifiers(type))}>{children.map(renderGalleryItem)}</ul> : null
+);
+
+Gallery.propTypes = {
+  children: PropTypes.arrayOf(PropTypes.element),
+  type: PropTypes.oneOf(['triad', 'quartet']),
+};
+
+export default Gallery;

--- a/resources/assets/components/Gallery/Gallery.test.js
+++ b/resources/assets/components/Gallery/Gallery.test.js
@@ -1,0 +1,16 @@
+import React from 'react';
+import renderer from 'react-test-renderer';
+import Gallery from './Gallery';
+
+test('it renders correctly with children', () => {
+  const tree = renderer.create(
+    <Gallery type="quartet">
+      <div>item one</div>
+      <div>item two</div>
+      <div>item three</div>
+      <div>item four</div>
+    </Gallery>
+  );
+
+  expect(tree).toMatchSnapshot();
+});

--- a/resources/assets/components/Gallery/Gallery.test.js
+++ b/resources/assets/components/Gallery/Gallery.test.js
@@ -9,7 +9,7 @@ test('it renders correctly with children', () => {
       <div>item two</div>
       <div>item three</div>
       <div>item four</div>
-    </Gallery>
+    </Gallery>,
   );
 
   expect(tree).toMatchSnapshot();

--- a/resources/assets/components/Gallery/SubmissionGallery.js
+++ b/resources/assets/components/Gallery/SubmissionGallery.js
@@ -1,0 +1,33 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import Gallery from './Gallery';
+import ReportbackItem from '../ReportbackItem';
+import { makeHash } from '../../helpers';
+
+const renderReportbackItem = (submission) => {
+  // @TODO: Normalize data for uploaded RBs vs API retrieved RBs if possible...
+  const key = makeHash(submission.media.uri || submission.media.filePreviewUrl);
+  const url = submission.media.uri || submission.media.filePreviewUrl;
+
+  return <ReportbackItem key={key} {...submission} url={url} reaction={null} basicDisplay />;
+};
+
+const SubmissionGallery = ({ submissions }) => {
+  const { isFetching = false, items } = submissions;
+
+
+  return isFetching
+    ? <div className="spinner -centered" />
+    : <Gallery type="triad">
+      {items.map(submission => renderReportbackItem(submission))}
+    </Gallery>;
+};
+
+SubmissionGallery.propTypes = {
+  submissions: PropTypes.shape({
+    isFetching: PropTypes.bool,
+    items: PropTypes.array,
+  }).isRequired,
+};
+
+export default SubmissionGallery;

--- a/resources/assets/components/Gallery/SubmissionGallery.test.js
+++ b/resources/assets/components/Gallery/SubmissionGallery.test.js
@@ -1,0 +1,36 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { shallowToJson } from 'enzyme-to-json';
+import SubmissionGallery from './SubmissionGallery';
+
+const mediaItem = {
+  media: {
+    uri: 'http://fakelink.com',
+  },
+};
+
+test('it renders correctly with required props', () => {
+  const component = shallow(
+    <SubmissionGallery submissions={{
+      isFetching: false,
+      items: [mediaItem],
+    }}
+    />,
+  );
+
+  const tree = shallowToJson(component);
+  expect(tree).toMatchSnapshot();
+});
+
+test('it renders loader while fetching', () => {
+  const component = shallow(
+    <SubmissionGallery submissions={{
+      isFetching: true,
+      items: [mediaItem],
+    }}
+    />,
+  );
+
+  const tree = shallowToJson(component);
+  expect(tree).toMatchSnapshot();
+});

--- a/resources/assets/components/Gallery/SubmissionGalleryContainer.js
+++ b/resources/assets/components/Gallery/SubmissionGalleryContainer.js
@@ -1,0 +1,14 @@
+import { connect } from 'react-redux';
+import SubmissionGallery from './SubmissionGallery';
+
+/**
+ * Provide state from the Redux store as props for this component.
+ */
+const mapStateToProps = state => ({
+  submissions: state.submissions,
+});
+
+/**
+ * Export the container component.
+ */
+export default connect(mapStateToProps)(SubmissionGallery);

--- a/resources/assets/components/Gallery/__snapshots__/Gallery.test.js.snap
+++ b/resources/assets/components/Gallery/__snapshots__/Gallery.test.js.snap
@@ -1,0 +1,28 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`it renders correctly with children 1`] = `
+<ul
+  className="gallery -quartet"
+>
+  <li>
+    <div>
+      item one
+    </div>
+  </li>
+  <li>
+    <div>
+      item two
+    </div>
+  </li>
+  <li>
+    <div>
+      item three
+    </div>
+  </li>
+  <li>
+    <div>
+      item four
+    </div>
+  </li>
+</ul>
+`;

--- a/resources/assets/components/Gallery/__snapshots__/SubmissionGallery.test.js.snap
+++ b/resources/assets/components/Gallery/__snapshots__/SubmissionGallery.test.js.snap
@@ -1,0 +1,34 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`it renders correctly with required props 1`] = `
+<Gallery
+  type="triad"
+>
+  <ReportbackItem
+    basicDisplay={true}
+    firstName="A Doer"
+    isFetching={false}
+    media={
+      Object {
+        "uri": "http://fakelink.com",
+      }
+    }
+    noun={
+      Object {
+        "plural": "items",
+        "singular": "item",
+      }
+    }
+    reaction={null}
+    toggleReactionOff={[Function]}
+    toggleReactionOn={[Function]}
+    url="http://fakelink.com"
+  />
+</Gallery>
+`;
+
+exports[`it renders loader while fetching 1`] = `
+<div
+  className="spinner -centered"
+/>
+`;

--- a/resources/assets/components/Gallery/index.js
+++ b/resources/assets/components/Gallery/index.js
@@ -1,27 +1,5 @@
-import PropTypes from 'prop-types';
-import React from 'react';
-import classnames from 'classnames';
-import { modifiers } from '../../helpers';
+export SubmissionGalleryContainer from './SubmissionGalleryContainer';
 
-const renderGalleryItem = (child, index) => <li key={`submission-${index}`} className="">{child}</li>;
+export SubmissionGallery from './SubmissionGallery';
 
-const Gallery = ({ isFetching, type = null, children }) => {
-  if (isFetching) {
-    return <div>loading…</div>;
-  }
-
-  return children.length ? <ul className={classnames('gallery', modifiers(type))}>{children.map(renderGalleryItem)}</ul> : null;
-};
-
-Gallery.propTypes = {
-  children: PropTypes.arrayOf(PropTypes.element),
-  isFetching: PropTypes.bool,
-  type: PropTypes.oneOf(['triad', 'quartet']),
-};
-
-Gallery.defaultProps = {
-  isFetching: false,
-};
-
-export default Gallery;
-
+export default from './Gallery';

--- a/resources/assets/components/ReportbackUploader/ReportbackUploader.js
+++ b/resources/assets/components/ReportbackUploader/ReportbackUploader.js
@@ -4,21 +4,10 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { BlockWrapper } from '../Block';
 import MediaUploader from '../MediaUploader';
-import Gallery from '../Gallery';
-import ReportbackItem from '../ReportbackItem';
 import FormMessage from '../FormMessage';
-import { makeHash } from '../../helpers';
 import './reportback-uploader.scss';
 
 class ReportbackUploader extends React.Component {
-  static renderReportbackItem(submission) {
-    // @TODO: Normalize data for uploaded RBs vs API retrieved RBs if possible...
-    const key = makeHash(submission.media.uri || submission.media.filePreviewUrl);
-    const url = submission.media.uri || submission.media.filePreviewUrl;
-
-    return <ReportbackItem key={key} {...submission} url={url} reaction={null} basicDisplay />;
-  }
-
   static setFormData(container) {
     const reportback = container;
     const formData = new FormData();
@@ -125,9 +114,6 @@ class ReportbackUploader extends React.Component {
             <button className="button" type="submit" disabled={submissions.isStoring}>Submit a new photo</button>
           </form>
         </div>
-        <Gallery isFetching={submissions.isFetching} type="triad">
-          {submissions.items.map(submission => ReportbackUploader.renderReportbackItem(submission))}
-        </Gallery>
       </BlockWrapper>
     );
   }

--- a/resources/assets/scss/base.scss
+++ b/resources/assets/scss/base.scss
@@ -25,3 +25,10 @@ h1, h2, h3, p {
     color: $white;
   }
 }
+
+.spinner {
+  &.-centered {
+    text-align: center;
+    width: 100%;
+  }
+}


### PR DESCRIPTION
### What does this PR do?
This PR continues the process for the updates and refactoring of the RB Uploader. It specifically works on separating out the Reportback Submission Gallery _out_ of the Reportback Uploader component, so they can be placed in different locations if desired.

![image](https://user-images.githubusercontent.com/105849/28040052-70b5cae2-6592-11e7-81b5-518a969000b3.png)

This is what the gallery looks like outside of the RB uploader. Next steps will include creating a `Card` component that combines with the `Block` to give the RB submission items the correct visual appearance, along with also some updates on the Contentful side for how the gallery gets included into the Action Steps.


### Any background context you want to provide?
Tackling the RB Uploader refactor in digestible chunks. 

### What are the relevant tickets/cards?
Refs https://trello.com/c/CifTBgbt/682-8-as-a-developer-i-want-to-do-some-cleanup-on-the-rb-uploader-and-make-some-enhancements-too

### Checklist
- [x] Added appropriate feature/unit tests.

