### PR TITLE
Twerking the action steps

### DIFF
--- a/app/Entities/Campaign.php
+++ b/app/Entities/Campaign.php
@@ -37,13 +37,9 @@ class Campaign extends Entity implements JsonSerializable
      */
     public function parseActionStepPhotos($photos)
     {
-        $output = [];
-
-        foreach ($photos as $photo) {
-            $output[] = get_image_url($photo, 'landscape');
-        }
-
-        return $output;
+        return collect($photos)->map(function ($photo) {
+            return get_image_url($photo, 'landscape');
+        });
     }
 
     /**
@@ -54,25 +50,20 @@ class Campaign extends Entity implements JsonSerializable
      */
     public function parseActionSteps($actionSteps)
     {
-        $output = [];
-
-        foreach ($actionSteps as $step) {
+        return collect($actionSteps)->map(function ($step) {
             $data = [];
 
             $data['title'] = $step->title;
-            $data['displayOptions'] = $step->displayOptions->shift();
+            $data['displayOptions'] = $step->displayOptions->first();
 
             $step->content ? $data['content'] = $step->content : null;
             $step->background ? $data['background'] = get_image_url($step->background, 'landscape') : null;
             $step->photos ? $data['photos'] = $this->parseActionStepPhotos($step->photos) : null;
-            $step->type ? $data['type'] = $step->type->shift() : null;
-            $step->customType ? $data['customType'] = $step->customType->shift() : null; // @TODO deprecate.
+            $step->customType ? $data['customType'] = $step->customType->first() : null;
             $step->additionalContent ? $data['additionalContent'] = $step->additionalContent : null;
 
-            $output[] = $data;
-        }
-
-        return $output;
+            return $data;
+        });
     }
 
     public function jsonSerialize()

--- a/resources/assets/components/ActionPage/ActionPage.js
+++ b/resources/assets/components/ActionPage/ActionPage.js
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { cloneDeep } from 'lodash';
 
-import ActionStepsWrapper from './ActionStepsWrapper';
+import ActionStepsWrapperContainer from './ActionStepsWrapperContainer';
 import './actionPage.scss';
 
 /**
@@ -11,7 +11,7 @@ import './actionPage.scss';
  * @returns {XML}
  */
 const ActionPage = (props) => {
-  const { steps, signedUp, featureFlags } = props;
+  const { steps, signedUp } = props;
 
   let actionSteps = cloneDeep(steps);
 
@@ -25,18 +25,13 @@ const ActionPage = (props) => {
   }
 
   return (
-    <ActionStepsWrapper actionSteps={actionSteps} featureFlags={featureFlags} />
+    <ActionStepsWrapperContainer actionSteps={actionSteps} />
   );
 };
 
 ActionPage.propTypes = {
-  featureFlags: PropTypes.object, // eslint-disable-line react/forbid-prop-types
   steps: PropTypes.array.isRequired, // eslint-disable-line react/forbid-prop-types
   signedUp: PropTypes.bool.isRequired,
-};
-
-ActionPage.defaultProps = {
-  featureFlags: null,
 };
 
 export default ActionPage;

--- a/resources/assets/components/ActionPage/ActionPage.js
+++ b/resources/assets/components/ActionPage/ActionPage.js
@@ -11,7 +11,7 @@ import './actionPage.scss';
  * @returns {XML}
  */
 const ActionPage = (props) => {
-  const { steps, signedUp } = props;
+  const { steps, signedUp, featureFlags } = props;
 
   let actionSteps = cloneDeep(steps);
 
@@ -25,13 +25,18 @@ const ActionPage = (props) => {
   }
 
   return (
-    <ActionStepsWrapper actionSteps={actionSteps} />
+    <ActionStepsWrapper actionSteps={actionSteps} featureFlags={featureFlags} />
   );
 };
 
 ActionPage.propTypes = {
+  featureFlags: PropTypes.object, // eslint-disable-line react/forbid-prop-types
   steps: PropTypes.array.isRequired, // eslint-disable-line react/forbid-prop-types
   signedUp: PropTypes.bool.isRequired,
+};
+
+ActionPage.defaultProps = {
+  featureFlags: null,
 };
 
 export default ActionPage;

--- a/resources/assets/components/ActionPage/ActionPageContainer.js
+++ b/resources/assets/components/ActionPage/ActionPageContainer.js
@@ -1,4 +1,5 @@
 import { connect } from 'react-redux';
+import { get } from 'lodash';
 import ActionPage from './ActionPage';
 
 /**
@@ -7,6 +8,7 @@ import ActionPage from './ActionPage';
 const mapStateToProps = state => ({
   steps: state.campaign.actionSteps,
   signedUp: state.signups.thisCampaign,
+  featureFlags: get(state.campaign.additionalContent, 'featureFlags'),
 });
 
 // Export the container component.

--- a/resources/assets/components/ActionPage/ActionStepsWrapper.js
+++ b/resources/assets/components/ActionPage/ActionStepsWrapper.js
@@ -111,21 +111,4 @@ ActionStepsWrapper.defaultProps = {
   featureFlags: null,
 };
 
-// ActionStepsWrapper.mapStateToProps = state => ({
-//   campaignId: state.campaign.legacyCampaignId,
-//   callToAction: state.campaign.callToAction,
-//   hasPendingSignup: state.signups.isPending,
-//   isSignedUp: state.signups.thisCampaign,
-//   isAuthenticated: state.user.id !== null,
-// });
-
-// ActionStepsWrapper.actionCreators = {
-//   clickedSignUp: clickedSignUpAction,
-// };
-
-// export default connect(
-//   ActionStepsWrapper.mapStateToProps,
-//   ActionStepsWrapper.actionCreators,
-// )(ActionStepsWrapper);
-
 export default ActionStepsWrapper;

--- a/resources/assets/components/ActionPage/ActionStepsWrapper.js
+++ b/resources/assets/components/ActionPage/ActionStepsWrapper.js
@@ -54,17 +54,15 @@ const ActionStepsWrapper = (props) => {
     }
 
     const title = step.title;
-
-    const sharedProps = {
-      content: step.content || null,
-      key: makeHash(title),
-    };
+    const content = step.content || null;
+    const key = makeHash(title);
 
     switch (type) {
       case 'competition':
         return (
           <CompetitionContainer
-            {...sharedProps}
+            key={key}
+            content={content}
             photo={step.photos[0]}
             byline={step.additionalContent}
           />
@@ -81,8 +79,9 @@ const ActionStepsWrapper = (props) => {
 
         return (
           <ActionStep
-            {...sharedProps}
+            key={key}
             title={title}
+            content={content}
             stepIndex={stepIndex}
             background={step.background}
             photos={step.photos}

--- a/resources/assets/components/ActionPage/ActionStepsWrapper.js
+++ b/resources/assets/components/ActionPage/ActionStepsWrapper.js
@@ -45,13 +45,7 @@ const ActionStepsWrapper = (props) => {
   let stepIndex = 0;
 
   const stepComponents = actionSteps.map((step) => {
-    let type = null;
-
-    if (get(props.featureFlags, 'useComponentActions')) {
-      type = step.type || 'default';
-    } else {
-      type = step.customType || step.type || 'default';
-    }
+    let type = step.customType || 'default';
 
     const title = step.title;
     const content = step.content || null;

--- a/resources/assets/components/ActionPage/ActionStepsWrapper.js
+++ b/resources/assets/components/ActionPage/ActionStepsWrapper.js
@@ -1,5 +1,4 @@
 import React from 'react';
-// import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import { get } from 'lodash';
 
@@ -10,7 +9,6 @@ import { makeHash } from '../../helpers';
 import CompetitionContainer from '../../containers/CompetitionContainer';
 import { ReportbackUploaderContainer } from '../ReportbackUploader';
 import { SubmissionGalleryContainer } from '../Gallery';
-// import { clickedSignUp as clickedSignUpAction } from '../../actions';
 
 const ActionStepsWrapper = (props) => {
   const { actionSteps, callToAction, campaignId, clickedSignUp,

--- a/resources/assets/components/ActionPage/ActionStepsWrapper.js
+++ b/resources/assets/components/ActionPage/ActionStepsWrapper.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
+import { get } from 'lodash';
 
 import ActionStep from './ActionStep';
 import Revealer from '../Revealer';
@@ -38,20 +39,24 @@ const ActionStepsWrapper = (props) => {
     />
   );
 
-  const revealerOrUploader = isSignedUp ? photoUploader : actionRevealer;
-
+  const renderPhotoUploader = isSignedUp ? photoUploader : actionRevealer;
   const renderSubmissionGallery = isSignedUp ? submissionGallery : null;
 
   let stepIndex = 0;
-  let appendPhotoUploader = true; // TODO: Remove this after contentful updates.
-  let appendSubmissionGallery = true; // TODO: Remove this after contentful updates.
 
   const stepComponents = actionSteps.map((step) => {
+    let type = null;
+
+    if (get(props.featureFlags, 'useComponentActions')) {
+      type = step.type || 'default';
+    } else {
+      type = step.customType || step.type || 'default';
+    }
+
     const title = step.title;
-    const type = step.customType[0] || 'default';
 
     const sharedProps = {
-      content: step.content,
+      content: step.content || null,
       key: makeHash(title),
     };
 
@@ -66,16 +71,10 @@ const ActionStepsWrapper = (props) => {
         );
 
       case 'photo-uploader':
-        // TODO: Remove this flag after contentful updates post deploy.
-        appendPhotoUploader = false;
-
-        return revealerOrUploader;
+        return (renderPhotoUploader);
 
       case 'submission-gallery':
-        // TODO: Remove this flag after contentful updates post deploy.
-        appendSubmissionGallery = false;
-
-        return renderSubmissionGallery;
+        return (renderSubmissionGallery);
 
       default:
         stepIndex += 1;
@@ -87,18 +86,14 @@ const ActionStepsWrapper = (props) => {
             stepIndex={stepIndex}
             background={step.background}
             photos={step.photos}
-            photoWidth={step.displayOptions[0] === 'full' ? 'full' : 'one-third'}
+            photoWidth={step.displayOptions === 'full' ? 'full' : 'one-third'}
             shouldTruncate={step.truncate}
           />
         );
     }
   });
 
-  if (appendPhotoUploader) {
-    stepComponents.push(revealerOrUploader);
-  }
-
-  if (appendSubmissionGallery) {
+  if (! get(props.featureFlags, 'useComponentActions')) {
     stepComponents.push(renderSubmissionGallery);
   }
 
@@ -113,10 +108,15 @@ ActionStepsWrapper.propTypes = {
   actionSteps: PropTypes.array.isRequired, // eslint-disable-line react/forbid-prop-types
   callToAction: PropTypes.string.isRequired,
   campaignId: PropTypes.string.isRequired,
+  clickedSignUp: PropTypes.func.isRequired,
+  featureFlags: PropTypes.object, // eslint-disable-line react/forbid-prop-types
   hasPendingSignup: PropTypes.bool.isRequired,
   isSignedUp: PropTypes.bool.isRequired,
   isAuthenticated: PropTypes.bool.isRequired,
-  clickedSignUp: PropTypes.func.isRequired,
+};
+
+ActionStepsWrapper.defaultProps = {
+  featureFlags: null,
 };
 
 ActionStepsWrapper.mapStateToProps = state => ({

--- a/resources/assets/components/ActionPage/ActionStepsWrapper.js
+++ b/resources/assets/components/ActionPage/ActionStepsWrapper.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { connect } from 'react-redux';
+// import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import { get } from 'lodash';
 
@@ -10,7 +10,7 @@ import { makeHash } from '../../helpers';
 import CompetitionContainer from '../../containers/CompetitionContainer';
 import { ReportbackUploaderContainer } from '../ReportbackUploader';
 import { SubmissionGalleryContainer } from '../Gallery';
-import { clickedSignUp as clickedSignUpAction } from '../../actions';
+// import { clickedSignUp as clickedSignUpAction } from '../../actions';
 
 const ActionStepsWrapper = (props) => {
   const { actionSteps, callToAction, campaignId, clickedSignUp,
@@ -111,19 +111,21 @@ ActionStepsWrapper.defaultProps = {
   featureFlags: null,
 };
 
-ActionStepsWrapper.mapStateToProps = state => ({
-  campaignId: state.campaign.legacyCampaignId,
-  callToAction: state.campaign.callToAction,
-  hasPendingSignup: state.signups.isPending,
-  isSignedUp: state.signups.thisCampaign,
-  isAuthenticated: state.user.id !== null,
-});
+// ActionStepsWrapper.mapStateToProps = state => ({
+//   campaignId: state.campaign.legacyCampaignId,
+//   callToAction: state.campaign.callToAction,
+//   hasPendingSignup: state.signups.isPending,
+//   isSignedUp: state.signups.thisCampaign,
+//   isAuthenticated: state.user.id !== null,
+// });
 
-ActionStepsWrapper.actionCreators = {
-  clickedSignUp: clickedSignUpAction,
-};
+// ActionStepsWrapper.actionCreators = {
+//   clickedSignUp: clickedSignUpAction,
+// };
 
-export default connect(
-  ActionStepsWrapper.mapStateToProps,
-  ActionStepsWrapper.actionCreators,
-)(ActionStepsWrapper);
+// export default connect(
+//   ActionStepsWrapper.mapStateToProps,
+//   ActionStepsWrapper.actionCreators,
+// )(ActionStepsWrapper);
+
+export default ActionStepsWrapper;

--- a/resources/assets/components/ActionPage/ActionStepsWrapper.js
+++ b/resources/assets/components/ActionPage/ActionStepsWrapper.js
@@ -45,8 +45,7 @@ const ActionStepsWrapper = (props) => {
   let stepIndex = 0;
 
   const stepComponents = actionSteps.map((step) => {
-    let type = step.customType || 'default';
-
+    const type = step.customType || 'default';
     const title = step.title;
     const content = step.content || null;
     const key = makeHash(title);

--- a/resources/assets/components/ActionPage/ActionStepsWrapperContainer.js
+++ b/resources/assets/components/ActionPage/ActionStepsWrapperContainer.js
@@ -1,0 +1,27 @@
+import { connect } from 'react-redux';
+import { get } from 'lodash';
+import ActionStepsWrapper from './ActionStepsWrapper';
+import { clickedSignUp as clickedSignUpAction } from '../../actions';
+
+/**
+ * Provide state from the Redux store as props for this component.
+ */
+const mapStateToProps = state => ({
+  campaignId: state.campaign.legacyCampaignId,
+  callToAction: state.campaign.callToAction,
+  featureFlags: get(state.campaign.additionalContent, 'featureFlags'),
+  hasPendingSignup: state.signups.isPending,
+  isSignedUp: state.signups.thisCampaign,
+  isAuthenticated: state.user.id !== null,
+});
+
+/**
+ * Provide pre-bound functions that allow the component to dispatch
+ * actions to the Redux store as props for this component.
+ */
+const mapDispatchToProps = {
+  clickedSignUp: clickedSignUpAction,
+};
+
+// Export the container component.
+export default connect(mapStateToProps, mapDispatchToProps)(ActionStepsWrapper);

--- a/resources/assets/components/ActionPage/ActionStepsWrapperContainer.js
+++ b/resources/assets/components/ActionPage/ActionStepsWrapperContainer.js
@@ -20,7 +20,7 @@ const mapStateToProps = state => ({
  * actions to the Redux store as props for this component.
  */
 const mapDispatchToProps = {
-  clickedSignUp: clickedSignUp,
+  clickedSignUp,
 };
 
 // Export the container component.

--- a/resources/assets/components/ActionPage/ActionStepsWrapperContainer.js
+++ b/resources/assets/components/ActionPage/ActionStepsWrapperContainer.js
@@ -1,7 +1,7 @@
 import { connect } from 'react-redux';
 import { get } from 'lodash';
 import ActionStepsWrapper from './ActionStepsWrapper';
-import { clickedSignUp as clickedSignUpAction } from '../../actions';
+import { clickedSignUp } from '../../actions';
 
 /**
  * Provide state from the Redux store as props for this component.
@@ -20,7 +20,7 @@ const mapStateToProps = state => ({
  * actions to the Redux store as props for this component.
  */
 const mapDispatchToProps = {
-  clickedSignUp: clickedSignUpAction,
+  clickedSignUp: clickedSignUp,
 };
 
 // Export the container component.

--- a/resources/assets/components/ActionPage/index.js
+++ b/resources/assets/components/ActionPage/index.js
@@ -1,5 +1,10 @@
 // Fully constructed Action Page.
 export ActionPageContainer from './ActionPageContainer';
 
+// Fully constructed Action Steps Wrapper.
+export ActionStepsWrapperContainer from './ActionStepsWrapperContainer';
+
+export ActionStepsWrapper from './ActionStepsWrapper';
+
 // Pure React component without Redux data.
 export default from './ActionPage';


### PR DESCRIPTION
### What does this PR do?
This PR makes a few updates to allow the use of _both_ `CampaignActionSteps` and `ComponentActionSteps`. The latter are simpler content types for the Action Steps that can be used to easily define a specific component to insert into the flow of the steps. Currently the available component steps to include are the `photo-uploader` and the `submission-gallery`, but we now have a system to easily allow adding more which we will be tackling in the near future when adding instant action steps.

What's nice, is that for more robust steps, like the `default` ones, which include photos, a background image, etc., they can still have variation types within them, such as the `competition` type.

![image](https://user-images.githubusercontent.com/105849/28085995-7222b6ec-664b-11e7-9ad8-d207b3d8b931.png)

When enabling the `ComponentActionStep` it revealed a sort of bug where the campaign would no longer render because we _used_ to depend on each action step having a `photos` property, even if it wasn't used. The new content type doesn't have this field, thus the site would break. The updates to the `app/Entities/Campaign.php` specifically address this new bug and resolve it.

### Any background context you want to provide?
This initially started as part of the work for the RB Uploader refactoring, but ended up also benefitting for upcoming instant actions and so it was approach in a way that could afford adding instant action in the future much simpler 😄 

This also introduces a potential approach to per-campaign feature flags via the `additionalContent` :)

### What are the relevant tickets/cards?
Refs https://trello.com/c/CifTBgbt/682-8-as-a-developer-i-want-to-do-some-cleanup-on-the-rb-uploader-and-make-some-enhancements-too

### Checklist
- [ ] Added appropriate feature/unit tests.

