### PR TITLE
Action page bug fix

### DIFF
--- a/resources/assets/components/ActionPage/ActionPage.js
+++ b/resources/assets/components/ActionPage/ActionPage.js
@@ -15,9 +15,11 @@ const ActionPage = (props) => {
 
   let actionSteps = cloneDeep(steps);
 
+  console.log(signedUp);
+
   if (! signedUp) {
     // Truncate steps if user isn't signed up & remove any custom steps.
-    actionSteps = actionSteps.filter(step => ! step.customType[0]).slice(0, 2);
+    actionSteps = actionSteps.filter(step => ! step.customType).slice(0, 2);
 
     if (actionSteps[actionSteps.length - 1]) {
       actionSteps[actionSteps.length - 1].truncate = true;

--- a/resources/assets/components/ActionPage/ActionPage.js
+++ b/resources/assets/components/ActionPage/ActionPage.js
@@ -15,8 +15,6 @@ const ActionPage = (props) => {
 
   let actionSteps = cloneDeep(steps);
 
-  console.log(signedUp);
-
   if (! signedUp) {
     // Truncate steps if user isn't signed up & remove any custom steps.
     actionSteps = actionSteps.filter(step => ! step.customType).slice(0, 2);

--- a/resources/assets/components/ActionPage/ActionStepsWrapper.js
+++ b/resources/assets/components/ActionPage/ActionStepsWrapper.js
@@ -37,9 +37,6 @@ const ActionStepsWrapper = (props) => {
     />
   );
 
-  const renderPhotoUploader = isSignedUp ? photoUploader : null;
-  const renderSubmissionGallery = isSignedUp ? submissionGallery : null;
-
   let stepIndex = 0;
 
   const stepComponents = actionSteps.map((step) => {
@@ -60,10 +57,10 @@ const ActionStepsWrapper = (props) => {
         );
 
       case 'photo-uploader':
-        return (renderPhotoUploader);
+        return isSignedUp ? photoUploader : null;
 
       case 'submission-gallery':
-        return (renderSubmissionGallery);
+        return isSignedUp ? submissionGallery : null;
 
       default:
         stepIndex += 1;

--- a/resources/assets/components/ActionPage/ActionStepsWrapper.js
+++ b/resources/assets/components/ActionPage/ActionStepsWrapper.js
@@ -37,7 +37,7 @@ const ActionStepsWrapper = (props) => {
     />
   );
 
-  const renderPhotoUploader = isSignedUp ? photoUploader : actionRevealer;
+  const renderPhotoUploader = isSignedUp ? photoUploader : null;
   const renderSubmissionGallery = isSignedUp ? submissionGallery : null;
 
   let stepIndex = 0;
@@ -82,6 +82,10 @@ const ActionStepsWrapper = (props) => {
         );
     }
   });
+
+  if (! isSignedUp) {
+    stepComponents.push(actionRevealer);
+  }
 
   if (! get(props.featureFlags, 'useComponentActions')) {
     stepComponents.push(renderSubmissionGallery);

--- a/resources/assets/components/ActionPage/ActionStepsWrapper.js
+++ b/resources/assets/components/ActionPage/ActionStepsWrapper.js
@@ -84,8 +84,8 @@ const ActionStepsWrapper = (props) => {
     stepComponents.push(actionRevealer);
   }
 
-  if (! get(props.featureFlags, 'useComponentActions')) {
-    stepComponents.push(renderSubmissionGallery);
+  if (isSignedUp && ! get(props.featureFlags, 'useComponentActions')) {
+    stepComponents.push(submissionGallery);
   }
 
   return (


### PR DESCRIPTION
### What does this PR do?
This PR fixes a bug I accidentally introduced in prior Action Page updates. Since now we return a string instead of an array of one item for the `customType` property in an action step, we needed to update how we check against it when deciding whether or not to remove customTypes for unaffiliated users.

It also reintroduces the Revealer in a nicer fashion and separates the dependency between it and the RB Photo Uploader 🎉 

### What are the relevant tickets/cards?
Refs https://trello.com/c/CifTBgbt/682-8-as-a-developer-i-want-to-do-some-cleanup-on-the-rb-uploader-and-make-some-enhancements-too

