### PR TITLE
Fixing action header responsiveness

### DIFF
--- a/resources/assets/components/ActionPage/actionPage.scss
+++ b/resources/assets/components/ActionPage/actionPage.scss
@@ -37,10 +37,16 @@
 
     img {
       width: 100%;
+      height: 100%;
       position: absolute;
-      top: 50%; left: 0;
-      transform: translateY(-50%);
+      top: 0; left: 0;
       filter: grayscale(100%);
+
+      @include media($medium) {
+        height: auto;
+        top: 50%;
+        transform: translateY(-50%);
+      }
     }
 
     span {


### PR DESCRIPTION
### What does this PR do?
Fixes the action header being weird on mobile not taking the full container height

<img width="587" alt="screen shot 2017-07-13 at 3 14 45 pm" src="https://user-images.githubusercontent.com/897368/28183618-1cb4e8b2-67de-11e7-9c85-7c4c98ff60c7.png">
<img width="353" alt="screen shot 2017-07-13 at 3 14 40 pm" src="https://user-images.githubusercontent.com/897368/28183617-1cb3784c-67de-11e7-8e98-51a81731d3a2.png">

It's a bit stretched on mobile, not sure of a great solution without alternating between landscape / square photos. I think if the effect was more dramatic I would work on that but seems low priority and not very noticeable. 