### PR TITLE
Updating to switch fetching User RBs from Uploader to Submission Gallery.

### DIFF
--- a/resources/assets/components/Gallery/SubmissionGallery.js
+++ b/resources/assets/components/Gallery/SubmissionGallery.js
@@ -4,30 +4,39 @@ import Gallery from './Gallery';
 import ReportbackItem from '../ReportbackItem';
 import { makeHash } from '../../helpers';
 
-const renderReportbackItem = (submission) => {
-  // @TODO: Normalize data for uploaded RBs vs API retrieved RBs if possible...
-  const key = makeHash(submission.media.uri || submission.media.filePreviewUrl);
-  const url = submission.media.uri || submission.media.filePreviewUrl;
+class SubmissionGallery extends React.Component {
+  static renderReportbackItem(submission) {
+    // @TODO: Normalize data for uploaded RBs vs API retrieved RBs if possible...
+    const key = makeHash(submission.media.uri || submission.media.filePreviewUrl);
+    const url = submission.media.uri || submission.media.filePreviewUrl;
 
-  return <ReportbackItem key={key} {...submission} url={url} reaction={null} basicDisplay />;
-};
+    return <ReportbackItem key={key} {...submission} url={url} reaction={null} basicDisplay />;
+  }
 
-const SubmissionGallery = ({ submissions }) => {
-  const { isFetching = false, items } = submissions;
+  componentDidMount() {
+    this.props.fetchUserReportbacks(this.props.userId, this.props.legacyCampaignId);
+  }
 
+  render() {
+    const isFetching = this.props.submissions.isFetching;
+    const items = this.props.submissions.items;
 
-  return isFetching
-    ? <div className="spinner -centered" />
-    : <Gallery type="triad">
-      {items.map(submission => renderReportbackItem(submission))}
-    </Gallery>;
-};
+    return isFetching
+      ? <div className="spinner -centered" />
+      : <Gallery type="triad">
+        {items.map(submission => SubmissionGallery.renderReportbackItem(submission))}
+      </Gallery>;
+  }
+}
 
 SubmissionGallery.propTypes = {
+  fetchUserReportbacks: PropTypes.func.isRequired,
+  legacyCampaignId: PropTypes.string.isRequired,
   submissions: PropTypes.shape({
     isFetching: PropTypes.bool,
     items: PropTypes.array,
   }).isRequired,
+  userId: PropTypes.string.isRequired,
 };
 
 export default SubmissionGallery;

--- a/resources/assets/components/Gallery/SubmissionGalleryContainer.js
+++ b/resources/assets/components/Gallery/SubmissionGalleryContainer.js
@@ -1,14 +1,25 @@
 import { connect } from 'react-redux';
 import SubmissionGallery from './SubmissionGallery';
+import { fetchUserReportbacks } from '../../actions';
 
 /**
  * Provide state from the Redux store as props for this component.
  */
 const mapStateToProps = state => ({
+  legacyCampaignId: state.campaign.legacyCampaignId,
   submissions: state.submissions,
+  userId: state.user.id,
 });
+
+/**
+ * Provide pre-bound functions that allow the component to dispatch
+ * actions to the Redux store as props for this component.
+ */
+const mapDispatchToProps = {
+  fetchUserReportbacks,
+};
 
 /**
  * Export the container component.
  */
-export default connect(mapStateToProps)(SubmissionGallery);
+export default connect(mapStateToProps, mapDispatchToProps)(SubmissionGallery);

--- a/resources/assets/components/ReportbackUploader/ReportbackUploader.js
+++ b/resources/assets/components/ReportbackUploader/ReportbackUploader.js
@@ -46,10 +46,6 @@ class ReportbackUploader extends React.Component {
     };
   }
 
-  componentDidMount() {
-    this.props.fetchUserReportbacks(this.props.userId, this.props.legacyCampaignId);
-  }
-
   handleOnFileUpload(media) {
     this.setState({ media });
   }
@@ -120,7 +116,6 @@ class ReportbackUploader extends React.Component {
 }
 
 ReportbackUploader.propTypes = {
-  fetchUserReportbacks: PropTypes.func.isRequired,
   legacyCampaignId: PropTypes.string.isRequired,
   submissions: PropTypes.shape({
     isFetching: PropTypes.bool,
@@ -130,7 +125,6 @@ ReportbackUploader.propTypes = {
     reportback: PropTypes.object,
   }).isRequired,
   submitReportback: PropTypes.func.isRequired,
-  userId: PropTypes.string.isRequired,
   noun: PropTypes.shape({
     singular: PropTypes.string,
     plural: PropTypes.string,

--- a/resources/assets/components/ReportbackUploader/ReportbackUploaderContainer.js
+++ b/resources/assets/components/ReportbackUploader/ReportbackUploaderContainer.js
@@ -1,7 +1,7 @@
 import { connect } from 'react-redux';
 import { get } from 'lodash';
 import ReportbackUploader from './ReportbackUploader';
-import { submitReportback, addSubmissionItemToList, fetchUserReportbacks } from '../../actions';
+import { submitReportback, addSubmissionItemToList } from '../../actions';
 
 /**
  * Provide state from the Redux store as props for this component.
@@ -11,7 +11,6 @@ const mapStateToProps = state => ({
   legacyCampaignId: state.campaign.legacyCampaignId,
   submissions: state.submissions,
   noun: get(state.campaign.additionalContent, 'noun'),
-  userId: state.user.id,
   uploads: state.uploads,
 });
 
@@ -22,7 +21,6 @@ const mapStateToProps = state => ({
 const actionCreators = {
   submitReportback,
   addSubmissionItemToList,
-  fetchUserReportbacks,
 };
 
 // Export the container component.


### PR DESCRIPTION
### What does this PR do?
This PR switches the call to `fetchUserReportbacks` from the `ReportbackUploader` component, over into the `SubmissionGallery` component where it belongs. _Now_™, the `SubmissionGallery` should have everything it needs to successfully be placed as any action step completely independent of the photo uploader!


### Any background context you want to provide?
Prior to this fix, the Reportback Uploader could be included as an action step by iteself, or with the Submission Gallery, BUT the Submission Gallery could not be place by itself without the Reportback Uploader since it contained the call to find the user's submitted RBs and populate the redux store.


### What are the relevant tickets/cards?
Refs# https://github.com/DoSomething/phoenix-next/issues/341
PivotalTracke: https://www.pivotaltracker.com/story/show/149006001


### Notes
Until DS Thor is back up and running I cannot fully test the last of my changes. So feel free to review the code, but I will not be merging until I can test locally with Thor!
