### PR TITLE
Adding sanctioned entities

### DIFF
--- a/app/Entities/Campaign.php
+++ b/app/Entities/Campaign.php
@@ -43,6 +43,28 @@ class Campaign extends Entity implements JsonSerializable
     }
 
     /**
+     * Parse and extract activity feed item data based on content type.
+     *
+     * @param  array $activityItems
+     * @return array
+     */
+    public function parseActivityFeed($activityItems)
+    {
+        return collect($activityItems)->map(function ($item) {
+            switch ($item->getContentType()) {
+                case 'campaignUpdate':
+                    return new CampaignUpdate($item->entry);
+
+                case 'customBlock':
+                    return new CustomBlock($item->entry);
+
+                default:
+                    return $item;
+            }
+        });
+    }
+
+    /**
      * Parse and extract data for action steps.
      *
      * @param  array $actionSteps
@@ -66,6 +88,11 @@ class Campaign extends Entity implements JsonSerializable
         });
     }
 
+    /**
+     * Convert the object into something JSON serializable.
+     *
+     * @return array
+     */
     public function jsonSerialize()
     {
         return [
@@ -85,7 +112,7 @@ class Campaign extends Entity implements JsonSerializable
             'affiliateSponsors' => $this->affiliateSponsors,
             'affiliatePartners' => $this->affiliatePartners,
             // @TODO: Why is it 'activity_feed' oy? ;/
-            'activityFeed' => $this->activity_feed,
+            'activityFeed' => $this->parseActivityFeed($this->activity_feed),
             'actionSteps' => $this->parseActionSteps($this->actionSteps),
             'dashboard' => $this->dashboard,
             'affirmation' => [

--- a/app/Entities/CampaignUpdate.php
+++ b/app/Entities/CampaignUpdate.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Entities;
+
+use JsonSerializable;
+
+class CampaignUpdate extends Entity implements JsonSerializable
+{
+    /**
+     * Convert the object into something JSON serializable.
+     *
+     * @return array
+     */
+    public function jsonSerialize()
+    {
+        return [
+            'id' => $this->entry->getId(),
+            'type' => $this->getContentType(),
+            'fields' => [
+                'displayOptions' => $this->displayOptions->first(),
+                'content' => $this->content,
+                'author' => new Staff($this->author->entry),
+            ],
+        ];
+    }
+}

--- a/app/Entities/CustomBlock.php
+++ b/app/Entities/CustomBlock.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Entities;
+
+use JsonSerializable;
+
+class CustomBlock extends Entity implements JsonSerializable
+{
+    /**
+     * Convert the object into something JSON serializable.
+     *
+     * @return array
+     */
+    public function jsonSerialize()
+    {
+        $fields = $this->entry->jsonSerialize()->fields;
+
+        $data = [
+            'id' => $this->entry->getId(),
+            'type' => $fields->type,
+            'fields' => $this->entry->jsonSerialize()->fields,
+        ];
+
+        $data['fields']->displayOptions = array_shift($data['fields']->displayOptions);
+
+        return $data;
+    }
+}

--- a/app/Entities/Entity.php
+++ b/app/Entities/Entity.php
@@ -75,6 +75,16 @@ class Entity implements ArrayAccess, JsonSerializable
     }
 
     /**
+     * Get the ContentType for the DynamicEntry.
+     *
+     * @return string
+     */
+    public function getContentType()
+    {
+        return $this->entry->getContentType()->getId();
+    }
+
+    /**
      * Offset to retrieve
      * @link http://php.net/manual/en/arrayaccess.offsetget.php
      *

--- a/app/Entities/Staff.php
+++ b/app/Entities/Staff.php
@@ -3,7 +3,6 @@
 namespace App\Entities;
 
 use JsonSerializable;
-use Contentful\Delivery\Asset;
 
 class Staff extends Entity implements JsonSerializable
 {

--- a/app/Entities/Staff.php
+++ b/app/Entities/Staff.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Entities;
+
+use JsonSerializable;
+use Contentful\Delivery\Asset;
+
+class Staff extends Entity implements JsonSerializable
+{
+    /**
+     * Convert the object into something JSON serializable.
+     *
+     * @return array
+     */
+    public function jsonSerialize()
+    {
+        return [
+            'id' => $this->entry->getId(),
+            'type' => $this->getContentType(),
+            'fields' => [
+                'name' => $this->name,
+                'jobTitle' => $this->jobTitle,
+                'avatar' => get_image_url($this->avatar, 'square'),
+            ],
+        ];
+    }
+}

--- a/app/Repositories/CampaignRepository.php
+++ b/app/Repositories/CampaignRepository.php
@@ -48,6 +48,7 @@ class CampaignRepository
         $query = (new Query)
             ->setContentType('campaign')
             ->where('fields.slug', $slug)
+            ->setInclude(3)
             ->setLimit(1);
 
         $campaigns = $this->makeRequest($query);

--- a/resources/assets/components/Block/Block.js
+++ b/resources/assets/components/Block/Block.js
@@ -2,6 +2,7 @@
 
 import React from 'react';
 import { CampaignUpdateBlockContainer } from '../CampaignUpdateBlock';
+import { CampaignUpdate } from '../CampaignUpdate';
 import PlaceholderBlock from '../PlaceholderBlock';
 import ReportbackBlock from '../ReportbackBlock';
 import StaticBlock from '../StaticBlock';
@@ -12,7 +13,17 @@ import { BlockJson } from '../../types';
 const DEFAULT_BLOCK: BlockJson = { fields: { type: null } };
 
 const Block = ({ json = DEFAULT_BLOCK }: { json: BlockJson }) => {
-  switch (json.fields.type) {
+  switch (json.type) {
+    case 'campaignUpdate':
+      return (
+        <CampaignUpdate
+          id={json.id}
+          displayOptions={json.fields.displayOptions}
+          content={json.fields.content}
+          author={json.fields.author}
+        />
+      );
+
     case 'campaign_update':
       return <CampaignUpdateBlockContainer id={json.id} fields={json.fields} />;
 

--- a/resources/assets/components/Block/Block.test.js
+++ b/resources/assets/components/Block/Block.test.js
@@ -8,7 +8,7 @@ jest.mock('../../containers/CallToActionBlockContainer', () => 'CallToActionBloc
 jest.mock('../CampaignUpdateBlock/CampaignUpdateBlockContainer', () => 'CampaignUpdateBlockContainer');
 
 test('it can display a campaign update', () => {
-  const wrapper = shallow(<Block json={{ id: '12345', type: 'campaign_update', }} />);
+  const wrapper = shallow(<Block json={{ id: '12345', type: 'campaign_update' }} />);
   expect(wrapper.find('CampaignUpdateBlockContainer')).toHaveLength(1);
 });
 

--- a/resources/assets/components/Block/Block.test.js
+++ b/resources/assets/components/Block/Block.test.js
@@ -8,28 +8,28 @@ jest.mock('../../containers/CallToActionBlockContainer', () => 'CallToActionBloc
 jest.mock('../CampaignUpdateBlock/CampaignUpdateBlockContainer', () => 'CampaignUpdateBlockContainer');
 
 test('it can display a campaign update', () => {
-  const wrapper = shallow(<Block json={{ id: '12345', fields: { type: 'campaign_update' } }} />);
+  const wrapper = shallow(<Block json={{ id: '12345', type: 'campaign_update', }} />);
   expect(wrapper.find('CampaignUpdateBlockContainer')).toHaveLength(1);
 });
 
 test('it can display a CTA block', () => {
-  const wrapper = shallow(<Block json={{ id: '12345', fields: { type: 'join_cta' } }} />);
+  const wrapper = shallow(<Block json={{ id: '12345', type: 'join_cta' }} />);
   expect(wrapper.find('CallToActionBlockContainer')).toHaveLength(1);
 });
 
 test('it can display a static block', () => {
-  const wrapper = shallow(<Block json={{ id: '12345', fields: { type: 'static' } }} />);
+  const wrapper = shallow(<Block json={{ id: '12345', type: 'static', fields: {} }} />);
   expect(wrapper.find('StaticBlock')).toHaveLength(1);
 });
 
 test('it can display a reportback block', () => {
-  const json = { id: '12345', fields: { type: 'reportbacks' }, reportbacks: [] };
+  const json = { id: '12345', type: 'reportbacks', fields: {}, reportbacks: [] };
   const wrapper = shallow(<Block json={json} />);
   expect(wrapper.find('ReportbackBlock')).toHaveLength(1);
 });
 
 test('it should display a placeholder for an unknown block type', () => {
-  const wrapper = shallow(<Block json={{ id: '12345', fields: { type: 'tongue_cat' } }} />);
+  const wrapper = shallow(<Block json={{ id: '12345', type: 'tongue_cat' }} />);
   expect(wrapper.find('PlaceholderBlock')).toHaveLength(1);
 });
 

--- a/resources/assets/components/CampaignUpdate/CampaignUpdate.js
+++ b/resources/assets/components/CampaignUpdate/CampaignUpdate.js
@@ -1,0 +1,7 @@
+// import React from 'react';
+// import Card from '../Card';
+// import Markdown from '../Markdown';
+
+const CampaignUpdate = () => (null);
+
+export default CampaignUpdate;

--- a/resources/assets/components/CampaignUpdate/index.js
+++ b/resources/assets/components/CampaignUpdate/index.js
@@ -1,0 +1,3 @@
+export CampaignUpdate from './CampaignUpdate';
+
+export default from './CampaignUpdate';

--- a/resources/assets/components/Feed/index.js
+++ b/resources/assets/components/Feed/index.js
@@ -14,7 +14,7 @@ import Block from '../Block';
  * @returns {XML}
  */
 const renderFeedItem = (block, index) => (
-  <FlexCell key={`${block.id}-${index}`} width={block.fields.displayOptions[0]}>
+  <FlexCell key={`${block.id}-${index}`} width={block.fields.displayOptions}>
     <Block json={block} />
   </FlexCell>
 );

--- a/resources/assets/components/ReportbackBlock/index.js
+++ b/resources/assets/components/ReportbackBlock/index.js
@@ -26,7 +26,7 @@ const ReportbackBlock = (props) => {
 
 ReportbackBlock.propTypes = {
   fields: PropTypes.shape({
-    displayOptions: PropTypes.array,
+    displayOptions: PropTypes.string,
   }).isRequired,
   reportbacks: PropTypes.arrayOf(PropTypes.string).isRequired,
 };

--- a/resources/assets/selectors/feed.js
+++ b/resources/assets/selectors/feed.js
@@ -41,7 +41,7 @@ export function totalBlocksInFeed(state) {
  */
 export function totalReportbackBlocksInFeed(state) {
   return getBlocks(state)
-    .filter(block => block.fields.type === 'reportbacks')
+    .filter(block => block.type === 'reportbacks')
     .reduce((total, block) => (
       total + mapDisplayToPoints(block.fields.displayOptions)
     ), 0);
@@ -75,6 +75,7 @@ export function getVisibleBlocks(state) {
   // Filter out blocks that don't fit within offset.
   const filteredBlocks = getBlocks(state).filter((block) => {
     totalPoints += mapDisplayToPoints(block.fields.displayOptions);
+
     return totalPoints <= blockOffset;
   });
 
@@ -107,7 +108,7 @@ export function getBlocksWithReportbacks(blocks, state) {
   let reportbackIndex = 0;
 
   return blocks.map((block) => {
-    if (block.fields.type !== 'reportbacks') {
+    if (block.type !== 'reportbacks') {
       return block;
     }
 


### PR DESCRIPTION
### What does this PR do?
This PR updates the entities in the system to add a few more `CampaignUpdate`, `Staff` and `CustomBlock` which all handle transforming the Contentful data to make it more usable. Defining the `CampaignUpdate` and `Staff` entities also signifies that we are trying to formalize their data structure both in the application and as formal content types on the Contentful side.

This also helps update entities so they follow a similar structure in the data they transform. It follows this pattern:

```javascript
{
  id: string
  type: string
  fields: {}
}
```


### Any background context you want to provide?
These updates aim to improve how we approach transforming data from Contentful but it's also specifically related to the update to add a `CampaignUpdate` component specifically for the new `campaignUpdate` content type on Contentful.


### What are the relevant tickets/cards?
Refs # https://www.pivotaltracker.com/story/show/148973337

### Checklist
- [x] Added appropriate feature/unit tests.

