### PR TITLE
Adds some customization options for campaign admins

### DIFF
--- a/app/Entities/Campaign.php
+++ b/app/Entities/Campaign.php
@@ -81,7 +81,6 @@ class Campaign extends Entity implements JsonSerializable
             $step->content ? $data['content'] = $step->content : null;
             $step->background ? $data['background'] = get_image_url($step->background, 'landscape') : null;
             $step->photos ? $data['photos'] = $this->parseActionStepPhotos($step->photos) : null;
-            $step->hideStepNumber ? $data['hideStepNumber'] = $step->hideStepNumber : null;
             $step->customType ? $data['customType'] = $step->customType->first() : null;
             $step->additionalContent ? $data['additionalContent'] = $step->additionalContent : null;
 

--- a/app/Entities/Campaign.php
+++ b/app/Entities/Campaign.php
@@ -81,6 +81,7 @@ class Campaign extends Entity implements JsonSerializable
             $step->content ? $data['content'] = $step->content : null;
             $step->background ? $data['background'] = get_image_url($step->background, 'landscape') : null;
             $step->photos ? $data['photos'] = $this->parseActionStepPhotos($step->photos) : null;
+            $step->hideStepNumber ? $data['hideStepNumber'] = $step->hideStepNumber : null;
             $step->customType ? $data['customType'] = $step->customType->first() : null;
             $step->additionalContent ? $data['additionalContent'] = $step->additionalContent : null;
 

--- a/resources/assets/components/ActionPage/ActionStep.js
+++ b/resources/assets/components/ActionPage/ActionStep.js
@@ -13,11 +13,16 @@ const renderPhoto = (photo, index) => (
   </div>
 );
 
-const ActionStep = ({ title, stepIndex, content, background, photos, photoWidth, shouldTruncate }) => ( // eslint-disable-line max-len
+const ActionStep = ({ title, stepIndex, content, background, photos, photoWidth, shouldTruncate, hideStepNumber }) => ( // eslint-disable-line max-len
   <FlexCell width="full">
     <div className={classnames('action-step', { '-truncate': shouldTruncate })}>
       <Flex>
-        <StepHeader title={title} step={stepIndex} background={background} />
+        <StepHeader
+          title={title}
+          step={stepIndex}
+          background={background}
+          hideStepNumber={hideStepNumber}
+        />
         <FlexCell width="two-thirds">
           <Markdown>{ content }</Markdown>
         </FlexCell>
@@ -39,12 +44,14 @@ ActionStep.propTypes = {
   photos: PropTypes.arrayOf(PropTypes.string),
   photoWidth: PropTypes.string.isRequired,
   shouldTruncate: PropTypes.bool,
+  hideStepNumber: PropTypes.bool,
 };
 
 ActionStep.defaultProps = {
   background: '',
   photos: [],
   shouldTruncate: false,
+  hideStepNumber: false,
 };
 
 export default ActionStep;

--- a/resources/assets/components/ActionPage/ActionStepsWrapper.js
+++ b/resources/assets/components/ActionPage/ActionStepsWrapper.js
@@ -13,7 +13,7 @@ const ActionStepsWrapper = (props) => {
   const { actionSteps, callToAction, campaignId, clickedSignUp,
     hasPendingSignup, isAuthenticated, isSignedUp } = props;
 
-  const photoUploader = photoUploaderProps => (
+  const renderPhotoUploader = photoUploaderProps => (
     <FlexCell key="reportback_uploader" width="full">
       <ReportbackUploaderContainer {...photoUploaderProps} />
     </FlexCell>
@@ -57,7 +57,7 @@ const ActionStepsWrapper = (props) => {
         );
 
       case 'photo-uploader':
-        return isSignedUp ? photoUploader({
+        return isSignedUp ? renderPhotoUploader({
           quantityOverride: additionalContent.quantityOverride || null,
         }) : null;
 

--- a/resources/assets/components/ActionPage/ActionStepsWrapper.js
+++ b/resources/assets/components/ActionPage/ActionStepsWrapper.js
@@ -73,6 +73,7 @@ const ActionStepsWrapper = (props) => {
             background={step.background}
             photos={step.photos}
             photoWidth={step.displayOptions === 'full' ? 'full' : 'one-third'}
+            hideStepNumber={step.hideStepNumber}
             shouldTruncate={step.truncate}
           />
         );

--- a/resources/assets/components/ActionPage/ActionStepsWrapper.js
+++ b/resources/assets/components/ActionPage/ActionStepsWrapper.js
@@ -42,7 +42,7 @@ const ActionStepsWrapper = (props) => {
     const type = step.customType || 'default';
     const title = step.title;
     const content = step.content || null;
-    const additionalContent = step.additionalContent;
+    const additionalContent = step.additionalContent || {};
     const key = makeHash(title);
 
     switch (type) {

--- a/resources/assets/components/ActionPage/ActionStepsWrapper.js
+++ b/resources/assets/components/ActionPage/ActionStepsWrapper.js
@@ -76,7 +76,7 @@ const ActionStepsWrapper = (props) => {
             background={step.background}
             photos={step.photos}
             photoWidth={step.displayOptions === 'full' ? 'full' : 'one-third'}
-            hideStepNumber={step.hideStepNumber}
+            hideStepNumber={additionalContent.hideStepNumber || false}
             shouldTruncate={step.truncate}
           />
         );

--- a/resources/assets/components/ActionPage/ActionStepsWrapper.js
+++ b/resources/assets/components/ActionPage/ActionStepsWrapper.js
@@ -13,9 +13,9 @@ const ActionStepsWrapper = (props) => {
   const { actionSteps, callToAction, campaignId, clickedSignUp,
     hasPendingSignup, isAuthenticated, isSignedUp } = props;
 
-  const photoUploader = (
+  const photoUploader = photoUploaderProps => (
     <FlexCell key="reportback_uploader" width="full">
-      <ReportbackUploaderContainer />
+      <ReportbackUploaderContainer {...photoUploaderProps} />
     </FlexCell>
   );
 
@@ -42,6 +42,7 @@ const ActionStepsWrapper = (props) => {
     const type = step.customType || 'default';
     const title = step.title;
     const content = step.content || null;
+    const additionalContent = step.additionalContent;
     const key = makeHash(title);
 
     switch (type) {
@@ -51,12 +52,14 @@ const ActionStepsWrapper = (props) => {
             key={key}
             content={content}
             photo={step.photos[0]}
-            byline={step.additionalContent}
+            byline={additionalContent}
           />
         );
 
       case 'photo-uploader':
-        return isSignedUp ? photoUploader : null;
+        return isSignedUp ? photoUploader({
+          quantityOverride: additionalContent.quantityOverride || null,
+        }) : null;
 
       case 'submission-gallery':
         return isSignedUp ? submissionGallery : null;

--- a/resources/assets/components/ActionPage/StepHeader.js
+++ b/resources/assets/components/ActionPage/StepHeader.js
@@ -5,11 +5,11 @@ import { FlexCell } from '../Flex';
 import LazyImage from '../LazyImage';
 import { convertNumberToWord } from '../../helpers';
 
-const StepHeader = ({ title, step, background }) => (
+const StepHeader = ({ title, step, background, hideStepNumber }) => (
   <FlexCell width="full">
     <div className="action-step__header">
       { background ? <LazyImage src={background} /> : null }
-      <span>step { convertNumberToWord(step) }</span>
+      { hideStepNumber ? null : <span>step { convertNumberToWord(step) }</span> }
       <h1>{ title }</h1>
     </div>
   </FlexCell>
@@ -18,6 +18,7 @@ const StepHeader = ({ title, step, background }) => (
 StepHeader.propTypes = {
   title: PropTypes.string.isRequired,
   step: PropTypes.number.isRequired,
+  hideStepNumber: PropTypes.bool.isRequired,
   background: PropTypes.string,
 };
 

--- a/resources/assets/components/ReportbackUploader/ReportbackUploader.js
+++ b/resources/assets/components/ReportbackUploader/ReportbackUploader.js
@@ -56,7 +56,7 @@ class ReportbackUploader extends React.Component {
     const reportback = {
       media: this.state.media,
       caption: this.caption.value,
-      impact: this.impact.value,
+      impact: this.props.quantityOverride || this.impact.value,
       whyParticipated: this.why_participated.value,
       campaignId: this.props.legacyCampaignId,
       status: 'pending',
@@ -79,6 +79,12 @@ class ReportbackUploader extends React.Component {
 
   render() {
     const submissions = this.props.submissions;
+    const impactInput = (
+      <div>
+        <label className="field-label" htmlFor="impact">Total number of {this.props.noun.plural} made?</label>
+        <input className="text-field" id="impact" name="impact" type="text" placeholder="Enter # here -- like '300' or '5'" ref={input => (this.impact = input)} />
+      </div>
+    );
 
     return (
       <BlockWrapper>
@@ -96,10 +102,7 @@ class ReportbackUploader extends React.Component {
                 <input className="text-field" id="caption" name="caption" type="text" placeholder="60 characters or less" ref={input => (this.caption = input)} />
               </div>
 
-              <div>
-                <label className="field-label" htmlFor="impact">Total number of {this.props.noun.plural} made?</label>
-                <input className="text-field" id="impact" name="impact" type="text" placeholder="Enter # here -- like '300' or '5'" ref={input => (this.impact = input)} />
-              </div>
+              { this.props.quantityOverride ? null : impactInput }
             </div>
 
             <div className="form-item">
@@ -129,6 +132,7 @@ ReportbackUploader.propTypes = {
     singular: PropTypes.string,
     plural: PropTypes.string,
   }),
+  quantityOverride: PropTypes.number,
 };
 
 ReportbackUploader.defaultProps = {
@@ -136,6 +140,7 @@ ReportbackUploader.defaultProps = {
     singular: 'item',
     plural: 'items',
   },
+  quantityOverride: null,
 };
 
 export default ReportbackUploader;


### PR DESCRIPTION
### What does this PR do?
To make the new Hunt campaign a better experience we're adding some new functionality for campaign admins to hide things on the action page

- Hide the "Step One", "Step Two", etc on the action steps
- Hide the quantity input field and submit a specific number as the impact (eg: 1)

### hide steps 
<img width="717" alt="screen shot 2017-08-03 at 2 47 23 pm" src="https://user-images.githubusercontent.com/897368/28940849-09710d4e-7864-11e7-8689-9363992e9d20.png">

### hide input, test submission
<img width="709" alt="screen shot 2017-08-03 at 3 52 18 pm" src="https://user-images.githubusercontent.com/897368/28940851-0973131e-7864-11e7-9f13-620288f0a2bb.png">
<img width="219" alt="screen shot 2017-08-03 at 3 52 11 pm" src="https://user-images.githubusercontent.com/897368/28940848-09704a08-7864-11e7-9a5e-e1f779c94f72.png">