### PR TITLE
Adding social share link to campaign update component

### DIFF
--- a/resources/assets/components/Block/Block.js
+++ b/resources/assets/components/Block/Block.js
@@ -2,7 +2,7 @@
 
 import React from 'react';
 import { CampaignUpdateBlockContainer } from '../CampaignUpdateBlock';
-import { CampaignUpdate } from '../CampaignUpdate';
+import { CampaignUpdateContainer } from '../CampaignUpdate';
 import PlaceholderBlock from '../PlaceholderBlock';
 import ReportbackBlock from '../ReportbackBlock';
 import StaticBlock from '../StaticBlock';
@@ -17,7 +17,7 @@ const Block = ({ json = DEFAULT_BLOCK }: { json: BlockJson }) => {
   switch (json.type) {
     case 'campaignUpdate':
       return (
-        <CampaignUpdate
+        <CampaignUpdateContainer
           id={json.id}
           displayOptions={json.fields.displayOptions}
           content={json.fields.content}

--- a/resources/assets/components/Byline/Byline.js
+++ b/resources/assets/components/Byline/Byline.js
@@ -1,12 +1,14 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import classnames from 'classnames';
+
 import { Figure } from '../Figure';
 import DEFAULT_AVATAR from './default-avatar.png';
 
 import './byline.scss';
 
-const Byline = ({ author, jobTitle, avatar, share }) => (
-  <div className="byline">
+const Byline = ({ author, jobTitle, avatar, share, className }) => (
+  <div className={classnames('byline', className)}>
     <Figure
       size="small"
       alignment="left"
@@ -24,6 +26,7 @@ const Byline = ({ author, jobTitle, avatar, share }) => (
 
 Byline.propTypes = {
   author: PropTypes.string,
+  className: PropTypes.string,
   jobTitle: PropTypes.string,
   avatar: PropTypes.oneOfType([
     PropTypes.string,
@@ -34,6 +37,7 @@ Byline.propTypes = {
 
 Byline.defaultProps = {
   author: 'Puppet Sloth',
+  className: null,
   jobTitle: 'DoSomething.org Staff',
   avatar: DEFAULT_AVATAR,
   share: null,

--- a/resources/assets/components/CampaignUpdate/CampaignUpdate.js
+++ b/resources/assets/components/CampaignUpdate/CampaignUpdate.js
@@ -4,8 +4,9 @@ import PropTypes from 'prop-types';
 import Card from '../Card';
 import Byline from '../Byline';
 import Markdown from '../Markdown';
+import { ShareContainer } from '../Share';
 
-const CampaignUpdate = ({ id, author, content }) => {
+const CampaignUpdate = ({ id, author, content, shareLink }) => {
   const { avatar, jobTitle, name } = author.fields;
 
   return (
@@ -14,11 +15,18 @@ const CampaignUpdate = ({ id, author, content }) => {
         {content}
       </Markdown>
 
-      <footer className="padded">
+      <footer className="padded clearfix">
         <Byline
           author={name}
           avatar={avatar || undefined}
           jobTitle={jobTitle || undefined}
+          className="fl-left"
+        />
+        <ShareContainer
+          link={shareLink}
+          variant="icon"
+          parentSource="campaignUpdate"
+          className="fl-right cl-none"
         />
       </footer>
     </Card>
@@ -33,6 +41,7 @@ CampaignUpdate.propTypes = {
     fields: PropTypes.object,
   }).isRequired,
   content: PropTypes.string.isRequired,
+  shareLink: PropTypes.string.isRequired,
 };
 
 export default CampaignUpdate;

--- a/resources/assets/components/CampaignUpdate/CampaignUpdate.js
+++ b/resources/assets/components/CampaignUpdate/CampaignUpdate.js
@@ -20,13 +20,13 @@ const CampaignUpdate = ({ id, author, content, shareLink }) => {
           author={name}
           avatar={avatar || undefined}
           jobTitle={jobTitle || undefined}
-          className="fl-left"
+          className="float-left"
         />
         <ShareContainer
           link={shareLink}
           variant="icon"
           parentSource="campaignUpdate"
-          className="fl-right cl-none"
+          className="float-right clear-none"
         />
       </footer>
     </Card>

--- a/resources/assets/components/CampaignUpdate/CampaignUpdate.test.js
+++ b/resources/assets/components/CampaignUpdate/CampaignUpdate.test.js
@@ -16,6 +16,7 @@ const component = shallow(
     id="1234567890"
     author={author}
     content="Donec id elit non mi porta gravida at eget metus."
+    shareLink="http://example.com/link-to-content"
   />,
 );
 

--- a/resources/assets/components/CampaignUpdate/CampaignUpdateContainer.js
+++ b/resources/assets/components/CampaignUpdate/CampaignUpdateContainer.js
@@ -1,7 +1,7 @@
 /* global window */
 
 import { connect } from 'react-redux';
-import CampaignUpdateBlock from './CampaignUpdateBlock';
+import CampaignUpdate from './CampaignUpdate';
 import { makeShareLink } from '../../helpers';
 
 const mapStateToProps = (state, props) => ({
@@ -12,4 +12,4 @@ const mapStateToProps = (state, props) => ({
   }),
 });
 
-export default connect(mapStateToProps)(CampaignUpdateBlock);
+export default connect(mapStateToProps)(CampaignUpdate);

--- a/resources/assets/components/CampaignUpdate/__snapshots__/CampaignUpdate.test.js.snap
+++ b/resources/assets/components/CampaignUpdate/__snapshots__/CampaignUpdate.test.js.snap
@@ -17,12 +17,12 @@ exports[`it generates a campaign update snapshot 1`] = `
     <Byline
       author="Aang"
       avatar="http://example.com/avatar-aang.jpg"
-      className="fl-left"
+      className="float-left"
       jobTitle="The Last Airbender"
       share={null}
     />
     <Connect(Share)
-      className="fl-right cl-none"
+      className="float-right clear-none"
       link="http://example.com/link-to-content"
       parentSource="campaignUpdate"
       variant="icon"

--- a/resources/assets/components/CampaignUpdate/__snapshots__/CampaignUpdate.test.js.snap
+++ b/resources/assets/components/CampaignUpdate/__snapshots__/CampaignUpdate.test.js.snap
@@ -12,13 +12,20 @@ exports[`it generates a campaign update snapshot 1`] = `
     Donec id elit non mi porta gravida at eget metus.
   </Markdown>
   <footer
-    className="padded"
+    className="padded clearfix"
   >
     <Byline
       author="Aang"
       avatar="http://example.com/avatar-aang.jpg"
+      className="fl-left"
       jobTitle="The Last Airbender"
       share={null}
+    />
+    <Connect(Share)
+      className="fl-right cl-none"
+      link="http://example.com/link-to-content"
+      parentSource="campaignUpdate"
+      variant="icon"
     />
   </footer>
 </Card>

--- a/resources/assets/components/CampaignUpdate/index.js
+++ b/resources/assets/components/CampaignUpdate/index.js
@@ -1,3 +1,5 @@
 export CampaignUpdate from './CampaignUpdate';
 
+export CampaignUpdateContainer from './CampaignUpdateContainer';
+
 export default from './CampaignUpdate';

--- a/resources/assets/components/CampaignUpdateBlock/CampaignUpdate.test.js
+++ b/resources/assets/components/CampaignUpdateBlock/CampaignUpdate.test.js
@@ -7,7 +7,7 @@ test('Campaign Update Block with no additional content snapshot test', () => {
   const component = shallow(
     <CampaignUpdateBlock
       id="1234512345"
-      shareLink="http://"
+      shareLink="http://example.com/link-to-content"
       fields={{
         title: 'Heyo!',
         content: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec id elit non mi porta gravida at eget metus. Vestibulum id ligula porta felis euismod semper. Vestibulum id ligula porta felis euismod semper. Morbi leo risus, porta ac consectetur ac, vestibulum at eros.',
@@ -22,7 +22,7 @@ test('Campaign Update Block with additional content snapshot test', () => {
   const component = shallow(
     <CampaignUpdateBlock
       id="1234512345"
-      shareLink="http://"
+      shareLink="http://example.com/link-to-content"
       fields={{
         title: 'Heyo!',
         content: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec id elit non mi porta gravida at eget metus. Vestibulum id ligula porta felis euismod semper. Vestibulum id ligula porta felis euismod semper. Morbi leo risus, porta ac consectetur ac, vestibulum at eros.',
@@ -40,7 +40,7 @@ test('Campaign Update Block with additional content as tweet snapshot test', () 
   const component = shallow(
     <CampaignUpdateBlock
       id="1234512345"
-      shareLink="http://"
+      shareLink="http://example.com/link-to-content"
       fields={{
         title: 'Heyo!',
         content: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec id elit non mi porta gravida at eget metus vestibulum.',

--- a/resources/assets/components/CampaignUpdateBlock/CampaignUpdateBlock.js
+++ b/resources/assets/components/CampaignUpdateBlock/CampaignUpdateBlock.js
@@ -28,7 +28,7 @@ const CampaignUpdateBlock = (props) => {
           author={additionalContent.author}
           jobTitle={additionalContent.jobTitle}
           avatar={additionalContent.avatar}
-          className="fl-left"
+          className="float-left"
         />
         : null }
 
@@ -37,7 +37,7 @@ const CampaignUpdateBlock = (props) => {
           link={props.shareLink}
           variant="icon"
           parentSource="campaign-update"
-          className="fl-right cl-none"
+          className="float-right clear-none"
         />
         : null }
     </BlockWrapper>

--- a/resources/assets/components/CampaignUpdateBlock/CampaignUpdateBlock.js
+++ b/resources/assets/components/CampaignUpdateBlock/CampaignUpdateBlock.js
@@ -13,14 +13,6 @@ const CampaignUpdateBlock = (props) => {
 
   const isTweet = content.length < 144;
 
-  const share = (
-    <ShareContainer
-      link={props.shareLink}
-      variant="icon"
-      parentSource="campaign-update"
-    />
-  );
-
   return (
     <BlockWrapper title="Campaign Update" id={props.id}>
       { isTweet ? null : <h2>{title}</h2> }
@@ -36,7 +28,16 @@ const CampaignUpdateBlock = (props) => {
           author={additionalContent.author}
           jobTitle={additionalContent.jobTitle}
           avatar={additionalContent.avatar}
-          share={share}
+          className="fl-left"
+        />
+        : null }
+
+      { props.shareLink ?
+        <ShareContainer
+          link={props.shareLink}
+          variant="icon"
+          parentSource="campaign-update"
+          className="fl-right cl-none"
         />
         : null }
     </BlockWrapper>

--- a/resources/assets/components/CampaignUpdateBlock/__snapshots__/CampaignUpdate.test.js.snap
+++ b/resources/assets/components/CampaignUpdateBlock/__snapshots__/CampaignUpdate.test.js.snap
@@ -13,12 +13,12 @@ exports[`Campaign Update Block with additional content as tweet snapshot test 1`
   <Byline
     author="Braümhilda Snosages"
     avatar={Object {}}
-    className="fl-left"
+    className="float-left"
     jobTitle="DoSomething.org Staff"
     share={null}
   />
   <Connect(Share)
-    className="fl-right cl-none"
+    className="float-right clear-none"
     link="http://example.com/link-to-content"
     parentSource="campaign-update"
     variant="icon"
@@ -42,12 +42,12 @@ exports[`Campaign Update Block with additional content snapshot test 1`] = `
   <Byline
     author="Braümhilda Snosages"
     avatar={Object {}}
-    className="fl-left"
+    className="float-left"
     jobTitle="DoSomething.org Staff"
     share={null}
   />
   <Connect(Share)
-    className="fl-right cl-none"
+    className="float-right clear-none"
     link="http://example.com/link-to-content"
     parentSource="campaign-update"
     variant="icon"
@@ -69,7 +69,7 @@ exports[`Campaign Update Block with no additional content snapshot test 1`] = `
     Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec id elit non mi porta gravida at eget metus. Vestibulum id ligula porta felis euismod semper. Vestibulum id ligula porta felis euismod semper. Morbi leo risus, porta ac consectetur ac, vestibulum at eros.
   </Markdown>
   <Connect(Share)
-    className="fl-right cl-none"
+    className="float-right clear-none"
     link="http://example.com/link-to-content"
     parentSource="campaign-update"
     variant="icon"

--- a/resources/assets/components/CampaignUpdateBlock/__snapshots__/CampaignUpdate.test.js.snap
+++ b/resources/assets/components/CampaignUpdateBlock/__snapshots__/CampaignUpdate.test.js.snap
@@ -13,14 +13,15 @@ exports[`Campaign Update Block with additional content as tweet snapshot test 1`
   <Byline
     author="Braümhilda Snosages"
     avatar={Object {}}
+    className="fl-left"
     jobTitle="DoSomething.org Staff"
-    share={
-      <Connect(Share)
-        link="http://"
-        parentSource="campaign-update"
-        variant="icon"
-      />
-    }
+    share={null}
+  />
+  <Connect(Share)
+    className="fl-right cl-none"
+    link="http://example.com/link-to-content"
+    parentSource="campaign-update"
+    variant="icon"
   />
 </BlockWrapper>
 `;
@@ -41,14 +42,15 @@ exports[`Campaign Update Block with additional content snapshot test 1`] = `
   <Byline
     author="Braümhilda Snosages"
     avatar={Object {}}
+    className="fl-left"
     jobTitle="DoSomething.org Staff"
-    share={
-      <Connect(Share)
-        link="http://"
-        parentSource="campaign-update"
-        variant="icon"
-      />
-    }
+    share={null}
+  />
+  <Connect(Share)
+    className="fl-right cl-none"
+    link="http://example.com/link-to-content"
+    parentSource="campaign-update"
+    variant="icon"
   />
 </BlockWrapper>
 `;
@@ -66,5 +68,11 @@ exports[`Campaign Update Block with no additional content snapshot test 1`] = `
   >
     Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec id elit non mi porta gravida at eget metus. Vestibulum id ligula porta felis euismod semper. Vestibulum id ligula porta felis euismod semper. Morbi leo risus, porta ac consectetur ac, vestibulum at eros.
   </Markdown>
+  <Connect(Share)
+    className="fl-right cl-none"
+    link="http://example.com/link-to-content"
+    parentSource="campaign-update"
+    variant="icon"
+  />
 </BlockWrapper>
 `;

--- a/resources/assets/components/Share/Share.js
+++ b/resources/assets/components/Share/Share.js
@@ -7,16 +7,17 @@ import { mergeMetadata } from '../../helpers/analytics';
 
 import './share.scss';
 
-const Share = ({ variant, clickedShare, parentSource, link }) => {
-  const className = classnames('button share', { '-black': variant === 'black', '-icon': variant === 'icon' });
-
+const Share = ({ variant, clickedShare, parentSource, link, className }) => {
   const metadata = mergeMetadata(Share.defaultMetadata, {
     parentSource,
     variant,
   });
 
   return (
-    <button className={className} onClick={() => clickedShare(link, metadata)}>
+    <button
+      className={classnames('button share', className, { '-black': variant === 'black', '-icon': variant === 'icon' })}
+      onClick={() => clickedShare(link, metadata)}
+    >
       {variant === 'icon' ? null : 'share on'}
       <i className="social-icon -facebook"><span>Facebook</span></i>
     </button>
@@ -24,17 +25,19 @@ const Share = ({ variant, clickedShare, parentSource, link }) => {
 };
 
 Share.propTypes = {
+  className: PropTypes.string,
   clickedShare: PropTypes.func,
+  link: PropTypes.string,
   parentSource: PropTypes.string,
   variant: PropTypes.oneOf(['black', 'blue', 'icon']),
-  link: PropTypes.string,
 };
 
 Share.defaultProps = {
-  variant: 'black',
+  className: null,
   clickedShare: () => {},
-  parentSource: null,
   link: window.location.href,
+  parentSource: null,
+  variant: 'black',
 };
 
 Share.defaultMetadata = {

--- a/resources/assets/components/Share/share.scss
+++ b/resources/assets/components/Share/share.scss
@@ -19,6 +19,11 @@
     background: none;
     border: none;
     color: $light-gray;
+
+    &:hover {
+      color: $med-gray;
+      cursor: pointer;
+    }
   }
 
   .social-icon {

--- a/resources/assets/helpers/index.js
+++ b/resources/assets/helpers/index.js
@@ -282,6 +282,24 @@ export function makeHash(string) {
 }
 
 /**
+ * Make a shareable link to a content item.
+ *
+ * @param  {Object} state
+ * @param  {String} key  An id or a slug for the content.
+ * @param  {String} type
+ * @return {String}
+ */
+export function makeShareLink(type, options = {}) {
+  switch (type) {
+    case 'campaigns':
+      return `${options.domain}/us/campaigns/${options.slug}/blocks/${options.key}`;
+
+    default:
+      throw new Error('Please provide an expected section type for generating the link.');
+  }
+}
+
+/**
  * Get the days between two Date objects
  * @see  http://stackoverflow.com/questions/2627473/how-to-calculate-the-number-of-days-between-two-dates-using-javascript
  *

--- a/resources/assets/helpers/index.js
+++ b/resources/assets/helpers/index.js
@@ -288,8 +288,9 @@ export function makeHash(string) {
  * @param  {String} key  An id or a slug for the content.
  * @param  {String} type
  * @return {String}
+ * @flow
  */
-export function makeShareLink(type, options = {}) {
+export function makeShareLink(type, options: { domain: string, slug?: string, key: string }) {
   switch (type) {
     case 'campaigns':
       return `${options.domain}/us/campaigns/${options.slug}/blocks/${options.key}`;

--- a/resources/assets/helpers/test.js
+++ b/resources/assets/helpers/test.js
@@ -1,8 +1,9 @@
 import {
   makeHash,
   modifiers,
-  contentfulImageUrl,
   pluralize,
+  makeShareLink,
+  contentfulImageUrl,
 } from './index';
 
 /**
@@ -41,6 +42,30 @@ test('cannot hash undefined or null value', () => {
   expect(() => makeHash(undefined)).toThrow();
   expect(() => makeHash(null)).toThrow();
 });
+
+/**
+ * Test makeShareLink()
+ */
+test('it makes the expected share link for a content item and app section type', () => {
+  const options = {
+    domain: 'http://awesome.com',
+    slug: 'seriously-awesome-campaign',
+    key: '123',
+  };
+
+  expect(makeShareLink('campaigns', options)).toBe('http://awesome.com/us/campaigns/seriously-awesome-campaign/blocks/123');
+});
+
+test('it cannot make share link with an unknown app section type', () => {
+  const options = {
+    domain: 'http://awesome.com',
+    slug: 'seriously-awesome-campaign',
+    key: '123',
+  };
+
+  expect(() => makeShareLink('unknown', options)).toThrow();
+});
+
 
 /**
  * Test modifiers()

--- a/resources/assets/scss/base.scss
+++ b/resources/assets/scss/base.scss
@@ -38,6 +38,30 @@ h1, h2, h3, p {
   border: 1px solid $primary-border-color;
 }
 
+.cl-both {
+  clear: both;
+}
+
+.cl-left {
+  clear: left;
+}
+
+.cl-right {
+  clear: right;
+}
+
+.cl-none {
+  clear: none;
+}
+
+.fl-left {
+  float: left;
+}
+
+.fl-right {
+  float: right;
+}
+
 .padded {
   padding: $half-spacing;
 }

--- a/resources/assets/scss/base.scss
+++ b/resources/assets/scss/base.scss
@@ -38,27 +38,27 @@ h1, h2, h3, p {
   border: 1px solid $primary-border-color;
 }
 
-.cl-both {
+.clear-both {
   clear: both;
 }
 
-.cl-left {
+.clear-left {
   clear: left;
 }
 
-.cl-right {
+.clear-right {
   clear: right;
 }
 
-.cl-none {
+.clear-none {
   clear: none;
 }
 
-.fl-left {
+.float-left {
   float: left;
 }
 
-.fl-right {
+.float-right {
   float: right;
 }
 


### PR DESCRIPTION
### What does this PR do?
This PR makes a few updates to the Campaign Update component(s), changes the structure for how the Byline and Share components are output in the Campaign Updates. This also properly adds the shareable facebook link to the new version of the `CampaignUpdate` component.


### Any background context you want to provide?
Sorry for the large number of files. 5 or so are just test related, and I split the commits into logical sections so might be easier going commit by commit
- [Updating the components](https://github.com/DoSomething/phoenix-next/pull/358/commits/436f72c05ebb84edc1233cb4f32fe54db162e4cd)
- [Making sure Block component knows to use the container instead](https://github.com/DoSomething/phoenix-next/pull/358/commits/51136647c775b65649f754d313cb43288758f18d)
- [Updates to the Byline and Share components](https://github.com/DoSomething/phoenix-next/pull/358/commits/d14f417c40d576a16191fc049525ff35369012d1)
- [Updating tests!](https://github.com/DoSomething/phoenix-next/pull/358/commits/f7278ec1669b0c528ced009d2da8600c7a946518)

Next up will be updating the `Card` component so that when an ID is passed, it makes the header (yellow bar text) a permalink to that content.

### What are the relevant tickets/cards?
Refs https://www.pivotaltracker.com/story/show/150140471

### Checklist
- [X] Added appropriate feature/unit tests.

