### PR TITLE
Adding permalink to card title

### DIFF
--- a/resources/assets/components/CampaignUpdate/CampaignUpdate.js
+++ b/resources/assets/components/CampaignUpdate/CampaignUpdate.js
@@ -10,7 +10,7 @@ const CampaignUpdate = ({ id, author, content, shareLink }) => {
   const { avatar, jobTitle, name } = author.fields;
 
   return (
-    <Card id={id} className="rounded bordered" title="Campaign Update">
+    <Card id={id} className="rounded bordered" link={shareLink} title="Campaign Update">
       <Markdown className="padded">
         {content}
       </Markdown>

--- a/resources/assets/components/CampaignUpdate/__snapshots__/CampaignUpdate.test.js.snap
+++ b/resources/assets/components/CampaignUpdate/__snapshots__/CampaignUpdate.test.js.snap
@@ -4,6 +4,7 @@ exports[`it generates a campaign update snapshot 1`] = `
 <Card
   className="rounded bordered"
   id="1234567890"
+  link="http://example.com/link-to-content"
   title="Campaign Update"
 >
   <Markdown

--- a/resources/assets/components/Card/Card.js
+++ b/resources/assets/components/Card/Card.js
@@ -4,15 +4,15 @@ import classnames from 'classnames';
 
 import './card.scss';
 
-const renderHeader = title => (
+const renderHeader = (title, link) => (
   <header className="card__title">
-    <h1>{title}</h1>
+    { link ? <h1><a href={link}>{title}</a></h1> : <h1>{title}</h1> }
   </header>
 );
 
-const Card = ({ children, className = '', title = null }) => (
+const Card = ({ children, className = '', link = null, title = null }) => (
   <article className={classnames('card', className)}>
-    { title ? renderHeader(title) : null }
+    { title ? renderHeader(title, link) : null }
 
     { children }
   </article>
@@ -25,11 +25,13 @@ Card.propTypes = {
     PropTypes.object,
   ]).isRequired,
   className: PropTypes.string,
+  link: PropTypes.string,
   title: PropTypes.string,
 };
 
 Card.defaultProps = {
   className: null,
+  link: null,
 };
 
 export default Card;

--- a/resources/assets/components/Card/card.scss
+++ b/resources/assets/components/Card/card.scss
@@ -15,4 +15,13 @@
     font-size: $font-regular;
     text-transform: uppercase;
   }
+
+  a {
+    color: $black;
+
+    &:hover {
+      color: rgba($black, 0.75);  // @TODO should be a variable
+      text-decoration: none;
+    }
+  }
 }


### PR DESCRIPTION
### What does this PR do?
This PR updates the `Card` component to allow passing in a `link` prop and if a `title` is provided as well, then the link will be used in the output of the title to enable it as an anchor permalink to that block's content.


### Any background context you want to provide?
🤔 


### What are the relevant tickets/cards?
Refs https://www.pivotaltracker.com/story/show/150140471

### Checklist
- [x] Added appropriate feature/unit tests.

