### PR TITLE
Make sure cards fill their container regardless of amount of content provided.

### DIFF
--- a/resources/assets/components/Card/card.scss
+++ b/resources/assets/components/Card/card.scss
@@ -3,6 +3,7 @@
 .card {
   background-color: $white;
   overflow: hidden;
+  width: 100%;
 }
 
 .card__title {


### PR DESCRIPTION
### What does this PR do?
This PR fixes a small styling bug with the `Card` component where it does not fill its parent container if there is not enough content.

Example of the bug:
![image](https://user-images.githubusercontent.com/105849/29289871-2fa5def8-810c-11e7-94fc-8367fd0b35bf.png)

