### PR TITLE
More field work on quizzes

### DIFF
--- a/app/Entities/Quiz.php
+++ b/app/Entities/Quiz.php
@@ -18,9 +18,9 @@ class Quiz extends Entity implements JsonSerializable
             return [];
         }
 
-        return collect($question['answers'])->map(function ($answer) {
-            $data = copyFieldIfSet(['title', 'award'], $answer);
-            $data['id'] = uniqid();
+        return collect($question['answers'])->map(function ($answer, $index) {
+            $data = array_only($answer, ['title', 'award']);
+            $data['id'] = $index;
 
             return $data;
         });
@@ -38,9 +38,9 @@ class Quiz extends Entity implements JsonSerializable
             return [];
         }
 
-        return collect($questions)->map(function ($question) {
-            $data = copyFieldIfSet(['title', 'background'], $question);
-            $data['id'] = uniqid();
+        return collect($questions)->map(function ($question, $index) {
+            $data = array_only($question, ['title', 'background']);
+            $data['id'] = $index;
             $data['answers'] = $this->parseAnswersFromQuestion($question);
 
             return $data;

--- a/app/Entities/Quiz.php
+++ b/app/Entities/Quiz.php
@@ -29,7 +29,7 @@ class Quiz extends Entity implements JsonSerializable
     /**
      * Parse out the questions from the json data.
      *
-     * @return Array
+     * @return array
      */
     private function parseQuestionsFromJson()
     {

--- a/app/Entities/Quiz.php
+++ b/app/Entities/Quiz.php
@@ -7,6 +7,47 @@ use JsonSerializable;
 class Quiz extends Entity implements JsonSerializable
 {
     /**
+     * Parse answers from the given question.
+     *
+     * @param  array $question
+     * @return array
+     */
+    private function parseAnswersFromQuestion($question)
+    {
+        if (! isset($question['answers'])) {
+            return [];
+        }
+
+        return collect($question['answers'])->map(function ($answer) {
+            $data = copyFieldIfSet(['title', 'award'], $answer);
+            $data['id'] = uniqid();
+
+            return $data;
+        });
+    }
+
+    /**
+     * Parse out the questions from the json data.
+     *
+     * @return Array
+     */
+    private function parseQuestionsFromJson()
+    {
+        $questions = $this->questions->get('items');
+        if (! $questions) {
+            return [];
+        }
+
+        return collect($questions)->map(function ($question) {
+            $data = copyFieldIfSet(['title', 'background'], $question);
+            $data['id'] = uniqid();
+            $data['answers'] = $this->parseAnswersFromQuestion($question);
+
+            return $data;
+        });
+    }
+
+    /**
      * Convert the object into something JSON serializable.
      *
      * @return array
@@ -21,7 +62,7 @@ class Quiz extends Entity implements JsonSerializable
                 'slug' => $this->slug,
                 'introduction' => $this->introduction,
                 'conclusion' => $this->conclusion,
-                'json' => $this->json,
+                'questions' => $this->parseQuestionsFromJson(),
             ],
         ];
     }

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -230,27 +230,6 @@ function useOverrideIfSet($field, $campaign, $override)
 }
 
 /**
- * Copy values into new array using the keys given
- * if the source has the same key set.
- *
- * @param  array $keys
- * @param  array $source
- * @return array
- */
-function copyFieldIfSet($keys, $source)
-{
-    $data = [];
-
-    foreach ($keys as $key) {
-        if (isset($source[$key])) {
-            $data[$key] = $source[$key];
-        }
-    }
-
-    return $data;
-}
-
-/**
  * Determine the fields to display in the social share.
  *
  * @param  Campaign $campaign

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -230,6 +230,27 @@ function useOverrideIfSet($field, $campaign, $override)
 }
 
 /**
+ * Copy values into new array using the keys given
+ * if the source has the same key set.
+ *
+ * @param  array $keys
+ * @param  array $source
+ * @return array
+ */
+function copyFieldIfSet($keys, $source)
+{
+    $data = [];
+
+    foreach ($keys as $key) {
+        if (isset($source[$key])) {
+            $data[$key] = $source[$key];
+        }
+    }
+
+    return $data;
+}
+
+/**
  * Determine the fields to display in the social share.
  *
  * @param  Campaign $campaign

--- a/resources/assets/components/Quiz/Answer.js
+++ b/resources/assets/components/Quiz/Answer.js
@@ -8,7 +8,7 @@ const Answer = ({ title }) => (
 );
 
 Answer.propTypes = {
-  title: PropTypes.string,.isRequired,
+  title: PropTypes.string.isRequired,
 };
 
 export default Answer;

--- a/resources/assets/components/Quiz/Answer.js
+++ b/resources/assets/components/Quiz/Answer.js
@@ -1,0 +1,16 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const Answer = ({ answer }) => (
+  <div className="answer">
+    <p>{ answer.title }</p>
+  </div>
+);
+
+Answer.propTypes = {
+  answer: PropTypes.shape({
+    title: PropTypes.string,
+  }).isRequired,
+};
+
+export default Answer;

--- a/resources/assets/components/Quiz/Answer.js
+++ b/resources/assets/components/Quiz/Answer.js
@@ -1,16 +1,14 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-const Answer = ({ answer }) => (
+const Answer = ({ title }) => (
   <div className="answer">
-    <p>{ answer.title }</p>
+    <p>{ title }</p>
   </div>
 );
 
 Answer.propTypes = {
-  answer: PropTypes.shape({
-    title: PropTypes.string,
-  }).isRequired,
+  title: PropTypes.string,.isRequired,
 };
 
 export default Answer;

--- a/resources/assets/components/Quiz/Question.js
+++ b/resources/assets/components/Quiz/Question.js
@@ -1,15 +1,20 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import Answer from './Answer';
 
 const Question = ({ question }) => (
   <div className="question">
     <h2>{ question.title }</h2>
+    {question.answers.map(answer => (
+      <Answer key={answer.id} answer={answer} />
+    ))}
   </div>
 );
 
 Question.propTypes = {
   question: PropTypes.shape({
     title: PropTypes.string,
+    answers: PropTypes.array,
   }).isRequired,
 };
 

--- a/resources/assets/components/Quiz/Question.js
+++ b/resources/assets/components/Quiz/Question.js
@@ -2,20 +2,18 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import Answer from './Answer';
 
-const Question = ({ question }) => (
+const Question = ({ title, answers }) => (
   <div className="question">
-    <h2>{ question.title }</h2>
-    {question.answers.map(answer => (
-      <Answer key={answer.id} answer={answer} />
+    <h2>{ title }</h2>
+    {answers.map(answer => (
+      <Answer key={answer.id} answer={...answer} />
     ))}
   </div>
 );
 
 Question.propTypes = {
-  question: PropTypes.shape({
-    title: PropTypes.string,
-    answers: PropTypes.array,
-  }).isRequired,
+  title: PropTypes.string.isRequired,
+  answers: PropTypes.array.isRequired,
 };
 
 export default Question;

--- a/resources/assets/components/Quiz/Question.js
+++ b/resources/assets/components/Quiz/Question.js
@@ -6,14 +6,14 @@ const Question = ({ title, answers }) => (
   <div className="question">
     <h2>{ title }</h2>
     {answers.map(answer => (
-      <Answer key={answer.id} answer={...answer} />
+      <Answer key={answer.id} {...answer} />
     ))}
   </div>
 );
 
 Question.propTypes = {
   title: PropTypes.string.isRequired,
-  answers: PropTypes.array.isRequired,
+  answers: PropTypes.array.isRequired, // eslint-disable-line react/forbid-prop-types
 };
 
 export default Question;

--- a/resources/assets/components/Quiz/Quiz.js
+++ b/resources/assets/components/Quiz/Quiz.js
@@ -2,26 +2,26 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import Markdown from '../Markdown';
 import Question from './Question';
-import { makeHash } from '../../helpers';
 
 const Quiz = ({ fields }) => (
   <div className="quiz">
     <h1 className="quiz__title">{fields.title}</h1>
-    { fields.introduction ? <Markdown>{fields.introduction}</Markdown> : null }
-    { fields.json.questions.map(question => (
-      <Question key={makeHash(question.title)} question={question} />
-    )) }
-    { fields.conclusion ? <Markdown>{fields.conclusion}</Markdown> : null }
+    <Markdown>{fields.introduction}</Markdown>
+    {fields.questions.map(question => (
+      <Question key={question.id} question={question} />
+    ))}
+    <Markdown>{fields.conclusion}</Markdown>
   </div>
 );
 
 Quiz.propTypes = {
   fields: PropTypes.shape({
+    id: PropTypes.string,
     title: PropTypes.string,
     slug: PropTypes.string,
     introduction: PropTypes.string,
     conclusion: PropTypes.string,
-    json: PropTypes.object,
+    questions: PropTypes.object,
   }).isRequired,
 };
 

--- a/resources/assets/components/Quiz/Quiz.js
+++ b/resources/assets/components/Quiz/Quiz.js
@@ -8,7 +8,7 @@ const Quiz = ({ fields }) => (
     <h1 className="quiz__title">{fields.title}</h1>
     <Markdown>{fields.introduction || ''}</Markdown>
     {(fields.questions || []).map(question => (
-      <Question key={question.id} question={question} />
+      <Question key={question.id} {...question} />
     ))}
     <Markdown>{fields.conclusion || ''}</Markdown>
   </div>

--- a/resources/assets/components/Quiz/Quiz.js
+++ b/resources/assets/components/Quiz/Quiz.js
@@ -6,11 +6,11 @@ import Question from './Question';
 const Quiz = ({ fields }) => (
   <div className="quiz">
     <h1 className="quiz__title">{fields.title}</h1>
-    <Markdown>{fields.introduction}</Markdown>
-    {fields.questions.map(question => (
+    <Markdown>{fields.introduction || ''}</Markdown>
+    {(fields.questions || []).map(question => (
       <Question key={question.id} question={question} />
     ))}
-    <Markdown>{fields.conclusion}</Markdown>
+    <Markdown>{fields.conclusion || ''}</Markdown>
   </div>
 );
 
@@ -21,7 +21,7 @@ Quiz.propTypes = {
     slug: PropTypes.string,
     introduction: PropTypes.string,
     conclusion: PropTypes.string,
-    questions: PropTypes.object,
+    questions: PropTypes.array,
   }).isRequired,
 };
 


### PR DESCRIPTION
### What does this PR do?
This pr does more work around the quiz fields and specifically does a bunch of work around adding answers to the questions.

### Any background context you want to provide?
I did some refactoring to make working with the json a bit safer. Also added ID's in the php side of things like previously suggested. 

Also, there is a new `award` variable. This is what we'll use to determine what we assign points to when people answer questions.

Here is the new json structure on the `questions` property in contentful 

```
{
    "items": [
        {
            "title": "test question",
            "answers": [
                {
                    "title": "this is a title",
					"award": "winner"
                },
                {
                    "title": "this is a second title",
					"award": "loser"
                }
            ]
        },
        {
            "title": "test second question",
            "answers": [
                {
                    "title": "this is a title",
					"award": "winner"
                },
                {
                    "title": "this is a second title",
					"award": "loser"
                },
                {
                    "title": "this is a third title",
					"award": "loser"
                }
            ]
        }
    ]
}
```