### PR TITLE
Campaign update links and tweets

### DIFF
--- a/app/Entities/CampaignUpdate.php
+++ b/app/Entities/CampaignUpdate.php
@@ -17,9 +17,10 @@ class CampaignUpdate extends Entity implements JsonSerializable
             'id' => $this->entry->getId(),
             'type' => $this->getContentType(),
             'fields' => [
-                'displayOptions' => $this->displayOptions->first(),
-                'content' => $this->content,
                 'author' => new Staff($this->author->entry),
+                'content' => $this->content,
+                'displayOptions' => $this->displayOptions->first(),
+                'link' => $this->link,
             ],
         ];
     }

--- a/resources/assets/components/Block/Block.js
+++ b/resources/assets/components/Block/Block.js
@@ -19,9 +19,10 @@ const Block = ({ json = DEFAULT_BLOCK }: { json: BlockJson }) => {
       return (
         <CampaignUpdateContainer
           id={json.id}
-          displayOptions={json.fields.displayOptions}
-          content={json.fields.content}
           author={json.fields.author}
+          content={json.fields.content}
+          displayOptions={json.fields.displayOptions}
+          link={json.fields.link}
         />
       );
 

--- a/resources/assets/components/CampaignUpdate/CampaignUpdate.js
+++ b/resources/assets/components/CampaignUpdate/CampaignUpdate.js
@@ -49,7 +49,12 @@ CampaignUpdate.propTypes = {
     fields: PropTypes.object,
   }).isRequired,
   content: PropTypes.string.isRequired,
+  link: PropTypes.string,
   shareLink: PropTypes.string.isRequired,
+};
+
+CampaignUpdate.defaultProps = {
+  link: null,
 };
 
 export default CampaignUpdate;

--- a/resources/assets/components/CampaignUpdate/CampaignUpdate.js
+++ b/resources/assets/components/CampaignUpdate/CampaignUpdate.js
@@ -13,8 +13,6 @@ const CampaignUpdate = ({ id, author, content, link, shareLink }) => {
 
   const isTweet = content.length < 144;
 
-  console.log(isTweet);
-
   return (
     <Card id={id} className="rounded bordered" link={shareLink} title="Campaign Update">
       <Markdown className={classnames('padded', { 'font-size-lg': isTweet })}>

--- a/resources/assets/components/CampaignUpdate/CampaignUpdate.js
+++ b/resources/assets/components/CampaignUpdate/CampaignUpdate.js
@@ -1,19 +1,27 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import classnames from 'classnames';
 
 import Card from '../Card';
+import Embed from '../Embed';
 import Byline from '../Byline';
 import Markdown from '../Markdown';
 import { ShareContainer } from '../Share';
 
-const CampaignUpdate = ({ id, author, content, shareLink }) => {
+const CampaignUpdate = ({ id, author, content, link, shareLink }) => {
   const { avatar, jobTitle, name } = author.fields;
+
+  const isTweet = content.length < 144;
+
+  console.log(isTweet);
 
   return (
     <Card id={id} className="rounded bordered" link={shareLink} title="Campaign Update">
-      <Markdown className="padded">
+      <Markdown className={classnames('padded', { 'font-size-lg': isTweet })}>
         {content}
       </Markdown>
+
+      { link ? <Embed className="padded" url={link} /> : null }
 
       <footer className="padded clearfix">
         <Byline

--- a/resources/assets/components/CampaignUpdate/CampaignUpdate.test.js
+++ b/resources/assets/components/CampaignUpdate/CampaignUpdate.test.js
@@ -15,7 +15,7 @@ const component = shallow(
   <CampaignUpdate
     id="1234567890"
     author={author}
-    content="Donec id elit non mi porta gravida at eget metus."
+    content="Duis mollis, est non commodo luctus, nisi erat porttitor ligula, eget lacinia odio sem nec elit. Morbi leo risus, porta ac consectetur ac, vestibulum at eros. Sed posuere consectetur est at lobortis. Sed posuere consectetur est at lobortis. Nullam quis risus eget urna mollis ornare vel eu leo. Etiam porta sem malesuada magna mollis euismod. Cras mattis consectetur purus sit amet fermentum."
     shareLink="http://example.com/link-to-content"
   />,
 );

--- a/resources/assets/components/CampaignUpdate/__snapshots__/CampaignUpdate.test.js.snap
+++ b/resources/assets/components/CampaignUpdate/__snapshots__/CampaignUpdate.test.js.snap
@@ -10,7 +10,7 @@ exports[`it generates a campaign update snapshot 1`] = `
   <Markdown
     className="padded"
   >
-    Donec id elit non mi porta gravida at eget metus.
+    Duis mollis, est non commodo luctus, nisi erat porttitor ligula, eget lacinia odio sem nec elit. Morbi leo risus, porta ac consectetur ac, vestibulum at eros. Sed posuere consectetur est at lobortis. Sed posuere consectetur est at lobortis. Nullam quis risus eget urna mollis ornare vel eu leo. Etiam porta sem malesuada magna mollis euismod. Cras mattis consectetur purus sit amet fermentum.
   </Markdown>
   <footer
     className="padded clearfix"

--- a/resources/assets/components/CampaignUpdateBlock/CampaignUpdateBlock.js
+++ b/resources/assets/components/CampaignUpdateBlock/CampaignUpdateBlock.js
@@ -21,9 +21,7 @@ const CampaignUpdateBlock = (props) => {
         {content}
       </Markdown>
 
-      <div className="padding-bottom-lg">
-        { link ? <Embed url={link} /> : null }
-      </div>
+      { link ? <div className="padding-bottom-lg"><Embed url={link} /></div> : null }
 
       { additionalContent ?
         <Byline

--- a/resources/assets/components/CampaignUpdateBlock/CampaignUpdateBlock.js
+++ b/resources/assets/components/CampaignUpdateBlock/CampaignUpdateBlock.js
@@ -21,7 +21,9 @@ const CampaignUpdateBlock = (props) => {
         {content}
       </Markdown>
 
-      { link ? <Embed url={link} /> : null }
+      <div className="padding-bottom-lg">
+        { link ? <Embed url={link} /> : null }
+      </div>
 
       { additionalContent ?
         <Byline

--- a/resources/assets/components/Embed/embed.scss
+++ b/resources/assets/components/Embed/embed.scss
@@ -1,30 +1,19 @@
 @import '../../scss/next-toolbox';
 
 .embed {
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  margin: 0 auto $base-spacing;
-  overflow: hidden;
-  min-height: 100px;
+  > .wrapper {
+    min-height: 100px;
+    overflow: hidden;
 
-  a {
-    color: $black;
-    text-decoration: none;
-    font-weight: $weight-normal;
+    > a {
+      display: block;
+      font-weight: $weight-normal;
+
+      &:hover {
+        background: $light-background-color;
+        text-decoration: none;
+      }
+    }
   }
 }
 
-.embed.-loaded {
-  display: block;
-  border: 1px solid $primary-border-color;
-  border-radius: $lg-border-radius;
-
-  &:hover {
-    background: $light-background-color;
-  }
-}
-
-.embed__preview {
-  padding: $base-spacing / 2;
-}

--- a/resources/assets/components/Embed/index.js
+++ b/resources/assets/components/Embed/index.js
@@ -1,3 +1,5 @@
+/* eslint-disable react/no-danger */
+
 import PropTypes from 'prop-types';
 import React from 'react';
 import classnames from 'classnames';
@@ -19,16 +21,16 @@ class Embed extends React.Component {
   }
 
   render() {
-    let embed = <div className="spinner" />;
+    let embed = <div className="spinner"/>;
 
     // If an <iframe> code snippet is provided, use that. Otherwise, build preview card.
     if (this.state.code) {
       const embedHtml = { __html: this.state.code };
-      embed = <div className="media-video" dangerouslySetInnerHTML={embedHtml} />; // eslint-disable-line react/no-danger
+      embed = (<div className="media-video" dangerouslySetInnerHTML={embedHtml} />);
     } else if (this.state.title && this.state.url) {
       embed = (
         <a href={this.state.url} target="_blank" rel="noopener noreferrer">
-          <Figure className="embed__preview" image={this.state.image || this.state.provider.icon} alt={this.state.provider.name} alignment="left-collapse" size="large">
+          <Figure className="padded" image={this.state.image || this.state.provider.icon} alt={this.state.provider.name} alignment="left-collapse" size="large">
             <h3>{ this.state.title }</h3>
             { this.state.description ? <p>{ this.state.description }</p> : null }
             <p className="footnote">{ this.state.provider.name }</p>
@@ -38,8 +40,14 @@ class Embed extends React.Component {
     }
 
     return (
-      <div className={classnames('embed', { '-loaded': this.state.title })}>
-        {embed}
+      <div className={classnames('embed', this.props.className)}>
+        <div className={classnames('wrapper', {
+          'flex-center-xy': ! this.state.title,
+          'bordered': this.state.title,
+          'rounded': this.state.title
+        })}>
+          {embed}
+        </div>
       </div>
     );
   }

--- a/resources/assets/components/Embed/index.js
+++ b/resources/assets/components/Embed/index.js
@@ -1,5 +1,3 @@
-/* eslint-disable react/no-danger */
-
 import PropTypes from 'prop-types';
 import React from 'react';
 import classnames from 'classnames';
@@ -21,12 +19,12 @@ class Embed extends React.Component {
   }
 
   render() {
-    let embed = <div className="spinner"/>;
+    let embed = <div className="spinner" />;
 
     // If an <iframe> code snippet is provided, use that. Otherwise, build preview card.
     if (this.state.code) {
       const embedHtml = { __html: this.state.code };
-      embed = (<div className="media-video" dangerouslySetInnerHTML={embedHtml} />);
+      embed = (<div className="media-video" dangerouslySetInnerHTML={embedHtml} />); //  eslint-disable-line react/no-danger
     } else if (this.state.title && this.state.url) {
       embed = (
         <a href={this.state.url} target="_blank" rel="noopener noreferrer">
@@ -43,9 +41,10 @@ class Embed extends React.Component {
       <div className={classnames('embed', this.props.className)}>
         <div className={classnames('wrapper', {
           'flex-center-xy': ! this.state.title,
-          'bordered': this.state.title,
-          'rounded': this.state.title
-        })}>
+          'bordered': this.state.title, // eslint-disable-line quote-props
+          'rounded': this.state.title, // eslint-disable-line quote-props
+        })}
+        >
           {embed}
         </div>
       </div>
@@ -54,7 +53,12 @@ class Embed extends React.Component {
 }
 
 Embed.propTypes = {
+  className: PropTypes.string,
   url: PropTypes.string.isRequired,
+};
+
+Embed.defaultProps = {
+  className: null,
 };
 
 export default Embed;

--- a/resources/assets/scss/base.scss
+++ b/resources/assets/scss/base.scss
@@ -87,6 +87,14 @@ h1, h2, h3, p {
   padding: $half-spacing;
 }
 
+.padding-bottom-md {
+  padding-bottom: $half-spacing;
+}
+
+.padding-bottom-lg {
+  padding-bottom: $base-spacing;
+}
+
 .padded-md { // @TODO rename to .padding-md
   padding: $half-spacing;
 }

--- a/resources/assets/scss/base.scss
+++ b/resources/assets/scss/base.scss
@@ -34,6 +34,12 @@ h1, h2, h3, p {
 }
 
 // Utility classes.
+// @TODO: Move over to Forge 7 soon!
+.background-image-centered {
+  background-position: center;
+  background-size: cover;
+}
+
 .bordered {
   border: 1px solid $primary-border-color;
 }
@@ -54,6 +60,12 @@ h1, h2, h3, p {
   clear: none;
 }
 
+.flex-center-xy {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
 .float-left {
   float: left;
 }
@@ -62,24 +74,27 @@ h1, h2, h3, p {
   float: right;
 }
 
+.font-size-lg {
+  font-size: $font-large;
+
+  p {
+    font-size: $font-large;
+  }
+}
+
 // TODO: Remove this.
 .padded {
   padding: $half-spacing;
 }
 
-.padded-md {
+.padded-md { // @TODO rename to .padding-md
   padding: $half-spacing;
 }
 
-.padded-lg {
+.padded-lg { // @TODO rename to .padding-lg
   padding: $base-spacing;
 }
 
 .rounded {
   border-radius: $lg-border-radius;
-}
-
-.background-image-centered {
-  background-position: center;
-  background-size: cover;
 }


### PR DESCRIPTION
### What does this PR do?
This PR updates the `CampaignUpdate` component to allow the last items of functionality that the old custom block type allowed; adding embedded links and option to show content as a tweet-style message if the content is less than 144 characters.


### Any background context you want to provide?
It cleans up the `Embed` component a bunch. I noticed that the embed component had a bunch of flexbox styles for it just to render the spinner in the center and then immediately overrode them once the content was loaded. So I reversed it a bit and now it uses a `.flex-center-xy` class that it toggles based on whether the content is loaded or not. I made a few other utility class usage improvements and maybe a [questionable one (due to the content being in `<p>` tags inside the Markdown component)](https://github.com/DoSomething/phoenix-next/pull/366/files#diff-96426e7dde62551c26e4b19018087095R66), but feel free to modify if you don't agree with it!

I only updated the existing tests, but didn't add new ones that could test for tweet style and passing a an embed link because I ran out of time before I'm off. I can add when I get back or feel free to add as well!

### What are the relevant tickets/cards?
?

