### PR TITLE
Adding actual signup to the quiz

### DIFF
--- a/resources/assets/actions/quiz.js
+++ b/resources/assets/actions/quiz.js
@@ -1,5 +1,6 @@
 import { find } from 'lodash';
 import {
+  clickedSignUp,
   queueEvent,
   PICK_QUIZ_ANSWER,
   COMPARE_QUIZ_ANSWER,
@@ -52,6 +53,9 @@ export function compareQuizAnswer(quizId) {
       dispatch(loadPreviousQuizState(quizId, questions));
       remove(quizId, QUIZ_STORAGE_KEY);
     }
+
+    const campaignId = getState().campaign.legacyCampaignId;
+    dispatch(clickedSignUp(campaignId, { source: 'quiz' }, false));
 
     return dispatch({ type: COMPARE_QUIZ_ANSWER, quizId });
   };

--- a/resources/assets/actions/signup.js
+++ b/resources/assets/actions/signup.js
@@ -10,7 +10,6 @@ import {
   queueEvent,
   trackEvent,
   addNotification,
-  convertExperiment,
   openModal,
 } from '../actions';
 
@@ -23,8 +22,6 @@ import {
 export function signupCreated(campaignId) {
   return (dispatch, getState) => {
     const { user } = getState();
-
-    dispatch(openModal());
 
     dispatch({
       type: SIGNUP_CREATED,
@@ -99,28 +96,24 @@ export function getTotalSignups(campaignId) {
   };
 }
 
-// Async Action: send signup to phoenix.
-export function clickedSignUp(campaignId, metadata) {
+// Async Action: send signup to phoenix and
+// check if the user is logged in or has an existing signup.
+export function clickedSignUp(campaignId, metadata, shouldUpdateExperience = true) {
   return (dispatch, getState) => {
-    if (getState().experiments.pitch_page_connected) {
-      dispatch(convertExperiment('pitch_page_connected'));
-    }
-
     // If the user is not logged in, handle this action later.
     if (! getState().user.id) {
-      dispatch(queueEvent('clickedSignUp', campaignId, metadata));
-      return;
+      return dispatch(queueEvent('clickedSignUp', campaignId, metadata));
     }
 
     // If we already have a signup, just go to the action page.
     if (getState().signups.data.includes(campaignId)) {
-      dispatch(push('/action'));
-      return;
+      console.log(shouldUpdateExperience);
+      return shouldUpdateExperience ? dispatch(push('/action')) : null;
     }
 
     dispatch(signupPending());
 
-    (new Phoenix()).post('next/signups', { campaignId }).then((response) => {
+    return (new Phoenix()).post('next/signups', { campaignId }).then((response) => {
       // Handle a bad signup response...
       if (! response) {
         dispatch(addNotification('error'));
@@ -133,7 +126,9 @@ export function clickedSignUp(campaignId, metadata) {
         dispatch(trackEvent('signup created', metadata));
 
         // Take user to the action page if campaign is open.
-        if (! isCampaignClosed(getState().campaign.endDate.date)) {
+        const isClosed = isCampaignClosed(getState().campaign.endDate.date);
+        if (shouldUpdateExperience && ! isClosed) {
+          dispatch(openModal());
           dispatch(push('/action'));
         }
       }

--- a/resources/assets/actions/signup.js
+++ b/resources/assets/actions/signup.js
@@ -107,7 +107,6 @@ export function clickedSignUp(campaignId, metadata, shouldUpdateExperience = tru
 
     // If we already have a signup, just go to the action page.
     if (getState().signups.data.includes(campaignId)) {
-      console.log(shouldUpdateExperience);
       return shouldUpdateExperience ? dispatch(push('/action')) : null;
     }
 

--- a/resources/assets/actions/signup.js
+++ b/resources/assets/actions/signup.js
@@ -98,7 +98,7 @@ export function getTotalSignups(campaignId) {
 
 // Async Action: send signup to phoenix and
 // check if the user is logged in or has an existing signup.
-export function clickedSignUp(campaignId, metadata, shouldUpdateExperience = true) {
+export function clickedSignUp(campaignId, metadata, shouldRedirectToActionTab = true) {
   return (dispatch, getState) => {
     // If the user is not logged in, handle this action later.
     if (! getState().user.id) {
@@ -107,7 +107,7 @@ export function clickedSignUp(campaignId, metadata, shouldUpdateExperience = tru
 
     // If we already have a signup, just go to the action page.
     if (getState().signups.data.includes(campaignId)) {
-      return shouldUpdateExperience ? dispatch(push('/action')) : null;
+      return shouldRedirectToActionTab ? dispatch(push('/action')) : null;
     }
 
     dispatch(signupPending());
@@ -126,7 +126,7 @@ export function clickedSignUp(campaignId, metadata, shouldUpdateExperience = tru
 
         // Take user to the action page if campaign is open.
         const isClosed = isCampaignClosed(getState().campaign.endDate.date);
-        if (shouldUpdateExperience && ! isClosed) {
+        if (shouldRedirectToActionTab && ! isClosed) {
           dispatch(openModal());
           dispatch(push('/action'));
         }


### PR DESCRIPTION
### What does this PR do?
This PR ensures that the quiz completion makes an actual signup on the campaign, and doesn't result in any changes to the user's experience afterwards like a traditional signup 