### PR TITLE
Updating utility class naming to better match our naming approach.

### DIFF
--- a/resources/assets/components/PhotoHeader/PhotoHeader.js
+++ b/resources/assets/components/PhotoHeader/PhotoHeader.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import './photo-header.scss';
 
-const photoHeaderClasses = 'photo-header background-image-centered padded-lg';
+const photoHeaderClasses = 'photo-header background-image-centered padding-lg';
 
 const PhotoHeader = ({ children, className, backgroundImage }) => (
   <div

--- a/resources/assets/components/PhotoHeader/__snapshots__/PhotoHeader.test.js.snap
+++ b/resources/assets/components/PhotoHeader/__snapshots__/PhotoHeader.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`PhotoHeader snapshot test 1`] = `
 <div
-  className="photo-header background-image-centered padded-lg"
+  className="photo-header background-image-centered padding-lg"
   style={
     Object {
       "backgroundImage": "url(https://fake-image.com/img.png)",

--- a/resources/assets/scss/base.scss
+++ b/resources/assets/scss/base.scss
@@ -95,11 +95,11 @@ h1, h2, h3, p {
   padding-bottom: $base-spacing;
 }
 
-.padded-md { // @TODO rename to .padding-md
+.padding-md {
   padding: $half-spacing;
 }
 
-.padded-lg { // @TODO rename to .padding-lg
+.padding-lg {
   padding: $base-spacing;
 }
 


### PR DESCRIPTION
### What does this PR do?
This PR updates the utility class naming strategy based on some recent decisions.

```
# Examples

.padded // all around padding, using the more common half-spacing size of 12px for elements; alias for padding-dm
.padding-md // same as above, but declared as a specific size of medium (12px)
.padding-lg // all around padding of large (24px)
.padding-bottom-md // bottom padding of medium size
.padding-bottom-lg // bottom padding of large size
```