### PR TITLE
Update to not require end date field.

### DIFF
--- a/resources/assets/actions/signup.js
+++ b/resources/assets/actions/signup.js
@@ -1,5 +1,6 @@
-import { Phoenix } from '@dosomething/gateway';
+import { get } from 'lodash';
 import { push } from 'react-router-redux';
+import { Phoenix } from '@dosomething/gateway';
 import { isCampaignClosed } from '../helpers';
 import {
   SIGNUP_CREATED,
@@ -125,7 +126,8 @@ export function clickedSignUp(campaignId, metadata, shouldRedirectToActionTab = 
         dispatch(trackEvent('signup created', metadata));
 
         // Take user to the action page if campaign is open.
-        const isClosed = isCampaignClosed(getState().campaign.endDate.date);
+        const endDate = get(getState().campaign.endDate, 'date', null);
+        const isClosed = isCampaignClosed(endDate);
         if (shouldRedirectToActionTab && ! isClosed) {
           dispatch(openModal());
           dispatch(push('/action'));

--- a/resources/assets/components/App.js
+++ b/resources/assets/components/App.js
@@ -1,9 +1,9 @@
-import PropTypes from 'prop-types';
 import React from 'react';
+import PropTypes from 'prop-types';
+import { get } from 'lodash';
 import { Provider } from 'react-redux';
 import { Switch, Route } from 'react-router-dom';
 import { ConnectedRouter } from 'react-router-redux';
-import { get } from 'lodash';
 
 import { initializeStore } from '../store';
 import { isCampaignClosed } from '../helpers';

--- a/resources/assets/components/App.js
+++ b/resources/assets/components/App.js
@@ -3,9 +3,10 @@ import React from 'react';
 import { Provider } from 'react-redux';
 import { Switch, Route } from 'react-router-dom';
 import { ConnectedRouter } from 'react-router-redux';
+import { get } from 'lodash';
+
 import { initializeStore } from '../store';
 import { isCampaignClosed } from '../helpers';
-
 import { paths } from '../helpers/navigation';
 import ChromeContainer from '../containers/ChromeContainer';
 import { FeedContainer } from './Feed';
@@ -24,7 +25,7 @@ const chrome = component => wrap(ChromeContainer, component);
 const App = ({ store, history }) => {
   initializeStore(store);
 
-  const endDate = store.getState().campaign.endDate.date;
+  const endDate = get(store.getState().campaign.endDate, 'date', null);
   const actionPage = isCampaignClosed(endDate) ? null : (
     <Route path={paths.action} component={chrome(ActionPageContainer)} />
   );

--- a/resources/assets/containers/TabbedNavigationContainer.js
+++ b/resources/assets/containers/TabbedNavigationContainer.js
@@ -1,12 +1,14 @@
-import PropTypes from 'prop-types';
 import React from 'react';
+import PropTypes from 'prop-types';
+import { get } from 'lodash';
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router-dom';
+
 import Button from '../components/Button/Button';
 import NavigationLink from '../components/Navigation/NavigationLink';
 import TabbedNavigation from '../components/Navigation/TabbedNavigation';
-import { clickedSignUp } from '../actions';
 import { paths } from '../helpers/navigation';
+import { clickedSignUp } from '../actions';
 import { isCampaignClosed } from '../helpers';
 
 const mapStateToProps = state => ({
@@ -14,7 +16,7 @@ const mapStateToProps = state => ({
   legacyCampaignId: state.campaign.legacyCampaignId,
   pages: state.campaign.pages,
   pathname: state.routing.location.pathname,
-  campaignEndDate: state.campaign.endDate.date,
+  campaignEndDate: get(state.campaign.endDate, 'date', null),
 });
 
 const mapDispatchToProps = {

--- a/resources/assets/helpers/index.js
+++ b/resources/assets/helpers/index.js
@@ -347,5 +347,9 @@ export function getFormattedScreenSize(screenWidth = window.innerWidth) {
  * @return {Boolean}
  */
 export function isCampaignClosed(endDate) {
+  if (! endDate) {
+    return false;
+  }
+
   return new Date(endDate) - new Date() < 0;
 }


### PR DESCRIPTION
### What does this PR do?
This PR updates the code to not require an "end date" for a campaign created in Contentful. The Contentful campaign content type does not indicate that an end date is required, but the code _did_ require it for the campaign to render. Considering Legacy campaigns using the "classic" template don't require and end date (especially for database campaigns), we shouldn't require it in the Contentful campaign content type so that it can be more versatile.


### Any background context you want to provide?
Working towards moving Legacy campaigns into Contentful.


### What are the relevant tickets/cards?
Refs https://www.pivotaltracker.com/story/show/149026419

