### PR TITLE
Improving answer styling based on Luke mock

### DIFF
--- a/resources/assets/components/Quiz/Answer.js
+++ b/resources/assets/components/Quiz/Answer.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import Card from '../Card';
 
-const Answer = ({ id, title, quizId, questionId, pickQuizAnswer, isActive, shouldHide }) => (
+const Answer = ({ id, title, quizId, questionId, pickQuizAnswer, isActive, shouldFade }) => (
   <a
     className="answer"
     onClick={() => pickQuizAnswer(quizId, questionId, id)}
@@ -13,7 +13,7 @@ const Answer = ({ id, title, quizId, questionId, pickQuizAnswer, isActive, shoul
     <Card
       className={classnames('bordered rounded padding-lg', {
         '-active': isActive,
-        '-hide': shouldHide,
+        fade: shouldFade,
       })}
     >
       <p>{ title }</p>
@@ -28,7 +28,7 @@ Answer.propTypes = {
   questionId: PropTypes.string.isRequired,
   pickQuizAnswer: PropTypes.func.isRequired,
   isActive: PropTypes.bool.isRequired,
-  shouldHide: PropTypes.bool.isRequired,
+  shouldFade: PropTypes.bool.isRequired,
 };
 
 export default Answer;

--- a/resources/assets/components/Quiz/Answer.js
+++ b/resources/assets/components/Quiz/Answer.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import Card from '../Card';
 
-const Answer = ({ id, title, quizId, questionId, pickQuizAnswer, isActive, shouldFade }) => (
+const Answer = ({ id, title, quizId, questionId, pickQuizAnswer, isActive, isFaded }) => (
   <a
     className="answer"
     onClick={() => pickQuizAnswer(quizId, questionId, id)}
@@ -13,7 +13,7 @@ const Answer = ({ id, title, quizId, questionId, pickQuizAnswer, isActive, shoul
     <Card
       className={classnames('bordered rounded padding-lg', {
         '-active': isActive,
-        fade: shouldFade,
+        faded: isFaded,
       })}
     >
       <p>{ title }</p>
@@ -28,7 +28,7 @@ Answer.propTypes = {
   questionId: PropTypes.string.isRequired,
   pickQuizAnswer: PropTypes.func.isRequired,
   isActive: PropTypes.bool.isRequired,
-  shouldFade: PropTypes.bool.isRequired,
+  isFaded: PropTypes.bool.isRequired,
 };
 
 export default Answer;

--- a/resources/assets/components/Quiz/Answer.js
+++ b/resources/assets/components/Quiz/Answer.js
@@ -3,14 +3,19 @@ import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import Card from '../Card';
 
-const Answer = ({ id, title, quizId, questionId, pickQuizAnswer, active }) => (
+const Answer = ({ id, title, quizId, questionId, pickQuizAnswer, isActive, shouldHide }) => (
   <a
     className="answer"
     onClick={() => pickQuizAnswer(quizId, questionId, id)}
     role="button"
     tabIndex={0}
   >
-    <Card className={classnames('bordered rounded padding-lg', { '-active': active })}>
+    <Card
+      className={classnames('bordered rounded padding-lg', {
+        '-active': isActive,
+        '-hide': shouldHide,
+      })}
+    >
       <p>{ title }</p>
     </Card>
   </a>
@@ -22,7 +27,8 @@ Answer.propTypes = {
   quizId: PropTypes.string.isRequired,
   questionId: PropTypes.string.isRequired,
   pickQuizAnswer: PropTypes.func.isRequired,
-  active: PropTypes.bool.isRequired,
+  isActive: PropTypes.bool.isRequired,
+  shouldHide: PropTypes.bool.isRequired,
 };
 
 export default Answer;

--- a/resources/assets/components/Quiz/Question.js
+++ b/resources/assets/components/Quiz/Question.js
@@ -3,6 +3,11 @@ import PropTypes from 'prop-types';
 import Answer from './Answer';
 import PhotoHeader from '../PhotoHeader';
 
+const isActive = (answer, activeAnswer) => answer.id === activeAnswer;
+const shouldHide = (answer, activeAnswer) => (
+  activeAnswer !== null && ! isActive(answer, activeAnswer)
+);
+
 const Question = ({ title, id, quizId, answers, pickQuizAnswer, activeAnswer }) => (
   <div className="question">
     <PhotoHeader>
@@ -16,7 +21,8 @@ const Question = ({ title, id, quizId, answers, pickQuizAnswer, activeAnswer }) 
           pickQuizAnswer={pickQuizAnswer}
           questionId={id}
           quizId={quizId}
-          active={answer.id === activeAnswer}
+          isActive={isActive(answer, activeAnswer)}
+          shouldHide={shouldHide(answer, activeAnswer)}
         />
       ))}
     </div>

--- a/resources/assets/components/Quiz/Question.js
+++ b/resources/assets/components/Quiz/Question.js
@@ -4,7 +4,7 @@ import Answer from './Answer';
 import PhotoHeader from '../PhotoHeader';
 
 const isActive = (answer, activeAnswer) => answer.id === activeAnswer;
-const shouldHide = (answer, activeAnswer) => (
+const shouldFade = (answer, activeAnswer) => (
   activeAnswer !== null && ! isActive(answer, activeAnswer)
 );
 
@@ -22,7 +22,7 @@ const Question = ({ title, id, quizId, answers, pickQuizAnswer, activeAnswer }) 
           questionId={id}
           quizId={quizId}
           isActive={isActive(answer, activeAnswer)}
-          shouldHide={shouldHide(answer, activeAnswer)}
+          shouldFade={shouldFade(answer, activeAnswer)}
         />
       ))}
     </div>

--- a/resources/assets/components/Quiz/Question.js
+++ b/resources/assets/components/Quiz/Question.js
@@ -22,7 +22,7 @@ const Question = ({ title, id, quizId, answers, pickQuizAnswer, activeAnswer }) 
           questionId={id}
           quizId={quizId}
           isActive={isActive(answer, activeAnswer)}
-          shouldFade={shouldFade(answer, activeAnswer)}
+          isFaded={shouldFade(answer, activeAnswer)}
         />
       ))}
     </div>

--- a/resources/assets/components/Quiz/helpers.js
+++ b/resources/assets/components/Quiz/helpers.js
@@ -29,7 +29,7 @@ export const pickWinner = (responses, questions) => {
   }, {});
 
   return Object.keys(finalTallies).sort((alpha, beta) => (
-    finalTallies[alpha] - finalTallies[beta]
+    finalTallies[beta] - finalTallies[alpha]
   ))[0];
 };
 

--- a/resources/assets/components/Quiz/quiz.scss
+++ b/resources/assets/components/Quiz/quiz.scss
@@ -19,17 +19,19 @@
     margin-top: $base-spacing;
     display: flex;
     flex-wrap: wrap;
-    justify-content: space-around;
   }
 
   .answer {
     margin-bottom: $base-spacing;
-    font-weight: normal;
+    font-weight: $weight-bold;
+    text-align: center;
     text-decoration: none;
+    width: 100%;
     outline: 0;
 
     @include media($medium) {
-      flex: 0 0 48%;
+      flex: 0 0 33%;
+      padding: 0 $half-spacing $half-spacing $half-spacing;
     }
 
     &:hover {
@@ -38,6 +40,11 @@
 
     .-active {
       border-color: $blue;
+      border-width: 2px;
+    }
+
+    .-hide {
+      opacity: 0.5;
     }
   }
 }

--- a/resources/assets/components/Quiz/quiz.scss
+++ b/resources/assets/components/Quiz/quiz.scss
@@ -42,9 +42,5 @@
       border-color: $blue;
       border-width: 2px;
     }
-
-    .-hide {
-      opacity: 0.5;
-    }
   }
 }

--- a/resources/assets/scss/base.scss
+++ b/resources/assets/scss/base.scss
@@ -107,6 +107,6 @@ h1, h2, h3, p {
   border-radius: $lg-border-radius;
 }
 
-.fade {
+.faded {
   opacity: 0.5;
 }

--- a/resources/assets/scss/base.scss
+++ b/resources/assets/scss/base.scss
@@ -106,3 +106,7 @@ h1, h2, h3, p {
 .rounded {
   border-radius: $lg-border-radius;
 }
+
+.fade {
+  opacity: 0.5;
+}


### PR DESCRIPTION
<img width="743" alt="screen shot 2017-08-22 at 2 45 41 pm" src="https://user-images.githubusercontent.com/897368/29581849-aa639206-8748-11e7-8f14-7dccb0eabb22.png">
<img width="499" alt="screen shot 2017-08-22 at 2 45 30 pm" src="https://user-images.githubusercontent.com/897368/29581848-aa631006-8748-11e7-94a2-018109a5c7fb.png">

this pr adds a few styling changes to the answer component,

- third sized column for now
- bold & centered text
- opacity for non selected answers
- larger border width for selected answer 
- fixing the width being incorrect on mobile 

<img width="169" alt="screen shot 2017-08-22 at 2 48 02 pm" src="https://user-images.githubusercontent.com/897368/29581936-ec2cfc18-8748-11e7-8516-306f03155ba7.png">
