### PR TITLE
Removing requirement for having data to output a Dashboard component.

### DIFF
--- a/resources/assets/components/Chrome.js
+++ b/resources/assets/components/Chrome.js
@@ -27,11 +27,13 @@ const Chrome = props => (
       clickedSignUp={props.clickedSignUp}
     />
     <div className="main">
-      <Dashboard
-        totalCampaignSignups={props.totalCampaignSignups}
-        content={props.dashboard}
-        endDate={props.endDate}
-      />
+      { props.dashboard ?
+        <Dashboard
+          totalCampaignSignups={props.totalCampaignSignups}
+          content={props.dashboard}
+          endDate={props.endDate}
+        />
+        : null }
       <TabbedNavigationContainer />
       <FeedEnclosure>
         {props.children}


### PR DESCRIPTION
### What does this PR do?
This PR removes the need to have Dashboard data defined in Contentful (the field is no longer required). If no data is provided, then no Dashboard is output.


### Any background context you want to provide?
Work related to Legacy Campaigns on Phoenix-Next

### What are the relevant tickets/cards?
Refs https://www.pivotaltracker.com/story/show/149026419
