### PR TITLE
Legacy compatible fixes part 3

### DIFF
--- a/app/Entities/Campaign.php
+++ b/app/Entities/Campaign.php
@@ -148,7 +148,7 @@ class Campaign extends Entity implements JsonSerializable
             'legacyCampaignId' => $this->legacyCampaignId,
             'legacyCampaignRunId' => get_legacy_campaign_data($this->legacyCampaignId, 'campaign_runs.current.en.id'),
             'type' => $this->entry->getContentType()->getId(),
-            'template' => $this->template->first(),
+            'template' => $this->template->first() ?: 'community',
             'title' => $this->title,
             'slug' => $this->slug,
             'endDate' => $this->endDate,

--- a/app/Entities/Campaign.php
+++ b/app/Entities/Campaign.php
@@ -148,6 +148,7 @@ class Campaign extends Entity implements JsonSerializable
             'legacyCampaignId' => $this->legacyCampaignId,
             'legacyCampaignRunId' => get_legacy_campaign_data($this->legacyCampaignId, 'campaign_runs.current.en.id'),
             'type' => $this->entry->getContentType()->getId(),
+            'template' => $this->template->first(),
             'title' => $this->title,
             'slug' => $this->slug,
             'endDate' => $this->endDate,


### PR DESCRIPTION
### What does this PR do?
This PR exposes a new field now available on the Campaign content type on Contentful for specifying a `template`, and makes it available within the Redux state for future use.


### Any background context you want to provide?
Initial groundwork for helping create the "classic" template on Phoenix-Next 😉 

_Note: I did not make the `template` field required for the time being in Contentful, because I didn't want to potentially break any campaigns. We can update current campaigns and eventually make the field required. For the meantime, I provide a default of `community` to the template field if the field was not filled out._

We might rename the `community` template to some other name but this works for now. Renaming since we've had talks where we might want to do a PN campaign without the community tab as an option in the future for very specific campaigns...


### What are the relevant tickets/cards?
Refs https://www.pivotaltracker.com/story/show/149026419
