### PR TITLE
Fixing sytles for markdown titles.

### DIFF
--- a/resources/assets/components/Markdown/markdown.scss
+++ b/resources/assets/components/Markdown/markdown.scss
@@ -59,8 +59,15 @@
     font-weight: 700;
   }
 
-  h3 {
+  h2, h3 {
     font-family: $primary-font-family;
+  }
+
+  h2 {
+    font-size: 28px;
+  }
+
+  h3 {
     font-size: 22px;
   }
 


### PR DESCRIPTION
### What does this PR do?
This PR updates the markdown titles to be styled as intended and more closely match the old style for the campaign update. There is still some variation with the padding for the first paragraph under the title which should have been `12px` but in the old version was not, because the element containing the title sat _outside_ of the markdown container.


### Any background context you want to provide?
Inconsistent title rendering form old to new campaign update block:
![screen shot 2017-08-24 at 10 47 16 am](https://user-images.githubusercontent.com/105849/29673123-3c6650e8-88bc-11e7-8395-7833c6bf3a71.png)

More-consistent™ rendering with slight padding difference:
![pasted image at 2017_08_24 10_58 am](https://user-images.githubusercontent.com/105849/29673127-3e90f83c-88bc-11e7-9da4-e42e06492986.png)
