### PR TITLE
Making the Dashboard data not be required.

### DIFF
--- a/resources/assets/components/Chrome.js
+++ b/resources/assets/components/Chrome.js
@@ -57,7 +57,11 @@ Chrome.propTypes = {
     description: PropTypes.string,
     url: PropTypes.string,
   }).isRequired,
-  dashboard: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
+  dashboard: PropTypes.shape({
+    id: PropTypes.string,
+    type: PropTypes.string,
+    fields: PropTypes.object,
+  }),
   endDate: PropTypes.shape({
     date: PropTypes.string,
     timezone: PropTypes.string,
@@ -77,6 +81,7 @@ Chrome.propTypes = {
 };
 
 Chrome.defaultProps = {
+  dashboard: null,
   isAffiliated: false,
 };
 


### PR DESCRIPTION
### What does this PR do?
This PR does a quick update to not make the Dashboard data for the Dashboard component be required, and thus throw console errors when trying to render a campaign that does not contain/need such data.


### Any background context you want to provide?
Part of the updates to allow rendering legacy campaigns in Phoenix-Next.

