### PR TITLE
Dual wielding campaigns

### DIFF
--- a/app/Entities/Campaign.php
+++ b/app/Entities/Campaign.php
@@ -148,7 +148,7 @@ class Campaign extends Entity implements JsonSerializable
             'legacyCampaignId' => $this->legacyCampaignId,
             'legacyCampaignRunId' => get_legacy_campaign_data($this->legacyCampaignId, 'campaign_runs.current.en.id'),
             'type' => $this->entry->getContentType()->getId(),
-            'template' => $this->template->first() ?: 'community',
+            'template' => $this->template->first() ?: 'mosaic',
             'title' => $this->title,
             'slug' => $this->slug,
             'endDate' => $this->endDate,

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "history": "^4.6.2",
     "lodash": "^4.17.4",
     "marked": "^0.3.6",
+    "moment": "^2.18.1",
     "prop-types": "^15.5.8",
     "react": "^15.6.1",
     "react-dom": "^15.6.1",

--- a/resources/assets/components/Chrome.js
+++ b/resources/assets/components/Chrome.js
@@ -25,6 +25,8 @@ const Chrome = props => (
       coverImage={props.coverImage}
       legacyCampaignId={props.legacyCampaignId}
       clickedSignUp={props.clickedSignUp}
+      endDate={props.endDate}
+      template={props.template}
     />
     <div className="main">
       { props.dashboard ?

--- a/resources/assets/components/Chrome.js
+++ b/resources/assets/components/Chrome.js
@@ -73,6 +73,7 @@ Chrome.propTypes = {
   isAffiliated: PropTypes.bool,
   signups: PropTypes.array.isRequired, // eslint-disable-line react/forbid-prop-types
   subtitle: PropTypes.string.isRequired,
+  template: PropTypes.string.isRequired,
   title: PropTypes.string.isRequired,
   totalCampaignSignups: PropTypes.number.isRequired,
   user: PropTypes.shape({

--- a/resources/assets/components/LedeBanner/LedeBanner.js
+++ b/resources/assets/components/LedeBanner/LedeBanner.js
@@ -1,55 +1,34 @@
-import PropTypes from 'prop-types';
 import React from 'react';
-import Markdown from '../Markdown';
+import PropTypes from 'prop-types';
+
+import LegacyTemplate from './templates/LegacyTemplate';
+import MosaicTemplate from './templates/MosaicTemplate';
 import { contentfulImageUrl } from '../../helpers';
 
 import './lede-banner.scss';
 
 const LedeBanner = (props) => {
-  const {
-    title,
-    subtitle,
-    blurb,
-    coverImage,
-    isAffiliated,
-    legacyCampaignId,
-    clickedSignUp,
-  } = props;
+  const { coverImage, template } = props;
 
   const backgroundImageStyle = {
     backgroundImage: `url(${contentfulImageUrl(coverImage.url, '800', '600', 'fill')})`,
   };
 
-  return (
-    <header role="banner" className="lede-banner">
-      <div className="lede-banner__image" style={backgroundImageStyle} />
-      <div className="lede-banner__content">
-        <div className="wrapper">
-          <div className="lede-banner__headline">
-            <h1 className="lede-banner__headline-title">{title}</h1>
-            <h2 className="lede-banner__headline-subtitle">{subtitle}</h2>
-          </div>
+  switch (template) {
+    case 'legacy':
+      return <LegacyTemplate backgroundImageStyle={backgroundImageStyle} {...props} />;
 
-          <Markdown className="lede-banner__blurb">{blurb}</Markdown>
-
-          { isAffiliated ? null : <button className="button" onClick={() => clickedSignUp(legacyCampaignId, { source: 'lede banner|text: Join us' })}>Join us</button> }
-        </div>
-      </div>
-    </header>
-  );
+    default:
+      return <MosaicTemplate backgroundImageStyle={backgroundImageStyle} {...props} />;
+  }
 };
 
 LedeBanner.propTypes = {
-  blurb: PropTypes.string.isRequired,
-  clickedSignUp: PropTypes.func.isRequired,
   coverImage: PropTypes.shape({
     description: PropTypes.string,
     url: PropTypes.string,
   }).isRequired,
-  isAffiliated: PropTypes.bool.isRequired,
-  legacyCampaignId: PropTypes.string.isRequired,
-  subtitle: PropTypes.string.isRequired,
-  title: PropTypes.string.isRequired,
+  template: PropTypes.string.isRequired,
 };
 
 

--- a/resources/assets/components/LedeBanner/LedeBanner.js
+++ b/resources/assets/components/LedeBanner/LedeBanner.js
@@ -10,10 +10,6 @@ import './lede-banner.scss';
 const LedeBanner = (props) => {
   const { coverImage, template } = props;
 
-  // const backgroundImageStyle = {
-  //   backgroundImage: `url(${contentfulImageUrl(coverImage.url, '800', '600', 'fill')})`,
-  // };
-
   const backgroundImageUrl = contentfulImageUrl(coverImage.url, '800', '600', 'fill');
 
   switch (template) {

--- a/resources/assets/components/LedeBanner/LedeBanner.js
+++ b/resources/assets/components/LedeBanner/LedeBanner.js
@@ -10,16 +10,18 @@ import './lede-banner.scss';
 const LedeBanner = (props) => {
   const { coverImage, template } = props;
 
-  const backgroundImageStyle = {
-    backgroundImage: `url(${contentfulImageUrl(coverImage.url, '800', '600', 'fill')})`,
-  };
+  // const backgroundImageStyle = {
+  //   backgroundImage: `url(${contentfulImageUrl(coverImage.url, '800', '600', 'fill')})`,
+  // };
+
+  const backgroundImageUrl = contentfulImageUrl(coverImage.url, '800', '600', 'fill');
 
   switch (template) {
     case 'legacy':
-      return <LegacyTemplate backgroundImageStyle={backgroundImageStyle} {...props} />;
+      return <LegacyTemplate backgroundImageUrl={backgroundImageUrl} {...props} />;
 
     default:
-      return <MosaicTemplate backgroundImageStyle={backgroundImageStyle} {...props} />;
+      return <MosaicTemplate backgroundImageUrl={backgroundImageUrl} {...props} />;
   }
 };
 

--- a/resources/assets/components/LedeBanner/templates/LegacyTemplate.js
+++ b/resources/assets/components/LedeBanner/templates/LegacyTemplate.js
@@ -6,12 +6,16 @@ const LegacyTemplate = (props) => {
   const {
     title,
     subtitle,
-    backgroundImageStyle,
+    backgroundImageUrl,
     isAffiliated,
     legacyCampaignId,
     clickedSignUp,
     endDate,
   } = props;
+
+  const backgroundImageStyle = {
+    backgroundImage: `url(${backgroundImageUrl})`,
+  };
 
   return (
     <header role="banner" className="header -hero header--action has-promotions" style={backgroundImageStyle}>
@@ -27,7 +31,7 @@ const LegacyTemplate = (props) => {
 };
 
 LegacyTemplate.propTypes = {
-  backgroundImageStyle: PropTypes.string.isRequired,
+  backgroundImageUrl: PropTypes.string.isRequired,
   clickedSignUp: PropTypes.func.isRequired,
   endDate: PropTypes.shape({
     date: PropTypes.string,

--- a/resources/assets/components/LedeBanner/templates/LegacyTemplate.js
+++ b/resources/assets/components/LedeBanner/templates/LegacyTemplate.js
@@ -1,0 +1,37 @@
+import React from 'react';
+import moment from 'moment';
+import PropTypes from 'prop-types';
+
+const LegacyTemplate = (props) => {
+  const {
+    title,
+    subtitle,
+    backgroundImageStyle,
+    isAffiliated,
+    legacyCampaignId,
+    clickedSignUp,
+    endDate,
+  } = props;
+
+  return (
+    <header role="banner" className="header -hero header--action has-promotions" style={backgroundImageStyle}>
+      <div className="wrapper">
+        <h1 className="header__title">{title}</h1>
+        <p className="header__subtitle">{subtitle}</p>
+        { endDate ? <p className="header__date"> Ends {moment(endDate.date).format('MMMM Do')}</p> : null }
+      </div>
+    </header>
+  );
+};
+
+LegacyTemplate.propTypes = {
+  // backgroundImageStyle: PropTypes.string.isRequired,
+  clickedSignUp: PropTypes.func.isRequired,
+  // endDate: PropTypes.string.
+  isAffiliated: PropTypes.bool.isRequired,
+  legacyCampaignId: PropTypes.string.isRequired,
+  subtitle: PropTypes.string.isRequired,
+  title: PropTypes.string.isRequired,
+};
+
+export default LegacyTemplate;

--- a/resources/assets/components/LedeBanner/templates/LegacyTemplate.js
+++ b/resources/assets/components/LedeBanner/templates/LegacyTemplate.js
@@ -18,20 +18,30 @@ const LegacyTemplate = (props) => {
       <div className="wrapper">
         <h1 className="header__title">{title}</h1>
         <p className="header__subtitle">{subtitle}</p>
-        { endDate ? <p className="header__date"> Ends {moment(endDate.date).format('MMMM Do')}</p> : null }
+        { endDate ? <p className="header__date">Ends {moment(endDate.date).format('MMMM Do')}</p> : null }
+
+        { isAffiliated ? null : <div className="header__signup"><button className="button" onClick={() => clickedSignUp(legacyCampaignId, { source: 'legacy lede banner|text: Join us' })}>Sign Up</button></div>}
       </div>
     </header>
   );
 };
 
 LegacyTemplate.propTypes = {
-  // backgroundImageStyle: PropTypes.string.isRequired,
+  backgroundImageStyle: PropTypes.string.isRequired,
   clickedSignUp: PropTypes.func.isRequired,
-  // endDate: PropTypes.string.
+  endDate: PropTypes.shape({
+    date: PropTypes.string,
+    timezone: PropTypes.string,
+    timezone_type: PropTypes.int,
+  }),
   isAffiliated: PropTypes.bool.isRequired,
   legacyCampaignId: PropTypes.string.isRequired,
   subtitle: PropTypes.string.isRequired,
   title: PropTypes.string.isRequired,
+};
+
+LegacyTemplate.defaultProps = {
+  endDate: null,
 };
 
 export default LegacyTemplate;

--- a/resources/assets/components/LedeBanner/templates/MosaicTemplate.js
+++ b/resources/assets/components/LedeBanner/templates/MosaicTemplate.js
@@ -8,11 +8,15 @@ const MosaicTemplate = (props) => {
     title,
     subtitle,
     blurb,
-    backgroundImageStyle,
+    backgroundImageUrl,
     isAffiliated,
     legacyCampaignId,
     clickedSignUp,
   } = props;
+
+  const backgroundImageStyle = {
+    backgroundImage: `url(${backgroundImageUrl})`,
+  };
 
   return (
     <header role="banner" className="lede-banner">
@@ -34,9 +38,7 @@ const MosaicTemplate = (props) => {
 };
 
 MosaicTemplate.propTypes = {
-  backgroundImageStyle: PropTypes.shape({
-    backgroundImage: PropTypes.string.isRequired,
-  }).isRequired,
+  backgroundImageUrl: PropTypes.string.isRequired,
   blurb: PropTypes.string.isRequired,
   clickedSignUp: PropTypes.func.isRequired,
   isAffiliated: PropTypes.bool.isRequired,

--- a/resources/assets/components/LedeBanner/templates/MosaicTemplate.js
+++ b/resources/assets/components/LedeBanner/templates/MosaicTemplate.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
 import Markdown from '../../Markdown';
 
@@ -10,7 +11,7 @@ const MosaicTemplate = (props) => {
     backgroundImageStyle,
     isAffiliated,
     legacyCampaignId,
-    clickedSignUp
+    clickedSignUp,
   } = props;
 
   return (
@@ -25,11 +26,23 @@ const MosaicTemplate = (props) => {
 
           <Markdown className="lede-banner__blurb">{blurb}</Markdown>
 
-          { isAffiliated ? null : <button className="button" onClick={() => clickedSignUp(legacyCampaignId, { source: 'lede banner|text: Join us' })}>Join us</button> }
+          { isAffiliated ? null : <button className="button" onClick={() => clickedSignUp(legacyCampaignId, { source: 'mosaic lede banner|text: Join us' })}>Join us</button> }
         </div>
       </div>
     </header>
   );
+};
+
+MosaicTemplate.propTypes = {
+  backgroundImageStyle: PropTypes.shape({
+    backgroundImage: PropTypes.string.isRequired,
+  }).isRequired,
+  blurb: PropTypes.string.isRequired,
+  clickedSignUp: PropTypes.func.isRequired,
+  isAffiliated: PropTypes.bool.isRequired,
+  legacyCampaignId: PropTypes.string.isRequired,
+  subtitle: PropTypes.string.isRequired,
+  title: PropTypes.string.isRequired,
 };
 
 export default MosaicTemplate;

--- a/resources/assets/components/LedeBanner/templates/MosaicTemplate.js
+++ b/resources/assets/components/LedeBanner/templates/MosaicTemplate.js
@@ -1,0 +1,35 @@
+import React from 'react';
+
+import Markdown from '../../Markdown';
+
+const MosaicTemplate = (props) => {
+  const {
+    title,
+    subtitle,
+    blurb,
+    backgroundImageStyle,
+    isAffiliated,
+    legacyCampaignId,
+    clickedSignUp
+  } = props;
+
+  return (
+    <header role="banner" className="lede-banner">
+      <div className="lede-banner__image" style={backgroundImageStyle} />
+      <div className="lede-banner__content">
+        <div className="wrapper">
+          <div className="lede-banner__headline">
+            <h1 className="lede-banner__headline-title">{title}</h1>
+            <h2 className="lede-banner__headline-subtitle">{subtitle}</h2>
+          </div>
+
+          <Markdown className="lede-banner__blurb">{blurb}</Markdown>
+
+          { isAffiliated ? null : <button className="button" onClick={() => clickedSignUp(legacyCampaignId, { source: 'lede banner|text: Join us' })}>Join us</button> }
+        </div>
+      </div>
+    </header>
+  );
+};
+
+export default MosaicTemplate;

--- a/resources/assets/containers/ChromeContainer.js
+++ b/resources/assets/containers/ChromeContainer.js
@@ -24,6 +24,7 @@ const mapStateToProps = (state, props) => ({
   noun: get(state.campaign.additionalContent, 'noun'),
   verb: get(state.campaign.additionalContent, 'verb'),
   shouldShowModal: state.modal.shouldShowModal,
+  template: state.campaign.template,
 });
 
 /**


### PR DESCRIPTION
### What does this PR do?
This PR is the start of trying to enable components to have templates that can be otherwise specified to use to visually render it differently depending on the template chosen. This first example is with the `LedeBanner` component and will allow rendering it for either the `legacy` template style or the `mosaic` template style.

#### Legacy template style for LedeBanner
![image](https://user-images.githubusercontent.com/105849/29841246-b943db98-8cd2-11e7-86b6-8593bafccdba.png)

#### Mosaic template style for LedeBanner
![image](https://user-images.githubusercontent.com/105849/29841279-d61128a2-8cd2-11e7-943f-e8652101b1c2.png)

