### PR TITLE
Fixing signup check on page start

### DIFF
--- a/resources/assets/actions/signup.js
+++ b/resources/assets/actions/signup.js
@@ -58,7 +58,11 @@ export function signupPending() {
 // Async Action: check if user already signed up for the campaign
 export function checkForSignup(campaignId) {
   return (dispatch, getState) => {
-    (new Phoenix()).get('next/signups', {
+    if (getState().user.id === null) {
+      return dispatch(signupNotFound());
+    }
+
+    return (new Phoenix()).get('next/signups', {
       campaigns: campaignId,
       user: getState().user.id,
     }).then((response) => {


### PR DESCRIPTION
### What does this PR do?
Check that we're only making the sign ups GET API request when a user is currently authenticated


### Any background context you want to provide?
Gateway was not adding the null user value like it previously did, which meant we got a default list of sign ups that made the app think the user was actually signed up, even though it was just a paginated list of all signups.