### PR TITLE
Ensure we always send an array

### DIFF
--- a/app/Http/Controllers/AuthController.php
+++ b/app/Http/Controllers/AuthController.php
@@ -48,7 +48,7 @@ class AuthController extends Controller
             session(['login.intended' => $intended]);
         }
 
-        $options = array_get($request->getQueryParams(), 'options') ?? [];
+        $options = array_get($request->getQueryParams(), 'options') ?: [];
         $destination = array_get($request->getQueryParams(), 'destination');
         $url = session('login.intended', $this->redirectTo);
 

--- a/app/Http/Controllers/AuthController.php
+++ b/app/Http/Controllers/AuthController.php
@@ -48,7 +48,7 @@ class AuthController extends Controller
             session(['login.intended' => $intended]);
         }
 
-        $options = array_get($request->getQueryParams(), 'options');
+        $options = array_get($request->getQueryParams(), 'options') ?? [];
         $destination = array_get($request->getQueryParams(), 'destination');
         $url = session('login.intended', $this->redirectTo);
 


### PR DESCRIPTION
### What does this PR do?
This PR ensures that every Authorize() request to Gateway has an array of options, even if its empty.


### Any background context you want to provide?
By potentially passing in the explicit null value, we're overriding the default array in Gateway, which is causing a server error when it tries to do an `array_merge` with the `$options`