### PR TITLE
(NOT 100% TESTED DONT MERGE) Queue refactor

### DIFF
--- a/resources/assets/actions/quiz.js
+++ b/resources/assets/actions/quiz.js
@@ -3,7 +3,7 @@
 import { find } from 'lodash';
 import {
   clickedSignUp,
-  queueEvent,
+  queueGenericAuthEvent,
   PICK_QUIZ_ANSWER,
   COMPARE_QUIZ_ANSWER,
   VIEW_QUIZ_RESULT,
@@ -35,7 +35,7 @@ export function quizConvert(quizId) {
       const quizData = getState().quiz[quizId];
       set(quizId, QUIZ_STORAGE_KEY, quizData.questions);
 
-      return dispatch(queueEvent('quizConvert', quizId));
+      return dispatch(queueGenericAuthEvent('quizConvert', quizId));
     }
 
     // Load questions from previous state if available

--- a/resources/assets/actions/reportback.js
+++ b/resources/assets/actions/reportback.js
@@ -17,7 +17,7 @@ import {
   REQUESTED_USER_SUBMISSIONS_FAILED,
   RECEIVED_USER_SUBMISSIONS,
   trackEvent,
-  queueEvent,
+  queueGenericAuthEvent,
 } from '../actions';
 
 /**
@@ -100,7 +100,7 @@ export function toggleReactionOn(reportbackItemId, termId, metadata) {
   return (dispatch, getState) => {
     // If the user is not logged in, handle this action later.
     if (! getState().user.id) {
-      dispatch(queueEvent('toggleReactionOn', reportbackItemId, termId));
+      dispatch(queueGenericAuthEvent('toggleReactionOn', reportbackItemId, termId));
       return;
     }
 

--- a/resources/assets/actions/signup.js
+++ b/resources/assets/actions/signup.js
@@ -8,7 +8,7 @@ import {
   SIGNUP_NOT_FOUND,
   SIGNUP_PENDING,
   SET_TOTAL_SIGNUPS,
-  queueEvent,
+  queueGenericAuthEvent,
   trackEvent,
   addNotification,
   openModal,
@@ -107,7 +107,7 @@ export function clickedSignUp(campaignId, metadata, shouldRedirectToActionTab = 
   return (dispatch, getState) => {
     // If the user is not logged in, handle this action later.
     if (! getState().user.id) {
-      return dispatch(queueEvent('clickedSignUp', campaignId, metadata));
+      return dispatch(queueGenericAuthEvent('clickedSignUp', campaignId, metadata));
     }
 
     // If we already have a signup, just go to the action page.

--- a/resources/assets/actions/signup.js
+++ b/resources/assets/actions/signup.js
@@ -9,6 +9,7 @@ import {
   SIGNUP_PENDING,
   SET_TOTAL_SIGNUPS,
   queueGenericAuthEvent,
+  queueFacebookAuthEvent,
   trackEvent,
   addNotification,
   openModal,
@@ -107,7 +108,7 @@ export function clickedSignUp(campaignId, metadata, shouldRedirectToActionTab = 
   return (dispatch, getState) => {
     // If the user is not logged in, handle this action later.
     if (! getState().user.id) {
-      return dispatch(queueGenericAuthEvent('clickedSignUp', campaignId, metadata));
+      return dispatch(queueGenericAuthEvent('clickedSignUp', campaignId, metadata, shouldRedirectToActionTab));
     }
 
     // If we already have a signup, just go to the action page.
@@ -138,5 +139,18 @@ export function clickedSignUp(campaignId, metadata, shouldRedirectToActionTab = 
         }
       }
     });
+  };
+}
+
+// Async Action: check if user is signed in, if not send to Facebook,
+// otherwise defer to signup action.
+export function clickedFacebookSignup(campaignId, metadata, shouldRedirectToActionTab = true) {
+  return (dispatch, getState) => {
+    // If the user is not logged in, handle this action later.
+    if (! getState().user.id) {
+      return dispatch(queueFacebookAuthEvent('clickedSignUp', campaignId, metadata, shouldRedirectToActionTab));
+    }
+
+    return dispatch(clickedSignUp(campaignId, metadata, shouldRedirectToActionTab));
   };
 }

--- a/resources/assets/reducers/events.js
+++ b/resources/assets/reducers/events.js
@@ -20,7 +20,7 @@ const events = (state = {}, action) => {
       storageAppend(action.deviceId, EVENT_STORAGE_KEY, action);
 
       if (action.requiresAuth) {
-        window.location.href = '/next/login';
+        window.location.href = action.auth.url;
       }
 
       return state;


### PR DESCRIPTION
### What does this PR do?
- Cut out a some extra stuff from the events we're not going to use, makes the code a bit nicer
- Added different types of auth events (Generic & Facebook)
- Added example Facebook signup action (Not used anywhere yet)

### Any background context you want to provide?
We want to run experiments that let people authenticate via Facebook with a 1 click experience. This work allows us to run these experiments. 

For example in the Quiz action,

```
export function quizConvert(quizId) {
  return ((dispatch, getState) => {
    // If the user is not logged in, handle this action later.
    if (! getState().user.id) {
      const quizData = getState().quiz[quizId];
      set(quizId, QUIZ_STORAGE_KEY, quizData.questions);

      return dispatch(queueFacebookAuthEvent('quizConvert', quizId));
    }
```

Note the last return!