### PR TITLE
Fixing the /campaigns page.

### DIFF
--- a/app/helpers.php
+++ b/app/helpers.php
@@ -291,14 +291,16 @@ function get_client_environment_vars()
  */
 function get_login_query($campaign = null)
 {
-    $title = $campaign ? $campaign->title : null;
+    if (! $campaign) {
+        return [];
+    }
 
     return [
-        'destination' => $title,
+        'destination' => $campaign->title,
         'options' => [
-            'title' => $title,
-            'coverImage' => $campaign ? get_image_url($campaign->coverImage) : null,
-            'callToAction' => $campaign ? $campaign->callToAction : null,
+            'title' => $campaign->title,
+            'coverImage' => get_image_url($campaign->coverImage),
+            'callToAction' => $campaign->callToAction,
         ],
     ];
 }

--- a/resources/views/partials/navigation.blade.php
+++ b/resources/views/partials/navigation.blade.php
@@ -25,7 +25,11 @@
                         <li><a href="{{ route('logout') }}" class="secondary-nav-item" id="link--logout">Log Out</a></li>
                     </ul>
                 @else
-                    <a href="{{ route('login', get_login_query($campaign)) }}">Log In</a>
+                    @if (isset($campaign))
+                        <a href="{{ route('login', get_login_query($campaign)) }}">Log In</a>
+                    @else
+                        <a href="{{ route('login') }}">Log In</a>
+                    @endif
                 @endif
             </li>
         </ul>


### PR DESCRIPTION
### What does this PR do?
This PR fixes some logic that was added to send campaign info to Northstar for when a user logs in. It accounted for when a user logs in via a specific campaign page, but not when logging in from any other page (which granted, we don't have right now unless you're an admin), like the `/campaigns` page.


### Any background context you want to provide?
I approached this solution keeping in mind that in the future, when we have static pages, etc on the Phoenix-Next platform, those pages won't have any campaign specific info to pass along to Northstar, so it only considers trying to do that if a `$campaigns` variable is even available.


