### PR TITLE
Action step header legacy styling

### DIFF
--- a/resources/assets/components/ActionPage/ActionStep.js
+++ b/resources/assets/components/ActionPage/ActionStep.js
@@ -13,7 +13,7 @@ const renderPhoto = (photo, index) => (
   </div>
 );
 
-const ActionStep = ({ title, stepIndex, content, background, photos, photoWidth, shouldTruncate, hideStepNumber }) => ( // eslint-disable-line max-len
+const ActionStep = ({ title, stepIndex, content, background, photos, photoWidth, shouldTruncate, hideStepNumber, template }) => ( // eslint-disable-line max-len
   <FlexCell width="full">
     <div className={classnames('action-step', { '-truncate': shouldTruncate })}>
       <Flex>
@@ -22,6 +22,7 @@ const ActionStep = ({ title, stepIndex, content, background, photos, photoWidth,
           step={stepIndex}
           background={background}
           hideStepNumber={hideStepNumber}
+          template={template}
         />
         <FlexCell width="two-thirds">
           <Markdown>{ content }</Markdown>
@@ -45,6 +46,7 @@ ActionStep.propTypes = {
   photoWidth: PropTypes.string.isRequired,
   shouldTruncate: PropTypes.bool,
   hideStepNumber: PropTypes.bool,
+  template: PropTypes.string.isRequired,
 };
 
 ActionStep.defaultProps = {

--- a/resources/assets/components/ActionPage/ActionStep.js
+++ b/resources/assets/components/ActionPage/ActionStep.js
@@ -13,29 +13,35 @@ const renderPhoto = (photo, index) => (
   </div>
 );
 
-const ActionStep = ({ title, stepIndex, content, background, photos, photoWidth, shouldTruncate, hideStepNumber, template }) => ( // eslint-disable-line max-len
-  <FlexCell width="full">
-    <div className={classnames('action-step', { '-truncate': shouldTruncate })}>
-      <Flex>
-        <StepHeader
-          title={title}
-          step={stepIndex}
-          background={background}
-          hideStepNumber={hideStepNumber}
-          template={template}
-        />
-        <FlexCell width="two-thirds">
-          <Markdown>{ content }</Markdown>
-        </FlexCell>
-        <FlexCell width={photoWidth}>
-          <div className={`action-step__photos -${photoWidth}`}>
-            { photos ? photos.map(renderPhoto) : null }
-          </div>
-        </FlexCell>
-      </Flex>
-    </div>
-  </FlexCell>
-);
+const ActionStep = (props) => {
+  const {
+    title, stepIndex, content, background, photos,
+    photoWidth, shouldTruncate, hideStepNumber, template
+  } = props;
+  return (
+    <FlexCell width="full">
+      <div className={classnames('action-step', { '-truncate': shouldTruncate })}>
+        <Flex>
+          <StepHeader
+            title={title}
+            step={stepIndex}
+            background={background}
+            hideStepNumber={hideStepNumber}
+            template={template}
+          />
+          <FlexCell width="two-thirds">
+            <Markdown>{ content }</Markdown>
+          </FlexCell>
+          <FlexCell width={photoWidth}>
+            <div className={`action-step__photos -${photoWidth}`}>
+              { photos ? photos.map(renderPhoto) : null }
+            </div>
+          </FlexCell>
+        </Flex>
+      </div>
+    </FlexCell>
+  )
+};
 
 ActionStep.propTypes = {
   title: PropTypes.string.isRequired,

--- a/resources/assets/components/ActionPage/ActionStep.js
+++ b/resources/assets/components/ActionPage/ActionStep.js
@@ -16,7 +16,7 @@ const renderPhoto = (photo, index) => (
 const ActionStep = (props) => {
   const {
     title, stepIndex, content, background, photos,
-    photoWidth, shouldTruncate, hideStepNumber, template
+    photoWidth, shouldTruncate, hideStepNumber, template,
   } = props;
   return (
     <FlexCell width="full">
@@ -40,7 +40,7 @@ const ActionStep = (props) => {
         </Flex>
       </div>
     </FlexCell>
-  )
+  );
 };
 
 ActionStep.propTypes = {

--- a/resources/assets/components/ActionPage/ActionStepsWrapper.js
+++ b/resources/assets/components/ActionPage/ActionStepsWrapper.js
@@ -11,7 +11,7 @@ import { SubmissionGalleryContainer } from '../Gallery';
 
 const ActionStepsWrapper = (props) => {
   const { actionSteps, callToAction, campaignId, clickedSignUp,
-    hasPendingSignup, isAuthenticated, isSignedUp } = props;
+    hasPendingSignup, isAuthenticated, isSignedUp, template } = props;
 
   const renderPhotoUploader = photoUploaderProps => (
     <FlexCell key="reportback_uploader" width="full">
@@ -78,6 +78,7 @@ const ActionStepsWrapper = (props) => {
             photoWidth={step.displayOptions === 'full' ? 'full' : 'one-third'}
             hideStepNumber={additionalContent.hideStepNumber || false}
             shouldTruncate={step.truncate}
+            template={template}
           />
         );
     }
@@ -102,6 +103,7 @@ ActionStepsWrapper.propTypes = {
   hasPendingSignup: PropTypes.bool.isRequired,
   isSignedUp: PropTypes.bool.isRequired,
   isAuthenticated: PropTypes.bool.isRequired,
+  template: PropTypes.string.isRequired,
 };
 
 export default ActionStepsWrapper;

--- a/resources/assets/components/ActionPage/ActionStepsWrapperContainer.js
+++ b/resources/assets/components/ActionPage/ActionStepsWrapperContainer.js
@@ -11,6 +11,7 @@ const mapStateToProps = state => ({
   hasPendingSignup: state.signups.isPending,
   isSignedUp: state.signups.thisCampaign,
   isAuthenticated: state.user.id !== null,
+  template: state.campaign.template,
 });
 
 /**

--- a/resources/assets/components/ActionPage/StepHeader.js
+++ b/resources/assets/components/ActionPage/StepHeader.js
@@ -7,17 +7,21 @@ import MosaicStepHeaderTemplate from './templates/MosaicStepHeaderTemplate';
 const StepHeader = ({ title, step, background, hideStepNumber, template }) => {
   switch (template) {
     case 'legacy':
-      return <LegacyStepHeaderTemplate
-              title={title}
-              step={step}
-            />;
+      return (
+        <LegacyStepHeaderTemplate
+          title={title}
+          step={step}
+        />
+      );
     default:
-      return <MosaicStepHeaderTemplate
-              title={title}
-              step={step}
-              background={background}
-              hideStepNumber={hideStepNumber}
-            />;
+      return (
+        <MosaicStepHeaderTemplate
+          title={title}
+          step={step}
+          background={background}
+          hideStepNumber={hideStepNumber}
+        />
+      );
   }
 };
 

--- a/resources/assets/components/ActionPage/StepHeader.js
+++ b/resources/assets/components/ActionPage/StepHeader.js
@@ -11,6 +11,7 @@ const StepHeader = ({ title, step, background, hideStepNumber, template }) => {
         <LegacyStepHeaderTemplate
           title={title}
           step={step}
+          hideStepNumber={hideStepNumber}
         />
       );
     default:

--- a/resources/assets/components/ActionPage/StepHeader.js
+++ b/resources/assets/components/ActionPage/StepHeader.js
@@ -1,24 +1,32 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import { FlexCell } from '../Flex';
-import PhotoHeader from '../PhotoHeader';
-import { convertNumberToWord } from '../../helpers';
+import LegacyStepHeaderTemplate from './templates/LegacyStepHeaderTemplate';
+import MosaicStepHeaderTemplate from './templates/MosaicStepHeaderTemplate';
 
-const StepHeader = ({ title, step, background, hideStepNumber }) => (
-  <FlexCell width="full">
-    <PhotoHeader className="action-step__header" backgroundImage={background}>
-      { hideStepNumber ? null : <span>step { convertNumberToWord(step) }</span> }
-      <h1>{ title }</h1>
-    </PhotoHeader>
-  </FlexCell>
-);
+const StepHeader = ({ title, step, background, hideStepNumber, template }) => {
+  switch (template) {
+    case 'legacy':
+      return <LegacyStepHeaderTemplate
+              title={title}
+              step={step}
+            />;
+    default:
+      return <MosaicStepHeaderTemplate
+              title={title}
+              step={step}
+              background={background}
+              hideStepNumber={hideStepNumber}
+            />;
+  }
+};
 
 StepHeader.propTypes = {
   title: PropTypes.string.isRequired,
   step: PropTypes.number.isRequired,
   hideStepNumber: PropTypes.bool.isRequired,
   background: PropTypes.string,
+  template: PropTypes.string.isRequired,
 };
 
 StepHeader.defaultProps = {

--- a/resources/assets/components/ActionPage/actionPage.scss
+++ b/resources/assets/components/ActionPage/actionPage.scss
@@ -62,10 +62,7 @@
     }
   }
 
-  .heading.-banner.legacy-step-header span {
-    font-family: $primary-font-family;
-    padding: $base-spacing 0px 0px;
-    margin-left: 0px;
+  .legacy-step-header {
     width: 100%;
   }
 

--- a/resources/assets/components/ActionPage/actionPage.scss
+++ b/resources/assets/components/ActionPage/actionPage.scss
@@ -62,14 +62,11 @@
     }
   }
 
-  .heading.-banner.legacy-step-header {
-
-    span {
-      font-family: Proxima Nova;
-      padding: 24px 0px 0px;
-      margin-left: 0px;
-      width: 100%;
-    }
+  .heading.-banner.legacy-step-header span {
+    font-family: $font-proxima-nova;
+    padding: 24px 0px 0px;
+    margin-left: 0px;
+    width: 100%;
   }
 
 

--- a/resources/assets/components/ActionPage/actionPage.scss
+++ b/resources/assets/components/ActionPage/actionPage.scss
@@ -62,6 +62,18 @@
     }
   }
 
+  .heading.-banner.legacy-step-header {
+
+    span {
+      font-family: Proxima Nova;
+      padding: 24px 0px 0px;
+      margin-left: 0px;
+      width: 100%;
+    }
+  }
+
+
+
   // Custom overrides for the various layouts on tablet+ devices.
   @include media($medium) {
     .action-step__photos.-one-third {

--- a/resources/assets/components/ActionPage/actionPage.scss
+++ b/resources/assets/components/ActionPage/actionPage.scss
@@ -63,8 +63,8 @@
   }
 
   .heading.-banner.legacy-step-header span {
-    font-family: $font-proxima-nova;
-    padding: 24px 0px 0px;
+    font-family: $primary-font-family;
+    padding: $base-spacing 0px 0px;
     margin-left: 0px;
     width: 100%;
   }

--- a/resources/assets/components/ActionPage/templates/LegacyStepHeaderTemplate.js
+++ b/resources/assets/components/ActionPage/templates/LegacyStepHeaderTemplate.js
@@ -4,7 +4,7 @@ import { FlexCell } from '../../Flex';
 
 const LegacyStepHeaderTemplate = ({ title, step, hideStepNumber }) => (
   <FlexCell width="full">
-    <h2 className="heading -banner legacy-step-header">
+    <h2 className="heading -emphasized legacy-step-header">
       <span>
         { hideStepNumber ? null : `Step ${step}: ` }
         {title}

--- a/resources/assets/components/ActionPage/templates/LegacyStepHeaderTemplate.js
+++ b/resources/assets/components/ActionPage/templates/LegacyStepHeaderTemplate.js
@@ -1,0 +1,17 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const LegacyStepHeaderTemplate = ({ title, step }) => (
+  <h2 className="heading -banner">
+    <span style={{ fontFamily: 'Proxima Nova', padding: '24px 0px 0px', marginLeft: '0px', width: '100%' }}>
+      Step { String(step) }: {title}
+    </span>
+  </h2>
+);
+
+LegacyStepHeaderTemplate.propTypes = {
+  title: PropTypes.string.isRequired,
+  step: PropTypes.number.isRequired,
+};
+
+export default LegacyStepHeaderTemplate;

--- a/resources/assets/components/ActionPage/templates/LegacyStepHeaderTemplate.js
+++ b/resources/assets/components/ActionPage/templates/LegacyStepHeaderTemplate.js
@@ -1,12 +1,15 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { FlexCell } from '../../Flex';
 
 const LegacyStepHeaderTemplate = ({ title, step }) => (
-  <h2 className="heading -banner">
-    <span style={{ fontFamily: 'Proxima Nova', padding: '24px 0px 0px', marginLeft: '0px', width: '100%' }}>
-      Step { String(step) }: {title}
-    </span>
-  </h2>
+  <FlexCell width="full">
+    <h2 className="heading -banner legacy-step-header">
+      <span>
+        Step { String(step) }: {title}
+      </span>
+    </h2>
+  </FlexCell>
 );
 
 LegacyStepHeaderTemplate.propTypes = {

--- a/resources/assets/components/ActionPage/templates/LegacyStepHeaderTemplate.js
+++ b/resources/assets/components/ActionPage/templates/LegacyStepHeaderTemplate.js
@@ -2,11 +2,12 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { FlexCell } from '../../Flex';
 
-const LegacyStepHeaderTemplate = ({ title, step }) => (
+const LegacyStepHeaderTemplate = ({ title, step, hideStepNumber }) => (
   <FlexCell width="full">
     <h2 className="heading -banner legacy-step-header">
       <span>
-        Step { String(step) }: {title}
+        { hideStepNumber ? null : `Step ${step}: ` }
+        {title}
       </span>
     </h2>
   </FlexCell>
@@ -14,7 +15,13 @@ const LegacyStepHeaderTemplate = ({ title, step }) => (
 
 LegacyStepHeaderTemplate.propTypes = {
   title: PropTypes.string.isRequired,
-  step: PropTypes.number.isRequired,
+  step: PropTypes.number,
+  hideStepNumber: PropTypes.bool,
+};
+
+LegacyStepHeaderTemplate.defaultProps = {
+  step: null,
+  hideStepNumber: false,
 };
 
 export default LegacyStepHeaderTemplate;

--- a/resources/assets/components/ActionPage/templates/MosaicStepHeaderTemplate.js
+++ b/resources/assets/components/ActionPage/templates/MosaicStepHeaderTemplate.js
@@ -16,13 +16,15 @@ const MosaicStepHeaderTemplate = ({ title, step, background, hideStepNumber }) =
 
 MosaicStepHeaderTemplate.propTypes = {
   title: PropTypes.string.isRequired,
-  step: PropTypes.number.isRequired,
-  hideStepNumber: PropTypes.bool.isRequired,
+  step: PropTypes.number,
+  hideStepNumber: PropTypes.bool,
   background: PropTypes.string,
 };
 
 MosaicStepHeaderTemplate.defaultProps = {
   background: null,
+  step: null,
+  hideStepNumber: false,
 };
 
 export default MosaicStepHeaderTemplate;

--- a/resources/assets/components/ActionPage/templates/MosaicStepHeaderTemplate.js
+++ b/resources/assets/components/ActionPage/templates/MosaicStepHeaderTemplate.js
@@ -1,0 +1,25 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import { convertNumberToWord } from '../../../helpers';
+import PhotoHeader from '../../PhotoHeader';
+
+const MosaicStepHeaderTemplate = ({ title, step, background, hideStepNumber }) => (
+  <PhotoHeader className="action-step__header" backgroundImage={background}>
+    { hideStepNumber ? null : <span>step { convertNumberToWord(step) }</span> }
+    <h1>{ title }</h1>
+  </PhotoHeader>
+);
+
+MosaicStepHeaderTemplate.propTypes = {
+  title: PropTypes.string.isRequired,
+  step: PropTypes.number.isRequired,
+  hideStepNumber: PropTypes.bool.isRequired,
+  background: PropTypes.string,
+};
+
+MosaicStepHeaderTemplate.defaultProps = {
+  background: null,
+};
+
+export default MosaicStepHeaderTemplate;

--- a/resources/assets/components/ActionPage/templates/MosaicStepHeaderTemplate.js
+++ b/resources/assets/components/ActionPage/templates/MosaicStepHeaderTemplate.js
@@ -1,14 +1,17 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { FlexCell } from '../../Flex';
 
 import { convertNumberToWord } from '../../../helpers';
 import PhotoHeader from '../../PhotoHeader';
 
 const MosaicStepHeaderTemplate = ({ title, step, background, hideStepNumber }) => (
-  <PhotoHeader className="action-step__header" backgroundImage={background}>
-    { hideStepNumber ? null : <span>step { convertNumberToWord(step) }</span> }
-    <h1>{ title }</h1>
-  </PhotoHeader>
+  <FlexCell width="full">
+    <PhotoHeader className="action-step__header" backgroundImage={background}>
+      { hideStepNumber ? null : <span>step { convertNumberToWord(step) }</span> }
+      <h1>{ title }</h1>
+    </PhotoHeader>
+  </FlexCell>
 );
 
 MosaicStepHeaderTemplate.propTypes = {


### PR DESCRIPTION
### What does this PR do?
Adds ability to render Action Step Headers with legacy styling.


### Any background context you want to provide?
*My first pull request!!*
Basing a lot of this off of the logic @weerd implemented for the [`LedeBanner`](https://github.com/DoSomething/phoenix-next/blob/dev/resources/assets/components/LedeBanner/LedeBanner.js). Using a templates folder and `switch` logic checking which `campaign.template` is being rendered.


### What are the relevant tickets/cards?
https://www.pivotaltracker.com/story/show/150968514

### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.

