### PR TITLE
Fix for broken campaign update links that use old component.

### DIFF
--- a/resources/assets/components/Block/BlockWrapper.js
+++ b/resources/assets/components/Block/BlockWrapper.js
@@ -6,26 +6,26 @@ import { Link } from 'react-router-dom';
 import './block-wrapper.scss';
 
 type BlockTitleProps = {
-  id: ?string,
+  shareLink: ?string,
   title: ?string,
 };
 
-const BlockTitle = ({ id, title }: BlockTitleProps) => {
-  const titleElement = id ? <Link to={`/blocks/${id}`}>{title}</Link> : title;
+const BlockTitle = ({ shareLink, title }: BlockTitleProps) => {
+  const titleElement = shareLink ? <Link to={shareLink}>{title}</Link> : title;
 
   return <h4 className="block-wrapper__title">{titleElement}</h4>;
 };
 
 type BlockWrapperProps = {
+  children: ?Element<any>,
   className: ?string,
+  shareLink: ?string,
   title: ?string,
-  id: ?string,
-  children: ?Element<any>
-}
+};
 
-const BlockWrapper = ({ id, title, className, children }: BlockWrapperProps) => (
+const BlockWrapper = ({ title, className, children, shareLink = null }: BlockWrapperProps) => (
   <article className={classnames('block-wrapper', className)}>
-    { title ? <BlockTitle title={title} id={id} /> : null }
+    { title ? <BlockTitle title={title} shareLink={shareLink} /> : null }
     { children }
   </article>
 );

--- a/resources/assets/components/Block/BlockWrapper.js
+++ b/resources/assets/components/Block/BlockWrapper.js
@@ -10,7 +10,7 @@ type BlockTitleProps = {
   title: ?string,
 };
 
-const BlockTitle = ({ shareLink, title }: BlockTitleProps) => {
+const BlockTitle = ({ title, shareLink }: BlockTitleProps) => {
   const titleElement = shareLink ? <Link to={shareLink}>{title}</Link> : title;
 
   return <h4 className="block-wrapper__title">{titleElement}</h4>;
@@ -23,7 +23,7 @@ type BlockWrapperProps = {
   title: ?string,
 };
 
-const BlockWrapper = ({ title, className, children, shareLink = null }: BlockWrapperProps) => (
+const BlockWrapper = ({ title, className, children, shareLink }: BlockWrapperProps) => (
   <article className={classnames('block-wrapper', className)}>
     { title ? <BlockTitle title={title} shareLink={shareLink} /> : null }
     { children }

--- a/resources/assets/components/Block/BlockWrapper.test.js
+++ b/resources/assets/components/Block/BlockWrapper.test.js
@@ -18,7 +18,7 @@ test('it renders without children', () => {
 
 test('it renders correctly with title', () => {
   const component = shallow((
-    <BlockWrapper title="Lets Do This" id="123abc">
+    <BlockWrapper title="Lets Do This">
       <div id="tongue-cat" />
     </BlockWrapper>
   ));
@@ -29,7 +29,7 @@ test('it renders correctly with title', () => {
 test('it links to a block', () => {
   const wrapper = mount((
     <MemoryRouter>
-      <BlockWrapper title="Lets Do This" id="123abc">
+      <BlockWrapper title="Lets Do This" shareLink="/blocks/123abc">
         <div id="tongue-cat" />
       </BlockWrapper>
     </MemoryRouter>

--- a/resources/assets/components/Block/__snapshots__/BlockWrapper.test.js.snap
+++ b/resources/assets/components/Block/__snapshots__/BlockWrapper.test.js.snap
@@ -15,7 +15,6 @@ exports[`it renders correctly with title 1`] = `
   className="block-wrapper"
 >
   <BlockTitle
-    id="123abc"
     title="Lets Do This"
   />
   <div

--- a/resources/assets/components/CampaignUpdateBlock/CampaignUpdateBlock.js
+++ b/resources/assets/components/CampaignUpdateBlock/CampaignUpdateBlock.js
@@ -14,7 +14,7 @@ const CampaignUpdateBlock = (props) => {
   const isTweet = content.length < 144;
 
   return (
-    <BlockWrapper title="Campaign Update" id={props.id} shareLink={props.shareLink} >
+    <BlockWrapper title="Campaign Update" shareLink={props.shareLink} >
       { isTweet ? null : <h2>{title}</h2> }
 
       <Markdown className={classnames('campaign-update__content', { '-tweet': isTweet })}>
@@ -45,7 +45,6 @@ const CampaignUpdateBlock = (props) => {
 };
 
 CampaignUpdateBlock.propTypes = {
-  id: PropTypes.string.isRequired,
   shareLink: PropTypes.string.isRequired,
   fields: PropTypes.shape({
     title: PropTypes.string,

--- a/resources/assets/components/CampaignUpdateBlock/CampaignUpdateBlock.js
+++ b/resources/assets/components/CampaignUpdateBlock/CampaignUpdateBlock.js
@@ -14,7 +14,7 @@ const CampaignUpdateBlock = (props) => {
   const isTweet = content.length < 144;
 
   return (
-    <BlockWrapper title="Campaign Update" id={props.id}>
+    <BlockWrapper title="Campaign Update" id={props.id} shareLink={props.shareLink} >
       { isTweet ? null : <h2>{title}</h2> }
 
       <Markdown className={classnames('campaign-update__content', { '-tweet': isTweet })}>

--- a/resources/assets/components/CampaignUpdateBlock/__snapshots__/CampaignUpdate.test.js.snap
+++ b/resources/assets/components/CampaignUpdateBlock/__snapshots__/CampaignUpdate.test.js.snap
@@ -3,6 +3,7 @@
 exports[`Campaign Update Block with additional content as tweet snapshot test 1`] = `
 <BlockWrapper
   id="1234512345"
+  shareLink="http://example.com/link-to-content"
   title="Campaign Update"
 >
   <Markdown
@@ -29,6 +30,7 @@ exports[`Campaign Update Block with additional content as tweet snapshot test 1`
 exports[`Campaign Update Block with additional content snapshot test 1`] = `
 <BlockWrapper
   id="1234512345"
+  shareLink="http://example.com/link-to-content"
   title="Campaign Update"
 >
   <h2>
@@ -58,6 +60,7 @@ exports[`Campaign Update Block with additional content snapshot test 1`] = `
 exports[`Campaign Update Block with no additional content snapshot test 1`] = `
 <BlockWrapper
   id="1234512345"
+  shareLink="http://example.com/link-to-content"
   title="Campaign Update"
 >
   <h2>

--- a/resources/assets/components/CampaignUpdateBlock/__snapshots__/CampaignUpdate.test.js.snap
+++ b/resources/assets/components/CampaignUpdateBlock/__snapshots__/CampaignUpdate.test.js.snap
@@ -2,7 +2,6 @@
 
 exports[`Campaign Update Block with additional content as tweet snapshot test 1`] = `
 <BlockWrapper
-  id="1234512345"
   shareLink="http://example.com/link-to-content"
   title="Campaign Update"
 >
@@ -29,7 +28,6 @@ exports[`Campaign Update Block with additional content as tweet snapshot test 1`
 
 exports[`Campaign Update Block with additional content snapshot test 1`] = `
 <BlockWrapper
-  id="1234512345"
   shareLink="http://example.com/link-to-content"
   title="Campaign Update"
 >
@@ -59,7 +57,6 @@ exports[`Campaign Update Block with additional content snapshot test 1`] = `
 
 exports[`Campaign Update Block with no additional content snapshot test 1`] = `
 <BlockWrapper
-  id="1234512345"
   shareLink="http://example.com/link-to-content"
   title="Campaign Update"
 >

--- a/resources/assets/components/Quiz/Quiz.test.js
+++ b/resources/assets/components/Quiz/Quiz.test.js
@@ -9,11 +9,17 @@ test('it should display a placeholder quiz', () => {
   const wrapper = mount(
     <Quiz
       id="1"
-      fields={{ title: 'test title', introduction: 'introduction', questions: [] }}
-      startQuiz={() => {}}
+      fields={{
+        callToAction: 'do it',
+        conclusion: 'conclusion',
+        introduction: 'introduction',
+        title: 'test title',
+        questions: [],
+      }}
+      completeQuiz={() => {}}
       viewQuizResult={() => {}}
+      startQuiz={() => {}}
       pickQuizAnswer={() => {}}
-      compareQuizAnswer={() => {}}
     />,
   );
 

--- a/resources/assets/helpers/index.js
+++ b/resources/assets/helpers/index.js
@@ -284,9 +284,9 @@ export function makeHash(string) {
 /**
  * Make a shareable link to a content item.
  *
- * @param  {Object} state
- * @param  {String} key  An id or a slug for the content.
  * @param  {String} type
+ * @param  {Object} options
+ * @param  {String} key  An id or a slug for the content.
  * @return {String}
  * @flow
  */


### PR DESCRIPTION
### What does this PR do?
This PR fixes an issue where the link generated by the `BlockWrapper` used by the old `CampaignUpdateBlock` component would not be the full link with the campaign and campaign slug, thus the specific block page would end up being broken.


### What are the relevant tickets/cards?
Fixes item 11 on https://docs.google.com/spreadsheets/d/1pgnbX3eQDjWnvDPe1Afie4xyEGgwMdW7eXMXyNNs3IQ/edit#gid=0
