### PR TITLE
Path bug fix

### DIFF
--- a/resources/assets/actions/signup.js
+++ b/resources/assets/actions/signup.js
@@ -1,5 +1,7 @@
+import { join } from 'path';
 import { get } from 'lodash';
 import { push } from 'react-router-redux';
+
 import { Phoenix } from '@dosomething/gateway';
 import { isCampaignClosed } from '../helpers';
 import {
@@ -104,6 +106,8 @@ export function getTotalSignups(campaignId) {
 // check if the user is logged in or has an existing signup.
 export function clickedSignUp(campaignId, shouldRedirectToActionTab = true) {
   return (dispatch, getState) => {
+    const campaignActionUrl = join('/us/campaigns', getState().campaign.slug, '/action');
+
     // If the user is not logged in, handle this action later.
     if (! getState().user.id) {
       return dispatch(queueEvent('clickedSignUp', campaignId));
@@ -111,7 +115,7 @@ export function clickedSignUp(campaignId, shouldRedirectToActionTab = true) {
 
     // If we already have a signup, just go to the action page.
     if (getState().signups.data.includes(campaignId)) {
-      return shouldRedirectToActionTab ? dispatch(push('/action')) : null;
+      return shouldRedirectToActionTab ? dispatch(push(campaignActionUrl)) : null;
     }
 
     dispatch(signupPending());
@@ -132,7 +136,7 @@ export function clickedSignUp(campaignId, shouldRedirectToActionTab = true) {
         const isClosed = isCampaignClosed(endDate);
         if (shouldRedirectToActionTab && ! isClosed) {
           dispatch(openModal());
-          dispatch(push('/action'));
+          dispatch(push(campaignActionUrl));
         }
       }
     });

--- a/resources/assets/components/ActionPage/ActionStep.js
+++ b/resources/assets/components/ActionPage/ActionStep.js
@@ -29,9 +29,13 @@ const ActionStep = (props) => {
             hideStepNumber={hideStepNumber}
             template={template}
           />
-          <FlexCell width="two-thirds">
-            <Markdown>{ content }</Markdown>
-          </FlexCell>
+          { content ?
+            <FlexCell width="two-thirds">
+              <Markdown>{ content }</Markdown>
+            </FlexCell>
+            :
+            null
+          }
           <FlexCell width={photoWidth}>
             <div className={`action-step__photos -${photoWidth}`}>
               { photos ? photos.map(renderPhoto) : null }
@@ -46,7 +50,7 @@ const ActionStep = (props) => {
 ActionStep.propTypes = {
   title: PropTypes.string.isRequired,
   stepIndex: PropTypes.number.isRequired,
-  content: PropTypes.string.isRequired,
+  content: PropTypes.string,
   background: PropTypes.string,
   photos: PropTypes.arrayOf(PropTypes.string),
   photoWidth: PropTypes.string.isRequired,
@@ -57,6 +61,7 @@ ActionStep.propTypes = {
 
 ActionStep.defaultProps = {
   background: '',
+  content: null,
   photos: [],
   shouldTruncate: false,
   hideStepNumber: false,


### PR DESCRIPTION
### What does this PR do?
This PR fixes the post-signup return to the action page to use the correct full campaign path which includes the campaign slug.

It also updates the `ActionSteps` to _not_ require the `content` property and _not_ output anything if the Campaign Lead adds no content. This field is also _not_ set to be required in Contentful so it didn't make sense for it to be required in the component if the field could be left empty.

### What are the relevant tickets/cards?
https://docs.google.com/spreadsheets/d/1pgnbX3eQDjWnvDPe1Afie4xyEGgwMdW7eXMXyNNs3IQ/edit#gid=0

