### PR TITLE
Modal rework

### DIFF
--- a/resources/assets/actions/modal.js
+++ b/resources/assets/actions/modal.js
@@ -1,7 +1,7 @@
 import { OPEN_MODAL, CLOSE_MODAL } from '../actions';
 
-export function openModal() {
-  return { type: OPEN_MODAL };
+export function openModal(modalType, blockId) {
+  return { type: OPEN_MODAL, modalType, blockId };
 }
 
 export function closeModal() {

--- a/resources/assets/actions/signup.js
+++ b/resources/assets/actions/signup.js
@@ -2,6 +2,7 @@ import { get } from 'lodash';
 import { push } from 'react-router-redux';
 import { Phoenix } from '@dosomething/gateway';
 import { isCampaignClosed } from '../helpers';
+import { POST_SIGNUP_MODAL } from '../components/Modal';
 import {
   SIGNUP_CREATED,
   SIGNUP_FOUND,
@@ -131,7 +132,7 @@ export function clickedSignUp(campaignId, shouldRedirectToActionTab = true) {
         const endDate = get(getState().campaign.endDate, 'date', null);
         const isClosed = isCampaignClosed(endDate);
         if (shouldRedirectToActionTab && ! isClosed) {
-          dispatch(openModal());
+          dispatch(openModal(POST_SIGNUP_MODAL));
           dispatch(push('/action'));
         }
       }

--- a/resources/assets/components/Campaign/Campaign.js
+++ b/resources/assets/components/Campaign/Campaign.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import Modal from '../Modal';
+import ModalSwitch from '../Modal';
 import { CampaignPageContainer, LandingPageContainer } from '../Page';
 import NotificationContainer from '../../containers/NotificationContainer';
 
@@ -11,7 +11,7 @@ const Campaign = (props) => {
   return (
     <div>
       <NotificationContainer />
-      <Modal />
+      <ModalSwitch />
 
       {(! isAffiliated && useLandingPage) ?
         <LandingPageContainer {...props} />

--- a/resources/assets/components/CampaignUpdate/CampaignUpdate.test.js
+++ b/resources/assets/components/CampaignUpdate/CampaignUpdate.test.js
@@ -3,6 +3,9 @@ import { shallow } from 'enzyme';
 import { shallowToJson } from 'enzyme-to-json';
 import CampaignUpdate from './CampaignUpdate';
 
+// Mock Redux containers so we don't need Provider context.
+jest.mock('../Share/ShareContainer', () => 'Share');
+
 const author = {
   fields: {
     avatar: 'http://example.com/avatar-aang.jpg',

--- a/resources/assets/components/CampaignUpdate/__snapshots__/CampaignUpdate.test.js.snap
+++ b/resources/assets/components/CampaignUpdate/__snapshots__/CampaignUpdate.test.js.snap
@@ -22,7 +22,7 @@ exports[`it generates a campaign update snapshot 1`] = `
       jobTitle="The Last Airbender"
       share={null}
     />
-    <Connect(Share)
+    <Share
       className="float-right clear-none"
       link="http://example.com/link-to-content"
       parentSource="campaignUpdate"

--- a/resources/assets/components/Modal/Modal.js
+++ b/resources/assets/components/Modal/Modal.js
@@ -1,11 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import Portal from 'react-portal';
-import { closeModal } from '../../actions';
 import './modal.scss';
-
-import { AffirmationContainer } from '../Affirmation';
-import CompetitionContainer from '../../containers/CompetitionContainer';
 
 class Modal extends React.Component {
   constructor() {
@@ -23,28 +19,13 @@ class Modal extends React.Component {
   }
 
   render() {
-    const { shouldShowModal, competitionStep } = this.props;
-
-    // @TODO: These should be injected from outside this component.
-    const children = [
-      <AffirmationContainer key="affirmation" />,
-    ];
-    if (competitionStep) {
-      children.push(
-        <CompetitionContainer
-          key="competition"
-          content={competitionStep.content}
-          photo={competitionStep.photos[0]}
-          byline={competitionStep.additionalContent}
-        />,
-      );
-    }
+    const { shouldShowModal, children } = this.props;
 
     return (
       <Portal closeOnEsc isOpened={shouldShowModal}>
         <div className="modal" role="presentation" ref={node => this.node = node} onClick={this.handleOverlayClick}>
           <div className="modal__container">
-            { children.map(child => <div key={child.key} className="modal__slide">{child}</div>) }
+            { children }
             <button className="modal__exit" onClick={this.props.closeModal}>×</button>
           </div>
         </div>
@@ -56,31 +37,11 @@ class Modal extends React.Component {
 Modal.propTypes = {
   shouldShowModal: PropTypes.bool.isRequired,
   closeModal: PropTypes.func.isRequired,
-  competitionStep: PropTypes.shape({
-    content: PropTypes.string.isRequired,
-    photo: PropTypes.string,
-    additionalContent: PropTypes.shape({
-      author: PropTypes.string.isRequired,
-      jobTitle: PropTypes.string.isRequired,
-      avatar: PropTypes.string.isRequired,
-    }).isRequired,
-  }),
+  children: PropTypes.node,
 };
 
 Modal.defaultProps = {
-  competitionStep: null,
-};
-
-
-Modal.mapStateToProps = state => ({
-  shouldShowModal: state.modal.shouldShowModal,
-  competitionStep: state.campaign.actionSteps.find(step => (
-    step.customType && step.customType[0] === 'competition'
-  )),
-});
-
-Modal.actionCreators = {
-  closeModal,
+  children: null,
 };
 
 export default Modal;

--- a/resources/assets/components/Modal/ModalSwitch.js
+++ b/resources/assets/components/Modal/ModalSwitch.js
@@ -1,0 +1,28 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Modal, PostSignupModal, POST_SIGNUP_MODAL } from '../Modal';
+
+const ModalSwitch = (props) => {
+  const { modalType } = props;
+  let children = null;
+
+  switch (modalType) {
+    case POST_SIGNUP_MODAL: children = <PostSignupModal />; break;
+    // TODO: <Page Modal>
+    default: break;
+  }
+
+  return (
+    <Modal>{ children }</Modal>
+  );
+};
+
+ModalSwitch.propTypes = {
+  modalType: PropTypes.string,
+};
+
+ModalSwitch.defaultProps = {
+  modalType: null,
+};
+
+export default ModalSwitch;

--- a/resources/assets/components/Modal/configurations/PostSignupModal.js
+++ b/resources/assets/components/Modal/configurations/PostSignupModal.js
@@ -6,12 +6,11 @@ import CompetitionContainer from '../../../containers/CompetitionContainer';
 const PostSignupModal = ({ competitionStep }) => (
   <article>
     <div className="modal__slide">
-      <AffirmationContainer key="affirmation" />
+      <AffirmationContainer />
     </div>
     <div className="modal__slide">
       { competitionStep ? (
         <CompetitionContainer
-          key="competition"
           content={competitionStep.content}
           photo={competitionStep.photos[0]}
           byline={competitionStep.additionalContent}

--- a/resources/assets/components/Modal/configurations/PostSignupModal.js
+++ b/resources/assets/components/Modal/configurations/PostSignupModal.js
@@ -1,0 +1,40 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { AffirmationContainer } from '../../Affirmation';
+import CompetitionContainer from '../../../containers/CompetitionContainer';
+
+const PostSignupModal = ({ competitionStep }) => (
+  <article>
+    <div className="modal__slide">
+      <AffirmationContainer key="affirmation" />
+    </div>
+    <div className="modal__slide">
+      { competitionStep ? (
+        <CompetitionContainer
+          key="competition"
+          content={competitionStep.content}
+          photo={competitionStep.photos[0]}
+          byline={competitionStep.additionalContent}
+        />
+      ) : null }
+    </div>
+  </article>
+);
+
+PostSignupModal.propTypes = {
+  competitionStep: PropTypes.shape({
+    content: PropTypes.string.isRequired,
+    photo: PropTypes.string,
+    additionalContent: PropTypes.shape({
+      author: PropTypes.string.isRequired,
+      jobTitle: PropTypes.string.isRequired,
+      avatar: PropTypes.string.isRequired,
+    }).isRequired,
+  }),
+};
+
+PostSignupModal.defaultProps = {
+  competitionStep: null,
+};
+
+export default PostSignupModal;

--- a/resources/assets/components/Modal/containers/ModalContainer.js
+++ b/resources/assets/components/Modal/containers/ModalContainer.js
@@ -1,0 +1,13 @@
+import { connect } from 'react-redux';
+import { closeModal } from '../../../actions/modal';
+import Modal from '../Modal';
+
+const mapStateToProps = state => ({
+  shouldShowModal: state.modal.shouldShowModal,
+});
+
+const actionCreators = {
+  closeModal,
+};
+
+export default connect(mapStateToProps, actionCreators)(Modal);

--- a/resources/assets/components/Modal/containers/ModalSwitchContainer.js
+++ b/resources/assets/components/Modal/containers/ModalSwitchContainer.js
@@ -1,0 +1,8 @@
+import { connect } from 'react-redux';
+import ModalSwitch from '../ModalSwitch';
+
+const mapStateToProps = state => ({
+  modalType: state.modal.modalType,
+});
+
+export default connect(mapStateToProps)(ModalSwitch);

--- a/resources/assets/components/Modal/containers/PostSignupModalContainer.js
+++ b/resources/assets/components/Modal/containers/PostSignupModalContainer.js
@@ -1,0 +1,10 @@
+import { connect } from 'react-redux';
+import PostSignupModal from '../configurations/PostSignupModal';
+
+const mapStateToProps = state => ({
+  competitionStep: state.campaign.actionSteps.find(step => (
+    step.customType && step.customType[0] === 'competition'
+  )),
+});
+
+export default connect(mapStateToProps)(PostSignupModal);

--- a/resources/assets/components/Modal/index.js
+++ b/resources/assets/components/Modal/index.js
@@ -1,4 +1,6 @@
-import { connect } from 'react-redux';
-import Modal from './Modal';
+export default from './containers/ModalSwitchContainer';
 
-export default connect(Modal.mapStateToProps, Modal.actionCreators)(Modal);
+export Modal from './containers/ModalContainer';
+export PostSignupModal from './containers/PostSignupModalContainer';
+
+export const POST_SIGNUP_MODAL = 'POST_SIGNUP_MODAL';

--- a/resources/assets/components/Page/CampaignPage/CampaignPage.js
+++ b/resources/assets/components/Page/CampaignPage/CampaignPage.js
@@ -61,6 +61,13 @@ const CampaignPage = (props) => {
             <Route path={`${match.url}/pages/:slug`} component={CampaignSubPageContainer} />
             <Route path={`${match.url}/blocks/:id`} component={BlockContainer} />
             <Route path={`${match.url}/quiz/:slug`} component={QuizContainer} />
+            <Route
+              path={`${match.url}/modal/:id`}
+              render={() => {
+                console.log(match);
+                return <Redirect to={`${match.url}`} />;
+              }}
+            />
           </Switch>
         </Enclosure>
       </div>

--- a/resources/assets/reducers/modal.js
+++ b/resources/assets/reducers/modal.js
@@ -2,8 +2,20 @@ import { OPEN_MODAL, CLOSE_MODAL } from '../actions';
 
 const modal = (state = {}, action) => {
   switch (action.type) {
-    case OPEN_MODAL: return { ...state, shouldShowModal: true };
-    case CLOSE_MODAL: return { ...state, shouldShowModal: false };
+    case OPEN_MODAL: return {
+      ...state,
+      shouldShowModal: true,
+      modalType: action.modalType,
+      blockId: action.blockId,
+    };
+
+    case CLOSE_MODAL: return {
+      ...state,
+      shouldShowModal: false,
+      modalType: null,
+      blockId: null,
+    };
+
     default: return state;
   }
 };

--- a/resources/assets/store.js
+++ b/resources/assets/store.js
@@ -61,6 +61,8 @@ const initialState = {
   },
   experiments: {},
   modal: {
+    modalType: null,
+    blockId: null,
     shouldShowModal: false,
   },
   uploads: {},


### PR DESCRIPTION
### What does this PR do?
Stopping myself before this gets bigger 😬 

This PR will let us do a few custom modal types without making the Contentful build extreme. This PR itself was just making the modal more flexible, the next one will be rendering a given contentful ID from the `modal/${id}` route.

### Any background context you want to provide?
Basically, we now have a `Modal Switch` component that determines what components are injected into the `Modal` component. I added the PostSignup version so we retain that functionality, and the next option will be for rendering the given Contentful ID.