### PR TITLE
Adding ability to display a page in a modal

### DIFF
--- a/resources/assets/actions/modal.js
+++ b/resources/assets/actions/modal.js
@@ -1,7 +1,7 @@
 import { OPEN_MODAL, CLOSE_MODAL } from '../actions';
 
-export function openModal(modalType, blockId) {
-  return { type: OPEN_MODAL, modalType, blockId };
+export function openModal(modalType, contentfulId) {
+  return { type: OPEN_MODAL, modalType, contentfulId };
 }
 
 export function closeModal() {

--- a/resources/assets/components/Modal/ModalSwitch.js
+++ b/resources/assets/components/Modal/ModalSwitch.js
@@ -1,6 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Modal, PostSignupModal, POST_SIGNUP_MODAL } from '../Modal';
+import {
+  Modal, PostSignupModal, PageModal,
+  POST_SIGNUP_MODAL, PAGE_MODAL,
+} from '../Modal';
 
 const ModalSwitch = (props) => {
   const { modalType } = props;
@@ -8,7 +11,7 @@ const ModalSwitch = (props) => {
 
   switch (modalType) {
     case POST_SIGNUP_MODAL: children = <PostSignupModal />; break;
-    // TODO: <Page Modal>
+    case PAGE_MODAL: children = <PageModal />; break;
     default: break;
   }
 

--- a/resources/assets/components/Modal/configurations/PageModal.js
+++ b/resources/assets/components/Modal/configurations/PageModal.js
@@ -1,0 +1,20 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import Card from '../../Card';
+import Markdown from '../../Markdown';
+
+const PageModal = ({ content }) => (
+  <Card className="bordered padded modal__slide">
+    <Markdown>{ content }</Markdown>
+  </Card>
+);
+
+PageModal.propTypes = {
+  content: PropTypes.string,
+};
+
+PageModal.defaultProps = {
+  content: '',
+};
+
+export default PageModal;

--- a/resources/assets/components/Modal/configurations/PageModal.js
+++ b/resources/assets/components/Modal/configurations/PageModal.js
@@ -10,11 +10,7 @@ const PageModal = ({ content }) => (
 );
 
 PageModal.propTypes = {
-  content: PropTypes.string,
-};
-
-PageModal.defaultProps = {
-  content: '',
+  content: PropTypes.string.isRequired,
 };
 
 export default PageModal;

--- a/resources/assets/components/Modal/containers/PageModalContainer.js
+++ b/resources/assets/components/Modal/containers/PageModalContainer.js
@@ -8,10 +8,17 @@ const mapStateToProps = (state) => {
     return null;
   }
 
-  // TODO: Search other content objects, eg: blocks
-
   const page = find(state.campaign.pages, { id: contentfulId });
-  return page ? { content: page.fields.content } : null;
+  if (! page) {
+    return null;
+  }
+
+  const content = page.fields.content;
+  if (! content) {
+    return null;
+  }
+
+  return { content };
 };
 
 export default connect(mapStateToProps)(PageModal);

--- a/resources/assets/components/Modal/containers/PageModalContainer.js
+++ b/resources/assets/components/Modal/containers/PageModalContainer.js
@@ -1,0 +1,17 @@
+import { connect } from 'react-redux';
+import { find } from 'lodash';
+import PageModal from '../configurations/PageModal';
+
+const mapStateToProps = (state) => {
+  const blockId = state.modal.blockId;
+  if (! blockId) {
+    return null;
+  }
+
+  // TODO: Search other content objects, eg: blocks
+
+  const page = find(state.campaign.pages, { id: blockId });
+  return page ? { content: page.fields.content } : null;
+};
+
+export default connect(mapStateToProps)(PageModal);

--- a/resources/assets/components/Modal/containers/PageModalContainer.js
+++ b/resources/assets/components/Modal/containers/PageModalContainer.js
@@ -3,14 +3,14 @@ import { find } from 'lodash';
 import PageModal from '../configurations/PageModal';
 
 const mapStateToProps = (state) => {
-  const blockId = state.modal.blockId;
-  if (! blockId) {
+  const contentfulId = state.modal.contentfulId;
+  if (! contentfulId) {
     return null;
   }
 
   // TODO: Search other content objects, eg: blocks
 
-  const page = find(state.campaign.pages, { id: blockId });
+  const page = find(state.campaign.pages, { id: contentfulId });
   return page ? { content: page.fields.content } : null;
 };
 

--- a/resources/assets/components/Modal/index.js
+++ b/resources/assets/components/Modal/index.js
@@ -2,5 +2,7 @@ export default from './containers/ModalSwitchContainer';
 
 export Modal from './containers/ModalContainer';
 export PostSignupModal from './containers/PostSignupModalContainer';
+export PageModal from './containers/PageModalContainer';
 
 export const POST_SIGNUP_MODAL = 'POST_SIGNUP_MODAL';
+export const PAGE_MODAL = 'PAGE_MODAL';

--- a/resources/assets/components/Page/CampaignPage/CampaignPage.js
+++ b/resources/assets/components/Page/CampaignPage/CampaignPage.js
@@ -14,11 +14,15 @@ import { ActionPageContainer } from '../../ActionPage';
 import { CampaignSubPageContainer } from '../CampaignSubPage';
 import TabbedNavigationContainer from '../../../containers/TabbedNavigationContainer';
 import CampaignFooter from '../../CampaignFooter';
+import { PAGE_MODAL } from '../../Modal';
+
+// TODO: If they click a modal link from the action page, this takes them to the root /.
+// We should probably make a solution that lets them stay on the page they were already at.
 
 const CampaignPage = (props) => {
   const {
     affiliatePartners, affiliateSponsors, blurb, campaignLead, clickedSignUp, coverImage,
-    dashboard, endDate, isAffiliated, legacyCampaignId, match, slug, subtitle, template,
+    dashboard, endDate, isAffiliated, legacyCampaignId, match, openModal, slug, subtitle, template,
     title, totalCampaignSignups,
   } = props;
 
@@ -66,8 +70,8 @@ const CampaignPage = (props) => {
             <Route path={`${match.url}/quiz/:slug`} component={QuizContainer} />
             <Route
               path={`${match.url}/modal/:id`}
-              render={() => {
-                console.log(match);
+              render={(routingProps) => {
+                openModal(PAGE_MODAL, routingProps.match.params.id);
                 return <Redirect to={`${match.url}`} />;
               }}
             />
@@ -115,6 +119,7 @@ CampaignPage.propTypes = {
   template: PropTypes.string.isRequired,
   title: PropTypes.string.isRequired,
   totalCampaignSignups: PropTypes.number,
+  openModal: PropTypes.func.isRequired,
 };
 
 CampaignPage.defaultProps = {

--- a/resources/assets/components/Page/CampaignPage/CampaignPageContainer.js
+++ b/resources/assets/components/Page/CampaignPage/CampaignPageContainer.js
@@ -2,7 +2,7 @@ import { get } from 'lodash';
 import { connect } from 'react-redux';
 
 import CampaignPage from './CampaignPage';
-import { clickedSignUp, convertExperiment } from '../../../actions';
+import { clickedSignUp, convertExperiment, openModal } from '../../../actions';
 
 /**
  * Provide state from the Redux store as props for this component.
@@ -31,6 +31,7 @@ const mapStateToProps = state => ({
 const mapActionsToProps = {
   clickedSignUp,
   convertExperiment,
+  openModal,
 };
 
 /**

--- a/resources/assets/containers/CompetitionContainer.js
+++ b/resources/assets/containers/CompetitionContainer.js
@@ -1,6 +1,6 @@
 import { connect } from 'react-redux';
 import CompetitionBlock from '../components/CompetitionBlock';
-import { joinCompetition, checkForCompetition } from '../actions';
+import { joinCompetition, checkForCompetition } from '../actions/competition';
 
 /**
  * Provide state from the Redux store as props for this component.

--- a/resources/assets/reducers/modal.js
+++ b/resources/assets/reducers/modal.js
@@ -6,14 +6,14 @@ const modal = (state = {}, action) => {
       ...state,
       shouldShowModal: true,
       modalType: action.modalType,
-      blockId: action.blockId,
+      contentfulId: action.contentfulId,
     };
 
     case CLOSE_MODAL: return {
       ...state,
       shouldShowModal: false,
       modalType: null,
-      blockId: null,
+      contentfulId: null,
     };
 
     default: return state;

--- a/resources/assets/store.js
+++ b/resources/assets/store.js
@@ -62,7 +62,7 @@ const initialState = {
   experiments: {},
   modal: {
     modalType: null,
-    blockId: null,
+    contentfulId: null,
     shouldShowModal: false,
   },
   uploads: {},


### PR DESCRIPTION
### What does this PR do?
<img width="962" alt="screen shot 2017-09-21 at 3 43 10 pm" src="https://user-images.githubusercontent.com/897368/30715349-fceb30e4-9ee3-11e7-884d-a0dbd71831d5.png">

This PR lets you route to `/us/campaigns/test-teens-for-jeans/modal/24tJwKV9WgMoSmIcg2IgcE` which is the contentful id for the FAQ page of that campaign. 

### Any background context you want to provide?
As I noted in the comments if you link to a modal from a page other than the root it's going to annoy users because the page under the modal will be the root page. For the legacy experience, this should be fine, however, since we don't have tabs.

I also renamed `blockId` to `contentfulId` since it's not specific to blocks or pages technically 