### PR TITLE
reversing for activity feed ordering

### DIFF
--- a/app/Entities/Campaign.php
+++ b/app/Entities/Campaign.php
@@ -182,7 +182,7 @@ class Campaign extends Entity implements JsonSerializable
             // @TODO: Why is it 'activity_feed' oy? ;/
             'activityFeed' => $this->parseActivityFeed(
                 $this->activity_feed,
-                array_get($this->additionalContent, 'reverseUpdateOrder', true)
+                array_get($this->additionalContent, 'reverseActivityFeedOrder', true)
             ),
             'actionSteps' => $this->parseActionSteps($this->actionSteps),
             'quizzes' => $this->parseQuizzes($this->quizzes),

--- a/app/Entities/Campaign.php
+++ b/app/Entities/Campaign.php
@@ -79,9 +79,9 @@ class Campaign extends Entity implements JsonSerializable
      * @param  array $activityItems
      * @return array
      */
-    public function parseActivityFeed($activityItems)
+    public function parseActivityFeed($activityItems, $reverseActivityFeedOrder)
     {
-        return collect($activityItems)->map(function ($item) {
+        $parsedActivityItems = collect($activityItems)->map(function ($item) {
             switch ($item->getContentType()) {
                 case 'campaignUpdate':
                     return new CampaignUpdate($item->entry);
@@ -96,7 +96,13 @@ class Campaign extends Entity implements JsonSerializable
                 default:
                     return $item;
             }
-        })->flatten(1);
+        });
+
+        if ($reverseActivityFeedOrder) {
+            $parsedActivityItems = $parsedActivityItems->reverse();
+        }
+
+        return $parsedActivityItems->flatten(1);
     }
 
     /**
@@ -174,7 +180,10 @@ class Campaign extends Entity implements JsonSerializable
             'affiliateSponsors' => $this->parseAffiliates($this->affiliateSponsors),
             'affiliatePartners' => $this->parseAffiliates($this->affiliatePartners),
             // @TODO: Why is it 'activity_feed' oy? ;/
-            'activityFeed' => $this->parseActivityFeed($this->activity_feed),
+            'activityFeed' => $this->parseActivityFeed(
+                $this->activity_feed,
+                array_get($this->additionalContent, 'reverseUpdateOrder', true)
+            ),
             'actionSteps' => $this->parseActionSteps($this->actionSteps),
             'quizzes' => $this->parseQuizzes($this->quizzes),
             'dashboard' => $this->dashboard,

--- a/app/Entities/Campaign.php
+++ b/app/Entities/Campaign.php
@@ -79,7 +79,7 @@ class Campaign extends Entity implements JsonSerializable
      * @param  array $activityItems
      * @return array
      */
-    public function parseActivityFeed($activityItems, $reverseActivityFeedOrder)
+    public function parseActivityFeed($activityItems, $reverseActivityFeedOrder = true)
     {
         $parsedActivityItems = collect($activityItems)->map(function ($item) {
             switch ($item->getContentType()) {


### PR DESCRIPTION
### What does this PR do?
By default, a campaign's `activityFeed` order will be reversed to avoid dragging in Contentful. 
To cancel the reversing, the `reverseActivityFeedOrder` field in `additionalContent` should be set to `false`. (This'd probably apply to old campaigns where the order has already been manually reversed.)


### What are the relevant tickets/cards?
https://www.pivotaltracker.com/story/show/151126984

