### PR TITLE
PostGallery component for use on Legacy template and elsewhere.

### DIFF
--- a/resources/assets/actions/reportback.js
+++ b/resources/assets/actions/reportback.js
@@ -207,9 +207,6 @@ export function fetchReportbacks() {
     const node = getState().campaign.legacyCampaignId;
     const page = getState().reportbacks.page;
 
-    console.log(node);
-    console.log(page);
-
     dispatch(requestedReportbacks(node));
 
     (new Phoenix()).get('next/reportbackItems', { campaigns: node, page }).then((json) => {

--- a/resources/assets/actions/reportback.js
+++ b/resources/assets/actions/reportback.js
@@ -207,6 +207,9 @@ export function fetchReportbacks() {
     const node = getState().campaign.legacyCampaignId;
     const page = getState().reportbacks.page;
 
+    console.log(node);
+    console.log(page);
+
     dispatch(requestedReportbacks(node));
 
     (new Phoenix()).get('next/reportbackItems', { campaigns: node, page }).then((json) => {

--- a/resources/assets/components/ActionPage/ActionStepsWrapper.js
+++ b/resources/assets/components/ActionPage/ActionStepsWrapper.js
@@ -3,11 +3,12 @@ import PropTypes from 'prop-types';
 
 import ActionStep from './ActionStep';
 import Revealer from '../Revealer';
-import { Flex, FlexCell } from '../Flex';
 import { makeHash } from '../../helpers';
-import CompetitionContainer from '../../containers/CompetitionContainer';
-import { ReportbackUploaderContainer } from '../ReportbackUploader';
+import { Flex, FlexCell } from '../Flex';
+import { PostGalleryContainer } from '../Gallery';
 import { SubmissionGalleryContainer } from '../Gallery';
+import { ReportbackUploaderContainer } from '../ReportbackUploader';
+import CompetitionContainer from '../../containers/CompetitionContainer';
 
 const ActionStepsWrapper = (props) => {
   const { actionSteps, callToAction, campaignId, clickedSignUp,
@@ -17,6 +18,10 @@ const ActionStepsWrapper = (props) => {
     <FlexCell key="reportback_uploader" width="full">
       <ReportbackUploaderContainer {...photoUploaderProps} />
     </FlexCell>
+  );
+
+  const postGallery = (
+    <PostGalleryContainer key="post_gallery" />
   );
 
   const submissionGallery = (
@@ -87,6 +92,8 @@ const ActionStepsWrapper = (props) => {
   if (! isSignedUp) {
     stepComponents.push(actionRevealer);
   }
+
+  stepComponents.unshift(postGallery);
 
   return (
     <Flex>

--- a/resources/assets/components/ActionPage/ActionStepsWrapper.js
+++ b/resources/assets/components/ActionPage/ActionStepsWrapper.js
@@ -5,10 +5,9 @@ import ActionStep from './ActionStep';
 import Revealer from '../Revealer';
 import { makeHash } from '../../helpers';
 import { Flex, FlexCell } from '../Flex';
-import { PostGalleryContainer } from '../Gallery';
-import { SubmissionGalleryContainer } from '../Gallery';
 import { ReportbackUploaderContainer } from '../ReportbackUploader';
 import CompetitionContainer from '../../containers/CompetitionContainer';
+import { PostGalleryContainer, SubmissionGalleryContainer } from '../Gallery';
 
 const ActionStepsWrapper = (props) => {
   const { actionSteps, callToAction, campaignId, clickedSignUp,

--- a/resources/assets/components/ActionPage/ActionStepsWrapper.js
+++ b/resources/assets/components/ActionPage/ActionStepsWrapper.js
@@ -93,7 +93,9 @@ const ActionStepsWrapper = (props) => {
     stepComponents.push(actionRevealer);
   }
 
-  stepComponents.unshift(postGallery);
+  if (template === 'legacy') {
+    stepComponents.push(postGallery);
+  }
 
   return (
     <Flex>

--- a/resources/assets/components/Gallery/PostGallery.js
+++ b/resources/assets/components/Gallery/PostGallery.js
@@ -1,0 +1,37 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import Gallery from './Gallery';
+import ReportbackItemContainer from '../../containers/ReportbackItemContainer';
+
+class PostGallery extends React.Component {
+  constructor() {
+    super();
+
+    this.renderItem = this.renderItem.bind(this);
+  }
+
+  componentDidMount() {
+    console.log('PostGallery mounted!');
+  }
+
+  renderItem(key) {
+    const post = this.props.reportbacks.itemEntities[key];
+
+    return (
+      <ReportbackItemContainer key={key} id={post.id} />
+    );
+  }
+
+  render() {
+    const { isFetching, itemEntities } = this.props.reportbacks;
+
+    return isFetching
+      ? <div className="spinner -centered" />
+      : <Gallery type="triad">
+        {Object.keys(itemEntities).map(this.renderItem)}
+      </Gallery>;
+  }
+}
+
+export default PostGallery;

--- a/resources/assets/components/Gallery/PostGallery.js
+++ b/resources/assets/components/Gallery/PostGallery.js
@@ -12,14 +12,14 @@ class PostGallery extends React.Component {
   }
 
   componentDidMount() {
-    console.log('PostGallery mounted!');
+    //
   }
 
   renderItem(key) {
     const post = this.props.reportbacks.itemEntities[key];
 
     return (
-      <ReportbackItemContainer key={key} id={post.id} />
+      <ReportbackItemContainer key={key} id={post.reportback.id} />
     );
   }
 
@@ -33,5 +33,13 @@ class PostGallery extends React.Component {
       </Gallery>;
   }
 }
+
+PostGallery.propTypes = {
+  reportbacks: PropTypes.shape({
+    entities: PropTypes.objectOf(PropTypes.object),
+    isFetching: PropTypes.bool,
+    itemEntities: PropTypes.objectOf(PropTypes.object),
+  }),
+};
 
 export default PostGallery;

--- a/resources/assets/components/Gallery/PostGallery.js
+++ b/resources/assets/components/Gallery/PostGallery.js
@@ -39,7 +39,7 @@ PostGallery.propTypes = {
     entities: PropTypes.objectOf(PropTypes.object),
     isFetching: PropTypes.bool,
     itemEntities: PropTypes.objectOf(PropTypes.object),
-  }),
+  }).isRequired,
 };
 
 export default PostGallery;

--- a/resources/assets/components/Gallery/PostGalleryContainer.js
+++ b/resources/assets/components/Gallery/PostGalleryContainer.js
@@ -1,0 +1,14 @@
+import { connect } from 'react-redux';
+import PostGallery from './PostGallery';
+import { fetchReportbacks } from '../../actions';
+
+const mapStateToProps = state => ({
+  legacyCampaignId: state.campaign.legacyCampaignId,
+  reportbacks: state.reportbacks,
+});
+
+const mapActionsToProps = {
+  fetchReportbacks,
+};
+
+export default connect(mapStateToProps, mapActionsToProps)(PostGallery);

--- a/resources/assets/components/Gallery/SubmissionGallery.js
+++ b/resources/assets/components/Gallery/SubmissionGallery.js
@@ -1,8 +1,9 @@
-import PropTypes from 'prop-types';
 import React from 'react';
+import PropTypes from 'prop-types';
+
 import Gallery from './Gallery';
-import ReportbackItem from '../ReportbackItem';
 import { makeHash } from '../../helpers';
+import ReportbackItem from '../ReportbackItem';
 
 class SubmissionGallery extends React.Component {
   static renderReportbackItem(submission) {

--- a/resources/assets/components/Gallery/index.js
+++ b/resources/assets/components/Gallery/index.js
@@ -1,5 +1,9 @@
-export SubmissionGalleryContainer from './SubmissionGalleryContainer';
+export PostGallery from './PostGallery';
+
+export PostGalleryContainer from './PostGalleryContainer';
 
 export SubmissionGallery from './SubmissionGallery';
+
+export SubmissionGalleryContainer from './SubmissionGalleryContainer';
 
 export default from './Gallery';


### PR DESCRIPTION
### What does this PR do?
This PR does some initial work with getting a gallery of Reportbacks output on the Legacy template action page.

Example output:
![image](https://user-images.githubusercontent.com/105849/30877285-34e26a94-a2c7-11e7-91da-eb02682a012e.png)


### Any background context you want to provide?
Currently, this just loads whatever RBs have already been retrieved on initial page load and stored in the Redux store. Upcoming work will need to handle showing more of the RBs for a campaign when user clicks on a "view more" link.


### What are the relevant tickets/cards?
Refs https://www.pivotaltracker.com/story/show/151058515
