### PR TITLE
Design qa

### DIFF
--- a/resources/assets/components/Byline/Byline.js
+++ b/resources/assets/components/Byline/Byline.js
@@ -12,7 +12,6 @@ const Byline = ({ author, jobTitle, avatar, share, className }) => (
     <Figure
       size="small"
       alignment="left"
-      verticalAlignment="center"
       image={avatar}
       alt={`picture of ${author}`}
       imageClassName="avatar"

--- a/resources/assets/components/ReportbackItem/reportback-item.scss
+++ b/resources/assets/components/ReportbackItem/reportback-item.scss
@@ -21,7 +21,7 @@
   }
 
   > .figure__body p {
-    word-break: break-all;
+    word-break: break-word;
   }
 }
 

--- a/resources/assets/components/ReportbackItem/reportback-item.scss
+++ b/resources/assets/components/ReportbackItem/reportback-item.scss
@@ -19,6 +19,10 @@
       width: 480px; // HACK: Expand smaller images to fit in card.
     }
   }
+
+  > .figure__body p {
+    word-break: break-all;
+  }
 }
 
 .padded {

--- a/resources/assets/components/Share/share.scss
+++ b/resources/assets/components/Share/share.scss
@@ -20,7 +20,7 @@
     border: none;
     color: $light-gray;
 
-    &:hover {
+    &:hover, &:active, &:focus {
       color: $med-gray;
       cursor: pointer;
       background: none;

--- a/resources/assets/components/Share/share.scss
+++ b/resources/assets/components/Share/share.scss
@@ -23,6 +23,7 @@
     &:hover {
       color: $med-gray;
       cursor: pointer;
+      background: none;
     }
   }
 


### PR DESCRIPTION
### What does this PR do?
1. Fixes the reportback item going extra wide if the figure body is one continuous word (eg: a youtube link)

<img width="732" alt="screen shot 2017-09-27 at 10 19 05 am" src="https://user-images.githubusercontent.com/897368/30918839-b76ddbd2-a36d-11e7-92a1-e87d8c95548c.png">

2. Fixes the byline so it displays inline with the share

<img width="723" alt="screen shot 2017-09-27 at 10 19 24 am" src="https://user-images.githubusercontent.com/897368/30918859-c5c6826a-a36d-11e7-91b7-4f32d7b7e5cf.png">

3. Fixes the Share hover effect