### PR TITLE
Updates to use different sized cover images based on template.

### DIFF
--- a/resources/assets/components/LedeBanner/LedeBanner.js
+++ b/resources/assets/components/LedeBanner/LedeBanner.js
@@ -3,29 +3,22 @@ import PropTypes from 'prop-types';
 
 import LegacyTemplate from './templates/LegacyTemplate';
 import MosaicTemplate from './templates/MosaicTemplate';
-import { contentfulImageUrl } from '../../helpers';
 
 import './lede-banner.scss';
 
 const LedeBanner = (props) => {
-  const { coverImage, template } = props;
-
-  const backgroundImageUrl = contentfulImageUrl(coverImage.url, '800', '600', 'fill');
+  const { template } = props;
 
   switch (template) {
     case 'legacy':
-      return <LegacyTemplate backgroundImageUrl={backgroundImageUrl} {...props} />;
+      return <LegacyTemplate {...props} />;
 
     default:
-      return <MosaicTemplate backgroundImageUrl={backgroundImageUrl} {...props} />;
+      return <MosaicTemplate {...props} />;
   }
 };
 
 LedeBanner.propTypes = {
-  coverImage: PropTypes.shape({
-    description: PropTypes.string,
-    url: PropTypes.string,
-  }).isRequired,
   template: PropTypes.string.isRequired,
 };
 

--- a/resources/assets/components/LedeBanner/templates/LegacyTemplate.js
+++ b/resources/assets/components/LedeBanner/templates/LegacyTemplate.js
@@ -2,14 +2,15 @@ import React from 'react';
 import moment from 'moment';
 import PropTypes from 'prop-types';
 
-import SponsorPromotion from '../../SponsorPromotion';
 import SignupButtonFactory from '../../SignupButton';
+import SponsorPromotion from '../../SponsorPromotion';
+import { contentfulImageUrl } from '../../../helpers';
 
 const LegacyTemplate = (props) => {
   const {
     title,
     subtitle,
-    backgroundImageUrl,
+    coverImage,
     isAffiliated,
     legacyCampaignId,
     endDate,
@@ -17,7 +18,7 @@ const LegacyTemplate = (props) => {
   } = props;
 
   const backgroundImageStyle = {
-    backgroundImage: `url(${backgroundImageUrl})`,
+    backgroundImage: `url(${contentfulImageUrl(coverImage.url, '1440', '810', 'fill')})`,
   };
 
   // @TODO: consider whether there can be more than one affiliate, or
@@ -55,14 +56,17 @@ const LegacyTemplate = (props) => {
 };
 
 LegacyTemplate.propTypes = {
-  backgroundImageUrl: PropTypes.string.isRequired,
+  coverImage: PropTypes.shape({
+    description: PropTypes.string,
+    url: PropTypes.string,
+  }).isRequired,
   endDate: PropTypes.shape({
     date: PropTypes.string,
     timezone: PropTypes.string,
     timezone_type: PropTypes.int,
   }),
   isAffiliated: PropTypes.bool.isRequired,
-  affiliateSponsors: PropTypes.array.isRequired, // eslint-disable-line react/forbid-prop-types
+  affiliateSponsors: PropTypes.arrayOf(PropTypes.object).isRequired,
   legacyCampaignId: PropTypes.string.isRequired,
   subtitle: PropTypes.string.isRequired,
   title: PropTypes.string.isRequired,

--- a/resources/assets/components/LedeBanner/templates/MosaicTemplate.js
+++ b/resources/assets/components/LedeBanner/templates/MosaicTemplate.js
@@ -3,19 +3,20 @@ import PropTypes from 'prop-types';
 
 import Markdown from '../../Markdown';
 import SignupButtonFactory from '../../SignupButton';
+import { contentfulImageUrl } from '../../../helpers';
 
 const MosaicTemplate = (props) => {
   const {
     title,
     subtitle,
     blurb,
-    backgroundImageUrl,
+    coverImage,
     isAffiliated,
     legacyCampaignId,
   } = props;
 
   const backgroundImageStyle = {
-    backgroundImage: `url(${backgroundImageUrl})`,
+    backgroundImage: `url(${contentfulImageUrl(coverImage.url, '800', '600', 'fill')})`,
   };
 
   const SignupButton = SignupButtonFactory(({ clickedSignUp }) => (
@@ -42,8 +43,11 @@ const MosaicTemplate = (props) => {
 };
 
 MosaicTemplate.propTypes = {
-  backgroundImageUrl: PropTypes.string.isRequired,
   blurb: PropTypes.string.isRequired,
+  coverImage: PropTypes.shape({
+    description: PropTypes.string,
+    url: PropTypes.string,
+  }).isRequired,
   isAffiliated: PropTypes.bool.isRequired,
   legacyCampaignId: PropTypes.string.isRequired,
   subtitle: PropTypes.string.isRequired,


### PR DESCRIPTION
### What does this PR do?
This PR provides an update to allow using different sized cover images based on the template they are used in. The legacy template requires a wider image but currently it is using the mosaic sized cover image and stretching it... no longer!

### What are the relevant tickets/cards?
Fixes https://www.pivotaltracker.com/story/show/151521560
