### PR TITLE
Fix dashboard

### DIFF
--- a/resources/assets/components/Dashboard/index.js
+++ b/resources/assets/components/Dashboard/index.js
@@ -57,7 +57,7 @@ const Dashboard = (props) => {
 };
 
 Dashboard.propTypes = {
-  totalCampaignSignups: PropTypes.number.isRequired,
+  totalCampaignSignups: PropTypes.number,
   endDate: PropTypes.shape({
     date: PropTypes.string,
   }).isRequired,
@@ -74,6 +74,7 @@ Dashboard.propTypes = {
 };
 
 Dashboard.defaultProps = {
+  totalCampaignSignups: 0,
   content: {
     fields: {
       // ...!

--- a/resources/assets/components/Dashboard/index.js
+++ b/resources/assets/components/Dashboard/index.js
@@ -20,8 +20,10 @@ const Dashboard = (props) => {
    * @return {String}
    */
   function replaceTemplateVars(text) {
+    const totalCampaignSignups = (props.totalCampaignSignups || 0).toLocaleString();
+
     return text
-      .replace('{totalSignups}', props.totalCampaignSignups.toLocaleString())
+      .replace('{totalSignups}', totalCampaignSignups)
       .replace('{endDate}', getDaysBetween(new Date(), new Date(props.endDate.date)));
   }
 


### PR DESCRIPTION
### What does this PR do?
This PR guarantees we will no longer get any possible errors from the dashboard totalSignups being null or the prop value given being null.

(Also note: the default value in the store is 0)