### PR TITLE
rendering `a` tag when shareLink prop is absolute

### DIFF
--- a/resources/assets/components/Block/BlockWrapper.js
+++ b/resources/assets/components/Block/BlockWrapper.js
@@ -5,16 +5,21 @@ import classnames from 'classnames';
 import { Link } from 'react-router-dom';
 import './block-wrapper.scss';
 
-type BlockTitleProps = {
-  shareLink: ?string,
-  title: ?string,
+type BlockTitleLinkProps = {
+  shareLink: string,
+  title: string,
 };
 
-const BlockTitleLink = ({ title, shareLink }: BlockTitleProps) => (
+const BlockTitleLink = ({ title, shareLink }: BlockTitleLinkProps) => (
   shareLink.match(/http/) ?
     <a href={shareLink}>{title}</a>
     : <Link to={shareLink}>{title}</Link>
 );
+
+type BlockTitleProps = {
+  shareLink: ?string,
+  title: ?string,
+};
 
 const BlockTitle = ({ title, shareLink }: BlockTitleProps) => {
   const titleElement = shareLink ? <BlockTitleLink title={title} shareLink={shareLink} /> : title;

--- a/resources/assets/components/Block/BlockWrapper.js
+++ b/resources/assets/components/Block/BlockWrapper.js
@@ -7,7 +7,7 @@ import './block-wrapper.scss';
 
 type BlockTitleLinkProps = {
   shareLink: string,
-  title: string,
+  title: ?string,
 };
 
 const BlockTitleLink = ({ title, shareLink }: BlockTitleLinkProps) => (

--- a/resources/assets/components/Block/BlockWrapper.js
+++ b/resources/assets/components/Block/BlockWrapper.js
@@ -10,8 +10,14 @@ type BlockTitleProps = {
   title: ?string,
 };
 
+const BlockTitleLink = ({ title, shareLink }: BlockTitleProps) => (
+  shareLink.match(/http/) ?
+    <a href={shareLink}>{title}</a>
+    : <Link to={shareLink}>{title}</Link>
+);
+
 const BlockTitle = ({ title, shareLink }: BlockTitleProps) => {
-  const titleElement = shareLink ? <Link to={shareLink}>{title}</Link> : title;
+  const titleElement = shareLink ? <BlockTitleLink title={title} shareLink={shareLink} /> : title;
 
   return <h4 className="block-wrapper__title">{titleElement}</h4>;
 };


### PR DESCRIPTION
### What does this PR do?
Temp fix for an issue with campaigns using the old campaign update block in activity feed. The link is a full absolute link that gets rendered in a React `Link`, that appends the given URL to the current URL, causing agony and grief.

![image](https://user-images.githubusercontent.com/12417657/31034713-42cdbbb8-a533-11e7-8060-08654fffd5c5.png)



### Any background context you want to provide?
This is a bit explicit and inelegant but perhaps a sufficient temporary fix for an issue we'd like to do away with. To quote the great Diego:

> "I’m debating if we should just transfer the old updates to the new style and call it a day. then we can ideally fully deprecate the old campaign update and remove it as an option for campaign leads to use :thinking_face:"