### PR TITLE
Fixing bug with repeated RB posts showing up.

### DIFF
--- a/resources/assets/components/Gallery/PostGallery/PostGallery.js
+++ b/resources/assets/components/Gallery/PostGallery/PostGallery.js
@@ -17,23 +17,24 @@ class PostGallery extends React.Component {
   }
 
   renderItem(key) {
-    const post = this.props.reportbacks.itemEntities[key];
+    const itemId = this.props.reportbacks.entities[key].reportback_items[0];
+    const post = this.props.reportbacks.itemEntities[itemId];
 
     return (
-      <Card className="rounded" key={key}>
+      <Card className="rounded" key={post.id}>
         <ReportbackItemContainer id={post.reportback.id} />
       </Card>
     );
   }
 
   render() {
-    const { isFetching, itemEntities } = this.props.reportbacks;
+    const { entities, isFetching } = this.props.reportbacks;
 
     return isFetching ?
       <div className="spinner -centered" />
       :
       <Gallery type="triad" className="expand-horizontal-md">
-        {Object.keys(itemEntities).map(this.renderItem)}
+        {Object.keys(entities).map(this.renderItem)}
       </Gallery>;
   }
 }

--- a/resources/assets/components/ReportbackItem/ReportbackItemContainer.js
+++ b/resources/assets/components/ReportbackItem/ReportbackItemContainer.js
@@ -11,11 +11,13 @@ import {
  */
 const mapStateToProps = (state, props) => {
   const reportback = state.reportbacks.entities[props.id];
+
   if (! reportback) {
     return { isFetching: true };
   }
 
   const reportbackItem = state.reportbacks.itemEntities[reportback.reportback_items[0]];
+
   return {
     isFetching: false,
     id: reportbackItem.id,


### PR DESCRIPTION
### What does this PR do?
This PR provides a fix for a bug where the `PostGallery` was showing all RB item posts for a user in the gallery, instead of just showing their latest post.

### What are the relevant tickets/cards?
Refs https://www.pivotaltracker.com/story/show/151058515
