### PR TITLE
fixing variable names

### DIFF
--- a/resources/assets/components/Share/Share.js
+++ b/resources/assets/components/Share/Share.js
@@ -18,7 +18,7 @@ const Share = (props) => {
   const onClick = () => {
     trackEvent('clicked facebook share', trackingData);
 
-    showFacebookSharePrompt({ link, quote }, (response) => {
+    showFacebookSharePrompt({ href: link, quote }, (response) => {
       if (response) {
         trackEvent('facebook share posted', trackingData);
       } else {


### PR DESCRIPTION
### What does this PR do?
the helper expects an `href` but it was being given a `url` prop instead, see example below

```
showFacebookSharePrompt({ link, quote }, (response) => {
```

```
export function showFacebookSharePrompt(share, callback) {
  const { href, quote } = share;
```
