### PR TITLE
Viewing more posts in post gallery.

### DIFF
--- a/resources/assets/actions/reportback.js
+++ b/resources/assets/actions/reportback.js
@@ -203,6 +203,8 @@ export function fetchUserReportbacks(userId, campaignId) {
 
 // Async Action: fetch another page of reportbacks.
 export function fetchReportbacks() {
+  console.log('🤖 Fetching Reportback!');
+
   return (dispatch, getState) => {
     const node = getState().campaign.legacyCampaignId;
     const page = getState().reportbacks.page;

--- a/resources/assets/actions/reportback.js
+++ b/resources/assets/actions/reportback.js
@@ -203,8 +203,6 @@ export function fetchUserReportbacks(userId, campaignId) {
 
 // Async Action: fetch another page of reportbacks.
 export function fetchReportbacks() {
-  console.log('🤖 Fetching Reportback!');
-
   return (dispatch, getState) => {
     const node = getState().campaign.legacyCampaignId;
     const page = getState().reportbacks.page;

--- a/resources/assets/components/ActionPage/ActionStepsWrapper.js
+++ b/resources/assets/components/ActionPage/ActionStepsWrapper.js
@@ -94,8 +94,8 @@ const ActionStepsWrapper = (props) => {
   }
 
   if (template === 'legacy') {
-    stepComponents.unshift(
-      <div key="user_gallery" className="margin-top-xlg margin-bottom-xlg">
+    stepComponents.push(
+      <div key="user_gallery" className="action-step margin-top-xlg margin-bottom-xlg margin-horizontal-md">
         <h2 className="heading -emphasized legacy-step-header margin-top-md margin-bottom-md">
           <span>User Gallery</span>
         </h2>

--- a/resources/assets/components/ActionPage/ActionStepsWrapper.js
+++ b/resources/assets/components/ActionPage/ActionStepsWrapper.js
@@ -94,7 +94,7 @@ const ActionStepsWrapper = (props) => {
   }
 
   if (template === 'legacy') {
-    stepComponents.push(
+    stepComponents.unshift(
       <div key="user_gallery" className="margin-top-xlg margin-bottom-xlg">
         <h2 className="heading -emphasized legacy-step-header margin-top-md margin-bottom-md">
           <span>User Gallery</span>

--- a/resources/assets/components/Button/button.scss
+++ b/resources/assets/components/Button/button.scss
@@ -10,4 +10,12 @@
   &.-align-right {
     float: right;
   }
+
+  &.-secondary,
+  &.is-loading {
+    &:focus {
+      border: 0 none;
+      box-shadow: none;
+    }
+  }
 }

--- a/resources/assets/components/Gallery/Gallery.js
+++ b/resources/assets/components/Gallery/Gallery.js
@@ -8,11 +8,11 @@ const renderGalleryItem = (child, index) => <li key={`submission-${index}`}>{chi
 
 const Gallery = ({ type, children, className = null }) => (
   children.length ?
-  <ul className={classnames('gallery', className, modifiers(type))}>
-    {children.map(renderGalleryItem)}
-  </ul>
-  :
-  null
+    <ul className={classnames('gallery', className, modifiers(type))}>
+      {children.map(renderGalleryItem)}
+    </ul>
+    :
+    null
 );
 
 Gallery.propTypes = {

--- a/resources/assets/components/Gallery/Gallery.js
+++ b/resources/assets/components/Gallery/Gallery.js
@@ -7,7 +7,12 @@ import { modifiers } from '../../helpers';
 const renderGalleryItem = (child, index) => <li key={`submission-${index}`}>{child}</li>;
 
 const Gallery = ({ type, children, className = null }) => (
-  children.length ? <ul className={classnames('gallery', className, modifiers(type))}>{children.map(renderGalleryItem)}</ul> : null
+  children.length ?
+  <ul className={classnames('gallery', className, modifiers(type))}>
+    {children.map(renderGalleryItem)}
+  </ul>
+  :
+  null
 );
 
 Gallery.propTypes = {

--- a/resources/assets/components/Gallery/PostGallery/PostGallery.js
+++ b/resources/assets/components/Gallery/PostGallery/PostGallery.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 
 import Card from '../../Card';
 import Gallery from '../Gallery';
+import LoadMore from '../../LoadMore';
 import ReportbackItemContainer from '../../ReportbackItem';
 
 class PostGallery extends React.Component {
@@ -10,10 +11,16 @@ class PostGallery extends React.Component {
     super();
 
     this.renderItem = this.renderItem.bind(this);
+
+    this.state = {
+      isLoading: true,
+    };
   }
 
   componentDidMount() {
-    //
+    this.setState({
+      isLoading: false,
+    });
   }
 
   renderItem(key) {
@@ -30,12 +37,18 @@ class PostGallery extends React.Component {
   render() {
     const { entities, isFetching } = this.props.reportbacks;
 
-    return isFetching ?
+    console.log(this.state.isLoading);
+
+    return this.state.isLoading ?
       <div className="spinner -centered" />
       :
-      <Gallery type="triad" className="expand-horizontal-md">
-        {Object.keys(entities).map(this.renderItem)}
-      </Gallery>;
+      <div>
+        <Gallery type="triad" className="expand-horizontal-md">
+          {Object.keys(entities).map(this.renderItem)}
+        </Gallery>
+
+        <LoadMore className="padding-lg" text="view more" onClick={this.props.fetchReportbacks} />
+      </div>;
   }
 }
 

--- a/resources/assets/components/Gallery/PostGallery/PostGallery.js
+++ b/resources/assets/components/Gallery/PostGallery/PostGallery.js
@@ -11,16 +11,6 @@ class PostGallery extends React.Component {
     super();
 
     this.renderItem = this.renderItem.bind(this);
-
-    this.state = {
-      isLoading: true,
-    };
-  }
-
-  componentDidMount() {
-    this.setState({
-      isLoading: false,
-    });
   }
 
   renderItem(key) {
@@ -37,9 +27,7 @@ class PostGallery extends React.Component {
   render() {
     const { entities, isFetching } = this.props.reportbacks;
 
-    console.log(this.state.isLoading);
-
-    return this.state.isLoading ?
+    return ! this.props.reportbacks.total ?
       <div className="spinner -centered" />
       :
       <div>
@@ -47,16 +35,18 @@ class PostGallery extends React.Component {
           {Object.keys(entities).map(this.renderItem)}
         </Gallery>
 
-        <LoadMore className="padding-lg" text="view more" onClick={this.props.fetchReportbacks} />
+        <LoadMore className="padding-lg text-centered" text="view more" onClick={this.props.fetchReportbacks} isLoading={isFetching} />
       </div>;
   }
 }
 
 PostGallery.propTypes = {
+  fetchReportbacks: PropTypes.func.isRequired,
   reportbacks: PropTypes.shape({
     entities: PropTypes.objectOf(PropTypes.object),
     isFetching: PropTypes.bool,
     itemEntities: PropTypes.objectOf(PropTypes.object),
+    total: PropTypes.number,
   }).isRequired,
 };
 

--- a/resources/assets/components/LoadMore/LoadMore.js
+++ b/resources/assets/components/LoadMore/LoadMore.js
@@ -1,0 +1,30 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import classnames from 'classnames';
+
+import Button from '../Button/Button';
+
+const LoadMore = ({
+  onClick,
+  buttonClassName = null,
+  className = null,
+  text = 'Load More',
+}) => (
+  <div className={classnames('loader', className)}>
+    <Button className={classnames(buttonClassName)} onClick={onClick} text={text} />
+  </div>
+);
+
+LoadMore.propTypes = {
+  buttonClassName: PropTypes.string,
+  className: PropTypes.string,
+  text: PropTypes.string,
+};
+
+LoadMore.defaultProps = {
+  buttonClassName: '-secondary',
+  className: null,
+  text: 'Load More',
+};
+
+export default LoadMore;

--- a/resources/assets/components/LoadMore/LoadMore.js
+++ b/resources/assets/components/LoadMore/LoadMore.js
@@ -8,22 +8,30 @@ const LoadMore = ({
   onClick,
   buttonClassName = null,
   className = null,
+  isLoading = false,
   text = 'Load More',
 }) => (
   <div className={classnames('loader', className)}>
-    <Button className={classnames(buttonClassName)} onClick={onClick} text={text} />
+    <Button
+      className={classnames(buttonClassName, { 'is-loading': isLoading })}
+      onClick={onClick}
+      text={text}
+    />
   </div>
 );
 
 LoadMore.propTypes = {
   buttonClassName: PropTypes.string,
   className: PropTypes.string,
+  isLoading: PropTypes.bool,
+  onClick: PropTypes.func.isRequired,
   text: PropTypes.string,
 };
 
 LoadMore.defaultProps = {
   buttonClassName: '-secondary',
   className: null,
+  isLoading: false,
   text: 'Load More',
 };
 

--- a/resources/assets/components/LoadMore/index.js
+++ b/resources/assets/components/LoadMore/index.js
@@ -1,0 +1,1 @@
+export default from './LoadMore';

--- a/resources/assets/components/ReportbackUploader/ReportbackUploader.js
+++ b/resources/assets/components/ReportbackUploader/ReportbackUploader.js
@@ -87,7 +87,7 @@ class ReportbackUploader extends React.Component {
     );
 
     return (
-      <BlockWrapper>
+      <BlockWrapper className="margin-horizontal-md">
         <div className="reportback-uploader">
           <h2 className="heading">Upload your photos</h2>
 

--- a/resources/assets/scss/base.scss
+++ b/resources/assets/scss/base.scss
@@ -165,6 +165,16 @@ h1, h2, h3, p {
   margin: $base-spacing;
 }
 
+.margin-horizontal-lg {
+  margin-left: $base-spacing;
+  margin-right: $base-spacing;
+}
+
+.margin-horizontal-md {
+  margin-left: $half-spacing;
+  margin-right: $half-spacing;
+}
+
 .margin-bottom-md {
   margin-bottom: $half-spacing;
 }
@@ -195,6 +205,10 @@ h1, h2, h3, p {
 
 .faded {
   opacity: 0.5;
+}
+
+.text-centered {
+  text-align: center;
 }
 
 .default-container {


### PR DESCRIPTION
### What does this PR do?
This PR updates the `PostGallery` to allow users to "view more" item posts in the gallery if there are more available. It currently does not show/hide the "view more" button based on whether there actually are more items or not. That's coming up in next PR.

![screen recording 2017-10-03 at 12 21 pm](https://user-images.githubusercontent.com/105849/31137036-e9d1f04e-a837-11e7-9fed-845e3785745e.gif)

This also addresses a visual bug on mobile where the Post uploader and the gallery did not have any spacing on either side. cc @lkpttn 

### Any background context you want to provide?
Next PR will also aim to tackle making sure there is always a full row at the bottom of the gallery as items are loaded. Currently the `fetchReportbacks()` method grabs 25 items, so there's always a single hanging post item at the bottom of the gallery if there are 25 or more. If there are less than 25 items, than an unfilled row it is.


### What are the relevant tickets/cards?
Refs https://www.pivotaltracker.com/story/show/151058515

