### PR TITLE
Sticky tab and scroll concierge™ fix

### DIFF
--- a/resources/assets/components/Page/CampaignPage/CampaignPage.js
+++ b/resources/assets/components/Page/CampaignPage/CampaignPage.js
@@ -42,7 +42,7 @@ const CampaignPage = (props) => {
         affiliateSponsors={affiliateSponsors}
       />
 
-      <div className="main">
+      <div className="main clearfix">
         { dashboard ?
           <Dashboard
             totalCampaignSignups={totalCampaignSignups}

--- a/resources/assets/components/ScrollConcierge/index.js
+++ b/resources/assets/components/ScrollConcierge/index.js
@@ -64,7 +64,8 @@ class ScrollConcierge extends React.Component {
     // Wait for headline font to load so we don't scroll to
     // the wrong place when the page reflows & offset changes.
     font.load().then(() => {
-      // Get node offset from top of viewport combined with scroll distance to obtain desired scroll target
+      // Get node offset from top of viewport combined with
+      // scroll distance to obtain desired scroll target
       const viewportOffset = this.node.getBoundingClientRect().top;
       const pageOffset = window.scrollY + viewportOffset;
 

--- a/resources/assets/components/ScrollConcierge/index.js
+++ b/resources/assets/components/ScrollConcierge/index.js
@@ -64,13 +64,14 @@ class ScrollConcierge extends React.Component {
     // Wait for headline font to load so we don't scroll to
     // the wrong place when the page reflows & offset changes.
     font.load().then(() => {
-      const offsetParent = this.node.offsetParent;
-      const offsetTop = offsetParent.offsetTop + this.node.offsetTop;
+      // Get node offset from top of viewport combined with scroll distance to obtain desired scroll target
+      const viewportOffset = this.node.getBoundingClientRect().top;
+      const pageOffset = window.scrollY + viewportOffset;
 
       const VISUAL_OFFSET = 95;
 
       // Wait until the page has finished layout, then scroll.
-      waitForLayout(() => scrollTo(offsetTop - VISUAL_OFFSET));
+      waitForLayout(() => scrollTo(pageOffset - VISUAL_OFFSET));
     });
   }
 

--- a/resources/assets/components/ScrollConcierge/index.js
+++ b/resources/assets/components/ScrollConcierge/index.js
@@ -64,10 +64,13 @@ class ScrollConcierge extends React.Component {
     // Wait for headline font to load so we don't scroll to
     // the wrong place when the page reflows & offset changes.
     font.load().then(() => {
+      const offsetParent = this.node.offsetParent;
+      const offsetTop = offsetParent.offsetTop + this.node.offsetTop;
+
       const VISUAL_OFFSET = 95;
 
       // Wait until the page has finished layout, then scroll.
-      waitForLayout(() => scrollTo(this.node.offsetTop - VISUAL_OFFSET));
+      waitForLayout(() => scrollTo(offsetTop - VISUAL_OFFSET));
     });
   }
 


### PR DESCRIPTION
### What does this PR do?
- Adds parent div offset in `ScrollConcierge` to account for the `div` in `CampaignPage` that encloses the `TabbedNavigation`
- Adds `clearfix` class to that new `div` to force wrap all content to make sticky tab work

### Any background context you want to provide?
The Tabbed Navigation and Scroll Concierge were out of order

![and-justice-for-all-movie-misquote-captioned](https://user-images.githubusercontent.com/12417657/31130952-ceeb60aa-a826-11e7-9cc2-3f92b053db09.gif)

due to a new parent element in `CampaignPage` that was messing with the Scroll Concierge[™]'s `offset` calculation (being that the node now has a new `offsetParent`) and since this new element wasn't wrapping all content properly, it was causing the `sticky` rule to fail on tabbed navigation.
But that all works now!!!!
(HT Dave and Diego!)

### What are the relevant tickets/cards?
https://www.pivotaltracker.com/story/show/151553928

### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.

