### PR TITLE
Update default database to match setup guide.

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,7 +7,7 @@ APP_URL=http://localhost
 DB_CONNECTION=mysql
 DB_HOST=127.0.0.1
 DB_PORT=3306
-DB_DATABASE=homestead
+DB_DATABASE=phoenix
 DB_USERNAME=homestead
 DB_PASSWORD=secret
 


### PR DESCRIPTION
### What does this PR do?
In our [Homestead setup guide](https://github.com/DoSomething/communal-docs/tree/master/Homestead), we create a `phoenix` database but in our default `.env` we just connect to `homestead`. We should use app-specific databases by default so we don't run into conflicts when working on more than one application. 🔨


### Any background context you want to provide?
This came up while some of the Team Bleed folks were setting up environments.

### What are the relevant tickets/cards?
N/A

### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
