### PR TITLE
fixing file path for italic @font-face

### DIFF
--- a/resources/assets/scss/fonts.scss
+++ b/resources/assets/scss/fonts.scss
@@ -25,8 +25,8 @@
 
 @font-face {
   font-family: 'Source Sans Pro';
-  src: url('../fonts/sourcesanspro-bold.woff') format('woff2'),
-       url('../fonts/sourcesanspro-bold.woff') format('woff');
+  src: url('../fonts/sourcesanspro-italic.woff') format('woff2'),
+       url('../fonts/sourcesanspro-italic.woff') format('woff');
   font-weight: 400;
   font-style: italic;
 }


### PR DESCRIPTION
### What does this PR do?
Fixes the path in the `@font-face` for italics to the proper italic font


### Any background context you want to provide?
Seems the path for italics was set to grab the `bold` font. Probably due to a copy-paste snafu.
The good news is we weren't rendering [`papyrus`](https://youtu.be/jVhlJNJopOQ)

![giphy](https://user-images.githubusercontent.com/12417657/31192749-218653ee-a910-11e7-8c64-2e55be34fd03.gif)



### What are the relevant tickets/cards?
https://www.pivotaltracker.com/story/show/151134350

### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.

