### PR TITLE
Post gallery show hide view more

### DIFF
--- a/resources/assets/actions/reportback.js
+++ b/resources/assets/actions/reportback.js
@@ -30,8 +30,25 @@ export function requestedReportbacks(node) {
 }
 
 // Action: new reportback data received.
-export function receivedReportbacks({ reportbacks, reportbackItems, reactions }, page, total) {
-  return { type: RECEIVED_REPORTBACKS, reportbacks, reportbackItems, reactions, page, total };
+export function receivedReportbacks(
+  {
+    reportbacks,
+    reportbackItems,
+    reactions,
+  },
+  currentPage,
+  totalPages,
+  total,
+) {
+  return {
+    type: RECEIVED_REPORTBACKS,
+    reportbacks,
+    reportbackItems,
+    reactions,
+    currentPage,
+    totalPages,
+    total,
+  };
 }
 
 // Action: toggled a reaction
@@ -204,17 +221,22 @@ export function fetchUserReportbacks(userId, campaignId) {
 // Async Action: fetch another page of reportbacks.
 export function fetchReportbacks() {
   return (dispatch, getState) => {
+    // console.log(getState().reportbacks);
+    // console.log(getState().reportbacks.currentPage, 'The current page...');
     const node = getState().campaign.legacyCampaignId;
-    const page = getState().reportbacks.page;
+    const page = getState().reportbacks.currentPage + 1;
+    // console.log(getState().reportbacks);
+    // console.log(page, 'The next page...');
 
     dispatch(requestedReportbacks(node));
 
     (new Phoenix()).get('next/reportbackItems', { campaigns: node, page }).then((json) => {
       const normalizedData = normalizeReportbackItemResponse(json.data);
       const currentPage = get(json, 'meta.pagination.current_page', 1);
+      const totalPages = get(json, 'meta.pagination.total_pages', 1);
       const total = get(json, 'meta.pagination.total', 0);
 
-      dispatch(receivedReportbacks(normalizedData, currentPage, total));
+      dispatch(receivedReportbacks(normalizedData, currentPage, totalPages, total));
     });
   };
 }

--- a/resources/assets/actions/reportback.js
+++ b/resources/assets/actions/reportback.js
@@ -221,12 +221,8 @@ export function fetchUserReportbacks(userId, campaignId) {
 // Async Action: fetch another page of reportbacks.
 export function fetchReportbacks() {
   return (dispatch, getState) => {
-    // console.log(getState().reportbacks);
-    // console.log(getState().reportbacks.currentPage, 'The current page...');
     const node = getState().campaign.legacyCampaignId;
     const page = getState().reportbacks.currentPage + 1;
-    // console.log(getState().reportbacks);
-    // console.log(page, 'The next page...');
 
     dispatch(requestedReportbacks(node));
 

--- a/resources/assets/components/Gallery/PostGallery/PostGallery.js
+++ b/resources/assets/components/Gallery/PostGallery/PostGallery.js
@@ -48,10 +48,12 @@ class PostGallery extends React.Component {
 PostGallery.propTypes = {
   fetchReportbacks: PropTypes.func.isRequired,
   reportbacks: PropTypes.shape({
+    currentPage: PropTypes.number,
     entities: PropTypes.objectOf(PropTypes.object),
     isFetching: PropTypes.bool,
     itemEntities: PropTypes.objectOf(PropTypes.object),
     total: PropTypes.number,
+    totalPages: PropTypes.number,
   }).isRequired,
 };
 

--- a/resources/assets/components/Gallery/PostGallery/PostGallery.js
+++ b/resources/assets/components/Gallery/PostGallery/PostGallery.js
@@ -25,9 +25,9 @@ class PostGallery extends React.Component {
   }
 
   render() {
-    const { entities, isFetching } = this.props.reportbacks;
+    const { currentPage, entities, isFetching, total, totalPages } = this.props.reportbacks;
 
-    return ! this.props.reportbacks.total ?
+    return ! total ?
       <div className="spinner -centered" />
       :
       <div>
@@ -35,7 +35,12 @@ class PostGallery extends React.Component {
           {Object.keys(entities).map(this.renderItem)}
         </Gallery>
 
-        <LoadMore className="padding-lg text-centered" text="view more" onClick={this.props.fetchReportbacks} isLoading={isFetching} />
+        {
+          currentPage !== totalPages ?
+            <LoadMore className="padding-lg text-centered" text="view more" onClick={this.props.fetchReportbacks} isLoading={isFetching} />
+            :
+            null
+        }
       </div>;
   }
 }

--- a/resources/assets/reducers/reportbacks.js
+++ b/resources/assets/reducers/reportbacks.js
@@ -19,10 +19,12 @@ const reportbacks = (state = {}, action) => {
       };
 
     case RECEIVED_REPORTBACKS:
+      // console.log(action, 'action');
       return {
         ...state,
+        currentPage: action.currentPage,
         isFetching: false,
-        page: action.page + 1,
+        totalPages: action.totalPages,
         total: action.total,
         ids: state.ids.concat(Object.keys(action.reportbacks)),
         entities: merge(state.entities, action.reportbacks),

--- a/resources/assets/reducers/reportbacks.js
+++ b/resources/assets/reducers/reportbacks.js
@@ -19,7 +19,6 @@ const reportbacks = (state = {}, action) => {
       };
 
     case RECEIVED_REPORTBACKS:
-      // console.log(action, 'action');
       return {
         ...state,
         currentPage: action.currentPage,

--- a/resources/assets/store.js
+++ b/resources/assets/store.js
@@ -19,9 +19,10 @@ const initialState = {
     activityFeed: [],
   },
   reportbacks: {
+    currentPage: 0,
     isFetching: false,
     total: 0,
-    page: 1,
+    totalPages: 1,
     ids: [],
     entities: {},
     itemEntities: {},


### PR DESCRIPTION
### What does this PR do?
This PR updates the `reportbacks` reducer to more clearly account for the current "page" of reportbacks and also pass along the total pages of reportbacks returned from the API.

This allows doing a check to then decide whether to show or hide the view more button for loading more RB post items depending on whether or not we've seen all the pages of items.


### What are the relevant tickets/cards?
Refs https://www.pivotaltracker.com/story/show/151058515
