### PR TITLE
Avoid empty items in row of posts 3 or 2 items across.

### DIFF
--- a/resources/assets/actions/reportback.js
+++ b/resources/assets/actions/reportback.js
@@ -221,7 +221,7 @@ export function fetchUserReportbacks(userId, campaignId) {
 // Async Action: fetch another page of reportbacks.
 export function fetchReportbacks() {
   return (dispatch, getState) => {
-    const count = 24;
+    const count = 24; // Count of items divisible by 2, 3, and 4,for full gallery rows!
     const node = getState().campaign.legacyCampaignId;
     const page = getState().reportbacks.currentPage + 1;
 

--- a/resources/assets/actions/reportback.js
+++ b/resources/assets/actions/reportback.js
@@ -221,12 +221,13 @@ export function fetchUserReportbacks(userId, campaignId) {
 // Async Action: fetch another page of reportbacks.
 export function fetchReportbacks() {
   return (dispatch, getState) => {
+    const count = 24;
     const node = getState().campaign.legacyCampaignId;
     const page = getState().reportbacks.currentPage + 1;
 
     dispatch(requestedReportbacks(node));
 
-    (new Phoenix()).get('next/reportbackItems', { campaigns: node, page }).then((json) => {
+    (new Phoenix()).get('next/reportbackItems', { campaigns: node, count, page }).then((json) => {
       const normalizedData = normalizeReportbackItemResponse(json.data);
       const currentPage = get(json, 'meta.pagination.current_page', 1);
       const totalPages = get(json, 'meta.pagination.total_pages', 1);


### PR DESCRIPTION
### What does this PR do?
This PR provides a simple (albeit hard coded for now) solution to ensure that we get items by page in a count divisible by both 2, 3, and 4 which is useful for how we display items in a variety of galleries.

### Any background context you want to provide?
Avoid this:
![image](https://user-images.githubusercontent.com/105849/31197325-b612bed6-a91e-11e7-97ba-d0c28152cefc.png)

Aiming for this:
![image](https://user-images.githubusercontent.com/105849/31197353-cfed744a-a91e-11e7-9f88-a55e3636e6ad.png)



### What are the relevant tickets/cards?
Refs https://www.pivotaltracker.com/story/show/151058515