### PR TITLE
Pass opt out option to queued event

### DIFF
--- a/resources/assets/actions/signup.js
+++ b/resources/assets/actions/signup.js
@@ -106,7 +106,7 @@ export function getTotalSignups(campaignId) {
 
 // Async Action: send signup to phoenix and
 // check if the user is logged in or has an existing signup.
-export function clickedSignUp(campaignId, shouldRedirectToActionTab = true) {
+export function clickedSignUp(campaignId, options = null, shouldRedirectToActionTab = true) {
   return (dispatch, getState) => {
     const campaignActionUrl = join('/us/campaigns', getState().campaign.slug, '/action');
 
@@ -114,15 +114,15 @@ export function clickedSignUp(campaignId, shouldRedirectToActionTab = true) {
     const campaignRunId = getState().campaign.legacyCampaignRunId;
 
     // If we show an affiliate option, send the value over to Rogue as details
-    let details = null;
+    let details = options;
 
-    if (getState().campaign.additionalContent.displayAffilitateOptOut) {
+    if (getState().campaign.additionalContent.displayAffilitateOptOut && ! details) {
       details = getState().signups.affiliateMessagingOptOut ? 'affiliate-opt-out' : null;
     }
 
     // If the user is not logged in, handle this action later.
     if (! getState().user.id) {
-      return dispatch(queueEvent('clickedSignUp', campaignId));
+      return dispatch(queueEvent('clickedSignUp', campaignId, details));
     }
 
     // If we already have a signup, just go to the action page.


### PR DESCRIPTION
### What does this PR do?

If a user is unauthenticated, they click to signup to a campaign and we redirect them to northstar. We then direct them back to PN where we re-initialize the store and lose any state we updated before the redirect

It looks like the signup action gets queued when that happens so I added support for an `options` parameter that we can pass in any options that got set before the redirect. That way if a user opts-out, then signs up, then signs in on northstar to authenticate, we caption the opt out value in the signup request. 

### What are the relevant tickets/cards?
Fixes a bug found where we were not capturing opt-in/opt-out options of unauthenticated users during campaign signup.

Fixes https://www.pivotaltracker.com/story/show/151767351

### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.

