### PR TITLE
Using display block instead of visibility

### DIFF
--- a/resources/assets/components/AffiliateOption/affiliateOption.scss
+++ b/resources/assets/components/AffiliateOption/affiliateOption.scss
@@ -19,10 +19,10 @@
   }
 
   .footnote-details {
-    visibility: hidden;
+    display: none;
 
     &.is-expanded {
-      visibility: visible;
+      display: block;
     }
   }
 }


### PR DESCRIPTION
### What does this PR do?
This PR removes the use of `visibility` to hide content, as it currently "jumps" the header to the center of the banner

<img width="419" alt="screen shot 2017-10-13 at 10 11 12 am" src="https://user-images.githubusercontent.com/897368/31550320-0432e97e-afff-11e7-9f7f-2d2691178257.png">

By using display block/none, it keeps things at the bottom

<img width="508" alt="screen shot 2017-10-13 at 10 11 26 am" src="https://user-images.githubusercontent.com/897368/31550334-0d366334-afff-11e7-98c4-32af96f6bab7.png">