### PR TITLE
Updating to add separate ThirdPartyAction component and new Actions directory.

### DIFF
--- a/app/Entities/Campaign.php
+++ b/app/Entities/Campaign.php
@@ -125,6 +125,10 @@ class Campaign extends Entity implements JsonSerializable
             $step->customType ? $data['customType'] = $step->customType->first() : null;
             $step->additionalContent ? $data['additionalContent'] = $step->additionalContent : null;
 
+            if ($step->type) {
+                $data['customType'] = $step->type;
+            }
+
             return $data;
         });
     }

--- a/resources/assets/components/ActionPage/ActionStepsWrapper.js
+++ b/resources/assets/components/ActionPage/ActionStepsWrapper.js
@@ -6,6 +6,7 @@ import Revealer from '../Revealer';
 import { makeHash } from '../../helpers';
 import { Flex, FlexCell } from '../Flex';
 import { PostGalleryContainer } from '../Gallery/PostGallery';
+import { ThirdPartyActionContainer } from '../Actions/ThirdPartyAction';
 import { ReportbackUploaderContainer } from '../ReportbackUploader';
 import { CompetitionBlockContainer } from '../CompetitionBlock';
 import { SubmissionGalleryContainer } from '../Gallery/SubmissionGallery';
@@ -68,6 +69,22 @@ const ActionStepsWrapper = (props) => {
 
       case 'submission-gallery':
         return isSignedUp ? submissionGallery : null;
+
+      case 'third-party-action':
+        stepIndex += 1;
+
+        return (
+          <ThirdPartyActionContainer
+            key={key}
+            title={title}
+            template="legacy"
+            content={content}
+            stepIndex={stepIndex}
+            dynamicLink={additionalContent.dynamicLink || null}
+            hideStepNumber={additionalContent.hideStepNumber || false}
+            dynamicUrlParams={additionalContent.dynamicUrlParams || null}
+          />
+        );
 
       default:
         stepIndex += 1;

--- a/resources/assets/components/Actions/ThirdPartyAction/ThirdPartyAction.js
+++ b/resources/assets/components/Actions/ThirdPartyAction/ThirdPartyAction.js
@@ -15,11 +15,9 @@ const ThirdParyAction = (props) => {
   let contentLink = '';
 
   const urlParams = dynamicUrlParams.map((param) => {
-    if (param === 'northstarId') {
-      return `northstarId=${userId}`;
-    }
+    const value = param === 'northstarId' ? userId : props[param];
 
-    return `${param}=${props[param]}`;
+    return `${param}=${value}`;
   });
 
   if (dynamicLink) {

--- a/resources/assets/components/Actions/ThirdPartyAction/ThirdPartyAction.js
+++ b/resources/assets/components/Actions/ThirdPartyAction/ThirdPartyAction.js
@@ -12,6 +12,8 @@ const ThirdParyAction = (props) => {
     template, title, userId,
   } = props;
 
+  let contentLink = '';
+
   const urlParams = dynamicUrlParams.map((param) => {
     if (param === 'northstarId') {
       return `northstarId=${userId}`;
@@ -20,10 +22,12 @@ const ThirdParyAction = (props) => {
     return `${param}=${props[param]}`;
   });
 
-  const contentLink = dynamicLink.indexOf('?') === -1 ?
-    `${dynamicLink}?${urlParams.join('&')}`
-    :
-    `${dynamicLink}&${urlParams.join('&')}`;
+  if (dynamicLink) {
+    contentLink = dynamicLink.indexOf('?') === -1 ?
+      `${dynamicLink}?${urlParams.join('&')}`
+      :
+      `${dynamicLink}&${urlParams.join('&')}`;
+  }
 
   return (
     <FlexCell width="full">
@@ -62,7 +66,7 @@ ThirdParyAction.propTypes = {
 ThirdParyAction.defaultProps = {
   content: null,
   dynamicLink: null,
-  dynamicUrlParams: null,
+  dynamicUrlParams: [],
   hideStepNumber: false,
   userId: null,
 };

--- a/resources/assets/components/Actions/ThirdPartyAction/ThirdPartyAction.js
+++ b/resources/assets/components/Actions/ThirdPartyAction/ThirdPartyAction.js
@@ -1,0 +1,70 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import classnames from 'classnames';
+
+import Markdown from '../../Markdown';
+import { Flex, FlexCell } from '../../Flex';
+import StepHeader from '../../ActionPage/StepHeader';
+
+const ThirdParyAction = (props) => {
+  const {
+    content, dynamicLink, dynamicUrlParams, hideStepNumber, stepIndex,
+    template, title, userId,
+  } = props;
+
+  const urlParams = dynamicUrlParams.map((param) => {
+    if (param === 'northstarId') {
+      return `northstarId=${userId}`;
+    }
+
+    return `${param}=${props[param]}`;
+  });
+
+  const contentLink = dynamicLink.indexOf('?') === -1 ?
+    `${dynamicLink}?${urlParams.join('&')}`
+    :
+    `${dynamicLink}&${urlParams.join('&')}`;
+
+  return (
+    <FlexCell width="full">
+      <div className={classnames('action-step')}>
+        <Flex>
+          <StepHeader
+            title={title}
+            step={stepIndex}
+            template={template}
+            hideStepNumber={hideStepNumber}
+          />
+          { content ?
+            <FlexCell width="two-thirds">
+              <Markdown>{ content.replace(/:::[a-zA-Z]*:::/gi, contentLink) }</Markdown>
+            </FlexCell>
+            :
+            null
+          }
+        </Flex>
+      </div>
+    </FlexCell>
+  );
+};
+
+ThirdParyAction.propTypes = {
+  content: PropTypes.string,
+  dynamicLink: PropTypes.string,
+  dynamicUrlParams: PropTypes.arrayOf(PropTypes.string),
+  hideStepNumber: PropTypes.bool,
+  stepIndex: PropTypes.number.isRequired,
+  template: PropTypes.string.isRequired,
+  title: PropTypes.string.isRequired,
+  userId: PropTypes.string,
+};
+
+ThirdParyAction.defaultProps = {
+  content: null,
+  dynamicLink: null,
+  dynamicUrlParams: null,
+  hideStepNumber: false,
+  userId: null,
+};
+
+export default ThirdParyAction;

--- a/resources/assets/components/Actions/ThirdPartyAction/ThirdPartyActionContainer.js
+++ b/resources/assets/components/Actions/ThirdPartyAction/ThirdPartyActionContainer.js
@@ -1,0 +1,9 @@
+import { connect } from 'react-redux';
+
+import ThirdPartyAction from './ThirdPartyAction';
+
+const mapStateToProps = state => ({
+  userId: state.user.id,
+});
+
+export default connect(mapStateToProps)(ThirdPartyAction);

--- a/resources/assets/components/Actions/ThirdPartyAction/index.js
+++ b/resources/assets/components/Actions/ThirdPartyAction/index.js
@@ -1,0 +1,8 @@
+export ThirdPartyAction from './ThirdPartyAction';
+
+export ThirdPartyActionContainer from './ThirdPartyActionContainer';
+
+/**
+ * By default we prefer to export the container.
+ */
+export default from './ThirdPartyActionContainer';

--- a/resources/assets/components/Actions/index.js
+++ b/resources/assets/components/Actions/index.js
@@ -1,0 +1,1 @@
+export * from './ThirdPartyAction';


### PR DESCRIPTION
### What does this PR do?
This PR adds a new `ThirdPartyAction` component which will _eventually_ be a custom type for allowing more flexibility when we have external actions that can be done in a campaign or otherwise (for now just in campaign). It's very similar to the `ActionStep` component but I decided to split it as its own component to help with future work on having actions be their own components and not necessarily be forced to be a "step" as well as allow for more flexibility in more unique action items.

This particular component is using the `customBlock` content type but renders as the `ThirdPartyAction` component and retrieves the user's Northstar ID to append to a custom external link that needed the id as a url param. URL params for now can be passed as a series of strings in an array in the `additionalContent` field.


### What are the relevant tickets/cards?
Refs https://www.pivotaltracker.com/story/show/151885515
