### PR TITLE
Enforcing landscape for shares

### DIFF
--- a/app/Entities/Campaign.php
+++ b/app/Entities/Campaign.php
@@ -176,7 +176,7 @@ class Campaign extends Entity implements JsonSerializable
             'coverImage' => [
                 'description' => $this->coverImage ? $this->coverImage->getDescription() : '',
                 'url' => get_image_url($this->coverImage),
-                'landscape_url' => get_image_url($this->coverImage, 'landscape'),
+                'landscapeUrl' => get_image_url($this->coverImage, 'landscape'),
             ],
             'affiliateSponsors' => $this->parseAffiliates($this->affiliateSponsors),
             'affiliatePartners' => $this->parseAffiliates($this->affiliatePartners),

--- a/app/Entities/Campaign.php
+++ b/app/Entities/Campaign.php
@@ -176,6 +176,7 @@ class Campaign extends Entity implements JsonSerializable
             'coverImage' => [
                 'description' => $this->coverImage ? $this->coverImage->getDescription() : '',
                 'url' => get_image_url($this->coverImage),
+                'landscape_url' => get_image_url($this->coverImage, 'landscape'),
             ],
             'affiliateSponsors' => $this->parseAffiliates($this->affiliateSponsors),
             'affiliatePartners' => $this->parseAffiliates($this->affiliatePartners),

--- a/app/Entities/SocialOverride.php
+++ b/app/Entities/SocialOverride.php
@@ -19,7 +19,7 @@ class SocialOverride extends Entity implements JsonSerializable
             'fields' => [
                 'title' => $this->title,
                 'callToAction' => $this->callToAction,
-                'coverImage' => get_image_url($this->coverImage),
+                'coverImage' => get_image_url($this->coverImage, 'landscape'),
                 'quote' => $this->quote,
             ],
         ];

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -260,7 +260,7 @@ function get_social_fields($campaign, $uri)
     // If the image is pulled from socialOverride, its going to be a string.
     // But if its pulled from campaignFlattened, its an object containing a url string.
     if (gettype($coverImage) === 'object') {
-        $coverImage = $coverImage->url;
+        $coverImage = $coverImage->landscape_url;
     }
 
     return [

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -260,7 +260,7 @@ function get_social_fields($campaign, $uri)
     // If the image is pulled from socialOverride, its going to be a string.
     // But if its pulled from campaignFlattened, its an object containing a url string.
     if (gettype($coverImage) === 'object') {
-        $coverImage = $coverImage->landscape_url;
+        $coverImage = $coverImage->landscapeUrl;
     }
 
     return [


### PR DESCRIPTION
### What does this PR do?
We're currently hitting the 8mb photo limit on Facebook for one of our campaigns, this PR ensures we always send a standard sized landscape image in our open graph tags.

Tested with a normal campaign and a social override 