### PR TITLE
Slideshow

### DIFF
--- a/resources/assets/actions/index.js
+++ b/resources/assets/actions/index.js
@@ -71,3 +71,6 @@ export const VIEW_QUIZ_RESULT = 'VIEW_QUIZ_RESULT';
 export const COMPARE_QUIZ_ANSWER = 'COMPARE_QUIZ_ANSWER';
 export const QUIZ_ERROR = 'QUIZ_ERROR';
 export * from './quiz';
+
+export const NEXT_SLIDE = 'NEXT_SLIDE';
+export * from './slideshow';

--- a/resources/assets/actions/slideshow.js
+++ b/resources/assets/actions/slideshow.js
@@ -1,5 +1,5 @@
 import { NEXT_SLIDE } from '../actions';
 
-export function nextSlide(slideshowId) {
+export function nextSlide(slideshowId) { // eslint-disable-line import/prefer-default-export
   return { type: NEXT_SLIDE, slideshowId };
 }

--- a/resources/assets/actions/slideshow.js
+++ b/resources/assets/actions/slideshow.js
@@ -1,0 +1,5 @@
+import { NEXT_SLIDE } from '../actions';
+
+export function nextSlide(slideshowId) {
+  return { type: NEXT_SLIDE, slideshowId };
+}

--- a/resources/assets/components/Modal/configurations/PostSignupModal.js
+++ b/resources/assets/components/Modal/configurations/PostSignupModal.js
@@ -2,11 +2,11 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { AffirmationContainer } from '../../Affirmation';
 import { CompetitionBlockContainer } from '../../CompetitionBlock';
-import Slideshow from '../../Slideshow';
+import SlideshowContainer from '../../Slideshow';
 
-const PostSignupModal = ({ competitionStep }) => (
+const PostSignupModal = ({ competitionStep, closeModal }) => (
   <div className="modal__slide">
-    <Slideshow slideshowId="post signup modal">
+    <SlideshowContainer slideshowId="post signup modal" onComplete={closeModal}>
       { competitionStep ? (
         <CompetitionBlockContainer
           content={competitionStep.content}
@@ -15,11 +15,12 @@ const PostSignupModal = ({ competitionStep }) => (
         />
       ) : null }
       <AffirmationContainer />
-    </Slideshow>
+    </SlideshowContainer>
   </div>
 );
 
 PostSignupModal.propTypes = {
+  closeModal: PropTypes.func.isRequired,
   competitionStep: PropTypes.shape({
     content: PropTypes.string.isRequired,
     photo: PropTypes.string,

--- a/resources/assets/components/Modal/configurations/PostSignupModal.js
+++ b/resources/assets/components/Modal/configurations/PostSignupModal.js
@@ -4,8 +4,6 @@ import { AffirmationContainer } from '../../Affirmation';
 import { CompetitionBlockContainer } from '../../CompetitionBlock';
 import SlideshowContainer from '../../Slideshow';
 
-import Card from '../../Card';
-
 const PostSignupModal = ({ competitionStep, closeModal }) => (
   <div className="modal__slide">
     <SlideshowContainer slideshowId="post signup modal" onComplete={closeModal}>
@@ -16,10 +14,6 @@ const PostSignupModal = ({ competitionStep, closeModal }) => (
           byline={competitionStep.additionalContent}
         />
       ) : null }
-      <Card className="bordered padded">
-        <h1>Why hello there,</h1>
-        <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras et libero blandit, fermentum ante vitae, consequat velit. Proin ac sem hendrerit, volutpat elit eget, tincidunt ex. Sed sed lectus tellus. Morbi eleifend mauris nec sem egestas tincidunt. Praesent sollicitudin turpis ac sem dictum tincidunt. Aliquam ut est in enim ullamcorper ullamcorper. In egestas quam quis elit molestie, sed volutpat arcu tincidunt. Quisque eu ultrices magna. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Vestibulum sit amet mi dignissim, vulputate augue ut, fermentum metus. Nunc a elit in sapien efficitur imperdiet. Maecenas eget posuere dolor. Nulla hendrerit, mauris eget cursus semper, erat nibh scelerisque lectus, sed scelerisque dui ex et lorem. Maecenas nibh nulla, sodales ut ullamcorper ullamcorper, ullamcorper non nisl.</p>
-      </Card>
       <AffirmationContainer />
     </SlideshowContainer>
   </div>

--- a/resources/assets/components/Modal/configurations/PostSignupModal.js
+++ b/resources/assets/components/Modal/configurations/PostSignupModal.js
@@ -6,7 +6,7 @@ import SlideshowContainer from '../../Slideshow';
 
 const PostSignupModal = ({ competitionStep, closeModal }) => (
   <div className="modal__slide">
-    <SlideshowContainer slideshowId="post signup modal" onComplete={closeModal}>
+    <SlideshowContainer slideshowId="post-signup-modal" onComplete={closeModal}>
       { competitionStep ? (
         <CompetitionBlockContainer
           content={competitionStep.content}

--- a/resources/assets/components/Modal/configurations/PostSignupModal.js
+++ b/resources/assets/components/Modal/configurations/PostSignupModal.js
@@ -2,13 +2,11 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { AffirmationContainer } from '../../Affirmation';
 import { CompetitionBlockContainer } from '../../CompetitionBlock';
+import Slideshow from '../../Slideshow';
 
 const PostSignupModal = ({ competitionStep }) => (
-  <article>
-    <div className="modal__slide">
-      <AffirmationContainer />
-    </div>
-    <div className="modal__slide">
+  <div className="modal__slide">
+    <Slideshow slideshowId="post signup modal">
       { competitionStep ? (
         <CompetitionBlockContainer
           content={competitionStep.content}
@@ -16,8 +14,9 @@ const PostSignupModal = ({ competitionStep }) => (
           byline={competitionStep.additionalContent}
         />
       ) : null }
-    </div>
-  </article>
+      <AffirmationContainer />
+    </Slideshow>
+  </div>
 );
 
 PostSignupModal.propTypes = {

--- a/resources/assets/components/Modal/configurations/PostSignupModal.js
+++ b/resources/assets/components/Modal/configurations/PostSignupModal.js
@@ -4,6 +4,8 @@ import { AffirmationContainer } from '../../Affirmation';
 import { CompetitionBlockContainer } from '../../CompetitionBlock';
 import SlideshowContainer from '../../Slideshow';
 
+import Card from '../../Card';
+
 const PostSignupModal = ({ competitionStep, closeModal }) => (
   <div className="modal__slide">
     <SlideshowContainer slideshowId="post signup modal" onComplete={closeModal}>
@@ -14,6 +16,10 @@ const PostSignupModal = ({ competitionStep, closeModal }) => (
           byline={competitionStep.additionalContent}
         />
       ) : null }
+      <Card className="bordered padded">
+        <h1>Why hello there,</h1>
+        <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras et libero blandit, fermentum ante vitae, consequat velit. Proin ac sem hendrerit, volutpat elit eget, tincidunt ex. Sed sed lectus tellus. Morbi eleifend mauris nec sem egestas tincidunt. Praesent sollicitudin turpis ac sem dictum tincidunt. Aliquam ut est in enim ullamcorper ullamcorper. In egestas quam quis elit molestie, sed volutpat arcu tincidunt. Quisque eu ultrices magna. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Vestibulum sit amet mi dignissim, vulputate augue ut, fermentum metus. Nunc a elit in sapien efficitur imperdiet. Maecenas eget posuere dolor. Nulla hendrerit, mauris eget cursus semper, erat nibh scelerisque lectus, sed scelerisque dui ex et lorem. Maecenas nibh nulla, sodales ut ullamcorper ullamcorper, ullamcorper non nisl.</p>
+      </Card>
       <AffirmationContainer />
     </SlideshowContainer>
   </div>

--- a/resources/assets/components/Modal/containers/PostSignupModalContainer.js
+++ b/resources/assets/components/Modal/containers/PostSignupModalContainer.js
@@ -1,5 +1,6 @@
 import { connect } from 'react-redux';
 import PostSignupModal from '../configurations/PostSignupModal';
+import { closeModal } from '../../../actions/modal';
 
 const mapStateToProps = state => ({
   competitionStep: state.campaign.actionSteps.find(step => (
@@ -7,4 +8,8 @@ const mapStateToProps = state => ({
   )),
 });
 
-export default connect(mapStateToProps)(PostSignupModal);
+const actionCreators = {
+  closeModal,
+};
+
+export default connect(mapStateToProps, actionCreators)(PostSignupModal);

--- a/resources/assets/components/Slideshow/Slideshow.js
+++ b/resources/assets/components/Slideshow/Slideshow.js
@@ -1,22 +1,24 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-const Slideshow = ({ closeModal, isFinalSlide, nextSlide, slide, slideshowId }) => (
+// TODO: Investigate why the `no-confusing-arrow` rule isn't working in this file.
+/* eslint-disable no-confusing-arrow */
+const Slideshow = ({ isFinalSlide, nextSlide, onComplete, slide, slideshowId }) => (
   <div className="slideshow">
     <div className="slideshow__slide">
       { slide }
     </div>
     <button
       className="button slideshow__button"
-      onClick={() => isFinalSlide ? closeModal() : nextSlide(slideshowId)}
+      onClick={() => isFinalSlide ? onComplete() : nextSlide(slideshowId)}
     >{ isFinalSlide ? 'Close' : 'Next' }</button>
   </div>
 );
 
 Slideshow.propTypes = {
-  closeModal: PropTypes.func.isRequired,
   isFinalSlide: PropTypes.bool.isRequired,
   nextSlide: PropTypes.func.isRequired,
+  onComplete: PropTypes.func.isRequired,
   slide: PropTypes.node.isRequired,
   slideshowId: PropTypes.string.isRequired,
 };

--- a/resources/assets/components/Slideshow/Slideshow.js
+++ b/resources/assets/components/Slideshow/Slideshow.js
@@ -1,0 +1,24 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const Slideshow = ({ closeModal, isFinalSlide, nextSlide, slide, slideshowId }) => ({
+  <div className="slideshow">
+    <div className="slideshow__slide">
+      { slide }
+    </div>
+    <button
+      className="button slideshow__button"
+      onClick={() => isFinalSlide ? closeModal() : nextSlide(slideshowId)}
+    >{ isFinalSlide ? 'Close' : 'Next' }</button>
+  </div>
+});
+
+Slideshow.propTypes = {
+  closeModal: PropTypes.func.isRequired,
+  isFinalSlide: PropTypes.bool.isRequired,
+  nextSlide: PropTypes.func.isRequired,
+  slide: PropTypes.node.isRequired,
+  slideshowId: PropTypes.string.isRequired,
+};
+
+export default Slideshow;

--- a/resources/assets/components/Slideshow/Slideshow.js
+++ b/resources/assets/components/Slideshow/Slideshow.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import './slideshow.scss';
 
 // TODO: Investigate why the `no-confusing-arrow` rule isn't working in this file.
 /* eslint-disable no-confusing-arrow */
@@ -9,7 +10,7 @@ const Slideshow = ({ isFinalSlide, nextSlide, onComplete, slide, slideshowId }) 
       { slide }
     </div>
     <button
-      className="button slideshow__button"
+      className="button slideshow__button margin-top-lg"
       onClick={() => isFinalSlide ? onComplete() : nextSlide(slideshowId)}
     >{ isFinalSlide ? 'Close' : 'Next' }</button>
   </div>

--- a/resources/assets/components/Slideshow/Slideshow.js
+++ b/resources/assets/components/Slideshow/Slideshow.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-const Slideshow = ({ closeModal, isFinalSlide, nextSlide, slide, slideshowId }) => ({
+const Slideshow = ({ closeModal, isFinalSlide, nextSlide, slide, slideshowId }) => (
   <div className="slideshow">
     <div className="slideshow__slide">
       { slide }
@@ -11,7 +11,7 @@ const Slideshow = ({ closeModal, isFinalSlide, nextSlide, slide, slideshowId }) 
       onClick={() => isFinalSlide ? closeModal() : nextSlide(slideshowId)}
     >{ isFinalSlide ? 'Close' : 'Next' }</button>
   </div>
-});
+);
 
 Slideshow.propTypes = {
   closeModal: PropTypes.func.isRequired,

--- a/resources/assets/components/Slideshow/SlideshowContainer.js
+++ b/resources/assets/components/Slideshow/SlideshowContainer.js
@@ -1,22 +1,21 @@
 import React from 'react';
 import { connect } from 'react-redux';
-import { closeModal, nextSlide } from '../../actions';
+import { nextSlide } from '../../actions/slideshow';
 import Slideshow from './Slideshow';
 
 const mapStateToOwnProps = (state, ownProps) => {
   const slideIndex = state.slideshow[ownProps.slideshowId] || 0;
   const children = React.Children.toArray(ownProps.children);
-  console.log(children);
+  const slide = children[slideIndex] || null;
 
   return {
-    slideIndex,
-    isFinalSlide: false,
-    slide: null,
+    isFinalSlide: slideIndex >= children.length - 1,
+    slide,
   };
 };
 
 const actionCreators = {
-  closeModal, nextSlide,
+  nextSlide,
 };
 
 export default connect(mapStateToOwnProps, actionCreators)(Slideshow);

--- a/resources/assets/components/Slideshow/SlideshowContainer.js
+++ b/resources/assets/components/Slideshow/SlideshowContainer.js
@@ -1,10 +1,18 @@
+import React from 'react';
 import { connect } from 'react-redux';
 import { closeModal, nextSlide } from '../../actions';
 import Slideshow from './Slideshow';
 
 const mapStateToOwnProps = (state, ownProps) => {
-  // TODO;
-  return {};
+  const slideIndex = state.slideshow[ownProps.slideshowId] || 0;
+  const children = React.Children.toArray(ownProps.children);
+  console.log(children);
+
+  return {
+    slideIndex,
+    isFinalSlide: false,
+    slide: null,
+  };
 };
 
 const actionCreators = {

--- a/resources/assets/components/Slideshow/SlideshowContainer.js
+++ b/resources/assets/components/Slideshow/SlideshowContainer.js
@@ -1,0 +1,14 @@
+import { connect } from 'react-redux';
+import { closeModal, nextSlide } from '../../actions';
+import Slideshow from './Slideshow';
+
+const mapStateToOwnProps = (state, ownProps) => {
+  // TODO;
+  return {};
+};
+
+const actionCreators = {
+  closeModal, nextSlide,
+};
+
+export default connect(mapStateToOwnProps, actionCreators)(Slideshow);

--- a/resources/assets/components/Slideshow/index.js
+++ b/resources/assets/components/Slideshow/index.js
@@ -1,0 +1,3 @@
+export default from './SlideshowContainer';
+
+export Slideshow from './Slideshow';

--- a/resources/assets/components/Slideshow/slideshow.scss
+++ b/resources/assets/components/Slideshow/slideshow.scss
@@ -1,0 +1,5 @@
+.slideshow {
+  .slideshow__button {
+    width: 100%;
+  }
+}

--- a/resources/assets/reducers/index.js
+++ b/resources/assets/reducers/index.js
@@ -8,6 +8,7 @@ export notifications from './notifications';
 export reportbacks from './reportbacks';
 export share from './share';
 export signups from './signups';
+export slideshow from './slideshow';
 export submissions from './submissions';
 export uploads from './uploads';
 export user from './user';

--- a/resources/assets/reducers/slideshow.js
+++ b/resources/assets/reducers/slideshow.js
@@ -1,0 +1,19 @@
+import { NEXT_SLIDE } from '../actions';
+
+const slideshowReducer = (state = {}, action) => {
+  switch (action.type) {
+    case NEXT_SLIDE: {
+      const { slideshowId } = action;
+
+      return {
+        ...state,
+        [slideshowId]: slideshowId in state ? state[slideshowId] + 1 : 0,
+      };
+    }
+
+    default:
+      return state;
+  }
+};
+
+export default slideshowReducer;

--- a/resources/assets/reducers/slideshow.js
+++ b/resources/assets/reducers/slideshow.js
@@ -7,7 +7,7 @@ const slideshowReducer = (state = {}, action) => {
 
       return {
         ...state,
-        [slideshowId]: slideshowId in state ? state[slideshowId] + 1 : 0,
+        [slideshowId]: slideshowId in state ? state[slideshowId] + 1 : 1,
       };
     }
 

--- a/resources/assets/store.js
+++ b/resources/assets/store.js
@@ -66,6 +66,7 @@ const initialState = {
   },
   uploads: {},
   quiz: {},
+  slideshow: {},
 };
 
 /**


### PR DESCRIPTION
### What does this PR do?
- Adds a Slideshow component. (See section below for implementation details)
- Implements the Slideshow in the Post Signup Modal

See it in action: 
![](https://thumbs.gfycat.com/IncompatibleFaithfulHammerheadshark-size_restricted.gif)

### Any background context you want to provide?
In order to use the Slideshow, simply drop in the component and each child will be treated as a slide. You can have multiple slide shows, because each has its own counter for the current slide. The slideshow container takes care of identifying the current slide and slicing it from the children (This sentence sounds horrifying).

Things that could be a later TODO
- Supply a class name, like how we do for the Card component
- Support a "back" button
- Automatically advance the slide when you join a competition? (@product)
- More styling options for the navigation?

### What are the relevant tickets/cards?
https://www.pivotaltracker.com/story/show/151721587
