### PR TITLE
Making sure additional content is an object not null

### DIFF
--- a/resources/assets/actions/signup.js
+++ b/resources/assets/actions/signup.js
@@ -116,7 +116,8 @@ export function clickedSignUp(campaignId, options = null, shouldRedirectToAction
     // If we show an affiliate option, send the value over to Rogue as details
     let details = options;
 
-    if (getState().campaign.additionalContent.displayAffilitateOptOut && ! details) {
+    const additionalContent = getState().campaign.additionalContent || {};
+    if (additionalContent.displayAffilitateOptOut && ! details) {
       details = getState().signups.affiliateMessagingOptOut ? 'affiliate-opt-out' : null;
     }
 


### PR DESCRIPTION
### Any background context you want to provide?
Currently helping-hands-puerto-rico has a null additionalContent field. It's not clear why but it's preventing people from signing up because we're accessing a property of null. This is a temp fix to quickly move to prod.