### PR TITLE
Sticky join button mobile

### DIFF
--- a/resources/assets/components/CallToAction/CallToAction.js
+++ b/resources/assets/components/CallToAction/CallToAction.js
@@ -11,13 +11,17 @@ type CallToActionProps = {
   className: ?string,
 };
 
-const CallToAction = ({ legacyCampaignId, className }: CallToActionProps) => (
-  <div className={classnames('call-to-action', className)}>
-    { SignupButtonFactory(({ clickedSignUp }) => (
-      <Button onClick={() => clickedSignUp(legacyCampaignId)} />
-    ), 'call to action', { text: 'join us' })}
-  </div>
-);
+const CallToAction = ({ legacyCampaignId, className }: CallToActionProps) => {
+  const SignupButton = SignupButtonFactory(({ clickedSignUp }) => (
+    <Button onClick={() => clickedSignUp(legacyCampaignId)} />
+  ), 'call to action', { text: 'join us' });
+
+  return (
+    <div className={classnames('call-to-action', className)}>
+      <SignupButton />
+    </div>
+  );
+};
 
 CallToAction.defaultProps = {
   className: null,

--- a/resources/assets/components/CallToAction/__snapshots__/test.js.snap
+++ b/resources/assets/components/CallToAction/__snapshots__/test.js.snap
@@ -3,5 +3,7 @@
 exports[`CallToAction snapshot test 1`] = `
 <div
   className="call-to-action sample-class"
-/>
+>
+  <Connect(PuckWrapper) />
+</div>
 `;

--- a/resources/assets/components/CallToAction/test.js
+++ b/resources/assets/components/CallToAction/test.js
@@ -1,10 +1,9 @@
 import React from 'react';
-import renderer from 'react-test-renderer';
 import { shallow } from 'enzyme';
 import { shallowToJson } from 'enzyme-to-json';
 import CallToAction from './CallToAction';
 
-const component = shallow(<CallToAction className="sample-class" onClick={() => {}} />)
+const component = shallow(<CallToAction className="sample-class" onClick={() => {}} />);
 
 test('CallToAction snapshot test', () => {
   const tree = shallowToJson(component);

--- a/resources/assets/components/CallToAction/test.js
+++ b/resources/assets/components/CallToAction/test.js
@@ -1,11 +1,13 @@
 import React from 'react';
 import renderer from 'react-test-renderer';
+import { shallow } from 'enzyme';
+import { shallowToJson } from 'enzyme-to-json';
 import CallToAction from './CallToAction';
 
+const component = shallow(<CallToAction className="sample-class" onClick={() => {}} />)
+
 test('CallToAction snapshot test', () => {
-  const tree = renderer.create(
-    <CallToAction className="sample-class" onClick={() => {}} />,
-  ).toJSON();
+  const tree = shallowToJson(component);
 
   expect(tree).toMatchSnapshot();
 });

--- a/resources/assets/components/Page/CampaignPage/CampaignPage.js
+++ b/resources/assets/components/Page/CampaignPage/CampaignPage.js
@@ -11,6 +11,7 @@ import { BlockContainer } from '../../Block';
 import { isCampaignClosed } from '../../../helpers';
 import LedeBanner from '../../LedeBanner/LedeBanner';
 import { ActionPageContainer } from '../../ActionPage';
+import { CallToActionContainer } from '../../CallToAction';
 import { CampaignSubPageContainer } from '../CampaignSubPage';
 import TabbedNavigationContainer from '../../Navigation/TabbedNavigationContainer';
 import CampaignFooter from '../../CampaignFooter';
@@ -87,6 +88,7 @@ const CampaignPage = (props) => {
             />
           </Switch>
         </Enclosure>
+        { ! isAffiliated ? <CallToActionContainer key="callToAction" className="-sticky" /> : null }
       </div>
 
       <CampaignFooter


### PR DESCRIPTION
### What does this PR do?
Adds sticky "Join Us" button to bottom of campaign page on mobile.



![sticky nav](https://user-images.githubusercontent.com/12417657/31677871-31e654da-b33a-11e7-810b-f1271a66e7d7.gif)
 


### Any background context you want to provide?
It's just a matter of placing the bare bones `CallToAction` component at the end of `CampaignPage`. The button in the revealer at the bottom of most pages disappears on small screens and the cta button appears and is sticky af. Pages that have a `CallToActionBlock` at the bottom such as `ComponentSubPage` will still show their own Join Us button, and if that's a problem we can work on some fix.


### What are the relevant tickets/cards?
https://www.pivotaltracker.com/story/show/151861749

### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.

