### PR TITLE
Revealer button shenanigans

### DIFF
--- a/resources/assets/components/ActionPage/ActionStepsWrapper.js
+++ b/resources/assets/components/ActionPage/ActionStepsWrapper.js
@@ -13,7 +13,7 @@ import { SubmissionGalleryContainer } from '../Gallery/SubmissionGallery';
 
 const ActionStepsWrapper = (props) => {
   const { actionSteps, callToAction, campaignId, clickedSignUp,
-    hasPendingSignup, isAuthenticated, isSignedUp, template } = props;
+    hasPendingSignup, isSignedUp, template } = props;
 
   const renderPhotoUploader = photoUploaderProps => (
     <FlexCell key="reportback_uploader" width="full">
@@ -38,7 +38,7 @@ const ActionStepsWrapper = (props) => {
       callToAction={callToAction}
       isLoading={hasPendingSignup}
       onReveal={() => clickedSignUp(campaignId, { source: 'action page revealer' })}
-      isAuthenticated={isAuthenticated}
+      isSignedUp={isSignedUp}
     />
   );
 
@@ -135,7 +135,6 @@ ActionStepsWrapper.propTypes = {
   clickedSignUp: PropTypes.func.isRequired,
   hasPendingSignup: PropTypes.bool.isRequired,
   isSignedUp: PropTypes.bool.isRequired,
-  isAuthenticated: PropTypes.bool.isRequired,
   template: PropTypes.string.isRequired,
 };
 

--- a/resources/assets/components/ActionPage/ActionStepsWrapperContainer.js
+++ b/resources/assets/components/ActionPage/ActionStepsWrapperContainer.js
@@ -10,7 +10,6 @@ const mapStateToProps = state => ({
   callToAction: state.campaign.callToAction,
   hasPendingSignup: state.signups.isPending,
   isSignedUp: state.signups.thisCampaign,
-  isAuthenticated: state.user.id !== null,
   template: state.campaign.template,
 });
 

--- a/resources/assets/components/CallToActionBlock/CallToActionBlock.js
+++ b/resources/assets/components/CallToActionBlock/CallToActionBlock.js
@@ -26,7 +26,7 @@ const renderBackgroundImageStyle = imageUrl => (
 
 const CallToActionBlock = (props) => {
   const { isAffiliated, fields, imageUrl, campaignId, modifierClasses,
-    noun, verb, buttonOverride } = props;
+    noun, verb, buttonOverride, className } = props;
   const { title, content, additionalContent } = fields;
 
   const hasPhoto = additionalContent ? additionalContent.hasPhoto : false;
@@ -34,7 +34,7 @@ const CallToActionBlock = (props) => {
   const defaultText = isAffiliated ? `${verb.plural} ${noun.plural}` : 'Join Us';
   const buttonText = buttonOverride || defaultText;
 
-  const signupButtonClassNames = `button ${isAffiliated ? '' : 'join-us'}`;
+  const signupButtonClassNames = `button ${isAffiliated ? '' : 'is-not-affiliated'} ${className}`;
 
   const SignupButton = SignupButtonFactory(({ clickedSignUp }) => (
     <button
@@ -65,6 +65,7 @@ const CallToActionBlock = (props) => {
 CallToActionBlock.propTypes = {
   buttonOverride: PropTypes.string,
   campaignId: PropTypes.string.isRequired,
+  className: PropTypes.string,
   fields: PropTypes.shape({
     title: PropTypes.string,
     content: PropTypes.string,
@@ -85,6 +86,7 @@ CallToActionBlock.propTypes = {
 
 CallToActionBlock.defaultProps = {
   buttonOverride: null,
+  className: '',
   fields: {
     title: 'Ready to start?',
   },

--- a/resources/assets/components/CallToActionBlock/CallToActionBlock.js
+++ b/resources/assets/components/CallToActionBlock/CallToActionBlock.js
@@ -34,8 +34,13 @@ const CallToActionBlock = (props) => {
   const defaultText = isAffiliated ? `${verb.plural} ${noun.plural}` : 'Join Us';
   const buttonText = buttonOverride || defaultText;
 
+  const signupButtonClassNames = `button ${isAffiliated ? '' : 'join-us'}`;
+
   const SignupButton = SignupButtonFactory(({ clickedSignUp }) => (
-    <button className="button" onClick={() => clickedSignUp(campaignId)}>{ buttonText }</button>
+    <button
+      className={signupButtonClassNames}
+      onClick={() => clickedSignUp(campaignId)}
+    >{ buttonText }</button>
   ), 'call to action block', { text: buttonText });
 
   return (

--- a/resources/assets/components/CallToActionBlock/cta.scss
+++ b/resources/assets/components/CallToActionBlock/cta.scss
@@ -89,4 +89,12 @@
   .cta__impact-number {
     font-size: $font-hero;
   }
+
+  .button.join-us {
+    display: none;
+
+    @include media($medium) {
+      display: inline-block;
+    }
+  }
 }

--- a/resources/assets/components/CallToActionBlock/cta.scss
+++ b/resources/assets/components/CallToActionBlock/cta.scss
@@ -90,7 +90,7 @@
     font-size: $font-hero;
   }
 
-  .button.join-us {
+  .last-cta.is-not-affiliated {
     display: none;
 
     @include media($medium) {

--- a/resources/assets/components/Feed/Feed.js
+++ b/resources/assets/components/Feed/Feed.js
@@ -35,7 +35,7 @@ const Feed = (props) => {
       isLoading={hasPendingSignup}
       isVisible={(isAuthenticated && ! signedUp) || canLoadMorePages}
       onReveal={() => viewMoreOrSignup()}
-      isAuthenticated={isAuthenticated}
+      isSignedUp={signedUp}
     />
   );
 

--- a/resources/assets/components/Page/CampaignSubPage/CampaignSubPage.js
+++ b/resources/assets/components/Page/CampaignSubPage/CampaignSubPage.js
@@ -46,6 +46,7 @@ const CampaignSubPage = (props) => {
           <CallToActionBlockContainer
             fields={{ title: tagline }}
             modifierClasses="transparent border-none"
+            className="last-cta"
           />
         </span>
       ) : null }

--- a/resources/assets/components/Revealer/index.js
+++ b/resources/assets/components/Revealer/index.js
@@ -5,32 +5,35 @@ import classnames from 'classnames';
 import './revealer.scss';
 
 const Revealer = (props) => {
-  if (! props.isVisible) {
+  const { callToAction, isLoading, isVisible,
+    isSignedUp, onReveal, title } = props;
+
+  if (! isVisible) {
     return null;
   }
 
   return (
     <div className="revealer">
-      { props.callToAction ? <h1>{props.callToAction}</h1> : null }
-      <button disabled={props.isLoading} className={classnames('button', { 'is-loading': props.isLoading, 'is-cta': ! props.isAuthenticated })} onClick={props.onReveal}>{props.title}</button>
+      { callToAction ? <h1>{callToAction}</h1> : null }
+      <button disabled={isLoading} className={classnames('button', { 'is-loading': isLoading, 'is-cta': ! isSignedUp })} onClick={onReveal}>{title}</button>
     </div>
   );
 };
 
 Revealer.propTypes = {
   callToAction: PropTypes.string,
-  isAuthenticated: PropTypes.bool,
   isLoading: PropTypes.bool,
   isVisible: PropTypes.bool,
+  isSignedUp: PropTypes.bool,
   onReveal: PropTypes.func,
   title: PropTypes.string,
 };
 
 Revealer.defaultProps = {
   callToAction: null,
-  isAuthenticated: false,
   isLoading: false,
   isVisible: true,
+  isSignedUp: false,
   onReveal: () => {},
   title: 'view more',
 };


### PR DESCRIPTION
### What does this PR do?
Replaces the `isAuthenticated` prop in the `Revealer` component with `isSignedUp`. 
Adds hide button logic to `CallToActionBlock` for non-affiliated user.


### Any background context you want to provide?
The revealer adds an `is-cta` class to its button if the user is not authenticated. This class gets rid of the button for mobile, intended to make way for the sticky CTA button. 
This resulted in some collision though when the user is authenticated but not signed up for the campaign, so we still want to display the sticky CTA, but the Revealer's button - having no `is-cta` class - remains which results in two buttons. Using `isSignedUp` instead fixes this.

Adding this same logic to the `CallToActionBlock` allows for solving the same issue.

![image](https://user-images.githubusercontent.com/12417657/31721696-16fddcf2-b3e8-11e7-8d04-3ec97a284d39.png)


![image](https://user-images.githubusercontent.com/12417657/31721795-600611c6-b3e8-11e7-9e10-39e62b6d5db0.png)



### What are the relevant tickets/cards?
#457 

### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.

