### PR TITLE
Using include instead of exclude

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -17,8 +17,12 @@ module.exports = configure({
 
   module: {
     loaders: [
-      { enforce: 'pre', test: /\.js$/, use: 'eslint-loader', exclude: /node_modules/ },
+      { enforce: 'pre', test: /\.js$/, use: 'eslint-loader', include: path.join(__dirname, '/resources/assets') },
     ],
+  },
+
+  resolve: {
+    modules: [path.join(__dirname, 'node_modules')],
   },
 
   plugins: [


### PR DESCRIPTION
### What does this PR do?
We can't link other webpack modules (npm link) because eslint tries to parse the built files.

https://github.com/MoOx/eslint-loader/issues/165
https://github.com/webpack/webpack/issues/943
https://github.com/webpack/webpack/issues/985

### Any background context you want to provide?
Switching to include fixes the problem