### PR TITLE
changing background color on hover for `&-black` share button

### DIFF
--- a/resources/assets/components/Share/share.scss
+++ b/resources/assets/components/Share/share.scss
@@ -10,7 +10,7 @@
     border: 1px solid $dark-background-color;
 
     &:hover {
-      background: $light-background-color;
+      background: $dark-background-color;
     }
   }
 


### PR DESCRIPTION
### What does this PR do?
Fixes wonkiness in dashboard social share button hover by changing background color


### Any background context you want to provide?
![share-hover](https://user-images.githubusercontent.com/12417657/31733063-7c16dbaa-b408-11e7-87ac-d0cb0ea3dea8.gif)



### What are the relevant tickets/cards?
https://www.pivotaltracker.com/story/show/152050862

### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.

