### PR TITLE
Adds modal tracking for Puck

### DIFF
--- a/resources/assets/components/Modal/Modal.js
+++ b/resources/assets/components/Modal/Modal.js
@@ -8,6 +8,15 @@ class Modal extends React.Component {
     super();
 
     this.handleOverlayClick = this.handleOverlayClick.bind(this);
+    this.trackModalState = this.trackModalState.bind(this);
+  }
+
+  componentDidMount() {
+    this.trackModalState();
+  }
+
+  componentDidUpdate() {
+    this.trackModalState();
   }
 
   handleOverlayClick(event) {
@@ -16,6 +25,14 @@ class Modal extends React.Component {
     }
 
     this.props.closeModal();
+  }
+
+  trackModalState() {
+    const { modalType, shouldShowModal, trackEvent } = this.props;
+
+    if (shouldShowModal) {
+      trackEvent('open modal', { modalType });
+    }
   }
 
   render() {
@@ -35,13 +52,16 @@ class Modal extends React.Component {
 }
 
 Modal.propTypes = {
-  shouldShowModal: PropTypes.bool.isRequired,
-  closeModal: PropTypes.func.isRequired,
   children: PropTypes.node,
+  closeModal: PropTypes.func.isRequired,
+  modalType: PropTypes.string,
+  shouldShowModal: PropTypes.bool.isRequired,
+  trackEvent: PropTypes.func.isRequired,
 };
 
 Modal.defaultProps = {
   children: null,
+  modalType: null,
 };
 
 export default Modal;

--- a/resources/assets/components/Modal/containers/ModalContainer.js
+++ b/resources/assets/components/Modal/containers/ModalContainer.js
@@ -1,13 +1,23 @@
 import { connect } from 'react-redux';
+import { PuckConnector } from '@dosomething/puck-client';
 import { closeModal } from '../../../actions/modal';
 import Modal from '../Modal';
 
 const mapStateToProps = state => ({
   shouldShowModal: state.modal.shouldShowModal,
+  modalType: state.modal.modalType,
 });
 
 const actionCreators = {
   closeModal,
 };
 
-export default connect(mapStateToProps, actionCreators)(Modal);
+const mapPropsToEvents = trackEvent => ({
+  closeModal: ({ modalType }) => (
+    trackEvent('close modal', { modalType })
+  ),
+});
+
+export default connect(mapStateToProps, actionCreators)(
+  PuckConnector(Modal, mapPropsToEvents),
+);


### PR DESCRIPTION
### What does this PR do?
A good chunk of our modals are covered by URL's which means we're already tracking who's seeing them from the view event, but any non url modal (eg: post signup) won't get covered by that. Additionally, we're currently not tracking when that modal is closed.

This PR adds a `"open modal"` and `"close modal"` event. The close modal is handled by the Puck Connector without much modification, but the open modal required some lifecycle events because the event is based on the components state.

![screen shot 2017-10-18 at 2 31 40 pm](https://user-images.githubusercontent.com/897368/31736002-82d1548a-b411-11e7-8732-d9d58646b47d.png)

![screen shot 2017-10-18 at 2 31 27 pm](https://user-images.githubusercontent.com/897368/31736003-82eb1096-b411-11e7-884f-7ddda68487b9.png)


### What are the relevant tickets/cards?
It came up at dev round table and I figured why not!