### PR TITLE
Progress on adding CTA entity.

### DIFF
--- a/app/Entities/CallToAction.php
+++ b/app/Entities/CallToAction.php
@@ -6,19 +6,42 @@ use JsonSerializable;
 
 class CallToAction extends Entity implements JsonSerializable
 {
+    /**
+     * Convert the object into something JSON serializable.
+     *
+     * @return array
+     */
     public function jsonSerialize()
     {
-        // dd($this);
+        switch ($this->getContentType()) {
+            case 'callToAction':
+                $type = $this->getContentType();
+                $content = $this->content;
+                $impactPrefix = $this->impactPrefix ?: null;
+                $impactSuffix = $this->impactSuffix ?: null;
+                $impactValue = $this->impactValue ?: null;
+                break;
+
+            case 'customBlock':
+                $type = 'callToAction';
+                $content = $this->title;
+                $impactPrefix = $this->additionalContent['impactPrefix'] ?: null;
+                $impactSuffix = $this->additionalContent['impactMessage'] ?: null;
+                $impactValue = $this->additionalContent['impactNumber'] ?: null;
+                break;
+        }
 
         return [
             'id' => $this->entry->getId(),
-            'type' => $this->getContentType(),
+            'type' => $type,
             'fields' => [
-                'content' => $this->content,
+                'content' => $content,
                 'displayOptions' =>$this->displayOptions->first(),
-                'impactPrefix' => $this->impactPrefix ?: null,
-                'impactSuffix' => $this->impactSuffix ?: null,
-                'impactValue' => $this->impactValue ?: null,
+                'impactPrefix' => $impactPrefix,
+                'impactSuffix' => $impactSuffix,
+                'impactValue' => $impactValue,
+                'useCoverImage' => $this->useCoverImage ?: null,
+                'photo' => $this->photo ?: null,
             ],
         ];
     }

--- a/app/Entities/CallToAction.php
+++ b/app/Entities/CallToAction.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Entities;
+
+use JsonSerializable;
+
+class CallToAction extends Entity implements JsonSerializable
+{
+    public function jsonSerialize()
+    {
+        // dd($this);
+
+        return [
+            'id' => $this->entry->getId(),
+            'type' => $this->getContentType(),
+            'fields' => [
+                'content' => $this->content,
+                'displayOptions' =>$this->displayOptions->first(),
+                'impactPrefix' => $this->impactPrefix ?: null,
+                'impactSuffix' => $this->impactSuffix ?: null,
+                'impactValue' => $this->impactValue ?: null,
+            ],
+        ];
+    }
+}

--- a/app/Entities/Campaign.php
+++ b/app/Entities/Campaign.php
@@ -86,7 +86,16 @@ class Campaign extends Entity implements JsonSerializable
                 case 'campaignUpdate':
                     return new CampaignUpdate($item->entry);
 
+                case 'callToAction':
+                    return new CallToAction($item->entry);
+
                 case 'customBlock':
+                    // dump($item);
+
+                    // if ($item->entry->getType() === 'join_cta') {
+                    //     dd($item, 'boom');
+                    // }
+
                     if ($item->entry->getType() === 'reportbacks') {
                         return  $this->fillReportbackPosts($item->entry);
                     }

--- a/app/Entities/Campaign.php
+++ b/app/Entities/Campaign.php
@@ -90,11 +90,9 @@ class Campaign extends Entity implements JsonSerializable
                     return new CallToAction($item->entry);
 
                 case 'customBlock':
-                    // dump($item);
-
-                    // if ($item->entry->getType() === 'join_cta') {
-                    //     dd($item, 'boom');
-                    // }
+                    if ($item->entry->getType() === 'join_cta') {
+                        return new CallToAction($item->entry);
+                    }
 
                     if ($item->entry->getType() === 'reportbacks') {
                         return  $this->fillReportbackPosts($item->entry);

--- a/resources/assets/components/Block/Block.js
+++ b/resources/assets/components/Block/Block.js
@@ -15,6 +15,9 @@ const DEFAULT_BLOCK: BlockJson = { fields: { type: null } };
 
 const Block = ({ json = DEFAULT_BLOCK }: { json: BlockJson }) => {
   switch (json.type) {
+    case 'callToAction':
+      return <CallToActionBlockContainer fields={json.fields} modifierClasses="dark-bg" />;
+
     case 'campaignUpdate':
       return (
         <CampaignUpdateContainer
@@ -31,9 +34,6 @@ const Block = ({ json = DEFAULT_BLOCK }: { json: BlockJson }) => {
 
     case 'campaign_update':
       return <CampaignUpdateBlockContainer id={json.id} fields={json.fields} />;
-
-    case 'join_cta':
-      return <CallToActionBlockContainer fields={json.fields} modifierClasses="dark-bg" />;
 
     case 'reportbacks':
       return <ReportbackBlock fields={json.fields} reportbacks={json.reportbacks} />;

--- a/resources/assets/components/Block/Block.test.js
+++ b/resources/assets/components/Block/Block.test.js
@@ -13,7 +13,7 @@ test('it can display a campaign update', () => {
 });
 
 test('it can display a CTA block', () => {
-  const wrapper = shallow(<Block json={{ id: '12345', type: 'join_cta' }} />);
+  const wrapper = shallow(<Block json={{ id: '12345', type: 'callToAction' }} />);
   expect(wrapper.find('CallToActionBlockContainer')).toHaveLength(1);
 });
 


### PR DESCRIPTION
### What does this PR do?
This PR does some initial work for the upcoming `CallToAction` component updates. I took an approach that will end up being more versatile and not require us to make sure we update all the old instances of the CTA as a "Custom Block" with `join_cta` as the type. This approach takes both in and transforms the resulting `CallToAction` entity so regardless of what content type is used (moving forward with `callToAction` and still allowing/not-breaking the old `customBlock`).

CTAs rendering (top is the new content type, bottom is old content type):
![screen shot 2017-10-20 at 5 00 26 pm](https://user-images.githubusercontent.com/105849/31841615-3c889fd0-b5b8-11e7-9d29-1749e9415c88.png)

The two items in Contentful:
![image](https://user-images.githubusercontent.com/105849/31841855-58269066-b5b9-11e7-98d7-d71451763c34.png)


### Any background context you want to provide?
This will help setup work for the updates to the `CallToAction` component.


### What are the relevant tickets/cards?
Refs https://www.pivotaltracker.com/story/show/151174012