### PR TITLE
Shifting to a single CTA component.

### DIFF
--- a/app/Entities/CallToAction.php
+++ b/app/Entities/CallToAction.php
@@ -35,13 +35,16 @@ class CallToAction extends Entity implements JsonSerializable
             'id' => $this->entry->getId(),
             'type' => $type,
             'fields' => [
+                'buttonText' => 'Join us',
                 'content' => $content,
-                'displayOptions' =>$this->displayOptions->first(),
+                'displayOptions' => $this->displayOptions->first(),
                 'impactPrefix' => $impactPrefix,
                 'impactSuffix' => $impactSuffix,
                 'impactValue' => $impactValue,
-                'useCoverImage' => $this->useCoverImage ?: null,
                 'photo' => $this->photo ?: null,
+                'style' => $this->style ? $this->style->first() : 'light',
+                'useCampaignCoverImage' => $this->useCampaignCoverImage ?: null,
+                'useCampaignTagline' => $this->useCampaignTagline ?: true,
             ],
         ];
     }

--- a/app/Entities/CallToAction.php
+++ b/app/Entities/CallToAction.php
@@ -42,7 +42,7 @@ class CallToAction extends Entity implements JsonSerializable
                 'impactSuffix' => $impactSuffix,
                 'impactValue' => $impactValue,
                 'photo' => $this->photo ?: null,
-                'style' => $this->style ? $this->style->first() : 'light',
+                'visualStyle' => $this->visualStyle ? $this->visualStyle->first() : 'light',
                 'useCampaignCoverImage' => $this->useCampaignCoverImage ?: null,
                 'useCampaignTagline' => $this->useCampaignTagline ?: true,
             ],

--- a/app/Entities/Campaign.php
+++ b/app/Entities/Campaign.php
@@ -182,7 +182,8 @@ class Campaign extends Entity implements JsonSerializable
             'title' => $this->title,
             'slug' => $this->slug,
             'endDate' => $this->endDate,
-            'callToAction' => $this->callToAction,
+            'callToAction' => $this->callToAction, //@TODO: deprecate in favor of tagline.
+            'tagline' => $this->callToAction,
             'blurb' => $this->blurb,
             'coverImage' => [
                 'description' => $this->coverImage ? $this->coverImage->getDescription() : '',

--- a/resources/assets/components/Block/Block.js
+++ b/resources/assets/components/Block/Block.js
@@ -7,6 +7,8 @@ import PlaceholderBlock from '../PlaceholderBlock';
 import ReportbackBlock from '../ReportbackBlock';
 import StaticBlock from '../StaticBlock';
 import Quiz from '../Quiz';
+// import CallToActionContainer from '../CallToAction'; // doesn't find the container??
+import CallToActionContainer from '../CallToAction/CallToActionContainer';
 import CallToActionBlockContainer from '../CallToActionBlock';
 import { BlockJson } from '../../types';
 
@@ -16,7 +18,11 @@ const DEFAULT_BLOCK: BlockJson = { fields: { type: null } };
 const Block = ({ json = DEFAULT_BLOCK }: { json: BlockJson }) => {
   switch (json.type) {
     case 'callToAction':
-      return <CallToActionBlockContainer fields={json.fields} modifierClasses="dark-bg" />;
+      return (
+        <CallToActionContainer
+          className="something-cool"
+        />
+      );
 
     case 'campaignUpdate':
       return (
@@ -47,3 +53,9 @@ const Block = ({ json = DEFAULT_BLOCK }: { json: BlockJson }) => {
 };
 
 export default Block;
+
+
+// <CallToActionContainer
+//   fields={json.fields}
+//   modifierClasses="dark-bg"
+// />

--- a/resources/assets/components/Block/Block.js
+++ b/resources/assets/components/Block/Block.js
@@ -1,16 +1,15 @@
 /* @flow */
 
 import React from 'react';
-import { CampaignUpdateBlockContainer } from '../CampaignUpdateBlock';
-import { CampaignUpdateContainer } from '../CampaignUpdate';
-import PlaceholderBlock from '../PlaceholderBlock';
-import ReportbackBlock from '../ReportbackBlock';
-import StaticBlock from '../StaticBlock';
+
 import Quiz from '../Quiz';
-// import CallToActionContainer from '../CallToAction'; // doesn't find the container??
-import CallToActionContainer from '../CallToAction/CallToActionContainer';
-import CallToActionBlockContainer from '../CallToActionBlock';
 import { BlockJson } from '../../types';
+import StaticBlock from '../StaticBlock';
+import ReportbackBlock from '../ReportbackBlock';
+import PlaceholderBlock from '../PlaceholderBlock';
+import { CampaignUpdateContainer } from '../CampaignUpdate';
+import { CampaignUpdateBlockContainer } from '../CampaignUpdateBlock';
+import CallToActionContainer from '../CallToAction/CallToActionContainer';
 
 // If no block is passed, just render an empty "placeholder".
 const DEFAULT_BLOCK: BlockJson = { fields: { type: null } };
@@ -24,7 +23,7 @@ const Block = ({ json = DEFAULT_BLOCK }: { json: BlockJson }) => {
           impactPrefix={json.fields.impactPrefix}
           impactSuffix={json.fields.impactSuffix}
           impactValue={json.fields.impactValue}
-          style={json.fields.style}
+          visualStyle={json.fields.visualStyle}
           useCampaignTagline={json.fields.useCampaignTagline}
         />
       );

--- a/resources/assets/components/Block/Block.js
+++ b/resources/assets/components/Block/Block.js
@@ -25,6 +25,8 @@ const Block = ({ json = DEFAULT_BLOCK }: { json: BlockJson }) => {
           impactPrefix={json.fields.impactPrefix}
           impactSuffix={json.fields.impactSuffix}
           impactValue={json.fields.impactValue}
+          style={json.fields.style}
+          useCampaignTagline={json.fields.useCampaignTagline}
         />
       );
 

--- a/resources/assets/components/Block/Block.js
+++ b/resources/assets/components/Block/Block.js
@@ -21,6 +21,10 @@ const Block = ({ json = DEFAULT_BLOCK }: { json: BlockJson }) => {
       return (
         <CallToActionContainer
           className="something-cool"
+          content={json.fields.content}
+          impactPrefix={json.fields.impactPrefix}
+          impactSuffix={json.fields.impactSuffix}
+          impactValue={json.fields.impactValue}
         />
       );
 

--- a/resources/assets/components/Block/Block.js
+++ b/resources/assets/components/Block/Block.js
@@ -20,7 +20,6 @@ const Block = ({ json = DEFAULT_BLOCK }: { json: BlockJson }) => {
     case 'callToAction':
       return (
         <CallToActionContainer
-          className="something-cool"
           content={json.fields.content}
           impactPrefix={json.fields.impactPrefix}
           impactSuffix={json.fields.impactSuffix}
@@ -59,9 +58,3 @@ const Block = ({ json = DEFAULT_BLOCK }: { json: BlockJson }) => {
 };
 
 export default Block;
-
-
-// <CallToActionContainer
-//   fields={json.fields}
-//   modifierClasses="dark-bg"
-// />

--- a/resources/assets/components/Block/Block.test.js
+++ b/resources/assets/components/Block/Block.test.js
@@ -4,7 +4,7 @@ import Block from './Block';
 
 // Mock Redux containers so we don't need Provider context.
 jest.mock('./BlockContainer', () => 'BlockContainer');
-jest.mock('../CallToActionBlock', () => 'CallToActionBlockContainer');
+jest.mock('../CallToAction/CallToActionContainer', () => 'CallToActionContainer');
 jest.mock('../CampaignUpdateBlock/CampaignUpdateBlockContainer', () => 'CampaignUpdateBlockContainer');
 
 test('it can display a campaign update', () => {
@@ -13,8 +13,8 @@ test('it can display a campaign update', () => {
 });
 
 test('it can display a CTA block', () => {
-  const wrapper = shallow(<Block json={{ id: '12345', type: 'callToAction' }} />);
-  expect(wrapper.find('CallToActionBlockContainer')).toHaveLength(1);
+  const wrapper = shallow(<Block json={{ id: '12345', type: 'callToAction', fields: {} }} />);
+  expect(wrapper.find('CallToActionContainer')).toHaveLength(1);
 });
 
 test('it can display a static block', () => {

--- a/resources/assets/components/CallToAction/CallToAction.js
+++ b/resources/assets/components/CallToAction/CallToAction.js
@@ -2,9 +2,12 @@
 
 import React from 'react';
 import classnames from 'classnames';
+
+import Card from '../Card';
 import Button from '../Button/Button';
 import SignupButtonFactory from '../SignupButton';
-import './cta.scss';
+
+// import './cta.scss';
 
 type CallToActionProps = {
   legacyCampaignId: string,
@@ -12,14 +15,10 @@ type CallToActionProps = {
 };
 
 const CallToAction = ({ legacyCampaignId, className }: CallToActionProps) => {
-  const SignupButton = SignupButtonFactory(({ clickedSignUp }) => (
-    <Button onClick={() => clickedSignUp(legacyCampaignId)} />
-  ), 'call to action', { text: 'join us' });
-
   return (
-    <div className={classnames('call-to-action', className)}>
-      <SignupButton />
-    </div>
+    <Card className="call-to-action rounded padded">
+      jellooo
+    </Card>
   );
 };
 
@@ -28,3 +27,13 @@ CallToAction.defaultProps = {
 };
 
 export default CallToAction;
+
+// const SignupButton = SignupButtonFactory(({ clickedSignUp }) => (
+//   <Button onClick={() => clickedSignUp(legacyCampaignId)} />
+// ), 'call to action', { text: 'join us' });
+
+// return (
+//   <div className={classnames('call-to-action', className)}>
+//     <SignupButton />
+//   </div>
+// );

--- a/resources/assets/components/CallToAction/CallToAction.js
+++ b/resources/assets/components/CallToAction/CallToAction.js
@@ -9,15 +9,32 @@ import SignupButtonFactory from '../SignupButton';
 
 // import './cta.scss';
 
+const renderImpactContent = (prefix, value, suffix) => {
+  const valueElem = <span>{value}</span>;
+
+  return (
+    <div className="cta__impact">
+      { prefix ? `${prefix} ` : null } {valueElem} { suffix ? ` ${suffix}` : null }
+    </div>
+  );
+}
+
 type CallToActionProps = {
   legacyCampaignId: string,
   className: ?string,
+  impactPrefix: ?string,
+  impactSuffix: ?string,
+  impactValue: ?string,
 };
 
-const CallToAction = ({ legacyCampaignId, className }: CallToActionProps) => {
+const CallToAction = ({
+  legacyCampaignId, className, content, impactPrefix, impactSuffix, impactValue
+}: CallToActionProps) => {
   return (
-    <Card className="call-to-action rounded padded">
-      jellooo
+    <Card className="call-to-action rounded padded text-centered">
+      { impactValue ? renderImpactContent(impactPrefix, impactValue, impactSuffix) : null }
+
+      { content ? <div>{content}</div> : null }
     </Card>
   );
 };
@@ -37,3 +54,7 @@ export default CallToAction;
 //     <SignupButton />
 //   </div>
 // );
+
+// { prefix ? <span>{prefix}</span> : null }
+//       <span>{value}</span>
+//       { suffix ? <span>{suffix}</span> : null }

--- a/resources/assets/components/CallToAction/CallToAction.js
+++ b/resources/assets/components/CallToAction/CallToAction.js
@@ -17,35 +17,36 @@ const renderImpactContent = (prefix, value, suffix) => {
       { prefix ? `${prefix} ` : null } {valueElem} { suffix ? ` ${suffix}` : null }
     </div>
   );
-}
-
-const SignupButton = SignupButtonFactory(({ clickedSignUp }) => (
-  <Button onClick={() => clickedSignUp(legacyCampaignId)} />
-), 'call to action', { text: 'join us' });
+};
 
 type CallToActionProps = {
-  legacyCampaignId: string,
+  campaignId: string,
   className: ?string,
+  content: ?string,
   impactPrefix: ?string,
   impactSuffix: ?string,
   impactValue: ?string,
+  legacyCampaignId: ?string,
   tagline: string,
   useCampaignTagline: bool,
+  visualStyle: string,
 };
 
 const CallToAction = ({
-  legacyCampaignId, className, content, impactPrefix, impactSuffix, impactValue,
-  tagline, useCampaignTagline, style,
+  campaignId, className, content, impactPrefix, impactSuffix, impactValue,
+  legacyCampaignId, tagline, useCampaignTagline, visualStyle,
 }: CallToActionProps) => {
-
-  let classes;
+  const SignupButton = SignupButtonFactory(({ clickedSignUp }) => (
+    <Button onClick={() => clickedSignUp(legacyCampaignId || campaignId)} />
+  ), 'call to action', { text: 'join us' });
 
   return (
     <Card className={classnames('call-to-action rounded padded text-centered', className, {
-      'bg-white bordered light': style === 'light',
-      'bg-black dark': style === 'dark',
-      'bg-transparent border-none transparent': style === 'transparent',
-    })}>
+      'bg-white bordered light': visualStyle === 'light',
+      'bg-black dark': visualStyle === 'dark',
+      'bg-transparent border-none transparent': visualStyle === 'transparent',
+    })}
+    >
       { useCampaignTagline ? <div className="cta__tagline margin-bottom-lg">{tagline}</div> : null }
 
       { impactValue ? renderImpactContent(impactPrefix, impactValue, impactSuffix) : null }
@@ -59,6 +60,7 @@ const CallToAction = ({
 
 CallToAction.defaultProps = {
   className: null,
+  content: null,
 };
 
 export default CallToAction;

--- a/resources/assets/components/CallToAction/CallToAction.js
+++ b/resources/assets/components/CallToAction/CallToAction.js
@@ -61,6 +61,10 @@ const CallToAction = ({
 CallToAction.defaultProps = {
   className: null,
   content: null,
+  impactPrefix: null,
+  impactSuffix: null,
+  impactValue: null,
+  legacyCampaignId: null,
 };
 
 export default CallToAction;

--- a/resources/assets/components/CallToAction/CallToAction.js
+++ b/resources/assets/components/CallToAction/CallToAction.js
@@ -7,7 +7,7 @@ import Card from '../Card';
 import Button from '../Button/Button';
 import SignupButtonFactory from '../SignupButton';
 
-// import './cta.scss';
+import './cta.scss';
 
 const renderImpactContent = (prefix, value, suffix) => {
   const valueElem = <span>{value}</span>;
@@ -25,16 +25,30 @@ type CallToActionProps = {
   impactPrefix: ?string,
   impactSuffix: ?string,
   impactValue: ?string,
+  tagline: string,
+  useCampaignTagline: bool,
 };
 
 const CallToAction = ({
-  legacyCampaignId, className, content, impactPrefix, impactSuffix, impactValue
+  legacyCampaignId, className, content, impactPrefix, impactSuffix, impactValue,
+  tagline, useCampaignTagline, style,
 }: CallToActionProps) => {
+
+  let classes;
+
   return (
-    <Card className="call-to-action rounded padded text-centered">
+    <Card className={classnames('call-to-action rounded padded text-centered', {
+      'bg-white bordered light': style === 'light',
+      'bg-black dark': style === 'dark',
+      'bg-transparent border-none transparent': style === 'transparent',
+    })}>
+      { useCampaignTagline ? <div className="cta__tagline">{tagline}</div> : null }
+
       { impactValue ? renderImpactContent(impactPrefix, impactValue, impactSuffix) : null }
 
-      { content ? <div>{content}</div> : null }
+      { content ? <div className="cta__message">{content}</div> : null }
+
+       <button className="button" onClick={() => {}}>Join us</button>
     </Card>
   );
 };

--- a/resources/assets/components/CallToAction/CallToAction.js
+++ b/resources/assets/components/CallToAction/CallToAction.js
@@ -10,14 +10,18 @@ import SignupButtonFactory from '../SignupButton';
 import './cta.scss';
 
 const renderImpactContent = (prefix, value, suffix) => {
-  const valueElem = <span>{value}</span>;
+  const valueElem = <span className="cta__impact_number">{value}</span>;
 
   return (
-    <div className="cta__impact">
+    <div className="cta__impact margin-bottom-lg">
       { prefix ? `${prefix} ` : null } {valueElem} { suffix ? ` ${suffix}` : null }
     </div>
   );
 }
+
+const SignupButton = SignupButtonFactory(({ clickedSignUp }) => (
+  <Button onClick={() => clickedSignUp(legacyCampaignId)} />
+), 'call to action', { text: 'join us' });
 
 type CallToActionProps = {
   legacyCampaignId: string,
@@ -37,18 +41,18 @@ const CallToAction = ({
   let classes;
 
   return (
-    <Card className={classnames('call-to-action rounded padded text-centered', {
+    <Card className={classnames('call-to-action rounded padded text-centered', className, {
       'bg-white bordered light': style === 'light',
       'bg-black dark': style === 'dark',
       'bg-transparent border-none transparent': style === 'transparent',
     })}>
-      { useCampaignTagline ? <div className="cta__tagline">{tagline}</div> : null }
+      { useCampaignTagline ? <div className="cta__tagline margin-bottom-lg">{tagline}</div> : null }
 
       { impactValue ? renderImpactContent(impactPrefix, impactValue, impactSuffix) : null }
 
-      { content ? <div className="cta__message">{content}</div> : null }
+      { content ? <div className="cta__message margin-bottom-lg">{content}</div> : null }
 
-       <button className="button" onClick={() => {}}>Join us</button>
+      <SignupButton />
     </Card>
   );
 };
@@ -58,17 +62,3 @@ CallToAction.defaultProps = {
 };
 
 export default CallToAction;
-
-// const SignupButton = SignupButtonFactory(({ clickedSignUp }) => (
-//   <Button onClick={() => clickedSignUp(legacyCampaignId)} />
-// ), 'call to action', { text: 'join us' });
-
-// return (
-//   <div className={classnames('call-to-action', className)}>
-//     <SignupButton />
-//   </div>
-// );
-
-// { prefix ? <span>{prefix}</span> : null }
-//       <span>{value}</span>
-//       { suffix ? <span>{suffix}</span> : null }

--- a/resources/assets/components/CallToAction/CallToAction.test.js
+++ b/resources/assets/components/CallToAction/CallToAction.test.js
@@ -3,6 +3,9 @@ import { shallow } from 'enzyme';
 import { shallowToJson } from 'enzyme-to-json';
 import CallToAction from './CallToAction';
 
+// @TODO: Test was failing without having the mock, although it is
+// odd that it would need it for a specific test of the component.
+
 // Mock Redux containers so we don't need Provider context.
 jest.mock('./CallToActionContainer', () => 'CallToActionContainer');
 

--- a/resources/assets/components/CallToAction/CallToAction.test.js
+++ b/resources/assets/components/CallToAction/CallToAction.test.js
@@ -14,7 +14,7 @@ const component = shallow(
     campaignId="12345"
     legacyCampaignId="67890"
     tagline="Aenean eu leo quam. Pellentesque ornare sem vestibulum."
-    useCampaignTagline={true}
+    useCampaignTagline
     visualStyle="light"
   />,
 );

--- a/resources/assets/components/CallToAction/CallToAction.test.js
+++ b/resources/assets/components/CallToAction/CallToAction.test.js
@@ -3,7 +3,17 @@ import { shallow } from 'enzyme';
 import { shallowToJson } from 'enzyme-to-json';
 import CallToAction from './CallToAction';
 
-const component = shallow(<CallToAction className="sample-class" onClick={() => {}} />);
+console.log('hello');
+
+const component = shallow(
+  <CallToAction
+    campaignId="12345"
+    legacyCampaignId="67890"
+    tagline="Aenean eu leo quam. Pellentesque ornare sem vestibulum."
+    useCampaignTagline={true}
+    visualStyle="light"
+  />,
+);
 
 test('CallToAction snapshot test', () => {
   const tree = shallowToJson(component);

--- a/resources/assets/components/CallToAction/CallToAction.test.js
+++ b/resources/assets/components/CallToAction/CallToAction.test.js
@@ -3,6 +3,9 @@ import { shallow } from 'enzyme';
 import { shallowToJson } from 'enzyme-to-json';
 import CallToAction from './CallToAction';
 
+// Mock Redux containers so we don't need Provider context.
+jest.mock('./CallToActionContainer', () => 'CallToActionContainer');
+
 const component = shallow(
   <CallToAction
     campaignId="12345"

--- a/resources/assets/components/CallToAction/CallToAction.test.js
+++ b/resources/assets/components/CallToAction/CallToAction.test.js
@@ -3,8 +3,6 @@ import { shallow } from 'enzyme';
 import { shallowToJson } from 'enzyme-to-json';
 import CallToAction from './CallToAction';
 
-console.log('hello');
-
 const component = shallow(
   <CallToAction
     campaignId="12345"

--- a/resources/assets/components/CallToAction/CallToActionContainer.js
+++ b/resources/assets/components/CallToAction/CallToActionContainer.js
@@ -1,4 +1,6 @@
 import { connect } from 'react-redux';
+import { get } from 'lodash';
+
 import CallToAction from './CallToAction';
 
 /**
@@ -8,7 +10,7 @@ const mapStateToProps = state => ({
   campaignId: state.campaign.id,
   coverImageUrl: state.campaign.coverImage.url,
   isSignedUp: state.signups.thisCampaign,
-  legacyCampaignId: state.campaign.legacyCampaignId,
+  legacyCampaignId: get(state.campaign, 'legacyCampaignId', null),
   tagline: state.campaign.callToAction,
 });
 

--- a/resources/assets/components/CallToAction/CallToActionContainer.js
+++ b/resources/assets/components/CallToAction/CallToActionContainer.js
@@ -5,7 +5,12 @@ import CallToAction from './CallToAction';
  * Provide state from the Redux store as props for this component.
  */
 const mapStateToProps = state => ({
-  campaignId: state.campaign.legacyCampaignId,
+  campaignId: state.campaign.id,
+  legacyCampaignId: state.campaign.legacyCampaignId,
+  coverImageUrl: state.campaign.coverImage.url,
+  isSignedUp: state.signups.thisCampaign,
+  // noun: '',
+  // verb: '',
 });
 
 /**

--- a/resources/assets/components/CallToAction/CallToActionContainer.js
+++ b/resources/assets/components/CallToAction/CallToActionContainer.js
@@ -6,9 +6,10 @@ import CallToAction from './CallToAction';
  */
 const mapStateToProps = state => ({
   campaignId: state.campaign.id,
-  legacyCampaignId: state.campaign.legacyCampaignId,
   coverImageUrl: state.campaign.coverImage.url,
   isSignedUp: state.signups.thisCampaign,
+  legacyCampaignId: state.campaign.legacyCampaignId,
+  tagline: state.campaign.callToAction,
   // noun: '',
   // verb: '',
 });

--- a/resources/assets/components/CallToAction/CallToActionContainer.js
+++ b/resources/assets/components/CallToAction/CallToActionContainer.js
@@ -10,8 +10,6 @@ const mapStateToProps = state => ({
   isSignedUp: state.signups.thisCampaign,
   legacyCampaignId: state.campaign.legacyCampaignId,
   tagline: state.campaign.callToAction,
-  // noun: '',
-  // verb: '',
 });
 
 /**

--- a/resources/assets/components/CallToAction/__snapshots__/CallToAction.test.js.snap
+++ b/resources/assets/components/CallToAction/__snapshots__/CallToAction.test.js.snap
@@ -1,0 +1,16 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`CallToAction snapshot test 1`] = `
+<Card
+  className="call-to-action rounded padded text-centered bg-white bordered light"
+  link={null}
+  title={null}
+>
+  <div
+    className="cta__tagline margin-bottom-lg"
+  >
+    Aenean eu leo quam. Pellentesque ornare sem vestibulum.
+  </div>
+  <Connect(PuckWrapper) />
+</Card>
+`;

--- a/resources/assets/components/CallToAction/__snapshots__/test.js.snap
+++ b/resources/assets/components/CallToAction/__snapshots__/test.js.snap
@@ -1,9 +1,0 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
-
-exports[`CallToAction snapshot test 1`] = `
-<div
-  className="call-to-action sample-class"
->
-  <Connect(PuckWrapper) />
-</div>
-`;

--- a/resources/assets/components/CallToAction/cta.scss
+++ b/resources/assets/components/CallToAction/cta.scss
@@ -1,21 +1,50 @@
 @import '../../scss/next-toolbox';
 
 .call-to-action {
-  background-color: $white;
-  border-top: 1px solid $primary-border-color;
-  padding: $half-spacing;
+  // background-color: $white;
+  // border-top: 1px solid $primary-border-color;
+  // padding: $half-spacing;
 
-  &.-sticky {
-    bottom: -1px;
-    position: sticky;
-    z-index: $sticky-cta-zindex;
+  // &.-sticky {
+  //   bottom: -1px;
+  //   position: sticky;
+  //   z-index: $sticky-cta-zindex;
 
-    @include media($medium) {
-      display: none;
+  //   @include media($medium) {
+  //     display: none;
+  //   }
+
+  //   > .button {
+  //     width: 100%;
+  //   }
+  // }
+
+  &.light, &.transparent {
+    color: $dark-gray !important;
+  }
+
+  &.dark {
+    color: $white !important;
+
+    .cta__message {
+      color: $white !important;
     }
+  }
 
-    > .button {
-      width: 100%;
+  .cta__impact {
+    > span {
+      font-size: $font-hero;
+      display: block;
     }
+  }
+
+  .cta__message {
+    font-size: $font-regular;
+    font-style: italic;
+    font-weight: normal;
+  }
+
+  .cta__tagline {
+    font-weight: bold;
   }
 }

--- a/resources/assets/components/CallToAction/cta.scss
+++ b/resources/assets/components/CallToAction/cta.scss
@@ -1,41 +1,35 @@
 @import '../../scss/next-toolbox';
 
 .call-to-action {
-  // background-color: $white;
-  // border-top: 1px solid $primary-border-color;
-  // padding: $half-spacing;
+  &.-sticky {
+    bottom: -1px;
+    position: sticky;
+    z-index: $sticky-cta-zindex;
 
-  // &.-sticky {
-  //   bottom: -1px;
-  //   position: sticky;
-  //   z-index: $sticky-cta-zindex;
+    @include media($medium) {
+      display: none;
+    }
 
-  //   @include media($medium) {
-  //     display: none;
-  //   }
-
-  //   > .button {
-  //     width: 100%;
-  //   }
-  // }
-
-  &.light, &.transparent {
-    color: $dark-gray !important;
+    > .button {
+      width: 100%;
+    }
   }
 
-  &.dark {
-    color: $white !important;
-
-    .cta__message {
-      color: $white !important;
-    }
+  .cta__tagline {
+    font-weight: bold;
   }
 
   .cta__impact {
-    > span {
-      font-size: $font-hero;
-      display: block;
-    }
+    font-weight: bold;
+    line-height: 1.2;
+    text-transform: uppercase;
+  }
+
+  .cta__impact_number {
+    display: block;
+    font-family: $secondary-font-family;
+    font-size: $font-hero;
+    font-weight: normal;
   }
 
   .cta__message {
@@ -44,7 +38,27 @@
     font-weight: normal;
   }
 
-  .cta__tagline {
-    font-weight: bold;
+  &.light {
+    color: $dark-gray !important;
+  }
+
+  &.transparent {
+    color: $dark-gray !important;
+
+    .cta__tagline {
+      font-size: $font-medium;
+    }
+  }
+
+  &.dark {
+    color: $white !important;
+
+    .cta__tagline {
+      color: $primary-color;
+    }
+
+    .cta__message {
+      color: $white !important;
+    }
   }
 }

--- a/resources/assets/components/Page/CampaignSubPage/CampaignSubPage.js
+++ b/resources/assets/components/Page/CampaignSubPage/CampaignSubPage.js
@@ -5,7 +5,6 @@ import PropTypes from 'prop-types';
 import NotFound from '../../NotFound';
 import Markdown from '../../Markdown';
 import ScrollConcierge from '../../ScrollConcierge';
-// import CallToActionContainer from '../CallToAction'; // doesn't find the container??
 import CallToActionContainer from '../../CallToAction/CallToActionContainer';
 import CallToActionBlockContainer from '../../CallToActionBlock';
 import { isCampaignClosed } from '../../../helpers';
@@ -91,15 +90,3 @@ CampaignSubPage.defaultProps = {
 };
 
 export default CampaignSubPage;
-
-
-// <CallToActionBlockContainer
-//   fields={{ content: ctaContent }}
-//   modifierClasses="dark-bg"
-// />
-
-// <CallToActionBlockContainer
-//   fields={{ title: tagline }}
-//   modifierClasses="transparent border-none"
-//   className="last-cta"
-// />

--- a/resources/assets/components/Page/CampaignSubPage/CampaignSubPage.js
+++ b/resources/assets/components/Page/CampaignSubPage/CampaignSubPage.js
@@ -23,7 +23,7 @@ const CampaignSubPage = (props) => {
 
   const isClosed = isCampaignClosed(campaignEndDate);
 
-  const ctaContent = `${tagline}\n\n__Join hundreds of members and ${verb.plural} ${noun.plural}!__`;
+  const ctaContent = `${tagline} Join hundreds of members and ${verb.plural} ${noun.plural}!`;
 
   return (
     <div className="clearfix padded campaign-subpage" id={subPage.id}>
@@ -41,11 +41,16 @@ const CampaignSubPage = (props) => {
           <div className="secondary">
             <CallToActionContainer
               className="something-cooler"
+              content={ctaContent}
+              useCampaignTagline={true}
+              style="dark"
             />
           </div>
 
           <CallToActionContainer
               className="something-cooler"
+              useCampaignTagline={true}
+              style="transparent"
             />
         </span>
       ) : null }

--- a/resources/assets/components/Page/CampaignSubPage/CampaignSubPage.js
+++ b/resources/assets/components/Page/CampaignSubPage/CampaignSubPage.js
@@ -29,31 +29,29 @@ const CampaignSubPage = (props) => {
     <div className="clearfix padded campaign-subpage" id={subPage.id}>
       <div className="primary">
         <ScrollConcierge />
-        <article>
+        <article className="padded bordered rounded bg-white">
           <h2 className="visually-hidden">{ subPage.fields.title }</h2>
 
           <Markdown>{ subPage.fields.content }</Markdown>
         </article>
       </div>
 
-      { ! isClosed ? (
-        <span>
-          <div className="secondary">
-            <CallToActionContainer
-              className="something-cooler"
-              content={ctaContent}
-              useCampaignTagline={true}
-              style="dark"
-            />
-          </div>
-
+      { isClosed ? null : (
+        <div className="secondary">
           <CallToActionContainer
-              className="something-cooler"
-              useCampaignTagline={true}
-              style="transparent"
-            />
-        </span>
-      ) : null }
+            content={ctaContent}
+            useCampaignTagline={true}
+            style="dark"
+          />
+        </div>
+      )}
+
+      { isClosed ? null : (
+        <CallToActionContainer
+          useCampaignTagline={true}
+          style="transparent"
+        />
+      )}
     </div>
   );
 };

--- a/resources/assets/components/Page/CampaignSubPage/CampaignSubPage.js
+++ b/resources/assets/components/Page/CampaignSubPage/CampaignSubPage.js
@@ -2,12 +2,11 @@ import React from 'react';
 import { find } from 'lodash';
 import PropTypes from 'prop-types';
 
-import NotFound from '../../NotFound';
 import Markdown from '../../Markdown';
+import NotFound from '../../NotFound';
+import { isCampaignClosed } from '../../../helpers';
 import ScrollConcierge from '../../ScrollConcierge';
 import CallToActionContainer from '../../CallToAction/CallToActionContainer';
-import CallToActionBlockContainer from '../../CallToActionBlock';
-import { isCampaignClosed } from '../../../helpers';
 
 import './campaign-subpage.scss';
 
@@ -39,16 +38,16 @@ const CampaignSubPage = (props) => {
         <div className="secondary">
           <CallToActionContainer
             content={ctaContent}
-            useCampaignTagline={true}
-            style="dark"
+            useCampaignTagline
+            visualStyle="dark"
           />
         </div>
       )}
 
       { isClosed ? null : (
         <CallToActionContainer
-          useCampaignTagline={true}
-          style="transparent"
+          useCampaignTagline
+          visualStyle="transparent"
         />
       )}
     </div>

--- a/resources/assets/components/Page/CampaignSubPage/CampaignSubPage.js
+++ b/resources/assets/components/Page/CampaignSubPage/CampaignSubPage.js
@@ -5,6 +5,8 @@ import PropTypes from 'prop-types';
 import NotFound from '../../NotFound';
 import Markdown from '../../Markdown';
 import ScrollConcierge from '../../ScrollConcierge';
+// import CallToActionContainer from '../CallToAction'; // doesn't find the container??
+import CallToActionContainer from '../../CallToAction/CallToActionContainer';
 import CallToActionBlockContainer from '../../CallToActionBlock';
 import { isCampaignClosed } from '../../../helpers';
 
@@ -37,9 +39,8 @@ const CampaignSubPage = (props) => {
       { ! isClosed ? (
         <span>
           <div className="secondary">
-            <CallToActionBlockContainer
-              fields={{ content: ctaContent }}
-              modifierClasses="dark-bg"
+            <CallToActionContainer
+              className="something-cooler"
             />
           </div>
 
@@ -89,3 +90,9 @@ CampaignSubPage.defaultProps = {
 };
 
 export default CampaignSubPage;
+
+
+// <CallToActionBlockContainer
+//   fields={{ content: ctaContent }}
+//   modifierClasses="dark-bg"
+// />

--- a/resources/assets/components/Page/CampaignSubPage/CampaignSubPage.js
+++ b/resources/assets/components/Page/CampaignSubPage/CampaignSubPage.js
@@ -44,11 +44,9 @@ const CampaignSubPage = (props) => {
             />
           </div>
 
-          <CallToActionBlockContainer
-            fields={{ title: tagline }}
-            modifierClasses="transparent border-none"
-            className="last-cta"
-          />
+          <CallToActionContainer
+              className="something-cooler"
+            />
         </span>
       ) : null }
     </div>
@@ -95,4 +93,10 @@ export default CampaignSubPage;
 // <CallToActionBlockContainer
 //   fields={{ content: ctaContent }}
 //   modifierClasses="dark-bg"
+// />
+
+// <CallToActionBlockContainer
+//   fields={{ title: tagline }}
+//   modifierClasses="transparent border-none"
+//   className="last-cta"
 // />

--- a/resources/assets/components/Page/CampaignSubPage/campaign-subpage.scss
+++ b/resources/assets/components/Page/CampaignSubPage/campaign-subpage.scss
@@ -30,13 +30,4 @@
   > div {
     margin: $base-spacing 0;
   }
-
-  article {
-    @extend %block;
-  }
-
-  .cta {
-    clear: both;
-    margin: 0;
-  }
 }

--- a/resources/assets/scss/base.scss
+++ b/resources/assets/scss/base.scss
@@ -40,12 +40,20 @@ h1, h2, h3, p {
   background-size: cover;
 }
 
+.bg-black {
+  background-color: $black !important;
+}
+
 .bg-white {
-  background-color: $white;
+  background-color: $white !important;
 }
 
 .bg-light-gray {
   background-color: $light-gray;
+}
+
+.bg-transparent {
+  background-color: transparent !important;
 }
 
 .bordered {
@@ -53,7 +61,7 @@ h1, h2, h3, p {
 }
 
 .border-none {
-  border: 0 none;
+  border: 0 none !important;
 }
 
 .border-top {


### PR DESCRIPTION
### What does this PR do?
This PR established an official CTA component that eliminates the need for the custom block component as cta (code for old approach will be deleted in upcoming PR). It allows still supporting old style of cta entered on the Contentful side, but all CTAs now use the new component when rendering onto the page. It also makes a few other updates to clean things up relating around CTAs.

There are a few fields that have not been added to contentful so they have only been partially included in the CTA component, but will be getting added/updated in an upcoming PR.

### Any background context you want to provide?
Light version (with varying content):
![image](https://user-images.githubusercontent.com/105849/32385560-f9955c1c-c094-11e7-8c72-8fc863b73bfd.png)

Dark version (with varying content and as sidebar):
![image](https://user-images.githubusercontent.com/105849/32385669-44b78f44-c095-11e7-9376-1ead163603c3.png)

Transparent version (with varying content):
![image](https://user-images.githubusercontent.com/105849/32385631-295f3210-c095-11e7-8a7e-cebc24dfc5e9.png)


### What are the relevant tickets/cards?
Refs: https://www.pivotaltracker.com/story/show/151174012

### Checklist
- [x] Added appropriate feature/unit tests.

