### PR TITLE
formatting contentful image urls within provided merkdown string

### DIFF
--- a/resources/assets/components/Markdown/index.js
+++ b/resources/assets/components/Markdown/index.js
@@ -5,9 +5,9 @@ import { markdown, contentfulImageUrl } from '../../helpers';
 
 import './markdown.scss';
 
-const urlToFormat = /\/\/images\.contentful\.com.+\.(jpg|png)/g;
-const formatImageUrl = url => (contentfulImageUrl(url, '1000', '700', 'fill'));
-const formatImageUrls = string => (string.replace(urlToFormat, formatImageUrl));
+const pattern = /\/\/images\.contentful\.com.+\.(jpg|png)/g;
+const contentfulImageFormat = url => (contentfulImageUrl(url, '1000', '700', 'fill'));
+const formatImageUrls = string => (string.replace(pattern, contentfulImageFormat));
 
 const Markdown = ({ className = null, children }) => (
   <div className={classnames('markdown', 'with-lists', className)} dangerouslySetInnerHTML={markdown(formatImageUrls(children))} /> // eslint-disable-line react/no-danger

--- a/resources/assets/components/Markdown/index.js
+++ b/resources/assets/components/Markdown/index.js
@@ -5,8 +5,9 @@ import { markdown, contentfulImageUrl } from '../../helpers';
 
 import './markdown.scss';
 
+const urlToFormat = /\/\/images\.contentful\.com.+\.(jpg|png)/g;
 const formatImageUrl = url => (contentfulImageUrl(url, '1000', '700', 'fill'));
-const formatImageUrls = string => (string.replace(/\/\/images\.contentful\.com.+\.jpg/g, formatImageUrl));
+const formatImageUrls = string => (string.replace(urlToFormat, formatImageUrl));
 
 const Markdown = ({ className = null, children }) => (
   <div className={classnames('markdown', 'with-lists', className)} dangerouslySetInnerHTML={markdown(formatImageUrls(children))} /> // eslint-disable-line react/no-danger

--- a/resources/assets/components/Markdown/index.js
+++ b/resources/assets/components/Markdown/index.js
@@ -1,12 +1,15 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import classnames from 'classnames';
-import { markdown } from '../../helpers';
+import { markdown, contentfulImageUrl } from '../../helpers';
 
 import './markdown.scss';
 
+const formatImageUrl = url => (contentfulImageUrl(url, '1000', '700', 'fill'));
+const formatImageUrls = string => (string.replace(/\/\/images\.contentful\.com.+\.jpg/g, formatImageUrl));
+
 const Markdown = ({ className = null, children }) => (
-  <div className={classnames('markdown', 'with-lists', className)} dangerouslySetInnerHTML={markdown(children)} /> // eslint-disable-line react/no-danger
+  <div className={classnames('markdown', 'with-lists', className)} dangerouslySetInnerHTML={markdown(formatImageUrls(children))} /> // eslint-disable-line react/no-danger
 );
 
 Markdown.propTypes = {


### PR DESCRIPTION
### What does this PR do?
Formats any contentful image url within the string of markdown provided to the `Markdown` component, adding formatting through the `contentfulImageUrl` helper.


### Any background context you want to provide?
We're loading yuuuuge images by default which is killing our google score and performance speeds.

I somewhat arbitrarily decided on the measurements here (`w=1000, h=700`) Please let me know if you have an opinion on this. It's based on messing around with this campaign [https://www.dosomething.org/us/campaigns/sincerely-us](https://www.dosomething.org/us/campaigns/sincerely-us), and working to replace some images in the community tab campaign updates with a smaller version without reducing their size on the actual page:

*Original*:
![image](https://user-images.githubusercontent.com/12417657/31910019-1987072a-b80a-11e7-9fef-14e820b5baec.png)



*If formatted with `500/500`*:
![image](https://user-images.githubusercontent.com/12417657/31909968-e8c866f6-b809-11e7-9b57-169491abde3a.png)

*With current formatting* (actual image is smaller than original though):
![image](https://user-images.githubusercontent.com/12417657/31909997-08d950a4-b80a-11e7-888d-42ba3b8cfb3f.png)

Raw Image URL:
http://images.contentful.com/81iqaqpfd8fy/4TGGGR6PC8mMmMgiySK8Kq/9e98f4ed5cbcc1c5c3de28d4f9d17dd5/4V4A0326.jpg


### What are the relevant tickets/cards?
https://www.pivotaltracker.com/story/show/152201463

### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.

