### PR TITLE
removing height and fit args from contentfulImageUrl call

### DIFF
--- a/resources/assets/components/Markdown/index.js
+++ b/resources/assets/components/Markdown/index.js
@@ -6,7 +6,7 @@ import { markdown, contentfulImageUrl } from '../../helpers';
 import './markdown.scss';
 
 const pattern = /\/\/images\.contentful\.com.+\.(jpg|png)/g;
-const contentfulImageFormat = url => (contentfulImageUrl(url, '1000', '700', 'fill'));
+const contentfulImageFormat = url => (contentfulImageUrl(url, '1000'));
 const formatImageUrls = string => (string.replace(pattern, contentfulImageFormat));
 
 const Markdown = ({ className = null, children }) => (


### PR DESCRIPTION
### What does this PR do?
Removes `height` and `fit` arguments from the call to `contentfulImageUrl` in `Markdown` component.


### Any background context you want to provide?
This was causing images to resize in a weird cropped way. With just `width`, the images render appropriately, smaller in size, while retaining the aspect ratio. Unless the image is smaller in width than the width we provide, in which case it shrinks is size taken, but remains uncropped


### What are the relevant tickets/cards?
https://www.pivotaltracker.com/story/show/152201463

### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.

