### PR TITLE
Updating logic on whether to hide tabs

### DIFF
--- a/resources/assets/components/Navigation/TabbedNavigationContainer.js
+++ b/resources/assets/components/Navigation/TabbedNavigationContainer.js
@@ -37,29 +37,28 @@ const TabbedNavigationContainer = (props) => {
   const campaignSlug = props.campaignSlug;
 
   // Create links for additional "content" pages on this campaign in Contentful.
-  const additionalPages = pages.map((page) => {
-    if (page.fields.hideFromNavigation) {
-      return null;
-    }
+  const additionalPages = pages
+    .filter(page => ! page.fields.hideFromNavigation)
+    .map((page) => {
+      const path = join('/us/campaigns', campaignSlug, campaignPaths.pages, page.fields.slug);
 
-    const path = join('/us/campaigns', campaignSlug, campaignPaths.pages, page.fields.slug);
-
-    return (
-      <NavigationLink key={page.id} to={path}>{page.fields.title}</NavigationLink>
-    );
-  });
+      return (
+        <NavigationLink key={page.id} to={path}>{page.fields.title}</NavigationLink>
+      );
+    });
 
   const SignupButton = SignupButtonFactory(({ clickedSignUp }) => (
     <Button className="-inline nav-button" onClick={() => clickedSignUp(legacyCampaignId)} />
   ), 'tabbed navigation', { text: 'join us' });
 
   const shouldHideCommunity = (template === 'legacy') && ! hasActivityFeed;
+  const shouldHideAction = (isClosed || (shouldHideCommunity && additionalPages.length === 0));
 
   return (
     <TabbedNavigation>
       <div className="nav-items">
         { shouldHideCommunity ? null : <NavigationLink to={join('/us/campaigns', campaignSlug, campaignPaths.community)} exact>Community</NavigationLink> }
-        { isClosed ? null : <NavigationLink to={join('/us/campaigns', campaignSlug, campaignPaths.action)}>Action</NavigationLink> }
+        { shouldHideAction ? null : <NavigationLink to={join('/us/campaigns', campaignSlug, campaignPaths.action)}>Action</NavigationLink> }
         { additionalPages }
       </div>
       { isAffiliated ? null : <SignupButton /> }


### PR DESCRIPTION
### What does this PR do?

This logic accounts for hiding tabs when "action" is the only tab that would normally be shown. 

<img width="825" alt="screen shot 2017-10-25 at 3 35 31 pm" src="https://user-images.githubusercontent.com/897368/32019142-3deb6a52-b99a-11e7-8823-112e12fa0b3d.png">
<img width="941" alt="screen shot 2017-10-25 at 3 35 26 pm" src="https://user-images.githubusercontent.com/897368/32019143-3e045314-b99a-11e7-9a65-d808f5b07df7.png">

### Any background context you want to provide?
1. Filtered out the links with the hide from nav field (Returning null in the map function meant the array length was still `> 0`, which would break the logic in step 2). 
2. Added a conditional that checks if either the campaign is closed, OR, the community page tab is hidden and there are no additional pages to show (Thus the action tab is the only one).