### PR TITLE
Temp caching solution fixes

### DIFF
--- a/app/Http/Controllers/CampaignController.php
+++ b/app/Http/Controllers/CampaignController.php
@@ -56,19 +56,19 @@ class CampaignController extends Controller
      */
     public function show($slug)
     {
-        $campaignFlattened = $this->campaignRepository->findBySlug($slug);
+        $flattenedCampaign = $this->campaignRepository->findBySlug($slug);
 
         $env = get_client_environment_vars();
 
         // The slug argument will not contain `/blocks` or other path extensions, hence `::url()`.
-        $socialFields = get_social_fields($campaignFlattened, Request::url());
+        $socialFields = get_social_fields($flattenedCampaign, Request::url());
 
         return view('campaigns.show', [
-            'campaign' => $campaignFlattened,
+            'campaign' => $flattenedCampaign,
             'socialFields' => $socialFields,
             'env' => $env,
         ])->with('state', [
-            'campaign' => $campaignFlattened,
+            'campaign' => $flattenedCampaign,
             'share' => $socialFields,
             'user' => [
                 'id' => auth()->id(),

--- a/app/Http/Controllers/CampaignController.php
+++ b/app/Http/Controllers/CampaignController.php
@@ -56,18 +56,19 @@ class CampaignController extends Controller
      */
     public function show($slug)
     {
-        $campaign = $this->campaignRepository->findBySlug($slug);
+        $campaignFlattened = $this->campaignRepository->findBySlug($slug);
+
         $env = get_client_environment_vars();
 
         // The slug argument will not contain `/blocks` or other path extensions, hence `::url()`.
-        $socialFields = get_social_fields($campaign, Request::url());
+        $socialFields = get_social_fields($campaignFlattened, Request::url());
 
         return view('campaigns.show', [
-            'campaign' => $campaign,
+            'campaign' => $campaignFlattened,
             'socialFields' => $socialFields,
             'env' => $env,
         ])->with('state', [
-            'campaign' => $campaign,
+            'campaign' => $campaignFlattened,
             'share' => $socialFields,
             'user' => [
                 'id' => auth()->id(),

--- a/app/Http/Controllers/CampaignController.php
+++ b/app/Http/Controllers/CampaignController.php
@@ -56,19 +56,19 @@ class CampaignController extends Controller
      */
     public function show($slug)
     {
-        $flattenedCampaign = $this->campaignRepository->findBySlug($slug);
+        $campaign = $this->campaignRepository->findBySlug($slug);
 
         $env = get_client_environment_vars();
 
         // The slug argument will not contain `/blocks` or other path extensions, hence `::url()`.
-        $socialFields = get_social_fields($flattenedCampaign, Request::url());
+        $socialFields = get_social_fields($campaign, Request::url());
 
         return view('campaigns.show', [
-            'campaign' => $flattenedCampaign,
+            'campaign' => $campaign,
             'socialFields' => $socialFields,
             'env' => $env,
         ])->with('state', [
-            'campaign' => $flattenedCampaign,
+            'campaign' => $campaign,
             'share' => $socialFields,
             'user' => [
                 'id' => auth()->id(),

--- a/app/Repositories/CampaignRepository.php
+++ b/app/Repositories/CampaignRepository.php
@@ -45,6 +45,8 @@ class CampaignRepository
      */
     public function findBySlug($slug)
     {
+        $skipCache = ! config('services.contentful.cache');
+
         $flattenedCampaign = remember('campaign_'.$slug, 15, function () use ($slug) {
             $query = (new Query)
                 ->setContentType('campaign')
@@ -63,7 +65,7 @@ class CampaignRepository
                 // "Serialization of 'Closure' is not allowed" error.
                 return json_encode($campaign);
             }
-        });
+        }, $skipCache);
 
         if ($flattenedCampaign == 'not_found') {
             throw new ModelNotFoundException;

--- a/app/Repositories/CampaignRepository.php
+++ b/app/Repositories/CampaignRepository.php
@@ -66,7 +66,7 @@ class CampaignRepository
 
             $campaign = new Campaign($campaignEntry);
 
-            $flattenedCampaign = json_decode(json_encode($campaign));
+            $flattenedCampaign = json_encode($campaign);
 
             if (config('services.contentful.cache')) {
                 $expiresAt = Carbon::now()->addMinutes(15);
@@ -75,7 +75,7 @@ class CampaignRepository
             }
         }
 
-        return $flattenedCampaign;
+        return json_decode($flattenedCampaign);
     }
 
     /**

--- a/app/Repositories/CampaignRepository.php
+++ b/app/Repositories/CampaignRepository.php
@@ -2,8 +2,6 @@
 
 namespace App\Repositories;
 
-use Cache;
-use Carbon\Carbon;
 use App\Entities\Campaign;
 use Contentful\Delivery\Query;
 use Contentful\Delivery\Client as Contentful;
@@ -47,7 +45,7 @@ class CampaignRepository
      */
     public function findBySlug($slug)
     {
-        $flattenedCampaign = remember('campaign_'.$slug, 15, function () use($slug) {
+        $flattenedCampaign = remember('campaign_'.$slug, 15, function () use ($slug) {
             $query = (new Query)
                 ->setContentType('campaign')
                 ->where('fields.slug', $slug)

--- a/app/Repositories/CampaignRepository.php
+++ b/app/Repositories/CampaignRepository.php
@@ -61,6 +61,8 @@ class CampaignRepository
             } else {
                 $campaign = new Campaign($campaigns[0]);
 
+                // encoding campaign to provide serialized version of the campaign to cache, to avoid
+                // "Serialization of 'Closure' is not allowed" error.
                 return json_encode($campaign);
             }
         });

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -239,7 +239,7 @@ function useOverrideIfSet($field, $campaign, $override)
 /**
  * Determine the fields to display in the social share.
  *
- * @param  Campaign $campaign
+ * @param  stdClass $campaign
  * @param  string   $uri
  * @return array
  */
@@ -312,7 +312,7 @@ function get_client_environment_vars()
  * Get the presentation values we should package with our
  * Northstar authorization requests.
  *
- * @param  Campaign $campaign
+ * @param  stdClass $campaign
  * @return array
  */
 function get_login_query($campaign = null)

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -321,18 +321,11 @@ function get_login_query($campaign = null)
         return [];
     }
 
-    // This deals with when the $campaign is the flattenedCampaign std object
-    if (! $campaign instanceof App\Entities\Campaign) {
-        $coverImage = $campaign->coverImage->url;
-    } else {
-        $coverImage = get_image_url($campaign->coverImage);
-    }
-
     return [
         'destination' => $campaign->title,
         'options' => [
             'title' => $campaign->title,
-            'coverImage' => $coverImage,
+            'coverImage' => $campaign->coverImage->url,
             'callToAction' => $campaign->callToAction,
         ],
     ];

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -33,9 +33,9 @@ function scriptify($json = [], $store = 'STATE')
  * @param  \Closure  $callback
  * @return mixed
  */
-function remember($key, $minutes, Closure $callback)
+function remember($key, $minutes, Closure $callback, $skipCache = false)
 {
-    return app('cache')->remember($key, $minutes, $callback);
+    return $skipCache ? $callback() : app('cache')->remember($key, $minutes, $callback);
 }
 
 /**

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -243,15 +243,15 @@ function useOverrideIfSet($field, $campaign, $override)
  * @param  string   $uri
  * @return array
  */
-function get_social_fields($campaignFlattened, $uri)
+function get_social_fields($flattenedCampaign, $uri)
 {
-    $socialOverride = $campaignFlattened->socialOverride ? $campaignFlattened->socialOverride->fields : null;
-    $blockPath = $campaignFlattened->slug . '/blocks';
+    $socialOverride = $flattenedCampaign->socialOverride ? $flattenedCampaign->socialOverride->fields : null;
+    $blockPath = $flattenedCampaign->slug . '/blocks';
 
     if (str_contains($uri, $blockPath)) {
         $blockId = last(explode('/', $uri));
 
-        $block = array_first($campaignFlattened->activityFeed, function ($value) use ($blockId) {
+        $block = array_first($flattenedCampaign->activityFeed, function ($value) use ($blockId) {
             return $value->id === $blockId;
         });
 
@@ -260,19 +260,19 @@ function get_social_fields($campaignFlattened, $uri)
         }
     }
 
-    $coverImage = useOverrideIfSet('coverImage', $campaignFlattened, $socialOverride);
+    $coverImage = useOverrideIfSet('coverImage', $flattenedCampaign, $socialOverride);
     // If the image is pulled from socialOverride, its going to be a string.
-    // But if its pulled from campaignFlattened, its an object containing a url string.
+    // But if its pulled from flattenedCampaign, its an object containing a url string.
     if (gettype($coverImage) === 'object') {
         $coverImage = $coverImage->landscapeUrl;
     }
 
     return [
-        'title' => useOverrideIfSet('title', $campaignFlattened, $socialOverride),
-        'callToAction' => useOverrideIfSet('callToAction', $campaignFlattened, $socialOverride),
+        'title' => useOverrideIfSet('title', $flattenedCampaign, $socialOverride),
+        'callToAction' => useOverrideIfSet('callToAction', $flattenedCampaign, $socialOverride),
         'coverImage' => $coverImage,
         'facebookAppId' => config('services.analytics.facebook_id'),
-        'quote' => useOverrideIfSet('quote', $campaignFlattened, $socialOverride),
+        'quote' => useOverrideIfSet('quote', $flattenedCampaign, $socialOverride),
     ];
 }
 

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -321,11 +321,18 @@ function get_login_query($campaign = null)
         return [];
     }
 
+    // This deals with when the $campaign is the flattenedCampaign std object
+    if (! $campaign instanceof App\Entities\Campaign) {
+        $coverImage = $campaign->coverImage->url;
+    } else {
+        $coverImage = get_image_url($campaign->coverImage);
+    }
+
     return [
         'destination' => $campaign->title,
         'options' => [
             'title' => $campaign->title,
-            'coverImage' => get_image_url($campaign->coverImage),
+            'coverImage' => $coverImage,
             'callToAction' => $campaign->callToAction,
         ],
     ];

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -219,7 +219,12 @@ function get_legacy_campaign_data($id, $key = null)
  */
 function useOverrideIfSet($field, $campaign, $override)
 {
-    $base = $campaign->{$field};
+    if (! isset($campaign->{$field})) {
+        $base = null;
+    } else {
+        $base = $campaign->{$field};
+    }
+
     if ($override === null) {
         return $base;
     }
@@ -238,9 +243,8 @@ function useOverrideIfSet($field, $campaign, $override)
  * @param  string   $uri
  * @return array
  */
-function get_social_fields($campaign, $uri)
+function get_social_fields($campaignFlattened, $uri)
 {
-    $campaignFlattened = json_decode(json_encode($campaign));
     $socialOverride = $campaignFlattened->socialOverride ? $campaignFlattened->socialOverride->fields : null;
     $blockPath = $campaignFlattened->slug . '/blocks';
 
@@ -264,11 +268,11 @@ function get_social_fields($campaign, $uri)
     }
 
     return [
-        'title' => useOverrideIfSet('title', $campaign, $socialOverride),
-        'callToAction' => useOverrideIfSet('callToAction', $campaign, $socialOverride),
+        'title' => useOverrideIfSet('title', $campaignFlattened, $socialOverride),
+        'callToAction' => useOverrideIfSet('callToAction', $campaignFlattened, $socialOverride),
         'coverImage' => $coverImage,
         'facebookAppId' => config('services.analytics.facebook_id'),
-        'quote' => useOverrideIfSet('quote', $campaign, $socialOverride),
+        'quote' => useOverrideIfSet('quote', $campaignFlattened, $socialOverride),
     ];
 }
 

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -243,15 +243,15 @@ function useOverrideIfSet($field, $campaign, $override)
  * @param  string   $uri
  * @return array
  */
-function get_social_fields($flattenedCampaign, $uri)
+function get_social_fields($campaign, $uri)
 {
-    $socialOverride = $flattenedCampaign->socialOverride ? $flattenedCampaign->socialOverride->fields : null;
-    $blockPath = $flattenedCampaign->slug . '/blocks';
+    $socialOverride = $campaign->socialOverride ? $campaign->socialOverride->fields : null;
+    $blockPath = $campaign->slug . '/blocks';
 
     if (str_contains($uri, $blockPath)) {
         $blockId = last(explode('/', $uri));
 
-        $block = array_first($flattenedCampaign->activityFeed, function ($value) use ($blockId) {
+        $block = array_first($campaign->activityFeed, function ($value) use ($blockId) {
             return $value->id === $blockId;
         });
 
@@ -260,19 +260,19 @@ function get_social_fields($flattenedCampaign, $uri)
         }
     }
 
-    $coverImage = useOverrideIfSet('coverImage', $flattenedCampaign, $socialOverride);
+    $coverImage = useOverrideIfSet('coverImage', $campaign, $socialOverride);
     // If the image is pulled from socialOverride, its going to be a string.
-    // But if its pulled from flattenedCampaign, its an object containing a url string.
+    // But if its pulled from campaign, its an object containing a url string.
     if (gettype($coverImage) === 'object') {
         $coverImage = $coverImage->landscapeUrl;
     }
 
     return [
-        'title' => useOverrideIfSet('title', $flattenedCampaign, $socialOverride),
-        'callToAction' => useOverrideIfSet('callToAction', $flattenedCampaign, $socialOverride),
+        'title' => useOverrideIfSet('title', $campaign, $socialOverride),
+        'callToAction' => useOverrideIfSet('callToAction', $campaign, $socialOverride),
         'coverImage' => $coverImage,
         'facebookAppId' => config('services.analytics.facebook_id'),
-        'quote' => useOverrideIfSet('quote', $flattenedCampaign, $socialOverride),
+        'quote' => useOverrideIfSet('quote', $campaign, $socialOverride),
     ];
 }
 

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -213,7 +213,7 @@ function get_legacy_campaign_data($id, $key = null)
  * base object.
  *
  * @param  string $field
- * @param  Campaign $campaign
+ * @param  stdClass $campaign
  * @param  DynamicEntry $override
  * @return mixed
  */


### PR DESCRIPTION
### What does this PR do?
*Actually* caches all campaign data.


### Any background context you want to provide?
Previously in #471, we were caching only the raw campaign data. However most of the children of the campaign merely existed as `Links` without the content, and these Links would only be converted to full `DynamincEntry`'s with content (presumabely by always making yet more API calls to contentful) when the `json_encode` method was called on the campaign data in `helpers.php` - `get_social_fields`. (We were also calling it in `scriptify` which probably was triggering yet more calls.)

Now, we can have the `CampaignRepository`'s `findBySlug`, create the `Campaign`, call `json_encode` forcing all the children to be populated fully, and cache all that to begin with, saving all those extra API calls.

The only change is that now `CampaignRepository` is returning a std object of all campaign data, as opposed to an actual `CampaignEntity`. So `get_social_fields` had to be slightly adjusted to work with that.


### What are the relevant tickets/cards?
https://www.pivotaltracker.com/story/show/152202846

### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.

