### PR TITLE
changing User Gallery to Member Gallery

### DIFF
--- a/resources/assets/components/ActionPage/ActionStepsWrapper.js
+++ b/resources/assets/components/ActionPage/ActionStepsWrapper.js
@@ -112,9 +112,9 @@ const ActionStepsWrapper = (props) => {
 
   if (template === 'legacy') {
     stepComponents.push(
-      <div key="user_gallery" className="action-step margin-top-xlg margin-bottom-xlg margin-horizontal-md">
+      <div key="member_gallery" className="action-step margin-top-xlg margin-bottom-xlg margin-horizontal-md">
         <h2 className="heading -emphasized legacy-step-header margin-top-md margin-bottom-md">
-          <span>User Gallery</span>
+          <span>Member Gallery</span>
         </h2>
         {postGallery}
       </div>,


### PR DESCRIPTION
### What does this PR do?
A whole lot! 😓  
Changes the title of the User Gallery in `ActionStepsWrapper` to 'Member Gallery'.


### Any background context you want to provide?
Ben.


### What are the relevant tickets/cards?
https://www.pivotaltracker.com/story/show/152124449

### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.

