### PR TITLE
Flex cell fixes.

### DIFF
--- a/resources/assets/components/Feed/Feed.js
+++ b/resources/assets/components/Feed/Feed.js
@@ -15,18 +15,17 @@ import './feed.scss';
  * @param index
  * @returns {XML}
  */
-const renderFeedItem = (block, index) => {
-  console.log(block);
-
-
-  return (
-    <FlexCell key={`${block.id}-${index}`} width={block.fields.displayOptions} className={classnames('padded', {
+const renderFeedItem = (block, index) => (
+  <FlexCell
+    key={`${block.id}-${index}`}
+    width={block.fields.displayOptions}
+    className={classnames('padded', {
       'display-flex': block.type === 'reportbacks',
-    })}>
-      <Block json={block} />
-    </FlexCell>
-  );
-};
+    })}
+  >
+    <Block json={block} />
+  </FlexCell>
+);
 
 /**
  * Render the feed.

--- a/resources/assets/components/Feed/Feed.js
+++ b/resources/assets/components/Feed/Feed.js
@@ -1,9 +1,12 @@
-import PropTypes from 'prop-types';
 import React from 'react';
+import PropTypes from 'prop-types';
+import classnames from 'classnames';
+
+import Block from '../Block';
 import Revealer from '../Revealer';
 import { Flex, FlexCell } from '../Flex';
+
 import './feed.scss';
-import Block from '../Block';
 
 /**
  * Render a single feed item.
@@ -12,11 +15,18 @@ import Block from '../Block';
  * @param index
  * @returns {XML}
  */
-const renderFeedItem = (block, index) => (
-  <FlexCell className="padded" key={`${block.id}-${index}`} width={block.fields.displayOptions}>
-    <Block json={block} />
-  </FlexCell>
-);
+const renderFeedItem = (block, index) => {
+  console.log(block);
+
+
+  return (
+    <FlexCell key={`${block.id}-${index}`} width={block.fields.displayOptions} className={classnames('padded', {
+      'display-flex': block.type === 'reportbacks',
+    })}>
+      <Block json={block} />
+    </FlexCell>
+  );
+};
 
 /**
  * Render the feed.

--- a/resources/assets/components/Flex/flex.scss
+++ b/resources/assets/components/Flex/flex.scss
@@ -7,7 +7,6 @@
   }
 
   .flex__cell {
-    display: flex;
     flex: 1;
 
     &.-full {

--- a/resources/assets/components/ReportbackBlock/index.js
+++ b/resources/assets/components/ReportbackBlock/index.js
@@ -1,33 +1,20 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import BlockWrapper from '../Block/BlockWrapper';
-import { FlexCell } from '../Flex';
 import ReportbackItemContainer from '../ReportbackItem';
-import { mapDisplayToPoints } from '../../selectors/feed';
 import './reportback-block.scss';
 
-const ReportbackBlock = (props) => {
-  const items = [];
+const ReportbackBlock = ({ reportbacks }) => {
+  const id = reportbacks[0];
 
-  for (let i = 0; i < mapDisplayToPoints(props.fields.displayOptions); i += 1) {
-    const id = props.reportbacks[i];
-
-    items.push(
-      <FlexCell key={id || `null-${i}`}>
-        <BlockWrapper className="reportback-block">
-          <ReportbackItemContainer id={id} />
-        </BlockWrapper>
-      </FlexCell>,
-    );
-  }
-
-  return <FlexCell>{items}</FlexCell>;
+  return (
+    <BlockWrapper className="reportback-block" key={id}>
+      <ReportbackItemContainer id={id} />
+    </BlockWrapper>
+  );
 };
 
 ReportbackBlock.propTypes = {
-  fields: PropTypes.shape({
-    displayOptions: PropTypes.string,
-  }).isRequired,
   reportbacks: PropTypes.arrayOf(PropTypes.string).isRequired,
 };
 

--- a/resources/assets/scss/base.scss
+++ b/resources/assets/scss/base.scss
@@ -84,6 +84,14 @@ h1, h2, h3, p {
   clear: none;
 }
 
+.display-block {
+  display: block;
+}
+
+.display-flex {
+  display: flex;
+}
+
 .expand-horizontal-lg {
   margin-left: -$base-spacing;
   margin-right: -$base-spacing;


### PR DESCRIPTION
### What does this PR do?
This PR removes the `display: flex` style on the `.flex__cell` class which turns each flex item into a flex container as well. While this can be useful in some scenarios it was causing some unwanted issues with sidebar block sitting next to tall campaign updates for example, and forcing the sidebar block to stretch the full length of the campaign update:

![image](https://user-images.githubusercontent.com/105849/32196415-f838517c-bd96-11e7-8944-b5bfe6f2023b.png)

This update now lets sidebar block only span the size they need to:

![image](https://user-images.githubusercontent.com/105849/32196439-0fe72b40-bd97-11e7-86b1-65ab41633277.png)


You can restore the old behavior of stretching vertically by now adding the `.display-flex` class to `FlexCell` components as needed.

This PR also removes the multiple nested flex__cell divs that were being wrapped around `ReportbackBlock` items, which are no longer necessary ever since the PR that started rendering them as individual items from a while back.


### Any background context you want to provide?
This PR relates to work on the CTA components for an upcoming PR.


### What are the relevant tickets/cards?
Refs https://www.pivotaltracker.com/story/show/151174012
