### PR TITLE
Reportback affirmation adventures

### DIFF
--- a/resources/assets/actions/reportback.js
+++ b/resources/assets/actions/reportback.js
@@ -78,8 +78,11 @@ export function storeReportbackFailed(error) {
 }
 
 // Action: storing new user submitted reportback was successful.
-export function storeReportbackSuccessful() {
-  return { type: STORE_REPORTBACK_SUCCESSFUL };
+export function storeReportbackSuccessful(reportbackAffirmation) {
+  return {
+    type: STORE_REPORTBACK_SUCCESSFUL,
+    reportbackAffirmation,
+  };
 }
 
 export function requestingUserReportbacks() {
@@ -151,7 +154,7 @@ export function toggleReactionOff(reportbackItemId, reactionId) {
 }
 
 // Async Action: submit a new reportback and place in submissions gallery.
-export function submitReportback(reportback) {
+export function submitReportback(reportback, reportbackAffirmation) {
   return (dispatch) => {
     dispatch(storeReportback(reportback));
 
@@ -176,8 +179,7 @@ export function submitReportback(reportback) {
             dispatch(storeReportbackFailed(json));
           });
         } else {
-          dispatch(storeReportbackSuccessful());
-
+          dispatch(storeReportbackSuccessful(reportbackAffirmation));
           response.json().then((json) => {
             dispatch(addSubmissionMetadata(reportback, json.shift()));
             dispatch(addSubmissionItemToList(reportback));

--- a/resources/assets/components/ReportbackUploader/ReportbackUploader.js
+++ b/resources/assets/components/ReportbackUploader/ReportbackUploader.js
@@ -66,7 +66,10 @@ class ReportbackUploader extends React.Component {
 
     reportback.media.type = fileType ? fileType.substring(0, fileType.indexOf('/')) : null;
 
-    this.props.submitReportback(ReportbackUploader.setFormData(reportback));
+    this.props.submitReportback(
+      ReportbackUploader.setFormData(reportback),
+      this.props.reportbackAffirmation,
+    );
 
     // @TODO: only reset form AFTER successful RB submission.
     // We'll make this a lot better once we switch to storing all the state
@@ -133,6 +136,7 @@ ReportbackUploader.propTypes = {
     plural: PropTypes.string,
   }),
   quantityOverride: PropTypes.number,
+  reportbackAffirmation: PropTypes.string,
 };
 
 ReportbackUploader.defaultProps = {
@@ -141,6 +145,7 @@ ReportbackUploader.defaultProps = {
     plural: 'items',
   },
   quantityOverride: null,
+  reportbackAffirmation: 'Thanks! We got your photo and you\'re entered to win the scholarship!',
 };
 
 export default ReportbackUploader;

--- a/resources/assets/components/ReportbackUploader/ReportbackUploaderContainer.js
+++ b/resources/assets/components/ReportbackUploader/ReportbackUploaderContainer.js
@@ -12,6 +12,7 @@ const mapStateToProps = state => ({
   submissions: state.submissions,
   noun: get(state.campaign.additionalContent, 'noun'),
   uploads: state.uploads,
+  reportbackAffirmation: get(state.campaign.additionalContent, 'reportbackAffirmation'),
 });
 
 /**

--- a/resources/assets/reducers/submissions.js
+++ b/resources/assets/reducers/submissions.js
@@ -40,9 +40,7 @@ const submissions = (state = {}, action) => {
         ...state,
         messaging: {
           success: {
-            // @TODO: Add this to Contentful either in the the campaign or
-            // in the Photo Uploader Component.
-            message: 'Thanks! We got your photo and you\'re entered to win the scholarship!',
+            message: action.reportbackAffirmation,
           },
         },
         isStoring: false,


### PR DESCRIPTION
### What does this PR do?
Adds `reportbackAffirmation` prop from the states campaigns `additionalContent` to the ReportbackUploader and passes that message to the action and reducer for successful reportbacks.
The message does still fall back to the default message we were using up to this point if no reportbackAffirmation is set.

### Any background context you want to provide?
Eventually, we'll add this as a proper field in the Campaign model.


### What are the relevant tickets/cards?
https://www.pivotaltracker.com/story/show/152320169

### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.

