### PR TITLE
removing action-step class from legacy member gallery div

### DIFF
--- a/resources/assets/components/ActionPage/ActionStepsWrapper.js
+++ b/resources/assets/components/ActionPage/ActionStepsWrapper.js
@@ -112,11 +112,13 @@ const ActionStepsWrapper = (props) => {
 
   if (template === 'legacy') {
     stepComponents.push(
-      <div key="member_gallery" className="action-step margin-top-xlg margin-bottom-xlg margin-horizontal-md">
-        <h2 className="heading -emphasized legacy-step-header margin-top-md margin-bottom-md">
-          <span>Member Gallery</span>
-        </h2>
-        {postGallery}
+      <div key="member_gallery" className="action-step">
+        <div className="margin-top-xlg margin-bottom-xlg margin-horizontal-md">
+          <h2 className="heading -emphasized legacy-step-header margin-top-md margin-bottom-md">
+            <span>Member Gallery</span>
+          </h2>
+          {postGallery}
+        </div>
       </div>,
     );
   }


### PR DESCRIPTION
### What does this PR do?
~Removing the `action-step` class from the Member Gallery div. It doesn't seem to affect anything save for adding that `width: 100%` rule that causes the bug on mobile~

Implemented fix discovered by @weerd 

> Ok! @mendelB so I was less willing to remove the action-step class on just the one section to fix that. The problem does involve that, but moreso its because the action-step has a width:100% along with utility classes to add margins, which would make that div expand farther than 100% (100% plus both left and right margin amounts). I don't think I realized that when I initially added the utility classes to the gallery... 🤕

> So to fix it, we just need to add another div inside the action-steps div and move the utility classes to that div:

![image](https://user-images.githubusercontent.com/12417657/32300179-a9468392-bf2e-11e7-9c3c-1d4560f5a0b0.png)




### Any background context you want to provide?
If we want to keep that class, and remove the 100 percent width rule another way pls let me know.

### What are the relevant tickets/cards?
https://dosomething.slack.com/archives/C3ASB4204/p1509561233000488

### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.

