### PR TITLE
changing social share link to be modal instead of block

### DIFF
--- a/resources/assets/helpers/index.js
+++ b/resources/assets/helpers/index.js
@@ -292,7 +292,7 @@ export function makeHash(string) {
 export function makeShareLink(type, options: { domain: string, slug?: string, key: string }) {
   switch (type) {
     case 'campaigns':
-      return `${options.domain}/us/campaigns/${options.slug}/blocks/${options.key}`;
+      return `${options.domain}/us/campaigns/${options.slug}/modal/${options.key}`;
 
     default:
       throw new Error('Please provide an expected section type for generating the link.');

--- a/resources/assets/helpers/test.js
+++ b/resources/assets/helpers/test.js
@@ -53,7 +53,7 @@ test('it makes the expected share link for a content item and app section type',
     key: '123',
   };
 
-  expect(makeShareLink('campaigns', options)).toBe('http://awesome.com/us/campaigns/seriously-awesome-campaign/blocks/123');
+  expect(makeShareLink('campaigns', options)).toBe('http://awesome.com/us/campaigns/seriously-awesome-campaign/modal/123');
 });
 
 test('it cannot make share link with an unknown app section type', () => {


### PR DESCRIPTION
### What does this PR do?
- Changes the link generated by `makeShareLink` for `campaign` types, to be linking to the modal instead of the block. 
-  the facebook share button in `CampaignUpdate`s  and `CampaignUpdateBlock`s which make use of the `helpers#makeShareLink` to generate their social links, are now linking to modals as a result
- Another side effect of this is that the primary link atop a campaign update 
<img width="1082" alt="screen shot 2017-11-03 at 2 39 37 pm" src="https://user-images.githubusercontent.com/12417657/32390510-11f540a0-c0a5-11e7-81f5-fb704f20b674.png">
(in both blocks and regular) now also link to the modal. (Since the link used is the same as the social link). (This was approved by Ashley/Adam).



### Any background context you want to provide?
Older `CampaignUpdateBlocks` don't render so nicely in modals yet as for now they're being returned plainly in a `Card`. I'll work on another pull request to support them in models.


### What are the relevant tickets/cards?
https://www.pivotaltracker.com/story/show/152351435

### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.

