### PR TITLE
Campaign update blocks in modal

### DIFF
--- a/resources/assets/components/CampaignUpdateBlock/CampaignUpdateBlockContainer.js
+++ b/resources/assets/components/CampaignUpdateBlock/CampaignUpdateBlockContainer.js
@@ -1,15 +1,22 @@
 /* global window */
 
 import { connect } from 'react-redux';
+import { find } from 'lodash';
 import CampaignUpdateBlock from './CampaignUpdateBlock';
 import { makeShareLink } from '../../helpers';
 
-const mapStateToProps = (state, props) => ({
-  shareLink: makeShareLink('campaigns', {
-    domain: window.location.origin,
-    slug: state.campaign.slug,
-    key: props.id,
-  }),
-});
+const mapStateToProps = (state, props) => {
+  const campaignUpdateFields = props.fields ||
+    find(state.campaign.activityFeed, { id: props.id }).fields;
+
+  return {
+    fields: campaignUpdateFields,
+    shareLink: makeShareLink('campaigns', {
+      domain: window.location.origin,
+      slug: state.campaign.slug,
+      key: props.id,
+    }),
+  };
+};
 
 export default connect(mapStateToProps)(CampaignUpdateBlock);

--- a/resources/assets/components/Modal/configurations/ContentModal.js
+++ b/resources/assets/components/Modal/configurations/ContentModal.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import Card from '../../Card';
 import Markdown from '../../Markdown';
 import { CampaignUpdateContainer } from '../../CampaignUpdate';
+import { CampaignUpdateBlockContainer } from '../../CampaignUpdateBlock';
 
 const ContentModal = (props) => {
   const { content, title, type, contentfulId } = props;
@@ -10,6 +11,12 @@ const ContentModal = (props) => {
   const campaignUpdate = (
     <div className="modal__slide">
       <CampaignUpdateContainer id={contentfulId} bordered={false} />
+    </div>
+  );
+
+  const campaignUpdateBlock = (
+    <div className="modal__slide">
+      <CampaignUpdateBlockContainer id={contentfulId} />
     </div>
   );
 
@@ -22,6 +29,8 @@ const ContentModal = (props) => {
   switch (type) {
     case 'campaignUpdate':
       return campaignUpdate;
+    case 'campaign_update':
+      return campaignUpdateBlock;
     default:
       return card;
   }


### PR DESCRIPTION
### What does this PR do?
- Adds support for `CampaignUpdateBlock`s in the modal. Previously modal would just fall back to the default and render a plain `Card`.
- Adding functionality to `CampaignUpdateBlockContainer` to find the campaign update fields from the state through the `id` prop when no `fields` prop is passed through. (Copied this logic from the [`CampaignUpdateContainer`](https://github.com/DoSomething/phoenix-next/blob/dev/resources/assets/components/CampaignUpdate/CampaignUpdateContainer.js#L9))


### Any background context you want to provide?
#481 


### What are the relevant tickets/cards?
Fixes #

### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.

