### PR TITLE
adding twitter intent share button for campaignUpdates

### DIFF
--- a/resources/assets/components/Share/Share.js
+++ b/resources/assets/components/Share/Share.js
@@ -15,7 +15,7 @@ const Share = (props) => {
 
   const trackingData = { parentSource, variant, link, quote };
 
-  const onClick = () => {
+  const onFacebookClick = () => {
     trackEvent('clicked facebook share', trackingData);
 
     showFacebookSharePrompt({ href: link, quote }, (response) => {
@@ -27,14 +27,30 @@ const Share = (props) => {
     });
   };
 
+  const onTwitterClick = () => {
+    trackEvent('clicked twitter share', trackingData);
+  };
+
+  const buttonClassName = classnames(
+    'button share', className, { '-black': variant === 'black', '-icon': variant === 'icon' },
+  );
+
   return (
-    <button
-      className={classnames('button share', className, { '-black': variant === 'black', '-icon': variant === 'icon' })}
-      onClick={onClick}
-    >
-      {variant === 'icon' ? null : 'share on'}
-      <i className="social-icon -facebook"><span>Facebook</span></i>
-    </button>
+    <div>
+      <button className={buttonClassName} onClick={onFacebookClick}>
+        {variant === 'icon' ? null : 'share on'}
+        <i className="social-icon -facebook"><span>Facebook</span></i>
+      </button>
+
+      { variant === 'icon' ? (
+        <a href={`https://twitter.com/intent/tweet?url=${link}`} target="_blank" onClick={onTwitterClick}>
+          <button className={buttonClassName}>
+            {variant === 'icon' ? null : 'share on'}
+            <i className="social-icon -twitter"><span>Twitter</span></i>
+          </button>
+        </a>) : null
+      }
+    </div>
   );
 };
 

--- a/resources/assets/components/Share/Share.js
+++ b/resources/assets/components/Share/Share.js
@@ -30,7 +30,7 @@ const Share = (props) => {
   const onTwitterClick = () => {
     trackEvent('clicked twitter share', trackingData);
 
-    showTwitterSharePrompt({ href: link, quote });
+    showTwitterSharePrompt(link, quote || '');
   };
 
   const buttonClassName = classnames(

--- a/resources/assets/components/Share/Share.js
+++ b/resources/assets/components/Share/Share.js
@@ -32,16 +32,11 @@ const Share = (props) => {
   };
 
   const buttonClassName = classnames(
-    'button share', className, { '-black': variant === 'black', '-icon': variant === 'icon' },
+    'button share padding-horizontal-md', className, { '-black': variant === 'black', '-icon': variant === 'icon' },
   );
 
   return (
     <div>
-      <button className={buttonClassName} onClick={onFacebookClick}>
-        {variant === 'icon' ? null : 'share on'}
-        <i className="social-icon -facebook"><span>Facebook</span></i>
-      </button>
-
       { variant === 'icon' ? (
         <a href={`https://twitter.com/intent/tweet?url=${link}`} target="_blank" onClick={onTwitterClick}>
           <button className={buttonClassName}>
@@ -50,6 +45,11 @@ const Share = (props) => {
           </button>
         </a>) : null
       }
+
+      <button className={buttonClassName} onClick={onFacebookClick}>
+        {variant === 'icon' ? null : 'share on'}
+        <i className="social-icon -facebook"><span>Facebook</span></i>
+      </button>
     </div>
   );
 };

--- a/resources/assets/components/Share/Share.js
+++ b/resources/assets/components/Share/Share.js
@@ -3,7 +3,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import classnames from 'classnames';
-import { showFacebookSharePrompt } from '../../helpers';
+import { showFacebookSharePrompt, showTwitterSharePrompt } from '../../helpers';
 
 import './share.scss';
 
@@ -29,6 +29,8 @@ const Share = (props) => {
 
   const onTwitterClick = () => {
     trackEvent('clicked twitter share', trackingData);
+
+    showTwitterSharePrompt({ href: link, quote });
   };
 
   const buttonClassName = classnames(
@@ -38,11 +40,9 @@ const Share = (props) => {
   return (
     <div>
       { variant === 'icon' ? (
-        <a href={`https://twitter.com/intent/tweet?url=${link}`} target="_blank" onClick={onTwitterClick}>
-          <button className={buttonClassName}>
-            <i className="social-icon -twitter"><span>Twitter</span></i>
-          </button>
-        </a>) : null
+        <button className={buttonClassName} onClick={onTwitterClick}>
+          <i className="social-icon -twitter"><span>Twitter</span></i>
+        </button>) : null
       }
 
       <button className={buttonClassName} onClick={onFacebookClick}>

--- a/resources/assets/components/Share/Share.js
+++ b/resources/assets/components/Share/Share.js
@@ -40,7 +40,6 @@ const Share = (props) => {
       { variant === 'icon' ? (
         <a href={`https://twitter.com/intent/tweet?url=${link}`} target="_blank" onClick={onTwitterClick}>
           <button className={buttonClassName}>
-            {variant === 'icon' ? null : 'share on'}
             <i className="social-icon -twitter"><span>Twitter</span></i>
           </button>
         </a>) : null

--- a/resources/assets/helpers/index.js
+++ b/resources/assets/helpers/index.js
@@ -394,11 +394,10 @@ export function showFacebookSharePrompt(share, callback) {
 /**
  * Share a link by generating a Twitter intent share prompt.
  *
- * @param  {Object}   share
+ * @param  {String} href
+ * @param  {String} quote
  */
-export function showTwitterSharePrompt(share) {
-  const { href, quote } = share;
-
+export function showTwitterSharePrompt(href, quote) {
   const width = 550;
   const height = 420;
   const winHeight = window.screen.height;
@@ -411,6 +410,6 @@ export function showTwitterSharePrompt(share) {
     top = Math.round((winHeight / 2) - (height / 2));
   }
 
-  window.open(`https://twitter.com/intent/tweet?url=${href}&text=${quote || ''}`, 'intent',
+  window.open(`https://twitter.com/intent/tweet?url=${href}&text=${quote}`, 'intent',
     `scrollbars=yes,resizable=yes,toolbar=no,location=yes,width=${width},height=${height},left=${left},top=${top}`);
 }

--- a/resources/assets/helpers/index.js
+++ b/resources/assets/helpers/index.js
@@ -390,3 +390,27 @@ export function showFacebookSharePrompt(share, callback) {
     quote,
   }, callback);
 }
+
+/**
+ * Share a link by generating a Twitter intent share prompt.
+ *
+ * @param  {Object}   share
+ */
+export function showTwitterSharePrompt(share) {
+  const { href, quote } = share;
+
+  const width = 550;
+  const height = 420;
+  const winHeight = window.screen.height;
+  const winWidth = window.screen.width;
+
+  const left = Math.round((winWidth / 2) - (width / 2));
+  let top = 0;
+
+  if (winHeight > height) {
+    top = Math.round((winHeight / 2) - (height / 2));
+  }
+
+  window.open(`https://twitter.com/intent/tweet?url=${href}&text=${quote || ''}`, 'intent',
+    `scrollbars=yes,resizable=yes,toolbar=no,location=yes,width=${width},height=${height},left=${left},top=${top}`);
+}


### PR DESCRIPTION
### What does this PR do?
Adds a twitter icon with sharing capabilities (a link to a twitter intent pre-filled with update URL) to campaign updates (or any ShareContainer rendered with a `variant="icon"`)




### Any background context you want to provide?
- Unfortunately -along with the other faults of the tweet intent link- twitter won't give us a callback or trigger an event when the user actually tweets the tweet rather only when they click the link to tweet the tweet.
["Note that Web Intent events fire when the interaction occurs, not after the action completes."](https://dev.twitter.com/web/javascript/events)
So although there is a 'Twitter For Websites' JS plugin, for now, I don't believe there's even a reason to include it, as we can track the clicking ourselves thank you very much.

- One thing we could gain by using their plugin is that clicking the share button will pop up a modal, that is size formatted behind the scenes which feels a bit better than opening a new tab.
![image](https://user-images.githubusercontent.com/12417657/32466754-09d4756c-c316-11e7-86f2-9594772a0ac4.png)
Not sure if that makes it worthwhile?

- The tweet button has kinda been lumped in with the facebook sharing button in the `Share` component. I wasn't sure if now was the time to start creating separate social share components for each service as the twitter stuff doesn't add much complexity as of yet. If I'm wrong about that please do let me know.

- @lkpttn If you have any design thoughts on this. Here's how it looks as of now:
![image](https://user-images.githubusercontent.com/12417657/32466933-bd9db77a-c316-11e7-8c9e-4a928ef41136.png)



### What are the relevant tickets/cards?
https://www.pivotaltracker.com/story/show/152418373

### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.

