### PR TITLE
Fix footnotes

### DIFF
--- a/resources/assets/components/Markdown/markdown.scss
+++ b/resources/assets/components/Markdown/markdown.scss
@@ -97,5 +97,6 @@
   .footnotes-list, .footnote-item p {
     font-size: $font-small;
     color: $med-gray;
+    overflow-wrap: break-word;
   }
 }


### PR DESCRIPTION
### What does this PR do?
> Note: In contrast to overflow-wrap, word-break will create a break at the exact place where text would otherwise overflow its container (even if putting an entire word on its own line would negate the need for a break).

https://developer.mozilla.org/en-US/docs/Web/CSS/overflow-wrap

<img width="215" alt="screen shot 2017-11-07 at 12 40 33 pm" src="https://user-images.githubusercontent.com/897368/32508623-e9cb87c6-c3b8-11e7-8296-bcdebca2d786.png">
