### PR TITLE
Add script to clear the cache when deploying on production.

### DIFF
--- a/wercker.yml
+++ b/wercker.yml
@@ -21,6 +21,9 @@ deploy:
   steps:
     - bundle-install
     - script:
+        name: clear all cache
+        code: php artisan cache:clear
+    - script:
         name: write private key env var
         code: |-
           export CAP_PRIVATE_KEY=`mktemp`


### PR DESCRIPTION
### What does this PR do?
Since we have a 15 minute cache, there could be a possible scenario where we make updates to Contentful, and make changes to code that address these updates, yet after a deploy to Production, the prod website is still referring to different content structure based on content that is cached and could lead to trouble. Thus, we should be clearing the application cache whenever we deploy to Production.

### Any background context you want to provide?
I haven't messed much with Wercker before, so please tell me if I this is correct or not!

