### PR TITLE
Template on signup

### DIFF
--- a/resources/assets/components/SignupButton/SignupButton.js
+++ b/resources/assets/components/SignupButton/SignupButton.js
@@ -14,11 +14,16 @@ import SignupButtonContainer from './SignupButtonContainer';
  */
 const SignupButtonFactory = (WrappedComponent, source = null, sourceData = null) => {
   const SignupButton = (props) => {
-    const { clickedSignUp, trackEvent } = props;
+    const { clickedSignUp, template, trackEvent } = props;
 
     const onSignup = (campaignId) => {
       clickedSignUp(campaignId);
-      trackEvent('signup', { campaignId, source, sourceData });
+      trackEvent('signup', {
+        template,
+        campaignId,
+        source,
+        sourceData,
+      });
     };
 
     return (
@@ -28,7 +33,12 @@ const SignupButtonFactory = (WrappedComponent, source = null, sourceData = null)
 
   SignupButton.propTypes = {
     clickedSignUp: PropTypes.func.isRequired,
+    template: PropTypes.string,
     trackEvent: PropTypes.func.isRequired,
+  };
+
+  SignupButton.defaultProps = {
+    template: null,
   };
 
   return SignupButtonContainer(PuckConnector(SignupButton));

--- a/resources/assets/components/SignupButton/SignupButtonContainer.js
+++ b/resources/assets/components/SignupButton/SignupButtonContainer.js
@@ -1,7 +1,7 @@
 import { connect } from 'react-redux';
 import { clickedSignUp } from '../../actions/signup';
 
-const mapStateToProps = (state) => ({
+const mapStateToProps = state => ({
   template: state.campaign.template,
 });
 
@@ -9,4 +9,4 @@ const actionCreators = {
   clickedSignUp,
 };
 
-export default Component => connect(null, actionCreators)(Component);
+export default Component => connect(mapStateToProps, actionCreators)(Component);

--- a/resources/assets/components/SignupButton/SignupButtonContainer.js
+++ b/resources/assets/components/SignupButton/SignupButtonContainer.js
@@ -1,6 +1,10 @@
 import { connect } from 'react-redux';
 import { clickedSignUp } from '../../actions/signup';
 
+const mapStateToProps = (state) => ({
+  template: state.campaign.template,
+});
+
 const actionCreators = {
   clickedSignUp,
 };


### PR DESCRIPTION
### What does this PR do?
This PR adds the `template` data to every signup event dispatched so we can compare template signups broadly. 

NOTE: If we're doing an A/B test of the two templates on the same campaign, this property would not solve that. That would require injecting whatever custom data into the sourceData or (hopefully) automatically attaching relevant A/B test info.  EG: Put a flag in `experiments.json` that the test should be included in the signup event payload.

<img width="456" alt="screen shot 2017-11-08 at 2 18 43 pm" src="https://user-images.githubusercontent.com/897368/32569818-3d018062-c490-11e7-9ed9-50591f1f326b.png">
