### PR TITLE
ensuring we dont push blank reportbacks as blocks when insufficient reportbacks

### DIFF
--- a/resources/assets/selectors/feed.js
+++ b/resources/assets/selectors/feed.js
@@ -80,9 +80,13 @@ export function getVisibleBlocks(state) {
     return totalPoints <= blockOffset;
   });
 
+  // In case we don't have enough reportbacks in our state to fill the
+  // target amount, we'll shave the target number to fit with what we
+  // actually have so we don't churn out blank RBs.
   if ((state.reportbacks.ids.length + totalPoints) < blockOffset) {
     blockOffset = state.reportbacks.ids.length + totalPoints;
   }
+
   // If we weren't able to fill enough rows with blocks, add
   // additional reportback blocks until we hit the target.
   while (totalPoints < blockOffset && totalPoints < getMaximumOffset(state)) {

--- a/resources/assets/selectors/feed.js
+++ b/resources/assets/selectors/feed.js
@@ -69,7 +69,8 @@ export const getMaximumOffset = state => (
  * @param state
  */
 export function getVisibleBlocks(state) {
-  const blockOffset = getBlockOffset(state);
+  let blockOffset = getBlockOffset(state);
+
   let totalPoints = 0;
 
   // Filter out blocks that don't fit within offset.
@@ -79,6 +80,9 @@ export function getVisibleBlocks(state) {
     return totalPoints <= blockOffset;
   });
 
+  if ((state.reportbacks.ids.length + totalPoints) < blockOffset) {
+    blockOffset = state.reportbacks.ids.length + totalPoints;
+  }
   // If we weren't able to fill enough rows with blocks, add
   // additional reportback blocks until we hit the target.
   while (totalPoints < blockOffset && totalPoints < getMaximumOffset(state)) {


### PR DESCRIPTION
### What does this PR do?
When we don't have enough reportbacks in state to fill the specified block offset amount, this will set the amount to fit with however many reportbacks we have.


### Any background context you want to provide?
We fetch a static amount of 24 reportbacksItems from the API, we then normalize the data to parse out unique reportbacks. For missing-history this ended up being only 7 unique reportbacks. 
The issue is that we'd be trying to fill the offset block amount of 15 with only 7 reportbacks, leading to a bunch of blank reportbacks on the page:
![image](https://user-images.githubusercontent.com/12417657/32625984-f8d1a602-c55b-11e7-8ea8-d0d55a5277e6.png)


This PR will ensure that if we have less reportbacks available then the offset wants, instead of churning out blank reportbacks until we achieve that number, it will just set the number to be however many RB we have.

![image](https://user-images.githubusercontent.com/12417657/32626760-39a86984-c55e-11e7-8357-3b7848648136.png)


(This is a somewhat rushed attempt at a fix. The logic running the Blocks and RBs is fairly complicated so this took me a bit. Plese LMK if I'm very off base with this / if there's a better way to go about this. (one suggestion might be to either up the count of RB items we're requesting from Rogue to begin with which will probably prevent this from ever happening. Or to keep requesting more RBs until we have enough unique ones to fill the offset)) Anyways I'm rambling here so 🤐 


### What are the relevant tickets/cards?
https://www.pivotaltracker.com/story/show/152723398

### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.

