### PR TITLE
Combining custom block campaign update into single campaign update component.

### DIFF
--- a/app/Entities/Campaign.php
+++ b/app/Entities/Campaign.php
@@ -94,6 +94,10 @@ class Campaign extends Entity implements JsonSerializable
                         return new CallToAction($item->entry);
                     }
 
+                    if ($item->entry->getType() === 'campaign_update') {
+                        return new CampaignUpdate($item->entry);
+                    }
+
                     if ($item->entry->getType() === 'reportbacks') {
                         return  $this->fillReportbackPosts($item->entry);
                     }

--- a/app/Entities/CampaignUpdate.php
+++ b/app/Entities/CampaignUpdate.php
@@ -13,7 +13,7 @@ class CampaignUpdate extends Entity implements JsonSerializable
      */
     public function jsonSerialize()
     {
-        switch($this->getContentType()) {
+        switch ($this->getContentType()) {
             case 'campaignUpdate':
                 $type = $this->getContentType();
                 $author = new Staff($this->author->entry);

--- a/app/Entities/CampaignUpdate.php
+++ b/app/Entities/CampaignUpdate.php
@@ -13,15 +13,39 @@ class CampaignUpdate extends Entity implements JsonSerializable
      */
     public function jsonSerialize()
     {
+        switch($this->getContentType()) {
+            case 'campaignUpdate':
+                $type = $this->getContentType();
+                $author = new Staff($this->author->entry);
+                $content = $this->content;
+                $socialOverride = $this->socialOverride ? new SocialOverride($this->socialOverride->entry) : null;
+                break;
+
+            case 'customBlock':
+                $type = 'campaignUpdate';
+                $author = [
+                    'id' => null,
+                    'type' => 'staff',
+                    'fields' => [
+                        'name' => isset($this->additionalContent['author']) ? $this->additionalContent['author'] : null,
+                        'jobTitle' => isset($this->additionalContent['jobTitle']) ? $this->additionalContent['jobTitle'] : null,
+                        'avatar' => null,
+                    ],
+                ];
+                $content = "## {$this->title}\n\n {$this->content}";
+                $socialOverride = null;
+                break;
+        }
+
         return [
             'id' => $this->entry->getId(),
-            'type' => $this->getContentType(),
+            'type' => $type,
             'fields' => [
-                'author' => new Staff($this->author->entry),
-                'content' => $this->content,
+                'author' => $author,
+                'content' => $content,
                 'displayOptions' => $this->displayOptions->first(),
                 'link' => $this->link,
-                'socialOverride' => $this->socialOverride ? new SocialOverride($this->socialOverride->entry) : null,
+                'socialOverride' => $socialOverride,
             ],
         ];
     }


### PR DESCRIPTION
### What does this PR do?
This PR removes the use of the `CampaignUpdateBlock` component in favor of the `CampaignUpdate` component and allows the old style custom block version of the data to get processed and output as the official component.

### Checklist
- [ ] Added appropriate feature/unit tests.

