### PR TITLE
Affirmation trigger button on admin dashboard

### DIFF
--- a/resources/assets/actions/signup.js
+++ b/resources/assets/actions/signup.js
@@ -159,9 +159,7 @@ export function clickedSignUp(campaignId, options = null, shouldRedirectToAction
 // Action: triggers the post signup affirmation modal.
 // This is for admin usage.
 export function clickedShowAffirmation() {
-  return dispatch => (
-    dispatch(openModal(POST_SIGNUP_MODAL))
-  );
+  return openModal(POST_SIGNUP_MODAL);
 }
 
 // Action: sends whether the user opted out of affiliate messaging.

--- a/resources/assets/actions/signup.js
+++ b/resources/assets/actions/signup.js
@@ -159,7 +159,7 @@ export function clickedSignUp(campaignId, options = null, shouldRedirectToAction
 // Action: triggers the post signup affirmation modal.
 // This is for admin usage.
 export function clickedShowAffirmation() {
-  return (dispatch) => (
+  return dispatch => (
     dispatch(openModal(POST_SIGNUP_MODAL))
   );
 }

--- a/resources/assets/actions/signup.js
+++ b/resources/assets/actions/signup.js
@@ -156,6 +156,14 @@ export function clickedSignUp(campaignId, options = null, shouldRedirectToAction
   };
 }
 
+// Action: triggers the post signup affirmation modal.
+// This is for admin usage.
+export function clickedShowAffirmation() {
+  return (dispatch) => (
+    dispatch(openModal(POST_SIGNUP_MODAL))
+  );
+}
+
 // Action: sends whether the user opted out of affiliate messaging.
 export function clickedOptOut() {
   return { type: SIGNUP_CLICKED_OPT_OUT };

--- a/resources/assets/components/Campaign/Campaign.js
+++ b/resources/assets/components/Campaign/Campaign.js
@@ -9,13 +9,16 @@ import NotificationContainer from '../Notification';
 import AdminDashboardContainer from '../AdminDashboard';
 
 const Campaign = (props) => {
-  const { isAffiliated, useLandingPage, slug } = props;
+  const { isAffiliated, useLandingPage, slug, clickedShowAffirmation } = props;
 
   return (
     <div>
       <AdminDashboardContainer>
-        <a className="button -secondary" href={`/next/cache/campaign_${slug}?redirect=${window.location.pathname}`}>
+        <a className="button -secondary margin-horizontal-md" href={`/next/cache/campaign_${slug}?redirect=${window.location.pathname}`}>
           Clear Cache
+        </a>
+        <a className="button -secondary margin-horizontal-md" onClick={clickedShowAffirmation}>
+          Show Affirmation
         </a>
       </AdminDashboardContainer>
       <NotificationContainer />
@@ -33,6 +36,7 @@ Campaign.propTypes = {
   isAffiliated: PropTypes.bool,
   useLandingPage: PropTypes.bool,
   slug: PropTypes.string.isRequired,
+  clickedShowAffirmation: PropTypes.func.isRequired,
 };
 
 Campaign.defaultProps = {

--- a/resources/assets/components/Campaign/Campaign.js
+++ b/resources/assets/components/Campaign/Campaign.js
@@ -17,9 +17,9 @@ const Campaign = (props) => {
         <a className="button -secondary margin-horizontal-md" href={`/next/cache/campaign_${slug}?redirect=${window.location.pathname}`}>
           Clear Cache
         </a>
-        <a className="button -secondary margin-horizontal-md" onClick={clickedShowAffirmation}>
+        <button className="button -secondary margin-horizontal-md" onClick={clickedShowAffirmation}>
           Show Affirmation
-        </a>
+        </button>
       </AdminDashboardContainer>
       <NotificationContainer />
       <ModalSwitch />

--- a/resources/assets/components/Campaign/CampaignContainer.js
+++ b/resources/assets/components/Campaign/CampaignContainer.js
@@ -1,6 +1,7 @@
 import { connect } from 'react-redux';
 
 import Campaign from './Campaign';
+import { clickedShowAffirmation } from '../../actions/signup';
 
 const mapStateToProps = state => ({
   isAffiliated: state.signups.thisCampaign,
@@ -8,4 +9,8 @@ const mapStateToProps = state => ({
   slug: state.campaign.slug,
 });
 
-export default connect(mapStateToProps)(Campaign);
+const actionCreators = {
+  clickedShowAffirmation,
+};
+
+export default connect(mapStateToProps, actionCreators)(Campaign);


### PR DESCRIPTION
### What does this PR do?
adds Show Affirmation button to the admin dashboard to enable admins to preview the post signup affirmation conveniently.


### Any background context you want to provide?
- Added a special action to the `signup` actions to make this work as the regular way is within the whole mess of clickedSignup logic and flow.
- Styling with some margins for the buttons as they were sticking together.
- Just realized that with multiple buttons this will get pretty ugly on smaller screens. Should we deal with this now or later?


### What are the relevant tickets/cards?
https://www.pivotaltracker.com/story/show/152546110

### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.

