### PR TITLE
Fixing campaign info not showing on the NS login page

### DIFF
--- a/app/Http/Controllers/AuthController.php
+++ b/app/Http/Controllers/AuthController.php
@@ -48,7 +48,19 @@ class AuthController extends Controller
             session(['login.intended' => $intended]);
         }
 
-        $options = array_get($request->getQueryParams(), 'options') ?: [];
+        $options = [];
+        $jsonOptions = array_get($request->getQueryParams(), 'jsonOptions') ?: null;
+
+        // Check if the JS added auth options.
+        if ($jsonOptions) {
+            $options = (array) json_decode($jsonOptions);
+        }
+
+        // As a backup check the Blade template.
+        if (! $options) {
+            $options = array_get($request->getQueryParams(), 'options') ?: [];
+        }
+
         $destination = array_get($request->getQueryParams(), 'destination');
         $url = session('login.intended', $this->redirectTo);
 

--- a/resources/assets/actions/event.js
+++ b/resources/assets/actions/event.js
@@ -44,13 +44,21 @@ export function startQueue() {
 
 // Action: add an event to the queue.
 export function queueEvent(actionCreatorName, ...args) {
-  return {
-    type: actions.QUEUE_EVENT,
-    createdAt: Date.now(),
-    requiresAuth: true, // vLater - Allow more flexibility with configuring events
-    action: {
-      creatorName: actionCreatorName,
-      args,
-    },
+  return (dispatch, getState) => {
+    const northstarOptions = {};
+    northstarOptions.title = getState().campaign.title;
+    northstarOptions.coverImage = getState().campaign.coverImage.url;
+    northstarOptions.callToAction = getState().campaign.callToAction;
+
+    dispatch({
+      type: actions.QUEUE_EVENT,
+      createdAt: Date.now(),
+      requiresAuth: true, // vLater - Allow more flexibility with configuring events
+      northstarOptions,
+      action: {
+        creatorName: actionCreatorName,
+        args,
+      },
+    });
   };
 }

--- a/resources/assets/actions/event.js
+++ b/resources/assets/actions/event.js
@@ -46,9 +46,11 @@ export function startQueue() {
 export function queueEvent(actionCreatorName, ...args) {
   return (dispatch, getState) => {
     const northstarOptions = {};
-    northstarOptions.title = getState().campaign.title;
-    northstarOptions.coverImage = getState().campaign.coverImage.url;
-    northstarOptions.callToAction = getState().campaign.callToAction;
+    if (getState().campaign) {
+      northstarOptions.title = getState().campaign.title;
+      northstarOptions.coverImage = getState().campaign.coverImage.url;
+      northstarOptions.callToAction = getState().campaign.callToAction;
+    }
 
     dispatch({
       type: actions.QUEUE_EVENT,

--- a/resources/assets/actions/event.js
+++ b/resources/assets/actions/event.js
@@ -47,9 +47,11 @@ export function queueEvent(actionCreatorName, ...args) {
   return (dispatch, getState) => {
     const northstarOptions = {};
     if (getState().campaign) {
-      northstarOptions.title = getState().campaign.title;
-      northstarOptions.coverImage = getState().campaign.coverImage.url;
-      northstarOptions.callToAction = getState().campaign.callToAction;
+      const { callToAction, coverImage, title } = getState().campaign;
+
+      northstarOptions.title = title;
+      northstarOptions.coverImage = coverImage.url;
+      northstarOptions.callToAction = callToAction;
     }
 
     dispatch({

--- a/resources/assets/reducers/events.js
+++ b/resources/assets/reducers/events.js
@@ -20,7 +20,12 @@ const events = (state = {}, action) => {
       storageAppend('queue', EVENT_STORAGE_KEY, action);
 
       if (action.requiresAuth) {
-        window.location.href = '/next/login';
+        let path = '/next/login';
+        if (action.northstarOptions) {
+          path += `?jsonOptions=${JSON.stringify(action.northstarOptions)}`;
+        }
+
+        window.location.href = path;
       }
 
       return state;


### PR DESCRIPTION
### What does this PR do?
We were sending the campaign auth customization if you clicked "Log in" but not for users clicking signup buttons. This is because the login variables were only introduced in the php helpers & blade template.

This pr adds some logic so the client JS can send custom auth variables as well based on the current campaign to match the blade template logic.

https://www.pivotaltracker.com/story/show/152686373