### PR TITLE
removing collapsed footer

### DIFF
--- a/resources/views/partials/footer.blade.php
+++ b/resources/views/partials/footer.blade.php
@@ -26,7 +26,7 @@
       </ul>
     </div>
     <div class="footer__column -links">
-        <h4 class="js-toggle-collapsed is-collapsed is-toggleable">Who We Are</h4>
+        <h4>Who We Are</h4>
         <ul>
           <li><a href="{{ phoenixLink('us/about/who-we-are') }}">What is DoSomething.org?</a></li>
           <li><a href="{{ phoenixLink('us/about/our-people') }}">Our Team</a></li>
@@ -37,7 +37,7 @@
          </ul>
     </div>
     <div class="footer__column -links">
-        <h4 class="js-toggle-collapsed is-collapsed is-toggleable">Our Friends</h4>
+        <h4>Our Friends</h4>
         <ul>
           <li><a href="http://www.tmiagency.org">TMI Agency</a></li>
           <li><a href="{{ phoenixLink('us/about/our-partners') }}">Partners</a></li>
@@ -46,7 +46,7 @@
         </ul>
     </div>
     <div class="footer__column -links">
-        <h4 class="js-toggle-collapsed is-collapsed is-toggleable">Get Involved</h4>
+        <h4>Get Involved</h4>
         <ul>
           <li><a href="{{ phoenixLink('us/about/easy-scholarships') }}">Scholarships</a></li>
           <li><a href="{{ phoenixLink('us/about/join-our-team') }}">Jobs</a></li>


### PR DESCRIPTION
### What does this PR do?
Since we don't have the Forge JS stuffs running the footers can't be expanded on mobile. Rather than replicate the logic like we did for the Nav we just opt-ed to remove the collapsed classes on the elements themselves.

![screen shot 2017-11-13 at 11 08 34 am](https://user-images.githubusercontent.com/897368/32735788-ab981fdc-c863-11e7-9ae6-f95bab2eccd1.png)
 
https://www.pivotaltracker.com/story/show/152720060