### PR TITLE
Admin dash show pitch page

### DIFF
--- a/resources/assets/components/Campaign/Campaign.js
+++ b/resources/assets/components/Campaign/Campaign.js
@@ -8,29 +8,33 @@ import { CampaignPageContainer, LandingPageContainer } from '../Page';
 import NotificationContainer from '../Notification';
 import AdminDashboardContainer from '../AdminDashboard';
 
-const Campaign = (props) => {
-  const { isAffiliated, useLandingPage, slug, clickedShowAffirmation } = props;
+class Campaign extends React.Component {
 
-  return (
-    <div>
-      <AdminDashboardContainer>
-        <a className="button -secondary margin-horizontal-md" href={`/next/cache/campaign_${slug}?redirect=${window.location.pathname}`}>
-          Clear Cache
-        </a>
-        <button className="button -secondary margin-horizontal-md" onClick={clickedShowAffirmation}>
-          Show Affirmation
-        </button>
-      </AdminDashboardContainer>
-      <NotificationContainer />
-      <ModalSwitch />
+  render() {
+    const { isAffiliated, useLandingPage, slug, clickedShowAffirmation } = this.props;
 
-      {(! isAffiliated && useLandingPage) ?
-        <LandingPageContainer {...props} />
-        :
-        <CampaignPageContainer {...props} />}
-    </div>
-  );
-};
+    return (
+      <div>
+        <AdminDashboardContainer>
+          <a className="button -secondary margin-horizontal-md" href={`/next/cache/campaign_${slug}?redirect=${window.location.pathname}`}>
+            Clear Cache
+          </a>
+          <button className="button -secondary margin-horizontal-md" onClick={clickedShowAffirmation}>
+            Show Affirmation
+          </button>
+        </AdminDashboardContainer>
+
+        <NotificationContainer />
+        <ModalSwitch />
+
+        { (! isAffiliated && useLandingPage) ?
+          <LandingPageContainer {...this.props} />
+          :
+          <CampaignPageContainer {...this.props} />}
+      </div>
+    );
+  }
+}
 
 Campaign.propTypes = {
   isAffiliated: PropTypes.bool,

--- a/resources/assets/components/Campaign/Campaign.js
+++ b/resources/assets/components/Campaign/Campaign.js
@@ -9,9 +9,23 @@ import NotificationContainer from '../Notification';
 import AdminDashboardContainer from '../AdminDashboard';
 
 class Campaign extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      shouldShowLandingPage: false,
+    };
+
+    this.showLandingPage = this.showLandingPage.bind(this);
+  }
+
+  showLandingPage() {
+    this.setState({ shouldShowLandingPage: true });
+  }
 
   render() {
     const { isAffiliated, useLandingPage, slug, clickedShowAffirmation } = this.props;
+    const showLandingPage = (! isAffiliated && useLandingPage) || this.state.shouldShowLandingPage;
 
     return (
       <div>
@@ -22,12 +36,17 @@ class Campaign extends React.Component {
           <button className="button -secondary margin-horizontal-md" onClick={clickedShowAffirmation}>
             Show Affirmation
           </button>
+          { useLandingPage ?
+            <button className="button -secondary margin-horizontal-md" onClick={this.showLandingPage}>
+              Show Landing Page
+            </button>
+            : null }
         </AdminDashboardContainer>
 
         <NotificationContainer />
         <ModalSwitch />
 
-        { (! isAffiliated && useLandingPage) ?
+        { showLandingPage ?
           <LandingPageContainer {...this.props} />
           :
           <CampaignPageContainer {...this.props} />}


### PR DESCRIPTION
### What does this PR do?
- Adding button to admin dashboard to show the pitch page
- Button added only if the campaign has a landing page
- Converting the `Campaign` component to a `class`, so we can preserve and manipulate state

### Any background context you want to provide?
- Is it overkill to do all this for the admin landing page functionality? (I wasn't able to think of any better straightforward way)

### What are the relevant tickets/cards?
https://www.pivotaltracker.com/story/show/152546110

### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.

