### PR TITLE
Cleaning up custom block entity

### DIFF
--- a/app/Entities/CustomBlock.php
+++ b/app/Entities/CustomBlock.php
@@ -13,16 +13,22 @@ class CustomBlock extends Entity implements JsonSerializable
      */
     public function jsonSerialize()
     {
-        $fields = $this->entry->jsonSerialize()->fields;
-
-        $data = [
+        return [
             'id' => $this->entry->getId(),
-            'type' => $fields->type,
-            'fields' => $this->entry->jsonSerialize()->fields,
+            'type' => is_string($this->type) ? $this->type : $this->type->first(),
+            'fields' => [
+                'title' => $this->title,
+                'content' => $this->content,
+                'displayOptions' => $this->displayOptions->first(),
+                'link' => $this->link,
+
+                // Static block additional content
+                'source' => isset($this->additionalContent['source']) ? $this->additionalContent['source'] : null,
+
+                // Reportbacks block additional content
+                'count' => isset($this->additionalContent['count']) ? $this->additionalContent['count'] : null,
+                'filter' => isset($this->additionalContent['filter']) ? $this->additionalContent['filter'] : null,
+            ],
         ];
-
-        $data['fields']->displayOptions = array_shift($data['fields']->displayOptions);
-
-        return $data;
     }
 }

--- a/resources/assets/components/Block/Block.js
+++ b/resources/assets/components/Block/Block.js
@@ -42,11 +42,22 @@ const Block = ({ json = DEFAULT_BLOCK }: { json: BlockJson }) => {
     case 'quiz':
       return <Quiz />;
 
+    // @TODO: Will be refactored when switching to Rogue!
     case 'reportbacks':
-      return <ReportbackBlock fields={json.fields} reportbacks={json.reportbacks} />;
+      return (
+        <ReportbackBlock
+          reportbacks={json.reportbacks}
+        />
+      );
 
     case 'static':
-      return <StaticBlock fields={json.fields} />;
+      return (
+        <StaticBlock
+          content={json.fields.content}
+          source={json.fields.source}
+          title={json.fields.title}
+        />
+      );
 
     default:
       return <PlaceholderBlock />;

--- a/resources/assets/components/Block/Block.test.js
+++ b/resources/assets/components/Block/Block.test.js
@@ -18,7 +18,7 @@ test('it can display a CTA block', () => {
 });
 
 test('it can display a static block', () => {
-  const wrapper = shallow(<Block json={{ id: '12345', type: 'static', fields: {} }} />);
+  const wrapper = shallow(<Block json={{ id: '12345', type: 'static', fields: { content: 'Donec ullamcorper fringilla.', title: 'Nibh ornare' } }} />);
   expect(wrapper.find('StaticBlock')).toHaveLength(1);
 });
 

--- a/resources/assets/components/StaticBlock/index.js
+++ b/resources/assets/components/StaticBlock/index.js
@@ -4,23 +4,21 @@ import BlockWrapper from '../Block/BlockWrapper';
 import Markdown from '../Markdown';
 import './static-block.scss';
 
-const StaticBlock = (props) => {
-  const { source } = props.fields.additionalContent;
-
-  return (
-    <BlockWrapper title={props.fields.title}>
-      <Markdown>{props.fields.content}</Markdown>
-      { source ? <div className="static-block__citation"><p className="footnote">{source}</p></div> : null }
-    </BlockWrapper>
-  );
-};
+const StaticBlock = ({ content, source, title }) => (
+  <BlockWrapper title={title}>
+    <Markdown>{content}</Markdown>
+    { source ? <div className="static-block__citation"><p className="footnote">{source}</p></div> : null }
+  </BlockWrapper>
+);
 
 StaticBlock.propTypes = {
-  fields: PropTypes.shape({
-    title: PropTypes.string,
-    content: PropTypes.string,
-    additionalContent: PropTypes.object,
-  }).isRequired,
+  content: PropTypes.string.isRequired,
+  source: PropTypes.string,
+  title: PropTypes.string.isRequired,
+};
+
+StaticBlock.defaultProps = {
+  source: null,
 };
 
 export default StaticBlock;


### PR DESCRIPTION
### What does this PR do?
This PR updates the `CustomBlock` entity so that it works similarly to the new approach with entities. It will also allow us to switch up the `blockType` field on contentful to a checkbox of predetermined options instead of a "fill in the blank" which is less useful.


### Any background context you want to provide?
This [line](https://github.com/DoSomething/phoenix-next/pull/505/files#diff-994a369bc55070a6b84b299a547ae5b0R18) specifically will allow for us switching the field display for the block type from a text field to a checkbox and account that the single choice checkbox selection returns an array and not a string.


### Checklist
- [x] Added appropriate feature/unit tests.

