### PR TITLE
Admin dash redux

### DIFF
--- a/resources/assets/actions/admin.js
+++ b/resources/assets/actions/admin.js
@@ -1,0 +1,11 @@
+import { SHOW_LANDING_PAGE } from '../actions';
+
+/**
+ * Action Creators: these functions create actions, which describe changes
+ * to the state tree (either as a result of application logic or user input).
+ */
+
+// Action: show the campaigns landing page
+export default function clickedShowLandingPage() {
+  return { type: SHOW_LANDING_PAGE };
+}

--- a/resources/assets/actions/admin.js
+++ b/resources/assets/actions/admin.js
@@ -6,6 +6,6 @@ import { SHOW_LANDING_PAGE } from '../actions';
  */
 
 // Action: show the campaigns landing page
-export default function clickedShowLandingPage() {
+export function clickedShowLandingPage() { // eslint-disable-line import/prefer-default-export
   return { type: SHOW_LANDING_PAGE };
 }

--- a/resources/assets/actions/index.js
+++ b/resources/assets/actions/index.js
@@ -74,3 +74,6 @@ export * from './quiz';
 
 export const NEXT_SLIDE = 'NEXT_SLIDE';
 export * from './slideshow';
+
+export const SHOW_LANDING_PAGE = 'SHOW_LANDING_PAGE';
+export default from './admin';

--- a/resources/assets/actions/index.js
+++ b/resources/assets/actions/index.js
@@ -76,4 +76,4 @@ export const NEXT_SLIDE = 'NEXT_SLIDE';
 export * from './slideshow';
 
 export const SHOW_LANDING_PAGE = 'SHOW_LANDING_PAGE';
-export default from './admin';
+export * from './admin';

--- a/resources/assets/components/Campaign/Campaign.js
+++ b/resources/assets/components/Campaign/Campaign.js
@@ -9,7 +9,7 @@ import NotificationContainer from '../Notification';
 import AdminDashboardContainer from '../AdminDashboard';
 
 const Campaign = (props) => {
-  const { useLandingPage, slug, clickedShowAffirmation, clickedShowLandingPage,
+  const { hasLandingPage, slug, clickedShowAffirmation, clickedShowLandingPage,
     shouldShowLandingPage } = props;
 
   return (
@@ -21,7 +21,7 @@ const Campaign = (props) => {
         <button className="button -secondary margin-horizontal-md" onClick={clickedShowAffirmation}>
           Show Affirmation
         </button>
-        { useLandingPage ?
+        { hasLandingPage ?
           <button className="button -secondary margin-horizontal-md" onClick={clickedShowLandingPage}>
             Show Landing Page
           </button>
@@ -30,7 +30,7 @@ const Campaign = (props) => {
       <NotificationContainer />
       <ModalSwitch />
 
-      { (useLandingPage && shouldShowLandingPage) ?
+      { shouldShowLandingPage ?
         <LandingPageContainer {...props} />
         :
         <CampaignPageContainer {...props} />}
@@ -39,7 +39,7 @@ const Campaign = (props) => {
 };
 
 Campaign.propTypes = {
-  useLandingPage: PropTypes.bool,
+  hasLandingPage: PropTypes.bool,
   slug: PropTypes.string.isRequired,
   clickedShowAffirmation: PropTypes.func.isRequired,
   clickedShowLandingPage: PropTypes.func.isRequired,
@@ -47,7 +47,7 @@ Campaign.propTypes = {
 };
 
 Campaign.defaultProps = {
-  useLandingPage: false,
+  hasLandingPage: false,
   shouldShowLandingPage: false,
 };
 

--- a/resources/assets/components/Campaign/Campaign.js
+++ b/resources/assets/components/Campaign/Campaign.js
@@ -9,7 +9,8 @@ import NotificationContainer from '../Notification';
 import AdminDashboardContainer from '../AdminDashboard';
 
 const Campaign = (props) => {
-  const { isAffiliated, useLandingPage, slug, clickedShowAffirmation } = props;
+  const { useLandingPage, slug, clickedShowAffirmation, clickedShowLandingPage,
+    shouldShowLandingPage } = props;
 
   return (
     <div>
@@ -20,11 +21,16 @@ const Campaign = (props) => {
         <button className="button -secondary margin-horizontal-md" onClick={clickedShowAffirmation}>
           Show Affirmation
         </button>
+        { useLandingPage ?
+          <button className="button -secondary margin-horizontal-md" onClick={clickedShowLandingPage}>
+            Show Landing Page
+          </button>
+          : null}
       </AdminDashboardContainer>
       <NotificationContainer />
       <ModalSwitch />
 
-      {(! isAffiliated && useLandingPage) ?
+      { (useLandingPage && shouldShowLandingPage) ?
         <LandingPageContainer {...props} />
         :
         <CampaignPageContainer {...props} />}
@@ -33,15 +39,16 @@ const Campaign = (props) => {
 };
 
 Campaign.propTypes = {
-  isAffiliated: PropTypes.bool,
   useLandingPage: PropTypes.bool,
   slug: PropTypes.string.isRequired,
   clickedShowAffirmation: PropTypes.func.isRequired,
+  clickedShowLandingPage: PropTypes.func.isRequired,
+  shouldShowLandingPage: PropTypes.bool,
 };
 
 Campaign.defaultProps = {
-  isAffiliated: false,
   useLandingPage: false,
+  shouldShowLandingPage: false,
 };
 
 export default Campaign;

--- a/resources/assets/components/Campaign/CampaignContainer.js
+++ b/resources/assets/components/Campaign/CampaignContainer.js
@@ -2,15 +2,21 @@ import { connect } from 'react-redux';
 
 import Campaign from './Campaign';
 import { clickedShowAffirmation } from '../../actions/signup';
+import clickedShowLandingPage from '../../actions/admin';
 
-const mapStateToProps = state => ({
-  isAffiliated: state.signups.thisCampaign,
-  useLandingPage: state.campaign.landingPage !== null,
-  slug: state.campaign.slug,
-});
+const mapStateToProps = (state) => {
+  const shouldShowLandingPage = ! state.signups.thisCampaign || state.admin.shouldShowLandingPage;
+
+  return {
+    useLandingPage: state.campaign.landingPage !== null,
+    slug: state.campaign.slug,
+    shouldShowLandingPage,
+  };
+};
 
 const actionCreators = {
   clickedShowAffirmation,
+  clickedShowLandingPage,
 };
 
 export default connect(mapStateToProps, actionCreators)(Campaign);

--- a/resources/assets/components/Campaign/CampaignContainer.js
+++ b/resources/assets/components/Campaign/CampaignContainer.js
@@ -5,11 +5,15 @@ import { clickedShowAffirmation } from '../../actions/signup';
 import { clickedShowLandingPage } from '../../actions/admin';
 
 const mapStateToProps = (state) => {
-  const shouldShowLandingPage = ! state.signups.thisCampaign || state.admin.shouldShowLandingPage;
+  const isSignedUp = state.signups.thisCampaign;
+  const hasLandingPage = state.campaign.landingPage !== null;
+
+  const shouldShowLandingPage = hasLandingPage &&
+    (! isSignedUp || state.admin.shouldShowLandingPage);
 
   return {
-    useLandingPage: state.campaign.landingPage !== null,
     slug: state.campaign.slug,
+    hasLandingPage,
     shouldShowLandingPage,
   };
 };

--- a/resources/assets/components/Campaign/CampaignContainer.js
+++ b/resources/assets/components/Campaign/CampaignContainer.js
@@ -2,7 +2,7 @@ import { connect } from 'react-redux';
 
 import Campaign from './Campaign';
 import { clickedShowAffirmation } from '../../actions/signup';
-import clickedShowLandingPage from '../../actions/admin';
+import { clickedShowLandingPage } from '../../actions/admin';
 
 const mapStateToProps = (state) => {
   const shouldShowLandingPage = ! state.signups.thisCampaign || state.admin.shouldShowLandingPage;

--- a/resources/assets/reducers/admin.js
+++ b/resources/assets/reducers/admin.js
@@ -1,0 +1,14 @@
+import { SHOW_LANDING_PAGE } from '../actions';
+
+const admin = (state = {}, action) => {
+  switch (action.type) {
+    case SHOW_LANDING_PAGE: return {
+      ...state,
+      shouldShowLandingPage: true,
+    };
+
+    default: return state;
+  }
+};
+
+export default admin;

--- a/resources/assets/reducers/index.js
+++ b/resources/assets/reducers/index.js
@@ -1,3 +1,4 @@
+export admin from './admin';
 export blocks from './blocks';
 export campaign from './campaign';
 export competitions from './competitions';

--- a/resources/assets/store.js
+++ b/resources/assets/store.js
@@ -67,6 +67,9 @@ const initialState = {
   uploads: {},
   quiz: {},
   slideshow: {},
+  admin: {
+    shouldShowLandingPage: false,
+  },
 };
 
 /**


### PR DESCRIPTION
### What does this PR do?
#503 only it's using the redux store to track admin override (which for now is just show landing page). 
Moved some calculation for `shouldShowLandingPage` to the container, as we don't really need the `isAffiliated` prop within the component itself and this makes it read a bit better I think.

### Any background context you want to provide?
Did I do this right?


### What are the relevant tickets/cards?
#503 

### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.

