### PR TITLE
Admin dash action page button action

### DIFF
--- a/resources/assets/actions/admin.js
+++ b/resources/assets/actions/admin.js
@@ -1,4 +1,4 @@
-import { SHOW_LANDING_PAGE } from '../actions';
+import { SHOW_LANDING_PAGE, SHOW_ACTION_PAGE } from '../actions';
 
 /**
  * Action Creators: these functions create actions, which describe changes
@@ -6,6 +6,10 @@ import { SHOW_LANDING_PAGE } from '../actions';
  */
 
 // Action: show the campaigns landing page
-export function clickedShowLandingPage() { // eslint-disable-line import/prefer-default-export
+export function clickedShowLandingPage() {
   return { type: SHOW_LANDING_PAGE };
+}
+
+export function clickedShowActionPage() {
+  return { type: SHOW_ACTION_PAGE };
 }

--- a/resources/assets/actions/index.js
+++ b/resources/assets/actions/index.js
@@ -76,4 +76,5 @@ export const NEXT_SLIDE = 'NEXT_SLIDE';
 export * from './slideshow';
 
 export const SHOW_LANDING_PAGE = 'SHOW_LANDING_PAGE';
+export const SHOW_ACTION_PAGE = 'SHOW_ACTION_PAGE';
 export * from './admin';

--- a/resources/assets/components/Campaign/Campaign.js
+++ b/resources/assets/components/Campaign/Campaign.js
@@ -2,6 +2,7 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
+import { Link } from 'react-router-dom';
 
 import ModalSwitch from '../Modal';
 import { CampaignPageContainer, LandingPageContainer } from '../Page';
@@ -10,7 +11,7 @@ import AdminDashboardContainer from '../AdminDashboard';
 
 const Campaign = (props) => {
   const { hasLandingPage, slug, clickedShowAffirmation, clickedShowLandingPage,
-    shouldShowLandingPage } = props;
+    clickedShowActionPage, shouldShowLandingPage } = props;
 
   return (
     <div>
@@ -26,6 +27,9 @@ const Campaign = (props) => {
             Show Landing Page
           </button>
           : null}
+        <Link className="button -secondary margin-horizontal-md" to={`/us/campaigns/${slug}/action`} onClick={clickedShowActionPage}>
+          Show Action Page
+        </Link>
       </AdminDashboardContainer>
       <NotificationContainer />
       <ModalSwitch />
@@ -43,6 +47,7 @@ Campaign.propTypes = {
   slug: PropTypes.string.isRequired,
   clickedShowAffirmation: PropTypes.func.isRequired,
   clickedShowLandingPage: PropTypes.func.isRequired,
+  clickedShowActionPage: PropTypes.func.isRequired,
   shouldShowLandingPage: PropTypes.bool,
 };
 

--- a/resources/assets/components/Campaign/CampaignContainer.js
+++ b/resources/assets/components/Campaign/CampaignContainer.js
@@ -2,7 +2,7 @@ import { connect } from 'react-redux';
 
 import Campaign from './Campaign';
 import { clickedShowAffirmation } from '../../actions/signup';
-import { clickedShowLandingPage } from '../../actions/admin';
+import { clickedShowLandingPage, clickedShowActionPage } from '../../actions/admin';
 
 const mapStateToProps = (state) => {
   const isSignedUp = state.signups.thisCampaign;
@@ -21,6 +21,7 @@ const mapStateToProps = (state) => {
 const actionCreators = {
   clickedShowAffirmation,
   clickedShowLandingPage,
+  clickedShowActionPage,
 };
 
 export default connect(mapStateToProps, actionCreators)(Campaign);

--- a/resources/assets/components/Page/CampaignPage/CampaignPage.js
+++ b/resources/assets/components/Page/CampaignPage/CampaignPage.js
@@ -24,7 +24,7 @@ const CampaignPage = (props) => {
   const {
     affiliatePartners, affiliateSponsors, blurb, campaignLead, coverImage,
     dashboard, endDate, hasActivityFeed, isAffiliated, legacyCampaignId, match,
-    openModal, slug, subtitle, template, title, totalCampaignSignups,
+    openModal, shouldShowActionPage, slug, subtitle, template, title, totalCampaignSignups,
   } = props;
 
   // console.log(props.history);
@@ -72,7 +72,7 @@ const CampaignPage = (props) => {
             />
             <Route
               path={`${match.url}/action`}
-              render={() => (isClosed ?
+              render={() => (isClosed && ! shouldShowActionPage ?
                 <Redirect to={`${match.url}`} />
                 :
                 <ActionPageContainer />
@@ -144,6 +144,7 @@ CampaignPage.propTypes = {
   title: PropTypes.string.isRequired,
   totalCampaignSignups: PropTypes.number,
   openModal: PropTypes.func.isRequired,
+  shouldShowActionPage: PropTypes.bool,
 };
 
 CampaignPage.defaultProps = {
@@ -152,6 +153,7 @@ CampaignPage.defaultProps = {
   isAffiliated: false,
   totalCampaignSignups: 0,
   campaignLead: undefined,
+  shouldShowActionPage: false,
 };
 
 export default CampaignPage;

--- a/resources/assets/components/Page/CampaignPage/CampaignPageContainer.js
+++ b/resources/assets/components/Page/CampaignPage/CampaignPageContainer.js
@@ -18,6 +18,7 @@ const mapStateToProps = state => ({
   affiliatePartners: state.campaign.affiliatePartners,
   campaignLead: get(state.campaign.additionalContent, 'campaignLead'),
   legacyCampaignId: state.campaign.legacyCampaignId,
+  shouldShowActionPage: state.admin.shouldShowActionPage,
   slug: state.campaign.slug,
   subtitle: state.campaign.callToAction,
   template: state.campaign.template,

--- a/resources/assets/reducers/admin.js
+++ b/resources/assets/reducers/admin.js
@@ -1,10 +1,17 @@
-import { SHOW_LANDING_PAGE } from '../actions';
+import { SHOW_LANDING_PAGE, SHOW_ACTION_PAGE } from '../actions';
 
 const admin = (state = {}, action) => {
   switch (action.type) {
     case SHOW_LANDING_PAGE: return {
       ...state,
       shouldShowLandingPage: true,
+      shouldShowActionPage: false,
+    };
+
+    case SHOW_ACTION_PAGE: return {
+      ...state,
+      shouldShowActionPage: true,
+      shouldShowLandingPage: false,
     };
 
     default: return state;

--- a/resources/assets/store.js
+++ b/resources/assets/store.js
@@ -69,6 +69,7 @@ const initialState = {
   slideshow: {},
   admin: {
     shouldShowLandingPage: false,
+    shouldShowActionPage: false,
   },
 };
 


### PR DESCRIPTION
### What does this PR do?
- Adds show action page button to admin dashboard to display the action page.

![action bronson](https://user-images.githubusercontent.com/12417657/32752302-b0f8d326-c896-11e7-94c9-92dcac655e49.gif)


### Any background context you want to provide?
- Adding new prop to the admin store to account for 'show action page' override.
 - The reducer will need to toggle both states to make sure to turn off one override before turning on another.

Should we make the landing page button a `Link` as well so that the url is changed back to root in case an admin clicks the 'Show Action Page' button thus changing the url to `/action` and then clicks the `Show Landing Page` button - which for now is a plain button so the url remains `/action`?



### What are the relevant tickets/cards?
https://www.pivotaltracker.com/story/show/152202725

### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.

