### PR TITLE
adding twitter card meta tag for a large summary image

### DIFF
--- a/app.json
+++ b/app.json
@@ -12,12 +12,6 @@
     "CONTENTFUL_CONTENT_API_KEY": {
       "required": true
     },
-    "CONTENTFUL_CONTENT_DELIVERY_API_KEY": {
-      "required": true
-    },
-    "CONTENTFUL_CONTENT_PREVIEW_API_KEY": {
-      "required": true
-    },
     "CONTENTFUL_SPACE_ID": {
       "required": true
     },

--- a/app.json
+++ b/app.json
@@ -9,6 +9,9 @@
       "required": true
     },
     "APP_LOG": "errorlog",
+    "CONTENTFUL_CONTENT_API_KEY": {
+      "required": true
+    },
     "CONTENTFUL_CONTENT_DELIVERY_API_KEY": {
       "required": true
     },

--- a/resources/views/partials/social.blade.php
+++ b/resources/views/partials/social.blade.php
@@ -1,3 +1,5 @@
+<meta name="twitter:card" content="summary_large_image" />
+
 <meta property="og:title" content="{{ $socialFields['title'] }}" />
 <meta property="og:type"  content="article" />
 <meta property="og:description" content="{{ $socialFields['callToAction'] }}" />


### PR DESCRIPTION
### What does this PR do?
Adds a meta tag for a large summary Twitter card so twitter shares can look Magnifique.
- also added the new Contentful API key name we're using to the `app.json`, for the Heroku review app. And removed the old ones no longer in use.

Boiteux:
![image](https://user-images.githubusercontent.com/12417657/32857176-fdd55028-ca14-11e7-94ba-11f7b7fe9038.png)


Magnifique:
![image](https://user-images.githubusercontent.com/12417657/32857115-db81bed0-ca14-11e7-858f-cdf7a2c36d6a.png)


### Any background context you want to provide?
The other meta stuff should be read through our `og` (Original Gangster??) meta props.


### What are the relevant tickets/cards?
https://www.pivotaltracker.com/story/show/152826443

### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.

