### PR TITLE
adding env key to toggle contentful preview API

### DIFF
--- a/app.json
+++ b/app.json
@@ -15,6 +15,9 @@
     "CONTENTFUL_SPACE_ID": {
       "required": true
     },
+    "CONTENTFUL_USE_PREVIEW_API": {
+      "required": true
+    },
     "NORTHSTAR_AUTHORIZATION_ID": {
       "required": true
     },


### PR DESCRIPTION
### What does this PR do?
Adding the contentful preview api toggle env key so we can set to `true` and use the preview API for the review app.


### Any background context you want to provide?
https://github.com/DoSomething/phoenix-next/pull/515#issuecomment-344733433


### What are the relevant tickets/cards?
Fixes #

### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.

