### PR TITLE
Encode auth options before sending

### DIFF
--- a/resources/assets/actions/event.js
+++ b/resources/assets/actions/event.js
@@ -49,9 +49,9 @@ export function queueEvent(actionCreatorName, ...args) {
     if (getState().campaign) {
       const { callToAction, coverImage, title } = getState().campaign;
 
-      northstarOptions.title = title;
+      northstarOptions.title = encodeURIComponent(title);
       northstarOptions.coverImage = coverImage.url;
-      northstarOptions.callToAction = callToAction;
+      northstarOptions.callToAction = encodeURIComponent(callToAction);
     }
 
     dispatch({


### PR DESCRIPTION
### What does this PR do?
In a previous PR we added support for the client to pass campaign information along with the auth request (#501). This worked fine with Sincerely, Us, but we later discovered it doesn't work for Missing in History.

The reason it was breaking on Missing in History is that the callToAction uses the `&` symbol, which splits the json into another query parameter and prevents the server from parsing it. To resolve this, I just wrapped the potentially unsafe values with `encodeURIComponent`.

<img width="965" alt="screen shot 2017-11-16 at 10 35 45 am" src="https://user-images.githubusercontent.com/897368/32900146-c4258130-caba-11e7-9264-af66dc033c4c.png">

### What are the relevant tickets/cards?
https://www.pivotaltracker.com/story/show/152686373