### PR TITLE
Admin dash staff auth

### DIFF
--- a/resources/assets/components/AdminDashboard/AdminDashboard.js
+++ b/resources/assets/components/AdminDashboard/AdminDashboard.js
@@ -1,8 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-const AdminDashboard = ({ isAdmin, children }) => (
-  isAdmin ?
+const AdminDashboard = ({ enabled, children }) => (
+  enabled ?
     <div className="bg-light-gray -white">
       { children }
     </div>
@@ -12,7 +12,7 @@ const AdminDashboard = ({ isAdmin, children }) => (
 
 AdminDashboard.propTypes = {
   children: PropTypes.node.isRequired,
-  isAdmin: PropTypes.bool.isRequired,
+  enabled: PropTypes.bool.isRequired,
 };
 
 export default AdminDashboard;

--- a/resources/assets/components/AdminDashboard/AdminDashboardContainer.js
+++ b/resources/assets/components/AdminDashboard/AdminDashboardContainer.js
@@ -3,7 +3,7 @@ import AdminDashboard from './AdminDashboard';
 import { userHasRole } from '../../selectors/user';
 
 const mapStateToProps = state => ({
-  isAdmin: userHasRole(state, ['admin', 'staff']),
+  enabled: userHasRole(state, ['admin', 'staff']),
 });
 
 export default connect(mapStateToProps)(AdminDashboard);

--- a/resources/assets/components/AdminDashboard/AdminDashboardContainer.js
+++ b/resources/assets/components/AdminDashboard/AdminDashboardContainer.js
@@ -1,8 +1,9 @@
 import { connect } from 'react-redux';
 import AdminDashboard from './AdminDashboard';
+import { userHasRole } from '../../selectors/user';
 
 const mapStateToProps = state => ({
-  isAdmin: state.user.role === 'admin',
+  isAdmin: userHasRole(state, ['admin', 'staff']),
 });
 
 export default connect(mapStateToProps)(AdminDashboard);

--- a/resources/assets/selectors/user.js
+++ b/resources/assets/selectors/user.js
@@ -7,3 +7,14 @@
 export function getUserId(state) { // eslint-disable-line import/prefer-default-export
   return state.user.id;
 }
+
+/**
+ * Find out if the user had one of provided roles.
+ *
+ * @param {object} state
+ * @param {array}  roles
+ * @returns {boolean}
+ */
+export function userHasRole(state, roles) {
+  return roles.includes(state.user.role);
+}


### PR DESCRIPTION
### What does this PR do?
- Adds new selector to help determine user role.
- Using selector for `AdminDashboard` allowing 'staff' roles access as well as 'admin'.


### Any background context you want to provide?
Most staff could not see the admin dashboard!


### What are the relevant tickets/cards?
https://www.pivotaltracker.com/story/show/152546110
