### PR TITLE
Social share modal link

### DIFF
--- a/resources/assets/components/CampaignUpdate/CampaignUpdate.js
+++ b/resources/assets/components/CampaignUpdate/CampaignUpdate.js
@@ -8,13 +8,13 @@ import Byline from '../Byline';
 import Markdown from '../Markdown';
 import { ShareContainer } from '../Share';
 
-const CampaignUpdate = ({ id, author, content, link, shareLink, bordered }) => {
+const CampaignUpdate = ({ id, author, content, link, shareLink, bordered, titleLink }) => {
   const { avatar, jobTitle, name } = author.fields;
 
   const isTweet = content.length < 144;
 
   return (
-    <Card id={id} className={classnames('rounded', { bordered })} link={shareLink} title="Campaign Update">
+    <Card id={id} className={classnames('rounded', { bordered })} link={titleLink} title="Campaign Update">
       <Markdown className={classnames('padded', { 'font-size-lg': isTweet })}>
         {content}
       </Markdown>
@@ -49,6 +49,7 @@ CampaignUpdate.propTypes = {
   content: PropTypes.string.isRequired,
   link: PropTypes.string,
   shareLink: PropTypes.string.isRequired,
+  titleLink: PropTypes.string.isRequired,
   bordered: PropTypes.bool,
 };
 

--- a/resources/assets/components/CampaignUpdate/CampaignUpdate.test.js
+++ b/resources/assets/components/CampaignUpdate/CampaignUpdate.test.js
@@ -20,6 +20,7 @@ const component = shallow(
     author={author}
     content="Duis mollis, est non commodo luctus, nisi erat porttitor ligula, eget lacinia odio sem nec elit. Morbi leo risus, porta ac consectetur ac, vestibulum at eros. Sed posuere consectetur est at lobortis. Sed posuere consectetur est at lobortis. Nullam quis risus eget urna mollis ornare vel eu leo. Etiam porta sem malesuada magna mollis euismod. Cras mattis consectetur purus sit amet fermentum."
     shareLink="http://example.com/link-to-content"
+    titleLink="http://example.com/link-to-content"
   />,
 );
 

--- a/resources/assets/components/CampaignUpdate/CampaignUpdateContainer.js
+++ b/resources/assets/components/CampaignUpdate/CampaignUpdateContainer.js
@@ -8,16 +8,18 @@ import { makeShareLink } from '../../helpers';
 const mapStateToProps = (state, props) => {
   const campaignUpdate = find(state.campaign.activityFeed, { id: props.id });
   const { author, content, link } = campaignUpdate.fields;
+  const linkOptions = {
+    domain: window.location.origin,
+    slug: state.campaign.slug,
+    key: props.id,
+  };
 
   return {
     author,
     content,
     link,
-    shareLink: makeShareLink('campaigns', {
-      domain: window.location.origin,
-      slug: state.campaign.slug,
-      key: props.id,
-    }),
+    shareLink: makeShareLink('campaigns', { ...linkOptions, type: 'modal' }),
+    titleLink: makeShareLink('campaigns', { ...linkOptions, type: 'blocks' }),
   };
 };
 

--- a/resources/assets/helpers/index.js
+++ b/resources/assets/helpers/index.js
@@ -228,7 +228,7 @@ export function makeHash(string) {
  */
 export function makeShareLink(
   resource,
-  options: { domain: string, slug?: string, key: string, type: "blocks" | "modals" },
+  options: { domain: string, slug?: string, key: string, type: "blocks" | "modal" },
 ) {
   switch (resource) {
     case 'campaigns':

--- a/resources/assets/helpers/index.js
+++ b/resources/assets/helpers/index.js
@@ -227,8 +227,8 @@ export function makeHash(string) {
  * @flow
  */
 export function makeShareLink(
-  options: { domain: string, slug?: string, key: string, type: string },
   resource,
+  options: { domain: string, slug?: string, key: string, type: "blocks" | "modals" },
 ) {
   switch (resource) {
     case 'campaigns':

--- a/resources/assets/helpers/index.js
+++ b/resources/assets/helpers/index.js
@@ -227,10 +227,10 @@ export function makeHash(string) {
  * @flow
  */
 export function makeShareLink(
-  type,
   options: { domain: string, slug?: string, key: string, type: string },
+  resource,
 ) {
-  switch (type) {
+  switch (resource) {
     case 'campaigns':
       return `${options.domain}/us/campaigns/${options.slug}/${options.type}/${options.key}`;
 

--- a/resources/assets/helpers/index.js
+++ b/resources/assets/helpers/index.js
@@ -226,10 +226,13 @@ export function makeHash(string) {
  * @return {String}
  * @flow
  */
-export function makeShareLink(type, options: { domain: string, slug?: string, key: string }) {
+export function makeShareLink(
+  type,
+  options: { domain: string, slug?: string, key: string, type: string },
+) {
   switch (type) {
     case 'campaigns':
-      return `${options.domain}/us/campaigns/${options.slug}/blocks/${options.key}`;
+      return `${options.domain}/us/campaigns/${options.slug}/${options.type}/${options.key}`;
 
     default:
       throw new Error('Please provide an expected section type for generating the link.');

--- a/resources/assets/helpers/test.js
+++ b/resources/assets/helpers/test.js
@@ -51,6 +51,7 @@ test('it makes the expected share link for a content item and app section type',
     domain: 'http://awesome.com',
     slug: 'seriously-awesome-campaign',
     key: '123',
+    type: 'blocks',
   };
 
   expect(makeShareLink('campaigns', options)).toBe('http://awesome.com/us/campaigns/seriously-awesome-campaign/blocks/123');


### PR DESCRIPTION
### What does this PR do?
- adding option to the `makeShareLink` function to allow for either `modal` or `blocks` linking
- adding prop to `CampaignUpdate` component so that social links link out to modal and the heading link links to the block. 


### Any background context you want to provide?
I wasn't sure about how to handle this new 'modal/blocks' variable, so ended up going with a new `type` (not completely sold on that name either) option for the function. It does feel somewhat weird to be calling the `makeShareLink` twice in the container, but hopefully using the same `options` object twice dries it up somewhat. 
Also not completely sure about the `titleLink` prop name.

### What are the relevant tickets/cards?
https://www.pivotaltracker.com/story/show/152351435
#481 

### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.

