### PR TITLE
Markdown External Links in New Tab

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6667,6 +6667,11 @@
         "uc.micro": "1.0.3"
       }
     },
+    "markdown-it-attrs": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/markdown-it-attrs/-/markdown-it-attrs-1.2.0.tgz",
+      "integrity": "sha512-+8l8zMUI1hrPH1NgXy5vpmLnczIFUuTJ+lS+ki399yQ0zFE4jDanT+vNts9ruVn1PkyqjG8O9iqPKKYg7loJyA=="
+    },
     "markdown-it-footnote": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/markdown-it-footnote/-/markdown-it-footnote-3.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "history": "^4.7.2",
     "lodash": "^4.17.4",
     "markdown-it": "^8.4.0",
+    "markdown-it-attrs": "^1.2.0",
     "markdown-it-footnote": "^3.0.1",
     "prop-types": "^15.5.8",
     "react": "^15.6.1",

--- a/resources/assets/components/Markdown/index.js
+++ b/resources/assets/components/Markdown/index.js
@@ -10,7 +10,7 @@ const contentfulImageFormat = url => (contentfulImageUrl(url, '1000'));
 const formatImageUrls = string => (string.replace(pattern, contentfulImageFormat));
 
 // https://regex101.com/r/kaX9Kd/6 (regex explanation)
-const externalUrlPattern = /\[.+?(?=])]\(http(s)?:\/\/(?!(www\.)?(next\.)?dosomething\.org).+(?=\))\)/g;
+const externalUrlPattern = /\[.+?(?=])]\(http(s)?:\/\/(?!(www\.)?(next\.)?dosomething\.org).+?(?=\))\)/g;
 const addAttr = link => (`${link}{target="_blank"}`);
 const formatExternalLinks = string => (string.replace(externalUrlPattern, addAttr));
 

--- a/resources/assets/components/Markdown/index.js
+++ b/resources/assets/components/Markdown/index.js
@@ -9,6 +9,10 @@ const pattern = /\/\/images\.contentful\.com.+\.(jpg|png)/g;
 const contentfulImageFormat = url => (contentfulImageUrl(url, '1000'));
 const formatImageUrls = string => (string.replace(pattern, contentfulImageFormat));
 
+// https://regex101.com/r/kaX9Kd/6 (regex explanation)
+const externalUrlPattern = /\[.+?(?=])]\(http(s)?:\/\/(?!(www\.)?(next\.)?dosomething\.org).+(?=\))\)/g;
+const addAttr = url => (`${url}{target="_blank"}`);
+const formatExternalLinks = string => (string.replace(externalUrlPattern, addAttr));
 const Markdown = ({ className = null, children }) => (
   <div className={classnames('markdown', 'with-lists', className)} dangerouslySetInnerHTML={markdown(formatImageUrls(children))} /> // eslint-disable-line react/no-danger
 );

--- a/resources/assets/components/Markdown/index.js
+++ b/resources/assets/components/Markdown/index.js
@@ -13,6 +13,14 @@ const formatImageUrls = string => (string.replace(pattern, contentfulImageFormat
 const externalUrlPattern = /\[.+?(?=])]\(http(s)?:\/\/(?!(www\.)?(next\.)?dosomething\.org).+(?=\))\)/g;
 const addAttr = url => (`${url}{target="_blank"}`);
 const formatExternalLinks = string => (string.replace(externalUrlPattern, addAttr));
+
+const formatMarkdownString = (string) => {
+  const stringImagesFormatted = formatImageUrls(string);
+  const stringExternalLinksFormatted = formatExternalLinks(stringImagesFormatted);
+
+  return stringExternalLinksFormatted;
+};
+
 const Markdown = ({ className = null, children }) => (
   <div className={classnames('markdown', 'with-lists', className)} dangerouslySetInnerHTML={markdown(formatImageUrls(children))} /> // eslint-disable-line react/no-danger
 );

--- a/resources/assets/components/Markdown/index.js
+++ b/resources/assets/components/Markdown/index.js
@@ -11,7 +11,7 @@ const formatImageUrls = string => (string.replace(pattern, contentfulImageFormat
 
 // https://regex101.com/r/kaX9Kd/6 (regex explanation)
 const externalUrlPattern = /\[.+?(?=])]\(http(s)?:\/\/(?!(www\.)?(next\.)?dosomething\.org).+(?=\))\)/g;
-const addAttr = url => (`${url}{target="_blank"}`);
+const addAttr = link => (`${link}{target="_blank"}`);
 const formatExternalLinks = string => (string.replace(externalUrlPattern, addAttr));
 
 const formatMarkdownString = (string) => {

--- a/resources/assets/components/Markdown/index.js
+++ b/resources/assets/components/Markdown/index.js
@@ -9,7 +9,7 @@ const pattern = /\/\/images\.contentful\.com.+\.(jpg|png)/g;
 const contentfulImageFormat = url => (contentfulImageUrl(url, '1000'));
 const formatImageUrls = string => (string.replace(pattern, contentfulImageFormat));
 
-// https://regex101.com/r/kaX9Kd/6 (regex explanation)
+// https://regex101.com/r/kaX9Kd/8 (regex explanation)
 const externalUrlPattern = /\[.+?(?=])]\(http(s)?:\/\/(?!(www\.)?(next\.)?dosomething\.org).+?(?=\))\)/g;
 const addAttr = link => (`${link}{target="_blank"}`);
 const formatExternalLinks = string => (string.replace(externalUrlPattern, addAttr));

--- a/resources/assets/components/Markdown/index.js
+++ b/resources/assets/components/Markdown/index.js
@@ -22,7 +22,7 @@ const formatMarkdownString = (string) => {
 };
 
 const Markdown = ({ className = null, children }) => (
-  <div className={classnames('markdown', 'with-lists', className)} dangerouslySetInnerHTML={markdown(formatImageUrls(children))} /> // eslint-disable-line react/no-danger
+  <div className={classnames('markdown', 'with-lists', className)} dangerouslySetInnerHTML={markdown(formatMarkdownString(children))} /> // eslint-disable-line react/no-danger
 );
 
 Markdown.propTypes = {

--- a/resources/assets/helpers/index.js
+++ b/resources/assets/helpers/index.js
@@ -2,7 +2,8 @@
 
 import markdownItFootnote from 'markdown-it-footnote';
 import MarkdownIt from 'markdown-it';
-import markdownItAttrs from 'markdown-it-attrs';
+// importing browser build so Uglify doesn't crash. https://github.com/arve0/markdown-it-attrs/issues/43
+import markdownItAttrs from 'markdown-it-attrs/markdown-it-attrs.browser';
 import get from 'lodash/get';
 
 // Helper Constants

--- a/resources/assets/helpers/index.js
+++ b/resources/assets/helpers/index.js
@@ -2,6 +2,7 @@
 
 import markdownItFootnote from 'markdown-it-footnote';
 import MarkdownIt from 'markdown-it';
+import markdownItAttrs from 'markdown-it-attrs';
 import get from 'lodash/get';
 
 // Helper Constants
@@ -71,6 +72,7 @@ export function ready(fn) {
 export function markdown(source = '') {
   const markdownIt = new MarkdownIt();
   markdownIt.use(markdownItFootnote);
+  markdownIt.use(markdownItAttrs);
 
   return {
     __html: markdownIt.render(source),


### PR DESCRIPTION
### What does this PR do?
- adds new [`markdown-it-attrs`](https://www.npmjs.com/package/markdown-it-attrs) lib to allow us to add attributes to the `<a>` tag generated by markdown links.
- parsing markdown content to find external links, and adding a `target="blank"` attribute to open in new tab


### Any background context you want to provide?
External links opening in the same tab is bad. However, we can't just inject HTML `<a>` tags with `target="blank"` wherever an external link is because we've decided to block HTML injection in the markdown conversion.

Adding this new plugin will allow for adding curly braces next to links and other markdown elements to give attributes to the generated HTML tag. 

I went the route of us manually adding these attributes to the links ourselves as opposed to having admins manually perform this in Contentful. My thinking was to avoid more info and labor on that end, and also avoid necessarily 'announcing' this new attribute-adding feature.
 

I couldn't find any regex around to serve our specific case so I had to conjure up something myself:
https://regex101.com/r/kaX9Kd/6

![udpj8pi](https://user-images.githubusercontent.com/12417657/33032632-da0fe638-cdef-11e7-8e3b-7c7569c910d7.gif)


### What are the relevant tickets/cards?
https://www.pivotaltracker.com/story/show/148973233

### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.

