### PR TITLE
adding auto width to prevent photo overflow

### DIFF
--- a/resources/assets/components/ActionPage/actionPage.scss
+++ b/resources/assets/components/ActionPage/actionPage.scss
@@ -66,6 +66,7 @@
   @include media($medium) {
     .action-step__photos.-one-third {
       margin-left: $base-spacing;
+      width: auto;
     }
 
     .action-step__photos.-full {


### PR DESCRIPTION
### What does this PR do?
Adds a `width: auto;` rule to `.action-step__photos.-one-third` on larger screens.


### Any background context you want to provide?
When images were the right third of an action step, the `action-step__photo` `100%` width would combine with the `action-step__photos.-one-third`s `margin-left` and overflow
![image](https://user-images.githubusercontent.com/12417657/33078596-237af61c-cea1-11e7-98f9-590de84f88d1.png)

Using `width: auto` allows the images to take up as much space as possible without overflowing
![image](https://user-images.githubusercontent.com/12417657/33078621-3cc60cce-cea1-11e7-88b7-7f79f63ece3e.png)
 


### What are the relevant tickets/cards?
https://www.pivotaltracker.com/story/show/152966005

### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.

