### PR TITLE
Markdown external links new tab

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6672,6 +6672,11 @@
       "resolved": "https://registry.npmjs.org/markdown-it-footnote/-/markdown-it-footnote-3.0.1.tgz",
       "integrity": "sha1-fzcwdHysyG4v4L+KF6cQ80eRUXo="
     },
+    "markdown-it-for-inline": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/markdown-it-for-inline/-/markdown-it-for-inline-0.1.1.tgz",
+      "integrity": "sha1-Q18jFvW15o4UUM+iJC8rjVmtx18="
+    },
     "math-expression-evaluator": {
       "version": "1.2.17",
       "resolved": "https://registry.npmjs.org/math-expression-evaluator/-/math-expression-evaluator-1.2.17.tgz",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "lodash": "^4.17.4",
     "markdown-it": "^8.4.0",
     "markdown-it-footnote": "^3.0.1",
+    "markdown-it-for-inline": "^0.1.1",
     "prop-types": "^15.5.8",
     "react": "^15.6.1",
     "react-dom": "^15.6.1",

--- a/resources/assets/helpers/index.js
+++ b/resources/assets/helpers/index.js
@@ -1,9 +1,9 @@
 /* global window, document, Blob, FB, URL */
 
-import markdownItFootnote from 'markdown-it-footnote';
-import MarkdownIt from 'markdown-it';
 import get from 'lodash/get';
+import MarkdownIt from 'markdown-it';
 import iterator from 'markdown-it-for-inline';
+import markdownItFootnote from 'markdown-it-footnote';
 
 // Helper Constants
 export const EMPTY_IMAGE = 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7';

--- a/resources/assets/helpers/index.js
+++ b/resources/assets/helpers/index.js
@@ -1,4 +1,4 @@
-/* global window, document, Blob, FB */
+/* global window, document, Blob, FB, URL */
 
 import markdownItFootnote from 'markdown-it-footnote';
 import MarkdownIt from 'markdown-it';

--- a/resources/assets/helpers/index.js
+++ b/resources/assets/helpers/index.js
@@ -3,6 +3,7 @@
 import markdownItFootnote from 'markdown-it-footnote';
 import MarkdownIt from 'markdown-it';
 import get from 'lodash/get';
+import iterator from 'markdown-it-for-inline';
 
 // Helper Constants
 export const EMPTY_IMAGE = 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7';
@@ -76,6 +77,16 @@ export function ready(fn) {
 export function markdown(source = '') {
   const markdownIt = new MarkdownIt();
   markdownIt.use(markdownItFootnote);
+
+  markdownIt.use(iterator, 'url_new_win', 'link_open', (tokens, index) => {
+    const token = tokens[index];
+    const hrefIndex = token.attrIndex('href');
+    const url = token.attrs[hrefIndex][1];
+
+    if (isExternal(url)) {
+      token.attrPush(['target', '_blank']);
+    }
+  });
 
   return {
     __html: markdownIt.render(source),

--- a/resources/assets/helpers/index.js
+++ b/resources/assets/helpers/index.js
@@ -7,6 +7,11 @@ import get from 'lodash/get';
 // Helper Constants
 export const EMPTY_IMAGE = 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7';
 
+// Internal Helper Functions
+const isExternal = url => (
+  new URL(url, window.location.origin).hostname !== window.location.hostname
+);
+
 /**
  * Generate a Contentful Image URL with added url parameters.
  *


### PR DESCRIPTION
### What does this PR do?
Way cleaner method (courtesy of Dave) to make external links from markdown open in new tabs (by adding the `target="_blank"` attribute)


### Any background context you want to provide?
#524 


### What are the relevant tickets/cards?
closes #524 

### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.

