### PR TITLE
-Tentative- analytics tracking for reportback uploader

### DIFF
--- a/resources/assets/components/ReportbackUploader/ReportbackUploader.js
+++ b/resources/assets/components/ReportbackUploader/ReportbackUploader.js
@@ -70,12 +70,22 @@ class ReportbackUploader extends React.Component {
       ReportbackUploader.setFormData(reportback),
       this.props.reportbackAffirmation,
     ).then(() => {
+      const trackingData = { campaignId: this.props.legacyCampaignId };
+      let trackingMessage;
+
       if (this.props.submissions.messaging.success) {
         this.form.reset();
         this.setState({
           media: this.defaultMediaState,
         });
+
+        trackingMessage = "Successful Reportback";
+      } else {
+        trackingMessage = "Unsuccessful Reportback";
+        trackingData['submission_error'] = this.props.submissions.messaging.error;
       }
+
+      this.props.trackEvent(trackingMessage, trackingData);
     });
   }
 
@@ -136,6 +146,7 @@ ReportbackUploader.propTypes = {
   }),
   quantityOverride: PropTypes.number,
   reportbackAffirmation: PropTypes.string,
+  trackEvent: PropTypes.func.isRequired,
 };
 
 ReportbackUploader.defaultProps = {

--- a/resources/assets/components/ReportbackUploader/ReportbackUploader.js
+++ b/resources/assets/components/ReportbackUploader/ReportbackUploader.js
@@ -79,10 +79,10 @@ class ReportbackUploader extends React.Component {
           media: this.defaultMediaState,
         });
 
-        trackingMessage = "Successful Reportback";
+        trackingMessage = 'Successful Reportback';
       } else {
-        trackingMessage = "Unsuccessful Reportback";
-        trackingData['submission_error'] = this.props.submissions.messaging.error;
+        trackingMessage = 'Unsuccessful Reportback';
+        trackingData.submission_error = this.props.submissions.messaging.error;
       }
 
       this.props.trackEvent(trackingMessage, trackingData);

--- a/resources/assets/components/ReportbackUploader/ReportbackUploader.js
+++ b/resources/assets/components/ReportbackUploader/ReportbackUploader.js
@@ -69,14 +69,13 @@ class ReportbackUploader extends React.Component {
     this.props.submitReportback(
       ReportbackUploader.setFormData(reportback),
       this.props.reportbackAffirmation,
-    );
-
-    // @TODO: only reset form AFTER successful RB submission.
-    // We'll make this a lot better once we switch to storing all the state
-    // in the Redux store @_@
-    this.form.reset();
-    this.setState({
-      media: this.defaultMediaState,
+    ).then(() => {
+      if (this.props.submissions.messaging.success) {
+        this.form.reset();
+        this.setState({
+          media: this.defaultMediaState,
+        });
+      }
     });
   }
 

--- a/resources/assets/components/ReportbackUploader/ReportbackUploaderContainer.js
+++ b/resources/assets/components/ReportbackUploader/ReportbackUploaderContainer.js
@@ -1,5 +1,6 @@
 import { connect } from 'react-redux';
 import { get } from 'lodash';
+import { PuckConnector } from '@dosomething/puck-client';
 import ReportbackUploader from './ReportbackUploader';
 import { submitReportback, addSubmissionItemToList } from '../../actions';
 
@@ -25,4 +26,4 @@ const actionCreators = {
 };
 
 // Export the container component.
-export default connect(mapStateToProps, actionCreators)(ReportbackUploader);
+export default connect(mapStateToProps, actionCreators)(PuckConnector(ReportbackUploader));


### PR DESCRIPTION
### What does this PR do?
Adds Puck tracking for successful and unsuccessful reportback submissions.
 - Tracking `data` consists of the legacy campaign id on success, and the error object as well - if unsuccessful


### Any background context you want to provide?
This is stacked on top of the work in #526 
(Closed #526, merging this one)

### What are the relevant tickets/cards?
Fixes #

### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.

