### PR TITLE
Reportback caption styling

### DIFF
--- a/resources/assets/components/Reaction/index.js
+++ b/resources/assets/components/Reaction/index.js
@@ -16,7 +16,7 @@ const Reaction = (props) => {
 
   return (
     <button className="reaction" onClick={onToggle}>
-      <BaseFigure media={reactionButton} alignment="left">
+      <BaseFigure media={reactionButton} alignment="left" className="margin-bottom-none">
         <span className="reaction__meta">{total}</span>
       </BaseFigure>
     </button>

--- a/resources/assets/components/ReportbackItem/reportback-item.scss
+++ b/resources/assets/components/ReportbackItem/reportback-item.scss
@@ -24,6 +24,11 @@
   > .figure__body p {
     word-break: break-word;
   }
+
+  .figure.-right > .figure__body {
+    overflow: unset;
+  }
+
 }
 
 .padded {

--- a/resources/assets/components/ReportbackItem/reportback-item.scss
+++ b/resources/assets/components/ReportbackItem/reportback-item.scss
@@ -4,6 +4,7 @@
   font-family: $primary-font-family;
 
   h4 {
+    display: inline;
     font-size: $font-regular;
     font-weight: $weight-bold;
   }


### PR DESCRIPTION
### What does this PR do?
- Allows the 'description' or 'caption' for a reportback to spread across the full width of the card.
- removing the `margin-bottom` from `Reaction`s so that on mobile the caption can spread across full width as well.

### Any background context you want to provide?
before:
![image](https://user-images.githubusercontent.com/12417657/33285289-d853b4d8-d37f-11e7-9590-3ac2ad68a893.png)


after:
![image](https://user-images.githubusercontent.com/12417657/33285250-c2cb017a-d37f-11e7-9c70-cc9219d08cef.png)

mobile before:
![image](https://user-images.githubusercontent.com/12417657/33285410-37b2d148-d380-11e7-867f-7d74faf934e1.png)


mobile after:
![image](https://user-images.githubusercontent.com/12417657/33285427-49937d54-d380-11e7-824a-31f7ea572f2a.png)




### What are the relevant tickets/cards?
Fixes #

### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.

