### PR TITLE
Campaign update fixes for preview api

### DIFF
--- a/app/Entities/CampaignUpdate.php
+++ b/app/Entities/CampaignUpdate.php
@@ -16,7 +16,7 @@ class CampaignUpdate extends Entity implements JsonSerializable
         switch ($this->getContentType()) {
             case 'campaignUpdate':
                 $type = $this->getContentType();
-                $author = new Staff($this->author->entry);
+                $author = $this->author ? new Staff($this->author->entry) : null;
                 $content = $this->content;
                 $socialOverride = $this->socialOverride ? new SocialOverride($this->socialOverride->entry) : null;
                 break;

--- a/resources/assets/components/CampaignUpdate/CampaignUpdate.js
+++ b/resources/assets/components/CampaignUpdate/CampaignUpdate.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
+import { get } from 'lodash';
 
 import Card from '../Card';
 import Embed from '../Embed';
@@ -9,7 +10,7 @@ import Markdown from '../Markdown';
 import { ShareContainer } from '../Share';
 
 const CampaignUpdate = ({ id, author, content, link, shareLink, bordered, titleLink }) => {
-  const authorFields = (author && author.fields) || {};
+  const authorFields = get(author, 'fields', {});
 
   const isTweet = content.length < 144;
 

--- a/resources/assets/components/CampaignUpdate/CampaignUpdate.js
+++ b/resources/assets/components/CampaignUpdate/CampaignUpdate.js
@@ -9,7 +9,7 @@ import Markdown from '../Markdown';
 import { ShareContainer } from '../Share';
 
 const CampaignUpdate = ({ id, author, content, link, shareLink, bordered, titleLink }) => {
-  const { avatar, jobTitle, name } = author.fields;
+  const authorFields = (author && author.fields) || {};
 
   const isTweet = content.length < 144;
 
@@ -23,9 +23,9 @@ const CampaignUpdate = ({ id, author, content, link, shareLink, bordered, titleL
 
       <footer className="padded clearfix">
         <Byline
-          author={name}
-          avatar={avatar || undefined}
-          jobTitle={jobTitle || undefined}
+          author={authorFields.name}
+          avatar={authorFields.avatar || undefined}
+          jobTitle={authorFields.jobTitle || undefined}
           className="float-left"
         />
         <ShareContainer
@@ -56,9 +56,7 @@ CampaignUpdate.propTypes = {
 CampaignUpdate.defaultProps = {
   link: null,
   bordered: true,
-  author: {
-    fields: {},
-  },
+  author: null,
 };
 
 export default CampaignUpdate;

--- a/resources/assets/components/CampaignUpdate/CampaignUpdate.js
+++ b/resources/assets/components/CampaignUpdate/CampaignUpdate.js
@@ -45,7 +45,7 @@ CampaignUpdate.propTypes = {
     id: PropTypes.string,
     type: PropTypes.string,
     fields: PropTypes.object,
-  }).isRequired,
+  }),
   content: PropTypes.string.isRequired,
   link: PropTypes.string,
   shareLink: PropTypes.string.isRequired,
@@ -56,6 +56,9 @@ CampaignUpdate.propTypes = {
 CampaignUpdate.defaultProps = {
   link: null,
   bordered: true,
+  author: {
+    fields: {},
+  },
 };
 
 export default CampaignUpdate;

--- a/resources/assets/components/CampaignUpdate/CampaignUpdate.js
+++ b/resources/assets/components/CampaignUpdate/CampaignUpdate.js
@@ -12,12 +12,12 @@ import { ShareContainer } from '../Share';
 const CampaignUpdate = ({ id, author, content, link, shareLink, bordered, titleLink }) => {
   const authorFields = get(author, 'fields', {});
 
-  const isTweet = content.length < 144;
+  const isTweet = content && content.length < 144;
 
   return (
     <Card id={id} className={classnames('rounded', { bordered })} link={titleLink} title="Campaign Update">
       <Markdown className={classnames('padded', { 'font-size-lg': isTweet })}>
-        {content}
+        {content || 'Placeholder'}
       </Markdown>
 
       { link ? <Embed className="padded" url={link} /> : null }
@@ -47,7 +47,7 @@ CampaignUpdate.propTypes = {
     type: PropTypes.string,
     fields: PropTypes.object,
   }),
-  content: PropTypes.string.isRequired,
+  content: PropTypes.string,
   link: PropTypes.string,
   shareLink: PropTypes.string.isRequired,
   titleLink: PropTypes.string.isRequired,
@@ -58,6 +58,7 @@ CampaignUpdate.defaultProps = {
   link: null,
   bordered: true,
   author: null,
+  content: null,
 };
 
 export default CampaignUpdate;


### PR DESCRIPTION
### What does this PR do?
Accounts for scenario where when using contentful's preview API - a `CampaignUpdate`s `author` field might not be set. 

- Set to `null` instead of trying to create an `Author` entity
- In the React component - change Author to defaultProp, and let the `Author` component's default props to take over.



### Any background context you want to provide?
Slack discussion https://dosomething.slack.com/archives/C3ASB4204/p1511818759000348


### What are the relevant tickets/cards?
Fixes #

### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.

