### PR TITLE
adding Page entity for contentful Pages

### DIFF
--- a/app/Entities/Page.php
+++ b/app/Entities/Page.php
@@ -14,16 +14,13 @@ class Page extends Entity implements JsonSerializable
      */
     public function parseSidebar($sidebarItems)
     {
-        return collect($sidebarItems)->map(function ($sidebarItem) {
+        return collect($sidebarItems)->filter(function ($sidebarItem) {
             switch ($sidebarItem->getContentType()) {
                 case 'callToAction':
                     return new CallToAction($sidebarItem->entry);
 
                 case 'customBlock':
                     return new CustomBlock($sidebarItem->entry);
-
-                default:
-                    return $sidebarItem;
             }
         });
     }

--- a/app/Entities/Page.php
+++ b/app/Entities/Page.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Entities;
+
+use JsonSerializable;
+
+class Page extends Entity implements JsonSerializable
+{
+    /**
+     * Parse and extract data for the sidebar.
+     *
+     * @param  array $sidebarItems
+     * @return array
+     */
+    public function parseSidebar($sidebarItems)
+    {
+        return collect($sidebarItems)->map(function ($sidebarItem) {
+            switch ($sidebarItem->getContentType()) {
+                case 'callToAction':
+                    return new CallToAction($sidebarItem->entry);
+
+                case 'customBlock':
+                    return new CustomBlock($sidebarItem->entry);
+
+                default:
+                    return $sidebarItem;
+            }
+        });
+    }
+
+    /**
+     * Convert the object into something JSON serializable.
+     *
+     * @return array
+     */
+    public function jsonSerialize()
+    {
+        return [
+            'id' => $this->entry->getId(),
+            'type' => $this->getContentType(),
+            'fields' => [
+                'title' => $this->title,
+                'content' => $this->content,
+                'sidebar' => $this->parseSidebar($this->sidebar),
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
### What does this PR do?
Adds a new `Page` entity to our suite of `app/Entities`. 
This is for Contentful Page entities and is equipped with our standard `jsonSerialize` function so we can use this stuff on the frontend.


### Any background context you want to provide?
- This is going to be used for the new Pitch page, ("And all pages moving forward! Static pages as well!" - nice!) as we'll now be making use of the contentful fields in this Page entity, as opposed to before when we were pretty much just using the JSON `additionalFields` for some copy.

- The sidebar fields will consist of sidebar items that we'll probably standardize to be CallToActions or CustomBlocks, so there's a [parseSidebar](https://github.com/DoSomething/phoenix-next/compare/Page-entity?expand=1#diff-fd6da612b4f680e45d8e8feda2aa613fR15) function to take care of transforming the sidebar items to Entities.


### What are the relevant tickets/cards?
Beginnings of work for https://www.pivotaltracker.com/story/show/152925616

### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.

