### PR TITLE
Testing testing 1 2 3

### DIFF
--- a/app/Entities/Campaign.php
+++ b/app/Entities/Campaign.php
@@ -188,6 +188,7 @@ class Campaign extends Entity implements JsonSerializable
             'landingPage' => $this->landingPage ? new Page($this->landingPage->entry) : null,
             'socialOverride' => $this->socialOverride ? new SocialOverride($this->socialOverride->entry) : null,
             'additionalContent' => $this->additionalContent,
+            'allowExperiments' => $this->campaignSettings ? $this->campaignSettings->allowExperiments : null,
         ];
     }
 }

--- a/app/Entities/Page.php
+++ b/app/Entities/Page.php
@@ -37,9 +37,9 @@ class Page extends Entity implements JsonSerializable
             'type' => $this->getContentType(),
             'fields' => [
                 'title' => $this->title,
-                'content' => $this->content ? $this->content : $this->additionalContent['pitchContent'],
+                'content' => $this->content,
+                'legacyContent' => array_get($this->additionalContent, 'pitchContent', null),
                 'sidebar' => $this->parseSidebar($this->sidebar),
-                'isLegacyPitch' => array_get($this->additionalContent, 'isLegacyPitch', true),
             ],
         ];
     }

--- a/resources/assets/components/Page/LandingPage/LandingPage.js
+++ b/resources/assets/components/Page/LandingPage/LandingPage.js
@@ -23,8 +23,8 @@ const formatToMarkup = data => (
 
 const LandingPage = (props) => {
   const {
-    affiliateSponsors, blurb, coverImage, endDate,
-    isAffiliated, legacyCampaignId, legacyPitchContent,
+    affiliateSponsors, blurb, convertExperiment, coverImage,
+    endDate, isAffiliated, legacyCampaignId, legacyPitchContent,
     pitchContent, sidebar, showPartnerMsgOptIn, signupArrowContent,
     subtitle, tagline, template, title,
   } = props;
@@ -53,14 +53,14 @@ const LandingPage = (props) => {
             <ColumnizedContent
               experiment="landing_page"
               alternative="legacy_landing_page"
-              convert={props.convertExperiment}
+              convert={convertExperiment}
               className="container__block -half"
               content={formatToMarkup(legacyPitchContent)}
             />
             <LandingPageContentAlt
               experiment="landing_page"
               alternative="landing_page_alt"
-              convert={props.convertExperiment}
+              convert={convertExperiment}
               pitchContent={pitchContent}
               sidebarCTA={sidebarCTA}
             />

--- a/resources/assets/components/Page/LandingPage/LandingPage.js
+++ b/resources/assets/components/Page/LandingPage/LandingPage.js
@@ -24,9 +24,6 @@ const formatToMarkup = data => (
 const LandingPage = (props) => {
   const {
     affiliateSponsors, blurb, coverImage, endDate,
-    isAffiliated, isLegacyPitch, legacyCampaignId, pitchContent,
-    sidebar, showPartnerMsgOptIn, signupArrowContent, subtitle,
-    tagline, template, title,
     isAffiliated, legacyCampaignId, legacyPitchContent,
     pitchContent, sidebar, showPartnerMsgOptIn, signupArrowContent,
     subtitle, tagline, template, title,

--- a/resources/assets/components/Page/LandingPage/LandingPage.js
+++ b/resources/assets/components/Page/LandingPage/LandingPage.js
@@ -4,11 +4,11 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import Enclosure from '../../Enclosure';
+import ExperimentContainer from '../../Experiment';
 import LedeBanner from '../../LedeBanner/LedeBanner';
 import ColumnizedContent from '../../ColumnizedContent';
+import LandingPageContentAlt from './LandingPageContentAlt';
 import CallToActionContainer from '../../CallToAction/CallToActionContainer';
-import Markdown from '../../Markdown';
-import Card from '../../Card';
 
 import './landing-page.scss';
 
@@ -27,24 +27,12 @@ const LandingPage = (props) => {
     isAffiliated, isLegacyPitch, legacyCampaignId, pitchContent,
     sidebar, showPartnerMsgOptIn, signupArrowContent, subtitle,
     tagline, template, title,
+    isAffiliated, legacyCampaignId, legacyPitchContent,
+    pitchContent, sidebar, showPartnerMsgOptIn, signupArrowContent,
+    subtitle, tagline, template, title,
   } = props;
 
   const sidebarCTA = sidebar[0] && sidebar[0].fields;
-
-  const enclosureContent = isLegacyPitch ?
-    <ColumnizedContent className="container__block -half" content={formatToMarkup(pitchContent)} />
-    : (
-      <div className="campaign-subpage">
-        <div className="primary">
-          <Markdown>{ pitchContent[0] }</Markdown>
-        </div>
-        <div className="secondary">
-          <Card title={sidebarCTA.title} className="rounded bordered" >
-            <Markdown className="padded" >{ sidebarCTA.content }</Markdown>
-          </Card>
-        </div>
-      </div>
-    );
 
   return (
     <div>
@@ -64,7 +52,22 @@ const LandingPage = (props) => {
 
       <div className="clearfix bg-white">
         <Enclosure className="default-container margin-lg pitch-landing-page">
-          { enclosureContent }
+          <ExperimentContainer name="landing_page">
+            <ColumnizedContent
+              experiment="landing_page"
+              alternative="legacy_landing_page"
+              convert={props.convertExperiment}
+              className="container__block -half"
+              content={formatToMarkup(legacyPitchContent)}
+            />
+            <LandingPageContentAlt
+              experiment="landing_page"
+              alternative="landing_page_alt"
+              convert={props.convertExperiment}
+              pitchContent={pitchContent}
+              sidebarCTA={sidebarCTA}
+            />
+          </ExperimentContainer>
         </Enclosure>
       </div>
 

--- a/resources/assets/components/Page/LandingPage/LandingPage.js
+++ b/resources/assets/components/Page/LandingPage/LandingPage.js
@@ -95,7 +95,7 @@ LandingPage.propTypes = {
   isAffiliated: PropTypes.bool,
   affiliateSponsors: PropTypes.array.isRequired, // eslint-disable-line react/forbid-prop-types
   legacyCampaignId: PropTypes.string.isRequired,
-  pitchContent: PropTypes.array.isRequired, // eslint-disable-line react/forbid-prop-types
+  pitchContent: PropTypes.string.isRequired,
   showPartnerMsgOptIn: PropTypes.bool,
   signupArrowContent: PropTypes.string,
   subtitle: PropTypes.string.isRequired,
@@ -103,7 +103,8 @@ LandingPage.propTypes = {
   template: PropTypes.string.isRequired,
   title: PropTypes.string.isRequired,
   sidebar: PropTypes.arrayOf(PropTypes.object),
-  isLegacyPitch: PropTypes.bool.isRequired,
+  convertExperiment: PropTypes.func.isRequired,
+  legacyPitchContent: PropTypes.arrayOf(PropTypes.object).isRequired,
 };
 
 LandingPage.defaultProps = {

--- a/resources/assets/components/Page/LandingPage/LandingPageContainer.js
+++ b/resources/assets/components/Page/LandingPage/LandingPageContainer.js
@@ -10,11 +10,9 @@ import { convertExperiment } from '../../../actions';
 const mapStateToProps = (state) => {
   const landingPage = state.campaign.landingPage.fields;
 
-  const pitchContent = landingPage.content instanceof Array ?
-    landingPage.content : [landingPage.content];
-
   return {
-    pitchContent,
+    pitchContent: landingPage.content,
+    legacyPitchContent: landingPage.legacyContent,
     blurb: state.campaign.blurb,
     coverImage: state.campaign.coverImage,
     dashboard: state.campaign.dashboard,
@@ -29,7 +27,6 @@ const mapStateToProps = (state) => {
     template: state.campaign.template,
     title: state.campaign.title,
     sidebar: landingPage.sidebar,
-    isLegacyPitch: landingPage.isLegacyPitch,
   };
 };
 

--- a/resources/assets/components/Page/LandingPage/LandingPageContentAlt.js
+++ b/resources/assets/components/Page/LandingPage/LandingPageContentAlt.js
@@ -28,7 +28,7 @@ LandingPageContentAlt.propTypes = {
 LandingPageContentAlt.defaultProps = {
   sidebarCTA: {
     title: 'what you get',
-    content: '*You could win a $5,000 dollar scholarship!',
+    content: '*You could win a $5,000 dollar scholarship!*',
   },
 };
 

--- a/resources/assets/components/Page/LandingPage/LandingPageContentAlt.js
+++ b/resources/assets/components/Page/LandingPage/LandingPageContentAlt.js
@@ -1,0 +1,36 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import Markdown from '../../Markdown';
+import Card from '../../Card';
+
+const LandingPageContentAlt = ({ pitchContent, sidebarCTA }) => (
+  <div className="campaign-subpage">
+    <div className="primary">
+      <Markdown>{ pitchContent }</Markdown>
+    </div>
+    <div className="secondary">
+      <Card title={sidebarCTA.title} className="rounded bordered" >
+        <Markdown className="padded" >{ sidebarCTA.content }</Markdown>
+      </Card>
+    </div>
+  </div>
+);
+
+LandingPageContentAlt.propTypes = {
+  pitchContent: PropTypes.string.isRequired,
+  sidebarCTA: PropTypes.shape({
+    title: PropTypes.string,
+    content: PropTypes.string,
+  }).isRequired,
+};
+
+LandingPageContentAlt.defaultProps = {
+  sidebarCTA: {
+    title: 'what you get',
+    content: '*You could win a $5,000 dollar scholarship!',
+  },
+};
+
+export default LandingPageContentAlt;
+

--- a/resources/assets/components/SignupButton/SignupButton.js
+++ b/resources/assets/components/SignupButton/SignupButton.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { PuckConnector } from '@dosomething/puck-client';
 import SignupButtonContainer from './SignupButtonContainer';
+import { convertOnSignupIntent } from '../../helpers/sixpack';
 
 /**
  * HOC for wrapping signup buttons. Handles tracking
@@ -14,9 +15,18 @@ import SignupButtonContainer from './SignupButtonContainer';
  */
 const SignupButtonFactory = (WrappedComponent, source = null, sourceData = null) => {
   const SignupButton = (props) => {
-    const { clickedSignUp, template, trackEvent } = props;
+    const { clickedSignUp, template, trackEvent, experiments, convertExperiment } = props;
+
+    const afterSignup = () => {
+      Object.keys(experiments).forEach((experiment) => {
+        if (convertOnSignupIntent(experiment)) {
+          convertExperiment(experiment);
+        }
+      });
+    };
 
     const onSignup = (campaignId) => {
+      afterSignup();
       clickedSignUp(campaignId);
       trackEvent('signup', {
         template,
@@ -35,6 +45,8 @@ const SignupButtonFactory = (WrappedComponent, source = null, sourceData = null)
     clickedSignUp: PropTypes.func.isRequired,
     template: PropTypes.string,
     trackEvent: PropTypes.func.isRequired,
+    experiments: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
+    convertExperiment: PropTypes.func.isRequired,
   };
 
   SignupButton.defaultProps = {

--- a/resources/assets/components/SignupButton/SignupButton.js
+++ b/resources/assets/components/SignupButton/SignupButton.js
@@ -17,7 +17,7 @@ const SignupButtonFactory = (WrappedComponent, source = null, sourceData = null)
   const SignupButton = (props) => {
     const { clickedSignUp, template, trackEvent, experiments, convertExperiment } = props;
 
-    const afterSignup = () => {
+    const convertExperiments = () => {
       Object.keys(experiments).forEach((experiment) => {
         if (convertOnSignupIntent(experiment)) {
           convertExperiment(experiment);
@@ -26,7 +26,7 @@ const SignupButtonFactory = (WrappedComponent, source = null, sourceData = null)
     };
 
     const onSignup = (campaignId) => {
-      afterSignup();
+      convertExperiments();
       clickedSignUp(campaignId);
       trackEvent('signup', {
         template,

--- a/resources/assets/components/SignupButton/SignupButtonContainer.js
+++ b/resources/assets/components/SignupButton/SignupButtonContainer.js
@@ -1,12 +1,15 @@
 import { connect } from 'react-redux';
 import { clickedSignUp } from '../../actions/signup';
+import { convertExperiment } from '../../actions';
 
 const mapStateToProps = state => ({
   template: state.campaign.template,
+  experiments: state.experiments,
 });
 
 const actionCreators = {
   clickedSignUp,
+  convertExperiment,
 };
 
 export default Component => connect(mapStateToProps, actionCreators)(Component);

--- a/resources/assets/experiments.json
+++ b/resources/assets/experiments.json
@@ -22,5 +22,17 @@
       "b": "get_started",
       "c": "apply_now"
     }
+  },
+  "landing_page": {
+    "meta": {
+      "preTest": {
+        "campign.allowExperiments": true
+      },
+      "convertOnSignupIntent": true
+    },
+    "alternatives": {
+      "a": "legacy_landing_page",
+      "b": "landing_page_alt"
+    }
   }
 }

--- a/resources/assets/helpers/sixpack.js
+++ b/resources/assets/helpers/sixpack.js
@@ -17,6 +17,16 @@ export function sixpack() {
 }
 
 /**
+ * Check if experiment should be converted when user expresses Signup intent.
+ *
+ * @param  {String} name
+ * @return {Bool}
+ */
+export function ConvertOnSignupIntent(name) {
+  return experiments[name].meta.convertOnSignupIntent;
+}
+
+/**
  * Participate current client to specified experiment.
  *
  * @param  {String} name

--- a/resources/assets/helpers/sixpack.js
+++ b/resources/assets/helpers/sixpack.js
@@ -20,9 +20,9 @@ export function sixpack() {
  * Check if experiment should be converted when user expresses Signup intent.
  *
  * @param  {String} name
- * @return {Bool}
+ * @return {Boolean}
  */
-export function ConvertOnSignupIntent(name) {
+export function convertOnSignupIntent(name) {
   return experiments[name].meta.convertOnSignupIntent;
 }
 


### PR DESCRIPTION
### What does this PR do?
- Adds support for both versions of Pitch Page (Or in other words: the Landing Page primary content).
- Moving the new pitch page content into its own component.
- Adding sixpack A/B experiment to test between both versions of the pitch page content
- Adding experiment conversion for all experiments specified as `convertOnSignupIntent` in SignupButton when user clicks a Signup button.


### Any background context you want to provide?
We've decided to go with testing the legacy pitch page vs the new (mosaic?) pitch page.
The experiment will only run if the campaign settings 'allow A / B testing' is set to `true`. Any other campaign with a Landing Page will just default to the 'control' case which is the legacy pitch page.
Landing Pages will be expected to have both the old json format (pitch content as an array in the additional content json field.) as well as Markup content in the actual 'Content' field. The php `Page` entity will take care of setting those up, so that the component on the front end will just grab those fields in the container.


### What are the relevant tickets/cards?
https://www.pivotaltracker.com/story/show/152925616
Test spec:
https://docs.google.com/document/d/1nEFfJeHRkKgys7rBt3klKFvquJ6ATZaBwAsmx3emzJw/edit#

### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.

