### PR TITLE
changing pitchContent to optional prop and adding defaultProp

### DIFF
--- a/resources/assets/components/Page/LandingPage/LandingPage.js
+++ b/resources/assets/components/Page/LandingPage/LandingPage.js
@@ -95,7 +95,7 @@ LandingPage.propTypes = {
   isAffiliated: PropTypes.bool,
   affiliateSponsors: PropTypes.array.isRequired, // eslint-disable-line react/forbid-prop-types
   legacyCampaignId: PropTypes.string.isRequired,
-  pitchContent: PropTypes.string.isRequired,
+  pitchContent: PropTypes.string,
   showPartnerMsgOptIn: PropTypes.bool,
   signupArrowContent: PropTypes.string,
   subtitle: PropTypes.string.isRequired,
@@ -110,6 +110,7 @@ LandingPage.propTypes = {
 LandingPage.defaultProps = {
   endDate: null,
   isAffiliated: false,
+  pitchContent: null,
   tagline: 'Ready to start?',
   signupArrowContent: null,
   showPartnerMsgOptIn: false,

--- a/resources/assets/components/Page/LandingPage/LandingPageContentAlt.js
+++ b/resources/assets/components/Page/LandingPage/LandingPageContentAlt.js
@@ -18,7 +18,7 @@ const LandingPageContentAlt = ({ pitchContent, sidebarCTA }) => (
 );
 
 LandingPageContentAlt.propTypes = {
-  pitchContent: PropTypes.string.isRequired,
+  pitchContent: PropTypes.string,
   sidebarCTA: PropTypes.shape({
     title: PropTypes.string,
     content: PropTypes.string,
@@ -26,6 +26,7 @@ LandingPageContentAlt.propTypes = {
 };
 
 LandingPageContentAlt.defaultProps = {
+  pitchContent: null,
   sidebarCTA: {
     title: 'what you get',
     content: '*You could win a $5,000 dollar scholarship!*',


### PR DESCRIPTION
### What does this PR do?
Super small fix to the new Pitch Page situation:

We had the `pitchContent` prop marked as `required` in both the `LandingPage` and `LandingPageContentAlt` but on any legacy campaigns with Landing pages but no A/B testing, this value was `null` which logs an (non breaking) error.