### PR TITLE
Update to restore old code approach.

### DIFF
--- a/app/Entities/CampaignActionStep.php
+++ b/app/Entities/CampaignActionStep.php
@@ -37,12 +37,12 @@ class CampaignActionStep extends Entity implements JsonSerializable
             'type' => $this->getContentType(),
             'fields' => [
                 'title' => $this->title,
-                'displayOptions' => $this->displayOptions ? $this->displayOptions->first() : 'one-third',
+                'displayOptions' => $this->displayOptions->first(),
                 'hideStepNumber' => $hideStepNumber,
                 'content' => $this->content,
                 'background' => get_image_url($this->background, 'landscape'),
                 'photos' => $this->parseActionStepPhotos($this->photos),
-                'customType' => $this->type ?: ($this->customType ? $this->customType->first() : null),
+                'customType' => $this->type ?: $this->customType->first(),
                 'additionalContent' => $this->additionalContent,
             ],
         ];


### PR DESCRIPTION
### What does this PR do?
Reverts the code that transforms a couple fields in the `CampaignActionStep` entity. It was changed before due to the `PhotoUploaderAction` accidentally getting processed as a campaign action step, but this shouldn't ever be the case so reverting the code back since the change was unnecessary.


### Any background context you want to provide?
See conversation [here](https://github.com/DoSomething/phoenix-next/pull/540/files#r155355244).
