### PR TITLE
Typeform survey launcher

### DIFF
--- a/resources/assets/components/Campaign/Campaign.js
+++ b/resources/assets/components/Campaign/Campaign.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
+import SurveyContainer from '../Survey';
 import ModalSwitch from '../Modal';
 import { CampaignPageContainer, LandingPageContainer } from '../Page';
 import NotificationContainer from '../Notification';
@@ -14,6 +15,7 @@ const Campaign = props => (
 
     <NotificationContainer />
     <ModalSwitch />
+    <SurveyContainer />
 
     { props.shouldShowLandingPage ?
       <LandingPageContainer {...props} />

--- a/resources/assets/components/Campaign/Campaign.js
+++ b/resources/assets/components/Campaign/Campaign.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import SurveyContainer from '../Survey';
 import ModalSwitch from '../Modal';
 import { CampaignPageContainer, LandingPageContainer } from '../Page';
 import NotificationContainer from '../Notification';
@@ -15,7 +14,6 @@ const Campaign = props => (
 
     <NotificationContainer />
     <ModalSwitch />
-    <SurveyContainer />
 
     { props.shouldShowLandingPage ?
       <LandingPageContainer {...props} />

--- a/resources/assets/components/Modal/ModalSwitch.js
+++ b/resources/assets/components/Modal/ModalSwitch.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import {
-  Modal, PostSignupModal, ContentModal, ReportbackUploaderModal, SurveyModal,
+  Modal, PostSignupModal, ContentModal, ReportbackUploaderModal, SurveyModalContainer,
   POST_SIGNUP_MODAL, CONTENT_MODAL, REPORTBACK_UPLOADER_MODAL, SURVEY_MODAL,
 } from '../Modal';
 
@@ -20,7 +20,7 @@ const ModalSwitch = (props) => {
       children = <ReportbackUploaderModal />;
       break;
     case SURVEY_MODAL:
-      children = <SurveyModal />;
+      children = <SurveyModalContainer />;
       break;
     default: break;
   }

--- a/resources/assets/components/Modal/configurations/SurveyModal.js
+++ b/resources/assets/components/Modal/configurations/SurveyModal.js
@@ -3,7 +3,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import { SURVEY_DATA_URL } from '../../../constants/survey';
+const SURVEY_DATA_URL = 'https://dosomething.typeform.com/to/Bvcwvm';
 
 class SurveyModal extends React.Component {
   componentDidMount() {

--- a/resources/assets/components/Modal/configurations/SurveyModal.js
+++ b/resources/assets/components/Modal/configurations/SurveyModal.js
@@ -3,6 +3,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
+import { makeUrl } from '../../../helpers';
+
 const SURVEY_DATA_URL = 'https://dosomething.typeform.com/to/Bvcwvm';
 
 class SurveyModal extends React.Component {
@@ -13,12 +15,10 @@ class SurveyModal extends React.Component {
   render() {
     const { northstarId, campaignId, legacyCampaignId } = this.props;
 
+    const typeformUrl = makeUrl(SURVEY_DATA_URL, {'northstar_id': northstarId, 'campaign_id': campaignId, 'legacy_campaign_id': legacyCampaignId});
+
     return (
-      <div
-        className="modal__slide typeform-widget"
-        data-url={`${SURVEY_DATA_URL}?northstar_id=${northstarId}&campaign_id=${campaignId}&legacy_campaign_id=${legacyCampaignId}`}
-        style={{ width: '100%', height: '500px' }}
-      />
+      <div className="modal__slide typeform-widget" data-url={typeformUrl.href} style={{ width: '100%', height: '500px' }} />
     );
   }
 }

--- a/resources/assets/components/Modal/configurations/SurveyModal.js
+++ b/resources/assets/components/Modal/configurations/SurveyModal.js
@@ -15,7 +15,13 @@ class SurveyModal extends React.Component {
   render() {
     const { northstarId, campaignId, legacyCampaignId } = this.props;
 
-    const typeformUrl = makeUrl(SURVEY_DATA_URL, { northstar_id: northstarId, campaign_id: campaignId, legacy_campaign_id: legacyCampaignId });
+    const typeformQuery = {
+      northstar_id: northstarId,
+      campaign_id: campaignId,
+      legacy_campaign_id: legacyCampaignId,
+    };
+
+    const typeformUrl = makeUrl(SURVEY_DATA_URL, typeformQuery);
 
     return (
       <div className="modal__slide typeform-widget" data-url={typeformUrl.href} style={{ width: '100%', height: '500px' }} />

--- a/resources/assets/components/Modal/configurations/SurveyModal.js
+++ b/resources/assets/components/Modal/configurations/SurveyModal.js
@@ -15,7 +15,7 @@ class SurveyModal extends React.Component {
   render() {
     const { northstarId, campaignId, legacyCampaignId } = this.props;
 
-    const typeformUrl = makeUrl(SURVEY_DATA_URL, {'northstar_id': northstarId, 'campaign_id': campaignId, 'legacy_campaign_id': legacyCampaignId});
+    const typeformUrl = makeUrl(SURVEY_DATA_URL, { northstar_id: northstarId, campaign_id: campaignId, legacy_campaign_id: legacyCampaignId });
 
     return (
       <div className="modal__slide typeform-widget" data-url={typeformUrl.href} style={{ width: '100%', height: '500px' }} />

--- a/resources/assets/components/Modal/configurations/SurveyModal.js
+++ b/resources/assets/components/Modal/configurations/SurveyModal.js
@@ -11,12 +11,12 @@ class SurveyModal extends React.Component {
   }
 
   render() {
-    const { northstarId, campaignId, legacyCampaignId } = this.props;
+    const { dataUrl, northstarId, campaignId, legacyCampaignId } = this.props;
 
     return (
       <div
         className="modal__slide typeform-widget"
-        data-url={`${this.props.dataUrl}?nortstar_id=${northstarId}campaign_id=${campaignId}legacy_campaign_id=${legacyCampaignId}`}
+        data-url={`${dataUrl}?northstar_id=${northstarId}&campaign_id=${campaignId}&legacy_campaign_id=${legacyCampaignId}`}
         style={{ width: '100%', height: '500px' }}
       />
     );

--- a/resources/assets/components/Modal/configurations/SurveyModal.js
+++ b/resources/assets/components/Modal/configurations/SurveyModal.js
@@ -11,10 +11,12 @@ class SurveyModal extends React.Component {
   }
 
   render() {
+    const { northstarId, campaignId, legacyCampaignId } = this.props;
+
     return (
       <div
         className="modal__slide typeform-widget"
-        data-url={this.props.dataUrl}
+        data-url={`${this.props.dataUrl}?nortstar_id=${northstarId}campaign_id=${campaignId}legacy_campaign_id=${legacyCampaignId}`}
         style={{ width: '100%', height: '500px' }}
       />
     );
@@ -23,10 +25,16 @@ class SurveyModal extends React.Component {
 
 SurveyModal.propTypes = {
   dataUrl: PropTypes.string,
+  northstarId: PropTypes.string,
+  campaignId: PropTypes.string,
+  legacyCampaignId: PropTypes.string,
 };
 
 SurveyModal.defaultProps = {
   dataUrl: SURVEY_DATA_URL,
+  northstarId: null,
+  campaignId: null,
+  legacyCampaignId: null,
 };
 
 export default SurveyModal;

--- a/resources/assets/components/Modal/configurations/SurveyModal.js
+++ b/resources/assets/components/Modal/configurations/SurveyModal.js
@@ -11,12 +11,12 @@ class SurveyModal extends React.Component {
   }
 
   render() {
-    const { dataUrl, northstarId, campaignId, legacyCampaignId } = this.props;
+    const { northstarId, campaignId, legacyCampaignId } = this.props;
 
     return (
       <div
         className="modal__slide typeform-widget"
-        data-url={`${dataUrl}?northstar_id=${northstarId}&campaign_id=${campaignId}&legacy_campaign_id=${legacyCampaignId}`}
+        data-url={`${SURVEY_DATA_URL}?northstar_id=${northstarId}&campaign_id=${campaignId}&legacy_campaign_id=${legacyCampaignId}`}
         style={{ width: '100%', height: '500px' }}
       />
     );
@@ -24,17 +24,9 @@ class SurveyModal extends React.Component {
 }
 
 SurveyModal.propTypes = {
-  dataUrl: PropTypes.string,
-  northstarId: PropTypes.string,
-  campaignId: PropTypes.string,
-  legacyCampaignId: PropTypes.string,
-};
-
-SurveyModal.defaultProps = {
-  dataUrl: SURVEY_DATA_URL,
-  northstarId: null,
-  campaignId: null,
-  legacyCampaignId: null,
+  northstarId: PropTypes.string.isRequired,
+  campaignId: PropTypes.string.isRequired,
+  legacyCampaignId: PropTypes.string.isRequired,
 };
 
 export default SurveyModal;

--- a/resources/assets/components/Modal/containers/SurveyModalContainer.js
+++ b/resources/assets/components/Modal/containers/SurveyModalContainer.js
@@ -1,0 +1,10 @@
+import { connect } from 'react-redux';
+import SurveyModal from '../configurations/SurveyModal';
+
+const mapStateToProps = state => ({
+  northstarId: state.user.id,
+  campaignId: state.campaign.id,
+  legacyCampaignId: state.campaign.legacyCampaignId,
+});
+
+export default connect(mapStateToProps)(SurveyModal);

--- a/resources/assets/components/Modal/index.js
+++ b/resources/assets/components/Modal/index.js
@@ -1,10 +1,10 @@
 export default from './containers/ModalSwitchContainer';
 
 export Modal from './containers/ModalContainer';
+export SurveyModalContainer from './containers/SurveyModalContainer';
 export PostSignupModal from './containers/PostSignupModalContainer';
 export ContentModal from './containers/ContentModalContainer';
 export ReportbackUploaderModal from './configurations/ReportbackUploaderModal';
-export SurveyModal from './configurations/SurveyModal';
 
 export const POST_SIGNUP_MODAL = 'POST_SIGNUP_MODAL';
 export const CONTENT_MODAL = 'CONTENT_MODAL';

--- a/resources/assets/components/Survey/Survey.js
+++ b/resources/assets/components/Survey/Survey.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import { SURVEY_MODAL } from '../Modal';
+
 const SURVEY_COUNTDOWN = 5;
 
 class Survey extends React.Component {

--- a/resources/assets/components/Survey/Survey.js
+++ b/resources/assets/components/Survey/Survey.js
@@ -1,0 +1,50 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import { SURVEY_MODAL } from '../Modal';
+import { SURVEY_COUNTDOWN } from '../../constants/survey';
+
+class Survey extends React.Component {
+  constructor() {
+    super();
+
+    this.state = {
+      count: 0,
+    };
+
+    this.incrementOrLaunch = this.incrementOrLaunch.bind(this);
+  }
+
+  componentDidMount() {
+    if (this.props.isAuthenticated) {
+      this.timer = setInterval(this.incrementOrLaunch, 1000);
+    }
+  }
+
+  componentWillUnmount() {
+    clearInterval(this.timer);
+  }
+
+  incrementOrLaunch() {
+    if (this.state.count < SURVEY_COUNTDOWN) {
+      // For testing and sanity purposes
+      console.log(SURVEY_COUNTDOWN - this.state.count, 'seconds to survey launch');
+
+      this.setState(prevState => ({ count: prevState.count + 1 }));
+    } else {
+      this.props.openModal(SURVEY_MODAL);
+      clearInterval(this.timer);
+    }
+  }
+
+  render() {
+    return null;
+  }
+}
+
+Survey.propTypes = {
+  isAuthenticated: PropTypes.bool.isRequired,
+  openModal: PropTypes.func.isRequired,
+};
+
+export default Survey;

--- a/resources/assets/components/Survey/Survey.js
+++ b/resources/assets/components/Survey/Survey.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import { SURVEY_MODAL } from '../Modal';
-import { SURVEY_COUNTDOWN } from '../../constants/survey';
+const SURVEY_COUNTDOWN = 5;
 
 class Survey extends React.Component {
   constructor() {

--- a/resources/assets/components/Survey/SurveyContainer.js
+++ b/resources/assets/components/Survey/SurveyContainer.js
@@ -1,0 +1,25 @@
+import { connect } from 'react-redux';
+
+import Survey from './Survey';
+
+import { openModal } from '../../actions';
+
+/**
+ * Provide state from the Redux store as props for this component.
+ */
+const mapStateToProps = state => ({
+  isAuthenticated: state.user.id !== null,
+});
+
+/**
+ * Provide pre-bound functions that allow the component to dispatch
+ * actions to the Redux store as props for this component.
+ */
+const mapActionsToProps = {
+  openModal,
+};
+
+/**
+ * Export the container component.
+ */
+export default connect(mapStateToProps, mapActionsToProps)(Survey);

--- a/resources/assets/components/Survey/index.js
+++ b/resources/assets/components/Survey/index.js
@@ -1,0 +1,1 @@
+export default from './SurveyContainer';

--- a/resources/assets/constants/survey.js
+++ b/resources/assets/constants/survey.js
@@ -1,3 +1,3 @@
 // TODO SURVEY_COUNTDOWN should be set to 60. Set to 5 for testing and sanity.
 export const SURVEY_COUNTDOWN = 5;
-export const SURVEY_DATA_URL = 'https://dosomething.typeform.com/to/anehxy';
+export const SURVEY_DATA_URL = 'https://dosomething.typeform.com/to/Bvcwvm';

--- a/resources/assets/constants/survey.js
+++ b/resources/assets/constants/survey.js
@@ -1,2 +1,3 @@
-export const SURVEY_COUNTDOWN = 6;
+// TODO SURVEY_COUNTDOWN should be set to 60. Set to 5 for testing and sanity.
+export const SURVEY_COUNTDOWN = 5;
 export const SURVEY_DATA_URL = 'https://dosomething.typeform.com/to/anehxy';

--- a/resources/assets/constants/survey.js
+++ b/resources/assets/constants/survey.js
@@ -1,3 +1,0 @@
-// TODO SURVEY_COUNTDOWN should be set to 60. Set to 5 for testing and sanity.
-export const SURVEY_COUNTDOWN = 5;
-export const SURVEY_DATA_URL = 'https://dosomething.typeform.com/to/Bvcwvm';

--- a/resources/assets/helpers/index.js
+++ b/resources/assets/helpers/index.js
@@ -1,4 +1,4 @@
-/* global window, document, Blob, FB, URL */
+/* global window, document, Blob, FB, URL, URLSearchParams */
 
 import get from 'lodash/get';
 import MarkdownIt from 'markdown-it';
@@ -375,4 +375,19 @@ export function showTwitterSharePrompt(href, quote) {
  */
 export function toggleChromeLock() {
   document.getElementById('chrome').classList.toggle('-lock');
+}
+
+
+/**
+ * Construct URL with query params
+ *
+ * @param {String} url
+ * @param {object} query
+ * return {URL}
+ */
+export function makeUrl(path, query) {
+  const urlObject = new URL(path);
+  urlObject.search = new URLSearchParams(query);
+
+  return urlObject;
 }


### PR DESCRIPTION
### What does this PR do?
Adds core `Survey` component which functions as the launcher for the NPS (or any) survey in the Survey Modal.

EDIT:

- Adding a `SurveyModal` container along with user id, campaign id (legacy and contentful) to the `data-url` to be passed along to typeform.


### Any background context you want to provide?
The component sets a timer when user visits site (to be more specific, as of now this is only triggered on a campaign page and it's subpages, which is kind of our PN site right now), after the specified amount of elapsed seconds it triggers the `openModal` to open the survey modal which will embed the survey.

- Note that the only conditional set as of yet is that the user is authenticated. Much more to come, just trying to build this somewhat incrementally.

- This timer will refresh every time the user reloads a page, so anything outside of the SPA flow will restart this timer. (Perhaps we can handle this better once (or if) we introduce cookies or something to track user survey participation. Then we can perhaps track if they've immediately recently been on a PN page and we can just build on existing countdown).

- I shall remove the `<Survey />` from the `Campaign` component before merging this. Added for 

More to come!



### What are the relevant tickets/cards?
https://www.pivotaltracker.com/story/show/153366664
https://www.pivotaltracker.com/story/show/153288461
#548 

### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.

