### PR TITLE
Typeform survey tracking

### DIFF
--- a/resources/assets/components/Campaign/Campaign.js
+++ b/resources/assets/components/Campaign/Campaign.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
+import SurveyContainer from '../Survey';
 import ModalSwitch from '../Modal';
 import { CampaignPageContainer, LandingPageContainer } from '../Page';
 import NotificationContainer from '../Notification';
@@ -14,6 +15,7 @@ const Campaign = props => (
 
     <NotificationContainer />
     <ModalSwitch />
+    <SurveyContainer />
 
     { props.shouldShowLandingPage ?
       <LandingPageContainer {...props} />

--- a/resources/assets/components/Modal/configurations/SurveyModal.js
+++ b/resources/assets/components/Modal/configurations/SurveyModal.js
@@ -3,6 +3,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
+import { set } from '../../../helpers/storage';
 import { makeUrl } from '../../../helpers';
 
 const SURVEY_DATA_URL = 'https://dosomething.typeform.com/to/Bvcwvm';
@@ -10,6 +11,11 @@ const SURVEY_DATA_URL = 'https://dosomething.typeform.com/to/Bvcwvm';
 class SurveyModal extends React.Component {
   componentDidMount() {
     window.typeformInit();
+  }
+
+  componentWillUnmount() {
+    // @see: Survey.js
+    set(`${this.props.northstarId}_dismissed_survey`, 'timestamp', Date.now());
   }
 
   render() {

--- a/resources/assets/components/Modal/configurations/SurveyModal.js
+++ b/resources/assets/components/Modal/configurations/SurveyModal.js
@@ -19,13 +19,13 @@ class SurveyModal extends React.Component {
   }
 
   render() {
-    const { northstarId, campaignId, legacyCampaignId, campaignSlug } = this.props;
+    const { northstarId, campaignId, legacyCampaignId } = this.props;
 
     const typeformQuery = {
       northstar_id: northstarId,
       campaign_id: campaignId,
       legacy_campaign_id: legacyCampaignId,
-      campaign_slug: campaignSlug,
+      origin: window.location.pathname,
     };
 
     const typeformUrl = makeUrl(SURVEY_DATA_URL, typeformQuery);
@@ -40,7 +40,6 @@ SurveyModal.propTypes = {
   northstarId: PropTypes.string.isRequired,
   campaignId: PropTypes.string.isRequired,
   legacyCampaignId: PropTypes.string.isRequired,
-  campaignSlug: PropTypes.string.isRequired,
 };
 
 export default SurveyModal;

--- a/resources/assets/components/Modal/configurations/SurveyModal.js
+++ b/resources/assets/components/Modal/configurations/SurveyModal.js
@@ -13,12 +13,13 @@ class SurveyModal extends React.Component {
   }
 
   render() {
-    const { northstarId, campaignId, legacyCampaignId } = this.props;
+    const { northstarId, campaignId, legacyCampaignId, campaignSlug } = this.props;
 
     const typeformQuery = {
       northstar_id: northstarId,
       campaign_id: campaignId,
       legacy_campaign_id: legacyCampaignId,
+      campaign_slug: campaignSlug,
     };
 
     const typeformUrl = makeUrl(SURVEY_DATA_URL, typeformQuery);
@@ -33,6 +34,7 @@ SurveyModal.propTypes = {
   northstarId: PropTypes.string.isRequired,
   campaignId: PropTypes.string.isRequired,
   legacyCampaignId: PropTypes.string.isRequired,
+  campaignSlug: PropTypes.string.isRequired,
 };
 
 export default SurveyModal;

--- a/resources/assets/components/Modal/containers/SurveyModalContainer.js
+++ b/resources/assets/components/Modal/containers/SurveyModalContainer.js
@@ -1,10 +1,12 @@
 import { connect } from 'react-redux';
 import SurveyModal from '../configurations/SurveyModal';
+import { getUserId } from '../../../selectors/user';
 
 const mapStateToProps = state => ({
-  northstarId: state.user.id,
+  northstarId: getUserId(state),
   campaignId: state.campaign.id,
   legacyCampaignId: state.campaign.legacyCampaignId,
+  campaignSlug: state.campaign.slug,
 });
 
 export default connect(mapStateToProps)(SurveyModal);

--- a/resources/assets/components/Modal/containers/SurveyModalContainer.js
+++ b/resources/assets/components/Modal/containers/SurveyModalContainer.js
@@ -6,7 +6,6 @@ const mapStateToProps = state => ({
   northstarId: getUserId(state),
   campaignId: state.campaign.id,
   legacyCampaignId: state.campaign.legacyCampaignId,
-  campaignSlug: state.campaign.slug,
 });
 
 export default connect(mapStateToProps)(SurveyModal);

--- a/resources/assets/components/Survey/Survey.js
+++ b/resources/assets/components/Survey/Survey.js
@@ -45,7 +45,12 @@ class Survey extends React.Component {
 
 Survey.propTypes = {
   isAuthenticated: PropTypes.bool.isRequired,
+  userId: PropTypes.string,
   openModal: PropTypes.func.isRequired,
+};
+
+Survey.defaultProps = {
+  userId: null,
 };
 
 export default Survey;

--- a/resources/assets/components/Survey/Survey.js
+++ b/resources/assets/components/Survey/Survey.js
@@ -46,7 +46,7 @@ class Survey extends React.Component {
     // @see: SurveyModal.js
     const dismissalTime = get(`${userId}_dismissed_survey`, 'timestamp');
     // Check if the survey was dismissed over 30 days ago.
-    const isDismissed = isTimestampValid(dismissalTime, (1440 * 60 * 1000));
+    const isDismissed = isTimestampValid(dismissalTime, (30 * 1440 * 60 * 1000));
 
     return userId && ! isFinished && ! isDismissed;
   }

--- a/resources/assets/components/Survey/Survey.js
+++ b/resources/assets/components/Survey/Survey.js
@@ -8,7 +8,6 @@ import { SURVEY_MODAL } from '../Modal';
 import { get, set } from '../../helpers/storage';
 import { isTimestampValid } from '../../helpers';
 
-// TODO - SURVEY_COUNTDOWN should be set to 60. Set to 5 for testing and sanity.
 const SURVEY_COUNTDOWN = 60;
 
 class Survey extends React.Component {

--- a/resources/assets/components/Survey/Survey.js
+++ b/resources/assets/components/Survey/Survey.js
@@ -1,9 +1,12 @@
+/* global window */
+
 import React from 'react';
 import PropTypes from 'prop-types';
 
 import { SURVEY_MODAL } from '../Modal';
 
 const SURVEY_COUNTDOWN = 5;
+import { get, set } from '../../helpers/storage';
 
 class Survey extends React.Component {
   constructor() {
@@ -17,7 +20,11 @@ class Survey extends React.Component {
   }
 
   componentDidMount() {
-    if (this.props.isAuthenticated) {
+    // If the query params indicate a redirect from typeform post survey submission, track
+    if (window.location.search === '?finished_nps=1') {
+      set(`${this.props.userId}_finished_survey`, 'boolean', true);
+    }
+
       this.timer = setInterval(this.incrementOrLaunch, 1000);
     }
   }

--- a/resources/assets/components/Survey/SurveyContainer.js
+++ b/resources/assets/components/Survey/SurveyContainer.js
@@ -1,14 +1,14 @@
 import { connect } from 'react-redux';
 
 import Survey from './Survey';
-
 import { openModal } from '../../actions';
+import { getUserId } from '../../selectors/user';
 
 /**
  * Provide state from the Redux store as props for this component.
  */
 const mapStateToProps = state => ({
-  isAuthenticated: state.user.id !== null,
+  userId: getUserId(state),
 });
 
 /**


### PR DESCRIPTION
### What does this PR do?
Survey tracking!

- Added a parameter to the typeform survey's `data-url` with the current `pathname` so that typeform can redirect the user once the form is submitted back from whence they came, along with another query param indicated form completion. (`finished_nps=1`)
  - The `Survey` component will [keep an eye out](https://github.com/DoSomething/phoenix-next/pull/554/files#diff-f3403625e356c0466055cd619e81429eR28) for this query param and if found in the URL, we'll store the submission activity in local storage so that the user isn't presented with the survey again!

- [Tracking](https://github.com/DoSomething/phoenix-next/pull/554/files#diff-91782313185994f5936bc36904d2ec21R16) user dismissal of the survey (we can tell this occurred if the surveyModal is 'unmounted') storing the timestamp in local storage so we can make sure not to show 'em the survey again for 30 days.

- Added [Conditional logic](https://github.com/DoSomething/phoenix-next/pull/554/files#diff-f3403625e356c0466055cd619e81429eR41) based on all this tracking information and the user's ID to ensure we're only showing the survey to the right folks.


### Any background context you want to provide?
We've decided on simple straightforward local storage tracking for user survey interaction. The one bump in this road was the inability to locally track user survey submission since Typeform is embedding the form in an `iframe` rendering it kind of untrackable in React. 

Dave came up with the method for [redirecting](https://www.typeform.com/help/redirect-after-submitting/) the users on form submission and having typeform (which performs the redirect, and can use a custom URL for this along with variable from the 'hidden-fields') pass along a query param indicating that they've completed the survey. We can then inspect all URLs and if they contain that param, track the completion. 
The logic for dismissal is more straightforward and just stores a timestamp when they dismiss the form and runs a check to make sure 30 days have passed before showing it to 'em again. 


### What are the relevant tickets/cards?
https://www.pivotaltracker.com/story/show/153288430

### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
- [ ] Added screenshot to PR description of related front-end updates on **small** screens.
- [ ] Added screenshot to PR description of related front-end updates on **medium** screens.
- [ ] Added screenshot to PR description of related front-end updates on **large** screens.

