### PR TITLE
Nps Survey env setup

### DIFF
--- a/app/helpers.php
+++ b/app/helpers.php
@@ -297,6 +297,7 @@ function get_client_environment_vars()
         'SIXPACK_TIMEOUT' => config('services.sixpack.timeout'),
         'PUCK_URL' => config('services.analytics.puck_url'),
         'SURVEY_ACTIVE' => config('services.survey.active'),
+        'SURVEY_ENABLED' => config('services.survey.enabled'),
     ];
 }
 

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -296,6 +296,7 @@ function get_client_environment_vars()
         'SIXPACK_COOKIE_PREFIX' => config('services.sixpack.prefix'),
         'SIXPACK_TIMEOUT' => config('services.sixpack.timeout'),
         'PUCK_URL' => config('services.analytics.puck_url'),
+        'SURVEY_ACTIVE' => config('services.survey.active'),
     ];
 }
 

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -291,12 +291,11 @@ function phoenixLink($path)
 function get_client_environment_vars()
 {
     return [
-        'SIXPACK_ENABLED' => config('services.sixpack.enabled'),
+        'PUCK_URL' => config('services.analytics.puck_url'),
         'SIXPACK_BASE_URL' => config('services.sixpack.url'),
         'SIXPACK_COOKIE_PREFIX' => config('services.sixpack.prefix'),
+        'SIXPACK_ENABLED' => config('services.sixpack.enabled'),
         'SIXPACK_TIMEOUT' => config('services.sixpack.timeout'),
-        'PUCK_URL' => config('services.analytics.puck_url'),
-        'SURVEY_ACTIVE' => config('services.survey.active'),
         'SURVEY_ENABLED' => config('services.survey.enabled'),
     ];
 }

--- a/config/services.php
+++ b/config/services.php
@@ -61,6 +61,6 @@ return [
         'cache' => env('CONTENTFUL_CACHE', true),
     ],
     'survey' => [
-        'active' => env('SURVEY_ACTIVE', false),
+        'enabled' => env('SURVEY_ENABLED', false),
     ],
 ];

--- a/config/services.php
+++ b/config/services.php
@@ -60,4 +60,7 @@ return [
     'contentful' => [
         'cache' => env('CONTENTFUL_CACHE', true),
     ],
+    'survey' => [
+        'active' => env('SURVEY_ACTIVE', false),
+    ],
 ];

--- a/resources/assets/components/Survey/Survey.js
+++ b/resources/assets/components/Survey/Survey.js
@@ -48,7 +48,7 @@ class Survey extends React.Component {
     // Check if the survey was dismissed over 30 days ago.
     const isDismissed = isTimestampValid(dismissalTime, (30 * 1440 * 60 * 1000));
 
-    return env.SURVEY_ACTIVE && userId && ! isFinished && ! isDismissed;
+    return env.SURVEY_ENABLED && userId && ! isFinished && ! isDismissed;
   }
 
   incrementOrLaunch() {

--- a/resources/assets/components/Survey/Survey.js
+++ b/resources/assets/components/Survey/Survey.js
@@ -38,6 +38,7 @@ class Survey extends React.Component {
   }
 
   shouldSeeSurvey() {
+    const env = window.ENV || {};
     const userId = this.props.userId;
 
     const isFinished = get(`${userId}_finished_survey`, 'boolean');
@@ -47,7 +48,7 @@ class Survey extends React.Component {
     // Check if the survey was dismissed over 30 days ago.
     const isDismissed = isTimestampValid(dismissalTime, (30 * 1440 * 60 * 1000));
 
-    return userId && ! isFinished && ! isDismissed;
+    return env.SURVEY_ACTIVE && userId && ! isFinished && ! isDismissed;
   }
 
   incrementOrLaunch() {


### PR DESCRIPTION
### What does this PR do?
- Adds support for an env variable `SURVEY_ACTIVE` to toggle the survey's active status.
- Passing var along to client in `campaigns@show` for React.
- checking survey active status before showing survey.

### Any background context you want to provide?
I called the variable `SURVEY_ACTIVE`
and placed the config for it in `config/services`.
Please let me know if there's a better name / place for this variable.


### What are the relevant tickets/cards?
Turning of NPS for deploy
https://dosomething.slack.com/archives/C2BPA7M8F/p1513004694000362?thread_ts=1513004418.000807&cid=C2BPA7M8F
