### PR TITLE
Adding the Modal broadcast system

### DIFF
--- a/resources/assets/components/Modal/Modal.js
+++ b/resources/assets/components/Modal/Modal.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import Portal from 'react-portal';
+import ModalBeacon from '../Modal';
 import './modal.scss';
 
 class Modal extends React.Component {
@@ -40,12 +41,14 @@ class Modal extends React.Component {
 
     return (
       <Portal closeOnEsc isOpened={shouldShowModal}>
-        <div className="modal" role="presentation" ref={node => this.node = node} onClick={this.handleOverlayClick}>
-          <div className="modal__container">
-            { children }
-            <button className="modal__exit" onClick={this.props.closeModal}>×</button>
+        <ModalBeacon>
+          <div className="modal" role="presentation" ref={node => this.node = node} onClick={this.handleOverlayClick}>
+            <div className="modal__container">
+              { children }
+              <button className="modal__exit" onClick={this.props.closeModal}>×</button>
+            </div>
           </div>
-        </div>
+        </ModalBeacon>
       </Portal>
     );
   }

--- a/resources/assets/components/Modal/Modal.js
+++ b/resources/assets/components/Modal/Modal.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import Portal from 'react-portal';
-import ModalBeacon from '../Modal';
+import { ModalBeacon } from '../Modal';
 import './modal.scss';
 
 class Modal extends React.Component {

--- a/resources/assets/components/Modal/ModalBeacon.js
+++ b/resources/assets/components/Modal/ModalBeacon.js
@@ -1,0 +1,20 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+class ModalBeacon extends React.Component {
+  getChildContext() {
+    return {
+      withinModal: true,
+    };
+  }
+
+  render() {
+    return React.Children.only(this.props.children);
+  }
+}
+
+ModalBeacon.childContextTypes = {
+  withinModal: PropTypes.bool,
+};
+
+export default ModalBeacon;

--- a/resources/assets/components/Modal/ModalBeacon.js
+++ b/resources/assets/components/Modal/ModalBeacon.js
@@ -13,6 +13,10 @@ class ModalBeacon extends React.Component {
   }
 }
 
+ModalBeacon.propTypes = {
+  children: PropTypes.node.isRequired,
+};
+
 ModalBeacon.childContextTypes = {
   withinModal: PropTypes.bool,
 };

--- a/resources/assets/components/Modal/ModalListener.js
+++ b/resources/assets/components/Modal/ModalListener.js
@@ -2,15 +2,9 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 function ModalListenerConnector(WrappedComponent) {
-  class ModalListener extends React.Component {
-    render() {
-      const withinModal = this.context.withinModal;
-
-      return (
-        <WrappedComponent withinModal={withinModal} />
-      );
-    }
-  }
+  const ModalListener = (props, context) => (
+    <WrappedComponent withinModal={context.withinModal} />
+  );
 
   ModalListener.contextTypes = {
     withinModal: PropTypes.bool,
@@ -19,4 +13,4 @@ function ModalListenerConnector(WrappedComponent) {
   return ModalListener;
 }
 
-export default Listener;
+export default ModalListenerConnector;

--- a/resources/assets/components/Modal/ModalListener.js
+++ b/resources/assets/components/Modal/ModalListener.js
@@ -1,0 +1,22 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+function ModalListenerConnector(WrappedComponent) {
+  class ModalListener extends React.Component {
+    render() {
+      const withinModal = this.context.withinModal;
+
+      return (
+        <WrappedComponent withinModal={withinModal} />
+      );
+    }
+  }
+
+  ModalListener.contextTypes = {
+    withinModal: PropTypes.bool,
+  };
+
+  return ModalListener;
+}
+
+export default Listener;

--- a/resources/assets/components/Modal/index.js
+++ b/resources/assets/components/Modal/index.js
@@ -1,6 +1,8 @@
 export default from './containers/ModalSwitchContainer';
 
 export Modal from './containers/ModalContainer';
+export ModalBeacon from './ModalBeacon';
+export ModalListener from './ModalListener';
 export SurveyModalContainer from './containers/SurveyModalContainer';
 export PostSignupModal from './containers/PostSignupModalContainer';
 export ContentModal from './containers/ContentModalContainer';


### PR DESCRIPTION
### What does this PR do?
This PR introduces the Modal Broadcast System ™️ 

This system is going to be used so deeply nested components within a modal can have a clean interface to check if they are rendering within a modal or not, and apply whatever conditional logic is required. 

### Any background context you want to provide?
This approach uses the same architecture as [Puck](https://github.com/DoSomething/puck-client/blob/master/lib/Connector.js) in order to prevent components themselves from touching React context. 

In practice, it would look something like this.

```
import { ModalListener } from '../Modal';
import Card from './Card';

return ModalListener(Card);
```

Then within Card, you have a new prop called `withinModal`.

### What are the relevant tickets/cards?
https://www.pivotaltracker.com/story/show/152767171