### PR TITLE
Cards in modal

### DIFF
--- a/resources/assets/components/Card/Card.js
+++ b/resources/assets/components/Card/Card.js
@@ -11,13 +11,28 @@ const renderHeader = (title, link, onClose) => (
   </header>
 );
 
-const Card = ({ children, className = '', link = null, title = null, onClose }) => (
-  <article className={classnames('card', className)}>
-    { title ? renderHeader(title, link, onClose) : null }
+const Card = (props) => {
+  const {
+    children, className, closeModal, link,
+    title, onClose, withinModal,
+  } = props;
 
-    { children }
-  </article>
-);
+  let cardCloseFunction = onClose;
+
+  // If this card is in a modal, and we haven't specified an onClose function already,
+  // set the button to close the modal.
+  if (! onClose && withinModal && closeModal) {
+    cardCloseFunction = closeModal;
+  }
+
+  return (
+    <article className={classnames('card', className)}>
+      { title ? renderHeader(title, link, cardCloseFunction) : null }
+
+      { children }
+    </article>
+  );
+};
 
 Card.propTypes = {
   children: PropTypes.oneOfType([
@@ -26,16 +41,20 @@ Card.propTypes = {
     PropTypes.object,
   ]).isRequired,
   className: PropTypes.string,
+  closeModal: PropTypes.func, // TODO: make this required once everything uses the card container.
   link: PropTypes.string,
   onClose: PropTypes.func,
   title: PropTypes.string,
+  withinModal: PropTypes.bool,
 };
 
 Card.defaultProps = {
   className: null,
+  closeModal: null, // TODO: get rid of this once everything uses the card container.
   link: null,
   onClose: null,
   title: null,
+  withinModal: false,
 };
 
 export default Card;

--- a/resources/assets/components/Card/Card.js
+++ b/resources/assets/components/Card/Card.js
@@ -41,7 +41,7 @@ Card.propTypes = {
     PropTypes.object,
   ]).isRequired,
   className: PropTypes.string,
-  closeModal: PropTypes.func, // TODO: make this required once everything uses the card container.
+  closeModal: PropTypes.func,
   link: PropTypes.string,
   onClose: PropTypes.func,
   title: PropTypes.string,
@@ -50,7 +50,7 @@ Card.propTypes = {
 
 Card.defaultProps = {
   className: null,
-  closeModal: null, // TODO: get rid of this once everything uses the card container.
+  closeModal: null,
   link: null,
   onClose: null,
   title: null,

--- a/resources/assets/components/Card/CardContainer.js
+++ b/resources/assets/components/Card/CardContainer.js
@@ -1,0 +1,10 @@
+import { connect } from 'react-redux';
+import { ModalListener } from '../Modal';
+import { closeModal } from '../../actions/modal';
+import Card from './Card';
+
+const actionCreators = {
+  closeModal,
+};
+
+export default connect(null, actionCreators)(ModalListener(Card));

--- a/resources/assets/components/Card/index.js
+++ b/resources/assets/components/Card/index.js
@@ -1,1 +1,3 @@
+export CardContainer from './CardContainer';
+
 export default from './Card';

--- a/resources/assets/components/Modal/Modal.js
+++ b/resources/assets/components/Modal/Modal.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import Portal from 'react-portal';
+import ModalBeacon from '../Modal';
 import './modal.scss';
 
 class Modal extends React.Component {
@@ -40,12 +41,14 @@ class Modal extends React.Component {
 
     return (
       <Portal closeOnEsc isOpened={shouldShowModal}>
-        <div className="modal" role="presentation" ref={node => this.node = node} onClick={this.handleOverlayClick}>
-          <div className="modal__container">
-            { children }
-            <button className="modal__exit" onClick={this.props.closeModal}>×</button>
+        <ModalBeacon>
+          <div className="modal" role="presentation" ref={node => this.node = node} onClick={this.handleOverlayClick}>
+            <div className="modal__container">
+              { children }
+              <button className="modal__exit" onClick={this.props.closeModal}>×</button>
+            </div>
           </div>
-        </div>
+        </ModalBeacon>
       </Portal>
     );
   }

--- a/resources/assets/components/Modal/Modal.js
+++ b/resources/assets/components/Modal/Modal.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import Portal from 'react-portal';
-import ModalBeacon from '../Modal';
+import { ModalBeacon } from '../Modal';
 import './modal.scss';
 
 class Modal extends React.Component {

--- a/resources/assets/components/Modal/ModalBeacon.js
+++ b/resources/assets/components/Modal/ModalBeacon.js
@@ -1,0 +1,20 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+class ModalBeacon extends React.Component {
+  getChildContext() {
+    return {
+      withinModal: true,
+    };
+  }
+
+  render() {
+    return React.Children.only(this.props.children);
+  }
+}
+
+ModalBeacon.childContextTypes = {
+  withinModal: PropTypes.bool,
+};
+
+export default ModalBeacon;

--- a/resources/assets/components/Modal/ModalBeacon.js
+++ b/resources/assets/components/Modal/ModalBeacon.js
@@ -13,6 +13,10 @@ class ModalBeacon extends React.Component {
   }
 }
 
+ModalBeacon.propTypes = {
+  children: PropTypes.node.isRequired,
+};
+
 ModalBeacon.childContextTypes = {
   withinModal: PropTypes.bool,
 };

--- a/resources/assets/components/Modal/ModalListener.js
+++ b/resources/assets/components/Modal/ModalListener.js
@@ -2,15 +2,9 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 function ModalListenerConnector(WrappedComponent) {
-  class ModalListener extends React.Component {
-    render() {
-      const withinModal = this.context.withinModal;
-
-      return (
-        <WrappedComponent withinModal={withinModal} />
-      );
-    }
-  }
+  const ModalListener = (props, context) => (
+    <WrappedComponent withinModal={context.withinModal} />
+  );
 
   ModalListener.contextTypes = {
     withinModal: PropTypes.bool,
@@ -19,4 +13,4 @@ function ModalListenerConnector(WrappedComponent) {
   return ModalListener;
 }
 
-export default Listener;
+export default ModalListenerConnector;

--- a/resources/assets/components/Modal/ModalListener.js
+++ b/resources/assets/components/Modal/ModalListener.js
@@ -1,0 +1,22 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+function ModalListenerConnector(WrappedComponent) {
+  class ModalListener extends React.Component {
+    render() {
+      const withinModal = this.context.withinModal;
+
+      return (
+        <WrappedComponent withinModal={withinModal} />
+      );
+    }
+  }
+
+  ModalListener.contextTypes = {
+    withinModal: PropTypes.bool,
+  };
+
+  return ModalListener;
+}
+
+export default Listener;

--- a/resources/assets/components/Modal/index.js
+++ b/resources/assets/components/Modal/index.js
@@ -1,6 +1,8 @@
 export default from './containers/ModalSwitchContainer';
 
 export Modal from './containers/ModalContainer';
+export ModalBeacon from './ModalBeacon';
+export ModalListener from './ModalListener';
 export SurveyModalContainer from './containers/SurveyModalContainer';
 export PostSignupModal from './containers/PostSignupModalContainer';
 export ContentModal from './containers/ContentModalContainer';


### PR DESCRIPTION
### What does this PR do?
Following up on #559 -

This PR adds the Modal Listener to the Card, which allows the card to determine if the close button to link to the close modal action. With this, I also created a Card Container. I will update all of the Card imports in a follow-up PR, so this current one has a few TODO's that need to be resolved after that happens.

To demo it working, I rigged up a console log function as the closeModal prop and set `withinModal` to true. (Check the console for the `hi` messages at the bottom)

<img width="1508" alt="screen shot 2017-12-11 at 4 20 57 pm" src="https://user-images.githubusercontent.com/897368/33854509-f8fbff86-de8f-11e7-85c5-46557bb95c3e.png">

### What are the relevant tickets/cards?
https://www.pivotaltracker.com/story/show/152767171