### PR TITLE
Adding posts to Redux store along with cleanups!

### DIFF
--- a/resources/assets/actions/post.js
+++ b/resources/assets/actions/post.js
@@ -1,0 +1,9 @@
+/**
+ * Fetch posts for the specified campaign.
+ *
+ * @param  {String} $campaignId
+ * @return {[type]}
+ */
+export function fetchCampaignPosts($campaignId) {
+  console.log($campaignId);
+}

--- a/resources/assets/actions/post.js
+++ b/resources/assets/actions/post.js
@@ -7,3 +7,5 @@
 export function fetchCampaignPosts($campaignId) {
   console.log($campaignId);
 }
+
+export default {};

--- a/resources/assets/components/App.js
+++ b/resources/assets/components/App.js
@@ -6,7 +6,7 @@ import { ConnectedRouter } from 'react-router-redux';
 import { PuckProvider } from '@dosomething/puck-client';
 
 import { CampaignContainer } from './Campaign';
-import { initializeStore } from '../store';
+import { initializeStore } from '../store/store';
 import { getUserId } from '../selectors/user';
 import { env } from '../helpers';
 

--- a/resources/assets/init.js
+++ b/resources/assets/init.js
@@ -15,7 +15,7 @@ import React from 'react';
 import ReactDom from 'react-dom';
 import thunk from 'redux-thunk';
 import { routerReducer, routerMiddleware } from 'react-router-redux';
-import { configureStore } from './store';
+import { configureStore } from './store/store';
 import * as reducers from './reducers';
 
 // Browser polyfills

--- a/resources/assets/middleware/api.js
+++ b/resources/assets/middleware/api.js
@@ -1,7 +1,5 @@
 const apiMiddleware = ({ getState, dispatch }) => next => action => {
-  console.log(action.type);
   next(action);
-  console.log(action.type);
 };
 
 export default apiMiddleware;

--- a/resources/assets/middleware/api.js
+++ b/resources/assets/middleware/api.js
@@ -1,0 +1,7 @@
+const apiMiddleware = ({ getState, dispatch }) => next => action => {
+  console.log(action.type);
+  next(action);
+  console.log(action.type);
+};
+
+export default apiMiddleware;

--- a/resources/assets/middleware/api.js
+++ b/resources/assets/middleware/api.js
@@ -1,4 +1,4 @@
-const apiMiddleware = ({ getState, dispatch }) => next => action => {
+const apiMiddleware = () => next => (action) => {
   next(action);
 };
 

--- a/resources/assets/reducers/index.js
+++ b/resources/assets/reducers/index.js
@@ -6,6 +6,7 @@ export events from './events';
 export experiments from './experiments';
 export modal from './modal';
 export notifications from './notifications';
+export posts from './posts';
 export reportbacks from './reportbacks';
 export signups from './signups';
 export slideshow from './slideshow';

--- a/resources/assets/reducers/posts.js
+++ b/resources/assets/reducers/posts.js
@@ -1,0 +1,8 @@
+/**
+ * Posts reducer.
+ */
+const posts = (state = {}) => (
+  state
+);
+
+export default posts;

--- a/resources/assets/reducers/posts.js
+++ b/resources/assets/reducers/posts.js
@@ -1,8 +1,6 @@
 /**
  * Posts reducer.
  */
-const posts = (state = {}) => (
-  state
-);
+const posts = (state = {}) => state;
 
 export default posts;

--- a/resources/assets/store.js
+++ b/resources/assets/store.js
@@ -72,6 +72,7 @@ const initialState = {
     shouldShowLandingPage: false,
     shouldShowActionPage: false,
   },
+  posts: {},
 };
 
 /**

--- a/resources/assets/store/initialState.js
+++ b/resources/assets/store/initialState.js
@@ -1,0 +1,71 @@
+/**
+ * Initial state for the Redux store. This is where we
+ * set default values for when the application loads.
+ *
+ * @type {Object}
+ */
+const initialState = {
+  admin: {
+    shouldShowLandingPage: false,
+    shouldShowActionPage: false,
+  },
+  blocks: {
+    page: 1,
+  },
+  campaign: {
+    activityFeed: [],
+  },
+  competitions: {
+    data: [],
+    thisCampaign: false,
+    showConfirmation: false,
+    isPending: false,
+  },
+  events: {
+    queue: [],
+  },
+  experiments: {},
+  modal: {
+    modalType: null,
+    contentfulId: null,
+    shouldShowModal: false,
+  },
+  notifications: {
+    items: [],
+  },
+  posts: {},
+  quiz: {},
+  reportbacks: {
+    currentPage: 0,
+    isFetching: false,
+    total: 0,
+    totalPages: 1,
+    ids: [],
+    entities: {},
+    itemEntities: {},
+  },
+  signups: {
+    data: [],
+    thisCampaign: false,
+    thisSession: false,
+    isPending: false,
+    total: 0,
+    affiliateMessagingOptOut: false,
+  },
+  slideshow: {},
+  submissions: {
+    reportback: {},
+    isFetching: false,
+    isStoring: false,
+    items: [],
+    messaging: null,
+    shouldShowAffirmation: false,
+  },
+  uploads: {},
+  user: {
+    id: null,
+    role: null,
+  },
+};
+
+export default initialState;

--- a/resources/assets/store/middlewares.js
+++ b/resources/assets/store/middlewares.js
@@ -1,7 +1,9 @@
+import apiMiddleware from '../middleware/api';
 import experimentsMiddleware from '../middleware/experiments';
 import experimentsApiMiddleware from '../middleware/experimentsApi';
 
 const middlwares = [
+  apiMiddleware,
   experimentsApiMiddleware,
   experimentsMiddleware,
 ];

--- a/resources/assets/store/middlewares.js
+++ b/resources/assets/store/middlewares.js
@@ -1,0 +1,9 @@
+import experimentsMiddleware from '../middleware/experiments';
+import experimentsApiMiddleware from '../middleware/experimentsApi';
+
+const middlwares = [
+  experimentsApiMiddleware,
+  experimentsMiddleware,
+];
+
+export default middlwares;

--- a/resources/assets/store/store.js
+++ b/resources/assets/store/store.js
@@ -1,79 +1,10 @@
-import { createStore, combineReducers, applyMiddleware, compose } from 'redux';
 import merge from 'lodash/merge';
-import { checkForSignup, fetchReportbacks, startQueue, getTotalSignups } from './actions';
-import experimentsMiddleware from './middleware/experiments';
-import experimentsApiMiddleware from './middleware/experimentsApi';
-import { loadStorage } from './helpers/storage';
+import { createStore, combineReducers, applyMiddleware, compose } from 'redux';
 
-/**
- * Initial state for the Redux store. This is where we
- * set default values for when the application loads.
- *
- * @type {Object}
- */
-const initialState = {
-  blocks: {
-    page: 1,
-  },
-  campaign: {
-    activityFeed: [],
-  },
-  reportbacks: {
-    currentPage: 0,
-    isFetching: false,
-    total: 0,
-    totalPages: 1,
-    ids: [],
-    entities: {},
-    itemEntities: {},
-  },
-  submissions: {
-    reportback: {},
-    isFetching: false,
-    isStoring: false,
-    items: [],
-    messaging: null,
-    shouldShowAffirmation: false,
-  },
-  signups: {
-    data: [],
-    thisCampaign: false,
-    thisSession: false,
-    isPending: false,
-    total: 0,
-    affiliateMessagingOptOut: false,
-  },
-  competitions: {
-    data: [],
-    thisCampaign: false,
-    showConfirmation: false,
-    isPending: false,
-  },
-  user: {
-    id: null,
-    role: null,
-  },
-  events: {
-    queue: [],
-  },
-  notifications: {
-    items: [],
-  },
-  experiments: {},
-  modal: {
-    modalType: null,
-    contentfulId: null,
-    shouldShowModal: false,
-  },
-  uploads: {},
-  quiz: {},
-  slideshow: {},
-  admin: {
-    shouldShowLandingPage: false,
-    shouldShowActionPage: false,
-  },
-  posts: {},
-};
+import { checkForSignup, fetchReportbacks, startQueue, getTotalSignups } from '../actions';
+import { loadStorage } from '../helpers/storage';
+import initialState from './initialState';
+import customMiddlewares from './middlewares';
 
 /**
  * Create a new instance of the Redux store using the given
@@ -91,11 +22,8 @@ export function configureStore(reducers, middleware, preloadedState = {}) {
     middleware.push(createLogger({ collapsed: true }));
   }
 
-  // Experiments middleware
-  middleware.push(
-    experimentsMiddleware,
-    experimentsApiMiddleware,
-  );
+  // Collect Middlewares
+  middleware.push(...customMiddlewares);
 
   // If React DevTools are available, use instrumented compose function.
   const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose; // eslint-disable-line


### PR DESCRIPTION
### What does this PR do?
I'm working on a few things with the new API routes in Phoenix, and wanted to do a bit of cleanup for the store to start laying the foundation for using more middleware before/after actions are dispatched to the Redux store.

So this PR does a bit of `store.js` cleanup. It moves the `initialState` object out of the store to it's own file for easier editing, and also moves the custom middlewares being pushed to list of middleware into a separate file as well since this list will likely grow and be easier to manage in a separate file; both files are imported into the `/store/store.js` file.

It also adds a `post` property to the store and corresponding action/reducer files with no logic and an `apiMiddleware` that will also all play a role in an upcoming PR as I tie it all back together 🎗


### Any background context you want to provide?
Refs #562 


### What are the relevant tickets/cards?
Fixes #
