### PR TITLE
Action text

### DIFF
--- a/app/Entities/CallToAction.php
+++ b/app/Entities/CallToAction.php
@@ -35,7 +35,7 @@ class CallToAction extends Entity implements JsonSerializable
             'id' => $this->entry->getId(),
             'type' => $type,
             'fields' => [
-                'actionText' => $this->actionText ?: 'Join us',
+                'actionText' => $this->actionText,
                 'content' => $content,
                 'displayOptions' => $this->displayOptions->first(),
                 'impactPrefix' => $impactPrefix,

--- a/app/Entities/Campaign.php
+++ b/app/Entities/Campaign.php
@@ -223,6 +223,7 @@ class Campaign extends Entity implements JsonSerializable
             'socialOverride' => $this->socialOverride ? new SocialOverride($this->socialOverride->entry) : null,
             'additionalContent' => $this->additionalContent,
             'allowExperiments' => $this->campaignSettings ? $this->campaignSettings->allowExperiments : null,
+            'actionText' => $this->campaignSettings ? $this->campaignSettings->actionText : 'Join Us',
         ];
     }
 }

--- a/resources/assets/components/CallToAction/CallToActionContainer.js
+++ b/resources/assets/components/CallToAction/CallToActionContainer.js
@@ -12,7 +12,7 @@ const mapStateToProps = (state, ownProps) => ({
   isSignedUp: state.signups.thisCampaign,
   legacyCampaignId: get(state.campaign, 'legacyCampaignId', null),
   tagline: state.campaign.callToAction,
-  actionText: ownProps.actionText || state.campaign.actionText
+  actionText: ownProps.actionText || state.campaign.actionText,
 });
 
 /**

--- a/resources/assets/components/CallToAction/CallToActionContainer.js
+++ b/resources/assets/components/CallToAction/CallToActionContainer.js
@@ -6,12 +6,13 @@ import CallToAction from './CallToAction';
 /**
  * Provide state from the Redux store as props for this component.
  */
-const mapStateToProps = state => ({
+const mapStateToProps = (state, ownProps) => ({
   campaignId: state.campaign.id,
   coverImageUrl: state.campaign.coverImage.url,
   isSignedUp: state.signups.thisCampaign,
   legacyCampaignId: get(state.campaign, 'legacyCampaignId', null),
   tagline: state.campaign.callToAction,
+  actionText: ownProps.actionText || state.campaign.actionText
 });
 
 /**

--- a/resources/assets/components/Feed/Feed.js
+++ b/resources/assets/components/Feed/Feed.js
@@ -33,13 +33,13 @@ const renderFeedItem = (block, index) => (
  * @returns {XML}
  */
 const Feed = (props) => {
-  const { blocks, callToAction, campaignId, signedUp, hasPendingSignup, isAuthenticated,
+  const { actionText, blocks, callToAction, campaignId, signedUp, hasPendingSignup, isAuthenticated,
     canLoadMorePages, clickedViewMore, clickedSignUp } = props;
 
   const viewMoreOrSignup = signedUp ? clickedViewMore : () => clickedSignUp(campaignId);
   const revealer = (
     <Revealer
-      title={signedUp ? 'view more' : 'join us'}
+      title={signedUp ? 'view more' : actionText}
       callToAction={signedUp ? '' : callToAction}
       isLoading={hasPendingSignup}
       isVisible={(isAuthenticated && ! signedUp) || canLoadMorePages}
@@ -59,6 +59,7 @@ const Feed = (props) => {
 };
 
 Feed.propTypes = {
+  actionText: PropTypes.string.isRequired,
   blocks: PropTypes.arrayOf(PropTypes.shape({
     id: PropTypes.string.isRequired,
     type: PropTypes.string.isRequired,

--- a/resources/assets/components/Feed/FeedContainer.js
+++ b/resources/assets/components/Feed/FeedContainer.js
@@ -12,6 +12,7 @@ import {
  * Provide state from the Redux store as props for this component.
  */
 const mapStateToProps = state => ({
+  actionText: state.campaign.actionText,
   blocks: getBlocksWithReportbacks(getVisibleBlocks(state), state),
   canLoadMorePages: getTotalVisibleBlockPoints(state) < getMaximumBlockPoints(state),
   campaignId: state.campaign.legacyCampaignId,

--- a/resources/assets/components/LedeBanner/templates/LegacyTemplate.js
+++ b/resources/assets/components/LedeBanner/templates/LegacyTemplate.js
@@ -10,6 +10,7 @@ import { contentfulImageUrl } from '../../../helpers';
 
 const LegacyTemplate = (props) => {
   const {
+    actionText,
     title,
     subtitle,
     coverImage,
@@ -31,10 +32,10 @@ const LegacyTemplate = (props) => {
 
   const SignupButton = SignupButtonFactory(({ clickedSignUp }) => (
     <div>
-      <button className="button" onClick={() => clickedSignUp(legacyCampaignId)}>Sign Up</button>
+      <button className="button" onClick={() => clickedSignUp(legacyCampaignId)}>{actionText}</button>
       { showPartnerMsgOptIn ? <AffiliateOptionContainer /> : null }
     </div>
-  ), 'legacy lede banner', { text: 'sign up' });
+  ), 'legacy lede banner', { text: actionText });
 
   return (
     <header role="banner" className="header -hero header--action has-promotions" style={backgroundImageStyle}>
@@ -64,6 +65,7 @@ const LegacyTemplate = (props) => {
 };
 
 LegacyTemplate.propTypes = {
+  actionText: PropTypes.string.isRequired,
   coverImage: PropTypes.shape({
     description: PropTypes.string,
     url: PropTypes.string,

--- a/resources/assets/components/LedeBanner/templates/MosaicTemplate.js
+++ b/resources/assets/components/LedeBanner/templates/MosaicTemplate.js
@@ -9,6 +9,7 @@ import CampaignSignupArrow from '../../CampaignSignupArrow';
 
 const MosaicTemplate = (props) => {
   const {
+    actionText,
     title,
     subtitle,
     blurb,
@@ -30,10 +31,10 @@ const MosaicTemplate = (props) => {
   const SignupButton = SignupButtonFactory(({ clickedSignUp }) => (
     <div>
       { signupArrowComponent }
-      <button className="button" onClick={() => clickedSignUp(legacyCampaignId)}>Join Us</button>
+      <button className="button" onClick={() => clickedSignUp(legacyCampaignId)}>{actionText}}</button>
       { showPartnerMsgOptIn ? <AffiliateOptionContainer /> : null }
     </div>
-  ), 'lede banner', { text: 'join us' });
+  ), 'lede banner', { text: actionText });
 
   return (
     <header role="banner" className="lede-banner">
@@ -55,6 +56,7 @@ const MosaicTemplate = (props) => {
 };
 
 MosaicTemplate.propTypes = {
+  actionText: PropTypes.string.isRequired,
   blurb: PropTypes.string.isRequired,
   coverImage: PropTypes.shape({
     description: PropTypes.string,

--- a/resources/assets/components/LedeBanner/templates/MosaicTemplate.js
+++ b/resources/assets/components/LedeBanner/templates/MosaicTemplate.js
@@ -31,7 +31,7 @@ const MosaicTemplate = (props) => {
   const SignupButton = SignupButtonFactory(({ clickedSignUp }) => (
     <div>
       { signupArrowComponent }
-      <button className="button" onClick={() => clickedSignUp(legacyCampaignId)}>{actionText}}</button>
+      <button className="button" onClick={() => clickedSignUp(legacyCampaignId)}>{ actionText }</button>
       { showPartnerMsgOptIn ? <AffiliateOptionContainer /> : null }
     </div>
   ), 'lede banner', { text: actionText });

--- a/resources/assets/components/Navigation/TabbedNavigationContainer.js
+++ b/resources/assets/components/Navigation/TabbedNavigationContainer.js
@@ -13,6 +13,7 @@ import { isCampaignClosed } from '../../helpers';
 import SignupButtonFactory from '../SignupButton';
 
 const mapStateToProps = state => ({
+  actionText: state.campaign.actionText,
   hasActivityFeed: Boolean(state.campaign.activityFeed.length),
   isAffiliated: state.signups.thisCampaign,
   legacyCampaignId: state.campaign.legacyCampaignId,
@@ -24,7 +25,7 @@ const mapStateToProps = state => ({
 
 const TabbedNavigationContainer = (props) => {
   const {
-    hasActivityFeed, isAffiliated, legacyCampaignId,
+    actionText, hasActivityFeed, isAffiliated, legacyCampaignId,
     pages, campaignEndDate, template,
   } = props;
 
@@ -55,8 +56,8 @@ const TabbedNavigationContainer = (props) => {
     });
 
   const SignupButton = SignupButtonFactory(({ clickedSignUp }) => (
-    <Button className="-inline nav-button" onClick={() => clickedSignUp(legacyCampaignId)} />
-  ), 'tabbed navigation', { text: 'join us' });
+    <Button className="-inline nav-button" onClick={() => clickedSignUp(legacyCampaignId)} text={actionText} />
+  ), 'tabbed navigation', { text: actionText });
 
   const shouldHideCommunity = (template === 'legacy') && ! hasActivityFeed;
   const shouldHideAction = (isClosed || (shouldHideCommunity && additionalPages.length === 0));
@@ -74,6 +75,7 @@ const TabbedNavigationContainer = (props) => {
 };
 
 TabbedNavigationContainer.propTypes = {
+  actionText: PropTypes.string.isRequired,
   campaignEndDate: PropTypes.string.isRequired,
   campaignSlug: PropTypes.string.isRequired,
   hasActivityFeed: PropTypes.bool.isRequired,

--- a/resources/assets/components/Page/CampaignPage/CampaignPage.js
+++ b/resources/assets/components/Page/CampaignPage/CampaignPage.js
@@ -22,7 +22,7 @@ import { CONTENT_MODAL, REPORTBACK_UPLOADER_MODAL } from '../../Modal';
 
 const CampaignPage = (props) => {
   const {
-    affiliatePartners, affiliateSponsors, blurb, campaignLead, coverImage,
+    actionText, affiliatePartners, affiliateSponsors, blurb, campaignLead, coverImage,
     dashboard, endDate, hasActivityFeed, isAffiliated, legacyCampaignId, match,
     openModal, shouldShowActionPage, slug, subtitle, template, title, totalCampaignSignups,
   } = props;
@@ -44,6 +44,7 @@ const CampaignPage = (props) => {
         endDate={endDate}
         template={template}
         affiliateSponsors={affiliateSponsors}
+        actionText={actionText}
       />
 
       <div className="main clearfix">
@@ -113,6 +114,7 @@ const CampaignPage = (props) => {
 };
 
 CampaignPage.propTypes = {
+  actionText: PropTypes.string.isRequired,
   blurb: PropTypes.string.isRequired,
   coverImage: PropTypes.shape({
     description: PropTypes.string,

--- a/resources/assets/components/Page/CampaignPage/CampaignPageContainer.js
+++ b/resources/assets/components/Page/CampaignPage/CampaignPageContainer.js
@@ -8,6 +8,7 @@ import { convertExperiment, openModal } from '../../../actions';
  * Provide state from the Redux store as props for this component.
  */
 const mapStateToProps = state => ({
+  actionText: state.campaign.actionText,
   blurb: state.campaign.blurb,
   coverImage: state.campaign.coverImage,
   dashboard: state.campaign.dashboard,

--- a/resources/assets/components/Page/LandingPage/LandingPage.js
+++ b/resources/assets/components/Page/LandingPage/LandingPage.js
@@ -23,7 +23,7 @@ const formatToMarkup = data => (
 
 const LandingPage = (props) => {
   const {
-    affiliateSponsors, blurb, convertExperiment, coverImage,
+    actionText, affiliateSponsors, blurb, convertExperiment, coverImage,
     endDate, isAffiliated, legacyCampaignId, legacyPitchContent,
     pitchContent, sidebar, showPartnerMsgOptIn, signupArrowContent,
     subtitle, tagline, template, title,
@@ -45,6 +45,7 @@ const LandingPage = (props) => {
         affiliateSponsors={affiliateSponsors}
         signupArrowContent={signupArrowContent}
         showPartnerMsgOptIn={showPartnerMsgOptIn}
+        actionText={actionText}
       />
 
       <div className="clearfix bg-white">
@@ -69,7 +70,6 @@ const LandingPage = (props) => {
       </div>
 
       <CallToActionContainer
-        actionText="Sign up"
         className="legacy border-top border-radius-none bg-off-white padding-lg"
         content={tagline}
       />
@@ -82,6 +82,7 @@ const LandingPage = (props) => {
 };
 
 LandingPage.propTypes = {
+  actionText: PropTypes.string.isRequired,
   blurb: PropTypes.string.isRequired,
   coverImage: PropTypes.shape({
     description: PropTypes.string,

--- a/resources/assets/components/Page/LandingPage/LandingPageContainer.js
+++ b/resources/assets/components/Page/LandingPage/LandingPageContainer.js
@@ -27,6 +27,7 @@ const mapStateToProps = (state) => {
     template: state.campaign.template,
     title: state.campaign.title,
     sidebar: landingPage.sidebar,
+    actionText: state.campaign.actionText,
   };
 };
 


### PR DESCRIPTION
### What does this PR do?
- Adds an `actionText` field to the `Campaign` Entity, with a default of 'Join Us' for campaign-wide CTA and signup up button setting ability for admins.
- CTA container allowing either own prop to override, otherwise relying on campaign-wide action text for button.
- Signup Buttons in `LedeBanner`s (mosaic and legacy) and `TabbedNavigation`, using the new campaign-wide actionText


### Any background context you want to provide?
Diego explained this new hierarchy system succinctly in this thread:
https://dosomething.slack.com/archives/C2BPA7M8F/p1513010355000604?thread_ts=1513009823.000041&cid=C2BPA7M8F

The crux of the matter is: campaign leads can set campaign-wide button text that will be applied to all sign up buttons and CTA buttons. This can be overridden for individual CTA's in contentful.

```
1. Default button text of `Join Us` applies to all buttons.
2. If `campaignSettings` action text field filled out, then all buttons change to that.
3. CTAs use text depending on above 2 rules, unless they have their own action text defined for its specific button.
4. Profit!
```

- The default text is set in the `Campaign` entity and is as of now - 'Join Us'

### What are the relevant tickets/cards?
https://www.pivotaltracker.com/story/show/153558415

### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
- [ ] Added screenshot to PR description of related front-end updates on **small** screens.
- [ ] Added screenshot to PR description of related front-end updates on **medium** screens.
- [ ] Added screenshot to PR description of related front-end updates on **large** screens.

