### PR TITLE
Cleaning up env vars and exposing a few more needed for API work.

### DIFF
--- a/app/helpers.php
+++ b/app/helpers.php
@@ -291,6 +291,10 @@ function phoenixLink($path)
 function get_client_environment_vars()
 {
     return [
+        'GLADIATOR_URL' => config('services.gladiator.url'),
+        'NORTHSTAR_URL' => config('services.northstar.url'),
+        'PHOENIX_URL' => config('services.phoenix.url'),
+        'PHOENIX_LEGACY_URL' => config('services.phoenix-legacy.url'),
         'PUCK_URL' => config('services.analytics.puck_url'),
         'SIXPACK_BASE_URL' => config('services.sixpack.url'),
         'SIXPACK_COOKIE_PREFIX' => config('services.sixpack.prefix'),

--- a/config/services.php
+++ b/config/services.php
@@ -44,6 +44,10 @@ return [
         ],
     ],
 
+    'phoenix' => [
+        'url' => env('PHOENIX_URL'),
+    ],
+
     'phoenix-legacy' => [
         'url' => env('PHOENIX_LEGACY_URL', 'https://staging.dosomething.org'),
         'username' => env('PHOENIX_LEGACY_USERNAME'),

--- a/package.json
+++ b/package.json
@@ -70,7 +70,6 @@
     "@dosomething/eslint-config": "^3.1.2",
     "@dosomething/webpack-config": "^3.0.0",
     "babel-eslint": "^7.2.2",
-    "dotenv": "^4.0.0",
     "eslint-loader": "^1.9.0",
     "flow-bin": "0.59.0",
     "identity-obj-proxy": "^3.0.0",

--- a/resources/assets/constants/index.js
+++ b/resources/assets/constants/index.js
@@ -1,3 +1,5 @@
+/* global window */
+
 /**
  * Contains general constants for the application.
  */

--- a/resources/assets/constants/index.js
+++ b/resources/assets/constants/index.js
@@ -1,4 +1,5 @@
 /* global window */
+import { get } from 'lodash';
 
 /**
  * Contains general constants for the application.
@@ -6,4 +7,4 @@
 
 export const MEDIA_MEDIUM_SIZE_MIN = 759;
 
-export const PHOENIX_URL = window.ENV.PHOENIX_URL;
+export const PHOENIX_URL = get(window.ENV, 'PHOENIX_URL', null);

--- a/resources/assets/constants/index.js
+++ b/resources/assets/constants/index.js
@@ -4,5 +4,4 @@
 
 export const MEDIA_MEDIUM_SIZE_MIN = 759;
 
-// @TODO will be updating to pull from ENV. Only temporary!
-export const PHOENIX_BASE_URL = '//phoenix.dev';
+export const PHOENIX_URL = window.ENV.PHOENIX_URL;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -2,9 +2,6 @@ const webpack = require('webpack');
 const configure = require('@dosomething/webpack-config');
 const path = require('path');
 
-// Load any environment variables from `.env`.
-require('dotenv').config();
-
 // Configure Webpack using `@dosomething/webpack-config`.
 module.exports = configure({
   entry: {
@@ -24,18 +21,4 @@ module.exports = configure({
   resolve: {
     modules: [path.join(__dirname, 'node_modules')],
   },
-
-  plugins: [
-    // Inline Service URLs into the build.
-    new webpack.DefinePlugin({
-      services: {
-        GLADIATOR_URL: JSON.stringify(process.env.GLADIATOR_URL) || null,
-        NORTHSTAR_URL: JSON.stringify(process.env.NORTHSTAR_URL) || null,
-        PHOENIX_URL: JSON.stringify(process.env.PHOENIX_URL) || null,
-        PHOENIX_LEGACY_URL: JSON.stringify(process.env.PHOENIX_LEGACY_URL) || null,
-        KEEN_PROJECT_ID: JSON.stringify(process.env.KEEN_PROJECT_ID) || null,
-        KEEN_WRITE_KEY: JSON.stringify(process.env.KEEN_WRITE_KEY) || null,
-      },
-    }),
-  ],
 });


### PR DESCRIPTION
### What does this PR do?
This PR removes the env vars set up via Webpack which are a bit obscure in how they get implemented on build and harder to debug. Also, we totally stopped using them anywhere in the app in favor of adding env vars to the `window.ENV` object! So I moved/added more in there and got rid of the unused code and `dotenv` package from the app.

### What are the relevant tickets/cards?
Refs https://github.com/DoSomething/phoenix-next/issues/562
