### PR TITLE
Blurb is the word

### DIFF
--- a/app/Entities/Campaign.php
+++ b/app/Entities/Campaign.php
@@ -193,7 +193,7 @@ class Campaign extends Entity implements JsonSerializable
             'endDate' => $this->endDate,
             'callToAction' => $this->callToAction, //@TODO: deprecate in favor of tagline.
             'tagline' => $this->callToAction,
-            'blurb' => $this->blurb,
+            'blurb' => trim($this->blurb),
             'coverImage' => [
                 'description' => $this->coverImage ? $this->coverImage->getDescription() : '',
                 'url' => get_image_url($this->coverImage),

--- a/resources/assets/components/LedeBanner/templates/MosaicTemplate.js
+++ b/resources/assets/components/LedeBanner/templates/MosaicTemplate.js
@@ -46,7 +46,7 @@ const MosaicTemplate = (props) => {
             <h2 className="lede-banner__headline-subtitle">{subtitle}</h2>
           </div>
 
-          <Markdown className="lede-banner__blurb">{blurb}</Markdown>
+          { blurb ? <Markdown className="lede-banner__blurb">{blurb}</Markdown> : null }
 
           { isAffiliated ? null : <SignupButton /> }
         </div>

--- a/resources/assets/components/LedeBanner/templates/MosaicTemplate.js
+++ b/resources/assets/components/LedeBanner/templates/MosaicTemplate.js
@@ -57,7 +57,7 @@ const MosaicTemplate = (props) => {
 
 MosaicTemplate.propTypes = {
   actionText: PropTypes.string.isRequired,
-  blurb: PropTypes.string.isRequired,
+  blurb: PropTypes.string,
   coverImage: PropTypes.shape({
     description: PropTypes.string,
     url: PropTypes.string,
@@ -71,6 +71,7 @@ MosaicTemplate.propTypes = {
 };
 
 MosaicTemplate.defaultProps = {
+  blurb: null,
   showPartnerMsgOptIn: false,
   signupArrowContent: null,
 };

--- a/resources/assets/components/LedeBanner/templates/MosaicTemplate.js
+++ b/resources/assets/components/LedeBanner/templates/MosaicTemplate.js
@@ -46,7 +46,9 @@ const MosaicTemplate = (props) => {
             <h2 className="lede-banner__headline-subtitle">{subtitle}</h2>
           </div>
 
-          { blurb ? <Markdown className="lede-banner__blurb">{blurb}</Markdown> : null }
+          <div className="lede-banner__blurb">
+            { blurb ? <Markdown>{blurb}</Markdown> : null }
+          </div>
 
           { isAffiliated ? null : <SignupButton /> }
         </div>

--- a/resources/assets/components/Page/CampaignPage/CampaignPage.js
+++ b/resources/assets/components/Page/CampaignPage/CampaignPage.js
@@ -115,7 +115,7 @@ const CampaignPage = (props) => {
 
 CampaignPage.propTypes = {
   actionText: PropTypes.string.isRequired,
-  blurb: PropTypes.string.isRequired,
+  blurb: PropTypes.string,
   coverImage: PropTypes.shape({
     description: PropTypes.string,
     url: PropTypes.string,
@@ -150,6 +150,7 @@ CampaignPage.propTypes = {
 };
 
 CampaignPage.defaultProps = {
+  blurb: null,
   dashboard: null,
   endDate: null,
   isAffiliated: false,

--- a/resources/assets/components/Page/LandingPage/LandingPage.js
+++ b/resources/assets/components/Page/LandingPage/LandingPage.js
@@ -83,7 +83,7 @@ const LandingPage = (props) => {
 
 LandingPage.propTypes = {
   actionText: PropTypes.string.isRequired,
-  blurb: PropTypes.string.isRequired,
+  blurb: PropTypes.string,
   coverImage: PropTypes.shape({
     description: PropTypes.string,
     url: PropTypes.string,
@@ -109,6 +109,7 @@ LandingPage.propTypes = {
 };
 
 LandingPage.defaultProps = {
+  blurb: null,
   endDate: null,
   isAffiliated: false,
   tagline: 'Ready to start?',


### PR DESCRIPTION
### What does this PR do?
- Changing the `blurb` property (used in Mosaic Lede Banner) to not be required.
~- Adjusting some of the padding so that it remains consistent with or without the blurb~ (maintaining blurb styling with or without the blurb for now.)


### Any background context you want to provide?
We don't want to require the blurb anymore. We want to be able to just have the info on the pitch page even for Mosaic campaigns.


### What are the relevant tickets/cards?
https://www.pivotaltracker.com/story/show/153638522

### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
- [ ] Added screenshot to PR description of related front-end updates on **small** screens.
- [ ] Added screenshot to PR description of related front-end updates on **medium** screens.
- [ ] Added screenshot to PR description of related front-end updates on **large** screens.

