### PR TITLE
Ensuring default value is set for actionText if no campaign setting

### DIFF
--- a/app/Entities/Campaign.php
+++ b/app/Entities/Campaign.php
@@ -223,7 +223,7 @@ class Campaign extends Entity implements JsonSerializable
             'socialOverride' => $this->socialOverride ? new SocialOverride($this->socialOverride->entry) : null,
             'additionalContent' => $this->additionalContent,
             'allowExperiments' => $this->campaignSettings ? $this->campaignSettings->allowExperiments : null,
-            'actionText' => $this->campaignSettings ? $this->campaignSettings->actionText : 'Join Us',
+            'actionText' => array_get($this->campaignSettings, 'actionText') ?: 'Join Us',
         ];
     }
 }


### PR DESCRIPTION
### What does this PR do?
My mistake - the `actionText` field would be `null` if there was a `CampaignSettings` field but no set `actionText`. Just fixing this to ensure it'll grab the default value in such a case.