### PR TITLE
Using only campaignLead email for contact link in footer

### DIFF
--- a/resources/assets/components/CampaignFooter/CampaignFooter.js
+++ b/resources/assets/components/CampaignFooter/CampaignFooter.js
@@ -3,21 +3,20 @@ import PropTypes from 'prop-types';
 
 import AffiliateCredits from '../AffiliateCredits';
 
-const CampaignFooterContact = ({ email, name }) => (
-  <div className="info-bar__secondary">
-    Questions? <a
-      href={`mailto:${email || CampaignFooterContact.defaultProps.email}`}
-    >Contact {name || CampaignFooterContact.defaultProps.name}</a>
-  </div>
-);
+const CampaignFooterContact = ({ email }) => {
+  const contactEmail = email || CampaignFooterContact.defaultProps.email;
+  return (
+    <div className="info-bar__secondary">
+      Questions? <a href={`mailto:${contactEmail}`}>Contact {contactEmail}</a>
+    </div>
+  );
+};
 
 CampaignFooterContact.propTypes = {
-  name: PropTypes.string,
   email: PropTypes.string,
 };
 
 CampaignFooterContact.defaultProps = {
-  name: 'Us',
   email: 'help@dosomething.org',
 };
 


### PR DESCRIPTION
### What does this PR do?
Only using the `campaignLead` email for the footer contact link instead of name. 

![image](https://user-images.githubusercontent.com/12417657/33960407-a44a18ee-e018-11e7-94e1-7b817562ef83.png)

![image](https://user-images.githubusercontent.com/12417657/33960425-b516d824-e018-11e7-8f8a-e3f439c1f03d.png)



### Any background context you want to provide?
Should we be removing the name property in general from the footer prop hierarchy?
 (`CampaignPage` and `Footer` both define a `campaignLead` object as a prop with *both* name and email. IS this now unnecessary?)


### What are the relevant tickets/cards?
https://www.pivotaltracker.com/story/show/153558695

