### PR TITLE
Adding helpful error messaging for failed media uploads

### DIFF
--- a/resources/assets/components/FormMessage/index.js
+++ b/resources/assets/components/FormMessage/index.js
@@ -15,7 +15,7 @@ const renderValidationMessage = error => (
     <h3>Hmm, there were some issues with your submission.</h3>
     <ul className="list -compacted">
       {Object.keys(error.fields || {}).map(field => (
-        <li key={makeHash(field)}>{error.fields[field].join('. ')}</li>
+        <li key={makeHash(field)}>{error.fields[field].join(' ')}</li>
       ))}
     </ul>
   </div>

--- a/resources/assets/components/ReportbackUploader/ReportbackUploader.js
+++ b/resources/assets/components/ReportbackUploader/ReportbackUploader.js
@@ -133,13 +133,18 @@ class ReportbackUploader extends React.Component {
       </div>
     );
 
+    const modifiedSubmissionsMessaging = { ...submissions.messaging };
+    if (modifiedSubmissionsMessaging.error && modifiedSubmissionsMessaging.error.fields.media) {
+      modifiedSubmissionsMessaging.error.fields.media.push('Try uploading a smaller file.');
+    }
+
     return (
       <Flex>
         <FlexCell width="two-thirds" className="padding-horizontal-md margin-vertical-md">
           <Card title="Upload your photos" className="bordered rounded">
             <div className="reportback-uploader padding-md">
               { shouldDisplaySubmissionMessaging ? (
-                <FormMessage messaging={submissions.messaging} />
+                <FormMessage messaging={modifiedSubmissionsMessaging} />
               ) : null }
 
               <form className="reportback-form" onSubmit={this.handleOnSubmitForm} ref={form => (this.form = form)}>


### PR DESCRIPTION
### What does this PR do?
<img width="455" alt="screen shot 2017-12-13 at 3 11 59 pm" src="https://user-images.githubusercontent.com/897368/33960847-068bf0e4-e01a-11e7-8410-389c2deed9df.png">

This PR tries to give users additional context as to why the photo might have failed to upload.

### Any background context you want to provide?
If we want to bump up how large a photo we accept, we'll need to set that in the server configs. This is just to give more clarity to the user.