### PR TITLE
Mosaic lede banner styling

### DIFF
--- a/resources/assets/components/CampaignSignupArrow/campaignSignupArrow.scss
+++ b/resources/assets/components/CampaignSignupArrow/campaignSignupArrow.scss
@@ -27,7 +27,7 @@
 
   .message-callout__copy {
     @include media($large) {
-      margin-top: - $base-spacing;
+      margin-top: - $half-spacing;
     }
 
     @include media($medium) {

--- a/resources/assets/components/LedeBanner/lede-banner.scss
+++ b/resources/assets/components/LedeBanner/lede-banner.scss
@@ -14,6 +14,7 @@
 
   .button {
     width: 100%;
+    height: 70px;
 
     @include media($medium) {
       width: 50%;

--- a/resources/assets/components/LedeBanner/lede-banner.scss
+++ b/resources/assets/components/LedeBanner/lede-banner.scss
@@ -29,7 +29,7 @@
 .lede-banner__content {
   @include media($medium) {
     display: table-cell;
-    min-height: 500px;
+    vertical-align: middle;
     width: 50%;
   }
 

--- a/resources/assets/components/LedeBanner/lede-banner.scss
+++ b/resources/assets/components/LedeBanner/lede-banner.scss
@@ -8,6 +8,9 @@
   @include media($medium) {
     display: table;
   }
+  @include media($large) {
+    min-height: 500px;
+  }
 
   .button {
     width: 100%;

--- a/resources/assets/components/LedeBanner/lede-banner.scss
+++ b/resources/assets/components/LedeBanner/lede-banner.scss
@@ -16,6 +16,10 @@
       width: 50%;
     }
   }
+
+  .header__signup {
+    padding-top: $base-spacing;
+  }
 }
 
 .lede-banner__content {
@@ -85,7 +89,7 @@
 
 .lede-banner__blurb {
   font-family: $primary-font-family;
-  padding: $base-spacing 0;
+  padding-top: $base-spacing;
 
   strong {
     color: $primary-color;

--- a/resources/assets/components/LedeBanner/templates/MosaicTemplate.js
+++ b/resources/assets/components/LedeBanner/templates/MosaicTemplate.js
@@ -29,7 +29,7 @@ const MosaicTemplate = (props) => {
   ) : null;
 
   const SignupButton = SignupButtonFactory(({ clickedSignUp }) => (
-    <div>
+    <div className="header__signup">
       { signupArrowComponent }
       <button className="button" onClick={() => clickedSignUp(legacyCampaignId)}>{ actionText }</button>
       { showPartnerMsgOptIn ? <AffiliateOptionContainer /> : null }

--- a/resources/assets/components/LedeBanner/templates/MosaicTemplate.js
+++ b/resources/assets/components/LedeBanner/templates/MosaicTemplate.js
@@ -46,9 +46,7 @@ const MosaicTemplate = (props) => {
             <h2 className="lede-banner__headline-subtitle">{subtitle}</h2>
           </div>
 
-          <div className="lede-banner__blurb">
-            { blurb ? <Markdown>{blurb}</Markdown> : null }
-          </div>
+          { blurb ? <Markdown className="lede-banner__blurb">{blurb}</Markdown> : null }
 
           { isAffiliated ? null : <SignupButton /> }
         </div>


### PR DESCRIPTION
### What does this PR do?
Styling adjustments to the Mosaic Lede Banner®

- Padding between the signup button and heading is now independent of blurb. (Previously blurb was required, and was the only padding between the two).
- Large screens will now have a Lede Banner of at least `500px` in height (go hard or go home). 
- Signup button is now `70px` in height. 🎣 
- Heading and blurb will vertically align with the `LedeBanner`.


### Any background context you want to provide?
All based on the stylings of @lkpttn®

*Large Screen*
![image](https://user-images.githubusercontent.com/12417657/34112380-5fbba060-e3da-11e7-87fc-b1adbe1bb6d6.png)


*Medium Screen*
![image](https://user-images.githubusercontent.com/12417657/34112417-7f78c4a0-e3da-11e7-8a30-08bdf596160c.png)


*Small Screen*
![image](https://user-images.githubusercontent.com/12417657/34112456-98814af8-e3da-11e7-9803-35b7361fe14c.png)



### What are the relevant tickets/cards?
[#153448673](https://www.pivotaltracker.com/story/show/153448673)

### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
- [x] Added screenshot to PR description of related front-end updates on **small** screens.
- [x] Added screenshot to PR description of related front-end updates on **medium** screens.
- [x] Added screenshot to PR description of related front-end updates on **large** screens.

