### PR TITLE
Quick fix for step header sizing on responsive sizes.

### DIFF
--- a/resources/assets/components/ActionPage/actionPage.scss
+++ b/resources/assets/components/ActionPage/actionPage.scss
@@ -40,9 +40,13 @@
       color: $white;
       letter-spacing: 1.1px;
       font-family: $secondary-font-family;
-      font-size: $font-gigantic; // TODO: This needs to be the 65px one
+      font-size: $font-hero;
       font-weight: $weight-normal;
       text-shadow: $text-shadow;
+
+      @include media($medium) {
+        font-size: $font-gigantic;
+      }
     }
   }
 

--- a/resources/assets/components/PhotoHeader/PhotoHeader.js
+++ b/resources/assets/components/PhotoHeader/PhotoHeader.js
@@ -3,8 +3,6 @@ import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import './photo-header.scss';
 
-const photoHeaderClasses = 'photo-header padding-lg';
-
 const renderBackgroundImage = backgroundImage => (
   backgroundImage ?
     <div
@@ -17,7 +15,7 @@ const renderBackgroundImage = backgroundImage => (
 
 const PhotoHeader = ({ children, className, backgroundImage }) => (
   <div
-    className={classnames(photoHeaderClasses, className)}
+    className={classnames('photo-header padding-lg', className)}
   >
     { renderBackgroundImage(backgroundImage) }
     { children }

--- a/resources/assets/components/PhotoHeader/PhotoHeader.js
+++ b/resources/assets/components/PhotoHeader/PhotoHeader.js
@@ -3,13 +3,23 @@ import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import './photo-header.scss';
 
-const photoHeaderClasses = 'photo-header background-image-centered padding-lg';
+const photoHeaderClasses = 'photo-header padding-lg';
+
+const renderBackgroundImage = backgroundImage => (
+  backgroundImage ?
+    <div
+      className="photo-header__background-image background-image-centered"
+      style={{ backgroundImage: `url(${backgroundImage})` }}
+    />
+    :
+    null
+);
 
 const PhotoHeader = ({ children, className, backgroundImage }) => (
   <div
     className={classnames(photoHeaderClasses, className)}
-    style={{ backgroundImage: `url(${backgroundImage})` }}
   >
+    { renderBackgroundImage(backgroundImage) }
     { children }
   </div>
 );

--- a/resources/assets/components/PhotoHeader/__snapshots__/PhotoHeader.test.js.snap
+++ b/resources/assets/components/PhotoHeader/__snapshots__/PhotoHeader.test.js.snap
@@ -2,13 +2,16 @@
 
 exports[`PhotoHeader snapshot test 1`] = `
 <div
-  className="photo-header background-image-centered padding-lg"
-  style={
-    Object {
-      "backgroundImage": "url(https://fake-image.com/img.png)",
-    }
-  }
+  className="photo-header padding-lg"
 >
+  <div
+    className="photo-header__background-image background-image-centered"
+    style={
+      Object {
+        "backgroundImage": "url(https://fake-image.com/img.png)",
+      }
+    }
+  />
   <h1>
     title
   </h1>

--- a/resources/assets/components/PhotoHeader/photo-header.scss
+++ b/resources/assets/components/PhotoHeader/photo-header.scss
@@ -1,8 +1,19 @@
 @import '../../scss/next-toolbox.scss';
 
 .photo-header {
-  width: 100%;
   background-color: $dark-gray;
+  position: relative;
   text-align: center;
   text-transform: uppercase;
+  width: 100%;
+}
+
+.photo-header__background-image {
+  background-repeat: no-repeat;
+  filter: grayscale(1);
+  height: 100%;
+  left: 0;
+  position: absolute;
+  top: 0;
+  width: 100%;
 }

--- a/resources/assets/components/PhotoHeader/photo-header.scss
+++ b/resources/assets/components/PhotoHeader/photo-header.scss
@@ -1,7 +1,7 @@
 @import '../../scss/next-toolbox.scss';
 
 .photo-header {
-  background-color: $dark-gray;
+  background-color: $black;
   position: relative;
   text-align: center;
   text-transform: uppercase;
@@ -13,6 +13,7 @@
   filter: grayscale(1);
   height: 100%;
   left: 0;
+  opacity: 0.5;
   position: absolute;
   top: 0;
   width: 100%;


### PR DESCRIPTION
### What does this PR do?
This PR makes a few visual tweaks to help with inconsistencies in the design or just for helping the design flow better across various screen sizes.

Specifically it fixes text sizes on the Step Headers on the action page, so on small screens the text isn't GIGANTIC! It also adds an update to greyscale and lower opacity on all Step Header images so the background image will no loner conflict with legibility of the step header text! 🎉 

#### Step Header Text Size Fixes:
Current bug:
![screen shot 2017-12-18 at 4 01 59 pm](https://user-images.githubusercontent.com/105849/34228699-90ec9434-e59f-11e7-83d8-16d5dcd8644a.png)

Proposed Fix:
![screen shot 2017-12-18 at 4 01 27 pm](https://user-images.githubusercontent.com/105849/34228703-93e6072e-e59f-11e7-8dd9-308c1bac8005.png)


#### Step Header Photo Fixes:
<img width="456" alt="screen shot 2017-12-20 at 4 11 13 pm" src="https://user-images.githubusercontent.com/105849/34228955-9035aeee-e5a0-11e7-8ef4-d0bcdcc92f56.png">

<img width="992" alt="screen shot 2017-12-20 at 4 11 26 pm" src="https://user-images.githubusercontent.com/105849/34228959-94f43e1e-e5a0-11e7-9d44-976b3e537dac.png">


### Checklist
- [x] Added screenshot to PR description of related front-end updates on **small** screens.
- [x] Added screenshot to PR description of related front-end updates on **medium** screens.
- [x] Added screenshot to PR description of related front-end updates on **large** screens.

