### PR TITLE
Friend referral backend

### DIFF
--- a/app/Http/Controllers/ReferralController.php
+++ b/app/Http/Controllers/ReferralController.php
@@ -70,7 +70,6 @@ class ReferralController extends Controller
 
         Log::info('RB Response:', $response);
 
-        // Delete the uploaded file.
         UploadedMedia::delete($path);
 
         return $response;

--- a/app/Http/Controllers/ReferralController.php
+++ b/app/Http/Controllers/ReferralController.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Referral;
+use Illuminate\Http\Request;
+use App\Services\PhoenixLegacy;
+use App\Repositories\PostRepository;
+
+class ReferralController extends Controller
+{
+    /**
+     * ReferralController constructor.
+     */
+    public function __construct(PostRepository $postRepository, PhoenixLegacy $phoenixLegacy)
+    {
+        $this->phoenixLegacy = $phoenixLegacy;
+        $this->postRepository = $postRepository;
+
+        $this->middleware('auth', ['only' => ['store']]);
+    }
+
+    /**
+     * Store 'Refer a Friend' RB fields locally, then defer to regular reportback store method.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return \Illuminate\Http\Response
+     */
+    public function store(Request $request)
+    {
+        $this->validate($request, [
+            'friendName' => 'required',
+            'friendEmail' => 'required',
+            'friendStory' => 'required',
+            'media' => 'required|file|image',
+            'caption' => 'required|min:4|max:60',
+            'impact' => 'required|numeric',
+        ]);
+
+        Referral::create([
+            'friend_name' => $request->input('friendName'),
+            'friend_email' => $request->input('friendEmail'),
+            'friend_story' => $request->input('friendStory'),
+            'referrer_northstar_id' => auth()->id(),
+        ]);
+
+        // Static 'why participated' to pass validation.
+        $request['whyParticipated'] = 'Refer-A-Friend';
+
+        return $this->postRepository->storeReportback($this->phoenixLegacy, $request);
+    }
+}

--- a/app/Http/Controllers/ReferralController.php
+++ b/app/Http/Controllers/ReferralController.php
@@ -10,12 +10,26 @@ use App\Repositories\PostRepository;
 class ReferralController extends Controller
 {
     /**
+     * The post repository.
+     *
+     * @var PostRepository
+     */
+    private $postRepository;
+
+    /**
+     * The legacy Phoenix API.
+     *
+     * @var PhoenixLegacy
+     */
+    private $phoenixLegacy;
+
+    /**
      * ReferralController constructor.
      */
     public function __construct(PostRepository $postRepository, PhoenixLegacy $phoenixLegacy)
     {
-        $this->phoenixLegacy = $phoenixLegacy;
         $this->postRepository = $postRepository;
+        $this->phoenixLegacy = $phoenixLegacy;
 
         $this->middleware('auth')->only(['store']);
     }

--- a/app/Http/Controllers/ReferralController.php
+++ b/app/Http/Controllers/ReferralController.php
@@ -17,7 +17,7 @@ class ReferralController extends Controller
         $this->phoenixLegacy = $phoenixLegacy;
         $this->postRepository = $postRepository;
 
-        $this->middleware('auth', ['only' => ['store']]);
+        $this->middleware('auth')->only(['store']);
     }
 
     /**

--- a/app/Http/Controllers/ReportbackController.php
+++ b/app/Http/Controllers/ReportbackController.php
@@ -54,9 +54,9 @@ class ReportbackController extends Controller
             'whyParticipated' => 'required',
         ]);
 
-        return get_class($request->file('media'));
         // Store the uploaded file.
         $path = UploadedMedia::store($request->file('media'));
+
         $response = $this->phoenixLegacy->storeReportback(
             auth()->id(),
             $request->input('campaignId'),

--- a/app/Http/Controllers/ReportbackController.php
+++ b/app/Http/Controllers/ReportbackController.php
@@ -4,8 +4,8 @@ namespace App\Http\Controllers;
 
 use Illuminate\Http\Request;
 use App\Services\PhoenixLegacy;
-use Illuminate\Support\Facades\Log;
 use App\Services\UploadedMedia;
+use Illuminate\Support\Facades\Log;
 
 class ReportbackController extends Controller
 {

--- a/app/Http/Controllers/ReportbackController.php
+++ b/app/Http/Controllers/ReportbackController.php
@@ -2,11 +2,11 @@
 
 namespace App\Http\Controllers;
 
+use App\Models\Referral;
 use Illuminate\Http\Request;
 use App\Services\PhoenixLegacy;
 use Illuminate\Support\Facades\Log;
 use App\Exceptions\InvalidFileUploadException;
-use App\Models\Referral;
 
 class ReportbackController extends Controller
 {

--- a/app/Http/Controllers/ReportbackController.php
+++ b/app/Http/Controllers/ReportbackController.php
@@ -5,7 +5,7 @@ namespace App\Http\Controllers;
 use Illuminate\Http\Request;
 use App\Services\PhoenixLegacy;
 use Illuminate\Support\Facades\Log;
-use App\Exceptions\InvalidFileUploadException;
+use App\Services\UploadedMedia;
 
 class ReportbackController extends Controller
 {
@@ -54,15 +54,9 @@ class ReportbackController extends Controller
             'whyParticipated' => 'required',
         ]);
 
-        $reportbackPhoto = $request->file('media');
-
-        if (! $reportbackPhoto->isValid()) {
-            throw new InvalidFileUploadException;
-        }
-
+        return get_class($request->file('media'));
         // Store the uploaded file.
-        $path = '/uploads/'.$reportbackPhoto->store('images', 'uploads');
-
+        $path = UploadedMedia::store($request->file('media'));
         $response = $this->phoenixLegacy->storeReportback(
             auth()->id(),
             $request->input('campaignId'),
@@ -77,8 +71,7 @@ class ReportbackController extends Controller
 
         Log::info('RB Response:', $response);
 
-        // Delete the uploaded file.
-        app('files')->delete(public_path($path));
+        UploadedMedia::delete($path);
 
         return $response;
     }

--- a/app/Http/Controllers/ReportbackController.php
+++ b/app/Http/Controllers/ReportbackController.php
@@ -20,7 +20,7 @@ class ReportbackController extends Controller
 
         $this->postRepository = $postRepository;
 
-        $this->middleware('auth', ['only' => ['store']]);
+        $this->middleware('auth')->only(['store']);
     }
 
     /**

--- a/app/Http/Controllers/ReportbackController.php
+++ b/app/Http/Controllers/ReportbackController.php
@@ -54,7 +54,6 @@ class ReportbackController extends Controller
             'whyParticipated' => 'required',
         ]);
 
-        // Store the uploaded file.
         $path = UploadedMedia::store($request->file('media'));
 
         $response = $this->phoenixLegacy->storeReportback(

--- a/app/Repositories/PostRepository.php
+++ b/app/Repositories/PostRepository.php
@@ -53,7 +53,7 @@ class PostRepository
      *
      * @param \App\Services\PhoenixLegacy $client
      * @param \Illuminate\Http\Request    $request
-    */
+     */
     public function storeReportback($client, $request)
     {
         $reportbackPhoto = $request->file('media');

--- a/app/Repositories/PostRepository.php
+++ b/app/Repositories/PostRepository.php
@@ -3,8 +3,6 @@
 namespace App\Repositories;
 
 use App\Services\RogueClient;
-use Illuminate\Support\Facades\Log;
-use App\Exceptions\InvalidFileUploadException;
 
 class PostRepository
 {
@@ -46,42 +44,5 @@ class PostRepository
         $query['filter']['campaign_id'] = $id;
 
         return $this->rogue->get('v3/posts', $query);
-    }
-
-    /**
-     * Send reportback to Rogue for storage.
-     *
-     * @param \App\Services\PhoenixLegacy $client
-     * @param \Illuminate\Http\Request    $request
-     */
-    public function storeReportback($client, $request)
-    {
-        $reportbackPhoto = $request->file('media');
-
-        if (! $reportbackPhoto->isValid()) {
-            throw new InvalidFileUploadException;
-        }
-
-        // Store the uploaded file.
-        $path = '/uploads/'.$reportbackPhoto->store('images', 'uploads');
-
-        $response = $client->storeReportback(
-            auth()->id(),
-            $request->input('campaignId'),
-            [
-                'file_url' => config('app.env') !== 'local' ? config('app.url').'/next'.$path : 'https://placeimg.com/1000/768/animals',
-                'caption' => $request->input('caption'),
-                'quantity' => $request->input('impact'),
-                'why_participated' => $request->input('whyParticipated'),
-                'source' => 'phoenix-next',
-            ]
-        );
-
-        Log::info('RB Response:', $response);
-
-        // Delete the uploaded file.
-        app('files')->delete(public_path($path));
-
-        return $response;
     }
 }

--- a/app/Services/UploadedMedia.php
+++ b/app/Services/UploadedMedia.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Services;
+
+use App\Exceptions\InvalidFileUploadException;
+
+class UploadedMedia
+{
+    /**
+     * Store the uploaded file.
+     *
+     * @param  Illuminate\Http\UploadedFile  $media
+     * @return string
+     */
+    public static function store($media)
+    {
+        if (! $media->isValid()) {
+            throw new InvalidFileUploadException;
+        }
+
+        return '/uploads/'.$media->store('images', 'uploads');
+    }
+
+    /**
+     * Delete the uploaded file.
+     *
+     * @param string $path
+     */
+    public static function delete($path)
+    {
+        app('files')->delete(public_path($path));
+    }
+}

--- a/routes/web.php
+++ b/routes/web.php
@@ -46,6 +46,8 @@ $router->delete('next/reactions/{id}', 'ReactionController@delete');
 $router->resource('next/reportbacks', 'ReportbackController', ['except' => ['create', 'edit', 'destroy']]);
 $router->resource('next/reportbackItems', 'ReportbackItemsController', ['only' => ['index']]);
 
+$router->post('next/reportbacks/friend-referral', 'ReportbackController@friendReferral');
+
 // Signups
 $router->get('next/signups/total/{campaignId}', 'SignupController@total');
 $router->resource('next/signups', 'SignupController', ['except' => ['create', 'edit', 'destroy']]);

--- a/routes/web.php
+++ b/routes/web.php
@@ -46,7 +46,7 @@ $router->delete('next/reactions/{id}', 'ReactionController@delete');
 $router->resource('next/reportbacks', 'ReportbackController', ['except' => ['create', 'edit', 'destroy']]);
 $router->resource('next/reportbackItems', 'ReportbackItemsController', ['only' => ['index']]);
 
-$router->post('next/reportbacks/friend-referral', 'ReportbackController@friendReferral');
+$router->resource('next/referrals', 'ReferralController', ['only' => ['store']]);
 
 // Signups
 $router->get('next/signups/total/{campaignId}', 'SignupController@total');


### PR DESCRIPTION
### What does this PR do?
Adds route and controller action to handle reportback submissions of the 'Refer a Friend' variety.


### Any background context you want to provide?
I put the action in the reportback controller as this felt like a regular reportback at the end of the day. The `friendReferral` action takes care of validating and storing the fields we need locally in our temp table, and then passes the work on to the regular `store` action.

- We're also validating the regular RB fields in the `friendReferral` action since otherwise if for example *all* fields are blank, it'll only send back error messages for the friend referral specific ones. But for DRYness, would it be worth throwing the repeated validations in a class variable, and using that variable in both places?

- There's some static placeholder text for the `whyParticipated` field, as it's a required field in Rogue, but not needed for this type of RB.

EDIT: Added a `ReferralController` for storing referrals for more CRUDy controller setup. To prevent duplicating the regular RB storage logic, setup a new `storeReportback` method in the `PostRepository` and using that in the ReportbackController and ReferralController.


EDIT 2:
- Added a `UploadedMedia` service to DRY up storing and deleting the RB images.
- Moved the Reportback posting to the respective controllers.

### What are the relevant tickets/cards?
#576  #577 
[#153297514](https://www.pivotaltracker.com/story/show/153297514)
[#153297498](https://www.pivotaltracker.com/story/show/153297498)
  