### PR TITLE
Quick fix so small viewport is not broken if outputting the sample link.

### DIFF
--- a/resources/assets/components/VoterRegistration/VoterRegistration.js
+++ b/resources/assets/components/VoterRegistration/VoterRegistration.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { join } from 'path';
 import PropTypes from 'prop-types';
 
 const VoterRegistration = (props) => {
@@ -8,7 +9,7 @@ const VoterRegistration = (props) => {
   const query = `?r=user:${userId},campaign:${campaignRunId},source:web`;
 
   return (
-    <p>{query}</p>
+    <p className="margin-horizontal-md"><a href={join('/', query)}>TurboVote Link example</a></p>
   );
 };
 


### PR DESCRIPTION
### What does this PR do?
I'm working on small screen visual updates for the RB uploader and the output of the voter registration within the action steps was breaking the small screen viewport causing a bunch of overflow issues and horizontal scrolling. This PR provides a quick, simple fix so it doesn't distract while working on other features/updates.
