### PR TITLE
Progress on RB Post Photo Uploader updates.

### DIFF
--- a/resources/assets/components/ActionPage/ActionStepRenderers.js
+++ b/resources/assets/components/ActionPage/ActionStepRenderers.js
@@ -41,9 +41,12 @@ export function renderPhotoUploader(step, isSignedUp) {
   if (! isSignedUp) {
     return null;
   }
+
   return (
-    <FlexCell key="reportback_uploader" width="full">
-      <ReportbackUploaderContainer {...step.fields} />
+    <FlexCell key="reportback_uploader" className="margin-bottom-lg" width="full">
+      <div className="margin-horizontal-md">
+        <ReportbackUploaderContainer {...step.fields} />
+      </div>
     </FlexCell>
   );
 }

--- a/resources/assets/components/FormMessage/form-message.scss
+++ b/resources/assets/components/FormMessage/form-message.scss
@@ -4,7 +4,7 @@
   &.-error {
     color: red;
 
-    h3, p {
+    p, .title {
       color: red;
     }
   }
@@ -12,8 +12,12 @@
   &.-success {
     color: green;
 
-    h3, p {
+    p, .title {
       color: green;
     }
+  }
+
+  .title {
+    font-size: $font-regular;
   }
 }

--- a/resources/assets/components/FormMessage/index.js
+++ b/resources/assets/components/FormMessage/index.js
@@ -11,14 +11,14 @@ const renderMessage = message => (
 );
 
 const renderValidationMessage = error => (
-  <div>
-    <h3>Hmm, there were some issues with your submission.</h3>
+  <article>
+    <h1 className="title">Hmm, there were some issues with your submission.</h1>
     <ul className="list -compacted">
       {Object.keys(error.fields || {}).map(field => (
         <li key={makeHash(field)}>{error.fields[field].join('. ')}</li>
       ))}
     </ul>
-  </div>
+  </article>
 );
 
 const FormMessage = ({ messaging }) => {

--- a/resources/assets/components/MediaUploader/__snapshots__/test.js.snap
+++ b/resources/assets/components/MediaUploader/__snapshots__/test.js.snap
@@ -7,9 +7,13 @@ exports[`MediaUploader snapshot test 1`] = `
   <label
     htmlFor="media-uploader"
   >
-    <span>
-      Upload Media
-    </span>
+    <div
+      className="media-uploader__content media-uploader--action"
+    >
+      <span>
+        Upload Media
+      </span>
+    </div>
     <input
       id="media-uploader"
       name="media-uploader"

--- a/resources/assets/components/MediaUploader/index.js
+++ b/resources/assets/components/MediaUploader/index.js
@@ -1,9 +1,11 @@
-import PropTypes from 'prop-types';
 /* global FileReader, URL, Blob */
 
 import React from 'react';
+import PropTypes from 'prop-types';
 import classnames from 'classnames';
+
 import { processFile } from '../../helpers';
+
 import './media-uploader.scss';
 
 class MediaUploader extends React.Component {

--- a/resources/assets/components/MediaUploader/index.js
+++ b/resources/assets/components/MediaUploader/index.js
@@ -48,9 +48,17 @@ class MediaUploader extends React.Component {
     let content = null;
 
     if (filePreviewUrl) {
-      content = (<img src={filePreviewUrl} alt="uploaded file" />);
+      content = (
+        <div className="media-uploader__content media-uploader--file">
+          <img src={filePreviewUrl} alt="uploaded file" />
+        </div>
+      );
     } else {
-      content = (<span>{this.props.label}</span>);
+      content = (
+        <div className="media-uploader__content media-uploader--action">
+          <span>{this.props.label}</span>
+        </div>
+      );
     }
 
     return (

--- a/resources/assets/components/MediaUploader/media-uploader.scss
+++ b/resources/assets/components/MediaUploader/media-uploader.scss
@@ -53,10 +53,6 @@
         width: 50px;
       }
     }
-
-    .has-image & {
-      background-color: green;
-    }
   }
 
   &.has-image {

--- a/resources/assets/components/MediaUploader/media-uploader.scss
+++ b/resources/assets/components/MediaUploader/media-uploader.scss
@@ -3,6 +3,7 @@
 .media-uploader {
   background-color: #eee;
   color: $med-gray;
+  margin-bottom: $half-spacing;
   width: 100%;
 
   &:hover, &:focus {
@@ -13,7 +14,6 @@
     cursor: pointer;
     display: block;
     height: 0;
-    margin-bottom: $half-spacing;
     overflow: hidden;
     position: relative;
     padding-bottom: 100%;
@@ -54,24 +54,10 @@
       }
     }
 
-    &.media-uploader--file {
-
-    }
-
     .has-image & {
       background-color: green;
     }
   }
-
-  // .media-uploader__action {
-  //   background-color: fuchsia;
-  //   height: 100%;
-  //   left: 0;
-  //   position: absolute;
-  //   text-align: center;
-  //   top: 0;
-  //   width: 100%;
-  // }
 
   &.has-image {
     label {
@@ -85,9 +71,9 @@
     }
   }
 
-  // &.has-error {
-  //   border: 1px solid $error-color;
-  // }
+  &.has-error {
+    border: 1px solid $error-color;
+  }
 
   input {
     @include visually-hidden();

--- a/resources/assets/components/MediaUploader/media-uploader.scss
+++ b/resources/assets/components/MediaUploader/media-uploader.scss
@@ -36,13 +36,20 @@
     width: 100%;
 
     &.media-uploader--action {
+      span {
+        font-weight: $weight-sbold;
+        line-height: 1.3;
+        max-width: 170px;
+        text-align: center;
+      }
+
       span::before {
         background: transparent url('../../images/plus_sign.svg');
         background-size: cover;
         content: '';
         display: block;
         height: 50px;
-        margin: 0 auto 10px;
+        margin: 0 auto 12px;
         width: 50px;
       }
     }

--- a/resources/assets/components/MediaUploader/media-uploader.scss
+++ b/resources/assets/components/MediaUploader/media-uploader.scss
@@ -1,29 +1,44 @@
 @import '../../scss/next-toolbox.scss';
 
 .media-uploader {
-  width: 100%;
+  // width: 100%;
   background-color: #eee;
   color: $med-gray;
-  position: relative;
+  // position: relative;
 
-  &:after {
-    content: "";
-    display: block;
-    padding-bottom: 100%;
-  }
+  // &:after {
+  //   content: "";
+  //   display: block;
+  //   padding-bottom: 100%;
+
+  //   @include media($medium) {
+  //     padding-bottom: 30%;
+  //   }
+
+  //   @include media($large) {
+  //     padding-bottom: 100%;
+  //   }
+  // }
 
   &:hover {
     background-color: darken(#eee, 5%);
   }
 
   label {
+    align-items: center;
+    cursor: pointer;
+    // display: flex;
+    // flex-direction: column;
+    // height: 100%;
+    // justify-content: center;
+    // overflow: hidden;
     text-align: center;
     width: 100%;
 
-    // Perfect vertical centering
-    position: absolute;
-    top: 50%;
-    transform: perspective(1px) translateY(-50%);
+  //   // Perfect vertical centering
+  //   position: absolute;
+  //   top: 50%;
+  //   transform: perspective(1px) translateY(-50%);
 
     &::before {
       background: transparent url('../../images/plus_sign.svg');
@@ -31,13 +46,13 @@
       content: '';
       display: block;
       height: 50px;
-      margin: $half-spacing auto;
+  //     margin: $half-spacing auto;
       width: 50px;
     }
 
-    img {
-      max-height: 100%;
-    }
+  //   img {
+  //     max-height: 100%;
+  //   }
   }
 
   &.has-image {
@@ -48,9 +63,9 @@
     }
   }
 
-  &.has-error {
-    border: 1px solid $error-color;
-  }
+  // &.has-error {
+  //   border: 1px solid $error-color;
+  // }
 
   input {
     @include visually-hidden();

--- a/resources/assets/components/MediaUploader/media-uploader.scss
+++ b/resources/assets/components/MediaUploader/media-uploader.scss
@@ -1,65 +1,80 @@
 @import '../../scss/next-toolbox.scss';
 
 .media-uploader {
-  // width: 100%;
   background-color: #eee;
   color: $med-gray;
-  // position: relative;
+  width: 100%;
 
-  // &:after {
-  //   content: "";
-  //   display: block;
-  //   padding-bottom: 100%;
-
-  //   @include media($medium) {
-  //     padding-bottom: 30%;
-  //   }
-
-  //   @include media($large) {
-  //     padding-bottom: 100%;
-  //   }
-  // }
-
-  &:hover {
+  &:hover, &:focus {
     background-color: darken(#eee, 5%);
   }
 
   label {
-    align-items: center;
     cursor: pointer;
-    // display: flex;
-    // flex-direction: column;
-    // height: 100%;
-    // justify-content: center;
-    // overflow: hidden;
-    text-align: center;
+    display: block;
+    height: 0;
+    margin-bottom: $half-spacing;
+    overflow: hidden;
+    position: relative;
+    padding-bottom: 100%;
     width: 100%;
 
-  //   // Perfect vertical centering
-  //   position: absolute;
-  //   top: 50%;
-  //   transform: perspective(1px) translateY(-50%);
+    img {
+      max-height: 100%;
+    }
+  }
 
-    &::before {
-      background: transparent url('../../images/plus_sign.svg');
-      background-size: cover;
-      content: '';
-      display: block;
-      height: 50px;
-  //     margin: $half-spacing auto;
-      width: 50px;
+  .media-uploader__content {
+    align-items: center;
+    background-color: #eee;
+    display: flex;
+    height: 100%;
+    justify-content: center;
+    left: 0;
+    position: absolute;
+    top: 0;
+    width: 100%;
+
+    &.media-uploader--action {
+      span::before {
+        background: transparent url('../../images/plus_sign.svg');
+        background-size: cover;
+        content: '';
+        display: block;
+        height: 50px;
+        margin: 0 auto 10px;
+        width: 50px;
+      }
     }
 
-  //   img {
-  //     max-height: 100%;
-  //   }
+    &.media-uploader--file {
+
+    }
+
+    .has-image & {
+      background-color: green;
+    }
   }
+
+  // .media-uploader__action {
+  //   background-color: fuchsia;
+  //   height: 100%;
+  //   left: 0;
+  //   position: absolute;
+  //   text-align: center;
+  //   top: 0;
+  //   width: 100%;
+  // }
 
   &.has-image {
     label {
       &::before {
         display: none;
       }
+    }
+
+    .media-uploader__content {
+      background-color: $off-white;
     }
   }
 

--- a/resources/assets/components/ReportbackUploader/ReportbackUploader.js
+++ b/resources/assets/components/ReportbackUploader/ReportbackUploader.js
@@ -7,7 +7,6 @@ import classnames from 'classnames';
 
 import Card from '../Card';
 import Markdown from '../Markdown';
-import { Flex, FlexCell } from '../Flex';
 import FormMessage from '../FormMessage';
 import MediaUploader from '../MediaUploader';
 
@@ -66,41 +65,39 @@ class ReportbackUploader extends React.Component {
   handleOnSubmitForm(event) {
     event.preventDefault();
 
-    console.log('🤡 Clickity click!');
+    const reportback = {
+      campaignId: this.props.legacyCampaignId,
+      caption: this.caption.value,
+      impact: this.props.showQuantityField ? this.impact.value : 1,
+      media: this.state.media,
+      status: 'pending',
+      whyParticipated: this.why_participated.value,
+    };
 
-    // const reportback = {
-    //   media: this.state.media,
-    //   caption: this.caption.value,
-    //   impact: this.props.showQuantityField ? this.impact.value : 1,
-    //   whyParticipated: this.why_participated.value,
-    //   campaignId: this.props.legacyCampaignId,
-    //   status: 'pending',
-    // };
+    const fileType = reportback.media.file ? reportback.media.file.type : null;
 
-    // const fileType = reportback.media.file ? reportback.media.file.type : null;
+    reportback.media.type = fileType ? fileType.substring(0, fileType.indexOf('/')) : null;
 
-    // reportback.media.type = fileType ? fileType.substring(0, fileType.indexOf('/')) : null;
+    this.props.submitReportback(
+      ReportbackUploader.setFormData(reportback),
+    ).then(() => {
+      const trackingData = { campaignId: this.props.legacyCampaignId };
+      let trackingMessage;
 
-    // this.props.submitReportback(
-    //   ReportbackUploader.setFormData(reportback),
-    // ).then(() => {
-    //   const trackingData = { campaignId: this.props.legacyCampaignId };
-    //   let trackingMessage;
+      if (this.props.submissions.messaging.success) {
+        this.form.reset();
+        this.setState({
+          media: this.defaultMediaState,
+        });
 
-    //   if (this.props.submissions.messaging.success) {
-    //     this.form.reset();
-    //     this.setState({
-    //       media: this.defaultMediaState,
-    //     });
+        trackingMessage = 'Successful Reportback';
+      } else {
+        trackingMessage = 'Unsuccessful Reportback';
+        trackingData.submission_error = this.props.submissions.messaging.error;
+      }
 
-    //     trackingMessage = 'Successful Reportback';
-    //   } else {
-    //     trackingMessage = 'Unsuccessful Reportback';
-    //     trackingData.submission_error = this.props.submissions.messaging.error;
-    //   }
-
-    //   this.props.trackEvent(trackingMessage, trackingData);
-    // });
+      this.props.trackEvent(trackingMessage, trackingData);
+    });
   }
 
   render() {
@@ -109,13 +106,14 @@ class ReportbackUploader extends React.Component {
       shouldShowAffirmation, toggleReportbackAffirmation,
     } = this.props;
 
-    const shouldDisplaySubmissionMessaging = submissions.messaging && submissions.messaging.error;
+    const formHasErrors = get(submissions.messaging, 'error', null);
 
     const isInvalidField = name => (
       Object.keys(get(submissions, 'messaging.error.fields', {}))
         .indexOf(name) !== -1
     );
 
+    // @TODO: passing a hardcoded array is not sustainable...
     const inputClassnames = ['impact', 'caption', 'whyParticipated']
       .reduce((classes, input) => ({
         ...classes,
@@ -140,43 +138,56 @@ class ReportbackUploader extends React.Component {
     );
 
     return (
-      <div className="photo-uploader-action clearfix">
-        <div className="photo-uploader-form">
-          <Card title="Upload your photos" className="bordered rounded">
-            <form className="reportback-post-form" onSubmit={this.handleOnSubmitForm} ref={form => (this.form = form)}>
+      <div>
+        <div className="photo-uploader-action clearfix">
+          <div className="photo-uploader-form">
+            <Card title="Upload your photos" className="bordered rounded">
 
-              <div className="form-section">
-                <div className="form-item-group">
-                  <div className="padding-md">
-                    <MediaUploader label="Add your photo here" media={this.state.media} onChange={this.handleOnFileUpload} hasError={isInvalidField('media')} />
+              { formHasErrors ? <FormMessage messaging={submissions.messaging} /> : null }
 
-                    <label className={inputClassnames.caption.label} htmlFor="caption">Add a caption to your photo.</label>
-                    <input className={inputClassnames.caption.textField} id="caption" name="caption" type="text" placeholder="60 characters or less" ref={input => (this.caption = input)} />
+              <form className="reportback-post-form" onSubmit={this.handleOnSubmitForm} ref={form => (this.form = form)}>
+
+                <div className="form-section">
+                  <div className="form-item-group">
+                    <div className="padding-md">
+                      <MediaUploader label="Add your photo here" media={this.state.media} onChange={this.handleOnFileUpload} hasError={isInvalidField('media')} />
+
+                      <label className={inputClassnames.caption.label} htmlFor="caption">Add a caption to your photo.</label>
+                      <input className={inputClassnames.caption.textField} id="caption" name="caption" type="text" placeholder="60 characters or less" ref={input => (this.caption = input)} />
+                    </div>
                   </div>
                 </div>
-              </div>
 
-              <div className="form-section">
-                { showQuantityField ? impactInput : impactInput }
+                <div className="form-section">
+                  { showQuantityField ? impactInput : impactInput }
 
-                <div className="form-item-group">
-                  <div className="padding-md">
-                    <label className={inputClassnames.whyParticipated.label} htmlFor="why_participated">Why is this campaign important to you?</label>
-                    <textarea className={inputClassnames.whyParticipated.textField} id="why_participated" name="why_participated" placeholder="No need to write an essay, but we'd love to see why this matters to you!" ref={input => (this.why_participated = input)} />
+                  <div className="form-item-group">
+                    <div className="padding-md">
+                      <label className={inputClassnames.whyParticipated.label} htmlFor="why_participated">Why is this campaign important to you?</label>
+                      <textarea className={inputClassnames.whyParticipated.textField} id="why_participated" name="why_participated" placeholder="No need to write an essay, but we'd love to see why this matters to you!" ref={input => (this.why_participated = input)} />
+                    </div>
                   </div>
                 </div>
-              </div>
 
-              <button className="button" type="submit" disabled={submissions.isStoring}>Submit a new photo</button>
-            </form>
-          </Card>
-        </div>
+                <button className="button" type="submit" disabled={submissions.isStoring}>Submit a new photo</button>
+              </form>
+            </Card>
+          </div>
 
-        <div className="photo-uploader-information">
-          <Card title={informationTitle} className="bordered rounded">
+          <div className="photo-uploader-information">
+            <Card title={informationTitle} className="bordered rounded">
               <Markdown className="padding-md">{informationContent}</Markdown>
-          </Card>
+            </Card>
+          </div>
         </div>
+
+        { shouldShowAffirmation ? (
+          <div className="photo-uploader-affirmation margin-top-lg">
+            <Card title="We Got Your Photo" className="bordered rounded" onClose={() => toggleReportbackAffirmation(false)}>
+              <Markdown className="padding-md">{this.getAffirmationContent()}</Markdown>
+            </Card>
+          </div>
+        ) : null}
       </div>
     );
   }

--- a/resources/assets/components/ReportbackUploader/ReportbackUploader.js
+++ b/resources/assets/components/ReportbackUploader/ReportbackUploader.js
@@ -139,30 +139,6 @@ class ReportbackUploader extends React.Component {
       </div>
     );
 
-    // const reportbackUploader = (
-    //   <form className="reportback-form" onSubmit={this.handleOnSubmitForm} ref={form => (this.form = form)}>
-    //     <Flex>
-    //       <FlexCell width="full">
-    //         { shouldDisplaySubmissionMessaging ? (
-    //           <FormMessage messaging={submissions.messaging} />
-    //         ) : null }
-    //       </FlexCell>
-    //       <FlexCell width="half" className="reportback-form__uploader">
-    //         <MediaUploader label="Add your photo here" media={this.state.media} onChange={this.handleOnFileUpload} hasError={isInvalidField('media')} />
-    //         <div className="form-item">
-    //           <label className={inputClassnames.caption.label} htmlFor="caption">Add a caption to your photo.</label>
-    //           <input className={inputClassnames.caption.textField} id="caption" name="caption" type="text" placeholder="60 characters or less" ref={input => (this.caption = input)} />
-    //         </div>
-    //       </FlexCell>
-    //       <FlexCell width="half">
-    //         { showQuantityField ? impactInput : null }
-    //         <label className={inputClassnames.whyParticipated.label} htmlFor="why_participated">Why is this campaign important to you?</label>
-    //         <textarea className={inputClassnames.whyParticipated.textField} id="why_participated" name="why_participated" placeholder="No need to write an essay, but we'd love to see why this matters to you!" ref={input => (this.why_participated = input)} />
-    //       </FlexCell>
-    //     </Flex>
-    //   </form>
-    // );
-
     return (
       <div className="photo-uploader-action clearfix">
         <div className="photo-uploader-form">

--- a/resources/assets/components/ReportbackUploader/ReportbackUploader.js
+++ b/resources/assets/components/ReportbackUploader/ReportbackUploader.js
@@ -169,21 +169,25 @@ class ReportbackUploader extends React.Component {
           <Card title="Upload your photos" className="bordered rounded">
             <form className="reportback-post-form" onSubmit={this.handleOnSubmitForm} ref={form => (this.form = form)}>
 
-              <div className="form-item-group">
-                <div className="padding-md">
-                  <MediaUploader label="Add your photo here" media={this.state.media} onChange={this.handleOnFileUpload} hasError={isInvalidField('media')} />
+              <div className="form-section">
+                <div className="form-item-group">
+                  <div className="padding-md">
+                    <MediaUploader label="Add your photo here" media={this.state.media} onChange={this.handleOnFileUpload} hasError={isInvalidField('media')} />
 
-                  <label className={inputClassnames.caption.label} htmlFor="caption">Add a caption to your photo.</label>
-                  <input className={inputClassnames.caption.textField} id="caption" name="caption" type="text" placeholder="60 characters or less" ref={input => (this.caption = input)} />
+                    <label className={inputClassnames.caption.label} htmlFor="caption">Add a caption to your photo.</label>
+                    <input className={inputClassnames.caption.textField} id="caption" name="caption" type="text" placeholder="60 characters or less" ref={input => (this.caption = input)} />
+                  </div>
                 </div>
               </div>
 
-              { showQuantityField ? impactInput : impactInput }
+              <div className="form-section">
+                { showQuantityField ? impactInput : impactInput }
 
-              <div className="form-item-group">
-                <div className="padding-md">
-                  <label className={inputClassnames.whyParticipated.label} htmlFor="why_participated">Why is this campaign important to you?</label>
-                  <textarea className={inputClassnames.whyParticipated.textField} id="why_participated" name="why_participated" placeholder="No need to write an essay, but we'd love to see why this matters to you!" ref={input => (this.why_participated = input)} />
+                <div className="form-item-group">
+                  <div className="padding-md">
+                    <label className={inputClassnames.whyParticipated.label} htmlFor="why_participated">Why is this campaign important to you?</label>
+                    <textarea className={inputClassnames.whyParticipated.textField} id="why_participated" name="why_participated" placeholder="No need to write an essay, but we'd love to see why this matters to you!" ref={input => (this.why_participated = input)} />
+                  </div>
                 </div>
               </div>
 

--- a/resources/assets/components/ReportbackUploader/ReportbackUploader.js
+++ b/resources/assets/components/ReportbackUploader/ReportbackUploader.js
@@ -130,12 +130,14 @@ class ReportbackUploader extends React.Component {
         },
       }), {});
 
-    // const impactInput = (
-    //   <div className="form-item">
-    //     <label className={inputClassnames.impact.label} htmlFor="impact">Total number of {this.props.noun.plural} made?</label>
-    //     <input className={inputClassnames.impact.textField} id="impact" name="impact" type="text" placeholder="Enter # here -- like '300' or '5'" ref={input => (this.impact = input)} />
-    //   </div>
-    // );
+    const impactInput = (
+      <div className="form-item-group">
+        <div className="padding-md">
+          <label className={inputClassnames.impact.label} htmlFor="impact">Total number of {this.props.noun.plural} made?</label>
+          <input className={inputClassnames.impact.textField} id="impact" name="impact" type="text" placeholder="Enter # here -- like '300' or '5'" ref={input => (this.impact = input)} />
+        </div>
+      </div>
+    );
 
     // const reportbackUploader = (
     //   <form className="reportback-form" onSubmit={this.handleOnSubmitForm} ref={form => (this.form = form)}>
@@ -162,30 +164,39 @@ class ReportbackUploader extends React.Component {
     // );
 
     return (
-      <div className="photo-uploader-action">
-        <Card title="Upload your photos" className="bordered rounded">
-          <form className="reportback-post-form" onSubmit={this.handleOnSubmitForm} ref={form => (this.form = form)}>
+      <div className="photo-uploader-action clearfix">
+        <div className="photo-uploader-form">
+          <Card title="Upload your photos" className="bordered rounded">
+            <form className="reportback-post-form" onSubmit={this.handleOnSubmitForm} ref={form => (this.form = form)}>
 
-            <div className="form-item-group">
-              <div className="padding-md">
-                <MediaUploader label="Add your photo here" media={this.state.media} onChange={this.handleOnFileUpload} hasError={isInvalidField('media')} />
+              <div className="form-item-group">
+                <div className="padding-md">
+                  <MediaUploader label="Add your photo here" media={this.state.media} onChange={this.handleOnFileUpload} hasError={isInvalidField('media')} />
 
-                <div className="form-item">
                   <label className={inputClassnames.caption.label} htmlFor="caption">Add a caption to your photo.</label>
                   <input className={inputClassnames.caption.textField} id="caption" name="caption" type="text" placeholder="60 characters or less" ref={input => (this.caption = input)} />
                 </div>
               </div>
-            </div>
 
-            <div className="form-item-group">
-              <div className="padding-md">
-                oopa
+              { showQuantityField ? impactInput : impactInput }
+
+              <div className="form-item-group">
+                <div className="padding-md">
+                  <label className={inputClassnames.whyParticipated.label} htmlFor="why_participated">Why is this campaign important to you?</label>
+                  <textarea className={inputClassnames.whyParticipated.textField} id="why_participated" name="why_participated" placeholder="No need to write an essay, but we'd love to see why this matters to you!" ref={input => (this.why_participated = input)} />
+                </div>
               </div>
-            </div>
 
-            <button className="button" type="submit" disabled={submissions.isStoring}>Submit a new photo</button>
-          </form>
-        </Card>
+              <button className="button" type="submit" disabled={submissions.isStoring}>Submit a new photo</button>
+            </form>
+          </Card>
+        </div>
+
+        <div className="photo-uploader-information">
+          <Card title={informationTitle} className="bordered rounded">
+              <Markdown className="padding-md">{informationContent}</Markdown>
+          </Card>
+        </div>
       </div>
     );
   }

--- a/resources/assets/components/ReportbackUploader/ReportbackUploader.js
+++ b/resources/assets/components/ReportbackUploader/ReportbackUploader.js
@@ -1,14 +1,16 @@
 /* global FormData */
 
-import PropTypes from 'prop-types';
 import React from 'react';
-import classnames from 'classnames';
 import { get } from 'lodash';
+import PropTypes from 'prop-types';
+import classnames from 'classnames';
+
 import Card from '../Card';
-import { Flex, FlexCell } from '../Flex';
 import Markdown from '../Markdown';
-import MediaUploader from '../MediaUploader';
+import { Flex, FlexCell } from '../Flex';
 import FormMessage from '../FormMessage';
+import MediaUploader from '../MediaUploader';
+
 import './reportback-uploader.scss';
 
 class ReportbackUploader extends React.Component {
@@ -64,39 +66,41 @@ class ReportbackUploader extends React.Component {
   handleOnSubmitForm(event) {
     event.preventDefault();
 
-    const reportback = {
-      media: this.state.media,
-      caption: this.caption.value,
-      impact: this.props.showQuantityField ? this.impact.value : 1,
-      whyParticipated: this.why_participated.value,
-      campaignId: this.props.legacyCampaignId,
-      status: 'pending',
-    };
+    console.log('🤡 Clickity click!');
 
-    const fileType = reportback.media.file ? reportback.media.file.type : null;
+    // const reportback = {
+    //   media: this.state.media,
+    //   caption: this.caption.value,
+    //   impact: this.props.showQuantityField ? this.impact.value : 1,
+    //   whyParticipated: this.why_participated.value,
+    //   campaignId: this.props.legacyCampaignId,
+    //   status: 'pending',
+    // };
 
-    reportback.media.type = fileType ? fileType.substring(0, fileType.indexOf('/')) : null;
+    // const fileType = reportback.media.file ? reportback.media.file.type : null;
 
-    this.props.submitReportback(
-      ReportbackUploader.setFormData(reportback),
-    ).then(() => {
-      const trackingData = { campaignId: this.props.legacyCampaignId };
-      let trackingMessage;
+    // reportback.media.type = fileType ? fileType.substring(0, fileType.indexOf('/')) : null;
 
-      if (this.props.submissions.messaging.success) {
-        this.form.reset();
-        this.setState({
-          media: this.defaultMediaState,
-        });
+    // this.props.submitReportback(
+    //   ReportbackUploader.setFormData(reportback),
+    // ).then(() => {
+    //   const trackingData = { campaignId: this.props.legacyCampaignId };
+    //   let trackingMessage;
 
-        trackingMessage = 'Successful Reportback';
-      } else {
-        trackingMessage = 'Unsuccessful Reportback';
-        trackingData.submission_error = this.props.submissions.messaging.error;
-      }
+    //   if (this.props.submissions.messaging.success) {
+    //     this.form.reset();
+    //     this.setState({
+    //       media: this.defaultMediaState,
+    //     });
 
-      this.props.trackEvent(trackingMessage, trackingData);
-    });
+    //     trackingMessage = 'Successful Reportback';
+    //   } else {
+    //     trackingMessage = 'Unsuccessful Reportback';
+    //     trackingData.submission_error = this.props.submissions.messaging.error;
+    //   }
+
+    //   this.props.trackEvent(trackingMessage, trackingData);
+    // });
   }
 
   render() {
@@ -126,62 +130,63 @@ class ReportbackUploader extends React.Component {
         },
       }), {});
 
-    const impactInput = (
-      <div className="form-item">
-        <label className={inputClassnames.impact.label} htmlFor="impact">Total number of {this.props.noun.plural} made?</label>
-        <input className={inputClassnames.impact.textField} id="impact" name="impact" type="text" placeholder="Enter # here -- like '300' or '5'" ref={input => (this.impact = input)} />
-      </div>
-    );
+    // const impactInput = (
+    //   <div className="form-item">
+    //     <label className={inputClassnames.impact.label} htmlFor="impact">Total number of {this.props.noun.plural} made?</label>
+    //     <input className={inputClassnames.impact.textField} id="impact" name="impact" type="text" placeholder="Enter # here -- like '300' or '5'" ref={input => (this.impact = input)} />
+    //   </div>
+    // );
 
-    const reportbackUploader = (
-      <form className="reportback-form" onSubmit={this.handleOnSubmitForm} ref={form => (this.form = form)}>
-        <Flex>
-          <FlexCell width="full">
-            { shouldDisplaySubmissionMessaging ? (
-              <FormMessage messaging={submissions.messaging} />
-            ) : null }
-          </FlexCell>
-          <FlexCell width="half" className="reportback-form__uploader">
-            <MediaUploader label="Add your photo here" media={this.state.media} onChange={this.handleOnFileUpload} hasError={isInvalidField('media')} />
-            <div className="form-item">
-              <label className={inputClassnames.caption.label} htmlFor="caption">Add a caption to your photo.</label>
-              <input className={inputClassnames.caption.textField} id="caption" name="caption" type="text" placeholder="60 characters or less" ref={input => (this.caption = input)} />
-            </div>
-          </FlexCell>
-          <FlexCell width="half">
-            { showQuantityField ? impactInput : null }
-            <label className={inputClassnames.whyParticipated.label} htmlFor="why_participated">Why is this campaign important to you?</label>
-            <textarea className={inputClassnames.whyParticipated.textField} id="why_participated" name="why_participated" placeholder="No need to write an essay, but we'd love to see why this matters to you!" ref={input => (this.why_participated = input)} />
-          </FlexCell>
-        </Flex>
-      </form>
-    );
+    // const reportbackUploader = (
+    //   <form className="reportback-form" onSubmit={this.handleOnSubmitForm} ref={form => (this.form = form)}>
+    //     <Flex>
+    //       <FlexCell width="full">
+    //         { shouldDisplaySubmissionMessaging ? (
+    //           <FormMessage messaging={submissions.messaging} />
+    //         ) : null }
+    //       </FlexCell>
+    //       <FlexCell width="half" className="reportback-form__uploader">
+    //         <MediaUploader label="Add your photo here" media={this.state.media} onChange={this.handleOnFileUpload} hasError={isInvalidField('media')} />
+    //         <div className="form-item">
+    //           <label className={inputClassnames.caption.label} htmlFor="caption">Add a caption to your photo.</label>
+    //           <input className={inputClassnames.caption.textField} id="caption" name="caption" type="text" placeholder="60 characters or less" ref={input => (this.caption = input)} />
+    //         </div>
+    //       </FlexCell>
+    //       <FlexCell width="half">
+    //         { showQuantityField ? impactInput : null }
+    //         <label className={inputClassnames.whyParticipated.label} htmlFor="why_participated">Why is this campaign important to you?</label>
+    //         <textarea className={inputClassnames.whyParticipated.textField} id="why_participated" name="why_participated" placeholder="No need to write an essay, but we'd love to see why this matters to you!" ref={input => (this.why_participated = input)} />
+    //       </FlexCell>
+    //     </Flex>
+    //   </form>
+    // );
 
     return (
-      <Flex>
-        <FlexCell width="two-thirds" className="padding-horizontal-md margin-vertical-md">
-          <Card title="Upload your photos" className="bordered rounded">
-            <div className="reportback-uploader padding-md">
-              {reportbackUploader}
+      <div className="photo-uploader-action">
+        <Card title="Upload your photos" className="bordered rounded">
+          <form className="reportback-post-form" onSubmit={this.handleOnSubmitForm} ref={form => (this.form = form)}>
+
+            <div className="form-item-group">
+              <div className="padding-md">
+                <MediaUploader label="Add your photo here" media={this.state.media} onChange={this.handleOnFileUpload} hasError={isInvalidField('media')} />
+
+                <div className="form-item">
+                  <label className={inputClassnames.caption.label} htmlFor="caption">Add a caption to your photo.</label>
+                  <input className={inputClassnames.caption.textField} id="caption" name="caption" type="text" placeholder="60 characters or less" ref={input => (this.caption = input)} />
+                </div>
+              </div>
             </div>
-            <button className="button reportback-uploader-submit" type="submit" disabled={submissions.isStoring} onClick={this.handleOnSubmitForm}>Submit a new photo</button>
-          </Card>
-        </FlexCell>
-        { informationContent ? (
-          <FlexCell width="one-third" className="reportback-uploader-information margin-vertical-md">
-            <Card title={informationTitle} className="bordered rounded">
-              <Markdown className="padding-md">{informationContent}</Markdown>
-            </Card>
-          </FlexCell>
-        ) : null}
-        { shouldShowAffirmation ? (
-          <FlexCell width="two-thirds" className="padding-horizontal-md margin-vertical-md">
-            <Card title="We Got Your Photo" className="bordered rounded" onClose={() => toggleReportbackAffirmation(false)}>
-              <Markdown className="padding-md">{this.getAffirmationContent()}</Markdown>
-            </Card>
-          </FlexCell>
-        ) : null}
-      </Flex>
+
+            <div className="form-item-group">
+              <div className="padding-md">
+                oopa
+              </div>
+            </div>
+
+            <button className="button" type="submit" disabled={submissions.isStoring}>Submit a new photo</button>
+          </form>
+        </Card>
+      </div>
     );
   }
 }

--- a/resources/assets/components/ReportbackUploader/ReportbackUploader.js
+++ b/resources/assets/components/ReportbackUploader/ReportbackUploader.js
@@ -113,7 +113,7 @@ class ReportbackUploader extends React.Component {
         .indexOf(name) !== -1
     );
 
-    // @TODO: passing a hardcoded array is not sustainable...
+    // @TODO: using a hardcoded array is not sustainable...
     const inputClassnames = ['impact', 'caption', 'whyParticipated']
       .reduce((classes, input) => ({
         ...classes,

--- a/resources/assets/components/ReportbackUploader/reportback-uploader.scss
+++ b/resources/assets/components/ReportbackUploader/reportback-uploader.scss
@@ -12,7 +12,13 @@
   }
 
   textarea {
-    min-height: 100px;
+    // TODO: make this not hardcoded pixel values
+    // and/or use flexbox.
+    min-height: 120px;
+
+    @include media($medium) {
+      min-height: 180px;
+    }
   }
 
   .form-item-group + .form-item-group {
@@ -41,51 +47,22 @@
   }
 }
 
-// .reportback-form {
-//   .reportback-form__uploader {
-//     @include media($tablet) {
-//       padding-right: $base-spacing;
-//     }
-//   }
-
-//   .media-uploader {
-//     margin-bottom: $base-spacing;
-//   }
-
-//   .form-item {
-//     clear: both;
-//     margin-bottom: $base-spacing;
-//   }
-
-//   .field-label.has-error {
-//     color: $error-color;
-//   }
-
-//   // TODO: make this not hardcoded pixel values
-//   textarea {
-//     min-height: 120px;
-
-//     @include media($desktop) {
-//       min-height: 180px;
-//     }
-//   }
-// }
-
-// .reportback-uploader-information {
-//   padding-left: $half-spacing;
-//   padding-right: $half-spacing;
-
-//   @include media($tablet) {
-//     padding-left: 0;
-//     padding-right: 0;
-//   }
-// }
-
 .photo-uploader-form {
   @include media($large) {
     float: left;
     padding-right: $half-spacing;
     width: 66.6666666666666%;
+  }
+
+  .form-message {
+    border-bottom: 2px solid $light-gray;
+    padding: $half-spacing;
+  }
+
+  .field-label {
+    &.has-error {
+      color: $error-color;
+    }
   }
 }
 

--- a/resources/assets/components/ReportbackUploader/reportback-uploader.scss
+++ b/resources/assets/components/ReportbackUploader/reportback-uploader.scss
@@ -80,3 +80,10 @@
     font-size: $font-regular;
   }
 }
+
+.photo-uploader-affirmation {
+  @include media($large) {
+    padding-right: $half-spacing;
+    width: 66.6666666666666%;
+  }
+}

--- a/resources/assets/components/ReportbackUploader/reportback-uploader.scss
+++ b/resources/assets/components/ReportbackUploader/reportback-uploader.scss
@@ -1,47 +1,58 @@
 @import '../../scss/next-toolbox.scss';
 
-.reportback-uploader-submit {
-  display: block;
-  width: 100%;
-  border-radius: 0;
-}
-
-.reportback-form {
-  .reportback-form__uploader {
-    @include media($tablet) {
-      padding-right: $base-spacing;
-    }
+.photo-uploader-action {
+  .button {
+    border-radius: 0;
+    width: 100%;
   }
 
-  .media-uploader {
-    margin-bottom: $base-spacing;
-  }
-
-  .form-item {
-    clear: both;
-    margin-bottom: $base-spacing;
-  }
-
-  .field-label.has-error {
-    color: $error-color;
-  }
-
-  // TODO: make this not hardcoded pixel values
-  textarea {
-    min-height: 120px;
-
-    @include media($desktop) {
-      min-height: 180px;
-    }
+  .form-item-group + .form-item-group {
+    border-top: 2px solid fuchsia;
   }
 }
 
-.reportback-uploader-information {
-  padding-left: $half-spacing;
-  padding-right: $half-spacing;
+// .reportback-uploader-submit {
+//   display: block;
+//   width: 100%;
+//   border-radius: 0;
+// }
 
-  @include media($tablet) {
-    padding-left: 0;
-    padding-right: 0;
-  }
-}
+// .reportback-form {
+//   .reportback-form__uploader {
+//     @include media($tablet) {
+//       padding-right: $base-spacing;
+//     }
+//   }
+
+//   .media-uploader {
+//     margin-bottom: $base-spacing;
+//   }
+
+//   .form-item {
+//     clear: both;
+//     margin-bottom: $base-spacing;
+//   }
+
+//   .field-label.has-error {
+//     color: $error-color;
+//   }
+
+//   // TODO: make this not hardcoded pixel values
+//   textarea {
+//     min-height: 120px;
+
+//     @include media($desktop) {
+//       min-height: 180px;
+//     }
+//   }
+// }
+
+// .reportback-uploader-information {
+//   padding-left: $half-spacing;
+//   padding-right: $half-spacing;
+
+//   @include media($tablet) {
+//     padding-left: 0;
+//     padding-right: 0;
+//   }
+// }

--- a/resources/assets/components/ReportbackUploader/reportback-uploader.scss
+++ b/resources/assets/components/ReportbackUploader/reportback-uploader.scss
@@ -6,16 +6,18 @@
     width: 100%;
   }
 
+  .text-field {
+    display: block;
+  }
+
+  textarea {
+    min-height: 100px;
+  }
+
   .form-item-group + .form-item-group {
-    border-top: 2px solid fuchsia;
+    border-top: 2px solid $light-gray;
   }
 }
-
-// .reportback-uploader-submit {
-//   display: block;
-//   width: 100%;
-//   border-radius: 0;
-// }
 
 // .reportback-form {
 //   .reportback-form__uploader {
@@ -56,3 +58,26 @@
 //     padding-right: 0;
 //   }
 // }
+
+.photo-uploader-form {
+  @include media($large) {
+    float: left;
+    padding-right: $half-spacing;
+    width: 66.6666666666666%;
+  }
+}
+
+.photo-uploader-information {
+  margin-top: $base-spacing;
+
+  @include media($large) {
+    float: right;
+    margin-top: 0;
+    padding-left: $half-spacing;
+    width: 33.3333333333333%;
+  }
+
+  h1, h2, h3, h4, h5, h6 {
+    font-size: $font-regular;
+  }
+}

--- a/resources/assets/components/ReportbackUploader/reportback-uploader.scss
+++ b/resources/assets/components/ReportbackUploader/reportback-uploader.scss
@@ -3,6 +3,7 @@
 .photo-uploader-action {
   .button {
     border-radius: 0;
+    text-transform: none;
     width: 100%;
   }
 
@@ -16,6 +17,27 @@
 
   .form-item-group + .form-item-group {
     border-top: 2px solid $light-gray;
+  }
+
+  .form-section + .form-section {
+    border-top: 2px solid $light-gray;
+
+    @include media($medium) {
+      border-top: 0 none;
+    }
+  }
+
+  .form-section {
+    @include media($medium) {
+      float: left;
+      width: 50%;
+    }
+
+    &:first-child {
+      @include media($medium) {
+        border-right: 2px solid $light-gray;
+      }
+    }
   }
 }
 


### PR DESCRIPTION
### What does this PR do?
This PR does a bunch of updates to the Reportback Post Photo Uploader to address some new visual design updates and provide some bug fixes.


### Any background context you want to provide?
Sure. There's been a new design for the RB uploader and while some of the ideas have been implemented, this PR adds the rest and does a bit of cleanup.

### Responsive Sizes
Here's what the new design looks like across the different responsive sizes:

#### Small
<img width="413" alt="screen shot 2018-01-02 at 8 43 47 am" src="https://user-images.githubusercontent.com/105849/34487647-df08f00e-ef9a-11e7-95a4-80918df7e491.png">

#### Medium
<img width="687" alt="screen shot 2018-01-02 at 8 44 26 am" src="https://user-images.githubusercontent.com/105849/34487649-e18bf146-ef9a-11e7-94ed-8ffe0e58dafe.png">

#### Large
<img width="1082" alt="screen shot 2018-01-02 at 8 44 53 am" src="https://user-images.githubusercontent.com/105849/34487658-ea124bee-ef9a-11e7-9ef8-7965ca69cf6b.png">

### Image Sizes In Uploader
And it also account for any sized images that are uploaded, not just square ones:
<img width="712" alt="screen shot 2018-01-02 at 8 45 55 am" src="https://user-images.githubusercontent.com/105849/34487677-ff01fa40-ef9a-11e7-8ebc-d15bcd0b3cb7.png">

<img width="712" alt="screen shot 2018-01-02 at 8 46 22 am" src="https://user-images.githubusercontent.com/105849/34487682-0791d95a-ef9b-11e7-8980-1b8ebfcd7695.png">

<img width="716" alt="screen shot 2018-01-02 at 8 46 43 am" src="https://user-images.githubusercontent.com/105849/34487687-0bb8c282-ef9b-11e7-8516-705e248092cd.png">

### Validations
And here it is with the field validations as setup by @itsjoekent but with some design updates:
<img width="667" alt="screen shot 2018-01-04 at 9 37 14 am" src="https://user-images.githubusercontent.com/105849/34570506-fafbfb08-f139-11e7-98e9-0f31a928b9ae.png">

_Note: I did find a bug with validation where now since we allow campaign leads to toggle showing the impact field and we default it to `1` if it's toggled off (since it's also required by Rogue at the moment) we never really validate the impact field since it will always have a value. I feel we can ignore this for now and reassess, especially once the switch to posting to Rogue happens and quantity on the post is a thing.

### What are the relevant tickets/cards?
Refs https://www.pivotaltracker.com/story/show/153757088

### Checklist
- [x] Added appropriate feature/unit tests.
- [x] Added screenshot to PR description of related front-end updates on **small** screens.
- [x] Added screenshot to PR description of related front-end updates on **medium** screens.
- [x] Added screenshot to PR description of related front-end updates on **large** screens.


  