### PR TITLE
Action page root route

### DIFF
--- a/resources/assets/components/Navigation/TabbedNavigationContainer.js
+++ b/resources/assets/components/Navigation/TabbedNavigationContainer.js
@@ -59,7 +59,7 @@ const TabbedNavigationContainer = (props) => {
     <Button className="-inline nav-button" onClick={() => clickedSignUp(legacyCampaignId)} text={actionText} />
   ), 'tabbed navigation', { text: actionText });
 
-  const shouldHideCommunity = (template === 'legacy') && ! hasActivityFeed;
+  const shouldHideCommunity = ! hasActivityFeed;
   const shouldHideAction = (isClosed || (shouldHideCommunity && additionalPages.length === 0));
 
   return (

--- a/resources/assets/components/Page/CampaignPage/CampaignPage.js
+++ b/resources/assets/components/Page/CampaignPage/CampaignPage.js
@@ -33,7 +33,7 @@ const CampaignPage = (props) => {
 
   const renderActionOrFeed = () => (
     isClosed && ! shouldShowActionPage && hasActivityFeed ?
-      <FeedContainer />
+      <Redirect to={`${match.url}/community`} />
       : <ActionPageContainer />
   );
 
@@ -78,7 +78,7 @@ const CampaignPage = (props) => {
               path={`${match.url}/community`}
               render={() => {
                 if (template === 'legacy') {
-                  return hasActivityFeed ? <FeedContainer /> : <ActionPageContainer />;
+                  return hasActivityFeed ? <FeedContainer /> : <Redirect to={`${match.url}/action`} />;
                 }
 
                 return <FeedContainer />;

--- a/resources/assets/components/Page/CampaignPage/CampaignPage.js
+++ b/resources/assets/components/Page/CampaignPage/CampaignPage.js
@@ -31,7 +31,7 @@ const CampaignPage = (props) => {
 
   const isClosed = isCampaignClosed(get(endDate, 'date', null));
 
-  const renderActionPage = () => (
+  const renderActionOrFeed = () => (
     isClosed && ! shouldShowActionPage && hasActivityFeed ?
       <FeedContainer />
       : <ActionPageContainer />
@@ -68,11 +68,11 @@ const CampaignPage = (props) => {
             <Route
               path={`${match.url}`}
               exact
-              render={renderActionPage}
+              render={renderActionOrFeed}
             />
             <Route
               path={`${match.url}/action`}
-              render={renderActionPage}
+              render={renderActionOrFeed}
             />
             <Route
               path={`${match.url}/community`}

--- a/resources/assets/components/Page/CampaignPage/CampaignPage.js
+++ b/resources/assets/components/Page/CampaignPage/CampaignPage.js
@@ -105,6 +105,7 @@ const CampaignPage = (props) => {
                 return <Redirect to={`${match.url}`} />;
               }}
             />
+            <Redirect from={`${match.url}/:anything`} to={`${match.url}`} />
           </Switch>
         </Enclosure>
         { ! isAffiliated ? <CallToActionContainer key="callToAction" className="-sticky" /> : null }

--- a/resources/assets/components/Page/CampaignPage/CampaignPage.js
+++ b/resources/assets/components/Page/CampaignPage/CampaignPage.js
@@ -32,6 +32,12 @@ const CampaignPage = (props) => {
 
   const isClosed = isCampaignClosed(get(endDate, 'date', null));
 
+  const renderActionPage = () => (
+    isClosed && ! shouldShowActionPage && hasActivityFeed ?
+      <FeedContainer />
+      : <ActionPageContainer />
+  );
+
   return (
     <div>
       <LedeBanner
@@ -63,6 +69,14 @@ const CampaignPage = (props) => {
             <Route
               path={`${match.url}`}
               exact
+              render={renderActionPage}
+            />
+            <Route
+              path={`${match.url}/action`}
+              render={renderActionPage}
+            />
+            <Route
+              path={`${match.url}/community`}
               render={() => {
                 if (template === 'legacy') {
                   return hasActivityFeed ? <FeedContainer /> : <ActionPageContainer />;
@@ -70,14 +84,6 @@ const CampaignPage = (props) => {
 
                 return <FeedContainer />;
               }}
-            />
-            <Route
-              path={`${match.url}/action`}
-              render={() => (isClosed && ! shouldShowActionPage ?
-                <Redirect to={`${match.url}`} />
-                :
-                <ActionPageContainer />
-              )}
             />
             <Route path={`${match.url}/pages/:slug`} component={CampaignSubPageContainer} />
             <Route path={`${match.url}/blocks/:id`} component={BlockContainer} />

--- a/resources/assets/components/Page/CampaignPage/CampaignPage.js
+++ b/resources/assets/components/Page/CampaignPage/CampaignPage.js
@@ -27,7 +27,6 @@ const CampaignPage = (props) => {
     openModal, shouldShowActionPage, slug, subtitle, template, title, totalCampaignSignups,
   } = props;
 
-  // console.log(props.history);
   // TODO: if the history.length > 0, use the history.goBack after you trigger the content modal
 
   const isClosed = isCampaignClosed(get(endDate, 'date', null));

--- a/resources/assets/components/Page/CampaignPage/CampaignPage.js
+++ b/resources/assets/components/Page/CampaignPage/CampaignPage.js
@@ -27,10 +27,14 @@ const CampaignPage = (props) => {
     openModal, shouldShowActionPage, slug, subtitle, template, title, totalCampaignSignups,
   } = props;
 
-  // TODO: if the history.length > 0, use the history.goBack after you trigger the content modal
-
   const isClosed = isCampaignClosed(get(endDate, 'date', null));
 
+  /*
+    If the campaign is closed (and an admin has not specifically
+    toggled the show Action Page button), we want to render the ActivityFeed (community page)
+    *if* it's available (meaning the campaign has an activity feed property populated).
+    Otherwise, we render the ActionPage as usual.
+  */
   const renderActionOrFeed = () => (
     isClosed && ! shouldShowActionPage && hasActivityFeed ?
       <Redirect to={`${match.url}/community`} />
@@ -77,6 +81,11 @@ const CampaignPage = (props) => {
             <Route
               path={`${match.url}/community`}
               render={() => {
+                /*
+                  For legacy templates which don't require an ActivityFeed
+                  (community page elements), we first check to ensure
+                  that they indeed have a feed, otherwise we'll just redirect to the action page.
+                */
                 if (template === 'legacy') {
                   return hasActivityFeed ? <FeedContainer /> : <Redirect to={`${match.url}/action`} />;
                 }
@@ -104,6 +113,8 @@ const CampaignPage = (props) => {
                 return <Redirect to={`${match.url}`} />;
               }}
             />
+            { /* Any random route nested under a campaign will
+              just be redirected to the campaigns root page */ }
             <Redirect from={`${match.url}/:anything`} to={`${match.url}`} />
           </Switch>
         </Enclosure>

--- a/resources/assets/helpers/navigation.js
+++ b/resources/assets/helpers/navigation.js
@@ -3,7 +3,7 @@
 import { findKey } from 'lodash';
 
 export const campaignPaths = {
-  community: '/',
+  community: '/community',
   action: '/action',
   blocks: '/blocks/',
   quiz: '/quiz/',


### PR DESCRIPTION
### What does this PR do?

Renders the `action` page from the root route under `CampaignPage` `/us/campaigns/my-cool-campaign`

- added dedicated `/community` route.
- [retained](https://github.com/DoSomething/phoenix-next/commit/8604bd16b5fc8c391b2d3a4593a7e1cc82f8f32a#diff-def96fba41962ab39482b9b2baa8aedbR35) fallback logic in case campaign is closed - and there is a Feed - we'll render the community tab (or `Feed`) instead.

NEW:
[e6618d6](https://github.com/DoSomething/phoenix-next/pull/583/commits/e6618d6f74aa78f29fa02d79360fcd9b0c4d04ef)
- mosaic template campaigns with empty fields will now also hide the community tab as per [#154056394](https://www.pivotaltracker.com/story/show/154056394) (I tacked this on to this PR since it's kind of contingent on not having the community tab as the root of the campaign page)


### Any background context you want to provide?
One caveat here is that the `action` tab won't be 'active' (or highlighted) unless the route explicitly matches `.../action`, meaning it won't actually be highlighted on the root page. (With community, we had only rendered the page from the root route, so we'd [defined](https://github.com/DoSomething/phoenix-next/blob/dev/resources/assets/helpers/navigation.js#L6) the path as such. Here though, we wanted the root, as well as `/action` to render action, so we had to choose one of those for tab highlight activation, and went with `/action`).


### What are the relevant tickets/cards?
https://www.pivotaltracker.com/story/show/153639716
https://www.pivotaltracker.com/story/show/154056394
  