### PR TITLE
Adding the Share Action placeholder

### DIFF
--- a/app/Entities/Campaign.php
+++ b/app/Entities/Campaign.php
@@ -117,6 +117,8 @@ class Campaign extends Entity implements JsonSerializable
                     return new PhotoUploaderAction($step->entry);
                 case 'voterRegistrationAction':
                     return new VoterRegistrationAction($step->entry);
+                case 'shareAction':
+                    return new ShareAction($step->entry);
                 default:
                     return new CampaignActionStep($step->entry);
             }

--- a/app/Entities/ShareAction.php
+++ b/app/Entities/ShareAction.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Entities;
+
+use JsonSerializable;
+
+class ShareAction extends Entity implements JsonSerializable
+{
+    /**
+     * Convert the object into something JSON serializable.
+     *
+     * @return array
+     */
+    public function jsonSerialize()
+    {
+        return [
+            'id' => $this->entry->getId(),
+            'type' => $this->entry->getContentType(),
+            'fields' => [],
+        ];
+    }
+}

--- a/resources/assets/components/ActionPage/ActionStepRenderers.js
+++ b/resources/assets/components/ActionPage/ActionStepRenderers.js
@@ -197,7 +197,7 @@ export function renderVoterRegistration(step, stepIndex) {
  */
 export function renderShareAction() {
   return (
-    <FlexCell width="full">
+    <FlexCell width="full" key="share-action">
       <ShareActionContainer />
     </FlexCell>
   );

--- a/resources/assets/components/ActionPage/ActionStepRenderers.js
+++ b/resources/assets/components/ActionPage/ActionStepRenderers.js
@@ -9,6 +9,7 @@ import { ThirdPartyActionContainer } from '../Actions/ThirdPartyAction';
 import { ReportbackUploaderContainer } from '../ReportbackUploader';
 import { CompetitionBlockContainer } from '../CompetitionBlock';
 import { SubmissionGalleryContainer } from '../Gallery/SubmissionGallery';
+import { ShareActionContainer } from '../ShareAction';
 
 /**
  * Render a competition step.
@@ -175,10 +176,9 @@ export function renderVoterRegistration(step, stepIndex) {
   const { template, dynamicLink } = additionalContent;
 
   return (
-    <FlexCell>
+    <FlexCell width="full" key="voter-reg">
       <div className="action-step">
         <VoterRegistrationContainer
-          key="voter-reg"
           content={content}
           title={title}
           template={template}
@@ -186,6 +186,19 @@ export function renderVoterRegistration(step, stepIndex) {
           dynamicLink={dynamicLink}
         />
       </div>
+    </FlexCell>
+  );
+}
+
+/**
+ * Render a share action.
+ *
+ * @return {Component}
+ */
+export function renderShareAction() {
+  return (
+    <FlexCell width="full">
+      <ShareActionContainer />
     </FlexCell>
   );
 }

--- a/resources/assets/components/ActionPage/ActionStepsWrapper.js
+++ b/resources/assets/components/ActionPage/ActionStepsWrapper.js
@@ -5,7 +5,7 @@ import { Flex } from '../Flex';
 import {
   renderCompetitionStep, renderPhotoUploader, renderSubmissionGallery,
   renderThirdPartyAction, renderActionStep, renderRevealer,
-  renderLegacyGallery, renderVoterRegistration,
+  renderLegacyGallery, renderVoterRegistration, renderShareAction,
 } from './ActionStepRenderers';
 
 const ActionStepsWrapper = (props) => {
@@ -34,6 +34,9 @@ const ActionStepsWrapper = (props) => {
 
       case 'voterRegistrationAction':
         return renderVoterRegistration(step, stepIndex);
+
+      case 'shareAction':
+        return renderShareAction();
 
       default:
         stepIndex += 1;

--- a/resources/assets/components/ShareAction/ShareAction.js
+++ b/resources/assets/components/ShareAction/ShareAction.js
@@ -1,0 +1,36 @@
+/* global window */
+
+import PropTypes from 'prop-types';
+import React from 'react';
+import { showFacebookSharePrompt } from '../../helpers';
+
+const ShareAction = (props) => {
+  const { trackEvent } = props;
+
+  const link = window.location.href;
+  const trackingData = { link };
+
+  const onFacebookClick = () => {
+    trackEvent('clicked share action', trackingData);
+
+    showFacebookSharePrompt({ href: link }, (response) => {
+      if (response) {
+        trackEvent('share action completed', trackingData);
+      } else {
+        trackEvent('share action cancelled', trackingData);
+      }
+    });
+  };
+
+  return (
+    <button className="button" onClick={onFacebookClick}>
+      complete the share action
+    </button>
+  );
+};
+
+ShareAction.propTypes = {
+  trackEvent: PropTypes.func.isRequired,
+};
+
+export default ShareAction;

--- a/resources/assets/components/ShareAction/ShareActionContainer.js
+++ b/resources/assets/components/ShareAction/ShareActionContainer.js
@@ -1,0 +1,4 @@
+import { PuckConnector } from '@dosomething/puck-client';
+import ShareAction from './ShareAction';
+
+export default PuckConnector(ShareAction);

--- a/resources/assets/components/ShareAction/index.js
+++ b/resources/assets/components/ShareAction/index.js
@@ -1,0 +1,3 @@
+export default from './ShareAction';
+
+export ShareActionContainer from './ShareActionContainer';


### PR DESCRIPTION
### What does this PR do?
This PR is just adding all of the scaffolding and placeholder code for the eventual dedicated Share Action.

Example Puck output
<img width="799" alt="screen shot 2018-01-03 at 2 38 52 pm" src="https://user-images.githubusercontent.com/897368/34536680-efa21cde-f093-11e7-92ae-6b6fe41aa0a0.png">

### Any background context you want to provide?
I re-used some of the code from the Share component, but I didn't re-use the actual component intentionally. The end result of this Action (based on earlier conversations) could very well end up being something that more resembles a Card and has custom logic associated with it. Makes more sense to just have a different component I think instead of making the other component impossible to understand. (And there is a helper function being used already 😉)

### What are the relevant tickets/cards?
https://www.pivotaltracker.com/story/show/154008960