### PR TITLE
Pitch landing page cleanup

### DIFF
--- a/app/Entities/Page.php
+++ b/app/Entities/Page.php
@@ -38,7 +38,6 @@ class Page extends Entity implements JsonSerializable
             'fields' => [
                 'title' => $this->title,
                 'content' => $this->content,
-                'legacyContent' => array_get($this->additionalContent, 'pitchContent', null),
                 'sidebar' => $this->parseSidebar($this->sidebar),
             ],
         ];

--- a/resources/assets/components/Page/LandingPage/LandingPage.js
+++ b/resources/assets/components/Page/LandingPage/LandingPage.js
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 
 import Enclosure from '../../Enclosure';
 import LedeBanner from '../../LedeBanner/LedeBanner';
-import LandingPageContent from './LandingPageContent';
+import PitchTemplate from './templates/PitchTemplate';
 import CallToActionContainer from '../../CallToAction/CallToActionContainer';
 
 import './landing-page.scss';
@@ -39,7 +39,7 @@ const LandingPage = (props) => {
 
       <div className="clearfix bg-white">
         <Enclosure className="default-container margin-lg pitch-landing-page">
-          <LandingPageContent pitchContent={pitchContent} sidebarCTA={sidebarCTA} />
+          <PitchTemplate pitchContent={pitchContent} sidebarCTA={sidebarCTA} />
         </Enclosure>
       </div>
 

--- a/resources/assets/components/Page/LandingPage/LandingPage.js
+++ b/resources/assets/components/Page/LandingPage/LandingPage.js
@@ -4,28 +4,17 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import Enclosure from '../../Enclosure';
-import ExperimentContainer from '../../Experiment';
 import LedeBanner from '../../LedeBanner/LedeBanner';
-import ColumnizedContent from '../../ColumnizedContent';
 import LandingPageContent from './LandingPageContent';
 import CallToActionContainer from '../../CallToAction/CallToActionContainer';
 
 import './landing-page.scss';
 
-const formatToMarkup = data => (
-  data.map((item, dataIndex) => (
-    <div key={dataIndex}>
-      <h3>{item.title}</h3>
-      { item.content.map((paragraph, index) => (<p key={index}>{paragraph}</p>)) }
-    </div>
-  ))
-);
-
 const LandingPage = (props) => {
   const {
-    actionText, affiliateSponsors, blurb, convertExperiment, coverImage,
-    endDate, isAffiliated, legacyCampaignId, legacyPitchContent,
-    pitchContent, sidebar, showPartnerMsgOptIn, signupArrowContent,
+    actionText, affiliateSponsors, blurb, coverImage,
+    endDate, isAffiliated, legacyCampaignId, pitchContent,
+    sidebar, showPartnerMsgOptIn, signupArrowContent,
     subtitle, tagline, template, title,
   } = props;
 
@@ -50,22 +39,7 @@ const LandingPage = (props) => {
 
       <div className="clearfix bg-white">
         <Enclosure className="default-container margin-lg pitch-landing-page">
-          <ExperimentContainer name="landing_page">
-            <ColumnizedContent
-              experiment="landing_page"
-              alternative="legacy_landing_page"
-              convert={convertExperiment}
-              className="container__block -half"
-              content={formatToMarkup(legacyPitchContent)}
-            />
-            <LandingPageContent
-              experiment="landing_page"
-              alternative="landing_page_alt"
-              convert={convertExperiment}
-              pitchContent={pitchContent}
-              sidebarCTA={sidebarCTA}
-            />
-          </ExperimentContainer>
+          <LandingPageContent pitchContent={pitchContent} sidebarCTA={sidebarCTA} />
         </Enclosure>
       </div>
 
@@ -104,8 +78,6 @@ LandingPage.propTypes = {
   template: PropTypes.string.isRequired,
   title: PropTypes.string.isRequired,
   sidebar: PropTypes.arrayOf(PropTypes.object),
-  convertExperiment: PropTypes.func.isRequired,
-  legacyPitchContent: PropTypes.arrayOf(PropTypes.object).isRequired,
 };
 
 LandingPage.defaultProps = {

--- a/resources/assets/components/Page/LandingPage/LandingPage.js
+++ b/resources/assets/components/Page/LandingPage/LandingPage.js
@@ -7,7 +7,7 @@ import Enclosure from '../../Enclosure';
 import ExperimentContainer from '../../Experiment';
 import LedeBanner from '../../LedeBanner/LedeBanner';
 import ColumnizedContent from '../../ColumnizedContent';
-import LandingPageContentAlt from './LandingPageContentAlt';
+import LandingPageContent from './LandingPageContent';
 import CallToActionContainer from '../../CallToAction/CallToActionContainer';
 
 import './landing-page.scss';
@@ -58,7 +58,7 @@ const LandingPage = (props) => {
               className="container__block -half"
               content={formatToMarkup(legacyPitchContent)}
             />
-            <LandingPageContentAlt
+            <LandingPageContent
               experiment="landing_page"
               alternative="landing_page_alt"
               convert={convertExperiment}

--- a/resources/assets/components/Page/LandingPage/LandingPageContainer.js
+++ b/resources/assets/components/Page/LandingPage/LandingPageContainer.js
@@ -2,7 +2,6 @@ import { get } from 'lodash';
 import { connect } from 'react-redux';
 
 import LandingPage from './LandingPage';
-import { convertExperiment } from '../../../actions';
 
 /**
  * Provide state from the Redux store as props for this component.
@@ -12,7 +11,6 @@ const mapStateToProps = (state) => {
 
   return {
     pitchContent: landingPage.content,
-    legacyPitchContent: landingPage.legacyContent,
     blurb: state.campaign.blurb,
     coverImage: state.campaign.coverImage,
     dashboard: state.campaign.dashboard,
@@ -32,14 +30,6 @@ const mapStateToProps = (state) => {
 };
 
 /**
- * Provide pre-bound functions that allow the component to dispatch
- * actions to the Redux store as props for this component.
- */
-const mapActionsToProps = {
-  convertExperiment,
-};
-
-/**
  * Export the container component.
  */
-export default connect(mapStateToProps, mapActionsToProps)(LandingPage);
+export default connect(mapStateToProps)(LandingPage);

--- a/resources/assets/components/Page/LandingPage/LandingPageContent.js
+++ b/resources/assets/components/Page/LandingPage/LandingPageContent.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import Markdown from '../../Markdown';
 import Card from '../../Card';
 
-const LandingPageContentAlt = ({ pitchContent, sidebarCTA }) => (
+const LandingPageContent = ({ pitchContent, sidebarCTA }) => (
   <div className="campaign-subpage">
     <div className="primary">
       <Markdown>{ pitchContent }</Markdown>
@@ -17,7 +17,7 @@ const LandingPageContentAlt = ({ pitchContent, sidebarCTA }) => (
   </div>
 );
 
-LandingPageContentAlt.propTypes = {
+LandingPageContent.propTypes = {
   pitchContent: PropTypes.string.isRequired,
   sidebarCTA: PropTypes.shape({
     title: PropTypes.string,
@@ -25,12 +25,12 @@ LandingPageContentAlt.propTypes = {
   }).isRequired,
 };
 
-LandingPageContentAlt.defaultProps = {
+LandingPageContent.defaultProps = {
   sidebarCTA: {
     title: 'what you get',
     content: '*You could win a $5,000 dollar scholarship!*',
   },
 };
 
-export default LandingPageContentAlt;
+export default LandingPageContent;
 

--- a/resources/assets/components/Page/LandingPage/templates/PitchTemplate.js
+++ b/resources/assets/components/Page/LandingPage/templates/PitchTemplate.js
@@ -1,10 +1,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import Markdown from '../../Markdown';
-import Card from '../../Card';
+import Markdown from '../../../Markdown';
+import Card from '../../../Card';
 
-const LandingPageContent = ({ pitchContent, sidebarCTA }) => (
+const PitchTemplate = ({ pitchContent, sidebarCTA }) => (
   <div className="campaign-subpage">
     <div className="primary">
       <Markdown>{ pitchContent }</Markdown>
@@ -17,7 +17,7 @@ const LandingPageContent = ({ pitchContent, sidebarCTA }) => (
   </div>
 );
 
-LandingPageContent.propTypes = {
+PitchTemplate.propTypes = {
   pitchContent: PropTypes.string.isRequired,
   sidebarCTA: PropTypes.shape({
     title: PropTypes.string,
@@ -25,12 +25,12 @@ LandingPageContent.propTypes = {
   }).isRequired,
 };
 
-LandingPageContent.defaultProps = {
+PitchTemplate.defaultProps = {
   sidebarCTA: {
     title: 'what you get',
     content: '*You could win a $5,000 dollar scholarship!*',
   },
 };
 
-export default LandingPageContent;
+export default PitchTemplate;
 


### PR DESCRIPTION
### What does this PR do?

- Removing the Sixpack experiment for landing (pitch) pages 📦 📦 📦 📦 📦 📦  
- Removing the legacy landing (pitch) page, and associated fields and functions ✈️ 🛄 📟 


### Any background context you want to provide?
Not much going on here, just removing the experiment and the old landing page components, and crowning the `LandingPageContentAlt` as the `LandingPageContent` 👑 

EDIT:
Adding a `templates` folder and moving the `LandingPageContent` to a `PitchTemplate` component, as per Diego's idea below:

"So an interesting thought for this could be that the LandingPage component directory contains a templates directory and instead of rendering a LandingPageContent component it actually references a LandingPage/templates/PitchTemplate.js which is basically what is the current LandingPageContent but sets up an understanding of the hierarchy 😉"

# BEFORE MERGING 
- [ ] We must ensure all campaigns on Contentful that have a Landing Page, have the correct format to support the new Landing Page. (I believe @ashleybaldwin already took care of this?) (Is it pitch or landing page?? this has driven me crazy)


### What are the relevant tickets/cards?
[#154013212](https://www.pivotaltracker.com/story/show/154013212)


  