### PR TITLE
Fixing logic for impact field.

### DIFF
--- a/resources/assets/components/ReportbackUploader/ReportbackUploader.js
+++ b/resources/assets/components/ReportbackUploader/ReportbackUploader.js
@@ -159,7 +159,7 @@ class ReportbackUploader extends React.Component {
                 </div>
 
                 <div className="form-section">
-                  { showQuantityField ? impactInput : impactInput }
+                  { showQuantityField ? impactInput : null }
 
                   <div className="form-item-group">
                     <div className="padding-md">


### PR DESCRIPTION
### What does this PR do?
While testing I realized I left some logic in to always show the impact field while I was working on the design. This update should properly adjust the logic so it only shows if specified in the Contentful `PhotoUploaderAction` toggle.


### Any background context you want to provide?
🏂 
