### PR TITLE
Remove slideshow close button

### DIFF
--- a/resources/assets/components/Modal/configurations/PostSignupModal.js
+++ b/resources/assets/components/Modal/configurations/PostSignupModal.js
@@ -6,7 +6,7 @@ import SlideshowContainer from '../../Slideshow';
 
 const PostSignupModal = ({ competitionStep, closeModal }) => (
   <div className="modal__slide">
-    <SlideshowContainer slideshowId="post-signup-modal" onComplete={closeModal}>
+    <SlideshowContainer slideshowId="post-signup-modal" hideCloseButton>
       { competitionStep ? (
         <CompetitionBlockContainer
           content={competitionStep.content}

--- a/resources/assets/components/Modal/configurations/PostSignupModal.js
+++ b/resources/assets/components/Modal/configurations/PostSignupModal.js
@@ -4,7 +4,7 @@ import { AffirmationContainer } from '../../Affirmation';
 import { CompetitionBlockContainer } from '../../CompetitionBlock';
 import SlideshowContainer from '../../Slideshow';
 
-const PostSignupModal = ({ competitionStep, closeModal }) => (
+const PostSignupModal = ({ competitionStep }) => (
   <div className="modal__slide">
     <SlideshowContainer slideshowId="post-signup-modal" hideCloseButton>
       { competitionStep ? (
@@ -20,7 +20,6 @@ const PostSignupModal = ({ competitionStep, closeModal }) => (
 );
 
 PostSignupModal.propTypes = {
-  closeModal: PropTypes.func.isRequired,
   competitionStep: PropTypes.shape({
     content: PropTypes.string.isRequired,
     photo: PropTypes.string,

--- a/resources/assets/components/Modal/containers/PostSignupModalContainer.js
+++ b/resources/assets/components/Modal/containers/PostSignupModalContainer.js
@@ -1,6 +1,5 @@
 import { connect } from 'react-redux';
 import PostSignupModal from '../configurations/PostSignupModal';
-import { closeModal } from '../../../actions/modal';
 
 const mapStateToProps = state => ({
   competitionStep: state.campaign.actionSteps.find(step => (
@@ -8,8 +7,4 @@ const mapStateToProps = state => ({
   )),
 });
 
-const actionCreators = {
-  closeModal,
-};
-
-export default connect(mapStateToProps, actionCreators)(PostSignupModal);
+export default connect(mapStateToProps)(PostSignupModal);

--- a/resources/assets/components/Slideshow/Slideshow.js
+++ b/resources/assets/components/Slideshow/Slideshow.js
@@ -2,26 +2,41 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import './slideshow.scss';
 
-// TODO: Investigate why the `no-confusing-arrow` rule isn't working in this file.
-/* eslint-disable no-confusing-arrow */
-const Slideshow = ({ isFinalSlide, nextSlide, onComplete, slide, slideshowId }) => (
-  <div className="slideshow">
-    <div className="slideshow__slide">
-      { slide }
-    </div>
+const Slideshow = (props) => {
+  const {
+    hideCloseButton, isFinalSlide, nextSlide,
+    onComplete, slide, slideshowId,
+  } = props;
+
+  const SlideButton = isFinalSlide && hideCloseButton ? null : (
     <button
       className="button slideshow__button margin-top-lg"
       onClick={() => isFinalSlide ? onComplete() : nextSlide(slideshowId)}
     >{ isFinalSlide ? 'Close' : 'Next' }</button>
-  </div>
-);
+  );
+
+  return (
+    <div className="slideshow">
+      <div className="slideshow__slide">
+        { slide }
+      </div>
+      <SlideButton />
+    </div>
+  );
+};
 
 Slideshow.propTypes = {
+  hideCloseButton: PropTypes.bool,
   isFinalSlide: PropTypes.bool.isRequired,
   nextSlide: PropTypes.func.isRequired,
-  onComplete: PropTypes.func.isRequired,
+  onComplete: PropTypes.func,
   slide: PropTypes.node.isRequired,
   slideshowId: PropTypes.string.isRequired,
+};
+
+Slideshow.defaultProps = {
+  hideCloseButton: false,
+  onComplete: null,
 };
 
 export default Slideshow;

--- a/resources/assets/components/Slideshow/Slideshow.js
+++ b/resources/assets/components/Slideshow/Slideshow.js
@@ -8,12 +8,14 @@ const Slideshow = (props) => {
     onComplete, slide, slideshowId,
   } = props;
 
-  const SlideButton = isFinalSlide && hideCloseButton ? null : (
+  const nextFunc = isFinalSlide ? onComplete : () => nextSlide(slideshowId);
+
+  const SlideButton = () => (isFinalSlide && hideCloseButton ? null : (
     <button
       className="button slideshow__button margin-top-lg"
-      onClick={() => isFinalSlide ? onComplete() : nextSlide(slideshowId)}
+      onClick={() => nextFunc()}
     >{ isFinalSlide ? 'Close' : 'Next' }</button>
-  );
+  ));
 
   return (
     <div className="slideshow">


### PR DESCRIPTION
### What does this PR do?
in the updated modal designs Luke has the extra "close" button on the bottom no longer a thing, the only ways to close a modal are clicking anywhere on the screen outside the content, or the X button in the top right corner (which will soon only exist for modals that are not using a Card)


### What are the relevant tickets/cards?
https://www.pivotaltracker.com/story/show/152767171