### PR TITLE
Re-adding back the ternary missed when reconstructing RB markup.

### DIFF
--- a/resources/assets/components/ReportbackUploader/ReportbackUploader.js
+++ b/resources/assets/components/ReportbackUploader/ReportbackUploader.js
@@ -174,11 +174,13 @@ class ReportbackUploader extends React.Component {
             </Card>
           </div>
 
-          <div className="photo-uploader-information">
-            <Card title={informationTitle} className="bordered rounded">
-              <Markdown className="padding-md">{informationContent}</Markdown>
-            </Card>
-          </div>
+          { informationContent ? (
+            <div className="photo-uploader-information">
+              <Card title={informationTitle} className="bordered rounded">
+                <Markdown className="padding-md">{informationContent}</Markdown>
+              </Card>
+            </div>
+          ) : null }
         </div>
 
         { shouldShowAffirmation ? (
@@ -187,7 +189,7 @@ class ReportbackUploader extends React.Component {
               <Markdown className="padding-md">{this.getAffirmationContent()}</Markdown>
             </Card>
           </div>
-        ) : null}
+        ) : null }
       </div>
     );
   }


### PR DESCRIPTION
### What does this PR do?
This PR re-adds the ternary for wether to output the `informationContent` and its markup. Missed adding this back in with the restructuring that happened in 


### Any background context you want to provide?
This mistake was breaking campaigns with the old RB uploader.


### What are the relevant tickets/cards?
Refs #581
