### PR TITLE
Fixing a minor modal bug

### DIFF
--- a/resources/assets/actions/modal.js
+++ b/resources/assets/actions/modal.js
@@ -2,7 +2,7 @@ import { OPEN_MODAL, CLOSE_MODAL } from '../actions';
 import { toggleChromeLock } from '../helpers';
 
 export function openModal(modalType, contentfulId) {
-  toggleChromeLock();
+  toggleChromeLock(true);
   return { type: OPEN_MODAL, modalType, contentfulId };
 }
 

--- a/resources/assets/actions/modal.js
+++ b/resources/assets/actions/modal.js
@@ -1,12 +1,9 @@
 import { OPEN_MODAL, CLOSE_MODAL } from '../actions';
-import { toggleChromeLock } from '../helpers';
 
 export function openModal(modalType, contentfulId) {
-  toggleChromeLock(true);
   return { type: OPEN_MODAL, modalType, contentfulId };
 }
 
 export function closeModal() {
-  toggleChromeLock();
   return { type: CLOSE_MODAL };
 }

--- a/resources/assets/components/Modal/Modal.js
+++ b/resources/assets/components/Modal/Modal.js
@@ -1,8 +1,9 @@
+/* global document */
+
 import React from 'react';
 import PropTypes from 'prop-types';
 import Portal from 'react-portal';
 
-import { toggleChromeLock } from '../../helpers';
 import './modal.scss';
 
 class Modal extends React.Component {
@@ -39,13 +40,14 @@ class Modal extends React.Component {
 
   render() {
     const { shouldShowModal, children } = this.props;
+    const chrome = document.getElementById('chrome');
 
     return (
       <Portal
         closeOnEsc
         isOpened={shouldShowModal}
-        onOpen={() => toggleChromeLock(true)}
-        onClose={toggleChromeLock}
+        onOpen={() => chrome.classList.add('-lock')}
+        onClose={() => chrome.classList.remove('-lock')}
       >
         <div className="modal" role="presentation" ref={node => this.node = node} onClick={this.handleOverlayClick}>
           <div className="modal__container">

--- a/resources/assets/components/Modal/Modal.js
+++ b/resources/assets/components/Modal/Modal.js
@@ -1,6 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import Portal from 'react-portal';
+
+import { toggleChromeLock } from '../../helpers';
 import './modal.scss';
 
 class Modal extends React.Component {
@@ -39,7 +41,12 @@ class Modal extends React.Component {
     const { shouldShowModal, children } = this.props;
 
     return (
-      <Portal closeOnEsc isOpened={shouldShowModal}>
+      <Portal
+        closeOnEsc
+        isOpened={shouldShowModal}
+        onOpen={() => toggleChromeLock(true)}
+        onClose={toggleChromeLock}
+      >
         <div className="modal" role="presentation" ref={node => this.node = node} onClick={this.handleOverlayClick}>
           <div className="modal__container">
             { children }

--- a/resources/assets/components/Modal/configurations/ContentModal.js
+++ b/resources/assets/components/Modal/configurations/ContentModal.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import Card from '../../Card';
 import Markdown from '../../Markdown';
+import NotFound from '../../NotFound';
 import { CampaignUpdateContainer } from '../../CampaignUpdate';
 
 const ContentModal = (props) => {
@@ -15,7 +16,12 @@ const ContentModal = (props) => {
 
   const card = (
     <Card title={title} className="modal__slide">
-      <Markdown className="padded">{ content }</Markdown>
+      {
+        content ?
+          <Markdown className="padded">{ content }</Markdown>
+          :
+          <NotFound />
+      }
     </Card>
   );
 

--- a/resources/assets/helpers/index.js
+++ b/resources/assets/helpers/index.js
@@ -373,10 +373,11 @@ export function showTwitterSharePrompt(href, quote) {
 /**
  * Toggle the lock on the app chrome.
  */
-export function toggleChromeLock() {
-  document.getElementById('chrome').classList.toggle('-lock');
-}
+export function toggleChromeLock(lock) {
+  const classList = document.getElementById('chrome').classList;
 
+  return lock ? classList.add('-lock') : classList.remove('-lock');
+}
 
 /**
  * Construct URL with query params

--- a/resources/assets/helpers/index.js
+++ b/resources/assets/helpers/index.js
@@ -373,10 +373,10 @@ export function showTwitterSharePrompt(href, quote) {
 /**
  * Toggle the lock on the app chrome.
  */
-export function toggleChromeLock(lock) {
+export function toggleChromeLock(shouldLock) {
   const classList = document.getElementById('chrome').classList;
 
-  return lock ? classList.add('-lock') : classList.remove('-lock');
+  return shouldLock ? classList.add('-lock') : classList.remove('-lock');
 }
 
 /**

--- a/resources/assets/helpers/index.js
+++ b/resources/assets/helpers/index.js
@@ -371,15 +371,6 @@ export function showTwitterSharePrompt(href, quote) {
 }
 
 /**
- * Toggle the lock on the app chrome.
- */
-export function toggleChromeLock(shouldLock) {
-  const classList = document.getElementById('chrome').classList;
-
-  return shouldLock ? classList.add('-lock') : classList.remove('-lock');
-}
-
-/**
  * Construct URL with query params
  *
  * @param {String} url


### PR DESCRIPTION
### What does this PR do?

- adding a `lock` param to the `toggleChromeLock` helper method, to be able to specify locking/unlocking chrome.
- returning `NotFound` component in a `Card` from the `ContentModal` when no content exists (e.g. faulty contentful ID)


### Any background context you want to provide?
The bug is addressed in the [Pivotal Card](https://www.pivotaltracker.com/story/show/154087267). Essentially what's happening is that the - linked to - modal is attempting to load - it locks the screen and messes with the toggle setup for the affirmation modal which actually loads, but then locks the screen again when you dismiss it. So this adds a specification param so you can manually toggle adding or removing the chrome lock.

The other this addresses bad modal links such as an invalid contentful ID, where previously this would silently error out, and thus in this unaffiliated user scenario - post signup they wouldn't get to see the affirmation.


### What are the relevant tickets/cards?
[#154087267](https://www.pivotaltracker.com/story/show/154087267)
