### PR TITLE
Action step coloring Proposition

### DIFF
--- a/resources/assets/components/ActionPage/templates/MosaicStepHeaderTemplate.js
+++ b/resources/assets/components/ActionPage/templates/MosaicStepHeaderTemplate.js
@@ -3,14 +3,14 @@ import PropTypes from 'prop-types';
 import { FlexCell } from '../../Flex';
 
 import { convertNumberToWord } from '../../../helpers';
-import PhotoHeader from '../../PhotoHeader';
+import { PhotoHeaderContainer } from '../../PhotoHeader';
 
 const MosaicStepHeaderTemplate = ({ title, step, background, hideStepNumber }) => (
   <FlexCell width="full">
-    <PhotoHeader className="action-step__header" backgroundImage={background}>
+    <PhotoHeaderContainer className="action-step__header" backgroundImage={background}>
       { hideStepNumber ? null : <span>step { convertNumberToWord(step) }</span> }
       <h1>{ title }</h1>
-    </PhotoHeader>
+    </PhotoHeaderContainer>
   </FlexCell>
 );
 

--- a/resources/assets/components/PhotoHeader/PhotoHeader.js
+++ b/resources/assets/components/PhotoHeader/PhotoHeader.js
@@ -13,9 +13,9 @@ const renderBackgroundImage = backgroundImage => (
     null
 );
 
-const PhotoHeader = ({ children, className, backgroundImage }) => (
+const PhotoHeader = ({ children, className, backgroundImage, themeColor }) => (
   <div
-    className={classnames('photo-header padding-lg', className)}
+    className={classnames('photo-header padding-lg', className, themeColor)}
   >
     { renderBackgroundImage(backgroundImage) }
     { children }
@@ -26,11 +26,13 @@ PhotoHeader.propTypes = {
   backgroundImage: PropTypes.string,
   children: PropTypes.node.isRequired,
   className: PropTypes.string,
+  themeColor: PropTypes.string,
 };
 
 PhotoHeader.defaultProps = {
   backgroundImage: '',
   className: '',
+  themeColor: null,
 };
 
 export default PhotoHeader;

--- a/resources/assets/components/PhotoHeader/PhotoHeaderContainer.js
+++ b/resources/assets/components/PhotoHeader/PhotoHeaderContainer.js
@@ -1,0 +1,16 @@
+import { get } from 'lodash';
+import { connect } from 'react-redux';
+
+import PhotoHeader from './PhotoHeader';
+
+/**
+ * Provide state from the Redux store as props for this component.
+ */
+const mapStateToProps = state => ({
+  themeColor: get(state.campaign.additionalContent, 'themeColor'),
+});
+
+/**
+ * Export the container component.
+ */
+export default connect(mapStateToProps)(PhotoHeader);

--- a/resources/assets/components/PhotoHeader/index.js
+++ b/resources/assets/components/PhotoHeader/index.js
@@ -1,1 +1,4 @@
+export PhotoHeader from './PhotoHeader';
+export PhotoHeaderContainer from './PhotoHeaderContainer';
+
 export default from './PhotoHeader';

--- a/resources/assets/components/PhotoHeader/photo-header.scss
+++ b/resources/assets/components/PhotoHeader/photo-header.scss
@@ -6,6 +6,10 @@
   text-align: center;
   text-transform: uppercase;
   width: 100%;
+
+  &.purple {
+    background-color: $purple
+  }
 }
 
 .photo-header__background-image {

--- a/resources/assets/components/Quiz/Question.js
+++ b/resources/assets/components/Quiz/Question.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import Answer from './Answer';
-import PhotoHeader from '../PhotoHeader';
+import { PhotoHeader } from '../PhotoHeader';
 
 const isActive = (answer, activeAnswer) => answer.id === activeAnswer;
 const shouldFade = (answer, activeAnswer) => (


### PR DESCRIPTION
### What does this PR do?

Here's my proposal for this Action Step Color testing business:

We have a general campaign setting for the 'theme color' (for now this is just in additionalContent), the PhotoHeader component can check the state for this color, and add it to its class list.
If a proper color is set, the CSS will override the default `background-color` with the specified one. This will also be the new grayscale for any images added to stepheaders

`test-teens-for-jeans` (purple)
![image](https://user-images.githubusercontent.com/12417657/34622762-661d39b4-f21c-11e7-90dc-b8945d9373fc.png)

`grab-mic` (purple)
![image](https://user-images.githubusercontent.com/12417657/34622812-a14ccbc6-f21c-11e7-80a4-337291aa9122.png)




### Any background context you want to provide?
If y'all think this is a good way to go, and we decide to indeed test this, we can then move this to a `PhotoHeaderAlt` apply a sixpack test between that and the usual one. (And add whichever colors we so desire to the suite)


### What are the relevant tickets/cards?
[#154013236](https://www.pivotaltracker.com/story/show/154013236)

