### PR TITLE
Campaigns show endpoint

### DIFF
--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -8,8 +8,8 @@ use Illuminate\Auth\AuthenticationException;
 use Illuminate\Validation\ValidationException;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Symfony\Component\HttpKernel\Exception\HttpException;
-use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Illuminate\Foundation\Exceptions\Handler as ExceptionHandler;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 class Handler extends ExceptionHandler
 {

--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -3,10 +3,13 @@
 namespace App\Exceptions;
 
 use Exception;
+use Contentful\Exception\NotFoundException;
 use Illuminate\Auth\AuthenticationException;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Foundation\Exceptions\Handler as ExceptionHandler;
 use Illuminate\Validation\ValidationException;
 use Symfony\Component\HttpKernel\Exception\HttpException;
-use Illuminate\Foundation\Exceptions\Handler as ExceptionHandler;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 class Handler extends ExceptionHandler
 {
@@ -48,6 +51,11 @@ class Handler extends ExceptionHandler
      */
     public function render($request, Exception $exception)
     {
+        // Re-cast to more appropriate exception.
+        if ($exception instanceof ModelNotFoundException || $exception instanceof NotFoundException) {
+            $exception = new NotFoundHttpException('That resource could not be found.');
+        }
+
         if ($request->ajax() || $request->wantsJson()) {
             return $this->buildJsonResponse($request, $exception);
         }

--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -5,11 +5,11 @@ namespace App\Exceptions;
 use Exception;
 use Contentful\Exception\NotFoundException;
 use Illuminate\Auth\AuthenticationException;
-use Illuminate\Database\Eloquent\ModelNotFoundException;
-use Illuminate\Foundation\Exceptions\Handler as ExceptionHandler;
 use Illuminate\Validation\ValidationException;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Illuminate\Foundation\Exceptions\Handler as ExceptionHandler;
 
 class Handler extends ExceptionHandler
 {

--- a/app/Http/Controllers/Api/CampaignsController.php
+++ b/app/Http/Controllers/Api/CampaignsController.php
@@ -3,9 +3,27 @@
 namespace App\Http\Controllers\Api;
 
 use App\Http\Controllers\Controller;
+use App\Repositories\CampaignRepository;
 
 class CampaignsController extends Controller
 {
+    /**
+     * The campaign repository.
+     *
+     * @var CampaignRepository
+     */
+    private $campaignRepository;
+
+    /**
+     * Create a new CampaignController instance.
+     *
+     * @param CampaignRepository $campaignRepository
+     */
+    public function __construct(CampaignRepository $campaignRepository)
+    {
+        $this->campaignRepository = $campaignRepository;
+    }
+
     /**
      * Display a listing of the resource.
      *
@@ -15,5 +33,22 @@ class CampaignsController extends Controller
     {
         // @TODO 501 Not Implemented for now.
         abort(501);
+    }
+
+    /**
+     * Display the specified resource.
+     *
+     * @param  string $id - Contentful ID or Ashes ID
+     * @return \Illuminate\Http\JsonResponse
+     */
+    public function show($id)
+    {
+        if (is_legacy_id($id)) {
+            $data = $this->campaignRepository->findByLegacyCampaignId($id);
+        } else {
+            $data = $this->campaignRepository->getCampaign($id);
+        }
+
+        return response()->json($data);
     }
 }

--- a/app/Repositories/CampaignRepository.php
+++ b/app/Repositories/CampaignRepository.php
@@ -10,14 +10,21 @@ use Illuminate\Database\Eloquent\ModelNotFoundException;
 
 class CampaignRepository
 {
+    /**
+     * Contentful client instance.
+     */
     private $contentful;
 
+    /**
+     * PhoenixLegacy service instance.
+     */
     private $phoenixLegacy;
 
     /**
      * CampaignRepository constructor.
      *
      * @param Contentful $contentful
+     * @param PhoenixLegacy $phoenixLegacy
      */
     public function __construct(Contentful $contentful, PhoenixLegacy $phoenixLegacy)
     {

--- a/app/Repositories/CampaignRepository.php
+++ b/app/Repositories/CampaignRepository.php
@@ -3,20 +3,27 @@
 namespace App\Repositories;
 
 use App\Entities\Campaign;
-use Contentful\Delivery\Query;
 use Contentful\Delivery\Client as Contentful;
+use Contentful\Delivery\Query;
+use App\Services\PhoenixLegacy;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 
 class CampaignRepository
 {
+    private $contentful;
+
+    private $phoenixLegacy;
+
     /**
      * CampaignRepository constructor.
      *
      * @param Contentful $contentful
      */
-    public function __construct(Contentful $contentful)
+    public function __construct(Contentful $contentful, PhoenixLegacy $phoenixLegacy)
     {
-        $this->client = $contentful;
+        $this->contentful = $contentful;
+
+        $this->phoenixLegacy = $phoenixLegacy;
     }
 
     /**
@@ -28,12 +35,56 @@ class CampaignRepository
     {
         $query = (new Query)->setContentType('campaign');
 
-        $campaigns = $this->makeRequest($query);
+        $campaigns = $this->contentful->getEntries($query);
         $array = iterator_to_array($campaigns);
 
         return collect($array)->map(function ($entity) {
             return new Campaign($entity);
         });
+    }
+
+    /**
+     * Get specified Campaign resource.
+     *
+     * @param  string $id
+     * @return stdClass
+     */
+    public function getCampaign($id)
+    {
+        $campaign = $this->contentful->getEntry($id);
+
+        return new Campaign($campaign);
+    }
+
+    /**
+     * Find a campaign by its legacy ID.
+     *
+     * @param  string $id
+     * @return stdCalss
+     */
+    public function findByLegacyCampaignId($id)
+    {
+        // @TODO let's ignore any caching for now, and eventually provide a solution that
+        // can apply to more methods than just the findBySlug() used for the web app.
+        $query = (new Query)
+            ->setContentType('campaign')
+            ->where('fields.legacyCampaignId', $id)
+            ->setInclude(3)
+            ->setLimit(1);
+
+        $campaigns = $this->contentful->getEntries($query);
+
+        if (! $campaigns->count()) {
+            $legacyCampaign = $this->phoenixLegacy->getCampaign($id);
+
+            if (! $legacyCampaign) {
+                throw new ModelNotFoundException;
+            }
+
+            return $legacyCampaign['data'];
+        }
+
+        return new Campaign($campaigns[0]);
     }
 
     /**
@@ -54,7 +105,7 @@ class CampaignRepository
                 ->setInclude(3)
                 ->setLimit(1);
 
-            $campaigns = $this->makeRequest($query);
+            $campaigns = $this->contentful->getEntries($query);
 
             if (! $campaigns->count()) {
                 return 'not_found';
@@ -72,18 +123,5 @@ class CampaignRepository
         }
 
         return json_decode($flattenedCampaign);
-    }
-
-    /**
-     * Make a request to Contentful's Delivery API.
-     *
-     * @param $query
-     * @return \Contentful\ResourceArray
-     */
-    public function makeRequest($query)
-    {
-        $campaigns = $this->client->getEntries($query);
-
-        return $campaigns;
     }
 }

--- a/app/Repositories/CampaignRepository.php
+++ b/app/Repositories/CampaignRepository.php
@@ -3,9 +3,9 @@
 namespace App\Repositories;
 
 use App\Entities\Campaign;
-use Contentful\Delivery\Client as Contentful;
 use Contentful\Delivery\Query;
 use App\Services\PhoenixLegacy;
+use Contentful\Delivery\Client as Contentful;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 
 class CampaignRepository

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -16,7 +16,7 @@ use SeatGeek\Sixpack\Session\Base as Sixpack;
  * Determine if the supplied ID is likely a legacy campaign ID.
  *
  * @param  string $id
- * @return boolean
+ * @return bool
  */
 function is_legacy_id($id)
 {

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -13,10 +13,21 @@ use SeatGeek\Sixpack\Session\Base as Sixpack;
  */
 
 /**
+ * Determine if the supplied ID is likely a legacy campaign ID.
+ *
+ * @param  string $id
+ * @return boolean
+ */
+function is_legacy_id($id)
+{
+    return is_numeric($id);
+}
+
+/**
  * Create a script tag to set a global variable.
  *
- * @param $json
- * @param string $store
+ * @param  $json
+ * @param  string $store
  * @return HtmlString
  */
 function scriptify($json = [], $store = 'STATE')

--- a/docs/endpoints/v1/campaigns.md
+++ b/docs/endpoints/v1/campaigns.md
@@ -15,6 +15,8 @@ https://next.dosomething.org/api/v1/campaigns/6LQzMvDNQcYQYwso8qSkQ8
 
 Example Response:
 
+_Note:_ If supplied Legacy ID returns a campaign from Ashes, then the format below does not apply. Please refer to the [Ashes Retrieve a campaign endpoint response example](https://github.com/DoSomething/phoenix/blob/dev/documentation/endpoints/campaigns.md#retrieve-a-campaign). This is only temporary!
+
 ```
 {
     "id": "6LQzMvDNQcYQYwso8qSkQ8",

--- a/docs/endpoints/v1/campaigns.md
+++ b/docs/endpoints/v1/campaigns.md
@@ -1,5 +1,69 @@
 # Campaigns (v1)
 
+## Retrieve a Campaign
+```
+GET /api/v1/campaigns/{id}
+```
+
+The `id` can be either a Contentful ID or an Ashes Legacy ID.
+
+Example Request:
+
+```
+https://next.dosomething.org/api/v1/campaigns/6LQzMvDNQcYQYwso8qSkQ8
+```
+
+Example Response:
+
+```
+{
+    "id": "6LQzMvDNQcYQYwso8qSkQ8",
+    "legacyCampaignId": "1144",
+    "legacyCampaignRunId": "7430",
+    "type": "campaign",
+    "template": "mosaic",
+    "title": "[Test] Teens for Jeans",
+    "slug": "test-teens-for-jeans",
+    "endDate": {
+        "date": "2018-02-15 12:00:00.000000",
+        "timezone_type": 1,
+        "timezone": "-06:00"
+    },
+    "callToAction": "Let's collect another million jeans TOGETHER.",
+    "tagline": "Let's collect another million jeans TOGETHER.",
+    "blurb": "",
+    "coverImage": {
+        "description": null,
+        "url": "https://images.contentful.com/81iqaqpfd8fy/4k8rv5sN0kii0AoCawc6UQ/c22c3c132d1bb43055b6bafc248fcea5/vn7gpbosm9rx.jpg",
+        "landscapeUrl": "https://images.contentful.com/81iqaqpfd8fy/4k8rv5sN0kii0AoCawc6UQ/c22c3c132d1bb43055b6bafc248fcea5/vn7gpbosm9rx.jpg?w=1440&h=620&fm=jpg&fit=fill"
+    },
+    "campaignLead": {
+        "id": "4V3gy8KPBK4gAWuMGSKWuA",
+        "type": "staff",
+        "fields": {
+            "name": "Adam Garner",
+            "jobTitle": "Campaign Lead",
+            "avatar": "https://images.contentful.com/81iqaqpfd8fy/5dN0SxEQrYeI8eKwOAOwia/179e972eae699c6377faa74d611a50a2/Adam_Garner_Headshot.png?w=600&h=600&fm=jpg&fit=fill",
+            "email": "adam@dosomething.org"
+        }
+    },
+    "affiliateSponsors": [],
+    "affiliatePartners": [],
+    "activityFeed": [],
+    "actionSteps": [],
+    "quizzes": [],
+    "dashboard": null,
+    "affirmation": null,
+    "pages": [],
+    "landingPage": null,
+    "socialOverride": null,
+    "additionalContent": null,
+    "allowExperiments": true,
+    "actionText": "Join Us"
+}
+```
+
+
 ## Retrieve All Posts for a Campaign
 ```
 GET /api/v1/campaigns/{id}/posts

--- a/routes/api.php
+++ b/routes/api.php
@@ -18,6 +18,7 @@ $router->group(['prefix' => 'v1'], function () {
 
     // Campaigns
     $this->get('/campaigns', 'Api\CampaignsController@index');
+    $this->get('/campaigns/{id}', 'Api\CampaignsController@show');
 
     // Campaign Posts
     $this->get('/campaigns/{id}/posts', 'Api\CampaignPostsController@index');

--- a/tests/units/HelpersTest.php
+++ b/tests/units/HelpersTest.php
@@ -3,6 +3,18 @@
 class HelpersTest extends TestCase
 {
     /** @test */
+    public function can_check_if_legacy_id()
+    {
+        $legacyId = '1144';
+        $contentfulId = '6LQzMvDNQcYQYwso8qSkQ8';
+        $randomString = 'some-random-string';
+
+        $this->assertTrue(is_legacy_id($legacyId));
+        $this->assertFalse(is_legacy_id($contentfulId));
+        $this->assertFalse(is_legacy_id($randomString));
+    }
+
+    /** @test */
     public function can_get_a_campaign_cover_image_url()
     {
         $this->markTestIncomplete(


### PR DESCRIPTION
### What does this PR do?
This PR begins exposing Campaign data via a `/campaigns` endpoint in Pheonix (next). It allows passing either a Contentful ID or a Legacy ID, and will do the appropriate logic for looking up the Campaign and trying to find it.


### Any background context you want to provide?
I removed the `makeRequest()` method from the `CampaignRepository` since it was only applying as an alias for the `$this->contentful->getEntries()` and now that we also use the singular version of the `getEntry()` method, it seemed useless to have the alias.

**Adding update to docs for new endpoint and a couple tests in an upcoming commit.**

_Important Note_: Currently, if passing a Legacy ID and the campaign is not found on Contentful but found on Ashes, the returned data is NOT transformed to be in a similar structure as when a campaign is found on Contentful. The data structure of the JSON is different. I will be considering approaches to potentially transform it, to better match how we structure the JSON data from Contentful for the front-end so the responses from the endpoint are always the same, expected structure.

### What are the relevant tickets/cards?
Fixes https://www.pivotaltracker.com/story/show/154098523

### Checklist
- [x] Documentation added for new features/changed endpoints.
- [x] Added appropriate feature/unit tests.

  
  