### PR TITLE
Adding the sponsor to the lede banner

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
     "heroku-postbuild": "sh bootstrap/setup.sh"
   },
   "engines": {
-    "node": "6.x",
-    "npm": "4.x"
+    "node": "8.x",
+    "npm": "5.x"
   },
   "babel": {
     "presets": [

--- a/resources/assets/components/CampaignSignupArrow/CampaignSignupArrow.js
+++ b/resources/assets/components/CampaignSignupArrow/CampaignSignupArrow.js
@@ -4,7 +4,7 @@ import React from 'react';
 import './campaignSignupArrow.scss';
 
 const CampaignSignupArrow = ({ content, className }) => (
-  <div className={`message-callout -above -white ${className}`}>
+  <div className={`message-callout -below -white ${className}`}>
     <div className="message-callout__copy">
       <p>{content}</p>
     </div>

--- a/resources/assets/components/CampaignSignupArrow/campaignSignupArrow.scss
+++ b/resources/assets/components/CampaignSignupArrow/campaignSignupArrow.scss
@@ -1,4 +1,3 @@
-@import '~@dosomething/forge/scss/toolkit';
 @import '../../scss/next-toolbox.scss';
 
 .message-callout.-dynamic-right {
@@ -14,6 +13,7 @@
 }
 
 .message-callout.-mosaic-arrow {
+  transform: none;
 
   @include media($larger) {
     width: 45%;
@@ -34,20 +34,13 @@
       padding-left: $base-spacing * 2;
     }
 
-    margin-bottom: $half-spacing;
-
     @include media($small) {
-      margin-bottom: $base-spacing;
       margin-left: - $base-spacing * 2;
     }
   }
 
   .message-callout__copy::before {
     @include media($larger) {
-      transform: none;
-    }
-
-    @include media($medium) {
       background: url("~@dosomething/forge/assets/images/callout/arrow-left-white.png") 50% 50% / 35px no-repeat transparent !important;
       height: 19px;
       left: 0;
@@ -55,8 +48,6 @@
       right: auto;
       top: 50%;
       width: 38px;
-
-      transform: rotate(270deg);
     }
 
     @include media($small) {

--- a/resources/assets/components/LedeBanner/lede-banner.scss
+++ b/resources/assets/components/LedeBanner/lede-banner.scss
@@ -16,13 +16,17 @@
     width: 100%;
     height: 70px;
 
-    @include media($medium) {
+    @include media($large) {
       width: 50%;
     }
   }
 
   .header__signup {
     padding-top: $base-spacing;
+
+    .button {
+      float: left;
+    }
   }
 }
 
@@ -97,5 +101,15 @@
 
   strong {
     color: $primary-color;
+  }
+}
+
+.lede-banner__arrow {
+  clear: both;
+  margin-top: $half-spacing;
+
+  @include media($larger) {
+    clear: none;
+    margin-top: 0;
   }
 }

--- a/resources/assets/components/LedeBanner/lede-banner.scss
+++ b/resources/assets/components/LedeBanner/lede-banner.scss
@@ -24,7 +24,7 @@
   .header__signup {
     padding-top: $base-spacing;
 
-    .button {
+    .button.-float {
       float: left;
     }
   }

--- a/resources/assets/components/LedeBanner/lede-banner.scss
+++ b/resources/assets/components/LedeBanner/lede-banner.scss
@@ -112,4 +112,14 @@
     clear: none;
     margin-top: 0;
   }
+
+  .message-callout.-white .message-callout__copy p {
+    font-size: 24px;
+  }
+}
+
+.lede-banner__sponsor {
+  .promotion .__copy, .promotion .__image {
+    max-width: 100%;
+  }
 }

--- a/resources/assets/components/LedeBanner/lede-banner.scss
+++ b/resources/assets/components/LedeBanner/lede-banner.scss
@@ -104,7 +104,7 @@
   }
 }
 
-.lede-banner__arrow {
+.message-callout{
   clear: both;
   margin-top: $half-spacing;
 

--- a/resources/assets/components/LedeBanner/templates/MosaicTemplate.js
+++ b/resources/assets/components/LedeBanner/templates/MosaicTemplate.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import classnames from 'classnames';
 
 import Markdown from '../../Markdown';
 import AffiliateOptionContainer from '../../AffiliateOption';
@@ -42,9 +43,14 @@ const MosaicTemplate = (props) => {
     </div>
   ) : null;
 
+  const buttonClassname = classnames('button', { '-float': sponsor });
+
   const SignupButton = SignupButtonFactory(({ clickedSignUp }) => (
     <div className="header__signup">
-      <button className="button" onClick={() => clickedSignUp(legacyCampaignId)}>{ actionText }</button>
+      <button
+        className={buttonClassname}
+        onClick={() => clickedSignUp(legacyCampaignId)}
+      >{ actionText }</button>
       { signupArrowComponent }
       { showPartnerMsgOptIn ? <AffiliateOptionContainer /> : null }
       { sponsorComponent }

--- a/resources/assets/components/LedeBanner/templates/MosaicTemplate.js
+++ b/resources/assets/components/LedeBanner/templates/MosaicTemplate.js
@@ -6,10 +6,12 @@ import AffiliateOptionContainer from '../../AffiliateOption';
 import SignupButtonFactory from '../../SignupButton';
 import { contentfulImageUrl } from '../../../helpers';
 import CampaignSignupArrow from '../../CampaignSignupArrow';
+import SponsorPromotion from '../../SponsorPromotion';
 
 const MosaicTemplate = (props) => {
   const {
     actionText,
+    affiliateSponsors,
     title,
     subtitle,
     blurb,
@@ -25,14 +27,27 @@ const MosaicTemplate = (props) => {
   };
 
   const signupArrowComponent = signupArrowContent ? (
-    <CampaignSignupArrow content={signupArrowContent} className="-mosaic-arrow" />
+    <div className="lede-banner__arrow">
+      <CampaignSignupArrow content={signupArrowContent} className="-mosaic-arrow" />
+    </div>
+  ) : null;
+
+  const sponsor = affiliateSponsors[0];
+  const sponsorComponent = sponsor ? (
+    <div className="padding-top-lg clear-both">
+      <SponsorPromotion
+        imgUrl={sponsor.fields.logo.url}
+        title={sponsor.fields.logo.title}
+      />
+    </div>
   ) : null;
 
   const SignupButton = SignupButtonFactory(({ clickedSignUp }) => (
     <div className="header__signup">
-      { signupArrowComponent }
       <button className="button" onClick={() => clickedSignUp(legacyCampaignId)}>{ actionText }</button>
+      { signupArrowComponent }
       { showPartnerMsgOptIn ? <AffiliateOptionContainer /> : null }
+      { sponsorComponent }
     </div>
   ), 'lede banner', { text: actionText });
 
@@ -57,6 +72,7 @@ const MosaicTemplate = (props) => {
 
 MosaicTemplate.propTypes = {
   actionText: PropTypes.string.isRequired,
+  affiliateSponsors: PropTypes.arrayOf(PropTypes.object).isRequired,
   blurb: PropTypes.string,
   coverImage: PropTypes.shape({
     description: PropTypes.string,

--- a/resources/assets/components/LedeBanner/templates/MosaicTemplate.js
+++ b/resources/assets/components/LedeBanner/templates/MosaicTemplate.js
@@ -28,9 +28,7 @@ const MosaicTemplate = (props) => {
   };
 
   const signupArrowComponent = signupArrowContent ? (
-    <div className="lede-banner__arrow">
-      <CampaignSignupArrow content={signupArrowContent} className="-mosaic-arrow" />
-    </div>
+    <CampaignSignupArrow content={signupArrowContent} className="lede-banner__arrow -mosaic-arrow" />
   ) : null;
 
   const sponsor = affiliateSponsors[0];

--- a/resources/assets/components/LedeBanner/templates/MosaicTemplate.js
+++ b/resources/assets/components/LedeBanner/templates/MosaicTemplate.js
@@ -28,7 +28,7 @@ const MosaicTemplate = (props) => {
   };
 
   const signupArrowComponent = signupArrowContent ? (
-    <CampaignSignupArrow content={signupArrowContent} className="lede-banner__arrow -mosaic-arrow" />
+    <CampaignSignupArrow content={signupArrowContent} className="-mosaic-arrow" />
   ) : null;
 
   const sponsor = affiliateSponsors[0];

--- a/resources/assets/components/LedeBanner/templates/MosaicTemplate.js
+++ b/resources/assets/components/LedeBanner/templates/MosaicTemplate.js
@@ -34,7 +34,7 @@ const MosaicTemplate = (props) => {
 
   const sponsor = affiliateSponsors[0];
   const sponsorComponent = sponsor ? (
-    <div className="padding-top-lg clear-both">
+    <div className="lede-banner__sponsor padding-top-lg clear-both">
       <SponsorPromotion
         imgUrl={sponsor.fields.logo.url}
         title={sponsor.fields.logo.title}

--- a/resources/assets/scss/base.scss
+++ b/resources/assets/scss/base.scss
@@ -181,6 +181,10 @@ h1, h2, h3, p {
   padding-bottom: $base-spacing;
 }
 
+.padding-top-lg {
+  padding-top: $base-spacing;
+}
+
 .margin-md {
   margin: $half-spacing;
 }


### PR DESCRIPTION
### What does this PR do?
- Adding the sponsor to the lede banner
- Shifting the arrow logic around a bit. In the next PR we can deal with the right angle arrow.

#### Large
<img width="1460" alt="screen shot 2018-01-08 at 1 54 26 pm" src="https://user-images.githubusercontent.com/897368/34687155-e6ad47ca-f47b-11e7-8fbf-2270ff2c31b3.png">

#### Medium
[see updated photo in comment](https://github.com/DoSomething/phoenix-next/pull/593#discussion_r160721634)

#### Small
<img width="470" alt="screen shot 2018-01-08 at 1 53 58 pm" src="https://user-images.githubusercontent.com/897368/34687157-e6c8c680-f47b-11e7-8409-8d1a500b44e0.png">

### What are the relevant tickets/cards?
https://www.pivotaltracker.com/story/show/154037769
