### PR TITLE
raising the font-size for markdown blockquotes

### DIFF
--- a/resources/assets/components/Markdown/markdown.scss
+++ b/resources/assets/components/Markdown/markdown.scss
@@ -36,6 +36,10 @@
     display: block;
   }
 
+  blockquote p {
+    font-size: $font-medium;
+  }
+
   pre, blockquote {
     position: relative;
     margin: $base-spacing 0;


### PR DESCRIPTION
### What does this PR do?

Bumps the size of `<p/>`s in a markdown blockquote rendered through the `Markdown` component.

The `markdown-it` package seems to bump the size by `3.5px` (I'm not sure where they set that, I kinda deduced it from their [live demo](https://markdown-it.github.io/)), and `$font-medium` (`22.5px`) gives us a -close to the same- increase (over our regular font size of `18px`).

### What are the relevant tickets/cards?
[#154100030](https://www.pivotaltracker.com/story/show/154100030)

Before:
![image](https://user-images.githubusercontent.com/12417657/34744795-6650a46e-f55c-11e7-8065-58bc783324d9.png)

After:
![image](https://user-images.githubusercontent.com/12417657/34744813-757af2d2-f55c-11e7-8bff-bb0215fe0346.png)


