### PR TITLE
Moving sponsor out of the signup button component

### DIFF
--- a/resources/assets/components/LedeBanner/templates/MosaicTemplate.js
+++ b/resources/assets/components/LedeBanner/templates/MosaicTemplate.js
@@ -51,7 +51,6 @@ const MosaicTemplate = (props) => {
       >{ actionText }</button>
       { signupArrowComponent }
       { showPartnerMsgOptIn ? <AffiliateOptionContainer /> : null }
-      { sponsorComponent }
     </div>
   ), 'lede banner', { text: actionText });
 
@@ -68,6 +67,7 @@ const MosaicTemplate = (props) => {
           { blurb ? <Markdown className="lede-banner__blurb">{blurb}</Markdown> : null }
 
           { isAffiliated ? null : <SignupButton /> }
+          { sponsorComponent }
         </div>
       </div>
     </header>


### PR DESCRIPTION
### What does this PR do?
The sponsor logo should always appear, regardless of affiliation state.

<img width="1443" alt="screen shot 2018-01-12 at 10 12 20 am" src="https://user-images.githubusercontent.com/897368/34881284-26ba7f56-f781-11e7-8562-3380b1867cbd.png">
<img width="874" alt="screen shot 2018-01-12 at 10 12 14 am" src="https://user-images.githubusercontent.com/897368/34881285-26c5811c-f781-11e7-8a93-2420c66a1704.png">
<img width="463" alt="screen shot 2018-01-12 at 10 12 05 am" src="https://user-images.githubusercontent.com/897368/34881286-26ced3fc-f781-11e7-82a2-7735b760627e.png">