### PR TITLE
Update to resolve rate-limit issue.

### DIFF
--- a/app/Repositories/CampaignRepository.php
+++ b/app/Repositories/CampaignRepository.php
@@ -58,9 +58,15 @@ class CampaignRepository
      */
     public function getCampaign($id)
     {
-        $campaign = $this->contentful->getEntry($id);
+        $query = (new Query)
+            ->setContentType('campaign')
+            ->where('sys.id', $id)
+            ->setInclude(3)
+            ->setLimit(1);
 
-        return new Campaign($campaign);
+        $campaigns = $this->contentful->getEntries($query);
+
+        return new Campaign($campaigns[0]);
     }
 
     /**


### PR DESCRIPTION
### What does this PR do?
This PR switches to use the Query object, which is not ideal, but getting rate-limited is even less ideal... see below.


### Any background context you want to provide?
When testing the `/api/v2/campaigns/:contentfulId` endpoint to see how things were on Phoenix Preview (AKA: Next Thor), this endpoint kept erroring out due to exceeding the rate limit:

> You have exceeded the rate limit of the Organization this Space belongs to by making too many API requests within a short timespan. Please wait a moment before trying the request again.

This was strange given that `/api/v2/campaigns/:legacyId` kept working just fine and would also be hitting Contentful to find a campaign, except finding it by the field `legacyCampaignId`.

Turns out, when using the `getEntry($id)` method on Contentful's Delivery Client it only grabs the top level content. Then when we pass it to `new Campaign()` to eventually return a JSON response of the campaign, it digs into all the entries and makes calls to grab those but that led to the rate-limit being exceeded 😱 

When we try to find a campaign via the `legacyCampaignId`, we actually use a `where` clause to build out a `Query` object and within that tell it to include at least 3 levels of entries on the initial call and send that to the Delivery Client, etc.


### Checklist
- [ ] Added appropriate feature/unit tests.

