### PR TITLE
Initial progress on using TDD to drive out PN to Rogue API posting.

### DIFF
--- a/app/Http/Controllers/Api/CampaignPostsController.php
+++ b/app/Http/Controllers/Api/CampaignPostsController.php
@@ -47,9 +47,15 @@ class CampaignPostsController extends Controller
      * @param  string $id
      * @return \Illuminate\Http\JsonResponse
      */
-    public function store($id)
+    public function store($campaignId)
     {
-        // @TODO 501 Not Implemented for now.
-        abort(501);
+        $this->validate(request(), [
+            'media' => 'required',  //@TODO: add file|image
+            'caption' => 'required|min:4|max:60',
+            'impact' => 'required|integer|min:1',
+            'whyParticipated' => 'required',
+        ]);
+
+        return response()->json([], 201);
     }
 }

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -42,6 +42,7 @@ function array_random($array, $number = null)
     foreach ((array) $keys as $key) {
         $results[] = $array[$key];
     }
+
     return $results;
 }
 

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -13,6 +13,39 @@ use SeatGeek\Sixpack\Session\Base as Sixpack;
  */
 
 /**
+ * Get one or a specified number of random values from an array.
+ * @TODO: remove after upgrading Phoenix to Laravel 5.4.
+ *
+ * @param  array  $array
+ * @param  int|null  $number
+ * @return mixed
+ *
+ * @throws \InvalidArgumentException
+ */
+function array_random($array, $number = null)
+{
+    $requested = is_null($number) ? 1 : $number;
+    $count = count($array);
+    if ($requested > $count) {
+        throw new InvalidArgumentException(
+            "You requested {$requested} items, but there are only {$count} items available."
+        );
+    }
+    if (is_null($number)) {
+        return $array[array_rand($array)];
+    }
+    if ((int) $number === 0) {
+        return [];
+    }
+    $keys = array_rand($array, $number);
+    $results = [];
+    foreach ((array) $keys as $key) {
+        $results[] = $array[$key];
+    }
+    return $results;
+}
+
+/**
  * Determine if the supplied ID is likely a legacy campaign ID.
  *
  * @param  string $id

--- a/composer.lock
+++ b/composer.lock
@@ -792,16 +792,16 @@
         },
         {
             "name": "dosomething/gateway",
-            "version": "v1.9.5",
+            "version": "v1.14.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/DoSomething/gateway.git",
-                "reference": "b8463adf406395d9d1fb1bad5e490894f793eba8"
+                "reference": "3126df34d278548b72cb924409419fe60f72be4f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/DoSomething/gateway/zipball/b8463adf406395d9d1fb1bad5e490894f793eba8",
-                "reference": "b8463adf406395d9d1fb1bad5e490894f793eba8",
+                "url": "https://api.github.com/repos/DoSomething/gateway/zipball/3126df34d278548b72cb924409419fe60f72be4f",
+                "reference": "3126df34d278548b72cb924409419fe60f72be4f",
                 "shasum": ""
             },
             "require": {
@@ -811,16 +811,25 @@
                 "lcobucci/jwt": "^3.1",
                 "league/oauth2-client": "~2.2",
                 "nesbot/carbon": "~1.14",
+                "ramsey/uuid": "^3.7",
                 "symfony/psr-http-message-bridge": "^1.0",
                 "zendframework/zend-diactoros": "^1.3"
             },
             "require-dev": {
                 "illuminate/database": "^5.5.0",
                 "illuminate/http": "^5.5.0",
+                "mockery/mockery": "^1.0",
                 "phpunit/phpunit": "^4.8",
                 "symfony/var-dumper": "^3.1"
             },
             "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "DoSomething\\Gateway\\Laravel\\GatewayServiceProvider"
+                    ]
+                }
+            },
             "autoload": {
                 "psr-4": {
                     "DoSomething\\Gateway\\": "src/"
@@ -840,7 +849,7 @@
                 }
             ],
             "description": "Standard PHP API client for DoSomething.org services.",
-            "time": "2017-10-23T20:45:03+00:00"
+            "time": "2018-01-12T16:49:50+00:00"
         },
         {
             "name": "embed/embed",

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,10 +1,14 @@
 <?php
 
+use App\Exceptions\Handler;
 use App\Repositories\CampaignRepository;
+use DoSomething\Gateway\Testing\WithOAuthTokens;
+use Illuminate\Contracts\Debug\ExceptionHandler;
 
 abstract class TestCase extends Illuminate\Foundation\Testing\TestCase
 {
     use DatabaseSetup;
+    use WithOAuthTokens;
 
     /**
      * The base URL to use while testing the application.
@@ -25,6 +29,41 @@ abstract class TestCase extends Illuminate\Foundation\Testing\TestCase
         $app->make(Illuminate\Contracts\Console\Kernel::class)->bootstrap();
 
         return $app;
+    }
+
+    /**
+     * Helper method to assert validation errors based on error response structure.
+     *
+     * @param  string $field
+     */
+    protected function assertValidationError($field)
+    {
+        $this->assertResponseStatus(422);
+
+        $this->assertArrayHasKey($field, $this->decodeResponseJson()['error']['fields']);
+    }
+
+    /**
+     * Disable exception handling in Laravel acceptance tests when need more
+     * verbose error information.
+     * https://gist.github.com/adamwathan/c9752f61102dc056d157
+     *
+     * @return StdClass
+     */
+    protected function disableExceptionHandling()
+    {
+        $this->app->instance(ExceptionHandler::class, new class extends Handler {
+            public function __construct() {}
+
+            public function report(Exception $exception)
+            {
+                // no-op
+            }
+
+            public function render($request, Exception $exception) {
+                throw $exception;
+            }
+        });
     }
 
     /**

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -7,8 +7,7 @@ use Illuminate\Contracts\Debug\ExceptionHandler;
 
 abstract class TestCase extends Illuminate\Foundation\Testing\TestCase
 {
-    use DatabaseSetup;
-    use WithOAuthTokens;
+    use DatabaseSetup, WithOAuthTokens;
 
     /**
      * The base URL to use while testing the application.

--- a/tests/features/StorePhotoReportbackPostTest.php
+++ b/tests/features/StorePhotoReportbackPostTest.php
@@ -1,0 +1,183 @@
+<?php
+
+use Illuminate\Foundation\Testing\DatabaseMigrations;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Foundation\Testing\WithoutMiddleware;
+
+class StorePhotoReportbackPostTest extends TestCase
+{
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->campaignId = 1; // @TODO temp
+    }
+
+    /**
+     * Helper method to make JSON API call to store photo post.
+     *
+     * @param  array $params
+     */
+    private function storePhotoPost($params)
+    {
+        $this->withStandardAccessToken()->json('POST', "/api/v2/campaigns/{$this->campaignId}/posts", $params);
+    }
+
+    /** @test */
+    public function caption_is_required_to_submit_photo_post()
+    {
+        $this->storePhotoPost([
+            'impact' => '30',
+            'media' => 'not-a-file-upload',
+            'whyParticipated' => 'Because testing is very important.',
+        ]);
+
+        $this->assertValidationError('caption');
+    }
+
+    /** @test */
+    public function caption_must_be_4_characters_or_longer_to_submit_photo_post()
+    {
+        $this->storePhotoPost([
+            'caption' => 'duh',
+            'impact' => '30',
+            'media' => 'not-a-file-upload',
+            'whyParticipated' => 'Because testing is very important.',
+        ]);
+
+        $this->assertValidationError('caption');
+    }
+
+    /** @test */
+    public function caption_must_be_60_characters_or_shorter_to_submit_photo_post()
+    {
+        $this->storePhotoPost([
+            'caption' => 'This caption is way longer than 60 characters and thus should fail!',
+            'impact' => '30',
+            'media' => 'not-a-file-upload',
+            'whyParticipated' => 'Because testing is very important.',
+        ]);
+
+        $this->assertValidationError('caption');
+    }
+
+    /** @test */
+    public function impact_is_required_to_submit_photo_post()
+    {
+        $this->storePhotoPost([
+            'caption' => 'Great caption!',
+            'media' => 'not-a-file-upload',
+            'whyParticipated' => 'Because testing is very important.',
+        ]);
+
+        $this->assertValidationError('impact');
+    }
+
+    /** @test */
+    public function impact_must_be_a_valid_integer_to_submit_photo_post()
+    {
+        $this->storePhotoPost([
+            'caption' => 'Great caption!',
+            'impact' => 'not-an-integer',
+            'media' => 'not-a-file-upload',
+            'whyParticipated' => 'Because testing is very important.',
+        ]);
+
+        $this->assertValidationError('impact');
+    }
+
+    /** @test */
+    public function impact_must_be_a_whole_number_to_submit_photo_post()
+    {
+        $this->storePhotoPost([
+            'caption' => 'Great caption!',
+            'impact' => '3.5',
+            'media' => 'not-a-file-upload',
+            'whyParticipated' => 'Because testing is very important.',
+        ]);
+
+        $this->assertValidationError('impact');
+    }
+
+    /** @test */
+    public function impact_must_be_at_least_1_to_submit_photo_post()
+    {
+        $this->storePhotoPost([
+            'caption' => 'Great caption!',
+            'impact' => '0',
+            'media' => 'not-a-file-upload',
+            'whyParticipated' => 'Because testing is very important.',
+        ]);
+
+        $this->assertValidationError('impact');
+    }
+
+    /** @test */
+    public function media_is_required_to_submit_photo_post()
+    {
+        $this->storePhotoPost([
+            'caption' => 'Great caption!',
+            'impact' => '30',
+            'whyParticipated' => 'Because testing is very important.',
+        ]);
+
+        $this->assertValidationError('media');
+    }
+
+    /** @test */
+    public function media_must_be_a_valid_file_upload_to_submit_photo_post()
+    {
+        $this->markTestIncomplete('@TODO: Implement once we upgrade to Laravel 5.4.');
+
+        $this->storePhotoPost([
+            'media' => 'not-a-file-upload',
+        ]);
+
+        $this->assertValidationError('media');
+    }
+
+    /** @test */
+    public function media_must_be_a_valid_image_to_submit_photo_post()
+    {
+        $this->markTestIncomplete('@TODO: Implement once we upgrade to Laravel 5.4.');
+
+        $this->storePhotoPost([
+            'media' => 'not-a-file-upload',
+        ]);
+
+        $this->assertValidationError('media');
+    }
+
+    /** @test */
+    public function why_participated_is_required_to_submit_photo_post()
+    {
+        $this->storePhotoPost([
+            'caption' => 'Great caption!',
+            'impact' => '30',
+            'media' => 'not-a-file-upload',
+        ]);
+
+        $this->assertValidationError('whyParticipated');
+    }
+
+    /** @test */
+    public function registered_user_can_submit_photo_post()
+    {
+        $this->storePhotoPost([
+            'caption' => 'Great caption!',
+            'impact' => '30',
+            'media' => 'not-a-file-upload',
+            'whyParticipated' => 'Because testing is very important.',
+        ]);
+
+        $this->assertResponseStatus(201);
+    }
+
+    /** @test */
+    public function anonymous_user_cannot_submit_photo_post()
+    {
+        $this->json('POST', "/api/v2/campaigns/{$this->campaignId}/posts", []);
+
+        $this->assertResponseStatus(401);
+    }
+}


### PR DESCRIPTION
### What does this PR do?
This PR begins using some TDD (test-driven development) to drive out the work for Phoenix posting reportback photos to Rogue via the `v3` endpoint on Rogue's end.


### Any background context you want to provide?
I marked a couple tests related to the uploading of media as incomplete with `Implement once we upgrade to Laravel 5.4.`. There's some nice stuff that came in 5.4 for helping to fake uploaded files, etc that makes testing said functionality easier. I'm debating on holding off on doing the testing for that until we upgrade, so we might be doing the upgrade sooner rather than later!


### What are the relevant tickets/cards?
Refs https://www.pivotaltracker.com/story/show/154367578

### Checklist
- [x] Added appropriate feature/unit tests.