### PR TITLE
Designing the share action

### DIFF
--- a/resources/assets/components/ActionPage/actionPage.scss
+++ b/resources/assets/components/ActionPage/actionPage.scss
@@ -26,30 +26,6 @@
     font-family: $primary-font-family;
   }
 
-  .action-step__header {
-    span {
-      position: relative;
-      color: $primary-color;
-      font-size: $font-large; // TODO: This needs to be the 28px one
-      font-weight: $weight-bold;
-      text-shadow: $text-shadow;
-    }
-
-    h1 {
-      position: relative;
-      color: $white;
-      letter-spacing: 1.1px;
-      font-family: $secondary-font-family;
-      font-size: $font-hero;
-      font-weight: $weight-normal;
-      text-shadow: $text-shadow;
-
-      @include media($medium) {
-        font-size: $font-gigantic;
-      }
-    }
-  }
-
   .action-step__photos {
     display: flex;
     flex-direction: column;

--- a/resources/assets/components/ActionPage/templates/MosaicStepHeaderTemplate.js
+++ b/resources/assets/components/ActionPage/templates/MosaicStepHeaderTemplate.js
@@ -3,13 +3,17 @@ import PropTypes from 'prop-types';
 import { FlexCell } from '../../Flex';
 
 import { convertNumberToWord } from '../../../helpers';
-import PhotoHeader from '../../PhotoHeader';
+import PhotoHeader, { PhotoHeaderTitle } from '../../PhotoHeader';
 
 const MosaicStepHeaderTemplate = ({ title, step, background, hideStepNumber }) => (
   <FlexCell width="full">
-    <PhotoHeader className="action-step__header" backgroundImage={background}>
-      { hideStepNumber ? null : <span>step { convertNumberToWord(step) }</span> }
-      <h1>{ title }</h1>
+    <PhotoHeader backgroundImage={background}>
+      <PhotoHeaderTitle
+        primary={title}
+        secondary={hideStepNumber ? null : (
+          `step ${convertNumberToWord(step)}`
+        )}
+      />
     </PhotoHeader>
   </FlexCell>
 );

--- a/resources/assets/components/PhotoHeader/PhotoHeaderTitle.js
+++ b/resources/assets/components/PhotoHeader/PhotoHeaderTitle.js
@@ -1,0 +1,22 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import './photo-header-title.scss';
+
+const PhotoHeaderTitle = ({ primary, secondary }) => (
+  <div className="photo-header__title">
+    <span className="__secondary">{secondary}</span>
+    <h1 className="__primary">{primary}</h1>
+  </div>
+);
+
+PhotoHeaderTitle.defaultProps = {
+  primary: null,
+  secondary: null,
+};
+
+PhotoHeaderTitle.propTypes = {
+  primary: PropTypes.string,
+  secondary: PropTypes.string,
+};
+
+export default PhotoHeaderTitle;

--- a/resources/assets/components/PhotoHeader/index.js
+++ b/resources/assets/components/PhotoHeader/index.js
@@ -1,1 +1,3 @@
+export PhotoHeaderTitle from './PhotoHeaderTitle';
+
 export default from './PhotoHeader';

--- a/resources/assets/components/PhotoHeader/photo-header-title.scss
+++ b/resources/assets/components/PhotoHeader/photo-header-title.scss
@@ -1,0 +1,25 @@
+@import '../../scss/next-toolbox.scss';
+
+.photo-header__title {
+  .__secondary {
+    position: relative;
+    color: $primary-color;
+    font-size: $font-large; // TODO: This needs to be the 28px one
+    font-weight: $weight-bold;
+    text-shadow: $text-shadow;
+  }
+
+  .__primary {
+    position: relative;
+    color: $white;
+    letter-spacing: 1.1px;
+    font-family: $secondary-font-family;
+    font-size: $font-hero;
+    font-weight: $weight-normal;
+    text-shadow: $text-shadow;
+
+    @include media($medium) {
+      font-size: $font-gigantic;
+    }
+  }
+}

--- a/resources/assets/components/ShareAction/ShareAction.js
+++ b/resources/assets/components/ShareAction/ShareAction.js
@@ -2,7 +2,10 @@
 
 import PropTypes from 'prop-types';
 import React from 'react';
+import PhotoHeader, { PhotoHeaderTitle } from '../PhotoHeader';
+import Markdown from '../Markdown';
 import { showFacebookSharePrompt } from '../../helpers';
+import './share-action.scss';
 
 const ShareAction = (props) => {
   const { trackEvent } = props;
@@ -22,11 +25,22 @@ const ShareAction = (props) => {
     });
   };
 
+  // lint disable is for the Lorem ipsum, will be replaced with actual variable
+  /* eslint-disable max-len */
   return (
-    <button className="button" onClick={onFacebookClick}>
-      complete the share action
-    </button>
+    <div className="share-action margin-horizontal-md">
+      <PhotoHeader className="margin-bottom-lg">
+        <PhotoHeaderTitle primary={'Share all of your darkest secrets'} />
+      </PhotoHeader>
+      <Markdown className="margin-bottom-lg">
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+      </Markdown>
+      <ul className="share-action__list">
+        <li><a role="button" tabIndex="0" onClick={onFacebookClick}>share this</a></li>
+      </ul>
+    </div>
   );
+  /* eslint-enable max-len */
 };
 
 ShareAction.propTypes = {

--- a/resources/assets/components/ShareAction/share-action.scss
+++ b/resources/assets/components/ShareAction/share-action.scss
@@ -1,0 +1,10 @@
+@import '../../scss/next-toolbox.scss';
+
+.share-action {
+  margin-bottom: $base-spacing;
+
+  .share-action__list {
+    padding-left: $base-spacing;
+    list-style-type: square;
+  }
+}


### PR DESCRIPTION
### What does this PR do?
This PR designs the share action to look identical to the current share action. Eventually, it could likely end up looking more like a card but this is just the first iteration.

### Screenshots

#### Desktop
<img width="1050" alt="screen shot 2018-01-17 at 1 43 49 pm" src="https://user-images.githubusercontent.com/897368/35060697-368c25be-fb8d-11e7-8a3c-fb3c609100b3.png">

#### Tablet
<img width="815" alt="screen shot 2018-01-17 at 1 43 39 pm" src="https://user-images.githubusercontent.com/897368/35060698-369712f8-fb8d-11e7-996c-5abd5f2f6fdf.png">

#### Mobile
<img width="367" alt="screen shot 2018-01-17 at 1 43 32 pm" src="https://user-images.githubusercontent.com/897368/35060700-36d09258-fb8d-11e7-8960-85f0a4a1ec96.png">

_I personally think this is a great call to action but I understand why it might not be in the final version._

### Any background context you want to provide?
- In order to help keep things DRY, I moved the step header styling & markup into a new subcomponent (PhotoHeaderTitle). This means the PhotoHeader is now just a visual pattern for the dark-background w/ photo in a horizontal strip, and the PhotoHeaderTitle is the visual pattern for the bold white header and optional yellow label above that can go inside the PhotoHeader.

### What are the relevant tickets/cards?
https://www.pivotaltracker.com/story/show/154008960