### PR TITLE
Styling the share action

### DIFF
--- a/resources/assets/components/ActionPage/ActionStep.js
+++ b/resources/assets/components/ActionPage/ActionStep.js
@@ -18,6 +18,15 @@ const ActionStep = (props) => {
     title, stepIndex, content, background, photos,
     photoWidth, shouldTruncate, hideStepNumber, template,
   } = props;
+
+  const photoComponent = photos && photos.length ? (
+    <FlexCell width={photoWidth}>
+      <div className={`action-step__photos -${photoWidth}`}>
+        { photos ? photos.map(renderPhoto) : null }
+      </div>
+    </FlexCell>
+  ) : null;
+
   return (
     <FlexCell width="full">
       <div className={classnames('action-step', { '-truncate': shouldTruncate })}>
@@ -36,11 +45,7 @@ const ActionStep = (props) => {
             :
             null
           }
-          <FlexCell width={photoWidth}>
-            <div className={`action-step__photos -${photoWidth}`}>
-              { photos ? photos.map(renderPhoto) : null }
-            </div>
-          </FlexCell>
+          {photoComponent}
         </Flex>
       </div>
     </FlexCell>

--- a/resources/assets/components/ShareAction/ShareAction.js
+++ b/resources/assets/components/ShareAction/ShareAction.js
@@ -3,6 +3,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import { showFacebookSharePrompt } from '../../helpers';
+import './share-action.scss';
 
 const ShareAction = (props) => {
   const { trackEvent } = props;
@@ -23,9 +24,14 @@ const ShareAction = (props) => {
   };
 
   return (
-    <button className="button" onClick={onFacebookClick}>
-      complete the share action
-    </button>
+    <div className="share-action margin-bottom-lg">
+      <ul>
+        <li><a role="button" tabIndex="0" onClick={onFacebookClick}>share this</a></li>
+        <li><a role="button" tabIndex="0" onClick={onFacebookClick}>hi luke</a></li>
+        <li><a role="button" tabIndex="0" onClick={onFacebookClick}>luke hows your essay going</a></li>
+        <li><a role="button" tabIndex="0" onClick={onFacebookClick}>should we include a link to share your essay</a></li>
+      </ul>
+    </div>
   );
 };
 

--- a/resources/assets/components/ShareAction/share-action.scss
+++ b/resources/assets/components/ShareAction/share-action.scss
@@ -1,0 +1,8 @@
+@import '../../scss/next-toolbox.scss';
+
+.share-action {
+  ul {
+    padding-left: $base-spacing;
+    list-style-type: square;
+  }
+}


### PR DESCRIPTION
### What does this PR do?
This PR styles the share action to properly display a list of share links.

<img width="1095" alt="screen shot 2018-01-17 at 2 45 46 pm" src="https://user-images.githubusercontent.com/897368/35063457-250a0524-fb95-11e7-8039-0e514f6a0fbb.png">
<img width="844" alt="screen shot 2018-01-17 at 2 45 41 pm" src="https://user-images.githubusercontent.com/897368/35063458-25199df4-fb95-11e7-8015-6e4c26117189.png">
<img width="447" alt="screen shot 2018-01-17 at 2 45 34 pm" src="https://user-images.githubusercontent.com/897368/35063459-252b975c-fb95-11e7-81b2-9a451ce4487a.png">

### Any background context you want to provide?
- After talking with Luke, confirmed the action should only handle styling the links.
- The action step change is because we were adding an extra 24px to the bottom of action steps if they didn't have any photos, which made the spacing between the bullets and the markdown way too large

### What are the relevant tickets/cards?
https://www.pivotaltracker.com/story/show/154008960
