### PR TITLE
Adding the share component logic

### DIFF
--- a/app/Entities/ShareAction.php
+++ b/app/Entities/ShareAction.php
@@ -16,7 +16,9 @@ class ShareAction extends Entity implements JsonSerializable
         return [
             'id' => $this->entry->getId(),
             'type' => $this->entry->getContentType(),
-            'fields' => [],
+            'fields' => [
+                'additionalContent' => $this->additionalContent,
+            ],
         ];
     }
 }

--- a/resources/assets/components/ActionPage/ActionStepRenderers.js
+++ b/resources/assets/components/ActionPage/ActionStepRenderers.js
@@ -198,10 +198,10 @@ export function renderVoterRegistration(step, stepIndex) {
  *
  * @return {Component}
  */
-export function renderShareAction() {
+export function renderShareAction(step) {
   return (
     <FlexCell width="full" key="share-action">
-      <ShareActionContainer />
+      <ShareActionContainer {...step.fields} />
     </FlexCell>
   );
 }

--- a/resources/assets/components/ActionPage/ActionStepsWrapper.js
+++ b/resources/assets/components/ActionPage/ActionStepsWrapper.js
@@ -36,7 +36,7 @@ const ActionStepsWrapper = (props) => {
         return renderVoterRegistration(step, stepIndex);
 
       case 'shareAction':
-        return renderShareAction();
+        return renderShareAction(step);
 
       default:
         stepIndex += 1;

--- a/resources/assets/components/ShareAction/ShareAction.js
+++ b/resources/assets/components/ShareAction/ShareAction.js
@@ -24,7 +24,7 @@ const ShareAction = (props) => {
   };
 
   return (
-    <div className="share-action margin-bottom-lg">
+    <div className="share-action margin-horizontal-md margin-bottom-lg">
       <ul>
         <li><a role="button" tabIndex="0" onClick={onFacebookClick}>share this</a></li>
         <li><a role="button" tabIndex="0" onClick={onFacebookClick}>hi luke</a></li>

--- a/resources/assets/components/ShareAction/ShareAction.js
+++ b/resources/assets/components/ShareAction/ShareAction.js
@@ -1,17 +1,13 @@
-/* global window */
-
-import PropTypes from 'prop-types';
 import React from 'react';
+import PropTypes from 'prop-types';
 import { showFacebookSharePrompt } from '../../helpers';
 import './share-action.scss';
 
 const ShareAction = (props) => {
-  const { trackEvent } = props;
+  const { additionalContent, trackEvent } = props;
 
-  const link = window.location.href;
-  const trackingData = { link };
-
-  const onFacebookClick = () => {
+  const onFacebookClick = (link) => {
+    const trackingData = { link };
     trackEvent('clicked share action', trackingData);
 
     showFacebookSharePrompt({ href: link }, (response) => {
@@ -23,19 +19,38 @@ const ShareAction = (props) => {
     });
   };
 
+  const hasLinks = additionalContent && additionalContent.links;
+
   return (
     <div className="share-action margin-horizontal-md margin-bottom-lg">
-      <ul>
-        <li><a role="button" tabIndex="0" onClick={onFacebookClick}>share this</a></li>
-        <li><a role="button" tabIndex="0" onClick={onFacebookClick}>hi luke</a></li>
-        <li><a role="button" tabIndex="0" onClick={onFacebookClick}>luke hows your essay going</a></li>
-        <li><a role="button" tabIndex="0" onClick={onFacebookClick}>should we include a link to share your essay</a></li>
-      </ul>
+      {hasLinks ? (
+        <ul>
+          {additionalContent.links.map(({ title, link }) => (
+            <li>
+              <a
+                role="button"
+                tabIndex="0"
+                onClick={() => onFacebookClick(link)}
+              >{ title }</a>
+            </li>
+          ))}
+        </ul>
+      ) : null}
     </div>
   );
 };
 
+ShareAction.defaultProps = {
+  additionalContent: null,
+};
+
 ShareAction.propTypes = {
+  additionalContent: PropTypes.shape({
+    links: PropTypes.arrayOf(PropTypes.shape({
+      title: PropTypes.string,
+      link: PropTypes.string,
+    })),
+  }),
   trackEvent: PropTypes.func.isRequired,
 };
 


### PR DESCRIPTION
### What does this PR do?
This PR adds
- the additionalContent field to the share action
- injecting the field within the action steps render process
- the logic that handles mapping the JSON into share links

Contentful JSON
<img width="1032" alt="screen shot 2018-01-17 at 3 15 02 pm" src="https://user-images.githubusercontent.com/897368/35064885-73ee723e-fb99-11e7-8378-bd7c4b07c9ca.png">

Component rendered
<img width="1010" alt="screen shot 2018-01-17 at 3 15 13 pm" src="https://user-images.githubusercontent.com/897368/35064884-73e4c022-fb99-11e7-812e-41c2432a6da2.png">

Puck events
<img width="393" alt="screen shot 2018-01-17 at 3 15 57 pm" src="https://user-images.githubusercontent.com/897368/35064883-73dbb0a4-fb99-11e7-8b0c-4ff40f7d14d3.png">

### What are the relevant tickets/cards?
https://www.pivotaltracker.com/story/show/154008960
