### PR TITLE
Share action affirmation

### DIFF
--- a/app/Entities/ShareAction.php
+++ b/app/Entities/ShareAction.php
@@ -15,8 +15,9 @@ class ShareAction extends Entity implements JsonSerializable
     {
         return [
             'id' => $this->entry->getId(),
-            'type' => $this->entry->getContentType(),
+            'type' => $this->getContentType(),
             'fields' => [
+                'affirmation' => $this->affirmation,
                 'additionalContent' => $this->additionalContent,
             ],
         ];

--- a/app/Entities/ShareAction.php
+++ b/app/Entities/ShareAction.php
@@ -15,7 +15,7 @@ class ShareAction extends Entity implements JsonSerializable
     {
         return [
             'id' => $this->entry->getId(),
-            'type' => $this->getContentType(),
+            'type' => $this->entry->getContentType(),
             'fields' => [
                 'affirmation' => $this->affirmation,
                 'additionalContent' => $this->additionalContent,

--- a/resources/assets/components/Modal/ModalSwitch.js
+++ b/resources/assets/components/Modal/ModalSwitch.js
@@ -1,8 +1,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import {
-  Modal, PostSignupModal, ContentModal, ReportbackUploaderModal, SurveyModalContainer,
-  POST_SIGNUP_MODAL, CONTENT_MODAL, REPORTBACK_UPLOADER_MODAL, SURVEY_MODAL,
+  Modal, PostSignupModal, ContentModal, ReportbackUploaderModal,
+  PostShareModalContainer, SurveyModalContainer,
+  POST_SIGNUP_MODAL, CONTENT_MODAL, REPORTBACK_UPLOADER_MODAL,
+  POST_SHARE_MODAL, SURVEY_MODAL,
 } from '../Modal';
 
 const ModalSwitch = (props) => {
@@ -21,6 +23,9 @@ const ModalSwitch = (props) => {
       break;
     case SURVEY_MODAL:
       children = <SurveyModalContainer />;
+      break;
+    case POST_SHARE_MODAL:
+      children = <PostShareModalContainer />;
       break;
     default: break;
   }

--- a/resources/assets/components/Modal/configurations/PostShareModal.js
+++ b/resources/assets/components/Modal/configurations/PostShareModal.js
@@ -1,0 +1,30 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import Card from '../../Card';
+import Markdown from '../../Markdown';
+
+const PostShareModal = (props) => {
+  const { content, closeModal } = props;
+
+  return (
+    <Card title="Thanks for sharing!" className="modal__slide" onClose={closeModal}>
+      {
+        content ?
+          <Markdown className="padded">{ content }</Markdown>
+          :
+          null
+      }
+    </Card>
+  );
+};
+
+PostShareModal.propTypes = {
+  content: PropTypes.string,
+  closeModal: PropTypes.func.isRequired,
+};
+
+PostShareModal.defaultProps = {
+  content: null,
+};
+
+export default PostShareModal;

--- a/resources/assets/components/Modal/configurations/PostShareModal.js
+++ b/resources/assets/components/Modal/configurations/PostShareModal.js
@@ -8,12 +8,9 @@ const PostShareModal = (props) => {
 
   return (
     <Card title="Thanks for sharing!" className="modal__slide bordered rounded" onClose={closeModal}>
-      {
-        content ?
-          <Markdown className="padded">{ content }</Markdown>
-          :
-          null
-      }
+      <Markdown className="padded">
+        { content || PostShareModal.defaultProps.content }
+      </Markdown>
     </Card>
   );
 };

--- a/resources/assets/components/Modal/configurations/PostShareModal.js
+++ b/resources/assets/components/Modal/configurations/PostShareModal.js
@@ -24,7 +24,7 @@ PostShareModal.propTypes = {
 };
 
 PostShareModal.defaultProps = {
-  content: null,
+  content: 'Thanks for rallying your friends on Facebook!',
 };
 
 export default PostShareModal;

--- a/resources/assets/components/Modal/configurations/PostShareModal.js
+++ b/resources/assets/components/Modal/configurations/PostShareModal.js
@@ -7,7 +7,7 @@ const PostShareModal = (props) => {
   const { content, closeModal } = props;
 
   return (
-    <Card title="Thanks for sharing!" className="modal__slide" onClose={closeModal}>
+    <Card title="Thanks for sharing!" className="modal__slide bordered rounded" onClose={closeModal}>
       {
         content ?
           <Markdown className="padded">{ content }</Markdown>

--- a/resources/assets/components/Modal/containers/PostShareModalContainer.js
+++ b/resources/assets/components/Modal/containers/PostShareModalContainer.js
@@ -12,7 +12,7 @@ const mapStateToProps = (state) => {
   // TODO: If we have multiple share actions, keep in mind that
   // the copy for the 1+n action will always be 1 action. Requires a bit more
   // work in order to make this always apply to the correct action.
-  const shareAction = find(actions, { type: 'shareAction' });
+  const shareAction = find(actions, { type: { sys: { id: 'shareAction' } } });
 
   return {
     content: shareAction ? shareAction.fields.affirmation : {},

--- a/resources/assets/components/Modal/containers/PostShareModalContainer.js
+++ b/resources/assets/components/Modal/containers/PostShareModalContainer.js
@@ -1,0 +1,26 @@
+import { connect } from 'react-redux';
+import { find } from 'lodash';
+import PostShareModal from '../configurations/PostShareModal';
+import { closeModal } from '../../../actions/modal';
+
+const mapStateToProps = (state) => {
+  const actions = state.campaign.actionSteps;
+  if (! actions) {
+    return {};
+  }
+
+  // TODO: If we have multiple share actions, keep in mind that
+  // the copy for the 1+n action will always be 1 action. Requires a bit more
+  // work in order to make this always apply to the correct action.
+  const shareAction = find(actions, { type: 'shareAction' });
+
+  return {
+    content: shareAction ? shareAction.fields.affirmation : {},
+  };
+};
+
+const actionCreators = {
+  closeModal,
+};
+
+export default connect(mapStateToProps, actionCreators)(PostShareModal);

--- a/resources/assets/components/Modal/index.js
+++ b/resources/assets/components/Modal/index.js
@@ -2,6 +2,9 @@ export default from './containers/ModalSwitchContainer';
 
 export Modal from './containers/ModalContainer';
 export SurveyModalContainer from './containers/SurveyModalContainer';
+export PostShareModalContainer from './containers/PostShareModalContainer';
+
+// TODO: whoops, these probably need to be renamed to have 'Container' appended to the name.
 export PostSignupModal from './containers/PostSignupModalContainer';
 export ContentModal from './containers/ContentModalContainer';
 export ReportbackUploaderModal from './configurations/ReportbackUploaderModal';
@@ -10,3 +13,4 @@ export const POST_SIGNUP_MODAL = 'POST_SIGNUP_MODAL';
 export const CONTENT_MODAL = 'CONTENT_MODAL';
 export const REPORTBACK_UPLOADER_MODAL = 'REPORTBACK_UPLOADER_MODAL';
 export const SURVEY_MODAL = 'SURVEY_MODAL';
+export const POST_SHARE_MODAL = 'POST_SHARE_MODAL';

--- a/resources/assets/components/ShareAction/ShareAction.js
+++ b/resources/assets/components/ShareAction/ShareAction.js
@@ -1,10 +1,11 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { POST_SHARE_MODAL } from '../Modal';
 import { showFacebookSharePrompt } from '../../helpers';
 import './share-action.scss';
 
 const ShareAction = (props) => {
-  const { additionalContent, trackEvent } = props;
+  const { additionalContent, openModal, trackEvent } = props;
 
   const onFacebookClick = (link) => {
     const trackingData = { link };
@@ -13,6 +14,7 @@ const ShareAction = (props) => {
     showFacebookSharePrompt({ href: link }, (response) => {
       if (response) {
         trackEvent('share action completed', trackingData);
+        openModal(POST_SHARE_MODAL);
       } else {
         trackEvent('share action cancelled', trackingData);
       }
@@ -52,6 +54,7 @@ ShareAction.propTypes = {
       link: PropTypes.string,
     })),
   }),
+  openModal: PropTypes.func.isRequired,
   trackEvent: PropTypes.func.isRequired,
 };
 

--- a/resources/assets/components/ShareAction/ShareAction.js
+++ b/resources/assets/components/ShareAction/ShareAction.js
@@ -31,6 +31,7 @@ const ShareAction = (props) => {
                 role="button"
                 tabIndex="0"
                 onClick={() => onFacebookClick(link)}
+                key={title}
               >{ title }</a>
             </li>
           ))}

--- a/resources/assets/components/ShareAction/ShareAction.js
+++ b/resources/assets/components/ShareAction/ShareAction.js
@@ -28,12 +28,11 @@ const ShareAction = (props) => {
       {hasLinks ? (
         <ul>
           {additionalContent.links.map(({ title, link }) => (
-            <li>
+            <li key={title}>
               <a
                 role="button"
                 tabIndex="0"
                 onClick={() => onFacebookClick(link)}
-                key={title}
               >{ title }</a>
             </li>
           ))}

--- a/resources/assets/components/ShareAction/ShareActionContainer.js
+++ b/resources/assets/components/ShareAction/ShareActionContainer.js
@@ -1,4 +1,12 @@
+import { connect } from 'react-redux';
 import { PuckConnector } from '@dosomething/puck-client';
 import ShareAction from './ShareAction';
+import { openModal } from '../actions/modal';
 
-export default PuckConnector(ShareAction);
+const actionCreators = {
+  openModal,
+};
+
+export default connect(null, actionCreators)(
+  PuckConnector(ShareAction);
+);

--- a/resources/assets/components/ShareAction/ShareActionContainer.js
+++ b/resources/assets/components/ShareAction/ShareActionContainer.js
@@ -1,12 +1,12 @@
 import { connect } from 'react-redux';
 import { PuckConnector } from '@dosomething/puck-client';
 import ShareAction from './ShareAction';
-import { openModal } from '../actions/modal';
+import { openModal } from '../../actions/modal';
 
 const actionCreators = {
   openModal,
 };
 
 export default connect(null, actionCreators)(
-  PuckConnector(ShareAction);
+  PuckConnector(ShareAction),
 );


### PR DESCRIPTION
### What does this PR do?
This PR creates the post share action affirmation.

It's mostly re-using existing components/features, but a quick outline of the changes.
- Created the new post-share modal type, component, container
- Added this to the Modal Switch so it could be used
- Added an `affirmation` field to the Share Action so campaign leads can configure this content
- Called the `openModal` function from the share action

<img width="316" alt="screen shot 2018-01-18 at 12 37 43 pm" src="https://user-images.githubusercontent.com/897368/35112640-a512f2dc-fc4c-11e7-80f8-2598faff992d.png">

<img width="1039" alt="screen shot 2018-01-18 at 12 37 34 pm" src="https://user-images.githubusercontent.com/897368/35112641-a51ed8c2-fc4c-11e7-8727-d0e5af2d02e2.png">

We're aware of the fact we have two close buttons, Luke said it's ok to ship this and revisit the global close button next.

### Any background context you want to provide?
I left a few comments in places we may need to revisit in the future

### What are the relevant tickets/cards?
https://www.pivotaltracker.com/story/show/154258837