### PR TITLE
Making the global modal exit button a conditional display

### DIFF
--- a/resources/assets/components/CampaignUpdate/CampaignUpdate.js
+++ b/resources/assets/components/CampaignUpdate/CampaignUpdate.js
@@ -9,13 +9,18 @@ import Byline from '../Byline';
 import Markdown from '../Markdown';
 import { ShareContainer } from '../Share';
 
-const CampaignUpdate = ({ id, author, content, link, shareLink, bordered, titleLink }) => {
+const CampaignUpdate = (props) => {
+  const {
+    author, id, closeModal, content,
+    link, shareLink, bordered, titleLink,
+  } = props;
+
   const authorFields = get(author, 'fields', {});
 
   const isTweet = content && content.length < 144;
 
   return (
-    <Card id={id} className={classnames('rounded', { bordered })} link={titleLink} title="Campaign Update">
+    <Card id={id} className={classnames('rounded', { bordered })} link={titleLink} title="Campaign Update" onClose={closeModal}>
       <Markdown className={classnames('padded', { 'font-size-lg': isTweet })}>
         {content || 'Placeholder'}
       </Markdown>
@@ -41,12 +46,13 @@ const CampaignUpdate = ({ id, author, content, link, shareLink, bordered, titleL
 };
 
 CampaignUpdate.propTypes = {
-  id: PropTypes.string.isRequired,
   author: PropTypes.shape({
     id: PropTypes.string,
     type: PropTypes.string,
     fields: PropTypes.object,
   }),
+  id: PropTypes.string.isRequired,
+  closeModal: PropTypes.func,
   content: PropTypes.string,
   link: PropTypes.string,
   shareLink: PropTypes.string.isRequired,
@@ -59,6 +65,7 @@ CampaignUpdate.defaultProps = {
   bordered: true,
   author: null,
   content: null,
+  closeModal: null,
 };
 
 export default CampaignUpdate;

--- a/resources/assets/components/CampaignUpdate/CampaignUpdate.js
+++ b/resources/assets/components/CampaignUpdate/CampaignUpdate.js
@@ -46,12 +46,12 @@ const CampaignUpdate = (props) => {
 };
 
 CampaignUpdate.propTypes = {
+  id: PropTypes.string.isRequired,
   author: PropTypes.shape({
     id: PropTypes.string,
     type: PropTypes.string,
     fields: PropTypes.object,
   }),
-  id: PropTypes.string.isRequired,
   closeModal: PropTypes.func,
   content: PropTypes.string,
   link: PropTypes.string,

--- a/resources/assets/components/Modal/Modal.js
+++ b/resources/assets/components/Modal/Modal.js
@@ -3,6 +3,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import Portal from 'react-portal';
+import { POST_SHARE_MODAL, CONTENT_MODAL } from '../Modal';
 
 import './modal.scss';
 
@@ -39,8 +40,13 @@ class Modal extends React.Component {
   }
 
   render() {
-    const { shouldShowModal, children } = this.props;
+    const { modalType, shouldShowModal, children } = this.props;
     const chrome = document.getElementById('chrome');
+
+    const hideCloseButton = [
+      POST_SHARE_MODAL,
+      CONTENT_MODAL,
+    ].includes(modalType);
 
     return (
       <Portal
@@ -52,7 +58,7 @@ class Modal extends React.Component {
         <div className="modal" role="presentation" ref={node => this.node = node} onClick={this.handleOverlayClick}>
           <div className="modal__container">
             { children }
-            <button className="modal__exit" onClick={this.props.closeModal}>×</button>
+            { hideCloseButton ? null : <button className="modal__exit" onClick={this.props.closeModal}>×</button> }
           </div>
         </div>
       </Portal>

--- a/resources/assets/components/Modal/configurations/ContentModal.js
+++ b/resources/assets/components/Modal/configurations/ContentModal.js
@@ -6,16 +6,16 @@ import NotFound from '../../NotFound';
 import { CampaignUpdateContainer } from '../../CampaignUpdate';
 
 const ContentModal = (props) => {
-  const { content, title, type, contentfulId } = props;
+  const { content, closeModal, title, type, contentfulId } = props;
 
   const campaignUpdate = (
     <div className="modal__slide">
-      <CampaignUpdateContainer id={contentfulId} bordered={false} />
+      <CampaignUpdateContainer id={contentfulId} bordered={false} closeModal={closeModal} />
     </div>
   );
 
   const card = (
-    <Card title={title} className="modal__slide">
+    <Card title={title} className="modal__slide" onClose={closeModal}>
       {
         content ?
           <Markdown className="padded">{ content }</Markdown>
@@ -36,6 +36,7 @@ const ContentModal = (props) => {
 ContentModal.propTypes = {
   content: PropTypes.string.isRequired,
   contentfulId: PropTypes.string.isRequired,
+  closeModal: PropTypes.func.isRequired,
   title: PropTypes.string,
   type: PropTypes.string.isRequired,
 };

--- a/resources/assets/components/Modal/containers/ContentModalContainer.js
+++ b/resources/assets/components/Modal/containers/ContentModalContainer.js
@@ -1,6 +1,7 @@
 import { connect } from 'react-redux';
 import { find } from 'lodash';
 import ContentModal from '../configurations/ContentModal';
+import { closeModal } from '../../../actions/modal';
 
 const mapStateToProps = (state) => {
   const contentfulId = state.modal.contentfulId;
@@ -33,4 +34,8 @@ const mapStateToProps = (state) => {
   return { content, title, type, contentfulId };
 };
 
-export default connect(mapStateToProps)(ContentModal);
+const actionCreators = {
+  closeModal,
+};
+
+export default connect(mapStateToProps, actionCreators)(ContentModal);


### PR DESCRIPTION
### What does this PR do?
Part of the modal design QA is moving the X button from the top right corner to the specific content in the modal. However, not all modals are treated equal, so this PR does some conditional magic as well.

<img width="1066" alt="screen shot 2018-01-18 at 3 44 24 pm" src="https://user-images.githubusercontent.com/897368/35120591-9f12bcae-fc66-11e7-9c06-fab6b6f2012d.png">
<img width="822" alt="screen shot 2018-01-18 at 3 44 18 pm" src="https://user-images.githubusercontent.com/897368/35120593-9f398398-fc66-11e7-9e8c-f585d4d9efed.png">
<img width="350" alt="screen shot 2018-01-18 at 3 44 12 pm" src="https://user-images.githubusercontent.com/897368/35120594-9f47cd9a-fc66-11e7-8485-29834c1637c9.png">

And here is a non-modal Card in the community feed to demonstrate the X not showing in this setting,
<img width="1142" alt="screen shot 2018-01-18 at 3 48 05 pm" src="https://user-images.githubusercontent.com/897368/35120716-0cb8f21e-fc67-11e7-941e-c6d47e0ceb42.png">

### Any background context you want to provide?
I figured doing a pass-through of the `closeModal` function was the easiest way to accomplish this, but I'm definitely not convinced this is the most _proper_ solution. Refactoring the Card component to be container based, and updating all of those containers could be a PR in itself, so just did this, for now, to get the job done.

### What are the relevant tickets/cards?
https://www.pivotaltracker.com/story/show/152767171