### PR TITLE
Unifying campaigns endpoint response

### DIFF
--- a/app/Entities/Campaign.php
+++ b/app/Entities/Campaign.php
@@ -194,6 +194,7 @@ class Campaign extends Entity implements JsonSerializable
             'template' => $this->template->first() ?: 'mosaic',
             'title' => $this->title,
             'slug' => $this->slug,
+            'status' => null, // @TODO: calculate status based on the endDate!
             'endDate' => $this->endDate,
             'callToAction' => $this->callToAction, //@TODO: deprecate in favor of tagline.
             'tagline' => $this->callToAction,

--- a/app/Entities/LegacyCampaign.php
+++ b/app/Entities/LegacyCampaign.php
@@ -45,7 +45,6 @@ class LegacyCampaign implements JsonSerializable
                 'url' => $this->legacyCampaign['cover_image']['default']['uri'],
                 'landscapeUrl' => $this->legacyCampaign['cover_image']['default']['sizes']['landscape']['uri'],
             ],
-
         ];
     }
 }

--- a/app/Entities/LegacyCampaign.php
+++ b/app/Entities/LegacyCampaign.php
@@ -6,6 +6,11 @@ use JsonSerializable;
 
 class LegacyCampaign implements JsonSerializable
 {
+    /**
+     * The data for the legacy campaign.
+     *
+     * @var array
+     */
     protected $legacyCampaign;
 
     /**

--- a/app/Entities/LegacyCampaign.php
+++ b/app/Entities/LegacyCampaign.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Entities;
+
+use JsonSerializable;
+
+class LegacyCampaign implements JsonSerializable
+{
+    protected $legacyCampaign;
+
+    /**
+     * Create instance of the LegacyCampaign class.
+     *
+     * @param array $legacyCampaign
+     */
+    public function __construct($legacyCampaign)
+    {
+        $this->legacyCampaign = $legacyCampaign['data'];
+    }
+
+    /**
+     * Convert the object into something JSON serializable.
+     *
+     * @return array
+     */
+    public function jsonSerialize()
+    {
+        return [
+            'id' => null,
+            'legacyCampaignId' => $this->legacyCampaign['id'],
+            'legacyCampaignRunId' => $this->legacyCampaign['campaign_runs']['current']['en']['id'],
+            'type' => 'campaign',
+            'title' => $this->legacyCampaign['title'],
+            'slug' => null,
+            'status' => $this->legacyCampaign['status'],
+            'callToAction' => $this->legacyCampaign['tagline'],
+            'tagline' => $this->legacyCampaign['tagline'],
+            'coverImage' => [
+                'description' => null,
+                'url' => $this->legacyCampaign['cover_image']['default']['uri'],
+                'landscapeUrl' => $this->legacyCampaign['cover_image']['default']['sizes']['landscape']['uri'],
+            ],
+
+        ];
+    }
+}

--- a/app/Http/Controllers/Api/CampaignsController.php
+++ b/app/Http/Controllers/Api/CampaignsController.php
@@ -49,6 +49,6 @@ class CampaignsController extends Controller
             $data = $this->campaignRepository->getCampaign($id);
         }
 
-        return response()->json($data);
+        return response()->json(['data' => $data]);
     }
 }

--- a/app/Repositories/CampaignRepository.php
+++ b/app/Repositories/CampaignRepository.php
@@ -5,6 +5,7 @@ namespace App\Repositories;
 use App\Entities\Campaign;
 use Contentful\Delivery\Query;
 use App\Services\PhoenixLegacy;
+use App\Entities\LegacyCampaign;
 use Contentful\Delivery\Client as Contentful;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 
@@ -94,7 +95,7 @@ class CampaignRepository
                 throw new ModelNotFoundException;
             }
 
-            return $legacyCampaign['data'];
+            return new LegacyCampaign($legacyCampaign);
         }
 
         return new Campaign($campaigns[0]);

--- a/docs/endpoints/v2/campaigns.md
+++ b/docs/endpoints/v2/campaigns.md
@@ -15,10 +15,9 @@ https://next.dosomething.org/api/v2/campaigns/6LQzMvDNQcYQYwso8qSkQ8
 
 Example Response:
 
-_Note:_ If supplied Legacy ID returns a campaign from Ashes, then the format below does not apply. Please refer to the [Ashes Retrieve a campaign endpoint response example](https://github.com/DoSomething/phoenix/blob/dev/documentation/endpoints/campaigns.md#retrieve-a-campaign). This is only temporary!
-
 ```
 {
+  "data": {
     "id": "6LQzMvDNQcYQYwso8qSkQ8",
     "legacyCampaignId": "1144",
     "legacyCampaignRunId": "7430",
@@ -62,6 +61,7 @@ _Note:_ If supplied Legacy ID returns a campaign from Ashes, then the format bel
     "additionalContent": null,
     "allowExperiments": true,
     "actionText": "Join Us"
+  }
 }
 ```
 


### PR DESCRIPTION
### What does this PR do?
This PR introduces a new `LegacyCampaign` class that does some minimal work to transform the old Ashes campaign response to mimic the structure of how Phoenix (next) will respond with campaign data via the Phoenix (next) API.


### Any background context you want to provide?
I'm only aiming to pass through the content that Gambit/Rogue need, but not ALL the same props that would otherwise come from a Contentful-based campaign.

### Checklist
- [x] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.

