### PR TITLE
Quiz refactor + Custom title

### DIFF
--- a/app/Entities/Quiz.php
+++ b/app/Entities/Quiz.php
@@ -59,6 +59,7 @@ class Quiz extends Entity implements JsonSerializable
             'type' => $this->getContentType(),
             'fields' => [
                 'title' => $this->title,
+                'contentTitle' => $this->contentTitle,
                 'slug' => $this->slug,
                 'introduction' => $this->introduction,
                 'conclusion' => $this->conclusion,

--- a/resources/assets/components/Quiz/Quiz.js
+++ b/resources/assets/components/Quiz/Quiz.js
@@ -49,7 +49,7 @@ const Quiz = (props) => {
   return (
     <div className="quiz">
       <div className="quiz__introduction">
-        <h1 className="quiz__title">{fields.contentTitle || Quiz.defaultProps.contentTitle}</h1>
+        <h1 className="quiz__title">{fields.contentTitle || Quiz.defaultProps.fields.contentTitle}</h1>
         <h2 className="quiz__subtitle">{fields.title}</h2>
         {introduction}
       </div>

--- a/resources/assets/components/Quiz/Quiz.js
+++ b/resources/assets/components/Quiz/Quiz.js
@@ -6,43 +6,61 @@ import { ShareContainer } from '../Share';
 import Conclusion from './Conclusion';
 import './quiz.scss';
 
-const Quiz = ({ id, fields, data, completeQuiz, pickQuizAnswer }) => (
-  <div className="quiz">
-    <div className="quiz__introduction">
-      <h1 className="quiz__title">Quiz</h1>
-      <h2 className="quiz__subtitle">{fields.title}</h2>
-      {data.shouldSeeResult ? null : (
-        <Markdown className="quiz__description">{fields.introduction}</Markdown>
-      )}
-    </div>
-    {data.shouldSeeResult ? null : (fields.questions).map(question => (
-      <Question
-        key={question.id}
-        pickQuizAnswer={pickQuizAnswer}
-        quizId={id}
-        activeAnswer={data.questions ? data.questions[question.id] : null}
-        {...question}
+const Quiz = (props) => {
+  const { id, fields, data, completeQuiz, pickQuizAnswer } = props;
+  const { error, shouldSeeResult } = data;
+
+  const introduction = shouldSeeResult ? null : (
+    <Markdown className="quiz__description">{fields.introduction}</Markdown>
+  );
+
+  const questions = shouldSeeResult ? null : (fields.questions).map(question => (
+    <Question
+      key={question.id}
+      pickQuizAnswer={pickQuizAnswer}
+      quizId={id}
+      activeAnswer={data.questions ? data.questions[question.id] : null}
+      {...question}
+    />
+  ));
+
+  const quizError = error ? (
+    <p className="quiz__error">{data.error}</p>
+  ) : null;
+
+  const submitConclusion = shouldSeeResult ? null : (
+    <Conclusion callToAction={fields.callToAction}>
+      <button
+        onClick={() => completeQuiz(id)}
+        className="button quiz__submit"
+      >get results</button>
+    </Conclusion>
+  );
+
+  const shareConclusion = shouldSeeResult ? (
+    <Conclusion callToAction={fields.conclusion}>
+      <ShareContainer
+        className="quiz__share"
+        parentSource="quiz"
       />
-    ))}
-    { data.error ? <p className="quiz__error">{data.error}</p> : null }
-    { ! data.shouldSeeResult ? (
-      <Conclusion callToAction={fields.callToAction}>
-        <button
-          onClick={() => completeQuiz(id)}
-          className="button quiz__submit"
-        >get results</button>
-      </Conclusion>
-    ) : null}
-    { data.shouldSeeResult ? (
-      <Conclusion callToAction={fields.conclusion}>
-        <ShareContainer
-          className="quiz__share"
-          parentSource="quiz"
-        />
-      </Conclusion>
-    ) : null }
-  </div>
-);
+    </Conclusion>
+  ) : null;
+
+  return (
+    <div className="quiz">
+      <div className="quiz__introduction">
+        <h1 className="quiz__title">Quiz</h1>
+        <h2 className="quiz__subtitle">{fields.title}</h2>
+        {introduction}
+      </div>
+      {questions}
+      {quizError}
+      {conclusion}
+      {submitConclusion}
+      {shareConclusion}
+    </div>
+  );
+};
 
 Quiz.propTypes = {
   id: PropTypes.string.isRequired,

--- a/resources/assets/components/Quiz/Quiz.js
+++ b/resources/assets/components/Quiz/Quiz.js
@@ -55,7 +55,6 @@ const Quiz = (props) => {
       </div>
       {questions}
       {quizError}
-      {conclusion}
       {submitConclusion}
       {shareConclusion}
     </div>

--- a/resources/assets/components/Quiz/Quiz.js
+++ b/resources/assets/components/Quiz/Quiz.js
@@ -49,7 +49,7 @@ const Quiz = (props) => {
   return (
     <div className="quiz">
       <div className="quiz__introduction">
-        <h1 className="quiz__title">Quiz</h1>
+        <h1 className="quiz__title">{fields.contentTitle || 'Quiz'}</h1>
         <h2 className="quiz__subtitle">{fields.title}</h2>
         {introduction}
       </div>

--- a/resources/assets/components/Quiz/Quiz.js
+++ b/resources/assets/components/Quiz/Quiz.js
@@ -49,7 +49,7 @@ const Quiz = (props) => {
   return (
     <div className="quiz">
       <div className="quiz__introduction">
-        <h1 className="quiz__title">{fields.contentTitle || 'Quiz'}</h1>
+        <h1 className="quiz__title">{fields.contentTitle || Quiz.defaultProps.contentTitle}</h1>
         <h2 className="quiz__subtitle">{fields.title}</h2>
         {introduction}
       </div>
@@ -89,6 +89,7 @@ Quiz.defaultProps = {
     error: null,
   },
   fields: {
+    contentTitle: 'Quiz',
     introduction: '',
     questions: [],
     conclusion: '',


### PR DESCRIPTION
### What does this PR do?
1. Refactored the Quiz component a bit. Realized the fully-inline component was pretty but probably a bit confusing for someone else to jump into. Literally just copy-pasted the same code that was there but put it in named variables.

2. Added the `contentTitle` property to the Quiz Beta, which lets us change the "QUIZ" header to say anything the campaign lead wants. Title defaults to `Quiz` if nothing is given.

<img width="744" alt="screen shot 2018-01-22 at 11 44 27 am" src="https://user-images.githubusercontent.com/897368/35232541-b3293d02-ff69-11e7-95f2-2a753ceb0d7e.png">
<img width="1088" alt="screen shot 2018-01-22 at 11 39 57 am" src="https://user-images.githubusercontent.com/897368/35232543-b3390782-ff69-11e7-887e-3593080d87b3.png">

### What are the relevant tickets/cards?
https://www.pivotaltracker.com/story/show/154293082