### PR TITLE
Renaming content title to subtitle, reversing name usage

### DIFF
--- a/app/Entities/Quiz.php
+++ b/app/Entities/Quiz.php
@@ -59,7 +59,7 @@ class Quiz extends Entity implements JsonSerializable
             'type' => $this->getContentType(),
             'fields' => [
                 'title' => $this->title,
-                'contentTitle' => $this->contentTitle,
+                'subTitle' => $this->subTitle,
                 'slug' => $this->slug,
                 'introduction' => $this->introduction,
                 'conclusion' => $this->conclusion,

--- a/app/Entities/Quiz.php
+++ b/app/Entities/Quiz.php
@@ -59,7 +59,7 @@ class Quiz extends Entity implements JsonSerializable
             'type' => $this->getContentType(),
             'fields' => [
                 'title' => $this->title,
-                'subTitle' => $this->subTitle,
+                'subtitle' => $this->subtitle,
                 'slug' => $this->slug,
                 'introduction' => $this->introduction,
                 'conclusion' => $this->conclusion,

--- a/resources/assets/components/Quiz/Quiz.js
+++ b/resources/assets/components/Quiz/Quiz.js
@@ -49,7 +49,7 @@ const Quiz = (props) => {
   return (
     <div className="quiz">
       <div className="quiz__introduction">
-        <h1 className="quiz__subtitle">{fields.subTitle || Quiz.defaultProps.fields.subTitle}</h1>
+        <h1 className="quiz__subtitle">{fields.subtitle || Quiz.defaultProps.fields.subtitle}</h1>
         <h2 className="quiz__title">{fields.title}</h2>
         {introduction}
       </div>
@@ -89,7 +89,7 @@ Quiz.defaultProps = {
     error: null,
   },
   fields: {
-    subTitle: 'Quiz',
+    subtitle: 'Quiz',
     introduction: '',
     questions: [],
     conclusion: '',

--- a/resources/assets/components/Quiz/Quiz.js
+++ b/resources/assets/components/Quiz/Quiz.js
@@ -49,8 +49,8 @@ const Quiz = (props) => {
   return (
     <div className="quiz">
       <div className="quiz__introduction">
-        <h1 className="quiz__title">{fields.contentTitle || Quiz.defaultProps.fields.contentTitle}</h1>
-        <h2 className="quiz__subtitle">{fields.title}</h2>
+        <h1 className="quiz__subtitle">{fields.subTitle || Quiz.defaultProps.fields.subTitle}</h1>
+        <h2 className="quiz__title">{fields.title}</h2>
         {introduction}
       </div>
       {questions}
@@ -89,7 +89,7 @@ Quiz.defaultProps = {
     error: null,
   },
   fields: {
-    contentTitle: 'Quiz',
+    subTitle: 'Quiz',
     introduction: '',
     questions: [],
     conclusion: '',

--- a/resources/assets/components/Quiz/quiz.scss
+++ b/resources/assets/components/Quiz/quiz.scss
@@ -7,14 +7,14 @@
     text-align: center;
   }
 
-  .quiz__title {
+  .quiz__subtitle {
     color: $primary-color;
     font-size: $font-large;
     font-weight: $weight-bold;
     text-transform: uppercase;
   }
 
-  .quiz__subtitle {
+  .quiz__title {
     font-family: $secondary-font-family;
     font-size: $font-superhero;
     letter-spacing: 2px;


### PR DESCRIPTION
### What does this PR do?
- Renamed contentTitle to subTitle
- Reversed usage of subtitle and title

<img width="1086" alt="screen shot 2018-01-22 at 4 04 15 pm" src="https://user-images.githubusercontent.com/897368/35244432-14bc68fe-ff8e-11e7-931e-b9022d5d4d31.png">
<img width="1086" alt="screen shot 2018-01-22 at 4 04 06 pm" src="https://user-images.githubusercontent.com/897368/35244433-14c95f3c-ff8e-11e7-9681-d2169f5d2629.png">

### Any background context you want to provide?
- contentTitle was confusing and we wanted to get this changed [sooner rather than later](https://github.com/DoSomething/phoenix-next/pull/617#discussion_r163062381)
- the subtitle in the markup referencing the title field was also confusing  