### PR TITLE
Quick fix to the `isCampaignClosed ` helper function

### DIFF
--- a/resources/assets/helpers/index.js
+++ b/resources/assets/helpers/index.js
@@ -2,6 +2,7 @@
 
 import get from 'lodash/get';
 import MarkdownIt from 'markdown-it';
+import { isPast, parse } from 'date-fns';
 import iterator from 'markdown-it-for-inline';
 import markdownItFootnote from 'markdown-it-footnote';
 
@@ -306,7 +307,7 @@ export function isCampaignClosed(endDate) {
     return false;
   }
 
-  return new Date(endDate) - new Date() < 0;
+  return isPast(parse(endDate));
 }
 
 /**


### PR DESCRIPTION
### What does this PR do?
- Uses the `date-fns` package [`parse`](https://date-fns.org/v1.29.0/docs/parse) method to ensure dates are in the correct format for the `isCampaignClosed` helper method
- While I was at it, I found the [`isPast`](https://date-fns.org/v1.29.0/docs/isPast) method from said package and thought it was a nifty way to check if the campaign was closed.


### Any background context you want to provide?
Closed Campaigns were not being presented in the proper closed state in Safari. Some 🔬 returned that the Contentful date field we were [passing](https://github.com/DoSomething/phoenix-next/blob/dev/resources/assets/helpers/index.js#L309) to the `Date` constructor in the `isCampaignClosed` helper method was an invalid format, resulting in the method always returning `false`. 

![image](https://user-images.githubusercontent.com/12417657/35282969-e838b76e-0024-11e8-8598-d808400f247e.png)


(This was still working in Chrome/Firefox because they're cool. https://stackoverflow.com/a/4310986/5657278) 


### What are the relevant tickets/cards?
[#154259444](https://www.pivotaltracker.com/story/show/154259444)

