### PR TITLE
Updating campaign routing logic so the quiz is not gated

### DIFF
--- a/resources/assets/components/Campaign/CampaignContainer.js
+++ b/resources/assets/components/Campaign/CampaignContainer.js
@@ -2,13 +2,21 @@ import { connect } from 'react-redux';
 
 import Campaign from './Campaign';
 
-const mapStateToProps = (state) => {
+const mapStateToProps = (state, props) => {
   const hasLandingPage = state.campaign.landingPage !== null;
   const isSignedUp = state.signups.thisCampaign;
 
-  const shouldShowLandingPage = hasLandingPage &&
-    (! isSignedUp || state.admin.shouldShowLandingPage) &&
-    ! state.admin.shouldShowActionPage;
+  const { location, match } = props;
+  const isQuiz = location.pathname.replace(match.url, '').startsWith('/quiz/');
+
+  const blockLandingPage = state.admin.shouldShowActionPage || isQuiz;
+  let shouldShowLandingPage = false;
+
+  if (state.admin.shouldShowLandingPage) {
+    shouldShowLandingPage = true;
+  } else if (hasLandingPage && ! blockLandingPage) {
+    shouldShowLandingPage = ! isSignedUp;
+  }
 
   return {
     shouldShowLandingPage,

--- a/resources/assets/components/Campaign/CampaignContainer.js
+++ b/resources/assets/components/Campaign/CampaignContainer.js
@@ -9,12 +9,12 @@ const mapStateToProps = (state, props) => {
   const { location, match } = props;
   const isQuiz = location.pathname.replace(match.url, '').startsWith('/quiz/');
 
-  const blockLandingPage = state.admin.shouldShowActionPage || isQuiz;
+  const ignoreLandingPage = state.admin.shouldShowActionPage || isQuiz;
   let shouldShowLandingPage = false;
 
   if (state.admin.shouldShowLandingPage) {
     shouldShowLandingPage = true;
-  } else if (hasLandingPage && ! blockLandingPage) {
+  } else if (hasLandingPage && ! ignoreLandingPage) {
     shouldShowLandingPage = ! isSignedUp;
   }
 


### PR DESCRIPTION
### What does this PR do?
For Grab The Mic we want to use quizzes as a conversion point that can bypass the Landing Page. This required adding logic that checks if the current page is a quiz page. I achieved this by using the React Router props and subtracting the matched path from the entire URL, and seeing if the remainder string starts with `/quiz/`. In addition to this logical addition, I also broke the statement which determined whether to display a landing page into several parts. Hopefully, it is easy to follow this given all of the different conditionals floating around.

### What are the relevant tickets/cards?
https://www.pivotaltracker.com/story/show/154565578
