### PR TITLE
Adding some security to the Referrals CSV export

### DIFF
--- a/app/Http/Controllers/ReferralController.php
+++ b/app/Http/Controllers/ReferralController.php
@@ -78,6 +78,11 @@ class ReferralController extends Controller
 
     public function csvExport()
     {
+        // Only allowing administrators to perform the CSV export.
+        if (! auth()->user()->isAdmin()) {
+            return redirect('/');
+        }
+
         $fileName = 'referrals_export_'.Carbon::now().'.csv';
 
         $headers = [

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -55,4 +55,14 @@ class User extends Model implements AuthenticatableContract, NorthstarUserContra
     {
         return in_array($this->role, ['staff', 'admin']);
     }
+
+    /**
+     * Is this user an administrator?
+     *
+     * @return bool
+     */
+    public function isAdmin()
+    {
+        return $this->role === 'admin';
+    }
 }


### PR DESCRIPTION
### What does this PR do?

- Ensures the current user has a role of `admin`(istrator) before allowing them to preform the Referrals CSV export.
- Adds an `isAdmin` helper method to the `User` class.

### What are the relevant tickets/cards?
https://github.com/DoSomething/phoenix-next/pull/608#discussion_r163337337
https://www.pivotaltracker.com/story/show/154360555