### PR TITLE
adding cursor pointer rule for a tags in list

### DIFF
--- a/resources/assets/components/ShareAction/share-action.scss
+++ b/resources/assets/components/ShareAction/share-action.scss
@@ -8,6 +8,5 @@
     a {
       cursor: pointer;
     }
-
   }
 }

--- a/resources/assets/components/ShareAction/share-action.scss
+++ b/resources/assets/components/ShareAction/share-action.scss
@@ -4,5 +4,10 @@
   ul {
     padding-left: $base-spacing;
     list-style-type: square;
+
+    a {
+      cursor: pointer;
+    }
+
   }
 }


### PR DESCRIPTION
Super quick: I noticed that the links in the list of share links in [Grab the Mic](https://next-thor.dosomething.org/us/campaigns/grab-mic) (in 'STEP ONE') on thor does not turn to a pointer when you hover (perhaps because they're nested inside `<li>`s?)

Just added the explicit rule in the stylesheet.