### PR TITLE
Redesigning post signup modal to fit mock

### DIFF
--- a/resources/assets/components/Affirmation/Affirmation.js
+++ b/resources/assets/components/Affirmation/Affirmation.js
@@ -1,37 +1,42 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import Highlight from '../Highlight';
+import Card from '../Card';
+import { Flex, FlexCell } from '../Flex';
 import Markdown from '../Markdown';
-import { Figure } from '../Figure';
 import { ShareContainer } from '../Share';
 
 import './affirmation.scss';
 
-const Affirmation = ({ content }) => (
-  <div className="affirmation">
-    <div className="affirmation__section affirmation__section-heading">
-      <Highlight>{ content.header }</Highlight>
-    </div>
-    <div className="affirmation__section affirmation__section-quote">
-      <Figure className="margin-bottom-none" image={content.photo} alt={content.author} alignment="left">
-        <Markdown>{ content.quote }</Markdown>
-        <span>- { content.author }</span>
-      </Figure>
-    </div>
-    <div className="affirmation__section affirmation__section-share">
-      <div className="affirmation__block">
+/*
+  TODO: waiting on field...
+  import Byline from '../Byline';
+
+  <Byline
+    author={authorFields.name}
+    avatar={authorFields.avatar || undefined}
+    jobTitle={authorFields.jobTitle || undefined}
+    className="float-left"
+  />
+ */
+
+const Affirmation = ({ closeModal, content }) => (
+  <Card className="affirmation rounded" title="Thanks for joining us!" onClose={closeModal}>
+    <Markdown className="padded">{content.quote}</Markdown>
+    <Flex>
+      <FlexCell className="affirmation__cta padded" width="half">
         <h3>{ content.callToActionHeader }</h3>
         <p>{ content.callToActionDescription }</p>
-      </div>
-      <div className="affirmation__block margin-horizontal-md">
-        <ShareContainer variant="black" parentSource="affirmation" />
-      </div>
-    </div>
-  </div>
+      </FlexCell>
+      <FlexCell className="padded" width="half">
+        <ShareContainer variant="blue" parentSource="affirmation" />
+      </FlexCell>
+    </Flex>
+  </Card>
 );
 
 Affirmation.propTypes = {
+  closeModal: PropTypes.func.isRequired,
   content: PropTypes.shape({
     header: PropTypes.string,
     photo: PropTypes.string,

--- a/resources/assets/components/Affirmation/AffirmationContainer.js
+++ b/resources/assets/components/Affirmation/AffirmationContainer.js
@@ -1,8 +1,13 @@
 import { connect } from 'react-redux';
 import Affirmation from './Affirmation';
+import { closeModal } from '../../actions/modal';
 
 const mapStateToProps = state => ({
   content: state.campaign.affirmation,
 });
 
-export default connect(mapStateToProps)(Affirmation);
+const actionCreators = {
+  closeModal,
+};
+
+export default connect(mapStateToProps, actionCreators)(Affirmation);

--- a/resources/assets/components/Affirmation/affirmation.scss
+++ b/resources/assets/components/Affirmation/affirmation.scss
@@ -1,87 +1,9 @@
 @import '../../scss/next-toolbox.scss';
 
 .affirmation {
-  width: 100%;
-  padding: $half-spacing;
-  color: $primary-text-color;
-  background-color: $light-background-color;
-  position: relative;
-
-  @include media($medium) {
-    padding: $base-spacing;
-  }
-
-  .affirmation__section {
-    margin-bottom: $base-spacing;
-    width: 100%;
-    display: inline-flex;
-  }
-
-  .affirmation__section-heading {
-    text-align: center;
-
-    h1 {
-      letter-spacing: 1.1px;
-      font-family: $secondary-font-family;
-      font-size: $font-hero;
-      font-weight: $weight-normal;
-      color: $primary-text-color;
-      margin-left: auto;
-      margin-right: auto;
-
-      @include media($medium) {
-        font-size: $font-gigantic;
-      }
-    }
-  }
-
-  .affirmation__section-quote {
-    color: $primary-text-color;
-
-    .figure {
-      > .figure__media {
-        float: none;
-
-        img {
-          width: 256px;
-          height: 256px;
-        }
-      }
-
-      @media (min-width: 425px) {
-        > .figure__media {
-          float: left;
-
-          img {
-            width: 128px;
-            height: 128px;
-          }
-        }
-      }
-    }
-
-    span {
-      font-size: 14px;
-    }
-
-    img {
-      width: 128px;
-      height: 128px;
-      display: inline;
-      max-width: none;
-    }
-  }
-
-  .affirmation__section-share {
-    flex-direction: column;
-
-    @include media($medium) {
-      flex-direction: row;
-    }
-
+  .affirmation__cta {
     h3 {
-      font-family: $primary-font-family;
-      color: $primary-color;
+      font-weight: 800;
     }
   }
 }

--- a/resources/assets/components/Modal/Modal.js
+++ b/resources/assets/components/Modal/Modal.js
@@ -3,7 +3,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import Portal from 'react-portal';
-import { POST_SHARE_MODAL, CONTENT_MODAL } from '../Modal';
+import {
+  POST_SIGNUP_MODAL, POST_SHARE_MODAL, CONTENT_MODAL,
+} from '../Modal';
 
 import './modal.scss';
 
@@ -44,6 +46,7 @@ class Modal extends React.Component {
     const chrome = document.getElementById('chrome');
 
     const hideCloseButton = [
+      POST_SIGNUP_MODAL,
       POST_SHARE_MODAL,
       CONTENT_MODAL,
     ].includes(modalType);


### PR DESCRIPTION
### What does this PR do?
This PR designs the affirmation component in the post-signup modal to match Lukes latest mock _(disclaimer on latest, this has been on the back burner for a few weeks)_. It's still missing the `Byline` component at the bottom, but that will the next part because it's gonna require content model changes.

<img width="323" alt="screen shot 2018-01-23 at 3 28 46 pm" src="https://user-images.githubusercontent.com/897368/35299244-ae528b3c-0052-11e8-94ea-0bcedf26e95c.png">
<img width="766" alt="screen shot 2018-01-23 at 3 28 40 pm" src="https://user-images.githubusercontent.com/897368/35299245-ae674388-0052-11e8-9bc1-83b2a4a7d02a.png">
<img width="1024" alt="screen shot 2018-01-23 at 3 28 35 pm" src="https://user-images.githubusercontent.com/897368/35299246-ae7b43d8-0052-11e8-990e-720b65618893.png">

### Any background context you want to provide?
Still need to make the new author field for the byline

### What are the relevant tickets/cards?
https://www.pivotaltracker.com/story/show/152767171