### PR TITLE
Differentiating between run and campaign in voter reg. link

### DIFF
--- a/resources/assets/components/ActionPage/ActionStepRenderers.js
+++ b/resources/assets/components/ActionPage/ActionStepRenderers.js
@@ -179,7 +179,7 @@ export function renderVoterRegistration(step, stepIndex) {
   const { template, dynamicLink } = additionalContent;
 
   return (
-    <FlexCell width="full" key="voter-reg">
+    <FlexCell width="full" key={`voter-reg-${stepIndex}`}>
       <div className="action-step">
         <VoterRegistrationContainer
           content={content}

--- a/resources/assets/components/VoterRegistration/VoterRegistration.js
+++ b/resources/assets/components/VoterRegistration/VoterRegistration.js
@@ -29,6 +29,9 @@ const VoterRegistration = (props) => {
     link = makeUrl(baseUrl, query).href;
   }
 
+  const formattedContent = (
+    content || VoterRegistration.defaultProps.content
+  ).replace(/:::[a-zA-Z]*:::/gi, link);
 
   return (
     <Flex>
@@ -39,7 +42,7 @@ const VoterRegistration = (props) => {
         stepIndex={stepIndex}
       />
       <FlexCell width="two-thirds">
-        <Markdown>{ content.replace(/:::[a-zA-Z]*:::/gi, link) }</Markdown>
+        <Markdown>{ formattedContent }</Markdown>
       </FlexCell>
     </Flex>
   );

--- a/resources/assets/components/VoterRegistration/VoterRegistrationContainer.js
+++ b/resources/assets/components/VoterRegistration/VoterRegistrationContainer.js
@@ -6,6 +6,7 @@ import VoterRegistration from './VoterRegistration';
  */
 const mapStateToProps = state => ({
   userId: state.user.id,
+  campaignId: state.campaign.legacyCampaignId,
   campaignRunId: state.campaign.legacyCampaignRunId,
 });
 


### PR DESCRIPTION
### What does this PR do?
- Updated VoterRegAction container to pull in the campaign id
- Fixed component throwing error if content is null
- Fixed duplicate key bug if multiple voter reg actions are on the page 

<img width="901" alt="screen shot 2018-01-24 at 11 24 22 am" src="https://user-images.githubusercontent.com/897368/35347255-9957d5ce-0102-11e8-9995-d7674caffc06.png">

<img width="1165" alt="screen shot 2018-01-24 at 12 32 20 pm" src="https://user-images.githubusercontent.com/897368/35347275-a5fc11be-0102-11e8-80a0-8f11e38552c8.png">

### What are the relevant tickets/cards?
https://www.pivotaltracker.com/story/show/154590055