### PR TITLE
Adding trafficFraction as a param to experiment participation

### DIFF
--- a/resources/assets/helpers/sixpack.js
+++ b/resources/assets/helpers/sixpack.js
@@ -35,8 +35,9 @@ export function convertOnSignupIntent(name) {
 export function participate(name) {
   return new Promise((resolve, reject) => {
     const alternatives = Object.values(experiments[name].alternatives);
+    const trafficFraction = experiments[name].trafficFraction;
 
-    sixpack().participate(name, alternatives, (error, response) => {
+    sixpack().participate(name, alternatives, trafficFraction, (error, response) => {
       if (error) {
         reject(error);
       }


### PR DESCRIPTION
### What does this PR do?

Allows setting a `trafficFraction` option in `/experiments.json` for an experiment.


### Any background context you want to provide?
[#154484254](https://www.pivotaltracker.com/story/show/154484254)

> As the team, I want to setup web NPS so it only surveys 5% of our users

We're going to want to only display the NPS Survey feature to a certain percentage of our users, Sixpack has a nifty [`traffic_fraction`](443f491deb70a10e13889b6a7f22886629677c8ffefa888e257c97ee7dbbf645) param where you can specify the fraction of users that receive an experiment.

This PR would allow you to set an (optional) additional field for an experiment in `experiments.json`, to specify the traffic fraction for the experiment. Then, within the `helpers/sixpack.js#participate` function, we'll read that value and pass it along to the `sixpack-client`s `participate` function. (which [has its own interesting way](https://github.com/sixpack/sixpack-js/blob/master/sixpack.js#L64) of determining which of the optional params to pass along in the request to the sixpack API).

```
"dummy_test": {
    "meta": {
      "preTest": {
        "campaign.allowExperiments": true
      }
    },
    "alternatives": {
      "a": "control",
      "b": "survey"
    },
    "trafficFraction": 0.5
  }
```

UPDATE:
We won't be using this for the Survey traffic distribution / feature flagging, since it's somewhat of a hacky approach (this is meant for traffic distribution for *experiments* and *ab tests*).
However, this is still appropriate functionality as it relates to sixpack and ab testing.

### What are the relevant tickets/cards?
This is a precursor to the work for [#154484254](https://www.pivotaltracker.com/story/show/154484254)

If this is approved I'll add this to our sixpack setup documentation.

