### PR TITLE
Member Gallery Rendering Changes

### DIFF
--- a/resources/assets/components/ActionPage/ActionStepsWrapper.js
+++ b/resources/assets/components/ActionPage/ActionStepsWrapper.js
@@ -50,7 +50,7 @@ const ActionStepsWrapper = (props) => {
     ));
   }
 
-  if (template === 'legacy') {
+  if (template === 'legacy' || ! hasActivityFeed) {
     stepComponents.push(renderLegacyGallery());
   }
 

--- a/resources/assets/components/ActionPage/ActionStepsWrapper.js
+++ b/resources/assets/components/ActionPage/ActionStepsWrapper.js
@@ -10,7 +10,7 @@ import {
 
 const ActionStepsWrapper = (props) => {
   const { actionSteps, callToAction, campaignId,
-    hasPendingSignup, isSignedUp, template } = props;
+    hasActivityFeed, hasPendingSignup, isSignedUp, template } = props;
 
   let stepIndex = 0;
 
@@ -65,6 +65,7 @@ ActionStepsWrapper.propTypes = {
   actionSteps: PropTypes.array.isRequired, // eslint-disable-line react/forbid-prop-types
   callToAction: PropTypes.string.isRequired,
   campaignId: PropTypes.string.isRequired,
+  hasActivityFeed: PropTypes.bool.isRequired,
   hasPendingSignup: PropTypes.bool.isRequired,
   isSignedUp: PropTypes.bool.isRequired,
   template: PropTypes.string.isRequired,

--- a/resources/assets/components/ActionPage/ActionStepsWrapperContainer.js
+++ b/resources/assets/components/ActionPage/ActionStepsWrapperContainer.js
@@ -7,6 +7,7 @@ import ActionStepsWrapper from './ActionStepsWrapper';
 const mapStateToProps = state => ({
   campaignId: state.campaign.legacyCampaignId,
   callToAction: state.campaign.callToAction,
+  hasActivityFeed: Boolean(state.campaign.activityFeed.length),
   hasPendingSignup: state.signups.isPending,
   isSignedUp: state.signups.thisCampaign,
   template: state.campaign.template,


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_
We're adding the 'Member Gallery' to mosaic-template campaigns that have no community tab!

### What does this PR do?
It adds the `LegacyGallery` to the bottom of the Action page in a campaign, if the campaign does not have an activity feed - which would mean it does [not have](https://github.com/DoSomething/phoenix-next/blob/dev/resources/assets/components/Navigation/TabbedNavigationContainer.js#L62) a community tab.


### What are the relevant tickets/cards?
[#154369914](https://www.pivotaltracker.com/story/show/154369914)