### PR TITLE
Feature flags backend proposal

### DIFF
--- a/app/Http/Controllers/CampaignController.php
+++ b/app/Http/Controllers/CampaignController.php
@@ -55,10 +55,14 @@ class CampaignController extends Controller
      * @return \Illuminate\View\View
      */
     public function show($slug)
+    public function show(Request $request, $slug)
     {
         $campaign = $this->campaignRepository->findBySlug($slug);
 
         $env = get_client_environment_vars();
+
+        $cookies = Request::cookie();
+        $featureFlags = get_feature_flags($cookies);
 
         // The slug argument will not contain `/blocks` or other path extensions, hence `::url()`.
         $socialFields = get_social_fields($campaign, Request::url());
@@ -73,6 +77,7 @@ class CampaignController extends Controller
                 'id' => auth()->id(),
                 'role' => auth()->user() ? auth()->user()->role : null,
             ],
+            'featureFlags' => $featureFlags,
         ]);
     }
 }

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -398,3 +398,21 @@ function generate_streamed_csv($columns, $records)
 
     return fclose($file);
 }
+
+/**
+ * Get a list of feature flags from provided array.
+ *
+ * @param  array $list
+ * @return array
+ */
+function get_feature_flags($list) {
+    $featureFlags = [];
+
+    foreach ($list as $key => $value) {
+        if (preg_match('/feature_flag_/', $key)) {
+            $featureFlags[str_replace('feature_flag_', '', $key)] = $value;
+        }
+    }
+
+    return $featureFlags;
+}

--- a/resources/assets/store/store.js
+++ b/resources/assets/store/store.js
@@ -34,6 +34,8 @@ export function configureStore(reducers, middleware, preloadedState = {}) {
   // If React DevTools are available, use instrumented compose function.
   const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose; // eslint-disable-line
 
+  debugger
+
   // @TODO: Let's just merge all 3 states at once
   const transformedState = loadStorage(initialState, preloadedState);
 

--- a/resources/assets/store/store.js
+++ b/resources/assets/store/store.js
@@ -34,8 +34,6 @@ export function configureStore(reducers, middleware, preloadedState = {}) {
   // If React DevTools are available, use instrumented compose function.
   const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose; // eslint-disable-line
 
-  debugger
-
   // @TODO: Let's just merge all 3 states at once
   const transformedState = loadStorage(initialState, preloadedState);
 


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_
A proposal for some backend setup for feature flag cookies.

### What does this PR do?
- Adds a helper method that can parse through a list (of e.g. cookies) and return a list of feature flags.
- Uses this helper method in the `CampaignsController#show` action to pass feature flags along with the state to the front end.

### Any background context you want to provide?
This is related to the NPS Survey feature, where we want to display the survey feature to only a percentage of traffic. The idea here is that we'll have a cookie being set in Fastly config similarly to how it was done with [this instance](https://github.com/DoSomething/devops/issues/293) of splitting ashes and PN traffic. 
 
So for n percent of traffic, the request will hit us with a set cookie, such as `feature_flag_some_shiny_feature=true`. And we'll pass that along with the state in the response in a list of `featureFlags` as `some_shiny_feature => true`.

Then in React we can work with a feature wrapper component that can use this set state to optionally display the feature/s (I've got something in the works for that if we like this approach).


### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
