### PR TITLE
Referrals route change

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -9,6 +9,7 @@
 - [Architecture](development/architecture.md)
 - [Heroku Usage](development/heroku.md)
 - [Sixpack AB Testing](development/sixpack-ab-testing.md)
+- [Routing](development/routing.md)
 
 
 ## API Reference

--- a/docs/development/routing.md
+++ b/docs/development/routing.md
@@ -2,7 +2,7 @@
 ***
 
 Since Phoenix (next) is working alongside Phoenix Ashes (the legacy portion of our website), there are some magical routing configurations
-to ensure that user traffic is being directed to it's proper place (with some requests being directed the legacy application, and the others to 
+to ensure that user traffic is being directed to its proper place (with some requests being directed the legacy application, and the others to 
 shiny new Phoenix (next)).
 
 Therefore, any routing additions you might want to make need to be coordinated with the Devops team. Otherwise traffic to said route will be 

--- a/docs/development/routing.md
+++ b/docs/development/routing.md
@@ -1,0 +1,16 @@
+# Routing
+***
+
+Since Phoenix (next) is working alongside Phoenix Ashes (the legacy portion of our website), there are some magical routing configurations
+to ensure that user traffic is being directed to it's proper place (with some requests being directed the legacy application, and the others to 
+shiny new Phoenix (next)).
+
+Therefore, any routing additions you might want to make need to be coordinated with the Devops team. Otherwise traffic to said route will be 
+directed to the legacy Drupal site by default.
+
+You can hop into the #devops channel on Slack to get in touch with the relavent parties.
+
+
+## Tips
+- Any route nested under `/next` is configured to be directed to Phoenix (next). (e.g. `/next/this-cool-route` is ready for takeoff, no extra work needed).
+

--- a/resources/assets/components/AdminDashboard/CampaignDashboard/CampaignDashboard.js
+++ b/resources/assets/components/AdminDashboard/CampaignDashboard/CampaignDashboard.js
@@ -15,7 +15,7 @@ const CampaignDashboard = (props) => {
   const onReferralExportClick = () => {
     const message = 'Please confirm your intent to export this data. This will permanently mark the records as already exported and cannot be undone.';
     if (confirm(message)) { // eslint-disable-line no-alert
-      window.location.href = '/referrals/export';
+      window.location.href = '/next/referrals/export';
     }
   };
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -30,7 +30,7 @@ $router->get('next/cache/{cacheId}', 'CacheController');
 $router->get('next/embed', 'EmbedController@index');
 
 // Referrals CSV export
-$router->get('referrals/export', 'ReferralController@csvExport');
+$router->get('next/referrals/export', 'ReferralController@csvExport');
 
 /*
  * The following are API Routes that are currently using the web middleware,


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_
Changing the Referrals route, and adding some minor documentation.


### What does this PR do?
- Changes the referrals export route to be nested under `/next`
`next/referrals/export`.
- Adds a word or two about routing in the docs.

### Any background context you want to provide?
This route was not listed to be directed to PN. So nesting it under `/next` so that it is indeed directed to us properly.


### What are the relevant tickets/cards?
https://dosomething.slack.com/archives/C2BPA7M8F/p1517258987000292
