### PR TITLE
Adding northstar user fields to referrer objects before passing to csv builder

### DIFF
--- a/app/Http/Controllers/ReferralController.php
+++ b/app/Http/Controllers/ReferralController.php
@@ -86,7 +86,16 @@ class ReferralController extends Controller
 
         $referrals = $referralsEloquentBuilder->get();
 
-        $columns = ['id', 'created_at', 'friend_name', 'friend_email', 'friend_story', 'referrer_northstar_id'];
+        // Adding some referrer user details to the referral records, to be able to export them with the CSV.
+        foreach ($referrals as $referral) {
+            $user = gateway('northstar')->getUser('id', $referral->referrer_northstar_id);
+
+            $referral->referrer_first_name = $user->first_name;
+            $referral->referrer_last_name = $user->last_name;
+            $referral->referrer_email = $user->email;
+        }
+
+        $columns = ['id', 'created_at', 'friend_name', 'friend_email', 'friend_story', 'referrer_northstar_id', 'referrer_first_name', 'referrer_last_name', 'referrer_email'];
 
         $callback = function () use ($referrals, $columns, $referralsEloquentBuilder) {
             generate_streamed_csv($columns, $referrals);


### PR DESCRIPTION
### What does this PR do?
Adding some Northstar user fields to the `Referral` records before generating a CSV export.


### Any background context you want to provide?
We need some identifier fields for the referring user in our exported CSV of Referral records. 
I know that this is adding some clutter to the controller action which is something @weerd [wanted to avoid](https://github.com/DoSomething/phoenix-next/pull/608#discussion_r163068305). But I wasn't sure how to keep that [csv generating helper method](https://github.com/DoSomething/phoenix-next/blob/dev/app/helpers.php#L383) abstract, while also fetching these new fields that we needed for the CSV. 
Is there perhaps a better way? Maybe just make that helper method specific to our use case, and move all the logic there?


### What are the relevant tickets/cards?
https://dosomething.slack.com/archives/C2BPA7M8F/p1517260740000423
