### PR TITLE
[#154484254] adding traffic distribution component

### DIFF
--- a/resources/assets/components/TrafficDistribution/TrafficDistribution.js
+++ b/resources/assets/components/TrafficDistribution/TrafficDistribution.js
@@ -1,0 +1,30 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import { get, set } from '../../helpers/storage';
+
+const TrafficDistribution = ({ percentage, feature, children }) => {
+  let shouldSeeFeature;
+
+  const storedValue = get(feature, 'object');
+
+  if (! storedValue) {
+    shouldSeeFeature = (Math.random() * 100) <= percentage;
+
+    set(feature, 'object', { showFeature: shouldSeeFeature });
+  } else {
+    shouldSeeFeature = storedValue.showFeature;
+  }
+
+  return (
+    shouldSeeFeature ? <span>{ children }</span> : null
+  );
+};
+
+TrafficDistribution.propTypes = {
+  percentage: PropTypes.number.isRequired,
+  feature: PropTypes.string.isRequired,
+  children: PropTypes.node.isRequired,
+};
+
+export default TrafficDistribution;

--- a/resources/assets/components/TrafficDistribution/TrafficDistribution.js
+++ b/resources/assets/components/TrafficDistribution/TrafficDistribution.js
@@ -17,7 +17,7 @@ const TrafficDistribution = ({ percentage, feature, children }) => {
   }
 
   return (
-    shouldSeeFeature ? <span>{ children }</span> : null
+    shouldSeeFeature ? <div>{ children }</div> : null
   );
 };
 

--- a/resources/assets/components/TrafficDistribution/TrafficDistribution.js
+++ b/resources/assets/components/TrafficDistribution/TrafficDistribution.js
@@ -6,12 +6,12 @@ import { get, set } from '../../helpers/storage';
 const TrafficDistribution = ({ percentage, feature, children }) => {
   let shouldSeeFeature;
 
-  const storedValue = get(feature, 'object');
+  const storedValue = get(`TrafficDistribution_${feature}`, 'object');
 
   if (! storedValue) {
     shouldSeeFeature = (Math.random() * 100) <= percentage;
 
-    set(feature, 'object', { showFeature: shouldSeeFeature });
+    set(`TrafficDistribution_${feature}`, 'object', { showFeature: shouldSeeFeature });
   } else {
     shouldSeeFeature = storedValue.showFeature;
   }

--- a/resources/assets/components/TrafficDistribution/index.js
+++ b/resources/assets/components/TrafficDistribution/index.js
@@ -1,0 +1,1 @@
+export default from './TrafficDistribution';


### PR DESCRIPTION
### What does this PR do?
- Adds a `TrafficDistribution` component to handle exposing a feature to n percent of traffic.


### Any background context you want to provide?
We started this process in #641 but ended up deciding to approach distributing a feature across traffic from within React.

What this component does is act as a wrapper for any feature (any component etc.) and takes a couple of props:
- `percentage` (int): specifying the percentage of all traffic that should be exposed to this feature.
- `feature` (string): the name of the feature. For labeling and persistence purposes.
- `children` (node): the wrapped component.

It then checks localstorage to see if the user has already been designated to view the feature or not and acts appropriately. Otherwise, it'll do some simple math to randomly assign the user based on specified percentage and store their designation in localstorage.


(I'll add some documentation if this is approved. I've got some tests on the burner, but it would pay to wait for the approval of #635 cause there's some overlap in the testing helpers/setup we need to use.

### What are the relevant tickets/cards?
[#154484254](https://www.pivotaltracker.com/story/show/154484254)
#641 

### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
