### PR TITLE
Fixing NavLink highlights & tab order

### DIFF
--- a/resources/assets/components/Navigation/TabbedNavigationContainer.js
+++ b/resources/assets/components/Navigation/TabbedNavigationContainer.js
@@ -82,7 +82,6 @@ const TabbedNavigationContainer = (props) => {
   );
 
   const actionPagePath = join('/us/campaigns', campaignSlug, campaignPaths.action);
-
   const ActionNavigationLink = () => (
     shouldHideAction ? null : (
       <NavigationLink

--- a/resources/assets/components/Navigation/TabbedNavigationContainer.js
+++ b/resources/assets/components/Navigation/TabbedNavigationContainer.js
@@ -1,3 +1,5 @@
+/* global window */
+
 import React from 'react';
 import { join } from 'path';
 import { get } from 'lodash';
@@ -62,11 +64,37 @@ const TabbedNavigationContainer = (props) => {
   const shouldHideCommunity = ! hasActivityFeed;
   const shouldHideAction = (isClosed || (shouldHideCommunity && additionalPages.length === 0));
 
+  const isDefaultPage = window.location.pathname === join('/us/campaigns', campaignSlug);
+  const defaultPageIsActiveFunction = isFirst => (
+    isDefaultPage ? () => isFirst : null
+  );
+
+  const actionPagePath = join('/us/campaigns', campaignSlug, campaignPaths.action);
+
+  const ActionNavigationLink = () => (
+    shouldHideAction ? null : (
+      <NavigationLink
+        to={actionPagePath}
+        isActive={defaultPageIsActiveFunction(! shouldHideAction)}
+      >Action</NavigationLink>
+    )
+  );
+
+  const communityPagePath = join('/us/campaigns', campaignSlug, campaignPaths.community);
+  const CommunityNavigationLink = () => (
+    shouldHideCommunity ? null : (
+      <NavigationLink
+        to={communityPagePath}
+        isActive={defaultPageIsActiveFunction(shouldHideAction && ! shouldHideCommunity)}
+      >Community</NavigationLink>
+    )
+  );
+
   return (
     <TabbedNavigation>
       <div className="nav-items">
-        { shouldHideCommunity ? null : <NavigationLink to={join('/us/campaigns', campaignSlug, campaignPaths.community)} exact>Community</NavigationLink> }
-        { shouldHideAction ? null : <NavigationLink to={join('/us/campaigns', campaignSlug, campaignPaths.action)}>Action</NavigationLink> }
+        <ActionNavigationLink />
+        <CommunityNavigationLink />
         { additionalPages }
       </div>
       { isAffiliated ? null : <SignupButton /> }

--- a/resources/assets/components/Navigation/TabbedNavigationContainer.js
+++ b/resources/assets/components/Navigation/TabbedNavigationContainer.js
@@ -65,6 +65,18 @@ const TabbedNavigationContainer = (props) => {
   const shouldHideAction = (isClosed || (shouldHideCommunity && additionalPages.length === 0));
 
   const isDefaultPage = window.location.pathname === join('/us/campaigns', campaignSlug);
+
+  /**
+   * Check if the current page is the campaign root `/`,
+   * if it is, return a function that returns the value of isFirst.
+   *
+   * Used to bypass the default `isActive` function on the react-router-dom
+   * NavLink.
+   *
+   * @param  {Boolean} isFirst value describing if this is
+   *                           the first page in the list.
+   * @return {Function}
+   */
   const defaultPageIsActiveFunction = isFirst => (
     isDefaultPage ? () => isFirst : null
   );


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?
Fixes the tab ordering (Action page is the new default page). Additionally, I fixed the highlighting so the root page `/` will still highlight either "Action" or "Community" depending on what the default page is.

<img width="597" alt="screen shot 2018-01-31 at 11 31 10 am" src="https://user-images.githubusercontent.com/897368/35634672-418bf0aa-067a-11e8-84e8-9116ed3e8291.png">
<img width="593" alt="screen shot 2018-01-31 at 11 31 06 am" src="https://user-images.githubusercontent.com/897368/35634673-41a04cbc-067a-11e8-8a05-ccc8c24a3ec5.png">
<img width="597" alt="screen shot 2018-01-31 at 11 31 00 am" src="https://user-images.githubusercontent.com/897368/35634674-41ab620a-067a-11e8-9609-2a3847000e34.png">

### What are the relevant tickets/cards?
https://www.pivotaltracker.com/story/show/154379917