### PR TITLE
Updating puck to 1.4.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -193,9 +193,9 @@
       }
     },
     "@dosomething/puck-client": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@dosomething/puck-client/-/puck-client-1.3.0.tgz",
-      "integrity": "sha512-oy1r1uS4dhFitEloBx87gEwmyaDDts+biCRizKxxMSOyHKj/ugI2RTW0dHlq2ulWo6b2T5q2pX2IZOBiva3DgA==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@dosomething/puck-client/-/puck-client-1.4.0.tgz",
+      "integrity": "sha512-cdgxF3aqL3fBEf2cv1OmozbHUtc1BzRAbgFWcXQUinkwnLAq8BzUhOlXZHCW0+uIYfWEkGcMg2Ja5zXkUuznVg==",
       "requires": {
         "@researchgate/react-intersection-observer": "0.6.0",
         "intersection-observer": "0.5.0",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@dosomething/analytics": "^2.1.1",
     "@dosomething/forge": "^6.8.0",
     "@dosomething/gateway": "^1.1.5",
-    "@dosomething/puck-client": "^1.3.0",
+    "@dosomething/puck-client": "^1.4.0",
     "@publica/url-polyfill": "^0.5.8",
     "babel-jest": "^20.0.3",
     "babel-polyfill": "^6.26.0",


### PR DESCRIPTION
Updating Puck (`puck-client`) to the latest version (`1.4.0`)