### PR TITLE
Adding unique key to share actions

### DIFF
--- a/resources/assets/components/ActionPage/ActionStepRenderers.js
+++ b/resources/assets/components/ActionPage/ActionStepRenderers.js
@@ -200,7 +200,7 @@ export function renderVoterRegistration(step, stepIndex) {
  */
 export function renderShareAction(step) {
   return (
-    <FlexCell width="full" key="share-action">
+    <FlexCell width="full" key={`share-action-${step.id}`}>
       <ShareActionContainer {...step.fields} />
     </FlexCell>
   );


### PR DESCRIPTION
We're unable to render multiple Share actions on a page right now because the Share action is being given a static key.
![image](https://user-images.githubusercontent.com/12417657/35695051-5a095780-0751-11e8-875e-396739137495.png)

- Adding dynamic key for `Share` actions based on the `step.id`.

https://dosomething.slack.com/archives/C2BPA7M8F/p1517502395000298