### PR TITLE
Making the campaignEndDate prop optional!

### DIFF
--- a/resources/assets/components/Navigation/TabbedNavigationContainer.js
+++ b/resources/assets/components/Navigation/TabbedNavigationContainer.js
@@ -115,7 +115,7 @@ const TabbedNavigationContainer = (props) => {
 
 TabbedNavigationContainer.propTypes = {
   actionText: PropTypes.string.isRequired,
-  campaignEndDate: PropTypes.string.isRequired,
+  campaignEndDate: PropTypes.string,
   campaignSlug: PropTypes.string.isRequired,
   hasActivityFeed: PropTypes.bool.isRequired,
   isAffiliated: PropTypes.bool.isRequired,
@@ -127,6 +127,7 @@ TabbedNavigationContainer.propTypes = {
 };
 
 TabbedNavigationContainer.defaultProps = {
+  campaignEndDate: null,
   pages: [],
   template: null,
 };


### PR DESCRIPTION
The `campaignEndDate` prop is marked as required in the [`TabbedNavigationContainer`](https://github.com/DoSomething/phoenix-next/blob/dev/resources/assets/components/Navigation/TabbedNavigationContainer.js#L118)

In [Grab the Mic](https://www.dosomething.org/us/campaigns/grab-mic) we have no end date marked (presumably since this is an all year campaign?) and it's causing an annoying error in dev
![image](https://user-images.githubusercontent.com/12417657/35753720-d0efe7f0-082e-11e8-981d-b04065160e9d.png)

And we're [defaulting](https://github.com/DoSomething/phoenix-next/blob/dev/resources/assets/components/Navigation/TabbedNavigationContainer.js#L24) the value to `null` so this feels like a good idea?