### PR TITLE
[finishes ##154847175] Adding some waypoint event tracking

### DIFF
--- a/resources/assets/components/ActionPage/ActionStep.js
+++ b/resources/assets/components/ActionPage/ActionStep.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
+import { PuckWaypoint } from '@dosomething/puck-client';
 
 import StepHeader from './StepHeader';
 import Markdown from '../Markdown';
@@ -48,6 +49,7 @@ const ActionStep = (props) => {
           {photoComponent}
         </Flex>
       </div>
+      <PuckWaypoint name="action-step__bottom" waypointData={{ title }} />
     </FlexCell>
   );
 };

--- a/resources/assets/components/ActionPage/ActionStepRenderers.js
+++ b/resources/assets/components/ActionPage/ActionStepRenderers.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { PuckWaypoint } from '@dosomething/puck-client';
 import ActionStep from './ActionStep';
 import Revealer from '../Revealer';
 import SignupButtonFactory from '../SignupButton';
@@ -45,9 +46,11 @@ export function renderPhotoUploader(step, isSignedUp) {
 
   return (
     <FlexCell key="reportback_uploader" className="margin-bottom-lg" width="full">
+      <PuckWaypoint name="photo_uploader_action-top" />
       <div className="margin-horizontal-md">
         <ReportbackUploaderContainer actionType={step.type.sys.id} {...step.fields} />
       </div>
+      <PuckWaypoint name="photo_uploader_action-bottom" />
     </FlexCell>
   );
 }
@@ -180,6 +183,7 @@ export function renderVoterRegistration(step, stepIndex) {
 
   return (
     <FlexCell width="full" key={`voter-reg-${stepIndex}`}>
+      <PuckWaypoint name="voter_registration_action-top" />
       <div className="action-step">
         <VoterRegistrationContainer
           content={content}
@@ -189,6 +193,7 @@ export function renderVoterRegistration(step, stepIndex) {
           dynamicLink={dynamicLink}
         />
       </div>
+      <PuckWaypoint name="voter_registration_action-bottom" />
     </FlexCell>
   );
 }
@@ -201,7 +206,9 @@ export function renderVoterRegistration(step, stepIndex) {
 export function renderShareAction(step) {
   return (
     <FlexCell width="full" key={`share-action-${step.id}`}>
+      <PuckWaypoint name="social_share_action-top" />
       <ShareActionContainer {...step.fields} />
+      <PuckWaypoint name="social_share_action-bottom" />
     </FlexCell>
   );
 }

--- a/resources/assets/components/Page/LandingPage/LandingPage.js
+++ b/resources/assets/components/Page/LandingPage/LandingPage.js
@@ -2,6 +2,7 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
+import { PuckWaypoint } from '@dosomething/puck-client';
 
 import Enclosure from '../../Enclosure';
 import LedeBanner from '../../LedeBanner/LedeBanner';
@@ -43,10 +44,12 @@ const LandingPage = (props) => {
         </Enclosure>
       </div>
 
+      <PuckWaypoint name="landing_page_cta-top" />
       <CallToActionContainer
         className="legacy border-top border-radius-none bg-off-white padding-lg"
         content={tagline}
       />
+      <PuckWaypoint name="landing_page_cta-bottom" />
 
       <div className="info-bar -dark">
         <div className="wrapper">A DoSomething.org campaign. Join over 5.5 million members taking action. Any cause, anytime, anywhere.</div>


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_
Added a few Waypoints to the ole application.


### What does this PR do?
We've got this awesome Waypoint functionality in the books! (🎩 💁‍♂️ @itsjoekent )

Adds a few [Puck Waypoints](https://github.com/DoSomething/puck-client#react-waypoints):
- Before and after the VoterRegistration action
- Before and After the Photo Uploader action
- Before and after the Social Share action
- Before and after the CTA on the Landing Page
- After the ActionStep

![waypoints](https://user-images.githubusercontent.com/12417657/35743246-fff7d64e-080a-11e8-9d2d-7385e2841a20.gif)



### What are the relevant tickets/cards?
[#154847175](https://www.pivotaltracker.com/story/show/154847175)

