### PR TITLE
Update to fix odd bug with RB uploader and submissions gallery

### DIFF
--- a/resources/assets/actions/reportback.js
+++ b/resources/assets/actions/reportback.js
@@ -209,7 +209,7 @@ export function submitPhotoPost(post) {
   return submitReportback(url, post);
 }
 
-export function fetchUserReportbacks(userId, campaignId) {
+export function fetchUserReportbacks(userId, campaignId, campaignRunId) {
   if (! userId) {
     return (dispatch) => {
       dispatch(requestingUserReportbacksFailed());
@@ -219,7 +219,7 @@ export function fetchUserReportbacks(userId, campaignId) {
   return (dispatch) => {
     dispatch(requestingUserReportbacks());
 
-    return (new Phoenix()).get('next/signups', { campaigns: campaignId, users: userId })
+    return (new Phoenix()).get('next/signups', { campaigns: campaignId, users: userId, runs: campaignRunId })
       .then((json) => {
         dispatch(receivedUserReportbacks());
 

--- a/resources/assets/components/Gallery/SubmissionGallery/SubmissionGallery.js
+++ b/resources/assets/components/Gallery/SubmissionGallery/SubmissionGallery.js
@@ -15,9 +15,9 @@ class SubmissionGallery extends React.Component {
   }
 
   componentDidMount() {
-    const { userId, legacyCampaignId } = this.props;
+    const { userId, legacyCampaignId, legacyCampaignRunId } = this.props;
 
-    this.props.fetchUserReportbacks(userId, legacyCampaignId);
+    this.props.fetchUserReportbacks(userId, legacyCampaignId, legacyCampaignRunId);
   }
 
   render() {
@@ -34,6 +34,7 @@ class SubmissionGallery extends React.Component {
 SubmissionGallery.propTypes = {
   fetchUserReportbacks: PropTypes.func.isRequired,
   legacyCampaignId: PropTypes.string.isRequired,
+  legacyCampaignRunId: PropTypes.string.isRequired,
   submissions: PropTypes.shape({
     isFetching: PropTypes.bool,
     items: PropTypes.array,

--- a/resources/assets/components/Gallery/SubmissionGallery/SubmissionGalleryContainer.js
+++ b/resources/assets/components/Gallery/SubmissionGallery/SubmissionGalleryContainer.js
@@ -8,6 +8,7 @@ import { fetchUserReportbacks } from '../../../actions';
  */
 const mapStateToProps = state => ({
   legacyCampaignId: state.campaign.legacyCampaignId,
+  legacyCampaignRunId: state.campaign.legacyCampaignRunId,
   submissions: state.submissions,
   userId: state.user.id,
 });


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_


### What does this PR do?
This PR attempts to fix an odd bug we've been experiencing with the RB Uploader which seems to only occur on campaigns that may have multiple legacy runs.


### Any background context you want to provide?
On "Mirror Messages" campaign, which goes through a few runs, we've noticed some weird effects with the RB Uploader impact display likely due to the campaign having multiple runs associated with it and the proxied response from Rogue returns signup data for all runs instead of the specific campaign run.


### What are the relevant tickets/cards?
Fixes #660 
