### PR TITLE
Adding Contentful Id as waypointData to share action waypoints

### DIFF
--- a/resources/assets/components/ActionPage/ActionStepRenderers.js
+++ b/resources/assets/components/ActionPage/ActionStepRenderers.js
@@ -205,11 +205,13 @@ export function renderVoterRegistration(step, stepIndex) {
  * @return {Component}
  */
 export function renderShareAction(step) {
+  const contentfulId = step.id;
+
   return (
-    <FlexCell width="full" key={`share-action-${step.id}`}>
-      <PuckWaypoint name="social_share_action-top" />
+    <FlexCell width="full" key={`share-action-${contentfulId}`}>
+      <PuckWaypoint name="share_action-top" waypointData={{ contentfulId }} />
       <ShareActionContainer {...step.fields} />
-      <PuckWaypoint name="social_share_action-bottom" />
+      <PuckWaypoint name="share_action-bottom" waypointData={{ contentfulId }} />
     </FlexCell>
   );
 }


### PR DESCRIPTION
Adding the Contentful ID as an identifier for the tracking Waypoints for Share Actions. 
(This is to address the fact that there could be multiple share actions on a page)