### PR TITLE
Moving Voter Registration Action component into Actions directory

### DIFF
--- a/resources/assets/components/ActionPage/ActionStepRenderers.js
+++ b/resources/assets/components/ActionPage/ActionStepRenderers.js
@@ -3,7 +3,7 @@ import { PuckWaypoint } from '@dosomething/puck-client';
 import ActionStep from './ActionStep';
 import Revealer from '../Revealer';
 import SignupButtonFactory from '../SignupButton';
-import VoterRegistrationContainer from '../VoterRegistration';
+import VoterRegistrationActionContainer from '../Actions/VoterRegistrationAction';
 import { FlexCell } from '../Flex';
 import { PostGalleryContainer } from '../Gallery/PostGallery';
 import { ThirdPartyActionContainer } from '../Actions/ThirdPartyAction';
@@ -176,18 +176,18 @@ export function renderLegacyGallery() {
 }
 
 /**
- * Render the voter registration container.
+ * Render the voter registration action container.
  *
  * @return {Component}
  */
-export function renderVoterRegistration(step, stepIndex) {
+export function renderVoterRegistrationAction(step, stepIndex) {
   const { title, content, link } = step.fields;
 
   return (
-    <FlexCell width="full" key={`voter-registration-${step.id}`}>
+    <FlexCell width="full" key={`voter-registration-action-${step.id}`}>
       <PuckWaypoint name="voter_registration_action-top" />
       <div className="action-step">
-        <VoterRegistrationContainer
+        <VoterRegistrationActionContainer
           content={content}
           title={title}
           link={link}

--- a/resources/assets/components/ActionPage/ActionStepsWrapper.js
+++ b/resources/assets/components/ActionPage/ActionStepsWrapper.js
@@ -5,7 +5,7 @@ import { Flex } from '../Flex';
 import {
   renderCompetitionStep, renderPhotoUploader, renderSubmissionGallery,
   renderThirdPartyAction, renderActionStep, renderRevealer,
-  renderLegacyGallery, renderVoterRegistration, renderShareAction,
+  renderLegacyGallery, renderVoterRegistrationAction, renderShareAction,
   renderLinkAction,
 } from './ActionStepRenderers';
 
@@ -34,7 +34,7 @@ const ActionStepsWrapper = (props) => {
         return renderThirdPartyAction(step, stepIndex);
 
       case 'voterRegistrationAction':
-        return renderVoterRegistration(step, stepIndex);
+        return renderVoterRegistrationAction(step, stepIndex);
 
       case 'shareAction':
         return renderShareAction(step);

--- a/resources/assets/components/Actions/VoterRegistrationAction/VoterRegistrationAction.js
+++ b/resources/assets/components/Actions/VoterRegistrationAction/VoterRegistrationAction.js
@@ -1,15 +1,15 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import Card from '../Card';
-import Markdown from '../Markdown';
-import { Flex, FlexCell } from '../Flex';
-import SectionHeader from '../SectionHeader';
-import { dynamicString } from '../../helpers';
+import Card from '../../Card';
+import Markdown from '../../Markdown';
+import { Flex, FlexCell } from '../../Flex';
+import SectionHeader from '../../SectionHeader';
+import { dynamicString } from '../../../helpers';
 
-import './voter-registration.scss';
+import './voter-registration-action.scss';
 
-const VoterRegistration = (props) => {
+const VoterRegistrationAction = (props) => {
   const {
     campaignId,
     campaignRunId,
@@ -36,7 +36,7 @@ const VoterRegistration = (props) => {
         step={stepIndex}
       />
       <FlexCell width="two-thirds">
-        <Card className="rounded bordered voter-registration" title={title}>
+        <Card className="rounded bordered voter-registration" title="Register to vote">
           <div className="padded clearfix">
             <Markdown>{ content }</Markdown>
 
@@ -48,7 +48,7 @@ const VoterRegistration = (props) => {
   );
 };
 
-VoterRegistration.propTypes = {
+VoterRegistrationAction.propTypes = {
   campaignId: PropTypes.string.isRequired,
   campaignRunId: PropTypes.string.isRequired,
   content: PropTypes.string,
@@ -59,9 +59,9 @@ VoterRegistration.propTypes = {
   userId: PropTypes.string.isRequired,
 };
 
-VoterRegistration.defaultProps = {
+VoterRegistrationAction.defaultProps = {
   content: 'Register to vote!',
   hideStepNumber: true,
 };
 
-export default VoterRegistration;
+export default VoterRegistrationAction;

--- a/resources/assets/components/Actions/VoterRegistrationAction/VoterRegistrationAction.test.js
+++ b/resources/assets/components/Actions/VoterRegistrationAction/VoterRegistrationAction.test.js
@@ -1,11 +1,11 @@
 import React from 'react';
 import { render } from 'enzyme';
 
-import VoterRegistration from './VoterRegistration';
+import VoterRegistrationAction from './VoterRegistrationAction';
 
-test('VoterRegistration is rendered as a card component with a button', () => {
+test('VoterRegistrationAction is rendered as a card component with a button', () => {
   const wrapper = render(
-    <VoterRegistration
+    <VoterRegistrationAction
       campaignId="1234"
       campaignRunId="9876"
       content="Cras justo odio, dapibus ac facilisis in, egestas eget quam. Duis mollis, est non commodo luctus, nisi erat porttitor ligula."

--- a/resources/assets/components/Actions/VoterRegistrationAction/VoterRegistrationActionContainer.js
+++ b/resources/assets/components/Actions/VoterRegistrationAction/VoterRegistrationActionContainer.js
@@ -1,6 +1,6 @@
 import { connect } from 'react-redux';
 
-import VoterRegistration from './VoterRegistration';
+import VoterRegistrationAction from './VoterRegistrationAction';
 
 /**
  * Provide state from the Redux store as props for this component.
@@ -14,4 +14,4 @@ const mapStateToProps = state => ({
 /**
  * Export the container component.
  */
-export default connect(mapStateToProps)(VoterRegistration);
+export default connect(mapStateToProps)(VoterRegistrationAction);

--- a/resources/assets/components/Actions/VoterRegistrationAction/index.js
+++ b/resources/assets/components/Actions/VoterRegistrationAction/index.js
@@ -1,0 +1,3 @@
+export default from './VoterRegistrationActionContainer';
+
+export VoterRegistrationAction from './VoterRegistrationAction';

--- a/resources/assets/components/Actions/VoterRegistrationAction/voter-registration-action.scss
+++ b/resources/assets/components/Actions/VoterRegistrationAction/voter-registration-action.scss
@@ -1,5 +1,5 @@
 @import '~@dosomething/forge/scss/toolkit';
-@import '../../scss/next-toolbox.scss';
+@import '../../../scss/next-toolbox.scss';
 
 .voter-registration {
   .button {

--- a/resources/assets/components/Actions/index.js
+++ b/resources/assets/components/Actions/index.js
@@ -1,2 +1,3 @@
-export * from './ThirdPartyAction';
 export * from './LinkAction';
+export * from './ThirdPartyAction';
+export * from './VoterRegistrationAction';

--- a/resources/assets/components/VoterRegistration/index.js
+++ b/resources/assets/components/VoterRegistration/index.js
@@ -1,3 +1,0 @@
-export default from './VoterRegistrationContainer';
-
-export VoterRegistration from './VoterRegistration';


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_


### What does this PR do?
This PR just moves the Voter Registration Action component into the `/components/Actions` directory and renames everything to include the `*Action` suffix in the name.

It also hardcodes the title for the Voter Registration Action card component for the time being.
