### PR TITLE
Share action tests

### DIFF
--- a/resources/assets/__mocks__/facebookShareMock.js
+++ b/resources/assets/__mocks__/facebookShareMock.js
@@ -3,7 +3,7 @@ const setFBshare = (shouldBeSuccessful) => {
     ui: jest.fn((share, callback) => {
       callback(shouldBeSuccessful);
     }),
-  }
-}
+  };
+};
 
 export default setFBshare;

--- a/resources/assets/__mocks__/facebookShareMock.js
+++ b/resources/assets/__mocks__/facebookShareMock.js
@@ -1,0 +1,9 @@
+const setFBshare = (shouldBeSuccessful) => {
+  global.FB = {
+    ui: (share, callback) => {
+      callback(shouldBeSuccessful);
+    }
+  }
+}
+
+export default setFBshare;

--- a/resources/assets/__mocks__/facebookShareMock.js
+++ b/resources/assets/__mocks__/facebookShareMock.js
@@ -1,8 +1,8 @@
 const setFBshare = (shouldBeSuccessful) => {
   global.FB = {
-    ui: (share, callback) => {
+    ui: jest.fn((share, callback) => {
       callback(shouldBeSuccessful);
-    }
+    }),
   }
 }
 

--- a/resources/assets/components/ShareAction/ShareAction.test.js
+++ b/resources/assets/components/ShareAction/ShareAction.test.js
@@ -2,15 +2,14 @@ import React from 'react';
 import { shallow } from 'enzyme';
 
 import ShareAction from './ShareAction';
-import setFBshare from '../../__mocks__/facebookShareMock.js';
+import setFBshare from '../../__mocks__/facebookShareMock';
 
 describe('ShareAction component', () => {
-
   const url = 'https://dosomething.org';
   const trackingData = { url };
 
   let trackEventMock = jest.fn();
-  let openModalMock  = jest.fn();
+  let openModalMock = jest.fn();
 
   const getShallow = () => shallow(
     <ShareAction
@@ -95,5 +94,5 @@ describe('ShareAction component', () => {
       expect(trackEventMock).toHaveBeenCalledTimes(2);
       expect(trackEventMock.mock.calls[1]).toEqual(['share action cancelled', trackingData]);
     });
-  })
+  });
 });

--- a/resources/assets/components/ShareAction/ShareAction.test.js
+++ b/resources/assets/components/ShareAction/ShareAction.test.js
@@ -23,11 +23,7 @@ describe('ShareAction component', () => {
 
   // We'll declare this reference to the wrapper object, so we can more elegantly reset the
   // shallow copy of the component and test it as necessary.
-  let wrapper;
-
-  beforeAll(() => {
-    wrapper = getShallow();
-  })
+  let wrapper = getShallow();
 
   it('renders a Card component', () => {
     expect(wrapper.find('Card')).toHaveLength(1);

--- a/resources/assets/components/ShareAction/ShareAction.test.js
+++ b/resources/assets/components/ShareAction/ShareAction.test.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { shallow } from 'enzyme';
 
 import ShareAction from './ShareAction';
-import setFBshare from '../../__mocks__/facebookShareMock.js'
+import setFBshare from '../../__mocks__/facebookShareMock.js';
 
 describe('ShareAction component', () => {
 
@@ -39,6 +39,16 @@ describe('ShareAction component', () => {
     beforeEach(() => {
       trackEventMock = jest.fn();
       openModalMock = jest.fn();
+    });
+
+    it('calls the FB ui method to trigger the facebook share', () => {
+      const wrapper = getShallow();
+
+      setFBshare(true);
+
+      wrapper.find('button').simulate('click');
+
+      expect(global.FB.ui).toHaveBeenCalled();
     });
 
     it('tracks clicked share action event', () => {

--- a/resources/assets/components/ShareAction/ShareAction.test.js
+++ b/resources/assets/components/ShareAction/ShareAction.test.js
@@ -1,0 +1,89 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import ShareAction from './ShareAction';
+import setFBshare from '../../__mocks__/facebookShareMock.js'
+
+describe('ShareAction component', () => {
+
+  const url = 'https://dosomething.org';
+  const trackingData = { url };
+
+  let trackEventMock = jest.fn();
+  let openModalMock  = jest.fn();
+
+  const getShallow = () => shallow(
+    <ShareAction
+      title="Click on this link!"
+      content="This is a great link"
+      trackEvent={trackEventMock}
+      openModal={openModalMock}
+      link={url}
+    />,
+  );
+
+  it('renders a Card component', () => {
+    const wrapper = getShallow();
+
+    expect(wrapper.find('Card')).toHaveLength(1);
+    expect(wrapper.find('Card').find('Embed')).toHaveLength(1);
+  });
+
+  it('renders a Facebook Share button', () => {
+    const wrapper = getShallow();
+
+    expect(wrapper.find('button').text()).toEqual('Share on Facebook');
+  });
+
+  describe('Clicking the Social Share Button', () => {
+    beforeEach(() => {
+      trackEventMock = jest.fn();
+      openModalMock = jest.fn();
+    });
+
+    it('tracks clicked share action event', () => {
+      const wrapper = getShallow();
+
+      setFBshare(true);
+
+      wrapper.find('button').simulate('click');
+
+      expect(trackEventMock.mock.calls.length).toBeGreaterThan(0);
+
+      expect(trackEventMock.mock.calls[0]).toEqual(['clicked share action', trackingData]);
+      expect(trackEventMock.mock.calls[1]).toEqual(['share action completed', trackingData]);
+    });
+
+    it('tracks completed share action event when social share is successful', () => {
+      const wrapper = getShallow();
+
+      setFBshare(true);
+
+      wrapper.find('button').simulate('click');
+
+      expect(trackEventMock).toHaveBeenCalledTimes(2);
+      expect(trackEventMock.mock.calls[0]).toEqual(['clicked share action', trackingData]);
+    });
+
+    it('displays the affirmation modal when social share is successful', () => {
+      const wrapper = getShallow();
+
+      setFBshare(true);
+
+      wrapper.find('button').simulate('click');
+
+      expect(openModalMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('tracks completed share action event when social share is cancelled', () => {
+      const wrapper = getShallow();
+
+      setFBshare(false);
+
+      wrapper.find('button').simulate('click');
+
+      expect(trackEventMock).toHaveBeenCalledTimes(2);
+      expect(trackEventMock.mock.calls[1]).toEqual(['share action cancelled', trackingData]);
+    });
+  })
+});

--- a/resources/assets/components/ShareAction/ShareAction.test.js
+++ b/resources/assets/components/ShareAction/ShareAction.test.js
@@ -21,28 +21,34 @@ describe('ShareAction component', () => {
     />,
   );
 
-  it('renders a Card component', () => {
-    const wrapper = getShallow();
+  // We'll declare this reference to the wrapper object, so we can more elegantly reset the
+  // shallow copy of the component and test it as necessary.
+  let wrapper;
 
-    expect(wrapper.find('Card')).toHaveLength(1);
-    expect(wrapper.find('Card').find('Embed')).toHaveLength(1);
-  });
 
-  it('renders a Facebook Share button', () => {
-    const wrapper = getShallow();
+  describe('It renders', () => {
+    beforeEach(() => {
+      wrapper = getShallow();
+    })
 
-    expect(wrapper.find('button').text()).toEqual('Share on Facebook');
-  });
+    it('a Card component', () => {
+      expect(wrapper.find('Card')).toHaveLength(1);
+      expect(wrapper.find('Card').find('Embed')).toHaveLength(1);
+    });
+
+    it('a Facebook Share button', () => {
+      expect(wrapper.find('button').text()).toEqual('Share on Facebook');
+    });
+  })
 
   describe('Clicking the Social Share Button', () => {
     beforeEach(() => {
       trackEventMock = jest.fn();
       openModalMock = jest.fn();
+      wrapper = getShallow();
     });
 
     it('calls the FB ui method to trigger the facebook share', () => {
-      const wrapper = getShallow();
-
       setFBshare(true);
 
       wrapper.find('button').simulate('click');
@@ -51,8 +57,6 @@ describe('ShareAction component', () => {
     });
 
     it('tracks clicked share action event', () => {
-      const wrapper = getShallow();
-
       setFBshare(true);
 
       wrapper.find('button').simulate('click');
@@ -64,8 +68,6 @@ describe('ShareAction component', () => {
     });
 
     it('tracks completed share action event when social share is successful', () => {
-      const wrapper = getShallow();
-
       setFBshare(true);
 
       wrapper.find('button').simulate('click');
@@ -75,8 +77,6 @@ describe('ShareAction component', () => {
     });
 
     it('displays the affirmation modal when social share is successful', () => {
-      const wrapper = getShallow();
-
       setFBshare(true);
 
       wrapper.find('button').simulate('click');
@@ -85,8 +85,6 @@ describe('ShareAction component', () => {
     });
 
     it('tracks completed share action event when social share is cancelled', () => {
-      const wrapper = getShallow();
-
       setFBshare(false);
 
       wrapper.find('button').simulate('click');

--- a/resources/assets/components/ShareAction/ShareAction.test.js
+++ b/resources/assets/components/ShareAction/ShareAction.test.js
@@ -25,21 +25,18 @@ describe('ShareAction component', () => {
   // shallow copy of the component and test it as necessary.
   let wrapper;
 
-
-  describe('It renders', () => {
-    beforeEach(() => {
-      wrapper = getShallow();
-    })
-
-    it('a Card component', () => {
-      expect(wrapper.find('Card')).toHaveLength(1);
-      expect(wrapper.find('Card').find('Embed')).toHaveLength(1);
-    });
-
-    it('a Facebook Share button', () => {
-      expect(wrapper.find('button').text()).toEqual('Share on Facebook');
-    });
+  beforeAll(() => {
+    wrapper = getShallow();
   })
+
+  it('renders a Card component', () => {
+    expect(wrapper.find('Card')).toHaveLength(1);
+    expect(wrapper.find('Card').find('Embed')).toHaveLength(1);
+  });
+
+  it('renders a Facebook Share button', () => {
+    expect(wrapper.find('button').text()).toEqual('Share on Facebook');
+  });
 
   describe('Clicking the Social Share Button', () => {
     beforeEach(() => {


### PR DESCRIPTION
Adding some tests for the good ole [ShareAction](https://github.com/DoSomething/phoenix-next/blob/dev/resources/assets/components/ShareAction/ShareAction.js) component!

Also added a (somewhat meager) Facebook global object mock, to help with testing that we're triggering an FB share modal, and tracking the (successful or canceled) share.