### PR TITLE
Reportback uploader affirmation

### DIFF
--- a/resources/assets/actions/reportback.js
+++ b/resources/assets/actions/reportback.js
@@ -16,7 +16,6 @@ import {
   REQUESTED_USER_SUBMISSIONS,
   REQUESTED_USER_SUBMISSIONS_FAILED,
   RECEIVED_USER_SUBMISSIONS,
-  TOGGLE_REPORTBACK_AFFIRMATION,
   queueEvent,
 } from '../actions';
 
@@ -154,14 +153,6 @@ export function toggleReactionOff(reportbackItemId, reactionId) {
   };
 }
 
-// Action : toggle the reportback affirmation being displayed
-export function toggleReportbackAffirmation(shouldShowAffirmation) {
-  return {
-    type: TOGGLE_REPORTBACK_AFFIRMATION,
-    shouldShowAffirmation,
-  };
-}
-
 // Async Action: submit a new reportback and place in submissions gallery.
 export function submitReportback(url, reportback) {
   return (dispatch) => {
@@ -187,7 +178,6 @@ export function submitReportback(url, reportback) {
           });
         } else {
           dispatch(storeReportbackSuccessful());
-          dispatch(toggleReportbackAffirmation(true));
 
           response.json().then((json) => {
             dispatch(addSubmissionMetadata(reportback, json.shift()));

--- a/resources/assets/components/AdminDashboard/CampaignDashboard/CampaignDashboard.js
+++ b/resources/assets/components/AdminDashboard/CampaignDashboard/CampaignDashboard.js
@@ -4,10 +4,12 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom';
 
+import { POST_REPORTBACK_MODAL } from '../../Modal';
+
 const CampaignDashboard = (props) => {
   const { hasLandingPage, slug, clickedShowAffirmation, clickedShowLandingPage,
     clickedShowActionPage, clickedRemoveSignUp, hasReferralRB, signupCreated,
-    isAdmin, isSignedUp, toggleReportbackAffirmation,
+    isAdmin, isSignedUp, openModal,
   } = props;
 
   const onSignUpClick = () => (! isSignedUp ? signupCreated() : clickedRemoveSignUp());
@@ -38,7 +40,7 @@ const CampaignDashboard = (props) => {
       <button className="button -secondary margin-md" onClick={onSignUpClick}>
         {`Mock ${isSignedUp ? 'Un-sign Up' : 'Sign Up'}`}
       </button>
-      <button className="button -secondary margin-md" onClick={() => toggleReportbackAffirmation(true)}>
+      <button className="button -secondary margin-md" onClick={() => openModal(POST_REPORTBACK_MODAL)}>
         Show Reportback Affirmation
       </button>
       { hasReferralRB && isAdmin ?
@@ -60,8 +62,8 @@ CampaignDashboard.propTypes = {
   clickedShowActionPage: PropTypes.func.isRequired,
   clickedRemoveSignUp: PropTypes.func.isRequired,
   signupCreated: PropTypes.func.isRequired,
-  toggleReportbackAffirmation: PropTypes.func.isRequired,
   hasReferralRB: PropTypes.bool.isRequired,
+  openModal: PropTypes.func.isRequired,
 };
 
 CampaignDashboard.defaultProps = {

--- a/resources/assets/components/AdminDashboard/CampaignDashboard/CampaignDashboardContainer.js
+++ b/resources/assets/components/AdminDashboard/CampaignDashboard/CampaignDashboardContainer.js
@@ -4,7 +4,6 @@ import { get } from 'lodash';
 import CampaignDashboard from './CampaignDashboard';
 import { clickedShowLandingPage, clickedShowActionPage } from '../../../actions/admin';
 import { clickedShowAffirmation, signupCreated, clickedRemoveSignUp } from '../../../actions/signup';
-import { toggleReportbackAffirmation } from '../../../actions/reportback';
 import { userHasRole } from '../../../selectors/user';
 import { openModal } from '../../../actions/modal';
 
@@ -29,7 +28,6 @@ const actionCreators = {
   clickedShowActionPage,
   signupCreated,
   clickedRemoveSignUp,
-  toggleReportbackAffirmation,
   openModal,
 };
 

--- a/resources/assets/components/AdminDashboard/CampaignDashboard/CampaignDashboardContainer.js
+++ b/resources/assets/components/AdminDashboard/CampaignDashboard/CampaignDashboardContainer.js
@@ -6,6 +6,7 @@ import { clickedShowLandingPage, clickedShowActionPage } from '../../../actions/
 import { clickedShowAffirmation, signupCreated, clickedRemoveSignUp } from '../../../actions/signup';
 import { toggleReportbackAffirmation } from '../../../actions/reportback';
 import { userHasRole } from '../../../selectors/user';
+import { openModal } from '../../../actions/modal';
 
 const mapStateToProps = (state) => {
   const isSignedUp = state.signups.thisCampaign;
@@ -29,6 +30,7 @@ const actionCreators = {
   signupCreated,
   clickedRemoveSignUp,
   toggleReportbackAffirmation,
+  openModal,
 };
 
 export default connect(mapStateToProps, actionCreators)(CampaignDashboard);

--- a/resources/assets/components/Modal/ModalSwitch.js
+++ b/resources/assets/components/Modal/ModalSwitch.js
@@ -2,9 +2,9 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import {
   Modal, PostSignupModal, ContentModal, ReportbackUploaderModal,
-  PostShareModalContainer, SurveyModalContainer,
+  PostReportbackModalContainer, PostShareModalContainer, SurveyModalContainer,
   POST_SIGNUP_MODAL, CONTENT_MODAL, REPORTBACK_UPLOADER_MODAL,
-  POST_SHARE_MODAL, SURVEY_MODAL,
+  POST_SHARE_MODAL, SURVEY_MODAL, POST_REPORTBACK_MODAL,
 } from '../Modal';
 
 const ModalSwitch = (props) => {
@@ -26,6 +26,9 @@ const ModalSwitch = (props) => {
       break;
     case POST_SHARE_MODAL:
       children = <PostShareModalContainer />;
+      break;
+    case POST_REPORTBACK_MODAL:
+      children = <PostReportbackModalContainer />;
       break;
     default: break;
   }

--- a/resources/assets/components/Modal/configurations/PostReportbackModal.js
+++ b/resources/assets/components/Modal/configurations/PostReportbackModal.js
@@ -1,0 +1,27 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import Card from '../../Card';
+import Markdown from '../../Markdown';
+
+const PostReportbackModal = (props) => {
+  const { content, closeModal } = props;
+
+  return (
+    <Card title="We Got Your Photo" className="modal__slide bordered rounded" onClose={closeModal}>
+      <Markdown className="padding-md">
+        {content || PostReportbackModal.defaultProps.content }
+      </Markdown>
+    </Card>
+  );
+};
+
+PostReportbackModal.propTypes = {
+  content: PropTypes.string,
+  closeModal: PropTypes.func.isRequired,
+};
+
+PostReportbackModal.defaultProps = {
+  content: 'Thanks! We got your photo and you\'re entered to win the scholarship!',
+};
+
+export default PostReportbackModal;

--- a/resources/assets/components/Modal/containers/PostReportbackModalContainer.js
+++ b/resources/assets/components/Modal/containers/PostReportbackModalContainer.js
@@ -1,0 +1,20 @@
+import { connect } from 'react-redux';
+import { find } from 'lodash';
+import PostReportbackModal from '../configurations/PostReportbackModal';
+import { closeModal } from '../../../actions/modal';
+
+const mapStateToProps = (state) => {
+  const reportbackUploader = find(
+    state.campaign.actionSteps, { type: { sys: { id: 'photoUploaderAction' } } },
+  );
+
+  return {
+    content: reportbackUploader.fields.affirmationContent,
+  };
+};
+
+const actionCreators = {
+  closeModal,
+};
+
+export default connect(mapStateToProps, actionCreators)(PostReportbackModal);

--- a/resources/assets/components/Modal/index.js
+++ b/resources/assets/components/Modal/index.js
@@ -3,6 +3,7 @@ export default from './containers/ModalSwitchContainer';
 export Modal from './containers/ModalContainer';
 export SurveyModalContainer from './containers/SurveyModalContainer';
 export PostShareModalContainer from './containers/PostShareModalContainer';
+export PostReportbackModalContainer from './containers/PostReportbackModalContainer';
 
 // TODO: whoops, these probably need to be renamed to have 'Container' appended to the name.
 export PostSignupModal from './containers/PostSignupModalContainer';
@@ -14,3 +15,4 @@ export const CONTENT_MODAL = 'CONTENT_MODAL';
 export const REPORTBACK_UPLOADER_MODAL = 'REPORTBACK_UPLOADER_MODAL';
 export const SURVEY_MODAL = 'SURVEY_MODAL';
 export const POST_SHARE_MODAL = 'POST_SHARE_MODAL';
+export const POST_REPORTBACK_MODAL = 'POST_REPORTBACK_MODAL';

--- a/resources/assets/components/ReportbackUploader/ReportbackUploader.js
+++ b/resources/assets/components/ReportbackUploader/ReportbackUploader.js
@@ -36,7 +36,6 @@ class ReportbackUploader extends React.Component {
 
     this.handleOnSubmitForm = this.handleOnSubmitForm.bind(this);
     this.handleOnFileUpload = this.handleOnFileUpload.bind(this);
-    this.getAffirmationContent = this.getAffirmationContent.bind(this);
 
     this.defaultMediaState = {
       file: null,
@@ -59,12 +58,6 @@ class ReportbackUploader extends React.Component {
       impact: null,
       ...infoFields,
     };
-  }
-
-  getAffirmationContent() {
-    return this.props.affirmationContent || (
-      ReportbackUploader.defaultProps.affirmationContent
-    );
   }
 
   handleOnFileUpload(media) {
@@ -126,7 +119,7 @@ class ReportbackUploader extends React.Component {
   render() {
     const {
       submissions, showQuantityField, informationTitle, informationContent,
-      shouldShowAffirmation, toggleReportbackAffirmation, referralRB,
+      referralRB,
     } = this.props;
 
     const formHasErrors = get(submissions.messaging, 'error', null);
@@ -248,13 +241,6 @@ class ReportbackUploader extends React.Component {
           ) : null }
         </div>
 
-        { shouldShowAffirmation ? (
-          <div className="photo-uploader-affirmation margin-top-lg">
-            <Card title="We Got Your Photo" className="bordered rounded" onClose={() => toggleReportbackAffirmation(false)}>
-              <Markdown className="padding-md">{this.getAffirmationContent()}</Markdown>
-            </Card>
-          </div>
-        ) : null }
       </div>
     );
   }
@@ -262,7 +248,6 @@ class ReportbackUploader extends React.Component {
 
 ReportbackUploader.propTypes = {
   actionType: PropTypes.string,
-  affirmationContent: PropTypes.string,
   referralRB: PropTypes.bool,
   informationContent: PropTypes.string,
   informationTitle: PropTypes.string,
@@ -271,7 +256,6 @@ ReportbackUploader.propTypes = {
     singular: PropTypes.string,
     plural: PropTypes.string,
   }),
-  shouldShowAffirmation: PropTypes.bool,
   openModal: PropTypes.func.isRequired,
   showQuantityField: PropTypes.bool,
   submissions: PropTypes.shape({
@@ -284,12 +268,10 @@ ReportbackUploader.propTypes = {
   submitReferralPost: PropTypes.func.isRequired,
   submitPhotoPost: PropTypes.func.isRequired,
   trackEvent: PropTypes.func.isRequired,
-  toggleReportbackAffirmation: PropTypes.func.isRequired,
 };
 
 ReportbackUploader.defaultProps = {
   actionType: 'photoUploaderAction',
-  affirmationContent: 'Thanks! We got your photo and you\'re entered to win the scholarship!',
   referralRB: false,
   informationContent: null,
   informationTitle: null,
@@ -298,7 +280,6 @@ ReportbackUploader.defaultProps = {
     plural: 'items',
   },
   showQuantityField: true,
-  shouldShowAffirmation: false,
 };
 
 export default ReportbackUploader;

--- a/resources/assets/components/ReportbackUploader/ReportbackUploader.js
+++ b/resources/assets/components/ReportbackUploader/ReportbackUploader.js
@@ -9,6 +9,7 @@ import Card from '../Card';
 import Markdown from '../Markdown';
 import FormMessage from '../FormMessage';
 import MediaUploader from '../MediaUploader';
+import { POST_REPORTBACK_MODAL } from '../Modal';
 
 import './reportback-uploader.scss';
 
@@ -112,6 +113,7 @@ class ReportbackUploader extends React.Component {
           });
 
           trackingMessage = 'Successful Reportback';
+          this.props.openModal(POST_REPORTBACK_MODAL);
         } else {
           trackingMessage = 'Unsuccessful Reportback';
           trackingData.submission_error = this.props.submissions.messaging.error;
@@ -270,6 +272,7 @@ ReportbackUploader.propTypes = {
     plural: PropTypes.string,
   }),
   shouldShowAffirmation: PropTypes.bool,
+  openModal: PropTypes.func.isRequired,
   showQuantityField: PropTypes.bool,
   submissions: PropTypes.shape({
     isFetching: PropTypes.bool,

--- a/resources/assets/components/ReportbackUploader/ReportbackUploaderContainer.js
+++ b/resources/assets/components/ReportbackUploader/ReportbackUploaderContainer.js
@@ -5,7 +5,7 @@ import ReportbackUploader from './ReportbackUploader';
 import { openModal } from '../../actions/modal';
 import {
   addSubmissionItemToList, submitPhotoPost,
-  submitReferralPost, toggleReportbackAffirmation,
+  submitReferralPost,
 } from '../../actions';
 
 /**
@@ -17,7 +17,6 @@ const mapStateToProps = state => ({
   submissions: state.submissions,
   noun: get(state.campaign.additionalContent, 'noun'),
   uploads: state.uploads,
-  shouldShowAffirmation: state.submissions.shouldShowAffirmation,
   referralRB: get(state.campaign.additionalContent, 'referralRB'),
 });
 
@@ -29,7 +28,6 @@ const actionCreators = {
   addSubmissionItemToList,
   submitPhotoPost,
   submitReferralPost,
-  toggleReportbackAffirmation,
   openModal,
 };
 

--- a/resources/assets/components/ReportbackUploader/ReportbackUploaderContainer.js
+++ b/resources/assets/components/ReportbackUploader/ReportbackUploaderContainer.js
@@ -2,6 +2,7 @@ import { connect } from 'react-redux';
 import { get } from 'lodash';
 import { PuckConnector } from '@dosomething/puck-client';
 import ReportbackUploader from './ReportbackUploader';
+import { openModal } from '../../actions/modal';
 import {
   addSubmissionItemToList, submitPhotoPost,
   submitReferralPost, toggleReportbackAffirmation,
@@ -29,6 +30,7 @@ const actionCreators = {
   submitPhotoPost,
   submitReferralPost,
   toggleReportbackAffirmation,
+  openModal,
 };
 
 // Export the container component.

--- a/resources/assets/reducers/submissions.js
+++ b/resources/assets/reducers/submissions.js
@@ -8,7 +8,6 @@ import {
   STORE_REPORTBACK_SUCCESSFUL,
   ADD_SUBMISSION_METADATA,
   ADD_SUBMISSION_ITEM_TO_LIST,
-  TOGGLE_REPORTBACK_AFFIRMATION,
 } from '../actions';
 
 /**
@@ -60,12 +59,6 @@ const submissions = (state = {}, action) => {
 
     case ADD_SUBMISSION_ITEM_TO_LIST:
       return { ...state, items: [action.reportbackItem, ...state.items] };
-
-    case TOGGLE_REPORTBACK_AFFIRMATION:
-      return {
-        ...state,
-        shouldShowAffirmation: action.shouldShowAffirmation,
-      };
 
     default:
       return state;

--- a/resources/assets/store/initialState.js
+++ b/resources/assets/store/initialState.js
@@ -59,7 +59,6 @@ const initialState = {
     isStoring: false,
     items: [],
     messaging: null,
-    shouldShowAffirmation: false,
   },
   uploads: {},
   user: {


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_


### What does this PR do?
This PR:

- Adds a `PostReportbackModal` which displays the reportback affirmation message to the user after a successful RB submission.
- Removes the old ReportbackAffirmation card and associated logic for displaying the card under the RB uploader
- Triggers the PostReportbackModal from the Admin Campaigns Dashboard's 'Show Reportback Affirmation' button

![reportback-affirmation-modal](https://user-images.githubusercontent.com/12417657/36044541-002b7b8e-0da1-11e8-866c-c8b876ccb52e.gif)


### Any background context you want to provide?
I am super excited about this! This will ensure our users actually see the affirmation and hopefully feel more like the submission was concretely successful.



### What are the relevant tickets/cards?
[#154850816](https://www.pivotaltracker.com/story/show/154850816)
