### PR TITLE
Fix two issues with null values.

### DIFF
--- a/resources/assets/components/Page/CampaignPage/CampaignPageContainer.js
+++ b/resources/assets/components/Page/CampaignPage/CampaignPageContainer.js
@@ -9,8 +9,8 @@ import { convertExperiment, openModal } from '../../../actions';
  */
 const mapStateToProps = state => ({
   actionText: state.campaign.actionText,
-  affiliatedActionText: state.campaign.additionalContent.affiliatedActionText,
-  affiliatedActionLink: state.campaign.additionalContent.affiliatedActionLink,
+  affiliatedActionText: get(state, 'campaign.additionalContent.affiliatedActionText', null),
+  affiliatedActionLink: get(state, 'campaign.additionalContent.affiliatedActionLink', null),
   blurb: state.campaign.blurb,
   coverImage: state.campaign.coverImage,
   dashboard: state.campaign.dashboard,

--- a/resources/assets/middleware/api.js
+++ b/resources/assets/middleware/api.js
@@ -21,7 +21,7 @@ const apiMiddleware = () => next => (action) => {
     client.get(payload.url, payload.query)
       .then((response) => {
         // @TODO: more to come with handling the response!
-        if (response.data) {
+        if (response && response.data) {
           console.groupCollapsed('%c API Middleware Response: ',
             'background-color: rgba(137,161,188,0.5); color: rgba(33,70,112,1); display: block; font-weight: bold; line-height: 1.5;',
           );


### PR DESCRIPTION
### What does this PR do?
This PR fixes two kabooms:

1. If `response` in the Redux API middleware is `null`, it'd explode since it couldn't get a `.data` property from it. This just adds a check that `response` exists before we try to get things from it.

2. Grabs the `affiliatedActionText` properties from `additionalContent` more carefully, since it's provided as `null` when empty (rather than an `{}` empty object like I'd assumed!)

### Any background context you want to provide?
🙅‍♂️ 

### What are the relevant tickets/cards?
References [this convo](https://dosomething.slack.com/archives/C2BPA7M8F/p1518459824000076).

### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
- [ ] Added screenshot to PR description of related front-end updates on **small** screens.
- [ ] Added screenshot to PR description of related front-end updates on **medium** screens.
- [ ] Added screenshot to PR description of related front-end updates on **large** screens.