### PR TITLE
Adjust confirmation messaging for SMS share test.

### DIFF
--- a/resources/assets/components/ShareApp.js
+++ b/resources/assets/components/ShareApp.js
@@ -19,8 +19,11 @@ class ShareApp extends React.Component {
   }
 
   render() {
+    const confirmationMessage = `Thanks for sharing and demanding representation
+      in media! You're entered for the chance to win the $3000 scholarship.`;
+
     return this.state.hasShared ? (
-      <h3>Thanks for sharing!</h3>
+      <h3 style={{ textAlign: 'center' }}>{confirmationMessage}</h3>
     ) : (
       <ShareAction
         title="Share This"


### PR DESCRIPTION
### What does this PR do?
This PR includes a quick copy change for the SMS share page before we send out broadcast tests:

<img width="422" alt="screen shot 2018-02-12 at 2 15 28 pm" src="https://user-images.githubusercontent.com/583202/36114841-328fbf9e-0fff-11e8-9732-99b4abd92cf2.png">

### Any background context you want to provide?
N/A

### What are the relevant tickets/cards?
N/A

### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
- [ ] Added screenshot to PR description of related front-end updates on **small** screens.
- [ ] Added screenshot to PR description of related front-end updates on **medium** screens.
- [ ] Added screenshot to PR description of related front-end updates on **large** screens.
