### PR TITLE
Some updates to share flow for rapid response.

### DIFF
--- a/resources/assets/components/ShareApp.js
+++ b/resources/assets/components/ShareApp.js
@@ -19,11 +19,13 @@ class ShareApp extends React.Component {
   }
 
   render() {
-    const confirmationMessage = `Thanks for sharing and demanding representation
-      in media! You're entered for the chance to win the $3000 scholarship.`;
+    const defaultConfirmation = 'Thanks for sharing!';
+    const confirmationMessage = get(window.STATE, 'campaign.additionalContent.smsShareConfirmation', defaultConfirmation);
 
     return this.state.hasShared ? (
-      <h3 style={{ textAlign: 'center' }}>{confirmationMessage}</h3>
+      <div>
+        <h3 style={{ textAlign: 'center' }}>{confirmationMessage}</h3>
+      </div>
     ) : (
       <ShareAction
         title="Share This"

--- a/resources/assets/components/ShareApp.js
+++ b/resources/assets/components/ShareApp.js
@@ -1,3 +1,5 @@
+/* global window */
+
 import React from 'react';
 import PropTypes from 'prop-types';
 import { PuckProvider, PuckConnector } from '@dosomething/puck-client';
@@ -22,9 +24,15 @@ class ShareApp extends React.Component {
     const defaultConfirmation = 'Thanks for sharing!';
     const confirmationMessage = get(window.STATE, 'campaign.additionalContent.smsShareConfirmation', defaultConfirmation);
 
+    // HACK: Yowza! Is there a better way to do this??
+    const campaignPath = window.location.pathname.split('/').slice(0, -1).join('/');
+
     return this.state.hasShared ? (
       <div>
         <h3 style={{ textAlign: 'center' }}>{confirmationMessage}</h3>
+        <ul className="form-actions">
+          <li><a href={campaignPath} className="button -tertiary">back to campaign</a></li>
+        </ul>
       </div>
     ) : (
       <ShareAction

--- a/resources/assets/components/ShareApp.js
+++ b/resources/assets/components/ShareApp.js
@@ -40,7 +40,7 @@ class ShareApp extends React.Component {
           ) : (
             null
           )}
-          <li><a href={campaignPath} className="button -tertiary">back to campaign</a></li>
+          <li><a href={campaignPath} className="button -tertiary">or take another action</a></li>
         </ul>
       </div>
     ) : (

--- a/resources/assets/components/ShareApp.js
+++ b/resources/assets/components/ShareApp.js
@@ -25,11 +25,10 @@ class ShareApp extends React.Component {
     const defaultConfirmation = 'Thanks for sharing!';
     const confirmationMessage = get(window.STATE, 'campaign.additionalContent.smsShareConfirmation', defaultConfirmation);
 
-    // HACK: Yowza! Is there a better way to do this??
-    const campaignPath = window.location.pathname.split('/').slice(0, -1).join('/');
-
     const confirmationActionText = get(window.STATE, 'campaign.additionalContent.smsShareConfirmationActionText');
     const confirmationActionLink = get(window.STATE, 'campaign.additionalContent.smsShareConfirmationActionLink');
+
+    const campaignPath = window.location.pathname.replace('share', '');
 
     return this.state.hasShared ? (
       <div>

--- a/resources/assets/components/ShareApp.js
+++ b/resources/assets/components/ShareApp.js
@@ -3,6 +3,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { PuckProvider, PuckConnector } from '@dosomething/puck-client';
+import { get } from 'lodash';
 import { Flex, FlexCell } from './Flex';
 import { BlockWrapper } from './Block';
 import ShareAction from './ShareAction';
@@ -27,10 +28,18 @@ class ShareApp extends React.Component {
     // HACK: Yowza! Is there a better way to do this??
     const campaignPath = window.location.pathname.split('/').slice(0, -1).join('/');
 
+    const confirmationActionText = get(window.STATE, 'campaign.additionalContent.smsShareConfirmationActionText');
+    const confirmationActionLink = get(window.STATE, 'campaign.additionalContent.smsShareConfirmationActionLink');
+
     return this.state.hasShared ? (
       <div>
         <h3 style={{ textAlign: 'center' }}>{confirmationMessage}</h3>
         <ul className="form-actions">
+          { confirmationActionText && confirmationActionLink ? (
+            <li><a href={confirmationActionLink} className="button">{confirmationActionText}</a></li>
+          ) : (
+            null
+          )}
           <li><a href={campaignPath} className="button -tertiary">back to campaign</a></li>
         </ul>
       </div>

--- a/resources/assets/components/ShareApp.js
+++ b/resources/assets/components/ShareApp.js
@@ -28,7 +28,7 @@ class ShareApp extends React.Component {
     const confirmationActionText = get(window.STATE, 'campaign.additionalContent.smsShareConfirmationActionText');
     const confirmationActionLink = get(window.STATE, 'campaign.additionalContent.smsShareConfirmationActionLink');
 
-    const campaignPath = window.location.pathname.replace('share', '');
+    const campaignPath = window.location.pathname.replace(/share$/, '');
 
     return this.state.hasShared ? (
       <div>


### PR DESCRIPTION
### What does this PR do?
This PR adds some additional customization options to the SMS share flow for our rapid response this afternoon:

🔤 Allows customizing the confirmation message with `additionalContent.smsShareConfirmation`. The default text has been replaced with [a generic "Thanks for sharing!" message](https://user-images.githubusercontent.com/583202/36268462-899ac526-1244-11e8-99ba-510834d02fa0.png).

🔙 Adds a "back to campaign" link to allow users to visit the campaign page after sharing.

⏭ Adds an optional "post-share action" button which can link to any additional call-to-action. For the rapid response, we're going to link this to a `tel:+15551234567` link to CallPower (configurable within the `additionalContent` JSON).

### Any background context you want to provide?
Here's how this might look for the rapid response:

<img width="211" alt="screen shot 2018-02-15 at 12 03 17 pm" src="https://user-images.githubusercontent.com/583202/36269847-469d38fe-1248-11e8-8f0d-77147f234fbf.png">

### What are the relevant tickets/cards?
This was unplanned work, will make a ticket to track.

### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
- [x] Added screenshot to PR description of related front-end updates on **small** screens.
- [ ] Added screenshot to PR description of related front-end updates on **medium** screens.
- [ ] Added screenshot to PR description of related front-end updates on **large** screens.