### PR TITLE
Lede banner headline bug

### DIFF
--- a/resources/assets/components/LedeBanner/lede-banner.scss
+++ b/resources/assets/components/LedeBanner/lede-banner.scss
@@ -84,6 +84,13 @@
     font-size: 28px;
     top: -$half-spacing;
   }
+
+  @include media("(max-width: 450px)") {
+    &.smaller-font {
+      font-size: 15px;
+      top: -4px;
+    }
+  }
 }
 
 .lede-banner__headline-subtitle {

--- a/resources/assets/components/LedeBanner/templates/MosaicTemplate.js
+++ b/resources/assets/components/LedeBanner/templates/MosaicTemplate.js
@@ -71,7 +71,9 @@ const MosaicTemplate = (props) => {
       <div className="lede-banner__content">
         <div className="wrapper">
           <div className="lede-banner__headline">
-            <h1 className="lede-banner__headline-title">{title}</h1>
+            <h1 className={classnames('lede-banner__headline-title', { 'smaller-font': title.length > 25 })}>
+              {title}
+            </h1>
             <h2 className="lede-banner__headline-subtitle">{subtitle}</h2>
           </div>
 


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?
This PR fixes an issue in the `LedeBanner` where a long headline title would overlay the subtitle on smaller screens.

- Adding a `smaller-font` class to the `lede-banner__headline-title` if the `title` property is more then 25 characters
- Adjusting the font size to be smaller for headline-titles with a `smaller-font` class on screens `450px` wide or less


### What are the relevant tickets/cards?
Fixes #691 
Pivotal ID: [#155364724](https://www.pivotaltracker.com/story/show/155364724)

### Screenshots
[Before](https://user-images.githubusercontent.com/12417657/36434504-2901987e-162d-11e8-9198-40ffb2c4f228.png)
[After](https://user-images.githubusercontent.com/12417657/36443791-b60c5686-1647-11e8-90ea-5e30bfef23b0.png)


