### PR TITLE
Adding Twitter to the ShareAction

### DIFF
--- a/app/Entities/ShareAction.php
+++ b/app/Entities/ShareAction.php
@@ -21,7 +21,7 @@ class ShareAction extends Entity implements JsonSerializable
                 'content' => $this->content,
                 'link' => $this->link,
                 'affirmation' => $this->affirmation,
-                'socialPlatform' => $this->socialPlatform,
+                'socialPlatform' => $this->socialPlatform->first() ?: 'facebook',
             ],
         ];
     }

--- a/app/Entities/ShareAction.php
+++ b/app/Entities/ShareAction.php
@@ -21,6 +21,7 @@ class ShareAction extends Entity implements JsonSerializable
                 'content' => $this->content,
                 'link' => $this->link,
                 'affirmation' => $this->affirmation,
+                'socialPlatform' => $this->socialPlatform,
             ],
         ];
     }

--- a/docs/content-publishing/actions/share-action.md
+++ b/docs/content-publishing/actions/share-action.md
@@ -1,6 +1,6 @@
 # Share Action
 
-The `ShareAction` component renders a visual component which features an embedded link, and a social share button (for now specifically a Facebook share button). Clicking the social share button will trigger the Facebook Share modal to open, populated with the embedded link. The component includes functionality to track a successful or canceled share, for an automatic Reportback process (enabling the DoSomething member to skip manually reporting back with a snapshot of their Facebook share). 
+The `ShareAction` component renders a visual component which features an embedded link, and a social share button (specifically a Facebook or Twitter share button). Clicking the social share button will trigger the Facebook Share modal or Twitter intent window to open, populated with the embedded link. For Facebook shares, the component includes functionality to track a successful or canceled share, for an automatic Reportback process (enabling the DoSomething member to skip manually reporting back with a snapshot of their Facebook share).
 
 ![Share Action component](../_assets/share-action-component.png)  
 
@@ -8,6 +8,7 @@ The `ShareAction` component renders a visual component which features an embedde
 The Share Action consists of three fields:
 
 - **title (required)**: The title that will show up in the yellow bar atop the Link Action.
+- **socialPlatform (required)**: The social platform that the Share Action will share to. (Limited to Facebook or Twitter).
 - **content (optional)**: content in Markdown format that will appear within the card atop the link.
 - **link (required)**: a valid URL which will be embedded within the card, and used as the URL for the social share button.
 

--- a/resources/assets/components/ShareAction/ShareAction.js
+++ b/resources/assets/components/ShareAction/ShareAction.js
@@ -5,16 +5,16 @@ import Card from '../Card';
 import Embed from '../Embed';
 import Markdown from '../Markdown';
 import { POST_SHARE_MODAL } from '../Modal';
-import { showFacebookSharePrompt } from '../../helpers';
+import { showFacebookSharePrompt, showTwitterSharePrompt } from '../../helpers';
 
 import './share-action.scss';
 
 const ShareAction = (props) => {
-  const { title, content, link, openModal, trackEvent } = props;
+  const { title, content, link, socialPlatform, openModal, trackEvent } = props;
 
   const onFacebookClick = (url) => {
     const trackingData = { url };
-    trackEvent('clicked share action', trackingData);
+    trackEvent('clicked facebook share action', trackingData);
 
     showFacebookSharePrompt({ href: url }, (response) => {
       if (response) {
@@ -26,6 +26,25 @@ const ShareAction = (props) => {
     });
   };
 
+  const onTwitterClick = (url) => {
+    const trackingData = { url };
+    trackEvent('clicked twitter share action', trackingData);
+
+    showTwitterSharePrompt(link);
+    // @TODO Add post share affirmation modal trigger here.
+  };
+
+  const shareButton = socialPlatform === 'facebook' ? (
+    <button className="button" onClick={() => onFacebookClick(link)}>
+      Share on Facebook
+    </button>
+  ) : (
+    <button className="button" onClick={() => onTwitterClick(link)}>
+      Share on Twitter
+    </button>
+  );
+
+
   return (
     <div className="share-action margin-bottom-lg">
       <Card title={title} className="rounded bordered">
@@ -35,10 +54,7 @@ const ShareAction = (props) => {
 
         <Embed className="padded" url={link} />
 
-        <button
-          className="button"
-          onClick={() => onFacebookClick(link)}
-        >Share on Facebook</button>
+        { shareButton }
       </Card>
     </div>
   );
@@ -54,6 +70,7 @@ ShareAction.propTypes = {
   link: PropTypes.string.isRequired,
   openModal: PropTypes.func.isRequired,
   trackEvent: PropTypes.func.isRequired,
+  socialPlatform: PropTypes.oneOf(['twitter', 'facebook']).isRequired,
 };
 
 export default ShareAction;

--- a/resources/assets/components/ShareAction/ShareAction.js
+++ b/resources/assets/components/ShareAction/ShareAction.js
@@ -34,16 +34,24 @@ const ShareAction = (props) => {
     // @TODO Add post share affirmation modal trigger here.
   };
 
-  const shareButton = socialPlatform === 'facebook' ? (
-    <button className="button" onClick={() => onFacebookClick(link)}>
-      Share on Facebook
-    </button>
-  ) : (
-    <button className="button" onClick={() => onTwitterClick(link)}>
-      Share on Twitter
-    </button>
-  );
-
+  const shareButton = () => {
+    switch (socialPlatform) {
+      case 'facebook':
+        return (
+          <button className="button" onClick={() => onFacebookClick(link)}>
+            Share on Facebook
+          </button>
+        );
+      case 'twitter':
+        return (
+          <button className="button" onClick={() => onTwitterClick(link)}>
+            Share on Twitter
+          </button>
+        );
+      default:
+        return null;
+    }
+  };
 
   return (
     <div className="share-action margin-bottom-lg">
@@ -54,7 +62,7 @@ const ShareAction = (props) => {
 
         <Embed className="padded" url={link} />
 
-        { shareButton }
+        { shareButton() }
       </Card>
     </div>
   );

--- a/resources/assets/components/ShareAction/ShareAction.js
+++ b/resources/assets/components/ShareAction/ShareAction.js
@@ -30,8 +30,7 @@ const ShareAction = (props) => {
     const trackingData = { url };
     trackEvent('clicked twitter share action', trackingData);
 
-    showTwitterSharePrompt(link);
-    // @TODO Add post share affirmation modal trigger here.
+    showTwitterSharePrompt(link, '', openModal.bind(null, POST_SHARE_MODAL));
   };
 
   const shareButton = () => {

--- a/resources/assets/components/ShareAction/ShareAction.js
+++ b/resources/assets/components/ShareAction/ShareAction.js
@@ -30,7 +30,7 @@ const ShareAction = (props) => {
     const trackingData = { url };
     trackEvent('clicked twitter share action', trackingData);
 
-    showTwitterSharePrompt(link, '', openModal.bind(null, POST_SHARE_MODAL));
+    showTwitterSharePrompt(link, '', () => openModal(POST_SHARE_MODAL));
   };
 
   const shareButton = () => {

--- a/resources/assets/components/ShareAction/ShareAction.js
+++ b/resources/assets/components/ShareAction/ShareAction.js
@@ -12,11 +12,11 @@ import './share-action.scss';
 const ShareAction = (props) => {
   const { title, content, link, socialPlatform, openModal, trackEvent } = props;
 
-  const onFacebookClick = (url) => {
-    const trackingData = { url };
+  const onFacebookClick = () => {
+    const trackingData = { link };
     trackEvent('clicked facebook share action', trackingData);
 
-    showFacebookSharePrompt({ href: url }, (response) => {
+    showFacebookSharePrompt({ href: link }, (response) => {
       if (response) {
         trackEvent('share action completed', trackingData);
         openModal(POST_SHARE_MODAL);
@@ -26,8 +26,8 @@ const ShareAction = (props) => {
     });
   };
 
-  const onTwitterClick = (url) => {
-    const trackingData = { url };
+  const onTwitterClick = () => {
+    const trackingData = { link };
     trackEvent('clicked twitter share action', trackingData);
 
     showTwitterSharePrompt(link, '', () => openModal(POST_SHARE_MODAL));

--- a/resources/assets/components/ShareAction/ShareAction.js
+++ b/resources/assets/components/ShareAction/ShareAction.js
@@ -13,7 +13,7 @@ const ShareAction = (props) => {
   const { title, content, link, socialPlatform, openModal, trackEvent } = props;
 
   const onFacebookClick = () => {
-    const trackingData = { link };
+    const trackingData = { url: link };
     trackEvent('clicked facebook share action', trackingData);
 
     showFacebookSharePrompt({ href: link }, (response) => {
@@ -27,7 +27,7 @@ const ShareAction = (props) => {
   };
 
   const onTwitterClick = () => {
-    const trackingData = { link };
+    const trackingData = { url: link };
     trackEvent('clicked twitter share action', trackingData);
 
     showTwitterSharePrompt(link, '', () => openModal(POST_SHARE_MODAL));

--- a/resources/assets/components/ShareAction/ShareAction.test.js
+++ b/resources/assets/components/ShareAction/ShareAction.test.js
@@ -101,7 +101,10 @@ describe('ShareAction component', () => {
       wrapper = getShallow('twitter');
     });
 
-    global.open = jest.fn().mockReturnValue({closed: true});
+    // Mock the `open` function to test that we're opening the twitter intent window,
+    // and showing an affirmation once it's closed.
+    // (hence the mock return value to indicate closed status).
+    global.open = jest.fn().mockReturnValue({ closed: true });
 
     it('opens a new window with the proper Twitter intent URL', () => {
       wrapper.find('button').simulate('click');
@@ -121,6 +124,8 @@ describe('ShareAction component', () => {
     it('displays the affirmation modal when social share is successful', () => {
       wrapper.find('button').simulate('click');
 
+      // Run the timer a second so that the callback in -
+      // `setInterval` in the twitter share function runs.
       jest.runTimersToTime(1000);
 
       expect(openModalMock).toHaveBeenCalledTimes(1);

--- a/resources/assets/components/ShareAction/ShareAction.test.js
+++ b/resources/assets/components/ShareAction/ShareAction.test.js
@@ -4,6 +4,8 @@ import { shallow } from 'enzyme';
 import ShareAction from './ShareAction';
 import setFBshare from '../../__mocks__/facebookShareMock';
 
+jest.useFakeTimers();
+
 describe('ShareAction component', () => {
   const url = 'https://dosomething.org';
   const trackingData = { url };
@@ -11,7 +13,7 @@ describe('ShareAction component', () => {
   let trackEventMock = jest.fn();
   let openModalMock = jest.fn();
 
-  const getShallow = (socialPlatform) => shallow(
+  const getShallow = socialPlatform => shallow(
     <ShareAction
       title="Click on this link!"
       content="This is a great link"
@@ -99,13 +101,13 @@ describe('ShareAction component', () => {
       wrapper = getShallow('twitter');
     });
 
-    it('opens a new window with the proper Twitter intent URL', () => {
-      global.open = jest.fn();
+    global.open = jest.fn().mockReturnValue({closed: true});
 
+    it('opens a new window with the proper Twitter intent URL', () => {
       wrapper.find('button').simulate('click');
 
       expect(global.open).toHaveBeenCalled();
-      expect(global.open.mock.calls[0][0]).toEqual(`https://twitter.com/intent/tweet?url=${url}&text=${undefined}`);
+      expect(global.open.mock.calls[0][0]).toEqual(`https://twitter.com/intent/tweet?url=${url}&text=`);
     });
 
     it('tracks clicked share action event', () => {
@@ -116,11 +118,10 @@ describe('ShareAction component', () => {
       expect(trackEventMock.mock.calls[0]).toEqual(['clicked twitter share action', trackingData]);
     });
 
-    // @TODO activate this test when we properly implement the post share affirmaion modal for twitter share.
-    xit('displays the affirmation modal when social share is successful', () => {
-      setFBshare(true);
-
+    it('displays the affirmation modal when social share is successful', () => {
       wrapper.find('button').simulate('click');
+
+      jest.runTimersToTime(1000);
 
       expect(openModalMock).toHaveBeenCalledTimes(1);
     });

--- a/resources/assets/components/ShareAction/ShareAction.test.js
+++ b/resources/assets/components/ShareAction/ShareAction.test.js
@@ -11,34 +11,39 @@ describe('ShareAction component', () => {
   let trackEventMock = jest.fn();
   let openModalMock = jest.fn();
 
-  const getShallow = () => shallow(
+  const getShallow = (socialPlatform) => shallow(
     <ShareAction
       title="Click on this link!"
       content="This is a great link"
       trackEvent={trackEventMock}
       openModal={openModalMock}
       link={url}
+      socialPlatform={socialPlatform}
     />,
   );
 
   // We'll declare this reference to the wrapper object, so we can more elegantly reset the
   // shallow copy of the component and test it as necessary.
-  let wrapper = getShallow();
+  let wrapper = getShallow('facebook');
 
   it('renders a Card component', () => {
     expect(wrapper.find('Card')).toHaveLength(1);
     expect(wrapper.find('Card').find('Embed')).toHaveLength(1);
   });
 
-  it('renders a Facebook Share button', () => {
+  it('renders a proper Share button based on social platform', () => {
     expect(wrapper.find('button').text()).toEqual('Share on Facebook');
+
+    wrapper = getShallow('twitter');
+
+    expect(wrapper.find('button').text()).toEqual('Share on Twitter');
   });
 
-  describe('Clicking the Social Share Button', () => {
+  describe('Clicking the Social Share Button for a Facebook share', () => {
     beforeEach(() => {
       trackEventMock = jest.fn();
       openModalMock = jest.fn();
-      wrapper = getShallow();
+      wrapper = getShallow('facebook');
     });
 
     it('calls the FB ui method to trigger the facebook share', () => {
@@ -56,7 +61,7 @@ describe('ShareAction component', () => {
 
       expect(trackEventMock.mock.calls.length).toBeGreaterThan(0);
 
-      expect(trackEventMock.mock.calls[0]).toEqual(['clicked share action', trackingData]);
+      expect(trackEventMock.mock.calls[0]).toEqual(['clicked facebook share action', trackingData]);
       expect(trackEventMock.mock.calls[1]).toEqual(['share action completed', trackingData]);
     });
 
@@ -66,7 +71,7 @@ describe('ShareAction component', () => {
       wrapper.find('button').simulate('click');
 
       expect(trackEventMock).toHaveBeenCalledTimes(2);
-      expect(trackEventMock.mock.calls[0]).toEqual(['clicked share action', trackingData]);
+      expect(trackEventMock.mock.calls[0]).toEqual(['clicked facebook share action', trackingData]);
     });
 
     it('displays the affirmation modal when social share is successful', () => {
@@ -84,6 +89,40 @@ describe('ShareAction component', () => {
 
       expect(trackEventMock).toHaveBeenCalledTimes(2);
       expect(trackEventMock.mock.calls[1]).toEqual(['share action cancelled', trackingData]);
+    });
+  });
+
+  describe('Clicking the Social Share Button for a Twitter share', () => {
+    beforeEach(() => {
+      trackEventMock = jest.fn();
+      openModalMock = jest.fn();
+      wrapper = getShallow('twitter');
+    });
+
+    it('opens a new window with the proper Twitter intent URL', () => {
+      global.open = jest.fn();
+
+      wrapper.find('button').simulate('click');
+
+      expect(global.open).toHaveBeenCalled();
+      expect(global.open.mock.calls[0][0]).toEqual(`https://twitter.com/intent/tweet?url=${url}&text=${undefined}`);
+    });
+
+    it('tracks clicked share action event', () => {
+      wrapper.find('button').simulate('click');
+
+      expect(trackEventMock.mock.calls.length).toBeGreaterThan(0);
+
+      expect(trackEventMock.mock.calls[0]).toEqual(['clicked twitter share action', trackingData]);
+    });
+
+    // @TODO activate this test when we properly implement the post share affirmaion modal for twitter share.
+    xit('displays the affirmation modal when social share is successful', () => {
+      setFBshare(true);
+
+      wrapper.find('button').simulate('click');
+
+      expect(openModalMock).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/resources/assets/helpers/index.js
+++ b/resources/assets/helpers/index.js
@@ -373,7 +373,7 @@ export function showFacebookSharePrompt(share, callback) {
  * @param  {String} href
  * @param  {String} quote
  */
-export function showTwitterSharePrompt(href, quote = '') {
+export function showTwitterSharePrompt(href, quote = '', callback) {
   const width = 550;
   const height = 420;
   const winHeight = window.screen.height;
@@ -386,8 +386,21 @@ export function showTwitterSharePrompt(href, quote = '') {
     top = Math.round((winHeight / 2) - (height / 2));
   }
 
-  window.open(`https://twitter.com/intent/tweet?url=${href}&text=${quote}`, 'intent',
+  const twitterShareWindow = window.open(`https://twitter.com/intent/tweet?url=${href}&text=${quote}`, 'intent',
     `scrollbars=yes,resizable=yes,toolbar=no,location=yes,width=${width},height=${height},left=${left},top=${top}`);
+
+  let interval;
+
+  const check = () => {
+    if (twitterShareWindow.closed) {
+      clearInterval(interval);
+      callback();
+    }
+  };
+
+  if (callback) {
+    interval = setInterval(check, 1000);
+  }
 }
 
 /**

--- a/resources/assets/helpers/index.js
+++ b/resources/assets/helpers/index.js
@@ -373,7 +373,7 @@ export function showFacebookSharePrompt(share, callback) {
  * @param  {String} href
  * @param  {String} quote
  */
-export function showTwitterSharePrompt(href, quote) {
+export function showTwitterSharePrompt(href, quote = '') {
   const width = 550;
   const height = 420;
   const winHeight = window.screen.height;


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_


### What does this PR do?
This PR adds the ability to toggle the `ShareAction` to use Facebook or Twitter for the share button.

- added new `socialPlatform` field to the ShareAction Contentful Entry.
- based on this field the ShareAction will render a Facebook or Twitter share button
- added twitter share functionality and puck tracking

Also some additions to the `showTwitterSharePrompt` function, enabling it to receive an optional `callback` param, which it will trigger once the twitter share intent window is closed.


### Any background context you want to provide?
Being able to show a post share affirmation to the user for the twitter share proved to be somewhat difficult, and unlike Facebook, we do not have a callback for post success or canceled shares.

I went with setting up a `setInterval` to check for when the new twitter intent window is `closed`, and once that's true the callback is triggered. This is admittedly not the most optimal pattern but the best I was able to come up with under these circumstances!


### What are the relevant tickets/cards?
Pivotal ID [#154526005](https://www.pivotaltracker.com/story/show/154526005)
closes #695 


### Checklist
Visually the share is identical to how it is now (save for Twitter replacing Facebook in the button text, so I'll not attach the screenshots)

- [x] Documentation added for new features/changed endpoints.
- [x] Added appropriate feature/unit tests.
