### PR TITLE
Un-gate quiz results

### DIFF
--- a/resources/assets/actions/quiz.js
+++ b/resources/assets/actions/quiz.js
@@ -66,7 +66,9 @@ export function completeQuiz(quizId) {
     }
 
     document.querySelector('.main').scrollIntoView(true);
-    return dispatch(quizConvert(quizId));
+
+    return getState().user.id ?
+      dispatch(quizConvert(quizId)) : dispatch(viewQuizResult(quizId));
   });
 }
 

--- a/resources/assets/actions/quiz.js
+++ b/resources/assets/actions/quiz.js
@@ -3,7 +3,6 @@
 import { find } from 'lodash';
 import {
   clickedSignUp,
-  queueEvent,
   PICK_QUIZ_ANSWER,
   COMPARE_QUIZ_ANSWER,
   VIEW_QUIZ_RESULT,

--- a/resources/assets/actions/quiz.js
+++ b/resources/assets/actions/quiz.js
@@ -10,7 +10,6 @@ import {
   LOAD_PREVIOUS_QUIZ_STATE,
   QUIZ_ERROR,
 } from '../actions';
-import { QUIZ_STORAGE_KEY, set, get, remove } from '../helpers/storage';
 
 export function loadPreviousQuizState(quizId, questions) {
   return { type: LOAD_PREVIOUS_QUIZ_STATE, quizId, questions };

--- a/resources/assets/actions/quiz.js
+++ b/resources/assets/actions/quiz.js
@@ -30,21 +30,6 @@ export function viewQuizResult(quizId) {
 
 export function quizConvert(quizId) {
   return ((dispatch, getState) => {
-    // If the user is not logged in, handle this action later.
-    if (! getState().user.id) {
-      const quizData = getState().quiz[quizId];
-      set(quizId, QUIZ_STORAGE_KEY, quizData.questions);
-
-      return dispatch(queueEvent('quizConvert', quizId));
-    }
-
-    // Load questions from previous state if available
-    const questions = get(quizId, QUIZ_STORAGE_KEY);
-    if (questions) {
-      dispatch(loadPreviousQuizState(quizId, questions));
-      remove(quizId, QUIZ_STORAGE_KEY);
-    }
-
     const campaignId = getState().campaign.legacyCampaignId;
     dispatch(clickedSignUp(campaignId, 'source:quiz', false));
 

--- a/resources/assets/actions/quiz.js
+++ b/resources/assets/actions/quiz.js
@@ -46,7 +46,7 @@ export function quizConvert(quizId) {
     }
 
     const campaignId = getState().campaign.legacyCampaignId;
-    dispatch(clickedSignUp(campaignId, { source: 'quiz' }, false));
+    dispatch(clickedSignUp(campaignId, 'source:quiz', false));
 
     return dispatch(viewQuizResult(quizId));
   });


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?
This PR un-gates the Quiz, and allows user to see their quiz results without prompting the log-in flow.

Users who are already logged in will continue to be auto signed up for the Campaign but will also see their quiz results seamlessly.

Also changed the formatting of the `details` param when [dispatching a signup](https://github.com/DoSomething/phoenix-next/blob/ungate-quiz-results/resources/assets/actions/quiz.js#L49) from the quiz for logged in users. Previously we were passing through an object `{ source: 'quiz' }` which was causing an error and `500` from Rogue. Changed this over to a string. (`'source:quiz'`)


**Question**: There's still some logic in the [`quizConvert`](https://github.com/DoSomething/phoenix-next/blob/ungate-quiz-results/resources/assets/actions/quiz.js#L34) action that deals with an unauthenticated user, and triggers the Northstar flow. We're only calling this method now if they're authenticated so it won't bother us, but I can remove it if we think that it's not going to be needed anymore? -- UPDATE: REMOVED.

### What are the relevant tickets/cards?
Fixes [#154881463](https://www.pivotaltracker.com/story/show/154881463)

