### PR TITLE
Visual Bug Fix: Changing class name for the actionButton

### DIFF
--- a/resources/assets/components/LedeBanner/templates/MosaicTemplate.js
+++ b/resources/assets/components/LedeBanner/templates/MosaicTemplate.js
@@ -48,7 +48,7 @@ const MosaicTemplate = (props) => {
   ), 'lede banner', { text: actionText });
 
   const actionButton = affiliatedActionLink ? (
-    <div className="header__signup">
+    <div className="mosaic-lede-banner__signup">
       <Link className={classnames('button', '-action')} to={affiliatedActionLink}>
         {affiliatedActionText || 'Take Action'}
       </Link>


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

We [changed the class name for the Signup button](https://github.com/DoSomething/phoenix-next/pull/696/files#diff-656253a0f3c40c4373a3e08ff25896d5R40) (along with the class name in the stylesheet) during an overhaul of the LedeBanner. This will provide the same naming change for the `ActionButton` as well.

![image](https://user-images.githubusercontent.com/12417657/36678863-da1c67c2-1adf-11e8-9dfe-784e0e814224.png)


![image](https://user-images.githubusercontent.com/12417657/36678874-e0651be2-1adf-11e8-8fa8-fdeaa20f77d1.png)
