### PR TITLE
Quiz contentful migration add results field

### DIFF
--- a/contentful/migrations/2018_02_26_001_add_results_field_to_quiz.js
+++ b/contentful/migrations/2018_02_26_001_add_results_field_to_quiz.js
@@ -1,0 +1,14 @@
+module.exports = function (migration) {
+  const quiz = migration.editContentType('quizBeta');
+
+  quiz.createField('results')
+    .name('Results')
+    .type('Array')
+    .items({
+      type: 'Link',
+      linkType: 'Entry',
+    })
+    .required(false);
+
+  quiz.moveField('results').beforeField('questions');
+}

--- a/resources/assets/components/Campaign/CampaignContainer.js
+++ b/resources/assets/components/Campaign/CampaignContainer.js
@@ -7,10 +7,6 @@ const mapStateToProps = (state, props) => {
   const isSignedUp = state.signups.thisCampaign;
 
   const { location, match } = props;
-
-  console.log(location);
-  console.log(match);
-
   const isQuiz = location.pathname.replace(match.url, '').startsWith('/quiz/');
 
   const ignoreLandingPage = state.admin.shouldShowActionPage || isQuiz;

--- a/resources/assets/components/Campaign/CampaignContainer.js
+++ b/resources/assets/components/Campaign/CampaignContainer.js
@@ -7,6 +7,10 @@ const mapStateToProps = (state, props) => {
   const isSignedUp = state.signups.thisCampaign;
 
   const { location, match } = props;
+
+  console.log(location);
+  console.log(match);
+
   const isQuiz = location.pathname.replace(match.url, '').startsWith('/quiz/');
 
   const ignoreLandingPage = state.admin.shouldShowActionPage || isQuiz;

--- a/resources/assets/components/Quiz/Quiz.js
+++ b/resources/assets/components/Quiz/Quiz.js
@@ -1,9 +1,11 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+
 import Markdown from '../Markdown';
 import Question from './Question';
-import { ShareContainer } from '../Share';
 import Conclusion from './Conclusion';
+import { ShareContainer } from '../Share';
+
 import './quiz.scss';
 
 const Quiz = (props) => {


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_


### What does this PR do?
This PR adds a contentful migration to add a `results` field to the Quiz content type. The results will act as a reference field containing references to different action blocks that are available to show as results to the user depending on their answers.

It also does a tiny bit of cleanup at the top of the `Quiz.js` file to follow patterns with spacing of imports like in other JS files 👌 

### What are the relevant tickets/cards?
Refs #704 
