### PR TITLE
Move Lede Banner into individual pages, and allow toggling it!

### DIFF
--- a/app/Entities/Quiz.php
+++ b/app/Entities/Quiz.php
@@ -66,6 +66,7 @@ class Quiz extends Entity implements JsonSerializable
                 'comparison' => $this->comparison,
                 'callToAction' => $this->callToAction,
                 'questions' => $this->parseQuestionsFromJson(),
+                'additionalContent' => $this->additionalContent,
             ],
         ];
     }

--- a/resources/assets/components/Dashboard/DashboardContainer.js
+++ b/resources/assets/components/Dashboard/DashboardContainer.js
@@ -1,0 +1,15 @@
+import { connect } from 'react-redux';
+
+import Dashboard from './index';
+
+/**
+ * Provide state from the Redux store as props for this component.
+ */
+const mapStateToProps = state => ({
+  totalCampaignSignups: state.signups.total,
+  content: state.campaign.dashboard,
+  endDate: state.campaign.endDate,
+});
+
+// Export the container component.
+export default connect(mapStateToProps)(Dashboard);

--- a/resources/assets/components/Feed/Feed.js
+++ b/resources/assets/components/Feed/Feed.js
@@ -5,6 +5,10 @@ import classnames from 'classnames';
 import ContentfulEntry from '../ContentfulEntry';
 import Revealer from '../Revealer';
 import { Flex, FlexCell } from '../Flex';
+import Enclosure from '../Enclosure';
+import DashboardContainer from '../Dashboard/DashboardContainer';
+import LedeBannerContainer from '../LedeBanner/LedeBannerContainer';
+import TabbedNavigationContainer from '../Navigation/TabbedNavigationContainer';
 
 import './feed.scss';
 
@@ -33,8 +37,8 @@ const renderFeedItem = (block, index) => (
  * @returns {XML}
  */
 const Feed = (props) => {
-  const { actionText, blocks, callToAction, campaignId, signedUp, hasPendingSignup, isAuthenticated,
-    canLoadMorePages, clickedViewMore, clickedSignUp } = props;
+  const { actionText, blocks, callToAction, campaignId, dashboard, signedUp, hasPendingSignup,
+    isAuthenticated, canLoadMorePages, clickedViewMore, clickedSignUp } = props;
 
   const viewMoreOrSignup = signedUp ? clickedViewMore : () => clickedSignUp(campaignId);
   const revealer = (
@@ -50,10 +54,17 @@ const Feed = (props) => {
 
   return (
     <div>
-      <Flex className="feed">
-        {blocks.map(renderFeedItem)}
-      </Flex>
-      {revealer}
+      <LedeBannerContainer />
+      <div className="main clearfix">
+        { dashboard ? <DashboardContainer /> : null }
+        <TabbedNavigationContainer />
+        <Enclosure className="default-container margin-top-lg margin-bottom-lg">
+          <Flex className="feed">
+            {blocks.map(renderFeedItem)}
+          </Flex>
+          {revealer}
+        </Enclosure>
+      </div>
     </div>
   );
 };
@@ -68,6 +79,11 @@ Feed.propTypes = {
   })),
   callToAction: PropTypes.string.isRequired,
   campaignId: PropTypes.string.isRequired,
+  dashboard: PropTypes.shape({
+    id: PropTypes.string,
+    type: PropTypes.string,
+    fields: PropTypes.object,
+  }),
   signedUp: PropTypes.bool.isRequired,
   hasPendingSignup: PropTypes.bool.isRequired,
   isAuthenticated: PropTypes.bool.isRequired,
@@ -78,6 +94,7 @@ Feed.propTypes = {
 
 Feed.defaultProps = {
   blocks: [],
+  dashboard: null,
 };
 
 export default Feed;

--- a/resources/assets/components/Feed/FeedContainer.js
+++ b/resources/assets/components/Feed/FeedContainer.js
@@ -17,6 +17,7 @@ const mapStateToProps = state => ({
   canLoadMorePages: getTotalVisibleBlockPoints(state) < getMaximumBlockPoints(state),
   campaignId: state.campaign.legacyCampaignId,
   callToAction: state.campaign.callToAction,
+  dashboard: state.campaign.dashboard,
   signedUp: state.signups.data.includes(state.campaign.legacyCampaignId),
   hasNewSignup: state.signups.thisSession,
   hasPendingSignup: state.signups.isPending,

--- a/resources/assets/components/LedeBanner/LedeBannerContainer.js
+++ b/resources/assets/components/LedeBanner/LedeBannerContainer.js
@@ -1,0 +1,25 @@
+import get from 'lodash/get';
+import { connect } from 'react-redux';
+
+import LedeBanner from './LedeBanner';
+
+/**
+ * Provide state from the Redux store as props for this component.
+ */
+const mapStateToProps = state => ({
+  actionText: state.campaign.actionText,
+  affiliatedActionText: get(state, 'campaign.additionalContent.affiliatedActionText', null),
+  affiliatedActionLink: get(state, 'campaign.additionalContent.affiliatedActionLink', null),
+  blurb: state.campaign.blurb,
+  coverImage: state.campaign.coverImage,
+  endDate: state.campaign.endDate,
+  isAffiliated: state.signups.thisCampaign,
+  affiliateSponsors: state.campaign.affiliateSponsors,
+  legacyCampaignId: state.campaign.legacyCampaignId,
+  subtitle: state.campaign.callToAction,
+  template: state.campaign.template,
+  title: state.campaign.title,
+});
+
+// Export the container component.
+export default connect(mapStateToProps)(LedeBanner);

--- a/resources/assets/components/Navigation/TabbedNavigationContainer.js
+++ b/resources/assets/components/Navigation/TabbedNavigationContainer.js
@@ -22,6 +22,7 @@ const mapStateToProps = state => ({
   pages: state.campaign.pages,
   pathname: state.routing.location.pathname,
   campaignEndDate: get(state.campaign.endDate, 'date', null),
+  campaignSlug: state.campaign.slug,
   template: state.campaign.template,
 });
 

--- a/resources/assets/components/Page/ActionPage/ActionPage.js
+++ b/resources/assets/components/Page/ActionPage/ActionPage.js
@@ -1,6 +1,10 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import { cloneDeep } from 'lodash';
+import Enclosure from '../../Enclosure';
+import DashboardContainer from '../../Dashboard/DashboardContainer';
+import LedeBannerContainer from '../../LedeBanner/LedeBannerContainer';
+import TabbedNavigationContainer from '../../Navigation/TabbedNavigationContainer';
 
 import ActionStepsContainer from './ActionStepsContainer';
 
@@ -10,7 +14,7 @@ import ActionStepsContainer from './ActionStepsContainer';
  * @returns {XML}
  */
 const ActionPage = (props) => {
-  const { steps, signedUp } = props;
+  const { dashboard, steps, signedUp } = props;
 
   let actionSteps = cloneDeep(steps);
 
@@ -24,13 +28,31 @@ const ActionPage = (props) => {
   }
 
   return (
-    <ActionStepsContainer actionSteps={actionSteps} />
+    <div>
+      <LedeBannerContainer />
+      <div className="main clearfix">
+        { dashboard ? <DashboardContainer /> : null }
+        <TabbedNavigationContainer />
+        <Enclosure className="default-container margin-top-lg margin-bottom-lg">
+          <ActionStepsContainer actionSteps={actionSteps} />
+        </Enclosure>
+      </div>
+    </div>
   );
 };
 
 ActionPage.propTypes = {
   steps: PropTypes.array.isRequired, // eslint-disable-line react/forbid-prop-types
+  dashboard: PropTypes.shape({
+    id: PropTypes.string,
+    type: PropTypes.string,
+    fields: PropTypes.object,
+  }),
   signedUp: PropTypes.bool.isRequired,
+};
+
+ActionPage.defaultProps = {
+  dashboard: null,
 };
 
 export default ActionPage;

--- a/resources/assets/components/Page/ActionPage/ActionPageContainer.js
+++ b/resources/assets/components/Page/ActionPage/ActionPageContainer.js
@@ -7,6 +7,7 @@ import ActionPage from './ActionPage';
  */
 const mapStateToProps = state => ({
   steps: state.campaign.actionSteps,
+  dashboard: state.campaign.dashboard,
   signedUp: state.signups.thisCampaign,
   featureFlags: get(state.campaign.additionalContent, 'featureFlags'),
 });

--- a/resources/assets/components/Page/CampaignPage/CampaignPage.js
+++ b/resources/assets/components/Page/CampaignPage/CampaignPage.js
@@ -3,17 +3,13 @@ import { get } from 'lodash';
 import PropTypes from 'prop-types';
 import { Switch, Route, Redirect } from 'react-router-dom';
 
-import DashboardContainer from '../../Dashboard/DashboardContainer';
-import Enclosure from '../../Enclosure';
 import { FeedContainer } from '../../Feed'; // @TODO: rename to ActivityFeed or ActivityPage...
 import { QuizContainer } from '../../Quiz';
 import ActivityFeedBlock from '../../ActivityFeedBlock';
 import { isCampaignClosed } from '../../../helpers';
-import LedeBannerContainer from '../../LedeBanner/LedeBannerContainer';
 import { ActionPageContainer } from '../ActionPage';
 import { CallToActionContainer } from '../../CallToAction';
 import { CampaignSubPageContainer } from '../CampaignSubPage';
-import TabbedNavigationContainer from '../../Navigation/TabbedNavigationContainer';
 import CampaignFooter from '../../CampaignFooter';
 import { CONTENT_MODAL, REPORTBACK_UPLOADER_MODAL } from '../../Modal';
 
@@ -23,7 +19,7 @@ import { CONTENT_MODAL, REPORTBACK_UPLOADER_MODAL } from '../../Modal';
 const CampaignPage = (props) => {
   const {
     affiliatePartners, affiliateSponsors, campaignLead,
-    dashboard, endDate, hasActivityFeed, isAffiliated, match,
+    endDate, hasActivityFeed, isAffiliated, match,
     openModal, shouldShowActionPage, template,
   } = props;
 
@@ -32,9 +28,9 @@ const CampaignPage = (props) => {
   /*
     If the campaign is closed (and an admin has not specifically
     toggled the show Action Page button), we want to render the ActivityFeed (community page)
-    *if* it's available (meaning the campaign has an activity feed property populated).
+   *if* it's available (meaning the campaign has an activity feed property populated).
     Otherwise, we render the ActionPage as usual.
-  */
+    */
   const shouldShowActivityFeed = isClosed && ! shouldShowActionPage && hasActivityFeed;
   const ActionPageOrActivityFeed = () => (shouldShowActivityFeed ? (
     <Redirect to={`${match.url}/community`} />
@@ -44,57 +40,52 @@ const CampaignPage = (props) => {
 
   return (
     <div>
-      <LedeBannerContainer />
-      <div className="main clearfix">
-        { dashboard ? <DashboardContainer /> : null }
-        <TabbedNavigationContainer />
-        <Enclosure className="default-container margin-top-lg margin-bottom-lg">
-          <Switch>
-            <Route
-              path={`${match.url}`}
-              exact
-              component={ActionPageOrActivityFeed}
-            />
-            <Route
-              path={`${match.url}/action`}
-              component={ActionPageOrActivityFeed}
-            />
-            <Route
-              path={`${match.url}/community`}
-              render={() => {
-                // Does this campaign have an activity feed? (Some on the
-                // "legacy" template don't.) If not, redirect to action page.
-                if (template === 'legacy' && ! hasActivityFeed) {
-                  return <Redirect to={`${match.url}/action`} />;
-                }
+      <div>
+        <Switch>
+          <Route
+            path={`${match.url}`}
+            exact
+            component={ActionPageOrActivityFeed}
+          />
+          <Route
+            path={`${match.url}/action`}
+            component={ActionPageOrActivityFeed}
+          />
+          <Route
+            path={`${match.url}/community`}
+            render={() => {
+              // Does this campaign have an activity feed? (Some on the
+              // "legacy" template don't.) If not, redirect to action page.
+              if (template === 'legacy' && ! hasActivityFeed) {
+                return <Redirect to={`${match.url}/action`} />;
+              }
 
-                return <FeedContainer />;
-              }}
-            />
-            <Route path={`${match.url}/pages/:slug`} component={CampaignSubPageContainer} />
-            <Route path={`${match.url}/blocks/:id`} component={ActivityFeedBlock} />
-            <Route path={`${match.url}/quiz/:slug`} component={QuizContainer} />
-            <Route
-              path={`${match.url}/modal/:id`}
-              render={(routingProps) => {
-                const { id } = routingProps.match.params;
+              return <FeedContainer />;
+            }}
+          />
+          <Route path={`${match.url}/pages/:slug`} component={CampaignSubPageContainer} />
+          <Route path={`${match.url}/blocks/:id`} component={ActivityFeedBlock} />
+          <Route path={`${match.url}/quiz/:slug`} component={QuizContainer} />
+          <Route
+            path={`${match.url}/modal/:id`}
+            render={(routingProps) => {
+              const { id } = routingProps.match.params;
 
-                switch (id) {
-                  case 'reportback':
-                    openModal(REPORTBACK_UPLOADER_MODAL);
-                    break;
-                  default:
-                    openModal(CONTENT_MODAL, id);
-                    break;
-                }
+              switch (id) {
+                case 'reportback':
+                  openModal(REPORTBACK_UPLOADER_MODAL);
+                  break;
+                default:
+                  openModal(CONTENT_MODAL, id);
+                  break;
+              }
 
-                return <Redirect to={`${match.url}`} />;
-              }}
-            />
-            { /* If no route matches, just redirect back to the main page: */ }
-            <Redirect from={`${match.url}/:anything`} to={`${match.url}`} />
-          </Switch>
-        </Enclosure>
+              return <Redirect to={`${match.url}`} />;
+            }}
+          />
+          { /* If no route matches, just redirect back to the main page: */ }
+          <Redirect from={`${match.url}/:anything`} to={`${match.url}`} />
+        </Switch>
         { ! isAffiliated ? <CallToActionContainer key="callToAction" className="-sticky" /> : null }
       </div>
       <CampaignFooter
@@ -107,11 +98,6 @@ const CampaignPage = (props) => {
 };
 
 CampaignPage.propTypes = {
-  dashboard: PropTypes.shape({
-    id: PropTypes.string,
-    type: PropTypes.string,
-    fields: PropTypes.object,
-  }),
   endDate: PropTypes.shape({
     date: PropTypes.string,
     timezone: PropTypes.string,
@@ -132,7 +118,6 @@ CampaignPage.propTypes = {
 };
 
 CampaignPage.defaultProps = {
-  dashboard: null,
   endDate: null,
   isAffiliated: false,
   campaignLead: null,

--- a/resources/assets/components/Page/CampaignPage/CampaignPage.js
+++ b/resources/assets/components/Page/CampaignPage/CampaignPage.js
@@ -3,7 +3,7 @@ import { get } from 'lodash';
 import PropTypes from 'prop-types';
 import { Switch, Route, Redirect } from 'react-router-dom';
 
-import Dashboard from '../../Dashboard';
+import DashboardContainer from '../../Dashboard/DashboardContainer';
 import Enclosure from '../../Enclosure';
 import { FeedContainer } from '../../Feed'; // @TODO: rename to ActivityFeed or ActivityPage...
 import { QuizContainer } from '../../Quiz';
@@ -24,7 +24,7 @@ const CampaignPage = (props) => {
   const {
     affiliatePartners, affiliateSponsors, campaignLead,
     dashboard, endDate, hasActivityFeed, isAffiliated, match,
-    openModal, shouldShowActionPage, slug, template, totalCampaignSignups,
+    openModal, shouldShowActionPage, slug, template,
   } = props;
 
   const isClosed = isCampaignClosed(get(endDate, 'date', null));
@@ -47,13 +47,7 @@ const CampaignPage = (props) => {
       <LedeBannerContainer />
 
       <div className="main clearfix">
-        { dashboard ?
-          <Dashboard
-            totalCampaignSignups={totalCampaignSignups}
-            content={dashboard}
-            endDate={endDate}
-          />
-          : null }
+        { dashboard ? <DashboardContainer /> : null }
 
         <TabbedNavigationContainer campaignSlug={slug} />
 
@@ -138,7 +132,6 @@ CampaignPage.propTypes = {
   match: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
   slug: PropTypes.string.isRequired,
   template: PropTypes.string.isRequired,
-  totalCampaignSignups: PropTypes.number,
   openModal: PropTypes.func.isRequired,
   shouldShowActionPage: PropTypes.bool.isRequired,
 };
@@ -147,7 +140,6 @@ CampaignPage.defaultProps = {
   dashboard: null,
   endDate: null,
   isAffiliated: false,
-  totalCampaignSignups: 0,
   campaignLead: null,
 };
 

--- a/resources/assets/components/Page/CampaignPage/CampaignPage.js
+++ b/resources/assets/components/Page/CampaignPage/CampaignPage.js
@@ -9,7 +9,7 @@ import { FeedContainer } from '../../Feed'; // @TODO: rename to ActivityFeed or 
 import { QuizContainer } from '../../Quiz';
 import ActivityFeedBlock from '../../ActivityFeedBlock';
 import { isCampaignClosed } from '../../../helpers';
-import LedeBanner from '../../LedeBanner/LedeBanner';
+import LedeBannerContainer from '../../LedeBanner/LedeBannerContainer';
 import { ActionPageContainer } from '../ActionPage';
 import { CallToActionContainer } from '../../CallToAction';
 import { CampaignSubPageContainer } from '../CampaignSubPage';
@@ -22,10 +22,9 @@ import { CONTENT_MODAL, REPORTBACK_UPLOADER_MODAL } from '../../Modal';
 
 const CampaignPage = (props) => {
   const {
-    actionText, affiliatePartners, affiliateSponsors, blurb, campaignLead, coverImage,
-    dashboard, endDate, hasActivityFeed, isAffiliated, legacyCampaignId, match,
-    openModal, shouldShowActionPage, slug, subtitle, template, title, totalCampaignSignups,
-    affiliatedActionLink, affiliatedActionText,
+    affiliatePartners, affiliateSponsors, campaignLead,
+    dashboard, endDate, hasActivityFeed, isAffiliated, match,
+    openModal, shouldShowActionPage, slug, template, totalCampaignSignups,
   } = props;
 
   const isClosed = isCampaignClosed(get(endDate, 'date', null));
@@ -45,20 +44,7 @@ const CampaignPage = (props) => {
 
   return (
     <div>
-      <LedeBanner
-        isAffiliated={isAffiliated}
-        title={title}
-        subtitle={subtitle}
-        blurb={blurb}
-        coverImage={coverImage}
-        legacyCampaignId={legacyCampaignId}
-        endDate={endDate}
-        template={template}
-        affiliateSponsors={affiliateSponsors}
-        affiliatedActionLink={affiliatedActionLink}
-        affiliatedActionText={affiliatedActionText}
-        actionText={actionText}
-      />
+      <LedeBannerContainer />
 
       <div className="main clearfix">
         { dashboard ?
@@ -131,14 +117,6 @@ const CampaignPage = (props) => {
 };
 
 CampaignPage.propTypes = {
-  affiliatedActionText: PropTypes.string,
-  affiliatedActionLink: PropTypes.string,
-  actionText: PropTypes.string.isRequired,
-  blurb: PropTypes.string,
-  coverImage: PropTypes.shape({
-    description: PropTypes.string,
-    url: PropTypes.string,
-  }).isRequired,
   dashboard: PropTypes.shape({
     id: PropTypes.string,
     type: PropTypes.string,
@@ -157,21 +135,15 @@ CampaignPage.propTypes = {
   hasActivityFeed: PropTypes.bool.isRequired,
   affiliateSponsors: PropTypes.array.isRequired, // eslint-disable-line react/forbid-prop-types
   affiliatePartners: PropTypes.array.isRequired, // eslint-disable-line react/forbid-prop-types
-  legacyCampaignId: PropTypes.string.isRequired,
   match: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
   slug: PropTypes.string.isRequired,
-  subtitle: PropTypes.string.isRequired,
   template: PropTypes.string.isRequired,
-  title: PropTypes.string.isRequired,
   totalCampaignSignups: PropTypes.number,
   openModal: PropTypes.func.isRequired,
   shouldShowActionPage: PropTypes.bool.isRequired,
 };
 
 CampaignPage.defaultProps = {
-  affiliatedActionText: null,
-  affiliatedActionLink: null,
-  blurb: null,
   dashboard: null,
   endDate: null,
   isAffiliated: false,

--- a/resources/assets/components/Page/CampaignPage/CampaignPage.js
+++ b/resources/assets/components/Page/CampaignPage/CampaignPage.js
@@ -24,7 +24,7 @@ const CampaignPage = (props) => {
   const {
     affiliatePartners, affiliateSponsors, campaignLead,
     dashboard, endDate, hasActivityFeed, isAffiliated, match,
-    openModal, shouldShowActionPage, slug, template,
+    openModal, shouldShowActionPage, template,
   } = props;
 
   const isClosed = isCampaignClosed(get(endDate, 'date', null));
@@ -45,12 +45,9 @@ const CampaignPage = (props) => {
   return (
     <div>
       <LedeBannerContainer />
-
       <div className="main clearfix">
         { dashboard ? <DashboardContainer /> : null }
-
-        <TabbedNavigationContainer campaignSlug={slug} />
-
+        <TabbedNavigationContainer />
         <Enclosure className="default-container margin-top-lg margin-bottom-lg">
           <Switch>
             <Route
@@ -100,7 +97,6 @@ const CampaignPage = (props) => {
         </Enclosure>
         { ! isAffiliated ? <CallToActionContainer key="callToAction" className="-sticky" /> : null }
       </div>
-
       <CampaignFooter
         affiliateSponsors={affiliateSponsors}
         affiliatePartners={affiliatePartners}
@@ -130,7 +126,6 @@ CampaignPage.propTypes = {
   affiliateSponsors: PropTypes.array.isRequired, // eslint-disable-line react/forbid-prop-types
   affiliatePartners: PropTypes.array.isRequired, // eslint-disable-line react/forbid-prop-types
   match: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
-  slug: PropTypes.string.isRequired,
   template: PropTypes.string.isRequired,
   openModal: PropTypes.func.isRequired,
   shouldShowActionPage: PropTypes.bool.isRequired,

--- a/resources/assets/components/Page/CampaignPage/CampaignPageContainer.js
+++ b/resources/assets/components/Page/CampaignPage/CampaignPageContainer.js
@@ -8,13 +8,7 @@ import { convertExperiment, openModal } from '../../../actions';
  * Provide state from the Redux store as props for this component.
  */
 const mapStateToProps = state => ({
-  actionText: state.campaign.actionText,
-  affiliatedActionText: get(state, 'campaign.additionalContent.affiliatedActionText', null),
-  affiliatedActionLink: get(state, 'campaign.additionalContent.affiliatedActionLink', null),
-  blurb: state.campaign.blurb,
-  coverImage: state.campaign.coverImage,
   dashboard: state.campaign.dashboard,
-  endDate: state.campaign.endDate,
   isAffiliated: state.signups.thisCampaign,
   hasActivityFeed: Boolean(state.campaign.activityFeed.length),
   affiliateSponsors: state.campaign.affiliateSponsors,
@@ -23,9 +17,7 @@ const mapStateToProps = state => ({
   legacyCampaignId: state.campaign.legacyCampaignId,
   shouldShowActionPage: state.admin.shouldShowActionPage,
   slug: state.campaign.slug,
-  subtitle: state.campaign.callToAction,
   template: state.campaign.template,
-  title: state.campaign.title,
 });
 
 /**

--- a/resources/assets/components/Page/CampaignPage/CampaignPageContainer.js
+++ b/resources/assets/components/Page/CampaignPage/CampaignPageContainer.js
@@ -8,7 +8,6 @@ import { convertExperiment, openModal } from '../../../actions';
  * Provide state from the Redux store as props for this component.
  */
 const mapStateToProps = state => ({
-  dashboard: state.campaign.dashboard,
   isAffiliated: state.signups.thisCampaign,
   hasActivityFeed: Boolean(state.campaign.activityFeed.length),
   affiliateSponsors: state.campaign.affiliateSponsors,

--- a/resources/assets/components/Page/CampaignPage/CampaignPageContainer.js
+++ b/resources/assets/components/Page/CampaignPage/CampaignPageContainer.js
@@ -16,7 +16,6 @@ const mapStateToProps = state => ({
   campaignLead: get(state, 'campaign.campaignLead.fields', null),
   legacyCampaignId: state.campaign.legacyCampaignId,
   shouldShowActionPage: state.admin.shouldShowActionPage,
-  slug: state.campaign.slug,
   template: state.campaign.template,
 });
 

--- a/resources/assets/components/Page/CampaignPage/CampaignPageContainer.js
+++ b/resources/assets/components/Page/CampaignPage/CampaignPageContainer.js
@@ -26,7 +26,6 @@ const mapStateToProps = state => ({
   subtitle: state.campaign.callToAction,
   template: state.campaign.template,
   title: state.campaign.title,
-  totalCampaignSignups: state.signups.total,
 });
 
 /**

--- a/resources/assets/components/Page/CampaignSubPage/CampaignSubPage.js
+++ b/resources/assets/components/Page/CampaignSubPage/CampaignSubPage.js
@@ -7,10 +7,14 @@ import NotFound from '../../NotFound';
 import { isCampaignClosed } from '../../../helpers';
 import ScrollConcierge from '../../ScrollConcierge';
 import CallToActionContainer from '../../CallToAction/CallToActionContainer';
+import Enclosure from '../../Enclosure';
+import DashboardContainer from '../../Dashboard/DashboardContainer';
+import LedeBannerContainer from '../../LedeBanner/LedeBannerContainer';
+import TabbedNavigationContainer from '../../Navigation/TabbedNavigationContainer';
 
 import './campaign-subpage.scss';
 
-const CampaignSubPage = (props) => {
+const CampaignSubPageContent = (props) => {
   const { campaignEndDate, match, noun, pages, tagline, verb } = props;
 
   const subPage = find(pages, page => page.fields.slug.endsWith(match.params.slug));
@@ -54,7 +58,7 @@ const CampaignSubPage = (props) => {
   );
 };
 
-CampaignSubPage.propTypes = {
+CampaignSubPageContent.propTypes = {
   campaignEndDate: PropTypes.string.isRequired,
   match: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
   noun: PropTypes.shape({
@@ -75,7 +79,7 @@ CampaignSubPage.propTypes = {
   }),
 };
 
-CampaignSubPage.defaultProps = {
+CampaignSubPageContent.defaultProps = {
   pages: [],
   noun: {
     singular: 'action',
@@ -86,6 +90,36 @@ CampaignSubPage.defaultProps = {
     singular: 'take',
     plural: 'take',
   },
+};
+
+/**
+ * Render the page & chrome.
+ *
+ * @returns {XML}
+ */
+const CampaignSubPage = props => (
+  <div>
+    <LedeBannerContainer />
+    <div className="main clearfix">
+      { props.dashboard ? <DashboardContainer /> : null }
+      <TabbedNavigationContainer />
+      <Enclosure className="default-container margin-top-lg margin-bottom-lg">
+        <CampaignSubPageContent {...props} />
+      </Enclosure>
+    </div>
+  </div>
+);
+
+CampaignSubPage.propTypes = {
+  dashboard: PropTypes.shape({
+    id: PropTypes.string,
+    type: PropTypes.string,
+    fields: PropTypes.object,
+  }),
+};
+
+CampaignSubPage.defaultProps = {
+  dashboard: null,
 };
 
 export default CampaignSubPage;

--- a/resources/assets/components/Page/CampaignSubPage/CampaignSubPageContainer.js
+++ b/resources/assets/components/Page/CampaignSubPage/CampaignSubPageContainer.js
@@ -8,6 +8,7 @@ import CampaignSubPage from './CampaignSubPage';
  */
 const mapStateToProps = (state, ownProps) => ({
   pages: state.campaign.pages,
+  dashboard: state.campaign.dashboard,
   route: ownProps.match.params,
   noun: get(state.campaign.additionalContent, 'noun'),
   verb: get(state.campaign.additionalContent, 'verb'),

--- a/resources/assets/components/Quiz/Quiz.js
+++ b/resources/assets/components/Quiz/Quiz.js
@@ -4,12 +4,16 @@ import PropTypes from 'prop-types';
 import Markdown from '../Markdown';
 import Question from './Question';
 import Conclusion from './Conclusion';
+import Enclosure from '../Enclosure';
 import { ShareContainer } from '../Share';
+import DashboardContainer from '../Dashboard/DashboardContainer';
+import LedeBannerContainer from '../LedeBanner/LedeBannerContainer';
+import TabbedNavigationContainer from '../Navigation/TabbedNavigationContainer';
 
 import './quiz.scss';
 
 const Quiz = (props) => {
-  const { id, fields, data, completeQuiz, pickQuizAnswer, trackEvent } = props;
+  const { id, fields, data, dashboard, completeQuiz, pickQuizAnswer, trackEvent } = props;
   const { error, shouldSeeResult } = data;
 
   const introduction = shouldSeeResult ? null : (
@@ -55,16 +59,25 @@ const Quiz = (props) => {
   }
 
   return (
-    <div className="quiz">
-      <div className="quiz__introduction">
-        <h1 className="quiz__subtitle">{fields.subtitle || Quiz.defaultProps.fields.subtitle}</h1>
-        <h2 className="quiz__title">{fields.title}</h2>
-        {introduction}
+    <div>
+      <LedeBannerContainer />
+      <div className="main clearfix">
+        { dashboard ? <DashboardContainer /> : null }
+        <TabbedNavigationContainer />
+        <Enclosure className="default-container margin-top-lg margin-bottom-lg">
+          <div className="quiz">
+            <div className="quiz__introduction">
+              <h1 className="quiz__subtitle">{fields.subtitle || Quiz.defaultProps.fields.subtitle}</h1>
+              <h2 className="quiz__title">{fields.title}</h2>
+              {introduction}
+            </div>
+            {questions}
+            {quizError}
+            {submitConclusion}
+            {shareConclusion}
+          </div>
+        </Enclosure>
       </div>
-      {questions}
-      {quizError}
-      {submitConclusion}
-      {shareConclusion}
     </div>
   );
 };
@@ -86,6 +99,11 @@ Quiz.propTypes = {
     questions: PropTypes.object,
     error: PropTypes.string,
   }).isRequired,
+  dashboard: PropTypes.shape({
+    id: PropTypes.string,
+    type: PropTypes.string,
+    fields: PropTypes.object,
+  }),
   completeQuiz: PropTypes.func.isRequired,
   pickQuizAnswer: PropTypes.func.isRequired,
   trackEvent: PropTypes.func.isRequired,
@@ -97,6 +115,7 @@ Quiz.defaultProps = {
     questions: {},
     error: null,
   },
+  dashboard: null,
   fields: {
     subtitle: 'Quiz',
     introduction: '',

--- a/resources/assets/components/Quiz/Quiz.js
+++ b/resources/assets/components/Quiz/Quiz.js
@@ -13,7 +13,8 @@ import TabbedNavigationContainer from '../Navigation/TabbedNavigationContainer';
 import './quiz.scss';
 
 const Quiz = (props) => {
-  const { id, fields, data, dashboard, completeQuiz, pickQuizAnswer, trackEvent } = props;
+  const { id, fields, data, dashboard, completeQuiz,
+    pickQuizAnswer, trackEvent, showLedeBanner } = props;
   const { error, shouldSeeResult } = data;
 
   const introduction = shouldSeeResult ? null : (
@@ -60,10 +61,10 @@ const Quiz = (props) => {
 
   return (
     <div>
-      <LedeBannerContainer />
+      { showLedeBanner ? <LedeBannerContainer /> : null }
       <div className="main clearfix">
-        { dashboard ? <DashboardContainer /> : null }
-        <TabbedNavigationContainer />
+        { dashboard && showLedeBanner ? <DashboardContainer /> : null }
+        { showLedeBanner ? <TabbedNavigationContainer /> : null }
         <Enclosure className="default-container margin-top-lg margin-bottom-lg">
           <div className="quiz">
             <div className="quiz__introduction">
@@ -106,6 +107,7 @@ Quiz.propTypes = {
   }),
   completeQuiz: PropTypes.func.isRequired,
   pickQuizAnswer: PropTypes.func.isRequired,
+  showLedeBanner: PropTypes.bool.isRequired,
   trackEvent: PropTypes.func.isRequired,
 };
 

--- a/resources/assets/components/Quiz/QuizContainer.js
+++ b/resources/assets/components/Quiz/QuizContainer.js
@@ -1,6 +1,6 @@
 import { connect } from 'react-redux';
 import { PuckConnector } from '@dosomething/puck-client';
-import { find } from 'lodash';
+import { get, find } from 'lodash';
 import Quiz from './Quiz';
 import {
   pickWinner,
@@ -36,6 +36,7 @@ const mapStateToProps = (state, ownProps) => {
     fields: quizFields,
     data: quizData,
     dashboard: state.campaign.dashboard,
+    showLedeBanner: get(quizFields, 'additionalContent.showLedeBanner', true),
   };
 };
 

--- a/resources/assets/components/Quiz/QuizContainer.js
+++ b/resources/assets/components/Quiz/QuizContainer.js
@@ -35,6 +35,7 @@ const mapStateToProps = (state, ownProps) => {
     id: quizId,
     fields: quizFields,
     data: quizData,
+    dashboard: state.campaign.dashboard,
   };
 };
 


### PR DESCRIPTION
### What does this PR do?
This pull request moves the `LedeBanner`, `Dashboard`, and other "page chrome" into each individual page (rather than in the top-level campaign route). This allows us to easily toggle it case-by-case... for example, so we can hide it on a quiz page:

![screen shot 2018-02-27 at 3 40 20 pm](https://user-images.githubusercontent.com/583202/36753607-a4446f64-1bd4-11e8-8d7e-f1516463ff9c.png)

### Any background context you want to provide?
I created `LedeBannerContainer` and `DashboardContainer` so that these did not need props to be passed in from each parent component (and I think moves us closer to idiomatic Redux usage). I left a `dashboard` prop injected into each of the parent pages, so that the `Dashboard` component could be toggled based on whether or not it's set on the campaign. Not sure if that's ideal or not... 🤔

Moving the rest of the page layout into each specific Page component fits into larger refactoring goals that @weerd & I had talked about, but also makes [the real change](https://github.com/DoSomething/phoenix-next/pull/708/commits/3446b2bc00dfd9c4edbc540da1e97e6b41b4087a) pretty darn simple! Nice!

### What are the relevant tickets/cards?
[#154881362](https://www.pivotaltracker.com/story/show/154881362)

### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
- [ ] Added screenshot to PR description of related front-end updates on **small** screens.
- [ ] Added screenshot to PR description of related front-end updates on **medium** screens.
- [ ] Added screenshot to PR description of related front-end updates on **large** screens.