### PR TITLE
Progress on showing an action for a quiz result.

### DIFF
--- a/app/Entities/Campaign.php
+++ b/app/Entities/Campaign.php
@@ -106,7 +106,7 @@ class Campaign extends Entity implements JsonSerializable
     /**
      * Parse and extract data for an action step.
      *
-     * @param  Entry $entry
+     * @param  Entry $step
      * @return array
      */
     public function parseActionStep($step)

--- a/app/Entities/Quiz.php
+++ b/app/Entities/Quiz.php
@@ -33,6 +33,8 @@ class Quiz extends Entity implements JsonSerializable
      */
     private function parseQuestionsFromJson()
     {
+        // @TODO: Not sure why this was not named additionalContent like every other
+        // instance where we use an additionalContent JSON field @_@
         $questions = $this->questions->get('items');
         if (! $questions) {
             return [];
@@ -44,6 +46,42 @@ class Quiz extends Entity implements JsonSerializable
             $data['answers'] = $this->parseAnswersFromQuestion($question);
 
             return $data;
+        });
+    }
+
+    private function parseResultActionOptions()
+    {
+        return $this->questions->get('resultActions') ?: null;
+    }
+
+    /**
+     * Parse and extract data for a result option.
+     *
+     * @param  Entity $result
+     * @return mixed
+     */
+    private function parseResult($result)
+    {
+        switch ($result->getContentType()) {
+            case 'linkAction':
+                return new LinkAction($result->entry);
+            case 'shareAction':
+                return new ShareAction($result->entry);
+            default:
+                return null;
+        }
+    }
+
+    /**
+     * Parse and extract data for results options.
+     *
+     * @param  array $results
+     * @return array
+     */
+    private function parseResults($results)
+    {
+        return collect($results)->map(function ($result) {
+            return $this->parseResult($result);
         });
     }
 
@@ -67,6 +105,8 @@ class Quiz extends Entity implements JsonSerializable
                 'callToAction' => $this->callToAction,
                 'questions' => $this->parseQuestionsFromJson(),
                 'additionalContent' => $this->additionalContent,
+                'results' => $this->parseResults($this->results),
+                'resultActions' => $this->parseResultActionOptions(),
             ],
         ];
     }

--- a/app/Http/Controllers/CampaignController.php
+++ b/app/Http/Controllers/CampaignController.php
@@ -57,7 +57,7 @@ class CampaignController extends Controller
     public function show($slug)
     {
         $campaign = $this->campaignRepository->findBySlug($slug);
-        // dd($campaign);
+
         $env = get_client_environment_vars();
 
         // The slug argument will not contain `/blocks` or other path extensions, hence `::url()`.

--- a/app/Http/Controllers/CampaignController.php
+++ b/app/Http/Controllers/CampaignController.php
@@ -57,7 +57,7 @@ class CampaignController extends Controller
     public function show($slug)
     {
         $campaign = $this->campaignRepository->findBySlug($slug);
-
+        // dd($campaign);
         $env = get_client_environment_vars();
 
         // The slug argument will not contain `/blocks` or other path extensions, hence `::url()`.

--- a/resources/assets/actions/quiz.js
+++ b/resources/assets/actions/quiz.js
@@ -57,13 +57,8 @@ export function completeQuiz(quizId) {
     // @HACK: Here we go! For the first question, grab the answer, if it is equal to 0,
     // we show a share action since user is under age, otherwise we show a link action.
     const firstAnswer = Number(quizData.questions[0]);
-    let resultActionId = null;
-
-    if (firstAnswer === 0) {
-      resultActionId = get(quizContent.fields.resultActions, 'shareAction', null);
-    } else {
-      resultActionId = get(quizContent.fields.resultActions, 'linkAction', null);
-    }
+    const resultActionType = firstAnswer === 0 ? 'shareAction' : 'linkAction';
+    const resultActionId = get(quizContent.fields.resultActions, resultActionType, null);
 
     return getState().user.id ?
       dispatch(quizConvert(quizId, resultActionId))

--- a/resources/assets/components/Actions/LinkAction/LinkAction.js
+++ b/resources/assets/components/Actions/LinkAction/LinkAction.js
@@ -15,7 +15,7 @@ const LinkAction = (props) => {
   };
 
   return (
-    <div className="link-action margin-horizontal-md margin-bottom-lg">
+    <div className="link-action margin-bottom-lg">
       <Card
         title={title}
         className={classnames('rounded bordered', { 'affiliate-content': affiliateLogo })}

--- a/resources/assets/components/ContentfulEntry/renderers.js
+++ b/resources/assets/components/ContentfulEntry/renderers.js
@@ -135,7 +135,7 @@ export function renderVoterRegistrationAction(step, stepIndex) {
   const key = `voter-registration-action-${step.id}`;
 
   return (
-    <div key={key} className="margin-bottom-lg">
+    <div key={key} className="margin-bottom-lg margin-horizontal-md">
       <PuckWaypoint name="voter_registration_action-top" />
       <VoterRegistrationActionContainer
         content={content}

--- a/resources/assets/components/ContentfulEntry/renderers.js
+++ b/resources/assets/components/ContentfulEntry/renderers.js
@@ -157,7 +157,7 @@ export function renderShareAction(step) {
   const contentfulId = step.id;
 
   return (
-    <div key={`share-action-${contentfulId}`}>
+    <div key={`share-action-${contentfulId}`} className="margin-horizontal-md">
       <PuckWaypoint name="share_action-top" waypointData={{ contentfulId }} />
       <ShareActionContainer {...step.fields} />
       <PuckWaypoint name="share_action-bottom" waypointData={{ contentfulId }} />
@@ -174,7 +174,7 @@ export function renderLinkAction(step) {
   const contentfulId = step.id;
 
   return (
-    <div key={`link-action-${contentfulId}`}>
+    <div key={`link-action-${contentfulId}`} className="margin-horizontal-md">
       <PuckWaypoint name="link_action-top" waypointData={{ contentfulId }} />
       <LinkActionContainer {...step.fields} />
       <PuckWaypoint name="link_action-bottom" waypointData={{ contentfulId }} />

--- a/resources/assets/components/Quiz/Quiz.js
+++ b/resources/assets/components/Quiz/Quiz.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { find } from 'lodash';
 import PropTypes from 'prop-types';
 
 import Markdown from '../Markdown';
@@ -15,7 +16,7 @@ import './quiz.scss';
 const Quiz = (props) => {
   const { id, fields, data, dashboard, completeQuiz,
     pickQuizAnswer, trackEvent, showLedeBanner } = props;
-  const { error, shouldSeeResult } = data;
+  const { error, shouldSeeResult, selectedResult } = data;
 
   const introduction = shouldSeeResult ? null : (
     <Markdown className="quiz__description">{fields.introduction}</Markdown>
@@ -53,6 +54,22 @@ const Quiz = (props) => {
     </Conclusion>
   ) : null;
 
+  const showResultingAction = (selectedResult) => {
+    console.log(selectedResult);
+
+    const action = find(fields.results, { id: selectedResult });
+
+    console.log(action);
+
+    if (action.type.sys.id = 'linkAction') {
+      // return <LinkAction />;
+    }
+
+    if (action.type.sys.id = 'shareAction') {
+      // return <ShareAction />;
+    }
+  };
+
   if (shouldSeeResult) {
     trackEvent('converted on quiz', {
       responses: data.questions,
@@ -72,10 +89,14 @@ const Quiz = (props) => {
               <h2 className="quiz__title">{fields.title}</h2>
               {introduction}
             </div>
+
             {questions}
+
             {quizError}
+
             {submitConclusion}
-            {shareConclusion}
+
+            {fields.resultActions && selectedResult ? showResultingAction(selectedResult) : shareConclusion}
           </div>
         </Enclosure>
       </div>

--- a/resources/assets/components/Quiz/Quiz.js
+++ b/resources/assets/components/Quiz/Quiz.js
@@ -10,6 +10,8 @@ import { ShareContainer } from '../Share';
 import DashboardContainer from '../Dashboard/DashboardContainer';
 import LedeBannerContainer from '../LedeBanner/LedeBannerContainer';
 import TabbedNavigationContainer from '../Navigation/TabbedNavigationContainer';
+import { ShareActionContainer } from '../ShareAction';
+import LinkActionContainer from '../Actions/LinkAction';
 
 import './quiz.scss';
 
@@ -54,19 +56,23 @@ const Quiz = (props) => {
     </Conclusion>
   ) : null;
 
-  const showResultingAction = (selectedResult) => {
-    console.log(selectedResult);
-
+  const showResultingAction = () => {
     const action = find(fields.results, { id: selectedResult });
 
-    console.log(action);
+    const actionProps = {
+      ...action.fields,
+      content: `${fields.conclusion}\n${action.fields.content}`,
+    };
 
-    if (action.type.sys.id = 'linkAction') {
-      // return <LinkAction />;
-    }
+    switch (action.type.sys.id) {
+      case 'linkAction':
+        return <LinkActionContainer {...actionProps} />;
 
-    if (action.type.sys.id = 'shareAction') {
-      // return <ShareAction />;
+      case 'shareAction':
+        return <ShareActionContainer {...actionProps} />;
+
+      default:
+        return null;
     }
   };
 

--- a/resources/assets/components/Quiz/Quiz.js
+++ b/resources/assets/components/Quiz/Quiz.js
@@ -102,7 +102,7 @@ const Quiz = (props) => {
 
             {submitConclusion}
 
-            {fields.resultActions && selectedResult ? showResultingAction(selectedResult) : shareConclusion}
+            {fields.resultActions && selectedResult ? showResultingAction() : shareConclusion}
           </div>
         </Enclosure>
       </div>

--- a/resources/assets/components/Quiz/QuizContainer.js
+++ b/resources/assets/components/Quiz/QuizContainer.js
@@ -18,6 +18,7 @@ const mapStateToProps = (state, ownProps) => {
   const quizContent = find(state.campaign.quizzes, { fields: { slug } });
   const quizId = quizContent.id;
   const quizData = state.quiz[quizId];
+  console.log(quizData);
   let quizFields = quizContent.fields;
 
   const winner = pickWinner(quizData ? quizData.questions : {}, quizFields.questions);

--- a/resources/assets/components/Quiz/quiz.scss
+++ b/resources/assets/components/Quiz/quiz.scss
@@ -1,7 +1,7 @@
 @import '../../scss/next-toolbox.scss';
 
 .quiz {
-  margin: 0 $base-spacing;
+  margin: 0 $half-spacing;
 
   .quiz__introduction {
     text-align: center;
@@ -16,8 +16,7 @@
 
   .quiz__title {
     font-family: $secondary-font-family;
-    font-size: $font-superhero;
-    letter-spacing: 2px;
+    font-size: $font-hero;
     text-transform: uppercase;
     margin-bottom: $base-spacing;
   }
@@ -50,7 +49,7 @@
   }
 
   .answer {
-    margin-bottom: $base-spacing;
+    margin-bottom: $half-spacing;
     font-weight: $weight-bold;
     text-align: center;
     text-decoration: none;

--- a/resources/assets/reducers/quiz.js
+++ b/resources/assets/reducers/quiz.js
@@ -18,7 +18,7 @@ const ensureSafeState = (state, quizId) => {
 };
 
 const quiz = (state = {}, action) => {
-  const { quizId } = action;
+  const { quizId, resultActionId } = action;
   const safeState = ensureSafeState(state, quizId);
 
   switch (action.type) {
@@ -47,6 +47,7 @@ const quiz = (state = {}, action) => {
         [quizId]: {
           ...safeState[quizId],
           shouldSeeResult: true,
+          selectedResult: resultActionId,
         },
       };
     case COMPARE_QUIZ_ANSWER:


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_


### What does this PR do?
This PR Adds dynamic quiz result actions to the results shown from the Quiz - for now - specifically tailored for the `give-a-spit-about-cancer` quiz we're running.

- adding a `results` field to the Quiz Contentful Entry which is an array of references to the potential result actions
- adding a `resultActions` field to the Quiz Contentful Entry which is a reference to the `type` and `id` of the potential result actions
- adding internal logic to render the correct result action based on the users' response to the first question in the quiz
- some styling fixes 


### Any background context you want to provide?
We introduced a slight hack to the quiz so that based on the results of the first answer (Age), we'd be able to return a specific result action from the quiz.

It works like so:

We have a field of `results` containing an array of references to the potential result actions.
We specify the `type`s and `id`s of said results in a `resultActions` field. (This is set within the `questions` JSON field in contentful).
Once the user clicks 'Get Results' we check to see what they answered to the first questions and based on the response find the resultAction corresponding to the proper action 'type' and set that as the `resultActionId`.
Within the Quiz, we find the action with that ID, and render it as the quiz result!

![quiz](https://user-images.githubusercontent.com/12417657/36797250-7a52bfa2-1c75-11e8-80b0-39493be8c71c.gif)



### What are the relevant tickets/cards?
Pivotal ID [#154881437](https://www.pivotaltracker.com/story/show/154881437)
closes #704 
#705 


### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
- [ ] Added screenshot to PR description of related front-end updates on **small** screens.
- [ ] Added screenshot to PR description of related front-end updates on **medium** screens.
- [ ] Added screenshot to PR description of related front-end updates on **large** screens.
