### PR TITLE
Using the `toString` method to ensure proper rendering of search params

### DIFF
--- a/resources/assets/helpers/index.js
+++ b/resources/assets/helpers/index.js
@@ -399,7 +399,7 @@ export function showTwitterSharePrompt(href, quote) {
  */
 export function makeUrl(path, queryParameters) {
   const urlObject = new URL(path);
-  urlObject.search = new URLSearchParams(queryParameters);
+  urlObject.search = new URLSearchParams(queryParameters).toString();
 
   return urlObject;
 }


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_



### What does this PR do?
This PR adds a quick adjustment to the `makeUrl` helper method to ensure proper rendering of provided search params.


### Any background context you want to provide?
There was an issue with certain browsers not rendering the query parameters when using this method. This came up in relation to the [`SurveyModal`](https://github.com/DoSomething/phoenix-next/blob/master/resources/assets/components/Modal/configurations/SurveyModal.js#L31) not rendering the proper URL in the `data-url`, causing some missing fields in the results.

This seems to be a slight bug in the compatibility with `URLSearchParams` in Safari (confirmed, could be other browsers as well).

Either way - using the `toString` method results in proper query params being appended to the URL!

🎩 @DFurnes 

### What are the relevant tickets/cards?
Pivotal ID [#155533170](https://www.pivotaltracker.com/story/show/155533170)
