### PR TITLE
Allow the CTA pop-up bar to be hidden on some pages.

### DIFF
--- a/resources/assets/components/CallToAction/CallToAction.js
+++ b/resources/assets/components/CallToAction/CallToAction.js
@@ -27,6 +27,7 @@ type CallToActionProps = {
   impactPrefix: ?string,
   impactSuffix: ?string,
   impactValue: ?string,
+  hideIfSignedUp: ?bool,
   isSignedUp: bool,
   legacyCampaignId: ?string,
   tagline: string,
@@ -36,8 +37,12 @@ type CallToActionProps = {
 
 const CallToAction = ({
   actionText, campaignId, className, content, impactPrefix, impactSuffix, impactValue,
-  isSignedUp, legacyCampaignId, tagline, useCampaignTagline, visualStyle,
+  hideIfSignedUp, isSignedUp, legacyCampaignId, tagline, useCampaignTagline, visualStyle,
 }: CallToActionProps) => {
+  if (hideIfSignedUp && isSignedUp) {
+    return null;
+  }
+
   const SignupButton = SignupButtonFactory(({ clickedSignUp }) => (
     <Button onClick={() => clickedSignUp(legacyCampaignId || campaignId)} text={actionText} />
   ), 'call to action', { text: actionText });
@@ -67,6 +72,7 @@ CallToAction.defaultProps = {
   impactPrefix: null,
   impactSuffix: null,
   impactValue: null,
+  hideIfSignedUp: false,
   legacyCampaignId: null,
 };
 

--- a/resources/assets/components/Feed/Feed.js
+++ b/resources/assets/components/Feed/Feed.js
@@ -4,8 +4,9 @@ import classnames from 'classnames';
 
 import ContentfulEntry from '../ContentfulEntry';
 import Revealer from '../Revealer';
-import { Flex, FlexCell } from '../Flex';
 import Enclosure from '../Enclosure';
+import { Flex, FlexCell } from '../Flex';
+import { CallToActionContainer } from '../CallToAction';
 import DashboardContainer from '../Dashboard/DashboardContainer';
 import LedeBannerContainer from '../LedeBanner/LedeBannerContainer';
 import TabbedNavigationContainer from '../Navigation/TabbedNavigationContainer';
@@ -64,6 +65,7 @@ const Feed = (props) => {
           </Flex>
           {revealer}
         </Enclosure>
+        <CallToActionContainer className="-sticky" hideIfSignedUp />
       </div>
     </div>
   );

--- a/resources/assets/components/Page/ActionPage/ActionPage.js
+++ b/resources/assets/components/Page/ActionPage/ActionPage.js
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { cloneDeep } from 'lodash';
 import Enclosure from '../../Enclosure';
+import { CallToActionContainer } from '../../CallToAction';
 import DashboardContainer from '../../Dashboard/DashboardContainer';
 import LedeBannerContainer from '../../LedeBanner/LedeBannerContainer';
 import TabbedNavigationContainer from '../../Navigation/TabbedNavigationContainer';
@@ -36,6 +37,7 @@ const ActionPage = (props) => {
         <Enclosure className="default-container margin-top-lg margin-bottom-lg">
           <ActionStepsContainer actionSteps={actionSteps} />
         </Enclosure>
+        <CallToActionContainer className="-sticky" hideIfSignedUp />
       </div>
     </div>
   );

--- a/resources/assets/components/Page/CampaignPage/CampaignPage.js
+++ b/resources/assets/components/Page/CampaignPage/CampaignPage.js
@@ -19,7 +19,7 @@ import { CONTENT_MODAL, REPORTBACK_UPLOADER_MODAL } from '../../Modal';
 const CampaignPage = (props) => {
   const {
     affiliatePartners, affiliateSponsors, campaignLead,
-    endDate, hasActivityFeed, isAffiliated, match,
+    endDate, hasActivityFeed, match,
     openModal, shouldShowActionPage, template,
   } = props;
 
@@ -86,7 +86,7 @@ const CampaignPage = (props) => {
           { /* If no route matches, just redirect back to the main page: */ }
           <Redirect from={`${match.url}/:anything`} to={`${match.url}`} />
         </Switch>
-        { ! isAffiliated ? <CallToActionContainer key="callToAction" className="-sticky" /> : null }
+        <CallToActionContainer className="-sticky" hideIfSignedUp />
       </div>
       <CampaignFooter
         affiliateSponsors={affiliateSponsors}
@@ -107,7 +107,6 @@ CampaignPage.propTypes = {
     name: PropTypes.string,
     email: PropTypes.string,
   }),
-  isAffiliated: PropTypes.bool,
   hasActivityFeed: PropTypes.bool.isRequired,
   affiliateSponsors: PropTypes.array.isRequired, // eslint-disable-line react/forbid-prop-types
   affiliatePartners: PropTypes.array.isRequired, // eslint-disable-line react/forbid-prop-types
@@ -119,7 +118,6 @@ CampaignPage.propTypes = {
 
 CampaignPage.defaultProps = {
   endDate: null,
-  isAffiliated: false,
   campaignLead: null,
 };
 

--- a/resources/assets/components/Page/CampaignPage/CampaignPage.js
+++ b/resources/assets/components/Page/CampaignPage/CampaignPage.js
@@ -8,7 +8,6 @@ import { QuizContainer } from '../../Quiz';
 import BlockPageContainer from '../BlockPage';
 import { isCampaignClosed } from '../../../helpers';
 import { ActionPageContainer } from '../ActionPage';
-import { CallToActionContainer } from '../../CallToAction';
 import { CampaignSubPageContainer } from '../CampaignSubPage';
 import CampaignFooter from '../../CampaignFooter';
 import { CONTENT_MODAL, REPORTBACK_UPLOADER_MODAL } from '../../Modal';
@@ -86,7 +85,6 @@ const CampaignPage = (props) => {
           { /* If no route matches, just redirect back to the main page: */ }
           <Redirect from={`${match.url}/:anything`} to={`${match.url}`} />
         </Switch>
-        <CallToActionContainer className="-sticky" hideIfSignedUp />
       </div>
       <CampaignFooter
         affiliateSponsors={affiliateSponsors}

--- a/resources/assets/components/Page/CampaignPage/CampaignPageContainer.js
+++ b/resources/assets/components/Page/CampaignPage/CampaignPageContainer.js
@@ -8,7 +8,6 @@ import { convertExperiment, openModal } from '../../../actions';
  * Provide state from the Redux store as props for this component.
  */
 const mapStateToProps = state => ({
-  isAffiliated: state.signups.thisCampaign,
   hasActivityFeed: Boolean(state.campaign.activityFeed.length),
   affiliateSponsors: state.campaign.affiliateSponsors,
   affiliatePartners: state.campaign.affiliatePartners,

--- a/resources/assets/components/Page/CampaignSubPage/CampaignSubPage.js
+++ b/resources/assets/components/Page/CampaignSubPage/CampaignSubPage.js
@@ -5,8 +5,8 @@ import PropTypes from 'prop-types';
 import Markdown from '../../Markdown';
 import NotFound from '../../NotFound';
 import { isCampaignClosed } from '../../../helpers';
+import { CallToActionContainer } from '../../CallToAction';
 import ScrollConcierge from '../../ScrollConcierge';
-import CallToActionContainer from '../../CallToAction/CallToActionContainer';
 import Enclosure from '../../Enclosure';
 import DashboardContainer from '../../Dashboard/DashboardContainer';
 import LedeBannerContainer from '../../LedeBanner/LedeBannerContainer';
@@ -106,6 +106,7 @@ const CampaignSubPage = props => (
       <Enclosure className="default-container margin-top-lg margin-bottom-lg">
         <CampaignSubPageContent {...props} />
       </Enclosure>
+      <CallToActionContainer className="-sticky" hideIfSignedUp />
     </div>
   </div>
 );

--- a/resources/assets/components/Quiz/Quiz.js
+++ b/resources/assets/components/Quiz/Quiz.js
@@ -6,6 +6,7 @@ import Question from './Question';
 import Conclusion from './Conclusion';
 import Enclosure from '../Enclosure';
 import { ShareContainer } from '../Share';
+import { CallToActionContainer } from '../CallToAction';
 import DashboardContainer from '../Dashboard/DashboardContainer';
 import LedeBannerContainer from '../LedeBanner/LedeBannerContainer';
 import TabbedNavigationContainer from '../Navigation/TabbedNavigationContainer';
@@ -78,6 +79,7 @@ const Quiz = (props) => {
             {shareConclusion}
           </div>
         </Enclosure>
+        { showLedeBanner ? <CallToActionContainer className="-sticky" hideIfSignedUp /> : null }
       </div>
     </div>
   );


### PR DESCRIPTION
### What does this PR do?
This PR extracts the "CTA pop-up bar" from the top-level `CampaignPage` so we can apply it only on specific pages (just like we've done with `LedeBanner` in #708). In this case, I set it to appear on the pitch, action, and content pages when a user is unaffiliated. It only displays on the quiz when a user is unaffiliated AND the `showLedeBanner` setting is enabled.

### Any background context you want to provide?
I tried running through a couple campaigns and everything seems to work the same as production, but please help me QA this to make sure I didn't break any other experiences before we deploy! ✌️

### What are the relevant tickets/cards?
[Slack conversation](https://dosomething.slack.com/archives/C3ASB4204/p1519833461000292)

### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
- [ ] Added screenshot to PR description of related front-end updates on **small** screens.
- [ ] Added screenshot to PR description of related front-end updates on **medium** screens.
- [ ] Added screenshot to PR description of related front-end updates on **large** screens.