### PR TITLE
Arrow fix affiliate content update

### DIFF
--- a/resources/assets/components/Actions/LinkAction/LinkAction.js
+++ b/resources/assets/components/Actions/LinkAction/LinkAction.js
@@ -8,11 +8,16 @@ import Markdown from '../../Markdown';
 import SponsorPromotion from '../../SponsorPromotion';
 
 const LinkAction = (props) => {
-  const { title, content, link, affiliateLogo, trackEvent } = props;
+  const { content, link, affiliateLogo, trackEvent } = props;
 
   const onLinkClick = () => {
     trackEvent('clicked link action', { link });
   };
+
+  // The affiliate logo specific text is hard-coded for OZY. Though we can set this title
+  // in Contentful, we currently can't for CampaignUpdates which have a similar affiliate flow,
+  // so this ensures consistency until we make this part of the content editing process.
+  const title = affiliateLogo ? 'See More Be More Do More' : props.title;
 
   return (
     <div className="link-action margin-bottom-lg">

--- a/resources/assets/components/CampaignSignupArrow/campaignSignupArrow.scss
+++ b/resources/assets/components/CampaignSignupArrow/campaignSignupArrow.scss
@@ -46,12 +46,12 @@
   .message-callout__copy::before {
     @include media($larger) {
       background: url("~@dosomething/forge/assets/images/callout/arrow-left-white.png") 50% 50% / 35px no-repeat transparent !important;
-      height: 19px;
+      height: 19px !important;
       left: 0;
       margin-top: -9px;
-      right: auto;
-      top: 50%;
-      width: 38px;
+      right: auto !important;
+      top: 50% !important;
+      width: 38px !important;
     }
 
     @include media($small) {

--- a/resources/assets/components/CampaignUpdate/CampaignUpdate.js
+++ b/resources/assets/components/CampaignUpdate/CampaignUpdate.js
@@ -20,12 +20,16 @@ const CampaignUpdate = (props) => {
 
   const isTweet = content && content.length < 144;
 
+  // The affiliate logo specific text is hardcoded for OZY
+  // @TODO Make this a Contentful field?
+  const title = affiliateLogo ? 'See More Be More Do More' : 'Campaign Update';
+
   return (
     <Card
       id={id}
       className={classnames('rounded', { bordered, 'affiliate-content': affiliateLogo })}
       link={titleLink}
-      title="Campaign Update"
+      title={title}
       onClose={closeModal}
     >
       <Markdown className={classnames('padded', { 'font-size-lg': isTweet })}>

--- a/resources/assets/components/CampaignUpdate/__snapshots__/CampaignUpdate.test.js.snap
+++ b/resources/assets/components/CampaignUpdate/__snapshots__/CampaignUpdate.test.js.snap
@@ -6,7 +6,7 @@ exports[`it generates a campaign update in affiliate mode snapshot 1`] = `
   id="1234567890"
   link="http://example.com/link-to-content"
   onClose={null}
-  title="Campaign Update"
+  title="See More Be More Do More"
 >
   <Markdown
     className="padded"
@@ -37,7 +37,7 @@ exports[`it generates a campaign update snapshot 1`] = `
   id="1234567890"
   link="http://example.com/link-to-content"
   onClose={null}
-  title="Campaign Update"
+  title="See More Be More Do More"
 >
   <Markdown
     className="padded"


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_




### What does this PR do?
This PR:

- adds `!important` to some rules to fixes some styling funkiness with the signup arrow. (some rules from forge suddenly were not being overridden by our rules here for some reason...)
- adds some specific text for affiliate LinkActions and CampaignUpdates. This is static and hard-coded for OZY for now, until we formalize a contentful field for this or something.



### What are the relevant tickets/cards?
[Slack convo affiliate title](https://dosomething.slack.com/archives/C3ASB4204/p1519845930000784)
[Slack convo arrow](https://dosomething.slack.com/files/U5W0DL0LD/F9GDU5HU2/screen_shot_2018-02-28_at_1.53.29_pm.png)
