### PR TITLE
Embed internal link target

### DIFF
--- a/resources/assets/components/Embed/index.js
+++ b/resources/assets/components/Embed/index.js
@@ -2,7 +2,9 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import classnames from 'classnames';
 import { Phoenix } from '@dosomething/gateway';
+
 import { Figure } from '../Figure';
+import { isExternal } from '../../helpers';
 import './embed.scss';
 
 class Embed extends React.Component {
@@ -20,6 +22,7 @@ class Embed extends React.Component {
 
   render() {
     let embed = <div className="spinner" />;
+    const target = isExternal(this.state.url) ? '_blank' : '_self';
 
     // If an <iframe> code snippet is provided, use that. Otherwise, build preview card.
     if (this.state.code) {
@@ -27,7 +30,7 @@ class Embed extends React.Component {
       embed = (<div className="media-video" dangerouslySetInnerHTML={embedHtml} />); //  eslint-disable-line react/no-danger
     } else if (this.state.title && this.state.url) {
       embed = (
-        <a href={this.state.url} target="_blank" rel="noopener noreferrer">
+        <a href={this.state.url} target={target} rel="noopener noreferrer">
           <Figure className="padded margin-bottom-none" image={this.state.image || this.state.provider.icon} alt={this.state.provider.name} alignment="left-collapse" size="large">
             <h3>{ this.state.title }</h3>
             { this.state.description ? <p>{ this.state.description }</p> : null }

--- a/resources/assets/helpers/index.js
+++ b/resources/assets/helpers/index.js
@@ -9,10 +9,16 @@ import markdownItFootnote from 'markdown-it-footnote';
 // Helper Constants
 export const EMPTY_IMAGE = 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7';
 
-// Internal Helper Functions
-const isExternal = url => (
-  new URL(url, window.location.origin).hostname !== window.location.hostname
-);
+
+/**
+ * Return a boolean indicating as to weather the provided URL is external to the site.
+ *
+ * @param  {String} url
+ * @return {Boolean}
+ */
+export function isExternal(url) {
+  return new URL(url, window.location.origin).hostname !== window.location.hostname;
+}
 
 /**
  * Generate a Contentful Image URL with added url parameters.

--- a/resources/assets/helpers/index.js
+++ b/resources/assets/helpers/index.js
@@ -11,7 +11,7 @@ export const EMPTY_IMAGE = 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BA
 
 
 /**
- * Return a boolean indicating as to weather the provided URL is external to the site.
+ * Return a boolean indicating as to whether the provided URL is external to the site.
  *
  * @param  {String} url
  * @return {Boolean}


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_



### What does this PR do?
This PR ensures the internal links rendered through our `Embed` component do not open in a new tab.

- exporting the `isExternal` helper function from `helpers/index.js`
- dynamically setting the `target` attribute of `<a>` tags in `Embed` based on if the link is external or not.

I bumped into this clicking on the quiz link: https://www.dosomething.org/us/campaigns/give-spit-about-cancer#step-3YFdF9Y6bK4IUY66oyIa8a


### What are the relevant tickets/cards?
Memory lane for helper function reference #524 
