### PR TITLE
BUG FIX - Adding endDate prop from state

### DIFF
--- a/resources/assets/components/Page/CampaignPage/CampaignPageContainer.js
+++ b/resources/assets/components/Page/CampaignPage/CampaignPageContainer.js
@@ -15,6 +15,7 @@ const mapStateToProps = state => ({
   legacyCampaignId: state.campaign.legacyCampaignId,
   shouldShowActionPage: state.admin.shouldShowActionPage,
   template: state.campaign.template,
+  endDate: state.campaign.endDate,
 });
 
 /**


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_



### What does this PR do?
This PR adds the `endDate` prop to the `mapStateToProps` in the `CampaignPageContainer` so that we can determine if a campaign is closed. This one slyly slipped by us when we were adding this container to the mix in the great overhaul of the LedeBanner and co.

Pivotal ID: [#155608012](https://www.pivotaltracker.com/story/show/155608012)