### PR TITLE
Query params fun

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2663,6 +2663,11 @@
       "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
       "dev": true
     },
+    "decode-uri-component": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
+      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
+    },
     "deep-diff": {
       "version": "0.3.4",
       "resolved": "https://registry.npmjs.org/deep-diff/-/deep-diff-0.3.4.tgz",
@@ -7611,6 +7616,18 @@
         "prepend-http": "1.0.4",
         "query-string": "4.3.4",
         "sort-keys": "1.1.2"
+      },
+      "dependencies": {
+        "query-string": {
+          "version": "4.3.4",
+          "resolved": "https://registry.npmjs.org/query-string/-/query-string-4.3.4.tgz",
+          "integrity": "sha1-u7aTucqRXCMlFbIosaArYJBD2+s=",
+          "dev": true,
+          "requires": {
+            "object-assign": "4.1.1",
+            "strict-uri-encode": "1.1.0"
+          }
+        }
       }
     },
     "npm-run-path": {
@@ -9343,11 +9360,11 @@
       "dev": true
     },
     "query-string": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/query-string/-/query-string-4.3.4.tgz",
-      "integrity": "sha1-u7aTucqRXCMlFbIosaArYJBD2+s=",
-      "dev": true,
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/query-string/-/query-string-5.1.0.tgz",
+      "integrity": "sha512-F3DkxxlY0AqD/rwe4YAwjRE2HjOkKW7TxsuteyrS/Jbwrxw887PqYBL4sWUJ9D/V1hmFns0SCD6FDyvlwo9RCQ==",
       "requires": {
+        "decode-uri-component": "0.2.0",
         "object-assign": "4.1.1",
         "strict-uri-encode": "1.1.0"
       }
@@ -10367,8 +10384,7 @@
     "strict-uri-encode": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
-      "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=",
-      "dev": true
+      "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM="
     },
     "string-length": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "markdown-it-footnote": "^3.0.1",
     "markdown-it-for-inline": "^0.1.1",
     "prop-types": "^15.5.8",
+    "query-string": "^5.1.0",
     "react": "^15.6.1",
     "react-dom": "^15.6.1",
     "react-portal": "^3.2.0",

--- a/resources/assets/helpers/index.js
+++ b/resources/assets/helpers/index.js
@@ -1,4 +1,4 @@
-/* global window, document, Blob, FB, URL, URLSearchParams */
+/* global window, document, Blob, FB, URL */
 
 import get from 'lodash/get';
 import MarkdownIt from 'markdown-it';

--- a/resources/assets/helpers/index.js
+++ b/resources/assets/helpers/index.js
@@ -2,6 +2,7 @@
 
 import get from 'lodash/get';
 import MarkdownIt from 'markdown-it';
+import queryString from 'query-string';
 import { isPast, parse } from 'date-fns';
 import iterator from 'markdown-it-for-inline';
 import markdownItFootnote from 'markdown-it-footnote';
@@ -405,7 +406,7 @@ export function showTwitterSharePrompt(href, quote) {
  */
 export function makeUrl(path, queryParameters) {
   const urlObject = new URL(path);
-  urlObject.search = new URLSearchParams(queryParameters).toString();
+  urlObject.search = queryString.stringify(queryParameters);
 
   return urlObject;
 }
@@ -419,9 +420,9 @@ export function makeUrl(path, queryParameters) {
  */
 export function query(key, url = window.location) {
   // Ensure we have a URL object from the location.
-  const search = new URLSearchParams(url.search);
+  const search = queryString.parse(url.search);
 
-  return search.get(key);
+  return search[key];
 }
 
 /**


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_


Frustratingly, the [`URLSearchParams`](https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams) which we use to deal with safely [constructing](https://github.com/DoSomething/phoenix-next/blob/master/resources/assets/helpers/index.js#L408) and [parsing](https://github.com/DoSomething/phoenix-next/blob/master/resources/assets/helpers/index.js#L422) URL params acts funky with older versions of Safari and presumably some other browsers. We tried to appease them by stringifying things to no avail.

Upon @DFurnes [recommendation](https://dosomething.slack.com/archives/C2BPA7M8F/p1519941483000320), we're installing the `queryString` npm package and using that to do reliably preform our URL param manipulations. 

![browser-compatibility-meme](https://user-images.githubusercontent.com/12417657/36872810-8e63d210-1d74-11e8-8598-298b8d22ace7.jpg)

PIVOTAL ID [#155533170](https://www.pivotaltracker.com/story/show/155533170)
#710 😢 


