### PR TITLE
Puck tracking voter reg

### DIFF
--- a/resources/assets/components/Actions/VoterRegistrationAction/VoterRegistrationAction.js
+++ b/resources/assets/components/Actions/VoterRegistrationAction/VoterRegistrationAction.js
@@ -26,12 +26,19 @@ const VoterRegistrationAction = (props) => {
     source: 'web',
   };
 
+  const parsedLink = link && dynamicString(link, tokens);
+
+  const handleClick = () => {
+    const trackingData = { url: parsedLink, modal: modalType }
+    trackEvent('clicked voter registration action', trackingData)
+  }
+
   return (
     <Card className="rounded bordered voter-registration" title="Register to vote">
       <div className="padded clearfix">
         <Markdown>{ content }</Markdown>
 
-        { link ? <a className="button" href={dynamicString(link, tokens)} target="_blank">Start Registration</a> : null }
+        { parsedLink ? <a className="button" href={parsedLink} onClick={handleClick} target="_blank">Start Registration</a> : null }
       </div>
     </Card>
   );

--- a/resources/assets/components/Actions/VoterRegistrationAction/VoterRegistrationAction.js
+++ b/resources/assets/components/Actions/VoterRegistrationAction/VoterRegistrationAction.js
@@ -14,6 +14,7 @@ const VoterRegistrationAction = (props) => {
     content,
     contentfulId,
     link,
+    modalType,
     trackEvent,
     userId,
   } = props;
@@ -42,12 +43,14 @@ VoterRegistrationAction.propTypes = {
   content: PropTypes.string,
   contentfulId: PropTypes.string.isRequired,
   link: PropTypes.string.isRequired,
+  modalType: PropTypes.string,
   trackEvent: PropTypes.func.isRequired,
   userId: PropTypes.string.isRequired,
 };
 
 VoterRegistrationAction.defaultProps = {
   content: 'Register to vote!',
+  modalType: null,
 };
 
 export default VoterRegistrationAction;

--- a/resources/assets/components/Actions/VoterRegistrationAction/VoterRegistrationAction.js
+++ b/resources/assets/components/Actions/VoterRegistrationAction/VoterRegistrationAction.js
@@ -12,6 +12,7 @@ const VoterRegistrationAction = (props) => {
     campaignId,
     campaignRunId,
     content,
+    contentfulId,
     link,
     userId,
   } = props;
@@ -38,6 +39,7 @@ VoterRegistrationAction.propTypes = {
   campaignId: PropTypes.string.isRequired,
   campaignRunId: PropTypes.string.isRequired,
   content: PropTypes.string,
+  contentfulId: PropTypes.string.isRequired,
   link: PropTypes.string.isRequired,
   userId: PropTypes.string.isRequired,
 };

--- a/resources/assets/components/Actions/VoterRegistrationAction/VoterRegistrationAction.js
+++ b/resources/assets/components/Actions/VoterRegistrationAction/VoterRegistrationAction.js
@@ -29,9 +29,9 @@ const VoterRegistrationAction = (props) => {
   const parsedLink = link && dynamicString(link, tokens);
 
   const handleClick = () => {
-    const trackingData = { url: parsedLink, modal: modalType }
-    trackEvent('clicked voter registration action', trackingData)
-  }
+    const trackingData = { contentfulId, url: parsedLink, modal: modalType };
+    trackEvent('clicked voter registration action', trackingData);
+  };
 
   return (
     <Card className="rounded bordered voter-registration" title="Register to vote">

--- a/resources/assets/components/Actions/VoterRegistrationAction/VoterRegistrationAction.js
+++ b/resources/assets/components/Actions/VoterRegistrationAction/VoterRegistrationAction.js
@@ -14,6 +14,7 @@ const VoterRegistrationAction = (props) => {
     content,
     contentfulId,
     link,
+    trackEvent,
     userId,
   } = props;
 
@@ -41,6 +42,7 @@ VoterRegistrationAction.propTypes = {
   content: PropTypes.string,
   contentfulId: PropTypes.string.isRequired,
   link: PropTypes.string.isRequired,
+  trackEvent: PropTypes.func.isRequired,
   userId: PropTypes.string.isRequired,
 };
 

--- a/resources/assets/components/Actions/VoterRegistrationAction/VoterRegistrationAction.test.js
+++ b/resources/assets/components/Actions/VoterRegistrationAction/VoterRegistrationAction.test.js
@@ -1,21 +1,30 @@
 import React from 'react';
-import { render } from 'enzyme';
+import { shallow } from 'enzyme';
 
 import VoterRegistrationAction from './VoterRegistrationAction';
 
-test('VoterRegistrationAction is rendered as a card component with a button', () => {
-  const wrapper = render(
-    <VoterRegistrationAction
-      campaignId="1234"
-      campaignRunId="9876"
-      content="Cras justo odio, dapibus ac facilisis in, egestas eget quam. Duis mollis, est non commodo luctus, nisi erat porttitor ligula."
-      link="http://example.com?campaign={campaignId}&campaingRun={campaignRunId}&user={northstarId}&source={source}"
-      stepIndex={1}
-      title="Register to vote!"
-      userId="551234567890abcdefghijkl"
-    />,
-  );
+const trackEventMock = jest.fn();
 
-  expect(wrapper.find('.card').length).toEqual(1);
+const wrapper = shallow(
+  <VoterRegistrationAction
+    campaignId="1234"
+    campaignRunId="9876"
+    content="Cras justo odio, dapibus ac facilisis in, egestas eget quam. Duis mollis, est non commodo luctus, nisi erat porttitor ligula."
+    contentfulId="1234"
+    link="http://example.com?campaign={campaignId}&campaingRun={campaignRunId}&user={northstarId}&source={source}"
+    stepIndex={1}
+    title="Register to vote!"
+    userId="551234567890abcdefghijkl"
+    trackEvent={trackEventMock}
+  />,
+);
+
+test('VoterRegistrationAction is rendered as a card component with a button', () => {
+  expect(wrapper.find('Card').length).toEqual(1);
   expect(wrapper.find('.button').length).toEqual(1);
+});
+
+test('VoterRegistrationAction calls the event tracker prop function when the button is clicked', () => {
+  wrapper.find('.button').simulate('click');
+  expect(trackEventMock).toHaveBeenCalled();
 });

--- a/resources/assets/components/Actions/VoterRegistrationAction/VoterRegistrationActionContainer.js
+++ b/resources/assets/components/Actions/VoterRegistrationAction/VoterRegistrationActionContainer.js
@@ -1,4 +1,5 @@
 import { connect } from 'react-redux';
+import { PuckConnector } from '@dosomething/puck-client';
 
 import VoterRegistrationAction from './VoterRegistrationAction';
 
@@ -14,4 +15,4 @@ const mapStateToProps = state => ({
 /**
  * Export the container component.
  */
-export default connect(mapStateToProps)(VoterRegistrationAction);
+export default connect(mapStateToProps)(PuckConnector(VoterRegistrationAction));

--- a/resources/assets/components/Actions/VoterRegistrationAction/VoterRegistrationActionContainer.js
+++ b/resources/assets/components/Actions/VoterRegistrationAction/VoterRegistrationActionContainer.js
@@ -10,6 +10,7 @@ const mapStateToProps = state => ({
   userId: state.user.id,
   campaignId: state.campaign.legacyCampaignId,
   campaignRunId: state.campaign.legacyCampaignRunId,
+  modalType: state.modal.modalType,
 });
 
 /**

--- a/resources/assets/components/ContentfulEntry/renderers.js
+++ b/resources/assets/components/ContentfulEntry/renderers.js
@@ -138,6 +138,7 @@ export function renderVoterRegistrationAction(step, stepIndex) {
     <div key={key} className="margin-bottom-lg margin-horizontal-md">
       <PuckWaypoint name="voter_registration_action-top" />
       <VoterRegistrationActionContainer
+        contentfulId={step.id}
         content={content}
         title={title}
         link={link}


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_



### What does this PR do?
This PR adds `puck` tracking to the VoterRegistrationAction link.

- adding `contentfulId` prop to VoterRegistration so we can track it
- adding `modalType` prop (fetching it from the state through the container) so we can track when the voter reg is in a modal, and what type of modal (e.g. signup affirmation vs content modal (content modals are not currently supported, but will be what I'm working on next)). If it's not a modal we'll track it as `null`


### Any background context you want to provide?
The modal tracking logic is based on our current modal setup which will hopefully be changing soon. So just bear in mind the temporary nature of tracking the `modalType` through `state`. (Soon we'll hopefully be able to plainly see if it's a modal (and perhaps the type of modal if relevant) through the windows URL location).

Updated the tests to use `shallow` instead of `render` to be able to test interacting with the button for tracking tests. (As an aside, I'm always unsure -- are tracking tests a concern of the component? Is it indeed relevant to be testing tracking data?)


### What are the relevant tickets/cards?
Pivotal ID [#155479093](https://www.pivotaltracker.com/story/show/155479093)
[Some -Slack convo- context for the data setup](https://dosomething.slack.com/archives/C2BPA7M8F/p1520009934000069)

### Checklist
- [x] Added appropriate feature/unit tests.