### PR TITLE
BUG FIX: moving Embed `isExternal` call

### DIFF
--- a/resources/assets/components/Embed/index.js
+++ b/resources/assets/components/Embed/index.js
@@ -22,13 +22,13 @@ class Embed extends React.Component {
 
   render() {
     let embed = <div className="spinner" />;
-    const target = isExternal(this.state.url) ? '_blank' : '_self';
 
     // If an <iframe> code snippet is provided, use that. Otherwise, build preview card.
     if (this.state.code) {
       const embedHtml = { __html: this.state.code };
       embed = (<div className="media-video" dangerouslySetInnerHTML={embedHtml} />); //  eslint-disable-line react/no-danger
     } else if (this.state.title && this.state.url) {
+      const target = isExternal(this.state.url) ? '_blank' : '_self';
       embed = (
         <a href={this.state.url} target={target} rel="noopener noreferrer">
           <Figure className="padded margin-bottom-none" image={this.state.image || this.state.provider.icon} alt={this.state.provider.name} alignment="left-collapse" size="large">

--- a/resources/assets/helpers/index.js
+++ b/resources/assets/helpers/index.js
@@ -18,7 +18,7 @@ export const EMPTY_IMAGE = 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BA
  * @return {Boolean}
  */
 export function isExternal(url) {
-  return new URL(url, window.location.origin).hostname !== window.location.hostname;
+  return new URL(String(url), window.location.origin).hostname !== window.location.hostname;
 }
 
 /**
@@ -418,7 +418,7 @@ export function showTwitterSharePrompt(href, quote = '', callback) {
  * @return {URL}
  */
 export function makeUrl(path, queryParameters) {
-  const urlObject = new URL(path);
+  const urlObject = new URL(String(path));
   urlObject.search = queryString.stringify(queryParameters);
 
   return urlObject;


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_


### What does this PR do?
This PR moves the call to the `isExternal` helper function to after the `url` is set in `state`

Fixing a potential and inevitable breakage, when feeding `undefined` (non set url in state) to the helper function, and thus to `new URL` which would explode.

Also adding String casting before calling `new URL` in some helper functions for sanity check. (I didn't end up using `makeUrl` from `isExternal` since we have an extra param in `isExternal` in case of relative paths set in Contentful (I remember this issue popping up when we were adding this in))

### What are the relevant tickets/cards?
[Slack convo](https://dosomething.slack.com/archives/C3ASB4204/p1520016065000395)