### PR TITLE
Update content model to allow block types in Pages reference field.

### DIFF
--- a/contentful/migrations/2018_03_02_001_allow_blocks_in_pages.js
+++ b/contentful/migrations/2018_03_02_001_allow_blocks_in_pages.js
@@ -4,8 +4,8 @@ module.exports = function (migration) {
   block.editField('pages')
     .validations([{
       linkContentType: [
-        'page', 'customBlock', 'shareAction', 'linkAction',
-        'voterRegistrationAction', 'campaignUpdate',
+        'campaignUpdate', 'customBlock', 'linkAction', 'page',
+        'photoUploaderAction', 'shareAction', 'voterRegistrationAction',
       ],
     }])
 }

--- a/contentful/migrations/2018_03_02_001_allow_blocks_in_pages.js
+++ b/contentful/migrations/2018_03_02_001_allow_blocks_in_pages.js
@@ -1,0 +1,11 @@
+module.exports = function (migration) {
+  const block = migration.editContentType('campaign');
+
+  block.editField('pages')
+    .validations([{
+      linkContentType: [
+        'page', 'customBlock', 'shareAction', 'linkAction',
+        'voterRegistrationAction', 'campaignUpdate',
+      ],
+    }])
+}

--- a/resources/assets/components/Navigation/TabbedNavigationContainer.js
+++ b/resources/assets/components/Navigation/TabbedNavigationContainer.js
@@ -40,8 +40,9 @@ const TabbedNavigationContainer = (props) => {
 
   const campaignSlug = props.campaignSlug;
 
-  // Create links for additional "content" pages on this campaign in Contentful.
+  // Create links for any pages referenced on this campaign.
   const additionalPages = pages
+    .filter(entry => entry.type === 'page')
     .filter(page => ! page.fields.hideFromNavigation)
     .map((page) => {
       const pageHasCampaignSlug = page.fields.slug.indexOf(campaignSlug) >= 0;


### PR DESCRIPTION
### What does this PR do?
This PR updates our content model to allow block types in Pages reference field, and updates the `TabbedNavigationContainer` to ignore those for now! (We want them loaded to be able to use 'em in `BlockPage`, but not listed for now!)

<img width="776" alt="screen shot 2018-03-02 at 3 13 23 pm" src="https://user-images.githubusercontent.com/583202/36919877-cd42ec24-1e2c-11e8-9f84-2637c3f06d5e.png">


### Any background context you want to provide?
In the future, we might make a Navigatable "contract" where instead of requiring the `Page` content type to show up in the nav, we specifically check for things that have a `slug` and no `hideInNavigation` field specified.

For now, though, I wanted to keep it simple!!


### What are the relevant tickets/cards?
[#155551584](https://www.pivotaltracker.com/story/show/155551584)


### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
- [ ] Added screenshot to PR description of related front-end updates on **small** screens.
- [ ] Added screenshot to PR description of related front-end updates on **medium** screens.
- [ ] Added screenshot to PR description of related front-end updates on **large** screens.