### PR TITLE
Configure standardized block page for SMS shares.

### DIFF
--- a/app/Entities/Campaign.php
+++ b/app/Entities/Campaign.php
@@ -104,39 +104,41 @@ class Campaign extends Entity implements JsonSerializable
     }
 
     /**
-     * Parse and extract data for an action step.
+     * Parse and extract data for a block.
      *
      * @param  Entry $step
      * @return array
      */
-    public function parseActionStep($step)
+    public function parseBlock($block)
     {
-        switch ($step->getContentType()) {
+        switch ($block->getContentType()) {
             case 'photoUploaderAction':
-                return new PhotoUploaderAction($step->entry);
+                return new PhotoUploaderAction($block->entry);
             case 'voterRegistrationAction':
-                return new VoterRegistrationAction($step->entry);
+                return new VoterRegistrationAction($block->entry);
             case 'shareAction':
-                return new ShareAction($step->entry);
+                return new ShareAction($block->entry);
             case 'linkAction':
-                return new LinkAction($step->entry);
+                return new LinkAction($block->entry);
             case 'affirmation':
-                return new Affirmation($step->entry);
+                return new Affirmation($block->entry);
+            case 'page':
+                return $block;
             default:
-                return new CampaignActionStep($step->entry);
+                return new CampaignActionStep($block->entry);
         }
     }
 
     /**
-     * Parse and extract data for action steps.
+     * Parse and extract data for blocks.
      *
-     * @param  array $actionSteps
+     * @param  array $blocks
      * @return array
      */
-    public function parseActionSteps($actionSteps)
+    public function parseBlocks($blocks)
     {
-        return collect($actionSteps)->map(function ($step) {
-            return $this->parseActionStep($step);
+        return collect($blocks)->map(function ($block) {
+            return $this->parseBlock($block);
         });
     }
 
@@ -227,11 +229,11 @@ class Campaign extends Entity implements JsonSerializable
                 $this->activity_feed,
                 array_get($this->additionalContent, 'reverseActivityFeedOrder', true)
             ),
-            'actionSteps' => $this->parseActionSteps($this->actionSteps),
+            'actionSteps' => $this->parseBlocks($this->actionSteps),
             'quizzes' => $this->parseQuizzes($this->quizzes),
             'dashboard' => $this->dashboard,
-            'affirmation' => $this->parseActionStep($this->affirmation),
-            'pages' => $this->pages,
+            'affirmation' => $this->parseBlock($this->affirmation),
+            'pages' => $this->parseBlocks($this->pages),
             'landingPage' => $this->landingPage ? new Page($this->landingPage->entry) : null,
             'socialOverride' => $this->socialOverride ? new SocialOverride($this->socialOverride->entry) : null,
             'additionalContent' => $this->additionalContent,

--- a/app/Http/Controllers/CampaignController.php
+++ b/app/Http/Controllers/CampaignController.php
@@ -70,7 +70,7 @@ class CampaignController extends Controller
         ])->with('state', [
             'campaign' => $campaign,
             'user' => [
-                'id' => auth()->id(),
+                'id' => auth()->id() ?: request()->query('user_id'),
                 'isAuthenticated' => auth()->check(),
                 'role' => auth()->user() ? auth()->user()->role : null,
             ],

--- a/app/Http/Controllers/CampaignController.php
+++ b/app/Http/Controllers/CampaignController.php
@@ -71,6 +71,7 @@ class CampaignController extends Controller
             'campaign' => $campaign,
             'user' => [
                 'id' => auth()->id(),
+                'isAuthenticated' => auth()->check(),
                 'role' => auth()->user() ? auth()->user()->role : null,
             ],
         ]);

--- a/resources/assets/actions/event.js
+++ b/resources/assets/actions/event.js
@@ -2,6 +2,7 @@ import * as actions from '../actions';
 
 import { isTimestampValid } from '../helpers';
 import { getArray, EVENT_STORAGE_KEY } from '../helpers/storage';
+import { isAuthenticated } from '../selectors/user';
 
 // Action: remove completed event from storage.
 export function completedEvent(index) {
@@ -21,11 +22,10 @@ export function startQueue() {
       const isValidTimestamp = isTimestampValid(event.createdAt, (30 * 60 * 1000));
 
       // Check if the user successfully authenticated
-      const isAuthenticated = getState().user.id !== null;
-
+      const state = getState();
       let shouldFireEvent = isValidTimestamp;
       if (shouldFireEvent && event.requiresAuth) {
-        shouldFireEvent = isAuthenticated;
+        shouldFireEvent = isAuthenticated(state);
       }
 
       if (shouldFireEvent) {

--- a/resources/assets/actions/quiz.js
+++ b/resources/assets/actions/quiz.js
@@ -10,6 +10,7 @@ import {
   LOAD_PREVIOUS_QUIZ_STATE,
   QUIZ_ERROR,
 } from '../actions';
+import { isAuthenticated } from '../selectors/user';
 
 export function loadPreviousQuizState(quizId, questions) {
   return { type: LOAD_PREVIOUS_QUIZ_STATE, quizId, questions };
@@ -60,7 +61,8 @@ export function completeQuiz(quizId) {
     const resultActionType = firstAnswer === 0 ? 'shareAction' : 'linkAction';
     const resultActionId = get(quizContent.fields.resultActions, resultActionType, null);
 
-    return getState().user.id ?
+    const state = getState();
+    return isAuthenticated(state) ?
       dispatch(quizConvert(quizId, resultActionId))
       :
       dispatch(viewQuizResult(quizId, resultActionId));

--- a/resources/assets/actions/reportback.js
+++ b/resources/assets/actions/reportback.js
@@ -3,6 +3,7 @@
 import { Phoenix } from '@dosomething/gateway';
 import { has, get } from 'lodash';
 import { normalizeReportbackItemResponse } from '../normalizers';
+import { isAuthenticated } from '../selectors/user';
 import {
   REQUESTED_REPORTBACKS,
   RECEIVED_REPORTBACKS,
@@ -118,7 +119,8 @@ export function addSubmissionItemToList(reportbackItem) {
 export function toggleReactionOn(reportbackItemId, termId) {
   return (dispatch, getState) => {
     // If the user is not logged in, handle this action later.
-    if (! getState().user.id) {
+    const state = getState();
+    if (! isAuthenticated(state)) {
       dispatch(queueEvent('toggleReactionOn', reportbackItemId, termId));
       return;
     }

--- a/resources/assets/components/Campaign/CampaignContainer.js
+++ b/resources/assets/components/Campaign/CampaignContainer.js
@@ -6,10 +6,12 @@ const mapStateToProps = (state, props) => {
   const hasLandingPage = state.campaign.landingPage !== null;
   const isSignedUp = state.signups.thisCampaign;
 
+  // @TODO: Move these into the pages themselves.
   const { location, match } = props;
   const isQuiz = location.pathname.replace(match.url, '').startsWith('/quiz/');
+  const isBlock = location.pathname.replace(match.url, '').startsWith('/blocks/');
 
-  const ignoreLandingPage = state.admin.shouldShowActionPage || isQuiz;
+  const ignoreLandingPage = state.admin.shouldShowActionPage || isQuiz || isBlock;
   let shouldShowLandingPage = false;
 
   if (state.admin.shouldShowLandingPage) {

--- a/resources/assets/components/Feed/FeedContainer.js
+++ b/resources/assets/components/Feed/FeedContainer.js
@@ -7,6 +7,7 @@ import {
   getTotalVisibleBlockPoints,
   getMaximumBlockPoints,
 } from '../../selectors/feed';
+import { isAuthenticated } from '../../selectors/user';
 
 /**
  * Provide state from the Redux store as props for this component.
@@ -21,7 +22,7 @@ const mapStateToProps = state => ({
   signedUp: state.signups.data.includes(state.campaign.legacyCampaignId),
   hasNewSignup: state.signups.thisSession,
   hasPendingSignup: state.signups.isPending,
-  isAuthenticated: state.user.id !== null,
+  isAuthenticated: isAuthenticated(state),
 });
 
 /**

--- a/resources/assets/components/Page/BlockPage/BlockPage.js
+++ b/resources/assets/components/Page/BlockPage/BlockPage.js
@@ -2,7 +2,6 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import Enclosure from '../../Enclosure';
 import ContentfulEntry from '../../ContentfulEntry';
-import TabbedNavigationContainer from '../../Navigation/TabbedNavigationContainer';
 
 /**
  * Render the block page.
@@ -11,9 +10,11 @@ import TabbedNavigationContainer from '../../Navigation/TabbedNavigationContaine
  */
 const BlockPage = ({ json }) => (
   <div className="main clearfix">
-    <TabbedNavigationContainer />
     <Enclosure className="default-container margin-top-lg margin-bottom-lg">
       <ContentfulEntry json={json} />
+      <ul className="form-actions">
+        <li><a href=".." className="button -tertiary">or take another action</a></li>
+      </ul>
     </Enclosure>
   </div>
 );

--- a/resources/assets/components/Page/BlockPage/BlockPageContainer.js
+++ b/resources/assets/components/Page/BlockPage/BlockPageContainer.js
@@ -7,7 +7,10 @@ import BlockPage from './BlockPage';
  */
 const mapStateToProps = (state, ownProps) => {
   const { id } = ownProps.match.params;
-  const json = find(state.campaign.activityFeed, { id });
+
+  const json = find(state.campaign.pages, { id })
+    || find(state.campaign.actionSteps, { id })
+    || find(state.campaign.activityFeed, { id });
 
   return { json };
 };

--- a/resources/assets/components/ReportbackItem/ReportbackItemContainer.js
+++ b/resources/assets/components/ReportbackItem/ReportbackItemContainer.js
@@ -1,6 +1,7 @@
 import { connect } from 'react-redux';
 import { get } from 'lodash';
 import ReportbackItem from './ReportbackItem';
+import { isAuthenticated } from '../../selectors/user';
 import {
   toggleReactionOn,
   toggleReactionOff,
@@ -27,7 +28,7 @@ const mapStateToProps = (state, props) => {
     firstName: reportback.user.first_name,
     reaction: reportbackItem.reaction,
     caption: reportbackItem.caption,
-    isAuthenticated: state.user.id !== null,
+    isAuthenticated: isAuthenticated(state),
     reportback,
   };
 };

--- a/resources/assets/selectors/user.js
+++ b/resources/assets/selectors/user.js
@@ -5,7 +5,7 @@
  * @returns {String}
  */
 export function isAuthenticated(state) {
-  return Boolean(state.user.id);
+  return state.user.isAuthenticated;
 }
 
 /**

--- a/resources/assets/selectors/user.js
+++ b/resources/assets/selectors/user.js
@@ -4,6 +4,16 @@
  * @param state
  * @returns {String}
  */
+export function isAuthenticated(state) {
+  return Boolean(state.user.id);
+}
+
+/**
+ * Get the user id from the state.
+ *
+ * @param state
+ * @returns {String}
+ */
 export function getUserId(state) {
   return state.user.id;
 }

--- a/resources/assets/store/initialState.js
+++ b/resources/assets/store/initialState.js
@@ -63,6 +63,7 @@ const initialState = {
   uploads: {},
   user: {
     id: null,
+    isAuthenticated: false,
     role: null,
   },
 };


### PR DESCRIPTION
### What does this PR do?
This PR implements a standardized "block" page (based on the existing feature to let us link directly to blocks in the activity feed). This will allow campaign leads & the messaging team to spin up social shares and edit them without being scared off by writing JSON.

![blockpageshare](https://user-images.githubusercontent.com/583202/36985721-03625dea-2066-11e8-8367-08bf51a6af4a.png)

I'd recommend reviewing this pull request commit-by-commit:

🚜 Properly transform any blocks passed in the `pages` field, like we do elsewhere. 970db81

🔷 Simplify the `/blocks/:id` layout to match the SMS Share prototype. cd7fe13

👓 Look for blocks in any block reference field for the `/blocks/:id` page, not _just_ the community feed. This will allow us to link action page blocks or completely unique "link-only" blocks. 1b6af74

🔓 Allow anonymous users to visit `/blocks/:id` without being show the landing page. In the future, we should refactor this so that auth checks happen within each individual page. a618329

🔑 Extract `isAuthenticated` selector & use it to determine login status. b4d4e54

🍰 Finally, swap that `isAuthenticated` selector to use a new "isAuthenticated" boolean from the server so we can safely swap out `user.id` using the `?user_id=` query string without implying that the person is _really_ logged in. ec4aa28, 9ee9d48

### Any background context you want to provide?
This is part of an ongoing effort to make these elements more flexible, and is made possible due to the work in #700, #708, and #711. Rather than making a new "SMS Share" content type, we can just use the existing "Share Block" here!

### What are the relevant tickets/cards?
[#155551584](https://www.pivotaltracker.com/story/show/155551584)

### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
- [ ] Added screenshot to PR description of related front-end updates on **small** screens.
- [ ] Added screenshot to PR description of related front-end updates on **medium** screens.
- [ ] Added screenshot to PR description of related front-end updates on **large** screens.