### PR TITLE
Adds optional post-share button to the standard Share Action.

### DIFF
--- a/app/Entities/ShareAction.php
+++ b/app/Entities/ShareAction.php
@@ -22,6 +22,7 @@ class ShareAction extends Entity implements JsonSerializable
                 'link' => $this->link,
                 'affirmation' => $this->affirmation,
                 'socialPlatform' => $this->socialPlatform->first() ?: 'facebook',
+                'additionalContent' => $this->additionalContent,
             ],
         ];
     }

--- a/resources/assets/components/ContentfulEntry/renderers.js
+++ b/resources/assets/components/ContentfulEntry/renderers.js
@@ -160,7 +160,7 @@ export function renderShareAction(step) {
   return (
     <div key={`share-action-${contentfulId}`} className="margin-horizontal-md">
       <PuckWaypoint name="share_action-top" waypointData={{ contentfulId }} />
-      <ShareActionContainer {...step.fields} />
+      <ShareActionContainer id={step.id} {...step.fields} />
       <PuckWaypoint name="share_action-bottom" waypointData={{ contentfulId }} />
     </div>
   );

--- a/resources/assets/components/Modal/ModalSwitch.js
+++ b/resources/assets/components/Modal/ModalSwitch.js
@@ -8,10 +8,9 @@ import {
 } from '../Modal';
 
 const ModalSwitch = (props) => {
-  const { modalType } = props;
   let children = null;
 
-  switch (modalType) {
+  switch (props.modalType) {
     case POST_SIGNUP_MODAL:
       children = <PostSignupModal />;
       break;
@@ -25,7 +24,7 @@ const ModalSwitch = (props) => {
       children = <SurveyModalContainer />;
       break;
     case POST_SHARE_MODAL:
-      children = <PostShareModalContainer />;
+      children = <PostShareModalContainer id={props.id} />;
       break;
     case POST_REPORTBACK_MODAL:
       children = <PostReportbackModalContainer />;
@@ -40,10 +39,12 @@ const ModalSwitch = (props) => {
 
 ModalSwitch.propTypes = {
   modalType: PropTypes.string,
+  id: PropTypes.string,
 };
 
 ModalSwitch.defaultProps = {
   modalType: null,
+  id: null,
 };
 
 export default ModalSwitch;

--- a/resources/assets/components/Modal/configurations/PostShareModal.js
+++ b/resources/assets/components/Modal/configurations/PostShareModal.js
@@ -4,24 +4,33 @@ import Card from '../../Card';
 import Markdown from '../../Markdown';
 
 const PostShareModal = (props) => {
-  const { content, closeModal } = props;
+  const { content, confirmationAction, confirmationActionLink, closeModal } = props;
 
   return (
     <Card title="Thanks for sharing!" className="modal__slide bordered rounded" onClose={closeModal}>
       <Markdown className="padded">
         { content || PostShareModal.defaultProps.content }
       </Markdown>
+      { confirmationAction && confirmationActionLink ? (
+        <ul className="form-actions -padded">
+          <a className="button" href={confirmationActionLink}>{confirmationAction}</a>
+        </ul>
+      ) : null }
     </Card>
   );
 };
 
 PostShareModal.propTypes = {
   content: PropTypes.string,
+  confirmationAction: PropTypes.string,
+  confirmationActionLink: PropTypes.string,
   closeModal: PropTypes.func.isRequired,
 };
 
 PostShareModal.defaultProps = {
   content: 'Thanks for rallying your friends on Facebook!',
+  confirmationAction: null,
+  confirmationActionLink: null,
 };
 
 export default PostShareModal;

--- a/resources/assets/components/Modal/containers/PostShareModalContainer.js
+++ b/resources/assets/components/Modal/containers/PostShareModalContainer.js
@@ -1,5 +1,5 @@
 import { connect } from 'react-redux';
-import { find } from 'lodash';
+import { get, find } from 'lodash';
 import PostShareModal from '../configurations/PostShareModal';
 import { closeModal } from '../../../actions/modal';
 
@@ -9,13 +9,18 @@ const mapStateToProps = (state) => {
     return {};
   }
 
-  // TODO: If we have multiple share actions, keep in mind that
-  // the copy for the 1+n action will always be 1 action. Requires a bit more
-  // work in order to make this always apply to the correct action.
-  const shareAction = find(actions, { type: { sys: { id: 'shareAction' } } });
+  const id = state.modal.contentfulId;
+  const json = find(state.campaign.pages, { id })
+    || find(state.campaign.actionSteps, { id })
+    || find(state.campaign.activityFeed, { id });
+
+  const confirmationAction = get(json, 'fields.additionalContent.confirmationAction');
+  const confirmationActionLink = get(json, 'fields.additionalContent.confirmationActionLink');
 
   return {
-    content: shareAction ? shareAction.fields.affirmation : {},
+    content: json ? json.fields.affirmation : {},
+    confirmationAction,
+    confirmationActionLink,
   };
 };
 

--- a/resources/assets/components/ShareAction/ShareAction.js
+++ b/resources/assets/components/ShareAction/ShareAction.js
@@ -10,7 +10,7 @@ import { showFacebookSharePrompt, showTwitterSharePrompt } from '../../helpers';
 import './share-action.scss';
 
 const ShareAction = (props) => {
-  const { title, content, link, socialPlatform, openModal, trackEvent } = props;
+  const { id, title, content, link, socialPlatform, openModal, trackEvent } = props;
 
   const onFacebookClick = () => {
     const trackingData = { url: link };
@@ -19,7 +19,8 @@ const ShareAction = (props) => {
     showFacebookSharePrompt({ href: link }, (response) => {
       if (response) {
         trackEvent('share action completed', trackingData);
-        openModal(POST_SHARE_MODAL);
+        // @TODO: Render a <Modal>...</Modal> component here!
+        openModal(POST_SHARE_MODAL, id);
       } else {
         trackEvent('share action cancelled', trackingData);
       }
@@ -68,10 +69,17 @@ const ShareAction = (props) => {
 };
 
 ShareAction.defaultProps = {
+  affirmation: null,
+  confirmationAction: null,
+  confirmationActionLink: null,
   content: null,
 };
 
 ShareAction.propTypes = {
+  id: PropTypes.string.isRequired,
+  // affirmation: PropTypes.string,
+  // confirmationAction: PropTypes.string,
+  // confirmationActionLink: PropTypes.string,
   title: PropTypes.string.isRequired,
   content: PropTypes.string,
   link: PropTypes.string.isRequired,

--- a/resources/assets/components/ShareAction/ShareAction.js
+++ b/resources/assets/components/ShareAction/ShareAction.js
@@ -69,17 +69,11 @@ const ShareAction = (props) => {
 };
 
 ShareAction.defaultProps = {
-  affirmation: null,
-  confirmationAction: null,
-  confirmationActionLink: null,
   content: null,
 };
 
 ShareAction.propTypes = {
   id: PropTypes.string.isRequired,
-  // affirmation: PropTypes.string,
-  // confirmationAction: PropTypes.string,
-  // confirmationActionLink: PropTypes.string,
   title: PropTypes.string.isRequired,
   content: PropTypes.string,
   link: PropTypes.string.isRequired,


### PR DESCRIPTION
### What does this PR do?
This pull request adds the ability to have a post-share button on the standard "Share Action" block, just like we did with the SMS Share prototype. Unlike in the prototype though, we can use this on _any_ Share Action now (on mobile, desktop, you name it!)

<img width="422" alt="screen shot 2018-03-05 at 4 41 12 pm" src="https://user-images.githubusercontent.com/583202/37001285-0b1023fa-2094-11e8-8745-9784095fea53.png">

It also fixes what turns out was a long-standing issue where _all_ share affirmations would show the content from the first share on the given campaign, instead of showing the corresponding content for that particular share block.

### Any background context you want to provide?
I've kept these in `additionalContent` for this PR because I'd like some feedback on how best to model this kind of thing in Contentful. Two separate "Affirmation Button" and "Affirmation Link" fields?

Another idea I was toying with was a "Block" relationship that'd let us just display an optional block alongside this affirmation message... adds a bit more admin overhead, but could be handy!

### What are the relevant tickets/cards?
[#155551584](https://www.pivotaltracker.com/story/show/155551584)

### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
- [ ] Added screenshot to PR description of related front-end updates on **small** screens.
- [ ] Added screenshot to PR description of related front-end updates on **medium** screens.
- [ ] Added screenshot to PR description of related front-end updates on **large** screens.