### PR TITLE
Add affirmationBlock field to Share Action content type.

### DIFF
--- a/contentful/migrations/2018_03_06_001_add_block_field_to_share_blocks.js
+++ b/contentful/migrations/2018_03_06_001_add_block_field_to_share_blocks.js
@@ -1,0 +1,24 @@
+module.exports = function (migration) {
+  const shareAction = migration.editContentType('shareAction');
+
+  // Add 'affirmationBlock' link field to Share Actions.
+  shareAction.createField('affirmationBlock')
+    .name('Affirmation Block')
+    .type('Link')
+    .linkType('Entry')
+    .validations([
+      {
+        linkContentType: [
+          'campaignUpdate', 'customBlock', 'linkAction', 'page', 'affirmation',
+          'photoUploaderAction', 'shareAction', 'voterRegistrationAction',
+        ],
+      },
+    ])
+    .required(false);
+
+  shareAction.moveField('affirmationBlock').beforeField('affirmation');
+
+  // Change description of existing 'Affirmation' field.
+  shareAction.editField('affirmation')
+    .name('Affirmation Text');
+};


### PR DESCRIPTION
### What does this PR do?
This PR adds a new `affirmationBlock` field to the [Share Action](https://app.contentful.com/spaces/81iqaqpfd8fy/content_types/shareAction/fields) content type.

![screen shot 2018-03-06 at 11 44 17 am](https://user-images.githubusercontent.com/583202/37045371-cb1ac390-2133-11e8-855d-7fab9c148ffc.png)



### Any background context you want to provide?
We [can't set help text](https://git.io/vAdG8) via the migration CLI, so I'll add these two descriptions by hand afterwards:

> __Affirmation Block:__ This block will be displayed in a modal after a successful share. It may be used to thank the user or prompt them to complete another action.

> __Affirmation Text:__ A quick text-only affirmation message. If an affirmation block is set (above), this will be ignored!

### What are the relevant tickets/cards?
[#155551584](https://www.pivotaltracker.com/story/show/155551584)


### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
- [ ] Added screenshot to PR description of related front-end updates on **small** screens.
- [ ] Added screenshot to PR description of related front-end updates on **medium** screens.
- [ ] Added screenshot to PR description of related front-end updates on **large** screens.