### PR TITLE
Allow blocks as post-share affirmation modal.

### DIFF
--- a/app/Entities/Campaign.php
+++ b/app/Entities/Campaign.php
@@ -104,45 +104,6 @@ class Campaign extends Entity implements JsonSerializable
     }
 
     /**
-     * Parse and extract data for a block.
-     *
-     * @param  Entry $step
-     * @return array
-     */
-    public function parseBlock($block)
-    {
-        switch ($block->getContentType()) {
-            case 'photoUploaderAction':
-                return new PhotoUploaderAction($block->entry);
-            case 'voterRegistrationAction':
-                return new VoterRegistrationAction($block->entry);
-            case 'shareAction':
-                return new ShareAction($block->entry);
-            case 'linkAction':
-                return new LinkAction($block->entry);
-            case 'affirmation':
-                return new Affirmation($block->entry);
-            case 'page':
-                return $block;
-            default:
-                return new CampaignActionStep($block->entry);
-        }
-    }
-
-    /**
-     * Parse and extract data for blocks.
-     *
-     * @param  array $blocks
-     * @return array
-     */
-    public function parseBlocks($blocks)
-    {
-        return collect($blocks)->map(function ($block) {
-            return $this->parseBlock($block);
-        });
-    }
-
-    /**
      * Parse and extract data for quizzes.
      *
      * @param  array $quizzes

--- a/app/Entities/Entity.php
+++ b/app/Entities/Entity.php
@@ -75,7 +75,6 @@ class Entity implements ArrayAccess, JsonSerializable
         }
     }
 
-
     /**
      * Dynamically access the campaign's attributes.
      *

--- a/app/Entities/Entity.php
+++ b/app/Entities/Entity.php
@@ -33,6 +33,50 @@ class Entity implements ArrayAccess, JsonSerializable
     }
 
     /**
+     * Parse and extract data for blocks.
+     *
+     * @param  array $blocks
+     * @return array
+     */
+    public function parseBlocks($blocks)
+    {
+        return collect($blocks)->map(function ($block) {
+            return $this->parseBlock($block);
+        });
+    }
+
+    /**
+     * Parse and extract data for a block.
+     *
+     * @param  Entry $step
+     * @return array
+     */
+    public function parseBlock($block)
+    {
+        if (empty($block)) {
+            return null;
+        }
+
+        switch ($block->getContentType()) {
+            case 'photoUploaderAction':
+                return new PhotoUploaderAction($block->entry);
+            case 'voterRegistrationAction':
+                return new VoterRegistrationAction($block->entry);
+            case 'shareAction':
+                return new ShareAction($block->entry);
+            case 'linkAction':
+                return new LinkAction($block->entry);
+            case 'affirmation':
+                return new Affirmation($block->entry);
+            case 'page':
+                return $block;
+            default:
+                return new CampaignActionStep($block->entry);
+        }
+    }
+
+
+    /**
      * Dynamically access the campaign's attributes.
      *
      * @param  string $property

--- a/app/Entities/ShareAction.php
+++ b/app/Entities/ShareAction.php
@@ -21,6 +21,7 @@ class ShareAction extends Entity implements JsonSerializable
                 'content' => $this->content,
                 'link' => $this->link,
                 'affirmation' => $this->affirmation,
+                'affirmationBlock' => $this->parseBlock($this->affirmationBlock),
                 'socialPlatform' => $this->socialPlatform->first() ?: 'facebook',
                 'additionalContent' => $this->additionalContent,
             ],

--- a/resources/assets/components/Modal/configurations/PostShareModal.js
+++ b/resources/assets/components/Modal/configurations/PostShareModal.js
@@ -2,35 +2,39 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import Card from '../../Card';
 import Markdown from '../../Markdown';
+import ModalControls from '../ModalControls';
+import ContentfulEntry from '../../ContentfulEntry';
 
 const PostShareModal = (props) => {
-  const { content, confirmationAction, confirmationActionLink, closeModal } = props;
+  const { affirmationText, affirmationBlock, closeModal } = props;
 
+  // If we have a block to show, render it as a modal:
+  if (affirmationBlock) {
+    return (
+      <ModalControls onClose={closeModal}>
+        <ContentfulEntry json={affirmationBlock} />
+      </ModalControls>
+    );
+  }
+
+  // Otherwise, return a simple modal with the given Markdown:
   return (
     <Card title="Thanks for sharing!" className="modal__slide bordered rounded" onClose={closeModal}>
       <Markdown className="padded">
-        { content || PostShareModal.defaultProps.content }
+        { affirmationText }
       </Markdown>
-      { confirmationAction && confirmationActionLink ? (
-        <ul className="form-actions -padded">
-          <a className="button" href={confirmationActionLink}>{confirmationAction}</a>
-        </ul>
-      ) : null }
     </Card>
   );
 };
 
 PostShareModal.propTypes = {
-  content: PropTypes.string,
-  confirmationAction: PropTypes.string,
-  confirmationActionLink: PropTypes.string,
+  affirmationText: PropTypes.string,
+  affirmationBlock: PropTypes.object, // eslint-disable-line
   closeModal: PropTypes.func.isRequired,
 };
 
 PostShareModal.defaultProps = {
-  content: 'Thanks for rallying your friends on Facebook!',
-  confirmationAction: null,
-  confirmationActionLink: null,
+  affirmationText: 'Thanks for rallying your friends on Facebook!',
 };
 
 export default PostShareModal;

--- a/resources/assets/components/Modal/containers/PostShareModalContainer.js
+++ b/resources/assets/components/Modal/containers/PostShareModalContainer.js
@@ -9,13 +9,9 @@ const mapStateToProps = (state) => {
     || find(state.campaign.actionSteps, { id })
     || find(state.campaign.activityFeed, { id });
 
-  const confirmationAction = get(json, 'fields.additionalContent.confirmationAction');
-  const confirmationActionLink = get(json, 'fields.additionalContent.confirmationActionLink');
-
   return {
-    content: json ? json.fields.affirmation : {},
-    confirmationAction,
-    confirmationActionLink,
+    affirmationText: get(json, 'fields.affirmation'),
+    affirmationBlock: get(json, 'fields.affirmationBlock'),
   };
 };
 

--- a/resources/assets/components/Modal/containers/PostShareModalContainer.js
+++ b/resources/assets/components/Modal/containers/PostShareModalContainer.js
@@ -4,11 +4,6 @@ import PostShareModal from '../configurations/PostShareModal';
 import { closeModal } from '../../../actions/modal';
 
 const mapStateToProps = (state) => {
-  const actions = state.campaign.actionSteps;
-  if (! actions) {
-    return {};
-  }
-
   const id = state.modal.contentfulId;
   const json = find(state.campaign.pages, { id })
     || find(state.campaign.actionSteps, { id })


### PR DESCRIPTION
### What does this PR do?
This PR allows editors to use blocks as post-share affirmations (for example, registering to vote).

![kapture 2018-03-06 at 13 51 52](https://user-images.githubusercontent.com/583202/37051829-902c181c-2145-11e8-9441-987396fe1522.gif)

Of course, it works on tablet & desktop as well.

### Any background context you want to provide?
For simple use-cases (e.g. "yes, you're _really_ entered for that scholarship, so please don't bother Hannah about it"), editors can still use the "Affirmation Text" Markdown field.

### What are the relevant tickets/cards?
[#155551584](https://www.pivotaltracker.com/story/show/155551584)

### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
- [x] Added screenshot to PR description of related front-end updates on **small** screens.
- [ ] Added screenshot to PR description of related front-end updates on **medium** screens.
- [ ] Added screenshot to PR description of related front-end updates on **large** screens.