### PR TITLE
Adding general rule for smaller-font

### DIFF
--- a/resources/assets/components/LedeBanner/templates/mosaic-lede-banner.scss
+++ b/resources/assets/components/LedeBanner/templates/mosaic-lede-banner.scss
@@ -86,11 +86,9 @@
     top: -$half-spacing;
   }
 
-  @include media("(max-width: 450px)") {
-    &.smaller-font {
-      font-size: 15px;
-      top: -4px;
-    }
+  &.smaller-font {
+    position: relative;
+    top: 0;
   }
 }
 


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_



### What does this PR do?
This PR adds a general rule to the Mosaic Lede Banner, to remove the `absolute` positioning of the `.mosaic-lede-banner__headline-title` when there are more than 25 characters to prevent overflowing and blocking the subtitle.

We've bumped into this before on smaller screens, but evidently, this can be an issue in general. This seemed like a pretty straightforward way around this.

**Before**
![image](https://user-images.githubusercontent.com/12417657/37052605-cfe92614-2147-11e8-9c45-a48f0f95dbec.png)

**After**
![image](https://user-images.githubusercontent.com/12417657/37052644-e7f987b2-2147-11e8-95f4-a3345b1c5419.png)
