### PR TITLE
A slight scroll observer adjustment.

### DIFF
--- a/resources/assets/helpers/createHistoryHashObserver.js
+++ b/resources/assets/helpers/createHistoryHashObserver.js
@@ -49,7 +49,7 @@ export default (history, timeout = 1000) => {
       reset();
     }
 
-    if (action !== 'PUSH') {
+    if (action !== 'PUSH' && location.pathname !== window.location.pathname) {
       return;
     }
 

--- a/resources/assets/helpers/createHistoryHashObserver.js
+++ b/resources/assets/helpers/createHistoryHashObserver.js
@@ -49,10 +49,6 @@ export default (history, timeout = 1000) => {
       reset();
     }
 
-    if (action !== 'PUSH' && location.pathname !== window.location.pathname) {
-      return;
-    }
-
     if (typeof location.hash !== 'string') {
       return;
     }

--- a/resources/assets/helpers/createHistoryHashObserver.js
+++ b/resources/assets/helpers/createHistoryHashObserver.js
@@ -44,7 +44,7 @@ export default (history, timeout = 1000) => {
     return false;
   };
 
-  history.listen((location, action) => {
+  history.listen((location) => {
     if (timeoutId) {
       reset();
     }


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_


### What does this PR do?
This PR fixes an issue where a link to a step on a page would not receive the scroll functionality it so craves.

(A link coming from markdown seems to be coming through as a "POP" action causing us to [skip away from using the scroll functionality](https://github.com/DoSomething/phoenix-next/blob/master/resources/assets/helpers/createHistoryHashObserver.js#L52))
### Any background context you want to provide?
[This convo in the slack-o-sphere](https://dosomething.slack.com/archives/C3ASB4204/p1520004652000764)

**Not So Great**:
![scrollll](https://user-images.githubusercontent.com/12417657/37055070-bd7e9eda-214e-11e8-93db-59876cc12683.gif)

**Fantastico**
![scroll2](https://user-images.githubusercontent.com/12417657/37055293-55440200-214f-11e8-8917-88d2e10dabf2.gif)


This doesn't solve the issue on initial page loads with a hash in the [URL](https://www.dosomething.org/us/campaigns/grab-mic/action#step-7bdcOGPUAgKociOgEE4S4g) but it's hopefully a start.