### PR TITLE
Adding voter registration action modal with static content

### DIFF
--- a/resources/assets/components/Modal/Modal.js
+++ b/resources/assets/components/Modal/Modal.js
@@ -4,7 +4,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import Portal from 'react-portal';
 import {
-  POST_SIGNUP_MODAL, POST_SHARE_MODAL, BLOCK_MODAL,
+  POST_SIGNUP_MODAL, POST_SHARE_MODAL, BLOCK_MODAL, VOTER_REGISTRATION_MODAL,
 } from '../Modal';
 
 import './modal.scss';
@@ -49,6 +49,7 @@ class Modal extends React.Component {
       POST_SIGNUP_MODAL,
       POST_SHARE_MODAL,
       BLOCK_MODAL,
+      VOTER_REGISTRATION_MODAL,
     ].includes(modalType);
 
     return (

--- a/resources/assets/components/Modal/Modal.js
+++ b/resources/assets/components/Modal/Modal.js
@@ -5,6 +5,7 @@ import PropTypes from 'prop-types';
 import Portal from 'react-portal';
 import {
   POST_SIGNUP_MODAL, POST_SHARE_MODAL, BLOCK_MODAL, VOTER_REGISTRATION_MODAL,
+  POST_REPORTBACK_MODAL,
 } from '../Modal';
 
 import './modal.scss';
@@ -50,6 +51,7 @@ class Modal extends React.Component {
       POST_SHARE_MODAL,
       BLOCK_MODAL,
       VOTER_REGISTRATION_MODAL,
+      POST_REPORTBACK_MODAL,
     ].includes(modalType);
 
     return (

--- a/resources/assets/components/Modal/ModalSwitch.js
+++ b/resources/assets/components/Modal/ModalSwitch.js
@@ -3,8 +3,10 @@ import PropTypes from 'prop-types';
 import {
   Modal, PostSignupModal, BlockModalContainer, ReportbackUploaderModal,
   PostReportbackModalContainer, PostShareModalContainer, SurveyModalContainer,
+  VoterRegistrationModalContainer,
   POST_SIGNUP_MODAL, BLOCK_MODAL, REPORTBACK_UPLOADER_MODAL,
   POST_SHARE_MODAL, SURVEY_MODAL, POST_REPORTBACK_MODAL,
+  VOTER_REGISTRATION_MODAL,
 } from '../Modal';
 
 const ModalSwitch = (props) => {
@@ -28,6 +30,9 @@ const ModalSwitch = (props) => {
       break;
     case POST_REPORTBACK_MODAL:
       children = <PostReportbackModalContainer />;
+      break;
+    case VOTER_REGISTRATION_MODAL:
+      children = <VoterRegistrationModalContainer />;
       break;
     default: break;
   }

--- a/resources/assets/components/Modal/configurations/VoterRegistrationModal.js
+++ b/resources/assets/components/Modal/configurations/VoterRegistrationModal.js
@@ -9,11 +9,9 @@ const VoterRegistrationModal = (props) => {
   const link = 'https://dosomething.turbovote.org/?r=user:{northstarId},campaignID:{campaignId},campaignRunID:{campaignRunId},source:{source}';
 
   return (
-    <div className="modal__slide">
-      <ModalControls onClose={props.closeModal}>
-        <VoterRegistrationActionContainer content={content} link={link} />
-      </ModalControls>
-    </div>
+    <ModalControls className="modal__slide" onClose={props.closeModal}>
+      <VoterRegistrationActionContainer content={content} link={link} />
+    </ModalControls>
   );
 };
 

--- a/resources/assets/components/Modal/configurations/VoterRegistrationModal.js
+++ b/resources/assets/components/Modal/configurations/VoterRegistrationModal.js
@@ -1,0 +1,24 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import { ModalControls } from '../../Modal';
+import VoterRegistrationActionContainer from '../../Actions/VoterRegistrationAction';
+
+const VoterRegistrationModal = (props) => {
+  const content = 'Register to vote and encourage friends to do the same. YOU have the power to elect the officials who will create the future YOU want to see. Get loud in 2018.';
+  const link = 'https://dosomething.turbovote.org/?r=user:{northstarId},campaignID:{campaignId},campaignRunID:{campaignRunId},source:{source}';
+
+  return (
+    <div className="modal__slide">
+      <ModalControls onClose={props.closeModal}>
+        <VoterRegistrationActionContainer content={content} link={link} />
+      </ModalControls>
+    </div>
+  );
+};
+
+VoterRegistrationModal.propTypes = {
+  closeModal: PropTypes.func.isRequired,
+};
+
+export default VoterRegistrationModal;

--- a/resources/assets/components/Modal/containers/VoterRegistrationModalContainer.js
+++ b/resources/assets/components/Modal/containers/VoterRegistrationModalContainer.js
@@ -1,0 +1,13 @@
+import { connect } from 'react-redux';
+import VoterRegistrationModal from '../configurations/VoterRegistrationModal';
+import { closeModal } from '../../../actions/modal';
+
+/**
+ * Provide pre-bound functions that allow the component to dispatch
+ * actions to the Redux store as props for this component.
+ */
+const actionCreators = {
+  closeModal,
+};
+
+export default connect(null, actionCreators)(VoterRegistrationModal);

--- a/resources/assets/components/Modal/index.js
+++ b/resources/assets/components/Modal/index.js
@@ -7,6 +7,8 @@ export SurveyModalContainer from './containers/SurveyModalContainer';
 export PostShareModalContainer from './containers/PostShareModalContainer';
 export PostReportbackModalContainer from './containers/PostReportbackModalContainer';
 export BlockModalContainer from './containers/BlockModalContainer';
+export VoterRegistrationModalContainer from './containers/VoterRegistrationModalContainer';
+
 
 // TODO: whoops, these probably need to be renamed to have 'Container' appended to the name.
 export PostSignupModal from './containers/PostSignupModalContainer';
@@ -18,3 +20,4 @@ export const REPORTBACK_UPLOADER_MODAL = 'REPORTBACK_UPLOADER_MODAL';
 export const SURVEY_MODAL = 'SURVEY_MODAL';
 export const POST_SHARE_MODAL = 'POST_SHARE_MODAL';
 export const POST_REPORTBACK_MODAL = 'POST_REPORTBACK_MODAL';
+export const VOTER_REGISTRATION_MODAL = 'VOTER_REGISTRATION_MODAL';


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_


### What does this PR do?
This PR adds a `VoterRegistrationModal` component (along with the proper container, exports, and ModalSwitch `case`).


### Any background context you want to provide?
The modal is hardcoded with static content since [we've decided](https://dosomething.slack.com/archives/C3ASB4204/p1520279950000760) on showing this same modal across all campaigns that are feature-flagged for it to appear.

The actual rendering of this modal under some `TrafficDistribution` and feature flagging will be upcoming pending approval of the ModalLauncher changes #730 

![image](https://user-images.githubusercontent.com/12417657/37104781-93d778ec-21fb-11e8-8431-b5cf8f267d1d.png)



### What are the relevant tickets/cards?
Pivotal ID [#155551810](https://www.pivotaltracker.com/story/show/155551810)