### PR TITLE
Some controller cleanup & adds 'source' to user store.

### DIFF
--- a/app/Http/Controllers/CampaignController.php
+++ b/app/Http/Controllers/CampaignController.php
@@ -58,15 +58,12 @@ class CampaignController extends Controller
     {
         $campaign = $this->campaignRepository->findBySlug($slug);
 
-        $env = get_client_environment_vars();
-
         // The slug argument will not contain `/blocks` or other path extensions, hence `::url()`.
         $socialFields = get_social_fields($campaign, Request::url());
 
         return view('campaigns.show', [
             'campaign' => $campaign,
             'socialFields' => $socialFields,
-            'env' => $env,
         ])->with('state', [
             'campaign' => $campaign,
             'user' => [

--- a/app/Http/Controllers/CampaignController.php
+++ b/app/Http/Controllers/CampaignController.php
@@ -57,6 +57,7 @@ class CampaignController extends Controller
                 'id' => auth()->id() ?: $request->query('user_id'),
                 'isAuthenticated' => auth()->check(),
                 'role' => auth()->user() ? auth()->user()->role : null,
+                'source' => $request->query('utm_source'),
             ],
         ]);
     }

--- a/app/Http/Controllers/CampaignController.php
+++ b/app/Http/Controllers/CampaignController.php
@@ -48,6 +48,9 @@ class CampaignController extends Controller
         $campaign = $this->campaignRepository->findBySlug($slug);
 
         return view('campaigns.show', [
+            // This is used to build campaign-specific login links in the
+            // server-rendered top navigation bar.
+            'campaign' => $campaign,
             // We render social metatags server-side because Facebook & Twitter
             // do not render JavaScript when crawling pages like Google does.
             'socialFields' => get_social_fields($campaign, $request->url()),

--- a/app/Http/Controllers/CampaignController.php
+++ b/app/Http/Controllers/CampaignController.php
@@ -2,9 +2,7 @@
 
 namespace App\Http\Controllers;
 
-use Auth;
-use Request;
-use App\Services\PhoenixLegacy;
+use Illuminate\Http\Request;
 use App\Repositories\CampaignRepository;
 
 class CampaignController extends Controller
@@ -17,23 +15,14 @@ class CampaignController extends Controller
     protected $campaignRepository;
 
     /**
-     * The legacy Phoenix API.
-     *
-     * @var PhoenixLegacy
-     */
-    private $phoenixLegacy;
-
-    /**
      * Make a new CampaignController, inject dependencies,
      * and set middleware for this controller's methods.
      *
      * @param CampaignRepository $campaignRepository
-     * @param PhoenixLegacy $phoenixLegacy
      */
-    public function __construct(CampaignRepository $campaignRepository, PhoenixLegacy $phoenixLegacy)
+    public function __construct(CampaignRepository $campaignRepository)
     {
         $this->campaignRepository = $campaignRepository;
-        $this->phoenixLegacy = $phoenixLegacy;
     }
 
     /**
@@ -54,20 +43,18 @@ class CampaignController extends Controller
      * @param  int  $slug
      * @return \Illuminate\View\View
      */
-    public function show($slug)
+    public function show($slug, Request $request)
     {
         $campaign = $this->campaignRepository->findBySlug($slug);
 
-        // The slug argument will not contain `/blocks` or other path extensions, hence `::url()`.
-        $socialFields = get_social_fields($campaign, Request::url());
-
         return view('campaigns.show', [
-            'campaign' => $campaign,
-            'socialFields' => $socialFields,
+            // We render social metatags server-side because Facebook & Twitter
+            // do not render JavaScript when crawling pages like Google does.
+            'socialFields' => get_social_fields($campaign, $request->url()),
         ])->with('state', [
             'campaign' => $campaign,
             'user' => [
-                'id' => auth()->id() ?: request()->query('user_id'),
+                'id' => auth()->id() ?: $request->query('user_id'),
                 'isAuthenticated' => auth()->check(),
                 'role' => auth()->user() ? auth()->user()->role : null,
             ],

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -3,6 +3,7 @@
 namespace App\Providers;
 
 use Illuminate\Routing\Router;
+use Illuminate\Support\Facades\View;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\ServiceProvider;
 use Contentful\Delivery\Client as DeliveryClient;
@@ -29,6 +30,23 @@ class AppServiceProvider extends ServiceProvider
 
                 return redirect($to);
             });
+        });
+
+        // Attach "client-safe" environment variables to views.
+        View::composer('*', function ($view) {
+            $view->with('env', [
+                'APP_ENV' => config('app.env'),
+                'GLADIATOR_URL' => config('services.gladiator.url'),
+                'NORTHSTAR_URL' => config('services.northstar.url'),
+                'PHOENIX_URL' => config('services.phoenix.url'),
+                'PHOENIX_LEGACY_URL' => config('services.phoenix-legacy.url'),
+                'PUCK_URL' => config('services.analytics.puck_url'),
+                'SIXPACK_BASE_URL' => config('services.sixpack.url'),
+                'SIXPACK_COOKIE_PREFIX' => config('services.sixpack.prefix'),
+                'SIXPACK_ENABLED' => config('services.sixpack.enabled'),
+                'SIXPACK_TIMEOUT' => config('services.sixpack.timeout'),
+                'SURVEY_ENABLED' => config('services.survey.enabled'),
+            ]);
         });
     }
 

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -317,28 +317,6 @@ function phoenixLink($path)
 }
 
 /**
- * Get the env vars which are safe for client usage.
- *
- * @return array
- */
-function get_client_environment_vars()
-{
-    return [
-        'APP_ENV' => config('app.env'),
-        'GLADIATOR_URL' => config('services.gladiator.url'),
-        'NORTHSTAR_URL' => config('services.northstar.url'),
-        'PHOENIX_URL' => config('services.phoenix.url'),
-        'PHOENIX_LEGACY_URL' => config('services.phoenix-legacy.url'),
-        'PUCK_URL' => config('services.analytics.puck_url'),
-        'SIXPACK_BASE_URL' => config('services.sixpack.url'),
-        'SIXPACK_COOKIE_PREFIX' => config('services.sixpack.prefix'),
-        'SIXPACK_ENABLED' => config('services.sixpack.enabled'),
-        'SIXPACK_TIMEOUT' => config('services.sixpack.timeout'),
-        'SURVEY_ENABLED' => config('services.survey.enabled'),
-    ];
-}
-
-/**
  * Get the presentation values we should package with our
  * Northstar authorization requests.
  *

--- a/resources/views/partials/navigation.blade.php
+++ b/resources/views/partials/navigation.blade.php
@@ -21,15 +21,11 @@
                 @if (Auth::user())
                     <a id="js-account-toggle" class="navigation__dropdown-toggle">My Profile</a>
                     <ul>
-                        <li><a href="{{ phoenixLink('northstar/' . Auth::user()->northstar_id) }}">Profile</a></li>
+                        <li><a href="{{ phoenixLink('northstar/' . Auth::id()) }}">Profile</a></li>
                         <li><a href="{{ route('logout') }}" class="secondary-nav-item" id="link--logout">Log Out</a></li>
                     </ul>
                 @else
-                    @if (isset($campaign))
-                        <a href="{{ route('login', get_login_query($campaign)) }}">Log In</a>
-                    @else
-                        <a href="{{ route('login') }}">Log In</a>
-                    @endif
+                    <a href="{{ route('login', isset($campaign) ? get_login_query($campaign) : null) }}">Log In</a>
                 @endif
             </li>
         </ul>


### PR DESCRIPTION
### What does this PR do?
This pull request adds a `user.source` field to the store, filled with whatever `utm_source` query string the user "enters" the application with. This may be used to customize the experience later on (e.g. different copy for different audiences).

### Any background context you want to provide?
I took this as an opportunity to audit what's going on in `CampaignController`. I removed some unused variables and extracted client-side environment variables into a [view composer](https://laravel.com/docs/5.6/views#view-composers) so it'd automatically be attached to any view.

### What are the relevant tickets/cards?
[#155625289](https://www.pivotaltracker.com/story/show/155625289)

### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
- [ ] Added screenshot to PR description of related front-end updates on **small** screens.
- [ ] Added screenshot to PR description of related front-end updates on **medium** screens.
- [ ] Added screenshot to PR description of related front-end updates on **large** screens.