### PR TITLE
Disabling experiment participation on all campaigns via a script.

### DIFF
--- a/contentful/transforms/disable_experiments_on_all_campaign_settings.js
+++ b/contentful/transforms/disable_experiments_on_all_campaign_settings.js
@@ -1,0 +1,12 @@
+// Transformation to disable all A/B experiment participation on
+// all campaignSettings content types.
+module.exports = function (migration) {
+  migration.transformEntries({
+    contentType: 'campaignSettings',
+    from: ['allowExperiments'],
+    to: ['allowExperiments'],
+    transformEntryForLocale: function (fromFields, currentLocale) {
+      return { allowExperiments: false };
+    }
+  });
+}


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_


### What does this PR do?
This PR adds a generic migration to set all the `allowExperiments` fields on each `campaignSettings` content-type to `false` to disable participation in an experiment. I wanted to try this method out instead of changing each campaign's settings manually, one by one.

I placed this in a dedicated `transforms` directory, since it's not really a migration to run once, but something we could run a few times to clear out experiment participation across campaigns :)

Related to upcoming PR for a Sixpack experiment on the `ledeBanner`.


### Any background context you want to provide?
Hopefully this works!


### What are the relevant tickets/cards?
Refs PID [#155479845](https://www.pivotaltracker.com/story/show/155479845)
