### PR TITLE
Convert SignupButton into a plain ol' component.

### DIFF
--- a/resources/assets/components/CallToAction/CallToAction.js
+++ b/resources/assets/components/CallToAction/CallToAction.js
@@ -4,8 +4,7 @@ import React from 'react';
 import classnames from 'classnames';
 
 import Card from '../Card';
-import Button from '../Button/Button';
-import SignupButtonFactory from '../SignupButton';
+import SignupButton from '../SignupButton';
 
 import './cta.scss';
 
@@ -20,8 +19,6 @@ const renderImpactContent = (prefix, value, suffix) => {
 };
 
 type CallToActionProps = {
-  actionText: ?string,
-  campaignId: string,
   className: ?string,
   content: ?string,
   impactPrefix: ?string,
@@ -29,23 +26,18 @@ type CallToActionProps = {
   impactValue: ?string,
   hideIfSignedUp: ?bool,
   isSignedUp: bool,
-  legacyCampaignId: ?string,
   tagline: string,
   useCampaignTagline: bool,
   visualStyle: string,
 };
 
 const CallToAction = ({
-  actionText, campaignId, className, content, impactPrefix, impactSuffix, impactValue,
-  hideIfSignedUp, isSignedUp, legacyCampaignId, tagline, useCampaignTagline, visualStyle,
+  className, content, impactPrefix, impactSuffix, impactValue,
+  hideIfSignedUp, isSignedUp, tagline, useCampaignTagline, visualStyle,
 }: CallToActionProps) => {
   if (hideIfSignedUp && isSignedUp) {
     return null;
   }
-
-  const SignupButton = SignupButtonFactory(({ clickedSignUp }) => (
-    <Button onClick={() => clickedSignUp(legacyCampaignId || campaignId)} text={actionText} />
-  ), 'call to action', { text: actionText });
 
   return (
     <Card className={classnames('call-to-action rounded padded text-centered', className, {
@@ -60,20 +52,18 @@ const CallToAction = ({
 
       { content ? <div className="cta__message margin-bottom-lg">{content}</div> : null }
 
-      { isSignedUp ? null : <SignupButton /> }
+      { isSignedUp ? null : <SignupButton source="call to action" /> }
     </Card>
   );
 };
 
 CallToAction.defaultProps = {
-  actionText: 'Join us',
   className: null,
   content: null,
   impactPrefix: null,
   impactSuffix: null,
   impactValue: null,
   hideIfSignedUp: false,
-  legacyCampaignId: null,
 };
 
 export default CallToAction;

--- a/resources/assets/components/CallToAction/CallToActionContainer.js
+++ b/resources/assets/components/CallToAction/CallToActionContainer.js
@@ -1,18 +1,16 @@
 import { connect } from 'react-redux';
-import { get } from 'lodash';
 
 import CallToAction from './CallToAction';
 
 /**
  * Provide state from the Redux store as props for this component.
  */
-const mapStateToProps = (state, ownProps) => ({
+const mapStateToProps = state => ({
   campaignId: state.campaign.id,
   coverImageUrl: state.campaign.coverImage.url,
   isSignedUp: state.signups.thisCampaign,
-  legacyCampaignId: get(state.campaign, 'legacyCampaignId', null),
+  legacyCampaignId: state.campaign.legacyCampaignId,
   tagline: state.campaign.callToAction,
-  actionText: ownProps.actionText || state.campaign.actionText,
 });
 
 /**

--- a/resources/assets/components/CallToAction/__snapshots__/CallToAction.test.js.snap
+++ b/resources/assets/components/CallToAction/__snapshots__/CallToAction.test.js.snap
@@ -12,6 +12,8 @@ exports[`CallToAction snapshot test 1`] = `
   >
     Aenean eu leo quam. Pellentesque ornare sem vestibulum.
   </div>
-  <Connect(PuckWrapper) />
+  <Connect(PuckWrapper)
+    source="call to action"
+  />
 </Card>
 `;

--- a/resources/assets/components/LedeBanner/LedeBannerContainer.js
+++ b/resources/assets/components/LedeBanner/LedeBannerContainer.js
@@ -7,7 +7,6 @@ import LedeBanner from './LedeBanner';
  * Provide state from the Redux store as props for this component.
  */
 const mapStateToProps = state => ({
-  actionText: state.campaign.actionText,
   affiliatedActionText: get(state, 'campaign.additionalContent.affiliatedActionText', null),
   affiliatedActionLink: get(state, 'campaign.additionalContent.affiliatedActionLink', null),
   blurb: state.campaign.blurb,
@@ -15,7 +14,6 @@ const mapStateToProps = state => ({
   endDate: state.campaign.endDate,
   isAffiliated: state.signups.thisCampaign,
   affiliateSponsors: state.campaign.affiliateSponsors,
-  legacyCampaignId: state.campaign.legacyCampaignId,
   subtitle: state.campaign.callToAction,
   template: state.campaign.template,
   title: state.campaign.title,

--- a/resources/assets/components/LedeBanner/templates/MosaicTemplate.js
+++ b/resources/assets/components/LedeBanner/templates/MosaicTemplate.js
@@ -4,7 +4,7 @@ import classnames from 'classnames';
 import { Link } from 'react-router-dom';
 
 import Markdown from '../../Markdown';
-import SignupButtonFactory from '../../SignupButton';
+import SignupButton from '../../SignupButton';
 import SponsorPromotion from '../../SponsorPromotion';
 import { contentfulImageUrl } from '../../../helpers';
 import CampaignSignupArrow from '../../CampaignSignupArrow';
@@ -16,14 +16,12 @@ const MosaicTemplate = (props) => {
   const {
     affiliatedActionText,
     affiliatedActionLink,
-    actionText,
     affiliateSponsors,
     title,
     subtitle,
     blurb,
     coverImage,
     isAffiliated,
-    legacyCampaignId,
     showPartnerMsgOptIn,
     signupArrowContent,
   } = props;
@@ -32,20 +30,15 @@ const MosaicTemplate = (props) => {
     backgroundImage: `url(${contentfulImageUrl(coverImage.url, '800', '600', 'fill')})`,
   };
 
-  const signupArrowComponent = signupArrowContent ? (
-    <CampaignSignupArrow content={signupArrowContent} className="-mosaic-arrow" />
-  ) : null;
-
-  const SignupButton = SignupButtonFactory(({ clickedSignUp }) => (
+  const signupButton = (
     <div className="mosaic-lede-banner__signup">
-      <button
-        className={classnames('button', { '-float': affiliateSponsors.length })}
-        onClick={() => clickedSignUp(legacyCampaignId)}
-      >{ actionText }</button>
-      { signupArrowComponent }
+      <SignupButton className={classnames({ '-float': affiliateSponsors.length })} source="lede banner" />
+      { signupArrowContent ? (
+        <CampaignSignupArrow content={signupArrowContent} className="-mosaic-arrow" />
+      ) : null }
       { showPartnerMsgOptIn ? <AffiliateOptionContainer /> : null }
     </div>
-  ), 'lede banner', { text: actionText });
+  );
 
   const actionButton = affiliatedActionLink ? (
     <div className="mosaic-lede-banner__signup">
@@ -69,7 +62,7 @@ const MosaicTemplate = (props) => {
 
           { blurb ? <Markdown className="mosaic-lede-banner__blurb">{blurb}</Markdown> : null }
 
-          { isAffiliated ? actionButton : <SignupButton /> }
+          { isAffiliated ? actionButton : signupButton }
 
           { affiliateSponsors.length ?
             <SponsorPromotion
@@ -89,7 +82,6 @@ const MosaicTemplate = (props) => {
 MosaicTemplate.propTypes = {
   affiliatedActionText: PropTypes.string,
   affiliatedActionLink: PropTypes.string,
-  actionText: PropTypes.string.isRequired,
   affiliateSponsors: PropTypes.arrayOf(PropTypes.object).isRequired,
   blurb: PropTypes.string,
   coverImage: PropTypes.shape({
@@ -97,7 +89,6 @@ MosaicTemplate.propTypes = {
     url: PropTypes.string,
   }).isRequired,
   isAffiliated: PropTypes.bool.isRequired,
-  legacyCampaignId: PropTypes.string.isRequired,
   subtitle: PropTypes.string.isRequired,
   title: PropTypes.string.isRequired,
   showPartnerMsgOptIn: PropTypes.bool.isRequired,

--- a/resources/assets/components/Navigation/TabbedNavigationContainer.js
+++ b/resources/assets/components/Navigation/TabbedNavigationContainer.js
@@ -7,18 +7,15 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router-dom';
 
-import Button from '../Button/Button';
 import NavigationLink from '../Navigation/NavigationLink';
 import TabbedNavigation from './TabbedNavigation';
 import { campaignPaths } from '../../helpers/navigation';
 import { isCampaignClosed } from '../../helpers';
-import SignupButtonFactory from '../SignupButton';
+import SignupButton from '../SignupButton';
 
 const mapStateToProps = state => ({
-  actionText: state.campaign.actionText,
   hasActivityFeed: Boolean(state.campaign.activityFeed.length),
   isAffiliated: state.signups.thisCampaign,
-  legacyCampaignId: state.campaign.legacyCampaignId,
   pages: state.campaign.pages,
   pathname: state.routing.location.pathname,
   campaignEndDate: get(state.campaign.endDate, 'date', null),
@@ -28,7 +25,7 @@ const mapStateToProps = state => ({
 
 const TabbedNavigationContainer = (props) => {
   const {
-    actionText, hasActivityFeed, isAffiliated, legacyCampaignId,
+    hasActivityFeed, isAffiliated,
     pages, campaignEndDate, template,
   } = props;
 
@@ -58,10 +55,6 @@ const TabbedNavigationContainer = (props) => {
         <NavigationLink key={page.id} to={path}>{page.fields.title}</NavigationLink>
       );
     });
-
-  const SignupButton = SignupButtonFactory(({ clickedSignUp }) => (
-    <Button className="-inline nav-button" onClick={() => clickedSignUp(legacyCampaignId)} text={actionText} />
-  ), 'tabbed navigation', { text: actionText });
 
   const shouldHideCommunity = ! hasActivityFeed;
   const shouldHideAction = (isClosed || (shouldHideCommunity && additionalPages.length === 0));
@@ -110,18 +103,16 @@ const TabbedNavigationContainer = (props) => {
         <CommunityNavigationLink />
         { additionalPages }
       </div>
-      { isAffiliated ? null : <SignupButton /> }
+      { isAffiliated ? null : <SignupButton className="-inline nav-button" source="tabbed navigation" /> }
     </TabbedNavigation>
   );
 };
 
 TabbedNavigationContainer.propTypes = {
-  actionText: PropTypes.string.isRequired,
   campaignEndDate: PropTypes.string,
   campaignSlug: PropTypes.string.isRequired,
   hasActivityFeed: PropTypes.bool.isRequired,
   isAffiliated: PropTypes.bool.isRequired,
-  legacyCampaignId: PropTypes.string.isRequired,
   pages: PropTypes.oneOfType([
     PropTypes.array,
   ]),

--- a/resources/assets/components/Page/LandingPage/LandingPage.js
+++ b/resources/assets/components/Page/LandingPage/LandingPage.js
@@ -13,7 +13,7 @@ import './landing-page.scss';
 
 const LandingPage = (props) => {
   const {
-    actionText, affiliateSponsors, blurb, coverImage,
+    affiliateSponsors, blurb, coverImage,
     endDate, isAffiliated, legacyCampaignId, pitchContent,
     sidebar, showPartnerMsgOptIn, signupArrowContent,
     subtitle, tagline, template, title,
@@ -35,7 +35,6 @@ const LandingPage = (props) => {
         affiliateSponsors={affiliateSponsors}
         signupArrowContent={signupArrowContent}
         showPartnerMsgOptIn={showPartnerMsgOptIn}
-        actionText={actionText}
       />
 
       <div className="clearfix bg-white">
@@ -59,7 +58,6 @@ const LandingPage = (props) => {
 };
 
 LandingPage.propTypes = {
-  actionText: PropTypes.string.isRequired,
   blurb: PropTypes.string,
   coverImage: PropTypes.shape({
     description: PropTypes.string,

--- a/resources/assets/components/SignupButton/SignupButton.js
+++ b/resources/assets/components/SignupButton/SignupButton.js
@@ -4,8 +4,10 @@ import classnames from 'classnames';
 import { convertOnSignupIntent } from '../../helpers/sixpack';
 
 const SignupButton = (props) => {
-  const { actionText, className, clickedSignUp, experiments, template,
-    source, trackEvent, legacyCampaignId, convertExperiment } = props;
+  const { campaignActionText, className, clickedSignUp, experiments, source,
+    template, text, trackEvent, legacyCampaignId, convertExperiment } = props;
+
+  const buttonText = text || campaignActionText;
 
   const convertExperiments = () => {
     Object.keys(experiments).forEach((experiment) => {
@@ -23,17 +25,18 @@ const SignupButton = (props) => {
       template,
       legacyCampaignId,
       source,
-      sourceData: { text: actionText },
+      sourceData: { text: buttonText },
     });
   };
 
   return (
-    <button className={classnames('button', className)} onClick={onSignup}>{ actionText }</button>
+    <button className={classnames('button', className)} onClick={onSignup}>{ buttonText }</button>
   );
 };
 
 SignupButton.propTypes = {
-  actionText: PropTypes.string,
+  text: PropTypes.string,
+  campaignActionText: PropTypes.string,
   className: PropTypes.string,
   clickedSignUp: PropTypes.func.isRequired,
   convertExperiment: PropTypes.func.isRequired,
@@ -45,7 +48,8 @@ SignupButton.propTypes = {
 };
 
 SignupButton.defaultProps = {
-  actionText: 'Take Action',
+  text: null,
+  campaignActionText: 'Take Action',
   className: null,
   template: null,
 };

--- a/resources/assets/components/SignupButton/SignupButton.js
+++ b/resources/assets/components/SignupButton/SignupButton.js
@@ -1,59 +1,53 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { PuckConnector } from '@dosomething/puck-client';
-import SignupButtonContainer from './SignupButtonContainer';
+import classnames from 'classnames';
 import { convertOnSignupIntent } from '../../helpers/sixpack';
 
-/**
- * HOC for wrapping signup buttons. Handles tracking
- * and dispatching the signup action.
- *
- * @param {Component} WrappedComponent
- * @param {String} source
- * @param {Object} sourceData
- * @return {Class} <SignupButton />
- */
-const SignupButtonFactory = (WrappedComponent, source = null, sourceData = null) => {
-  const SignupButton = (props) => {
-    const { clickedSignUp, template, trackEvent, experiments, convertExperiment } = props;
+const SignupButton = (props) => {
+  const { actionText, className, clickedSignUp, experiments, template,
+    source, trackEvent, legacyCampaignId, convertExperiment } = props;
 
-    const convertExperiments = () => {
-      Object.keys(experiments).forEach((experiment) => {
-        if (convertOnSignupIntent(experiment)) {
-          convertExperiment(experiment);
-        }
-      });
-    };
-
-    const onSignup = (campaignId) => {
-      convertExperiments();
-      clickedSignUp(campaignId);
-      trackEvent('signup', {
-        template,
-        campaignId,
-        source,
-        sourceData,
-      });
-    };
-
-    return (
-      <WrappedComponent {...props} clickedSignUp={onSignup} />
-    );
+  const convertExperiments = () => {
+    Object.keys(experiments).forEach((experiment) => {
+      if (convertOnSignupIntent(experiment)) {
+        convertExperiment(experiment);
+      }
+    });
   };
 
-  SignupButton.propTypes = {
-    clickedSignUp: PropTypes.func.isRequired,
-    template: PropTypes.string,
-    trackEvent: PropTypes.func.isRequired,
-    experiments: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
-    convertExperiment: PropTypes.func.isRequired,
+  // Decorate click handler for A/B tests & analytics.
+  const onSignup = () => {
+    convertExperiments();
+    clickedSignUp(legacyCampaignId);
+    trackEvent('signup', {
+      template,
+      legacyCampaignId,
+      source,
+      sourceData: { text: actionText },
+    });
   };
 
-  SignupButton.defaultProps = {
-    template: null,
-  };
-
-  return SignupButtonContainer(PuckConnector(SignupButton));
+  return (
+    <button className={classnames('button', className)} onClick={onSignup}>{ actionText }</button>
+  );
 };
 
-export default SignupButtonFactory;
+SignupButton.propTypes = {
+  actionText: PropTypes.string,
+  className: PropTypes.string,
+  clickedSignUp: PropTypes.func.isRequired,
+  convertExperiment: PropTypes.func.isRequired,
+  experiments: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
+  legacyCampaignId: PropTypes.string.isRequired,
+  source: PropTypes.string.isRequired,
+  template: PropTypes.string,
+  trackEvent: PropTypes.func.isRequired,
+};
+
+SignupButton.defaultProps = {
+  actionText: 'Take Action',
+  className: null,
+  template: null,
+};
+
+export default SignupButton;

--- a/resources/assets/components/SignupButton/SignupButtonContainer.js
+++ b/resources/assets/components/SignupButton/SignupButtonContainer.js
@@ -1,4 +1,3 @@
-import { get } from 'lodash';
 import { connect } from 'react-redux';
 import { PuckConnector } from '@dosomething/puck-client';
 import { clickedSignUp } from '../../actions/signup';
@@ -12,7 +11,7 @@ import SignupButton from './SignupButton';
 const mapStateToProps = state => ({
   template: state.campaign.template,
   experiments: state.experiments,
-  actionText: state.campaign.actionText,
+  campaignActionText: state.campaign.actionText,
   legacyCampaignId: state.campaign.legacyCampaignId,
 });
 

--- a/resources/assets/components/SignupButton/SignupButtonContainer.js
+++ b/resources/assets/components/SignupButton/SignupButtonContainer.js
@@ -1,15 +1,29 @@
+import { get } from 'lodash';
 import { connect } from 'react-redux';
+import { PuckConnector } from '@dosomething/puck-client';
 import { clickedSignUp } from '../../actions/signup';
 import { convertExperiment } from '../../actions';
+import SignupButton from './SignupButton';
 
+
+/**
+ * Provide state from the Redux store as props for this component.
+ */
 const mapStateToProps = state => ({
   template: state.campaign.template,
   experiments: state.experiments,
+  actionText: state.campaign.actionText,
+  legacyCampaignId: state.campaign.legacyCampaignId,
 });
 
+/**
+ * Provide pre-bound functions that allow the component to dispatch
+ * actions to the Redux store as props for this component.
+ */
 const actionCreators = {
   clickedSignUp,
   convertExperiment,
 };
 
-export default Component => connect(mapStateToProps, actionCreators)(Component);
+// Export the container component.
+export default connect(mapStateToProps, actionCreators)(PuckConnector(SignupButton));

--- a/resources/assets/components/SignupButton/index.js
+++ b/resources/assets/components/SignupButton/index.js
@@ -1,1 +1,1 @@
-export default from './SignupButton';
+export default from './SignupButtonContainer';


### PR DESCRIPTION
### What does this PR do?
This pull request refactors the somewhat hairy `SignupButtonFactory` into plain ol... `SignupButton`. Along the way, I continued to pull things that are scattered amongst a bunch of different containers closer to the where they're actually used.

So instead of…

```jsx
import SignupButtonFactory from '../SignupButton';

const SignupButton = SignupButtonFactory(({ clickedSignUp }) => (
    <Button onClick={() => clickedSignUp(legacyCampaignId || campaignId)} text={actionText} />
), 'call to action', { text: actionText });

return <div>{ isSignedUp ? null : <SignupButton /> }</div>;
```

…it's just:

```jsx
import SignupButton from '../SignupButton';

return <div>{ isSignedUp ? null : <SignupButton source="call to action" /> }</div>;

```

Ahhhhh. 😌

### Any background context you want to provide?
I tried my best to make sure this works the same everywhere, but would love some additional eyes to make sure I haven't broken anything unintentionally. ~In particular, I removed the ability to customize `actionText` case-by-case because it doesn't seem we're actually doing that anywhere.~ Re-added for the heck of it in 8cc784e.

### What are the relevant tickets/cards?
[#155625023](https://www.pivotaltracker.com/story/show/155625023)

### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
- [ ] Added screenshot to PR description of related front-end updates on **small** screens.
- [ ] Added screenshot to PR description of related front-end updates on **medium** screens.
- [ ] Added screenshot to PR description of related front-end updates on **large** screens.