### PR TITLE
Updates and fixes

### DIFF
--- a/app/Entities/Affirmation.php
+++ b/app/Entities/Affirmation.php
@@ -32,7 +32,7 @@ class Affirmation extends Entity implements JsonSerializable
 
         return [
             'id' => $this->entry->getId(),
-            'type' => $this->entry->getContentType(),
+            'type' => $this->getContentType(),
             'fields' => [
                 'header' => $this->header,
                 'photo' => get_image_url($this->photo, 'square'),

--- a/app/Entities/LinkAction.php
+++ b/app/Entities/LinkAction.php
@@ -15,7 +15,7 @@ class LinkAction extends Entity implements JsonSerializable
     {
         return [
             'id' => $this->entry->getId(),
-            'type' => $this->entry->getContentType(),
+            'type' => $this->getContentType(),
             'fields' => [
                 'title' => $this->title,
                 'content' => $this->content,

--- a/app/Entities/PhotoUploaderAction.php
+++ b/app/Entities/PhotoUploaderAction.php
@@ -15,7 +15,7 @@ class PhotoUploaderAction extends Entity implements JsonSerializable
     {
         return [
             'id' => $this->entry->getId(),
-            'type' => $this->entry->getContentType(),
+            'type' => $this->getContentType(),
             'fields' => [
                 'informationTitle' => $this->informationTitle,
                 'informationContent' => $this->informationContent,

--- a/app/Entities/ShareAction.php
+++ b/app/Entities/ShareAction.php
@@ -15,7 +15,7 @@ class ShareAction extends Entity implements JsonSerializable
     {
         return [
             'id' => $this->entry->getId(),
-            'type' => $this->entry->getContentType(),
+            'type' => $this->getContentType(),
             'fields' => [
                 'title' => $this->title,
                 'content' => $this->content,

--- a/app/Entities/VoterRegistrationAction.php
+++ b/app/Entities/VoterRegistrationAction.php
@@ -15,7 +15,7 @@ class VoterRegistrationAction extends Entity implements JsonSerializable
     {
         return [
             'id' => $this->entry->getId(),
-            'type' => $this->entry->getContentType(),
+            'type' => $this->getContentType(),
             'fields' => [
                 'title' => $this->title,
                 'content' => $this->content,

--- a/resources/assets/components/Button/Button.js
+++ b/resources/assets/components/Button/Button.js
@@ -3,18 +3,22 @@ import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import './button.scss';
 
-const Button = ({ onClick, className, text }) => (
-  <button className={classnames('button', className)} onClick={onClick}>{text}</button>
-);
+const Button = ({ onClick, className, isLoading, text }) => {
+  const classNames = classnames('button', { 'is-loading': isLoading }, className);
+
+  return <button className={classNames} disabled={isLoading} onClick={onClick}>{text}</button>
+};
 
 Button.propTypes = {
   onClick: PropTypes.func.isRequired,
   className: PropTypes.string,
+  isLoading: PropTypes.bool,
   text: PropTypes.string,
 };
 
 Button.defaultProps = {
   className: null,
+  isLoading: false,
   text: 'Join Us',
 };
 

--- a/resources/assets/components/Button/Button.js
+++ b/resources/assets/components/Button/Button.js
@@ -6,7 +6,7 @@ import './button.scss';
 const Button = ({ onClick, className, isLoading, text }) => {
   const classNames = classnames('button', { 'is-loading': isLoading }, className);
 
-  return <button className={classNames} disabled={isLoading} onClick={onClick}>{text}</button>
+  return <button className={classNames} disabled={isLoading} onClick={onClick}>{text}</button>;
 };
 
 Button.propTypes = {

--- a/resources/assets/components/Button/__snapshots__/test.js.snap
+++ b/resources/assets/components/Button/__snapshots__/test.js.snap
@@ -3,6 +3,7 @@
 exports[`Button snapshot test 1`] = `
 <button
   className="button -modifier"
+  disabled={false}
   onClick={[Function]}
 >
   Join Us

--- a/resources/assets/components/ContentfulEntry/renderers.js
+++ b/resources/assets/components/ContentfulEntry/renderers.js
@@ -46,7 +46,7 @@ export function renderPhotoUploader(step, isSignedUp) {
     <div key="reportback_uploader" className="margin-bottom-lg">
       <PuckWaypoint name="photo_uploader_action-top" />
       <div className="margin-horizontal-md">
-        <ReportbackUploaderContainer actionType={step.type.sys.id} {...step.fields} />
+        <ReportbackUploaderContainer actionType={step.type} {...step.fields} />
       </div>
       <PuckWaypoint name="photo_uploader_action-bottom" />
     </div>

--- a/resources/assets/components/Feed/Feed.js
+++ b/resources/assets/components/Feed/Feed.js
@@ -38,8 +38,8 @@ const renderFeedItem = (block, index) => (
  * @returns {XML}
  */
 const Feed = (props) => {
-  const { actionText, blocks, callToAction, campaignId, dashboard, signedUp, hasPendingSignup,
-    isAuthenticated, canLoadMorePages, clickedViewMore, clickedSignUp } = props;
+  const { blocks, callToAction, dashboard, signedUp, hasPendingSignup,
+    isAuthenticated, canLoadMorePages, clickedViewMore } = props;
 
   const shouldShowRevealer = (isAuthenticated && ! signedUp) || canLoadMorePages;
   const revealer = (
@@ -71,7 +71,6 @@ const Feed = (props) => {
 };
 
 Feed.propTypes = {
-  actionText: PropTypes.string.isRequired,
   blocks: PropTypes.arrayOf(PropTypes.shape({
     id: PropTypes.string.isRequired,
     type: PropTypes.string.isRequired,
@@ -79,7 +78,6 @@ Feed.propTypes = {
     additionalContent: PropTypes.instanceOf(Object),
   })),
   callToAction: PropTypes.string.isRequired,
-  campaignId: PropTypes.string.isRequired,
   dashboard: PropTypes.shape({
     id: PropTypes.string,
     type: PropTypes.string,
@@ -90,7 +88,6 @@ Feed.propTypes = {
   isAuthenticated: PropTypes.bool.isRequired,
   canLoadMorePages: PropTypes.bool.isRequired,
   clickedViewMore: PropTypes.func.isRequired,
-  clickedSignUp: PropTypes.func.isRequired,
 };
 
 Feed.defaultProps = {

--- a/resources/assets/components/Feed/Feed.js
+++ b/resources/assets/components/Feed/Feed.js
@@ -41,14 +41,13 @@ const Feed = (props) => {
   const { actionText, blocks, callToAction, campaignId, dashboard, signedUp, hasPendingSignup,
     isAuthenticated, canLoadMorePages, clickedViewMore, clickedSignUp } = props;
 
-  const viewMoreOrSignup = signedUp ? clickedViewMore : () => clickedSignUp(campaignId);
+  const shouldShowRevealer = (isAuthenticated && ! signedUp) || canLoadMorePages;
   const revealer = (
     <Revealer
-      title={signedUp ? 'view more' : actionText}
+      title="view more"
       callToAction={signedUp ? '' : callToAction}
       isLoading={hasPendingSignup}
-      isVisible={(isAuthenticated && ! signedUp) || canLoadMorePages}
-      onReveal={() => viewMoreOrSignup()}
+      onReveal={clickedViewMore}
       isSignedUp={signedUp}
     />
   );
@@ -63,7 +62,7 @@ const Feed = (props) => {
           <Flex className="feed">
             {blocks.map(renderFeedItem)}
           </Flex>
-          {revealer}
+          {shouldShowRevealer ? revealer : null}
         </Enclosure>
         <CallToActionContainer className="-sticky" hideIfSignedUp />
       </div>

--- a/resources/assets/components/Feed/FeedContainer.js
+++ b/resources/assets/components/Feed/FeedContainer.js
@@ -1,22 +1,21 @@
 import { connect } from 'react-redux';
+
 import Feed from './Feed';
-import { clickedViewMore, clickedSignUp } from '../../actions';
+import { clickedViewMore } from '../../actions';
+import { isAuthenticated } from '../../selectors/user';
 import {
   getBlocksWithReportbacks,
   getVisibleBlocks,
   getTotalVisibleBlockPoints,
   getMaximumBlockPoints,
 } from '../../selectors/feed';
-import { isAuthenticated } from '../../selectors/user';
 
 /**
  * Provide state from the Redux store as props for this component.
  */
 const mapStateToProps = state => ({
-  actionText: state.campaign.actionText,
   blocks: getBlocksWithReportbacks(getVisibleBlocks(state), state),
   canLoadMorePages: getTotalVisibleBlockPoints(state) < getMaximumBlockPoints(state),
-  campaignId: state.campaign.legacyCampaignId,
   callToAction: state.campaign.callToAction,
   dashboard: state.campaign.dashboard,
   signedUp: state.signups.data.includes(state.campaign.legacyCampaignId),
@@ -31,7 +30,6 @@ const mapStateToProps = state => ({
  */
 const actionCreators = {
   clickedViewMore,
-  clickedSignUp,
 };
 
 // Export the container component.

--- a/resources/assets/components/LedeBanner/templates/CoverTemplate.js
+++ b/resources/assets/components/LedeBanner/templates/CoverTemplate.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom';
 
 import Markdown from '../../Markdown';
-import SignupButtonFactory from '../../SignupButton';
+import SignupButton from '../../SignupButton';
 import SponsorPromotion from '../../SponsorPromotion';
 import { contentfulImageUrl } from '../../../helpers';
 
@@ -11,13 +11,11 @@ import './cover-lede-banner.scss';
 
 const CoverTemplate = (props) => {
   const {
-    actionText,
     affiliatedActionLink,
     affiliatedActionText,
     affiliateSponsors,
     coverImage,
     isAffiliated,
-    legacyCampaignId,
     subtitle,
     title,
   } = props;
@@ -27,12 +25,6 @@ const CoverTemplate = (props) => {
   const backgroundImageStyle = {
     backgroundImage: `url(${contentfulImageUrl(coverImage.url, '1440', '810', 'fill')})`,
   };
-
-  const SignupButton = SignupButtonFactory(({ clickedSignUp }) => (
-    <div className="cover-lede-banner__signup">
-      <button className="button" onClick={() => clickedSignUp(legacyCampaignId)}>{ actionText }</button>
-    </div>
-  ));
 
   const actionButton = affiliatedActionLink ? (
     <div className="cover-lede-banner__signup">
@@ -51,7 +43,12 @@ const CoverTemplate = (props) => {
 
         { blurb ? <Markdown className="cover-lede-banner__blurb">{blurb}</Markdown> : null }
 
-        { isAffiliated ? actionButton : <SignupButton /> }
+        { isAffiliated ?
+          actionButton :
+          <div className="cover-lede-banner__signup">
+            <SignupButton source="cover lede banner" />
+          </div>
+        }
 
         { affiliateSponsors.length ?
           <SponsorPromotion
@@ -68,7 +65,6 @@ const CoverTemplate = (props) => {
 };
 
 CoverTemplate.propTypes = {
-  actionText: PropTypes.string.isRequired,
   affiliatedActionLink: PropTypes.string,
   affiliatedActionText: PropTypes.string,
   affiliateSponsors: PropTypes.arrayOf(PropTypes.object).isRequired,
@@ -76,7 +72,6 @@ CoverTemplate.propTypes = {
     description: PropTypes.string,
     url: PropTypes.string,
   }).isRequired,
-  legacyCampaignId: PropTypes.string.isRequired,
   isAffiliated: PropTypes.bool.isRequired,
   subtitle: PropTypes.string.isRequired,
   title: PropTypes.string.isRequired,

--- a/resources/assets/components/LedeBanner/templates/LegacyTemplate.js
+++ b/resources/assets/components/LedeBanner/templates/LegacyTemplate.js
@@ -2,20 +2,18 @@ import React from 'react';
 import { format } from 'date-fns';
 import PropTypes from 'prop-types';
 
-import AffiliateOptionContainer from '../../AffiliateOption';
-import SignupButtonFactory from '../../SignupButton';
+import SignupButton from '../../SignupButton';
 import SponsorPromotion from '../../SponsorPromotion';
-import CampaignSignupArrow from '../../CampaignSignupArrow';
 import { contentfulImageUrl } from '../../../helpers';
+import CampaignSignupArrow from '../../CampaignSignupArrow';
+import AffiliateOptionContainer from '../../AffiliateOption';
 
 const LegacyTemplate = (props) => {
   const {
-    actionText,
     title,
     subtitle,
     coverImage,
     isAffiliated,
-    legacyCampaignId,
     endDate,
     affiliateSponsors,
     signupArrowContent,
@@ -30,13 +28,6 @@ const LegacyTemplate = (props) => {
   // whether to grab single entry when transforming in PHP
   const sponsor = affiliateSponsors[0];
 
-  const SignupButton = SignupButtonFactory(({ clickedSignUp }) => (
-    <div>
-      <button className="button" onClick={() => clickedSignUp(legacyCampaignId)}>{actionText}</button>
-      { showPartnerMsgOptIn ? <AffiliateOptionContainer /> : null }
-    </div>
-  ), 'legacy lede banner', { text: actionText });
-
   return (
     <header role="banner" className="header -hero header--action has-promotions" style={backgroundImageStyle}>
       <div className="wrapper">
@@ -47,7 +38,10 @@ const LegacyTemplate = (props) => {
         { isAffiliated ? null : (
           <div className="header__signup">
             { signupArrowContent ? <CampaignSignupArrow content={signupArrowContent} /> : null }
-            <SignupButton />
+            <div>
+              <SignupButton source="legacy lede banner" />
+              { showPartnerMsgOptIn ? <AffiliateOptionContainer /> : null }
+            </div>
           </div>
         )}
 
@@ -65,7 +59,6 @@ const LegacyTemplate = (props) => {
 };
 
 LegacyTemplate.propTypes = {
-  actionText: PropTypes.string.isRequired,
   coverImage: PropTypes.shape({
     description: PropTypes.string,
     url: PropTypes.string,
@@ -77,7 +70,6 @@ LegacyTemplate.propTypes = {
   }),
   isAffiliated: PropTypes.bool.isRequired,
   affiliateSponsors: PropTypes.arrayOf(PropTypes.object).isRequired,
-  legacyCampaignId: PropTypes.string.isRequired,
   signupArrowContent: PropTypes.string,
   subtitle: PropTypes.string.isRequired,
   title: PropTypes.string.isRequired,

--- a/resources/assets/components/Page/ActionPage/ActionSteps.js
+++ b/resources/assets/components/Page/ActionPage/ActionSteps.js
@@ -1,13 +1,14 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import { get } from 'lodash';
+import PropTypes from 'prop-types';
+
+import Revealer from '../../Revealer';
 import { Flex, FlexCell } from '../../Flex';
 import SectionHeader from '../../SectionHeader';
 import ContentfulEntry from '../../ContentfulEntry';
-import { PostGalleryContainer } from '../../Gallery/PostGallery';
-import Revealer from '../../Revealer';
 import SignupButtonFactory from '../../SignupButton';
 import { parseContentfulType } from '../../../helpers';
+import { PostGalleryContainer } from '../../Gallery/PostGallery';
 
 /**
  * Render the action page revealer.

--- a/resources/assets/components/Page/ActionPage/ActionSteps.js
+++ b/resources/assets/components/Page/ActionPage/ActionSteps.js
@@ -6,7 +6,6 @@ import Revealer from '../../Revealer';
 import { Flex, FlexCell } from '../../Flex';
 import SectionHeader from '../../SectionHeader';
 import ContentfulEntry from '../../ContentfulEntry';
-import SignupButtonFactory from '../../SignupButton';
 import { parseContentfulType } from '../../../helpers';
 import { PostGalleryContainer } from '../../Gallery/PostGallery';
 
@@ -19,19 +18,14 @@ import { PostGalleryContainer } from '../../Gallery/PostGallery';
  * @param  {String}  campaignId
  * @return {Component}
  */
-export function renderRevealer(callToAction, hasPendingSignup, isSignedUp, campaignId) {
-  const SignupRevealer = SignupButtonFactory(({ clickedSignUp }) => (
+export function renderRevealer(callToAction, hasPendingSignup, isSignedUp) {
+  return (
     <Revealer
       title="Join Us"
       callToAction={callToAction}
       isLoading={hasPendingSignup}
-      onReveal={() => clickedSignUp(campaignId)}
       isSignedUp={isSignedUp}
     />
-  ), 'action page revealer', { text: 'Join Us', callToAction });
-
-  return (
-    <SignupRevealer key="revealer" />
   );
 }
 

--- a/resources/assets/components/Page/LandingPage/LandingPageContainer.js
+++ b/resources/assets/components/Page/LandingPage/LandingPageContainer.js
@@ -25,7 +25,6 @@ const mapStateToProps = (state) => {
     template: state.campaign.template,
     title: state.campaign.title,
     sidebar: landingPage.sidebar,
-    actionText: state.campaign.actionText,
   };
 };
 

--- a/resources/assets/components/Quiz/Quiz.js
+++ b/resources/assets/components/Quiz/Quiz.js
@@ -58,6 +58,9 @@ const Quiz = (props) => {
 
   const showResultingAction = () => {
     const action = find(fields.results, { id: selectedResult });
+    if (action) {
+      action.fields.content = `${fields.conclusion}\n${action.fields.content}`;
+    }
 
     return <ContentfulEntry json={action} />;
   };

--- a/resources/assets/components/Quiz/Quiz.js
+++ b/resources/assets/components/Quiz/Quiz.js
@@ -11,8 +11,7 @@ import { CallToActionContainer } from '../CallToAction';
 import DashboardContainer from '../Dashboard/DashboardContainer';
 import LedeBannerContainer from '../LedeBanner/LedeBannerContainer';
 import TabbedNavigationContainer from '../Navigation/TabbedNavigationContainer';
-import { ShareActionContainer } from '../ShareAction';
-import LinkActionContainer from '../Actions/LinkAction';
+import ContentfulEntry from '../ContentfulEntry';
 
 import './quiz.scss';
 
@@ -60,21 +59,7 @@ const Quiz = (props) => {
   const showResultingAction = () => {
     const action = find(fields.results, { id: selectedResult });
 
-    const actionProps = {
-      ...action.fields,
-      content: `${fields.conclusion}\n${action.fields.content}`,
-    };
-
-    switch (action.type.sys.id) {
-      case 'linkAction':
-        return <LinkActionContainer {...actionProps} />;
-
-      case 'shareAction':
-        return <ShareActionContainer {...actionProps} />;
-
-      default:
-        return null;
-    }
+    return <ContentfulEntry json={action} />;
   };
 
   if (shouldSeeResult) {

--- a/resources/assets/components/Quiz/Quiz.js
+++ b/resources/assets/components/Quiz/Quiz.js
@@ -2,16 +2,16 @@ import React from 'react';
 import { find } from 'lodash';
 import PropTypes from 'prop-types';
 
-import Markdown from '../Markdown';
 import Question from './Question';
-import Conclusion from './Conclusion';
+import Markdown from '../Markdown';
 import Enclosure from '../Enclosure';
+import Conclusion from './Conclusion';
 import { ShareContainer } from '../Share';
+import ContentfulEntry from '../ContentfulEntry';
 import { CallToActionContainer } from '../CallToAction';
 import DashboardContainer from '../Dashboard/DashboardContainer';
 import LedeBannerContainer from '../LedeBanner/LedeBannerContainer';
 import TabbedNavigationContainer from '../Navigation/TabbedNavigationContainer';
-import ContentfulEntry from '../ContentfulEntry';
 
 import './quiz.scss';
 

--- a/resources/assets/components/Revealer/index.js
+++ b/resources/assets/components/Revealer/index.js
@@ -1,21 +1,23 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import classnames from 'classnames';
+
+import SignupButton from '../SignupButton';
+import Button from '../Button/Button';
 
 import './revealer.scss';
 
 const Revealer = (props) => {
-  const { callToAction, isLoading, isVisible,
-    isSignedUp, onReveal, title } = props;
-
-  if (! isVisible) {
-    return null;
-  }
+  const { callToAction, isLoading, isSignedUp,
+    onReveal, title } = props;
 
   return (
     <div className="revealer">
       { callToAction ? <h1>{callToAction}</h1> : null }
-      <button disabled={isLoading} className={classnames('button', { 'is-loading': isLoading, 'is-cta': ! isSignedUp })} onClick={onReveal}>{title}</button>
+      { isSignedUp ? (
+        <Button isLoading={isLoading} onClick={onReveal} text={title} />
+      ) : (
+        <SignupButton className="is-cta" source="revealer" />
+      ) }
     </div>
   );
 };
@@ -23,7 +25,6 @@ const Revealer = (props) => {
 Revealer.propTypes = {
   callToAction: PropTypes.string,
   isLoading: PropTypes.bool,
-  isVisible: PropTypes.bool,
   isSignedUp: PropTypes.bool,
   onReveal: PropTypes.func,
   title: PropTypes.string,
@@ -32,7 +33,6 @@ Revealer.propTypes = {
 Revealer.defaultProps = {
   callToAction: null,
   isLoading: false,
-  isVisible: true,
   isSignedUp: false,
   onReveal: () => {},
   title: 'view more',

--- a/resources/assets/components/Revealer/index.js
+++ b/resources/assets/components/Revealer/index.js
@@ -1,5 +1,5 @@
-import PropTypes from 'prop-types';
 import React from 'react';
+import PropTypes from 'prop-types';
 import classnames from 'classnames';
 
 import './revealer.scss';

--- a/resources/assets/components/SignupButton/SignupButtonContainer.js
+++ b/resources/assets/components/SignupButton/SignupButtonContainer.js
@@ -1,18 +1,19 @@
 import { connect } from 'react-redux';
 import { PuckConnector } from '@dosomething/puck-client';
-import { clickedSignUp } from '../../actions/signup';
-import { convertExperiment } from '../../actions';
+
 import SignupButton from './SignupButton';
+import { convertExperiment } from '../../actions';
+import { clickedSignUp } from '../../actions/signup';
 
 
 /**
  * Provide state from the Redux store as props for this component.
  */
 const mapStateToProps = state => ({
-  template: state.campaign.template,
-  experiments: state.experiments,
   campaignActionText: state.campaign.actionText,
+  experiments: state.experiments,
   legacyCampaignId: state.campaign.legacyCampaignId,
+  template: state.campaign.template,
 });
 
 /**


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_


### What does this PR do?
This PR updates some entities to correctly grab the `type` as a string for an entity instead of grabbing a complete object (see images below). It also updates a few straggling `SignupButtonFactory`s that remained, so it's now officially wiped!

Entity type as an object (incorrect)
<img width="439" alt="screen shot 2018-03-07 at 5 24 56 pm" src="https://user-images.githubusercontent.com/105849/37161442-b2a84cb8-22c0-11e8-83ae-990ec2724ff9.png">

Entity type as a string (correct)
<img width="285" alt="screen shot 2018-03-07 at 5 24 24 pm" src="https://user-images.githubusercontent.com/105849/37161454-bae76314-22c0-11e8-9dc4-3105cc59d002.png">



### Any background context you want to provide?
- 5260b1a Updates entities to grab `type` as a string.
- 79e70f8 Removes the last straggling `SignupButtonFactory`s components in favor of `SignupButton` (missing `Revealer`, but @DFurnes is on that!)


