### PR TITLE
Lede banner design sixpack experiment

### DIFF
--- a/resources/assets/components/Experiment/Experiment.js
+++ b/resources/assets/components/Experiment/Experiment.js
@@ -1,8 +1,9 @@
 /* global window */
 
 import React from 'react';
-import PropTypes from 'prop-types';
 import { get } from 'lodash';
+import PropTypes from 'prop-types';
+
 import { assertTestPasses } from '../../helpers/experiments';
 
 class Experiment extends React.Component {

--- a/resources/assets/components/LedeBanner/LedeBannerAltB.js
+++ b/resources/assets/components/LedeBanner/LedeBannerAltB.js
@@ -1,0 +1,28 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import LegacyTemplate from './templates/LegacyTemplate';
+import MosaicTemplate from './templates/MosaicTemplate';
+import CoverTemplate from './templates/CoverTemplate';
+
+const LedeBanner = (props) => {
+  const { template } = props;
+
+  switch (template) {
+    case 'legacy':
+      return <LegacyTemplate {...props} />;
+
+    case 'cover':
+      return <CoverTemplate {...props} />;
+
+    default:
+      return <MosaicTemplate {...props} />;
+  }
+};
+
+LedeBanner.propTypes = {
+  template: PropTypes.string.isRequired,
+};
+
+
+export default LedeBanner;

--- a/resources/assets/components/LedeBanner/templates/CoverTemplate.js
+++ b/resources/assets/components/LedeBanner/templates/CoverTemplate.js
@@ -22,6 +22,9 @@ const CoverTemplate = (props) => {
 
   const blurb = 'Want to celebrate Black History Month by supporting diversity in TV and film? Take 5 minutes and you\'ll enter to win a $3000 scholarship.';
 
+  // Overriding with specific coverImage URL for A/B test.
+  coverImage.url = 'https://images.ctfassets.net/81iqaqpfd8fy/5u4wqT1Vte2SAWO0sK0oCS/78d47661fd65d2dc98235fe9fde221a6/grab-the-mic.png';
+
   const backgroundImageStyle = {
     backgroundImage: `url(${contentfulImageUrl(coverImage.url, '1440', '810', 'fill')})`,
   };

--- a/resources/assets/components/Page/LandingPage/LandingPage.js
+++ b/resources/assets/components/Page/LandingPage/LandingPage.js
@@ -42,7 +42,6 @@ const LandingPage = (props) => {
           affiliateSponsors={affiliateSponsors}
           signupArrowContent={signupArrowContent}
           showPartnerMsgOptIn={showPartnerMsgOptIn}
-          actionText={actionText}
         />
         <LedeBannerAltB
           experiment="lede_banner_design_variations"
@@ -59,7 +58,6 @@ const LandingPage = (props) => {
           affiliateSponsors={affiliateSponsors}
           signupArrowContent={signupArrowContent}
           showPartnerMsgOptIn={showPartnerMsgOptIn}
-          actionText={actionText}
         />
       </ExperimentContainer>
 

--- a/resources/assets/components/Page/LandingPage/LandingPage.js
+++ b/resources/assets/components/Page/LandingPage/LandingPage.js
@@ -5,8 +5,8 @@ import PropTypes from 'prop-types';
 import { PuckWaypoint } from '@dosomething/puck-client';
 
 import Enclosure from '../../Enclosure';
-import { convertExperiment } from '../../actions';
 import ExperimentContainer from '../../Experiment';
+import { convertExperiment } from '../../../actions';
 import LedeBanner from '../../LedeBanner/LedeBanner';
 import PitchTemplate from './templates/PitchTemplate';
 import LedeBannerAltB from '../../LedeBanner/LedeBannerAltB';
@@ -26,7 +26,7 @@ const LandingPage = (props) => {
 
   return (
     <div>
-      <ExperimentContainer>
+      <ExperimentContainer name="lede_banner_design_variations">
         <LedeBanner
           experiment="lede_banner_design_variations"
           alternative="mosaic"

--- a/resources/assets/components/Page/LandingPage/LandingPage.js
+++ b/resources/assets/components/Page/LandingPage/LandingPage.js
@@ -5,8 +5,11 @@ import PropTypes from 'prop-types';
 import { PuckWaypoint } from '@dosomething/puck-client';
 
 import Enclosure from '../../Enclosure';
+import { convertExperiment } from '../../actions';
+import ExperimentContainer from '../../Experiment';
 import LedeBanner from '../../LedeBanner/LedeBanner';
 import PitchTemplate from './templates/PitchTemplate';
+import LedeBannerAltB from '../../LedeBanner/LedeBannerAltB';
 import CallToActionContainer from '../../CallToAction/CallToActionContainer';
 
 import './landing-page.scss';
@@ -23,19 +26,42 @@ const LandingPage = (props) => {
 
   return (
     <div>
-      <LedeBanner
-        isAffiliated={isAffiliated}
-        title={title}
-        subtitle={subtitle}
-        blurb={blurb}
-        coverImage={coverImage}
-        legacyCampaignId={legacyCampaignId}
-        endDate={endDate}
-        template={template}
-        affiliateSponsors={affiliateSponsors}
-        signupArrowContent={signupArrowContent}
-        showPartnerMsgOptIn={showPartnerMsgOptIn}
-      />
+      <ExperimentContainer>
+        <LedeBanner
+          experiment="lede_banner_design_variations"
+          alternative="mosaic"
+          convert={convertExperiment}
+          isAffiliated={isAffiliated}
+          title={title}
+          subtitle={subtitle}
+          blurb={blurb}
+          coverImage={coverImage}
+          legacyCampaignId={legacyCampaignId}
+          endDate={endDate}
+          template={template}
+          affiliateSponsors={affiliateSponsors}
+          signupArrowContent={signupArrowContent}
+          showPartnerMsgOptIn={showPartnerMsgOptIn}
+          actionText={actionText}
+        />
+        <LedeBannerAltB
+          experiment="lede_banner_design_variations"
+          alternative="cover"
+          convert={convertExperiment}
+          isAffiliated={isAffiliated}
+          title={title}
+          subtitle={subtitle}
+          blurb={blurb}
+          coverImage={coverImage}
+          legacyCampaignId={legacyCampaignId}
+          endDate={endDate}
+          template="cover"
+          affiliateSponsors={affiliateSponsors}
+          signupArrowContent={signupArrowContent}
+          showPartnerMsgOptIn={showPartnerMsgOptIn}
+          actionText={actionText}
+        />
+      </ExperimentContainer>
 
       <div className="clearfix bg-white">
         <Enclosure className="default-container margin-lg pitch-landing-page">

--- a/resources/assets/experiments.json
+++ b/resources/assets/experiments.json
@@ -1,4 +1,15 @@
 {
+  "lede_banner_design_variations": {
+    "meta": {
+      "preTest": {
+        "campaign.allowExperiments": true
+      }
+    },
+    "alternatives": {
+      "a": "mosaic",
+      "b": "cover"
+    }
+  },
   "competitions_prompt_style": {
     "meta": {
       "preTest": {

--- a/resources/assets/experiments.json
+++ b/resources/assets/experiments.json
@@ -3,7 +3,8 @@
     "meta": {
       "preTest": {
         "campaign.allowExperiments": true
-      }
+      },
+      "convertOnSignupIntent": true
     },
     "alternatives": {
       "a": "mosaic",


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?
This PR adds a Sixpack A/B test for the `LedeBanner` to showcase the new "cover" design as an alternative test in a lede banner experiment. This experiment will affect _ALL_ campaigns, so the prior script in #736 removed experiment participation in all campaigns and I only re-enabled it for _Grab The Mic_.

Alternative A (default - mosaic)
![screen shot 2018-03-08 at 2 24 10 pm](https://user-images.githubusercontent.com/105849/37171670-9c2ee278-22dc-11e8-92ea-3b656bad32b9.png)


Alternative B (cover)
![screen shot 2018-03-08 at 2 24 21 pm](https://user-images.githubusercontent.com/105849/37171673-a13f1e36-22dc-11e8-8379-4b93b85fa580.png)



### What are the relevant tickets/cards?
Fixes [Pivotal ID #155479845](https://www.pivotaltracker.com/story/show/155479845)


