### PR TITLE
Landing page sweeeeep

### DIFF
--- a/resources/assets/components/LedeBanner/LedeBannerContainer.js
+++ b/resources/assets/components/LedeBanner/LedeBannerContainer.js
@@ -14,6 +14,8 @@ const mapStateToProps = state => ({
   endDate: state.campaign.endDate,
   isAffiliated: state.signups.thisCampaign,
   affiliateSponsors: state.campaign.affiliateSponsors,
+  signupArrowContent: get(state.campaign.additionalContent, 'signupArrowContent', null),
+  showPartnerMsgOptIn: get(state.campaign.additionalContent, 'displayAffilitateOptOut', false),
   subtitle: state.campaign.callToAction,
   template: state.campaign.template,
   title: state.campaign.title,

--- a/resources/assets/components/Page/LandingPage/LandingPage.js
+++ b/resources/assets/components/Page/LandingPage/LandingPage.js
@@ -5,37 +5,20 @@ import PropTypes from 'prop-types';
 import { PuckWaypoint } from '@dosomething/puck-client';
 
 import Enclosure from '../../Enclosure';
-import LedeBanner from '../../LedeBanner/LedeBanner';
 import PitchTemplate from './templates/PitchTemplate';
 import CallToActionContainer from '../../CallToAction/CallToActionContainer';
+import LedeBannerContainer from '../../LedeBanner/LedeBannerContainer';
 
 import './landing-page.scss';
 
 const LandingPage = (props) => {
-  const {
-    affiliateSponsors, blurb, coverImage,
-    endDate, isAffiliated, legacyCampaignId, pitchContent,
-    sidebar, showPartnerMsgOptIn, signupArrowContent,
-    subtitle, tagline, template, title,
-  } = props;
+  const { pitchContent, sidebar, tagline } = props;
 
   const sidebarCTA = sidebar[0] && sidebar[0].fields;
 
   return (
     <div>
-      <LedeBanner
-        isAffiliated={isAffiliated}
-        title={title}
-        subtitle={subtitle}
-        blurb={blurb}
-        coverImage={coverImage}
-        legacyCampaignId={legacyCampaignId}
-        endDate={endDate}
-        template={template}
-        affiliateSponsors={affiliateSponsors}
-        signupArrowContent={signupArrowContent}
-        showPartnerMsgOptIn={showPartnerMsgOptIn}
-      />
+      <LedeBannerContainer />
 
       <div className="clearfix bg-white">
         <Enclosure className="default-container margin-lg pitch-landing-page">
@@ -58,36 +41,13 @@ const LandingPage = (props) => {
 };
 
 LandingPage.propTypes = {
-  blurb: PropTypes.string,
-  coverImage: PropTypes.shape({
-    description: PropTypes.string,
-    url: PropTypes.string,
-  }).isRequired,
-  endDate: PropTypes.shape({
-    date: PropTypes.string,
-    timezone: PropTypes.string,
-    timezone_type: PropTypes.number,
-  }),
-  isAffiliated: PropTypes.bool,
-  affiliateSponsors: PropTypes.array.isRequired, // eslint-disable-line react/forbid-prop-types
-  legacyCampaignId: PropTypes.string.isRequired,
   pitchContent: PropTypes.string.isRequired,
-  showPartnerMsgOptIn: PropTypes.bool,
-  signupArrowContent: PropTypes.string,
-  subtitle: PropTypes.string.isRequired,
   tagline: PropTypes.string,
-  template: PropTypes.string.isRequired,
-  title: PropTypes.string.isRequired,
   sidebar: PropTypes.arrayOf(PropTypes.object),
 };
 
 LandingPage.defaultProps = {
-  blurb: null,
-  endDate: null,
-  isAffiliated: false,
   tagline: 'Ready to start?',
-  signupArrowContent: null,
-  showPartnerMsgOptIn: false,
   sidebar: null,
 };
 

--- a/resources/assets/components/Page/LandingPage/LandingPageContainer.js
+++ b/resources/assets/components/Page/LandingPage/LandingPageContainer.js
@@ -11,19 +11,7 @@ const mapStateToProps = (state) => {
 
   return {
     pitchContent: landingPage.content,
-    blurb: state.campaign.blurb,
-    coverImage: state.campaign.coverImage,
-    dashboard: state.campaign.dashboard,
-    endDate: state.campaign.endDate,
-    isAffiliated: state.signups.thisCampaign,
-    affiliateSponsors: state.campaign.affiliateSponsors,
-    legacyCampaignId: state.campaign.legacyCampaignId,
-    showPartnerMsgOptIn: get(state.campaign.additionalContent, 'displayAffilitateOptOut', false),
-    signupArrowContent: get(state.campaign.additionalContent, 'signupArrowContent', null),
-    subtitle: state.campaign.callToAction,
     tagline: get(state.campaign.additionalContent, 'tagline'),
-    template: state.campaign.template,
-    title: state.campaign.title,
     sidebar: landingPage.sidebar,
   };
 };


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_


I was doing some work on the Landing Page, and could not resist the temptation to sweep the heck out of it and utilize the `LedeBannerContainer` instead of all those repetitive props. It's literally the same exact thing, just added in two new props to the LedeBanner container that I guess before would only show up in the LedeBanner on the landing page but were only relevant to the Signup button, and thus only admins would've seen the disparity.
