### PR TITLE
Documentation and quick fix

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -13,6 +13,7 @@
   + [Routing](development/features/routing.md)
   + [Sixpack A/B Testing](development/features/sixpack-ab-testing.md)
   + [Traffic Distribution](development/features/traffic-distribution.md)
+  + [Modal Launcher](development/features/modal-launcher.md)
 - [Contributing](development/contributing.md)
 
 

--- a/docs/development/features/README.md
+++ b/docs/development/features/README.md
@@ -9,3 +9,4 @@ We've got loads of cool features we use for development within Phoenix (next). H
 
 ## Frontend Components
 - [Traffic Distribution](traffic-distribution.md)
+- [Modal Launcher](modal-launcher.md)

--- a/docs/development/features/modal-launcher.md
+++ b/docs/development/features/modal-launcher.md
@@ -1,0 +1,38 @@
+# Modal Launcher
+
+This feature allows for a pop up / modal (e.g. a survey, or some promotion) that is presented to the user after a specified amount of time.
+
+We use the ModalLauncher component to process the logic and set up the parameters for launching this component.
+
+It will conditionally launch the specified modal type, after the specified amount of time, under these conditions:
+
+- the user is logged in
+- the user has not dismissed the modal in 30 days (localstorage)
+- the user is not set to be hidden from the modal (localstorage)
+- the ENV (`.env`) is toggled to enable this specific modal feature (`[type in uppercase]_ENABLED=true`)
+
+## Usage Instructions
+
+Let's use our Survey example.
+
+If we only want to launch this Survey modal after 60 seconds and using the FUN_SURVEY_MODAL type:
+
+```jsx
+<ModalLauncher 
+  countdown={60}
+  type="fun_survey"
+  modalType="FUN_SURVEY_MODAL"
+/>
+```
+
+And viola! 
+
+Please note, that you are in charge of setting up the localstorage of user dismissal and hide feature fields. They should be set in the following format:
+
+(assuming use of the [`set`](https://git.io/vAhRx) storage helper)
+
+- `set('[user id]_dismissed_[modal feature name]', 'timestamp', Date.now())`
+- `set('[user id]_hide_[modal feature name]', 'boolean', true)`
+
+You can also have the 'hide' data stored automatically by redirecting the user to any page on PN with the following query parameter:
+`hide_[modal feature name]=1`

--- a/docs/development/features/modal-launcher.md
+++ b/docs/development/features/modal-launcher.md
@@ -27,7 +27,7 @@ If we only want to launch this FUN_SURVEY_MODAL modal type after 60 seconds:
 
 And viola! 
 
-## Please Note
+## Considerations
 
 Please note, that you are in charge of setting up the localstorage to track user dismissal and whether to hide the specific modal feature. This should be set in the following format:
 

--- a/docs/development/features/modal-launcher.md
+++ b/docs/development/features/modal-launcher.md
@@ -4,7 +4,7 @@ This feature allows for a pop up / modal (e.g. a survey, or some promotion) that
 
 We use the ModalLauncher component to process the logic and set up the parameters for launching this component.
 
-It will conditionally launch the specified modal type, after the specified amount of time, under these conditions:
+It will launch the specified modal type, after the specified amount of time, under these conditions:
 
 - the user is logged in
 - the user has not dismissed the modal in 30 days (localstorage)
@@ -15,7 +15,7 @@ It will conditionally launch the specified modal type, after the specified amoun
 
 Let's use our Survey example.
 
-If we only want to launch this Survey modal after 60 seconds and using the FUN_SURVEY_MODAL type:
+If we only want to launch this FUN_SURVEY_MODAL modal type after 60 seconds:
 
 ```jsx
 <ModalLauncher 
@@ -27,7 +27,9 @@ If we only want to launch this Survey modal after 60 seconds and using the FUN_S
 
 And viola! 
 
-Please note, that you are in charge of setting up the localstorage of user dismissal and hide feature fields. They should be set in the following format:
+## Please Note
+
+Please note, that you are in charge of setting up the localstorage to track user dismissal and whether to hide the specific modal feature. This should be set in the following format:
 
 (assuming use of the [`set`](https://git.io/vAhRx) storage helper)
 

--- a/resources/assets/components/ModalLauncher/ModalLauncher.js
+++ b/resources/assets/components/ModalLauncher/ModalLauncher.js
@@ -1,10 +1,8 @@
-/* global window */
-
 import React from 'react';
 import PropTypes from 'prop-types';
 
 import { get, set } from '../../helpers/storage';
-import { isTimestampValid, env } from '../../helpers';
+import { isTimestampValid, env, query } from '../../helpers';
 
 class ModalLauncher extends React.Component {
   constructor(props) {
@@ -12,11 +10,8 @@ class ModalLauncher extends React.Component {
 
     this.shouldSeeModal = this.shouldSeeModal.bind(this);
 
-    // If the query params indicate to store the feature modal to be hidden
-    // (including a legacy format for NPS Typeform Survey), store it.
-    if (window.location.search === '?finished_nps=1') {
-      set(`${props.userId}_finished_survey`, 'boolean', true);
-    } else if (window.location.search === `?hide_${props.type}=1`) {
+    // If the query params indicate to store the feature modal to be hidden, store it.
+    if (query(`hide_${props.type}`) === '1') {
       set(`${props.userId}_hide_${props.type}`, 'boolean', true);
     }
   }


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_



### What does this PR do?
This PR
- adds documentation for the `ModalLauncher` feature
- quick update to the `modalLauncher` to use the `query` helper method for param stuff and removing a soon to be defunct param for nps survey modal feature