### PR TITLE
Fixing postReportbackUploader and affirmation

### DIFF
--- a/resources/assets/components/Affirmation/Affirmation.js
+++ b/resources/assets/components/Affirmation/Affirmation.js
@@ -10,7 +10,7 @@ import { ShareContainer } from '../Share';
 import './affirmation.scss';
 
 const Affirmation = ({ closeModal, content }) => (
-  <Card className="affirmation rounded" title="Thanks for joining us!" onClose={closeModal}>
+  <Card className="affirmation rounded" title="Thanks for joining us!">
     <Markdown className="padded">{content.quote}</Markdown>
     <Flex className="flex-align-center">
       <FlexCell className="affirmation__cta padded" width="half">
@@ -26,7 +26,6 @@ const Affirmation = ({ closeModal, content }) => (
 );
 
 Affirmation.propTypes = {
-  closeModal: PropTypes.func.isRequired,
   content: PropTypes.shape({
     header: PropTypes.string,
     photo: PropTypes.string,

--- a/resources/assets/components/Affirmation/Affirmation.js
+++ b/resources/assets/components/Affirmation/Affirmation.js
@@ -9,7 +9,7 @@ import { ShareContainer } from '../Share';
 
 import './affirmation.scss';
 
-const Affirmation = ({ closeModal, content }) => (
+const Affirmation = ({ content }) => (
   <Card className="affirmation rounded" title="Thanks for joining us!">
     <Markdown className="padded">{content.quote}</Markdown>
     <Flex className="flex-align-center">

--- a/resources/assets/components/Modal/containers/PostReportbackModalContainer.js
+++ b/resources/assets/components/Modal/containers/PostReportbackModalContainer.js
@@ -5,7 +5,7 @@ import { closeModal } from '../../../actions/modal';
 
 const mapStateToProps = (state) => {
   const reportbackUploader = find(
-    state.campaign.actionSteps, { type: { sys: { id: 'photoUploaderAction' } } },
+    state.campaign.actionSteps, { type: 'photoUploaderAction' },
   );
 
   return {


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_



### What does this PR do?
This PR
- uses the correct `type` field when finding the `photoUploaderAction` from state. Based on the fix to `type`s in Contentful Entries in #739 
- removes the `closeModal` prop from the `Affirmation`, since that's now being added through a `modalControls` wrapper.