### PR TITLE
Test source-specific copy overrides on signup button.

### DIFF
--- a/resources/assets/components/SignupButton/SignupButton.js
+++ b/resources/assets/components/SignupButton/SignupButton.js
@@ -1,13 +1,25 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
+import { get } from 'lodash';
+
 import { convertOnSignupIntent } from '../../helpers/sixpack';
 
 const SignupButton = (props) => {
-  const { campaignActionText, className, clickedSignUp, experiments, source,
-    template, text, trackEvent, legacyCampaignId, convertExperiment } = props;
+  const { campaignActionText, sourceActionText, className, clickedSignUp, experiments, source,
+    template, text, trackEvent, trafficSource, legacyCampaignId, convertExperiment } = props;
 
-  const buttonText = text || campaignActionText;
+  // A/B Test: If a user has a traffic source, test different button language!
+  let sourceOverride = null;
+  if (trafficSource) {
+    sourceOverride = get(sourceActionText, trafficSource);
+
+    // @TODO ...
+  }
+
+  // In descending priority: button-specific text prop, source-specific override,
+  // campaign action text override, or standard "Take Action" copy.
+  const buttonText = text || sourceOverride || campaignActionText;
 
   const convertExperiments = () => {
     Object.keys(experiments).forEach((experiment) => {
@@ -37,6 +49,7 @@ const SignupButton = (props) => {
 SignupButton.propTypes = {
   text: PropTypes.string,
   campaignActionText: PropTypes.string,
+  sourceActionText: PropTypes.string,
   className: PropTypes.string,
   clickedSignUp: PropTypes.func.isRequired,
   convertExperiment: PropTypes.func.isRequired,
@@ -44,14 +57,17 @@ SignupButton.propTypes = {
   legacyCampaignId: PropTypes.string.isRequired,
   source: PropTypes.string.isRequired,
   template: PropTypes.string,
+  trafficSource: PropTypes.string,
   trackEvent: PropTypes.func.isRequired,
 };
 
 SignupButton.defaultProps = {
   text: null,
   campaignActionText: 'Take Action',
+  sourceActionText: null,
   className: null,
   template: null,
+  trafficSource: null,
 };
 
 export default SignupButton;

--- a/resources/assets/components/SignupButton/SignupButtonContainer.js
+++ b/resources/assets/components/SignupButton/SignupButtonContainer.js
@@ -1,5 +1,6 @@
 import { connect } from 'react-redux';
 import { PuckConnector } from '@dosomething/puck-client';
+import { get } from 'lodash';
 
 import SignupButton from './SignupButton';
 import { convertExperiment } from '../../actions';
@@ -11,9 +12,11 @@ import { clickedSignUp } from '../../actions/signup';
  */
 const mapStateToProps = state => ({
   campaignActionText: state.campaign.actionText,
+  sourceActionText: get(state, 'campaign.additionalContent.sourceActionText'),
   experiments: state.experiments,
   legacyCampaignId: state.campaign.legacyCampaignId,
   template: state.campaign.template,
+  trafficSource: state.user.source,
 });
 
 /**

--- a/resources/assets/experiments.json
+++ b/resources/assets/experiments.json
@@ -46,5 +46,17 @@
       "a": "legacy_landing_page",
       "b": "landing_page_alt"
     }
+  },
+  "source_signup_button": {
+    "meta": {
+      "preTest": {
+        "campaign.allowExperiments": true
+      },
+      "convertOnSignupIntent": true
+    },
+    "alternatives": {
+      "a": "default_signup_copy",
+      "b": "source_signup_copy"
+    }
   }
 }


### PR DESCRIPTION
### What does this PR do?
This PR adds the ability to specify source-specific copy overrides on the signup button.

![screen shot 2018-03-12 at 1 19 31 pm](https://user-images.githubusercontent.com/583202/37298936-3b03c7d8-25f8-11e8-9763-5be4ebcf6891.png)

__Note:__ This will _only_ opt users into an experiment if they have a `utm_source` and there is a `sourceActionText` key-value mapping set in the JSON field on that campaign, and then convert once they click the "signup button"!

### Any background context you want to provide?
N/A

### What are the relevant tickets/cards?
[#155625023](https://www.pivotaltracker.com/story/show/155625023)


### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
- [ ] Added screenshot to PR description of related front-end updates on **small** screens.
- [ ] Added screenshot to PR description of related front-end updates on **medium** screens.
- [ ] Added screenshot to PR description of related front-end updates on **large** screens.