### PR TITLE
Hide member gallery if the user is not signed up

### DIFF
--- a/resources/assets/components/Page/ActionPage/ActionSteps.js
+++ b/resources/assets/components/Page/ActionPage/ActionSteps.js
@@ -98,7 +98,7 @@ const ActionSteps = (props) => {
     ));
   }
 
-  if (template === 'legacy' || ! hasActivityFeed) {
+  if (isSignedUp && (template === 'legacy' || ! hasActivityFeed)) {
     stepComponents.push(renderLegacyGallery());
   }
 


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_


### What does this PR do?
This PR hides the Member Gallery if the user is not signed up for the campaign.
[Slack](https://dosomething.slack.com/archives/C3ASB4204/p1520948094000357)