### PR TITLE
Some cleanups to experiments.

### DIFF
--- a/resources/assets/experiments.json
+++ b/resources/assets/experiments.json
@@ -11,42 +11,6 @@
       "b": "cover"
     }
   },
-  "competitions_prompt_style": {
-    "meta": {
-      "preTest": {
-        "signups.thisCampaign": true,
-        "competitions.thisCampaign": false
-      }
-    },
-    "alternatives": {
-      "a": "default_block",
-      "b": "colorful_block"
-    }
-  },
-  "scholarship_cta_copy": {
-    "meta": {
-      "preTest": {
-        "signups.thisCampaign": false
-      }
-    },
-    "alternatives": {
-      "a": "default",
-      "b": "get_started",
-      "c": "apply_now"
-    }
-  },
-  "landing_page": {
-    "meta": {
-      "preTest": {
-        "campaign.allowExperiments": true
-      },
-      "convertOnSignupIntent": true
-    },
-    "alternatives": {
-      "a": "legacy_landing_page",
-      "b": "landing_page_alt"
-    }
-  },
   "source_signup_button": {
     "meta": {
       "preTest": {

--- a/resources/assets/experiments.json
+++ b/resources/assets/experiments.json
@@ -2,6 +2,7 @@
   "lede_banner_design_variations": {
     "meta": {
       "preTest": {
+        "campaign.slug": "grab-mic",
         "campaign.allowExperiments": true
       },
       "convertOnSignupIntent": true

--- a/resources/assets/helpers/experiments.js
+++ b/resources/assets/helpers/experiments.js
@@ -20,7 +20,7 @@ export function assertTestPasses(test, state) {
     const value = values[index];
 
     // Check if the test matches the app state.
-    if (! get(state, key, false) === value) {
+    if (get(state, key, false) !== value) {
       return false;
     }
   }


### PR DESCRIPTION
### What does this PR do?
This pull request makes a few cleanups/fixes to experiments:

🎤 Only run the lede banner experiment on Grab The Mic! We shouldn't have to turn off _all_ experiments in order to have this run on one campaign.

🗑 Remove old experiments that are no longer running from `experiments.json`.

❗️ Fixes an issue where we'd compare `!A === B`, which would only work for boolean pre-tests. By swapping that to check `A !== B`, we can test `"grab-mic" !== "current-slug"`.

### Any background context you want to provide?
This is a final round of clean-up for my work on the traffic-source test.

### What are the relevant tickets/cards?
[#155625023](https://www.pivotaltracker.com/story/show/155625023)

### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
- [ ] Added screenshot to PR description of related front-end updates on **small** screens.
- [ ] Added screenshot to PR description of related front-end updates on **medium** screens.
- [ ] Added screenshot to PR description of related front-end updates on **large** screens.