### PR TITLE
Contentful Migration - LinkAction `buttonText` field

### DIFF
--- a/contentful/migrations/2018_03_14_001_add_button_text_field_to_link_action.js
+++ b/contentful/migrations/2018_03_14_001_add_button_text_field_to_link_action.js
@@ -1,0 +1,10 @@
+module.exports = function (migration) {
+  const linkAction = migration.editContentType('linkAction');
+
+  linkAction.createField('buttonText')
+    .name('Button Text')
+    .type('Symbol')
+    .required(false);
+
+  linkAction.moveField('buttonText').afterField('link');
+}


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

![image](https://user-images.githubusercontent.com/12417657/37420655-a9010552-278d-11e8-8f92-365a6188a8c3.png)

### What does this PR do?
This PR adds a contentful migration that creates an optional `buttonText` field for the Link Action Contentful model.


### Any background context you want to provide?
This will be an optional field that - if filled out, will cause a button link to appear in the link action instead of the embed link.



### What are the relevant tickets/cards?
[Pivotal #155866139](https://www.pivotaltracker.com/story/show/155866139)
