### PR TITLE
Add support for gallery to ContentfulEntry, and more!

### DIFF
--- a/resources/assets/components/ContentfulEntry/ContentfulEntry.js
+++ b/resources/assets/components/ContentfulEntry/ContentfulEntry.js
@@ -9,6 +9,7 @@ import ReportbackBlock from '../ReportbackBlock';
 import NotFound from '../NotFound';
 import { CampaignUpdateContainer } from '../CampaignUpdate';
 import CallToActionContainer from '../CallToAction/CallToActionContainer';
+import { PostGalleryContainer } from '../Gallery/PostGallery';
 import { parseContentfulType } from '../../helpers';
 import {
   renderCompetitionStep, renderPhotoUploader, renderSubmissionGallery,
@@ -71,6 +72,9 @@ const ContentfulEntry = ({
           title={json.fields.title}
         />
       );
+
+    case 'gallery':
+      return <PostGalleryContainer />;
 
     case 'affirmation':
       return renderAffirmation(json);

--- a/resources/assets/components/ContentfulEntry/ContentfulEntry.js
+++ b/resources/assets/components/ContentfulEntry/ContentfulEntry.js
@@ -6,7 +6,7 @@ import Quiz from '../Quiz';
 import { ContentfulEntryJson } from '../../types';
 import StaticBlock from '../StaticBlock';
 import ReportbackBlock from '../ReportbackBlock';
-import PlaceholderBlock from '../PlaceholderBlock';
+import NotFound from '../NotFound';
 import { CampaignUpdateContainer } from '../CampaignUpdate';
 import CallToActionContainer from '../CallToAction/CallToActionContainer';
 import { parseContentfulType } from '../../helpers';
@@ -99,7 +99,7 @@ const ContentfulEntry = ({ json = DEFAULT_BLOCK, stepIndex, isSignedUp }: Conten
       return renderContentBlock(json, stepIndex);
 
     default:
-      return <PlaceholderBlock />;
+      return <NotFound />;
   }
 };
 

--- a/resources/assets/components/ContentfulEntry/ContentfulEntry.js
+++ b/resources/assets/components/ContentfulEntry/ContentfulEntry.js
@@ -21,7 +21,9 @@ const DEFAULT_BLOCK: ContentfulEntryJson = { fields: { type: null } };
 
 type ContentfulEntryProps = { json: ContentfulEntryJson, stepIndex: number, isSignedUp: boolean };
 
-const ContentfulEntry = ({ json = DEFAULT_BLOCK, stepIndex, isSignedUp }: ContentfulEntryProps) => {
+const ContentfulEntry = ({
+  json = DEFAULT_BLOCK, stepIndex = 1, isSignedUp,
+}: ContentfulEntryProps) => {
   const type = parseContentfulType(json);
 
   switch (type) {

--- a/resources/assets/components/ContentfulEntry/ContentfulEntry.test.js
+++ b/resources/assets/components/ContentfulEntry/ContentfulEntry.test.js
@@ -29,10 +29,10 @@ test('it can display a reportback block', () => {
 
 test('it should display a placeholder for an unknown block type', () => {
   const wrapper = shallow(<ContentfulEntry json={{ id: '12345', type: 'tongue_cat' }} />);
-  expect(wrapper.find('PlaceholderBlock')).toHaveLength(1);
+  expect(wrapper.find('NotFound')).toHaveLength(1);
 });
 
 test('it should display a placeholder for an empty block', () => {
   const wrapper = shallow(<ContentfulEntry />);
-  expect(wrapper.find('PlaceholderBlock')).toHaveLength(1);
+  expect(wrapper.find('NotFound')).toHaveLength(1);
 });

--- a/resources/assets/components/Markdown/index.js
+++ b/resources/assets/components/Markdown/index.js
@@ -9,12 +9,20 @@ const pattern = /\/\/images\.contentful\.com.+\.(jpg|png)/g;
 const contentfulImageFormat = url => (contentfulImageUrl(url, '1000'));
 const formatImageUrls = string => (string.replace(pattern, contentfulImageFormat));
 
-const Markdown = ({ className = null, children }) => (
-  <div className={classnames('markdown', 'with-lists', className)} dangerouslySetInnerHTML={markdown(formatImageUrls(children))} /> // eslint-disable-line react/no-danger
-);
+const Markdown = ({ className = null, children }) => {
+  // When directly writing content into this component, React may pass it as an
+  // array of strings. If so, combine them to get the Markdown source!
+  const sourceMarkdown = Array.isArray(children) ? children.join('') : children;
+  const html = markdown(formatImageUrls(sourceMarkdown));
+
+  return <div className={classnames('markdown', 'with-lists', className)} dangerouslySetInnerHTML={html} />; // eslint-disable-line react/no-danger
+};
 
 Markdown.propTypes = {
-  children: PropTypes.string.isRequired,
+  children: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.arrayOf(PropTypes.string),
+  ]).isRequired,
   className: PropTypes.string,
 };
 

--- a/resources/assets/components/NotFound.js
+++ b/resources/assets/components/NotFound.js
@@ -1,15 +1,20 @@
 import React from 'react';
-import { BlockWrapper } from '../components/Block';
-import { Flex, FlexCell } from '../components/Flex';
+
+import Card from '../components/Card';
+import Markdown from '../components/Markdown';
+
+const zendeskUrl = 'https://help.dosomething.org/hc/en-us/articles/115016093488-Help-The-page-I-m-looking-for-says-Page-Not-Found-';
 
 const NotFound = () => (
-  <Flex>
-    <FlexCell>
-      <BlockWrapper className="placeholder">
-        404, Not Found! :(
-      </BlockWrapper>
-    </FlexCell>
-  </Flex>
+  <Card title="Not Found" className="rounded bordered">
+    <Markdown className="padded">
+      __We searched our site, but couldn&apos;t find what you were looking for.__
+      Try [Grab the Mic](/us/campaigns/grab-mic?utm_source=404) and join our movement
+      to create the most civically active generation ever.
+
+      You can also try [our homepage](/) or [reach out]({zendeskUrl}) to us.
+    </Markdown>
+  </Card>
 );
 
 export default NotFound;

--- a/resources/assets/scss/chrome.scss
+++ b/resources/assets/scss/chrome.scss
@@ -8,6 +8,11 @@
   &.-lock {
     position: fixed;
   }
+
+  &.-plain .wrapper {
+    background: none;
+    box-shadow: none;
+  }
 }
 
 .main {

--- a/resources/assets/scss/container.scss
+++ b/resources/assets/scss/container.scss
@@ -7,7 +7,6 @@ $soft-box-shadow: 0px 1px 4px 1px rgba(0, 0, 0, 0.2);
 
 .container {
   &.-framed {
-    background-color: $white;
     margin-top: $base-spacing;
     overflow: hidden;
     padding: $section-spacing 0;
@@ -18,8 +17,6 @@ $soft-box-shadow: 0px 1px 4px 1px rgba(0, 0, 0, 0.2);
     }
 
     @include media($tablet) {
-      border-radius: $lg-border-radius;
-      box-shadow: $soft-box-shadow;
       max-width: $container-max-width;
       margin: $section-spacing auto;
 

--- a/resources/views/errors/404.blade.php
+++ b/resources/views/errors/404.blade.php
@@ -1,26 +1,24 @@
 @extends('layouts.takeover')
 
 @section('content')
-    <div class="chrome">
+    <div class="chrome -plain">
         <div class="wrapper">
-            <a class="construction__logo" href="http://dosomething.org"></a>
             <section class="container -framed">
-                <div class="wrapper">
-                    <div class="container__block -centered">
-                        <h2 class="heading -alpha">Page Not Found</h2>
-                        <h3>We couldn't find what you were looking for. </h3>
-                    </div>
-                    <div class="container__block -centered">
+                <article class="card rounded bordered">
+                    <header class="card__title"><h1>Not Found</h1></header>
+                    <div class="markdown with-lists padded">
                         <p>
-                            We searched our site, but couldn't find what you were looking for. Try
-                            <a href="{{ url('/us/campaigns/grab-mic?utm_source=404') }}">Grab the Mic</a>
+                            <strong>We searched our site, but couldn't find what you were looking for.</strong>
+                            Try <a href="{{ url('/us/campaigns/grab-mic?utm_source=404') }}">Grab the Mic</a>
                             and join our movement to create the most civically active generation ever.
+                        </p>
+                        <p>
                             You can also try <a href="{{ url('/') }}">our homepage</a> or
                             <a href="https://help.dosomething.org/hc/en-us/articles/115016093488-Help-The-page-I-m-looking-for-says-Page-Not-Found-">
                             reach out</a> to us.
                         </p>
                     </div>
-                </div>
+                </article>
             </section>
         </div>
     </div>


### PR DESCRIPTION
### What does this PR do?
This PR adds a few little touch-ups, and starts up gallery work for text reportbacks:

🚴 Makes our [Not Found page](https://user-images.githubusercontent.com/583202/37433344-e4439804-27b1-11e8-97a3-c1fe4fbb08db.png) look [less weird](https://user-images.githubusercontent.com/583202/37433323-d655b830-27b1-11e8-9109-e811e934ff20.png), and the same on server 404s & client 404s.

📃 Fixes an unlikely issue rendering Markdown with variable interpolation.

🔢 Sets a default "step index" of `1` for linking to blocks that require that. [Like this](https://user-images.githubusercontent.com/583202/37433378-160f2646-27b2-11e8-801f-e3ea63ff27ab.png)!

🖼 Allows `ContentfulEntry` to [render a gallery block](https://user-images.githubusercontent.com/583202/37433304-c4868800-27b1-11e8-9062-f72f55b9d04c.png).

### Any background context you want to provide?
Sometimes I just idly refactor things during staff meeting... sshhh!

### What are the relevant tickets/cards?
The last commit is relevant to [#155944555](https://www.pivotaltracker.com/story/show/155944555).


### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
- [ ] Added screenshot to PR description of related front-end updates on **small** screens.
- [ ] Added screenshot to PR description of related front-end updates on **medium** screens.
- [ ] Added screenshot to PR description of related front-end updates on **large** screens.