### PR TITLE
Moving the referrals export redirect under the second alert message

### DIFF
--- a/resources/assets/components/AdminDashboard/CampaignDashboard/CampaignDashboard.js
+++ b/resources/assets/components/AdminDashboard/CampaignDashboard/CampaignDashboard.js
@@ -17,9 +17,9 @@ const CampaignDashboard = (props) => {
   const onReferralExportClick = () => {
     const message = 'Please confirm your intent to export this data. This will permanently mark the records as already exported and cannot be undone.';
     if (confirm(message)) { // eslint-disable-line no-alert
-      window.location.href = '/next/referrals/export';
       const downloadSizeMessage = 'Please note: the max export size is 150 records at a time, so if your exported file contains that amount of rows, you may need to repeat the download to receive the rest of the records';
       alert(downloadSizeMessage); // eslint-disable-line no-alert
+      window.location.href = '/next/referrals/export';
     }
   };
 


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_


### What does this PR do?
Frustratingly, though on local it worked, on staging, the redirect seems to run and cancel out the second alert. (Though I'm not completely sure why I put in under the redirect to begin with 🤔)