### PR TITLE
Embed patch

### DIFF
--- a/app/Http/Controllers/EmbedController.php
+++ b/app/Http/Controllers/EmbedController.php
@@ -3,8 +3,8 @@
 namespace App\Http\Controllers;
 
 use Embed\Embed;
-use Embed\Http\CurlDispatcher;
 use Illuminate\Http\Request;
+use Embed\Http\CurlDispatcher;
 use Illuminate\Http\JsonResponse;
 
 class EmbedController extends Controller
@@ -27,11 +27,11 @@ class EmbedController extends Controller
         ]);
 
         $info = remember('embed.' . md5($url), 60, function () use ($url, $dispatcher) {
-                try {
-                    return Embed::create($url, null, $dispatcher);
-                } catch (\Exception $exception) {
-                    return 'Embed Request Unsuccessful. Error: '.$exception->getMessage();
-                }
+            try {
+                return Embed::create($url, null, $dispatcher);
+            } catch (\Exception $exception) {
+                return 'Embed Request Unsuccessful. Error: '.$exception->getMessage();
+            }
         });
 
         if (gettype($info) === 'string') {
@@ -50,7 +50,6 @@ class EmbedController extends Controller
                 'code' => $info->type === 'video' ? $info->code : null,
             ];
         }
-
     }
 
     /**

--- a/resources/assets/components/Embed/index.js
+++ b/resources/assets/components/Embed/index.js
@@ -38,6 +38,8 @@ class Embed extends React.Component {
           </Figure>
         </a>
       );
+    } else if (this.state.requestFailed) {
+      embed = <a href={this.props.url}>{this.props.url}</a>;
     }
 
     return (


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_


### What does this PR do?
This PR
- adds a custom dispatch configuration to the `Embed` object we create, so that we timeout requests way earlier.
- adding a `catch` to the `Embed` construction so that we can cache bad requests and timeouts (we catch the thrown exception, and cache the error message so that we don't repeatedly try this request again in a short time span)
- adding a case to the `Embed` component on the front end, to simply output a link in case the request fails.



### Any background context you want to provide?
This is a super quick patch so we can fix this and not lost RBs for team-dream tonight!


### What are the relevant tickets/cards?
[#156024745](https://www.pivotaltracker.com/story/show/156024745)
[Slack - this message above and below for context](https://dosomething.slack.com/archives/C2BPA7M8F/p1521146734000553)
