### PR TITLE
Adding migration to create text submission action content type.

### DIFF
--- a/contentful/migrations/2018_03_15_001_add_text_submission_action_content_type.js
+++ b/contentful/migrations/2018_03_15_001_add_text_submission_action_content_type.js
@@ -1,0 +1,42 @@
+module.exports = function (migration) {
+  const textSubmissionAction = migration.createContentType('textSubmissionAction')
+    .name('Text Submission Action')
+    .description('Action block for submitting text reportback posts.')
+    .displayField('internalTitle');
+
+  textSubmissionAction.createField('internalTitle')
+    .name('Internal Title')
+    .type('Symbol')
+    .required(true)
+    .localized(false);
+
+  textSubmissionAction.createField('title')
+    .name('Title')
+    .type('Symbol')
+    .required(false)
+    .localized(true);
+
+  textSubmissionAction.createField('textFieldLabel')
+    .name('Text Field Label')
+    .type('Symbol')
+    .required(false)
+    .localized(true);
+
+  textSubmissionAction.createField('textFieldPlaceholder')
+    .name('Text Field Placeholder Message')
+    .type('Symbol')
+    .required(false)
+    .localized(true);
+
+  textSubmissionAction.createField('buttonText')
+    .name('Button Text')
+    .type('Symbol')
+    .required(false)
+    .localized(true);
+
+  textSubmissionAction.createField('additionalContent')
+    .name('Additional Content')
+    .type('Object')
+    .required(false)
+    .localized(false);
+}


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_


### What does this PR do?
This PR adds a new Contentful migration script to add the new `textMigrationAction` content type into the system.

Since I don't know how to add character limit validations to fields via the API for the time being, I've excluded them and will add them via the Contentful UI. I've asked a question in the community portal to see if anyone knows if there's a way to do it programmatically.

### Any background context you want to provide?
![image](https://user-images.githubusercontent.com/105849/37491432-34bd0848-2874-11e8-80e2-22e6eb226d44.png)


### What are the relevant tickets/cards?
Refs [Pivotal ID #155866202](https://www.pivotaltracker.com/story/show/155866202)
