### PR TITLE
Quiz custom completion button

### DIFF
--- a/resources/assets/components/Quiz/Quiz.js
+++ b/resources/assets/components/Quiz/Quiz.js
@@ -18,7 +18,7 @@ import './quiz.scss';
 const Quiz = (props) => {
   const { id, fields, data, dashboard, completeQuiz,
     pickQuizAnswer, trackEvent, showLedeBanner,
-    completionButtonText } = props;
+    submitButtonText } = props;
   const { error, shouldSeeResult, selectedResult } = data;
 
   const introduction = shouldSeeResult ? null : (
@@ -45,7 +45,7 @@ const Quiz = (props) => {
         onClick={() => completeQuiz(id)}
         className="button quiz__submit"
       >
-        {completionButtonText || Quiz.defaultProps.completionButtonText}
+        {submitButtonText || Quiz.defaultProps.submitButtonText}
       </button>
     </Conclusion>
   );
@@ -128,7 +128,7 @@ Quiz.propTypes = {
   completeQuiz: PropTypes.func.isRequired,
   pickQuizAnswer: PropTypes.func.isRequired,
   showLedeBanner: PropTypes.bool.isRequired,
-  completionButtonText: PropTypes.string,
+  submitButtonText: PropTypes.string,
   trackEvent: PropTypes.func.isRequired,
 };
 
@@ -147,7 +147,7 @@ Quiz.defaultProps = {
     comparison: '',
     callToAction: '',
   },
-  completionButtonText: 'get results',
+  submitButtonText: 'get results',
 };
 
 export default Quiz;

--- a/resources/assets/components/Quiz/Quiz.js
+++ b/resources/assets/components/Quiz/Quiz.js
@@ -17,7 +17,8 @@ import './quiz.scss';
 
 const Quiz = (props) => {
   const { id, fields, data, dashboard, completeQuiz,
-    pickQuizAnswer, trackEvent, showLedeBanner } = props;
+    pickQuizAnswer, trackEvent, showLedeBanner,
+    completionButtonText } = props;
   const { error, shouldSeeResult, selectedResult } = data;
 
   const introduction = shouldSeeResult ? null : (
@@ -43,7 +44,9 @@ const Quiz = (props) => {
       <button
         onClick={() => completeQuiz(id)}
         className="button quiz__submit"
-      >get results</button>
+      >
+        {completionButtonText || Quiz.defaultProps.completionButtonText}
+      </button>
     </Conclusion>
   );
 
@@ -125,6 +128,7 @@ Quiz.propTypes = {
   completeQuiz: PropTypes.func.isRequired,
   pickQuizAnswer: PropTypes.func.isRequired,
   showLedeBanner: PropTypes.bool.isRequired,
+  completionButtonText: PropTypes.string,
   trackEvent: PropTypes.func.isRequired,
 };
 
@@ -143,6 +147,7 @@ Quiz.defaultProps = {
     comparison: '',
     callToAction: '',
   },
+  completionButtonText: 'get results',
 };
 
 export default Quiz;

--- a/resources/assets/components/Quiz/Quiz.test.js
+++ b/resources/assets/components/Quiz/Quiz.test.js
@@ -21,6 +21,7 @@ test('it should display a placeholder quiz', () => {
       startQuiz={() => {}}
       trackEvent={() => {}}
       pickQuizAnswer={() => {}}
+      showLedeBanner={false}
     />,
   );
 

--- a/resources/assets/components/Quiz/QuizContainer.js
+++ b/resources/assets/components/Quiz/QuizContainer.js
@@ -36,7 +36,7 @@ const mapStateToProps = (state, ownProps) => {
     fields: quizFields,
     data: quizData,
     dashboard: state.campaign.dashboard,
-    completionButtonText: get(quizFields, 'additionalContent.completionButtonText'),
+    submitButtonText: get(quizFields, 'additionalContent.submitButtonText'),
     showLedeBanner: get(quizFields, 'additionalContent.showLedeBanner', true),
   };
 };

--- a/resources/assets/components/Quiz/QuizContainer.js
+++ b/resources/assets/components/Quiz/QuizContainer.js
@@ -36,6 +36,7 @@ const mapStateToProps = (state, ownProps) => {
     fields: quizFields,
     data: quizData,
     dashboard: state.campaign.dashboard,
+    completionButtonText: get(quizFields, 'additionalContent.completionButtonText'),
     showLedeBanner: get(quizFields, 'additionalContent.showLedeBanner', true),
   };
 };


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_



### What does this PR do?
This PR adds a `submitButtonText` field to the Quiz to allow for customizing the 'Get Results' button at the end of a Quiz

(Also added a quick prop to a failing quiz test)


### What are the relevant tickets/cards?
[Pivotal #155866154](https://www.pivotaltracker.com/story/show/155866154)
