### PR TITLE
Connecting text submission action entity to component

### DIFF
--- a/resources/assets/components/ContentfulEntry/ContentfulEntry.js
+++ b/resources/assets/components/ContentfulEntry/ContentfulEntry.js
@@ -14,7 +14,7 @@ import { parseContentfulType } from '../../helpers';
 import {
   renderCompetitionStep, renderPhotoUploader, renderSubmissionGallery,
   renderThirdPartyAction, renderContentBlock, renderVoterRegistrationAction,
-  renderShareAction, renderLinkAction, renderAffirmation,
+  renderShareAction, renderLinkAction, renderAffirmation, renderTextSubmissionAction,
 } from './renderers';
 
 // If no block is passed, just render an empty "placeholder".
@@ -28,6 +28,9 @@ const ContentfulEntry = ({
   const type = parseContentfulType(json);
 
   switch (type) {
+    case 'affirmation':
+      return renderAffirmation(json);
+
     case 'callToAction':
       return (
         <CallToActionContainer
@@ -53,6 +56,22 @@ const ContentfulEntry = ({
         />
       );
 
+    case 'competition':
+      return renderCompetitionStep(json);
+
+    case 'contentBlock':
+      return renderContentBlock(json, stepIndex);
+
+    case 'gallery':
+      return <PostGalleryContainer />;
+
+    case 'linkAction':
+      return renderLinkAction(json);
+
+    case 'photoUploaderAction':
+    case 'photo-uploader':
+      return renderPhotoUploader(json, isSignedUp);
+
     case 'quiz':
       return <Quiz />;
 
@@ -64,6 +83,9 @@ const ContentfulEntry = ({
         />
       );
 
+    case 'shareAction':
+      return renderShareAction(json);
+
     case 'static':
       return (
         <StaticBlock
@@ -73,36 +95,17 @@ const ContentfulEntry = ({
         />
       );
 
-    case 'gallery':
-      return <PostGalleryContainer />;
-
-    case 'affirmation':
-      return renderAffirmation(json);
-
-    case 'competition':
-      return renderCompetitionStep(json);
-
-    case 'photoUploaderAction':
-    case 'photo-uploader':
-      return renderPhotoUploader(json, isSignedUp);
-
     case 'submission-gallery':
       return renderSubmissionGallery(isSignedUp);
+
+    case 'textSubmissionAction':
+      return renderTextSubmissionAction(json);
 
     case 'third-party-action':
       return renderThirdPartyAction(json, stepIndex);
 
     case 'voterRegistrationAction':
       return renderVoterRegistrationAction(json, stepIndex);
-
-    case 'shareAction':
-      return renderShareAction(json);
-
-    case 'linkAction':
-      return renderLinkAction(json);
-
-    case 'contentBlock':
-      return renderContentBlock(json, stepIndex);
 
     default:
       return <NotFound />;

--- a/resources/assets/components/ContentfulEntry/renderers.js
+++ b/resources/assets/components/ContentfulEntry/renderers.js
@@ -198,7 +198,7 @@ export function renderTextSubmissionAction(data) {
     <div key={`text-submission-action-${contentfulId}`} className="margin-horizontal-md">
       <PuckWaypoint name="text_submission_action-top" waypointData={{ contentfulId }} />
       <TextSubmissionActionContainer {...data.fields} />
-      <PuckWaypoint name="text_submission_action-top" waypointData={{ contentfulId }} />
+      <PuckWaypoint name="text_submission_action-bottom" waypointData={{ contentfulId }} />
     </div>
   );
 }

--- a/resources/assets/components/ContentfulEntry/renderers.js
+++ b/resources/assets/components/ContentfulEntry/renderers.js
@@ -1,14 +1,16 @@
 import React from 'react';
 import { PuckWaypoint } from '@dosomething/puck-client';
+
 import { ContentBlock } from '../Block';
-import VoterRegistrationActionContainer from '../actions/VoterRegistrationAction';
 import Affirmation from '../Affirmation';
-import { ThirdPartyActionContainer } from '../actions/ThirdPartyAction';
-import { ReportbackUploaderContainer } from '../ReportbackUploader';
-import { CompetitionBlockContainer } from '../CompetitionBlock';
-import { SubmissionGalleryContainer } from '../Gallery/SubmissionGallery';
 import { ShareActionContainer } from '../ShareAction';
 import LinkActionContainer from '../actions/LinkAction';
+import { CompetitionBlockContainer } from '../CompetitionBlock';
+import { ReportbackUploaderContainer } from '../ReportbackUploader';
+import { ThirdPartyActionContainer } from '../actions/ThirdPartyAction';
+import { SubmissionGalleryContainer } from '../Gallery/SubmissionGallery';
+import VoterRegistrationActionContainer from '../actions/VoterRegistrationAction';
+import TextSubmissionActionContainer from '../actions/TextSubmissionAction/TextSubmissionActionContainer';
 
 /**
  * Render a competition step.
@@ -179,6 +181,24 @@ export function renderLinkAction(step) {
       <PuckWaypoint name="link_action-top" waypointData={{ contentfulId }} />
       <LinkActionContainer {...step.fields} />
       <PuckWaypoint name="link_action-bottom" waypointData={{ contentfulId }} />
+    </div>
+  );
+}
+
+/**
+ * Render a link action.
+ *
+ * @param {Object} data
+ * @return {Component}
+ */
+export function renderTextSubmissionAction(data) {
+  const contentfulId = data.id;
+
+  return (
+    <div key={`text-submission-action-${contentfulId}`} className="margin-horizontal-md">
+      <PuckWaypoint name="text_submission_action-top" waypointData={{ contentfulId }} />
+      <TextSubmissionActionContainer {...data.fields} />
+      <PuckWaypoint name="text_submission_action-top" waypointData={{ contentfulId }} />
     </div>
   );
 }

--- a/resources/assets/components/actions/TextSubmissionAction/TextSubmissionAction.js
+++ b/resources/assets/components/actions/TextSubmissionAction/TextSubmissionAction.js
@@ -37,7 +37,7 @@ class TextSubmissionAction extends React.Component {
             </div>
             <p className="footnote">Your submission will be reviewed by a DoSomething.org staffer and added to our public gallery.</p>
           </div>
-          <input type="submit" defaultValue={this.props.buttonText} className="button" />
+          <input type="submit" defaultValue={this.props.buttonText} className="button" disabled />
         </form>
       </Card>
     );


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_


### What does this PR do?
This PR connects the data from the `TextSubmissionAction` entity, over into the `ContentfulEntry` component and associated renderer.

It also alphabetizes the list of cases when deciding which renderer to use 😉 

I also disabled the button on the `TextSubmissionAction` since it _could_ accidentally get added to a campaign page after this PR is merged and want it to be obvious that it can't be used just yet!


### Any background context you want to provide?
![image](https://user-images.githubusercontent.com/105849/37546104-c43258fc-2941-11e8-95d2-0a635bdc2d3a.png)



### What are the relevant tickets/cards?
Refs [Pivotal Tracker ID #155866202](https://www.pivotaltracker.com/story/show/155866202)
Refs #769 