### PR TITLE
Hide tabbed navigation phantom

### DIFF
--- a/resources/assets/components/Navigation/TabbedNavigationContainer.js
+++ b/resources/assets/components/Navigation/TabbedNavigationContainer.js
@@ -96,15 +96,21 @@ const TabbedNavigationContainer = (props) => {
     )
   );
 
+  const hideTabbedNavigation = (
+    shouldHideAction && shouldHideCommunity && ! additionalPages.length
+  );
+
   return (
-    <TabbedNavigation>
-      <div className="nav-items">
-        <ActionNavigationLink />
-        <CommunityNavigationLink />
-        { additionalPages }
-      </div>
-      { isAffiliated ? null : <SignupButton className="-inline nav-button" source="tabbed navigation" /> }
-    </TabbedNavigation>
+    hideTabbedNavigation ? null : (
+      <TabbedNavigation>
+        <div className="nav-items">
+          <ActionNavigationLink />
+          <CommunityNavigationLink />
+          { additionalPages }
+        </div>
+        { isAffiliated ? null : <SignupButton className="-inline nav-button" source="tabbed navigation" /> }
+      </TabbedNavigation>
+    )
   );
 };
 


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_



### What does this PR do?
This PR will update the `TabbedNavigationContainer`  to not render the `TabbedNavigation` component and associated children if there are no navigation links meant to be shown.


### Any background context you want to provide?
Bumped into a phantom fixed tabbed navigation, on a campaign with no displayed nav links.
![image](https://user-images.githubusercontent.com/12417657/37732899-c5ec59ca-2d1c-11e8-98df-1a96ff9355b6.png)
