### PR TITLE
adding contentful migration for new Quiz content type

### DIFF
--- a/contentful/migrations/2018_03_22_001_add_quiz_content_type.js
+++ b/contentful/migrations/2018_03_22_001_add_quiz_content_type.js
@@ -1,0 +1,31 @@
+module.exports = function (migration) {
+  const quiz = migration.createContentType('quiz')
+    .name('Quiz')
+    .description('Models a (BuzzFeed style) results oriented quiz')
+    .displayField('internalTitle');
+
+  quiz.createField('internalTitle')
+    .name('Internal Title')
+    .type('Symbol')
+    .required(true)
+    .localized(false);
+
+  quiz.createField('title')
+    .name('Title')
+    .type('Symbol')
+    .required(true)
+    .localized(true);
+
+  quiz.createField('slug')
+    .name('Slug')
+    .type('Symbol')
+    .required(true)
+    .validations([{'unique': true}])
+    .localized(false);
+
+  quiz.createField('additionalContent')
+    .name('Additional Content')
+    .type('Object')
+    .required(false)
+    .localized(false);
+}


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_


### What does this PR do?
This PR adds a new Contentful Migration CLI script to create a new `Quiz` content type with some basic fields.


### Any background context you want to provide?
I only added some of the obvious assured fields we're going to need, in favor of leaving most of the fields to be within `additionalContent` for now, until we solidify the way everything is going to work.


### What are the relevant tickets/cards?
[Pivotal #155783121](https://www.pivotaltracker.com/story/show/155783121)
#780 

![image](https://user-images.githubusercontent.com/12417657/37774897-d267cce8-2db7-11e8-9163-f1f24ed383b1.png)

