### PR TITLE
adding campaign quizzes field validation migration

### DIFF
--- a/contentful/migrations/2018_03_23_change_campaign_quizzes_field_to_allow_quiz.js
+++ b/contentful/migrations/2018_03_23_change_campaign_quizzes_field_to_allow_quiz.js
@@ -1,0 +1,10 @@
+module.exports = function (migration) {
+  const campaign = migration.editContentType('campaign');
+
+  campaign.editField('quizzes')
+    .validations([{
+      linkContentType: [
+        'quizBeta', 'quiz'
+      ],
+    }]);
+}


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_


### What does this PR do?
This PR adds a new Contentful Migration CLI script to edit the Campaigns `quizzes` field to allow linked `Quiz` entries!


### Any background context you want to provide?
This'll allow us to link to the new quiz content type!


### What are the relevant tickets/cards?
#780 
[Pivotal #155783121](https://www.pivotaltracker.com/story/show/155783121)

![image](https://user-images.githubusercontent.com/12417657/37837447-93a66efe-2e8b-11e8-811f-af83ef44f79d.png)

