### PR TITLE
Contentful Migrations update

### DIFF
--- a/contentful/migrations/2018_03_02_001_allow_blocks_in_pages.js
+++ b/contentful/migrations/2018_03_02_001_allow_blocks_in_pages.js
@@ -1,11 +1,16 @@
 module.exports = function (migration) {
   const block = migration.editContentType('campaign');
 
+  // https://www.contentfulcommunity.com/t/confusing-validations-error-from-the-migrations-cli/776/4
   block.editField('pages')
-    .validations([{
-      linkContentType: [
-        'campaignUpdate', 'customBlock', 'linkAction', 'page',
-        'photoUploaderAction', 'shareAction', 'voterRegistrationAction',
-      ],
-    }])
+    .items({
+      type: 'Link',
+      linkType: 'Entry',
+      .validations([{
+        linkContentType: [
+          'campaignUpdate', 'customBlock', 'linkAction', 'page',
+          'photoUploaderAction', 'shareAction', 'voterRegistrationAction',
+        ],
+      }]
+    });
 }

--- a/contentful/migrations/2018_03_02_001_allow_blocks_in_pages.js
+++ b/contentful/migrations/2018_03_02_001_allow_blocks_in_pages.js
@@ -1,7 +1,7 @@
 module.exports = function (migration) {
   const block = migration.editContentType('campaign');
 
-  // https://www.contentfulcommunity.com/t/confusing-validations-error-from-the-migrations-cli/776/4
+  // @see https://www.contentfulcommunity.com/t/confusing-validations-error-from-the-migrations-cli/776/4
   block.editField('pages')
     .items({
       type: 'Link',

--- a/contentful/migrations/2018_03_23_001_change_campaign_quizzes_field_to_allow_quiz.js
+++ b/contentful/migrations/2018_03_23_001_change_campaign_quizzes_field_to_allow_quiz.js
@@ -1,7 +1,7 @@
 module.exports = function (migration) {
   const campaign = migration.editContentType('campaign');
 
-  // https://www.contentfulcommunity.com/t/confusing-validations-error-from-the-migrations-cli/776/4
+  // @see https://www.contentfulcommunity.com/t/confusing-validations-error-from-the-migrations-cli/776/4
   campaign.editField('quizzes')
     .items({
       type: 'Link',

--- a/contentful/migrations/2018_03_23_001_change_campaign_quizzes_field_to_allow_quiz.js
+++ b/contentful/migrations/2018_03_23_001_change_campaign_quizzes_field_to_allow_quiz.js
@@ -1,10 +1,15 @@
 module.exports = function (migration) {
   const campaign = migration.editContentType('campaign');
 
+  // https://www.contentfulcommunity.com/t/confusing-validations-error-from-the-migrations-cli/776/4
   campaign.editField('quizzes')
-    .validations([{
-      linkContentType: [
-        'quizBeta', 'quiz'
-      ],
-    }]);
+    .items({
+      type: 'Link',
+      linkType: 'Entry',
+      validations: [{
+        linkContentType: [
+          'quizBeta', 'quiz'
+        ],
+      }]
+    });
 }


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_



### What does this PR do?
This PR updates two of our Contentful Migration scripts to work with the `validations` field quirk.


### Any background context you want to provide?
[Slack convo](https://dosomething.slack.com/archives/C3ASB4204/p1521821160000253)

Evidentally, we cannot set the `validations` field directly on a field that is an array, instead, one must use the `items` fields, and reset all the fields along with `validations`
https://www.contentfulcommunity.com/t/confusing-validations-error-from-the-migrations-cli/776/4


(The changes from these migrations have already been set manually on Contentful. This is just so we have a working backfill of these migrations).