### PR TITLE
Adding escape chars for valid JS regex

### DIFF
--- a/contentful/migrations/2018_03_26_001_change_validation_for_link_field_in_link_action.js
+++ b/contentful/migrations/2018_03_26_001_change_validation_for_link_field_in_link_action.js
@@ -5,7 +5,7 @@ module.exports = function (migration) {
   linkAction.editField('link')
     .validations([{
       regexp: {
-        pattern: '^((ftp|http|https):\/\/(\w+:{0,1}\w*@)?(\S+)(:[0-9]+)?(\/|\/([\w#!:.?+=&%@!\-\/]))?$|tel\:?\d[ -.]?\(?\d\d\d\)?[ -.]?\d\d\d[ -.]?\d\d\d\d$)',
+        pattern: '^((ftp|http|https):\\/\\/(\\w+:{0,1}\\w*@)?(\\S+)(:[0-9]+)?(\\/|\\/([\\w#!:.?+=&%@!\\-\\/]))?$|tel\\:?\\d[ -.]?\\(?\\d\\d\\d\\)?[ -.]?\\d\\d\\d[ -.]?\\d\\d\\d\\d$)',
       },
     }]);
 }


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

Everything remains the same. Just added some back-slash escapes since otherwise, it'll error out.
![image](https://user-images.githubusercontent.com/12417657/37923592-7dfb6568-30fd-11e8-92b6-5679083d266b.png)
