### PR TITLE
Handling multiple action storing

### DIFF
--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -8,8 +8,9 @@ use Illuminate\Auth\AuthenticationException;
 use Illuminate\Validation\ValidationException;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Symfony\Component\HttpKernel\Exception\HttpException;
-use Illuminate\Foundation\Exceptions\Handler as ExceptionHandler;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Illuminate\Foundation\Exceptions\Handler as ExceptionHandler;
+use DoSomething\Gateway\Exceptions\ValidationException as GatewayValidationException;
 
 class Handler extends ExceptionHandler
 {
@@ -94,6 +95,10 @@ class Handler extends ExceptionHandler
             $code = 422;
 
             $fields = $exception->validator->errors()->getMessages();
+        } elseif ($exception instanceof GatewayValidationException) {
+            $code = 422;
+
+            $fields = $exception->getErrors();
         } elseif ($exception instanceof AuthenticationException) {
             $code = 401;
         } else {

--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -8,8 +8,8 @@ use Illuminate\Auth\AuthenticationException;
 use Illuminate\Validation\ValidationException;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Symfony\Component\HttpKernel\Exception\HttpException;
-use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Illuminate\Foundation\Exceptions\Handler as ExceptionHandler;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use DoSomething\Gateway\Exceptions\ValidationException as GatewayValidationException;
 
 class Handler extends ExceptionHandler

--- a/app/Http/Controllers/Api/CampaignPostsController.php
+++ b/app/Http/Controllers/Api/CampaignPostsController.php
@@ -58,41 +58,10 @@ class CampaignPostsController extends Controller
      */
     public function store($id, PostRequest $request)
     {
-        // @TODO: Reactivate this once in upcoming pull request:
+        $request->merge(['campaign_id' => $id]);
 
-        // $this->validate($request, [
-        //     'media' => 'required',  //@TODO: add file|image
-        //     'caption' => 'required|min:4|max:60',
-        //     'impact' => 'required|integer|min:1',
-        //     'whyParticipated' => 'required',
-        // ]);
+        $data = $this->postRepository->storePost($request->all());
 
-        // $request->merge(['campaign_id' => $id]);
-
-        // // Append the Campaign Run ID to Request if Legacy Campaign
-        // if (is_legacy_id($id)) {
-        //     $legacyCampaign = $this->campaignRepository->findByLegacyCampaignId($id);
-        //     $legacyCampaign = $legacyCampaign->jsonSerialize();
-
-        //     $request->merge(['campaign_run_id' => $legacyCampaign['legacyCampaignRunId']]);
-        // }
-
-        // // @TODO: Rename the following items on the front-end so they more easily
-        // // match with the params Rogue is expecting and thus don't need to manipulate
-        // // these params here.
-        // $request->merge(['file' => $request->file('media')]);
-        // $request->offsetUnset('media');
-
-        // $request->merge(['quantity' => intval($request->input('impact'))]);
-        // $request->offsetUnset('impact');
-
-        // $request->merge(['why_participated' => $request->input('whyParticipated')]);
-        // $request->offsetUnset('whyParticipated');
-
-        // $data = $this->postRepository->storePost($request->all());
-
-        // return response()->json($data, 201);
-
-        return null;
+        return response()->json($data, 201);
     }
 }

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -36,6 +36,7 @@ class Kernel extends HttpKernel
             \App\Http\Middleware\VerifyCsrfToken::class,
             \Illuminate\Routing\Middleware\SubstituteBindings::class,
             \App\Http\Middleware\SetLocale::class,
+            \DoSomething\Gateway\Laravel\Middleware\RefreshTokenMiddleware::class,
         ],
 
         'api' => [

--- a/app/Http/Requests/PostRequest.php
+++ b/app/Http/Requests/PostRequest.php
@@ -28,6 +28,7 @@ class PostRequest extends FormRequest
             case 'text':
                 return [
                     'text.required' => 'The text field with your message is required.',
+                    'text.max' => 'The message may not be greater than :max characters.',
                 ];
 
             default:
@@ -54,7 +55,7 @@ class PostRequest extends FormRequest
 
             case 'text':
                 return [
-                    'text' => 'required',
+                    'text' => 'required|max:256',
                 ];
 
             default:

--- a/app/Repositories/PostRepository.php
+++ b/app/Repositories/PostRepository.php
@@ -56,11 +56,13 @@ class PostRepository
      */
     public function storePost($payload = [])
     {
-        unset($payload['media']);
+        if (array_has($payload, 'file')) {
+            unset($payload['media']);
 
-        // Guzzle expects specific file object for multipart form.
-        // @TODO: upadte Gateway to handle multipart form data.
-        $payload['file'] = fopen($payload['file']->getPathname(), 'r');
+            // Guzzle expects specific file object for multipart form.
+            // @TODO: upadte Gateway to handle multipart form data.
+            $payload['file'] = fopen($payload['file']->getPathname(), 'r');
+        }
 
         $multipartData = collect($payload)->map(function ($value, $key) {
             return ['name' => $key, 'contents' => $value];

--- a/resources/assets/actions/post.js
+++ b/resources/assets/actions/post.js
@@ -28,10 +28,11 @@ export function fetchCampaignPosts() {
 /**
  * Store posts for the specified campaign.
  *
+ * @param {String} id
  * @param  {FormData} data
  * @return {function}
  */
-export function storeCampaignPost(data) {
+export function storeCampaignPost(id, data) {
   if (! (data instanceof FormData)) {
     throw Error(`The supplied data must be an instance of FormData, instead it is an instance of ${data.constructor.name}.`);
   }
@@ -42,7 +43,7 @@ export function storeCampaignPost(data) {
     dispatch(apiRequest('POST', {
       token,
       body: data,
-      url: `${window.location.origin}/api/v2/campaigns/${data.get('campaignId')}/posts`,
+      url: `${window.location.origin}/api/v2/campaigns/${id}/posts`,
     }));
   };
 }

--- a/resources/assets/components/actions/TextSubmissionAction/TextSubmissionAction.js
+++ b/resources/assets/components/actions/TextSubmissionAction/TextSubmissionAction.js
@@ -10,7 +10,6 @@ import './text-submission-action.scss';
 
 class TextSubmissionAction extends React.Component {
   state = {
-    isWaiting: false,
     textValue: '',
   };
 
@@ -20,7 +19,6 @@ class TextSubmissionAction extends React.Component {
     const formData = new FormData();
 
     formData.append('action', this.props.action);
-    formData.append('campaignId', this.props.campaignId);
     formData.append('type', this.props.type);
     formData.append('text', this.state.textValue);
 
@@ -32,7 +30,7 @@ class TextSubmissionAction extends React.Component {
     }
 
     // Send this off to the backend API to validate and send off to Rogue.
-    this.props.storeCampaignPost(formData);
+    this.props.storeCampaignPost(this.props.campaignId, formData);
   }
 
   handleChange = (event) => {


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_


### What does this PR do?
This PR adds some updates to help with processing the text submission action when it is submitted. It gets validated by the `PostRequest` and then if all looks good continues on its way within the `store()` method on the `CampaignPostsController`, which passes it to the `storePost()` in the `PostRepository`. From here it gets prepped as a multipart form data and sent to Rogue and returns a response.


### Any background context you want to provide?
An update was made to the `Handler.php` as well, because we were only handling Laravel `ValidationException`s and not validation exceptions from Gateway (aliases as `GatewayValidationException`). So errors coming from Rogue were not being handled properly; `422` validation errors with its proper messaging was being turned into a `500` error with a generic server error message. But no longer!


### What are the relevant tickets/cards?
Refs [Pivotal ID #155866202](https://www.pivotaltracker.com/story/show/155866202)


### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
