### PR TITLE
Fix issue where arrays would be turned into objects.

### DIFF
--- a/app/Entities/Entity.php
+++ b/app/Entities/Entity.php
@@ -42,7 +42,7 @@ class Entity implements ArrayAccess, JsonSerializable
     {
         return collect($blocks)->map(function ($block) {
             return $this->parseBlock($block);
-        });
+        })->values();
     }
 
     /**


### PR DESCRIPTION
### What does this PR do?
This PR fixes an issue where we'd sometimes return block references as an object.

### Any background context you want to provide?
When we map over a collection that has `null` values, it gets encoded as an number-indexed object with the "null" values omitted (e.g. `{0: ..., 1: ..., 3: ...}`). By using [`values()`](https://laravel.com/docs/5.6/collections#method-values), we reset those indexes so it gets encoded as the correct JSON type.


### What are the relevant tickets/cards?
Fixes [#156347478](https://www.pivotaltracker.com/story/show/156347478). References [this Slack conversation](https://dosomething.slack.com/archives/C2BPA7M8F/p1522184708000223).


### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
- [ ] Added screenshot to PR description of related front-end updates on **small** screens.
- [ ] Added screenshot to PR description of related front-end updates on **medium** screens.
- [ ] Added screenshot to PR description of related front-end updates on **large** screens.