### PR TITLE
Quiz rendering

### DIFF
--- a/resources/assets/components/ContentfulEntry/ContentfulEntry.js
+++ b/resources/assets/components/ContentfulEntry/ContentfulEntry.js
@@ -12,7 +12,6 @@ import CallToActionContainer from '../CallToAction/CallToActionContainer';
 import CampaignGalleryBlockContainer from '../CampaignGalleryBlock/CampaignGalleryBlockContainer';
 import { parseContentfulType } from '../../helpers';
 import LegacyQuizContainer from '../LegacyQuiz/LegacyQuizContainer';
-
 import {
   renderCompetitionStep, renderPhotoUploader, renderSubmissionGallery,
   renderThirdPartyAction, renderContentBlock, renderVoterRegistrationAction,

--- a/resources/assets/components/ContentfulEntry/ContentfulEntry.js
+++ b/resources/assets/components/ContentfulEntry/ContentfulEntry.js
@@ -77,7 +77,7 @@ const ContentfulEntry = ({
       return <QuizContainer {...json.fields} />;
 
     case 'quizBeta':
-      return <LegacyQuizContainer />;
+      return <LegacyQuizContainer quizContent={json} />;
 
     // @TODO: Will be refactored when switching to Rogue!
     case 'reportbacks':

--- a/resources/assets/components/ContentfulEntry/ContentfulEntry.js
+++ b/resources/assets/components/ContentfulEntry/ContentfulEntry.js
@@ -2,7 +2,7 @@
 
 import React from 'react';
 
-import LegacyQuiz from '../LegacyQuiz';
+import QuizContainer from '../Quiz/QuizContainer';
 import { ContentfulEntryJson } from '../../types';
 import StaticBlock from '../StaticBlock';
 import ReportbackBlock from '../ReportbackBlock';
@@ -11,6 +11,8 @@ import { CampaignUpdateContainer } from '../CampaignUpdate';
 import CallToActionContainer from '../CallToAction/CallToActionContainer';
 import CampaignGalleryBlockContainer from '../CampaignGalleryBlock/CampaignGalleryBlockContainer';
 import { parseContentfulType } from '../../helpers';
+import LegacyQuizContainer from '../LegacyQuiz/LegacyQuizContainer';
+
 import {
   renderCompetitionStep, renderPhotoUploader, renderSubmissionGallery,
   renderThirdPartyAction, renderContentBlock, renderVoterRegistrationAction,
@@ -73,7 +75,10 @@ const ContentfulEntry = ({
       return renderPhotoUploader(json, isSignedUp);
 
     case 'quiz':
-      return <LegacyQuiz />;
+      return <QuizContainer {...json.fields} />;
+
+    case 'quizBeta':
+      return <LegacyQuizContainer />;
 
     // @TODO: Will be refactored when switching to Rogue!
     case 'reportbacks':

--- a/resources/assets/components/LegacyQuiz/LegacyQuiz.js
+++ b/resources/assets/components/LegacyQuiz/LegacyQuiz.js
@@ -4,21 +4,15 @@ import PropTypes from 'prop-types';
 
 import Question from './Question';
 import Markdown from '../Markdown';
-import Enclosure from '../Enclosure';
 import Conclusion from './Conclusion';
 import { ShareContainer } from '../Share';
 import ContentfulEntry from '../ContentfulEntry';
-import { CallToActionContainer } from '../CallToAction';
-import DashboardContainer from '../Dashboard/DashboardContainer';
-import LedeBannerContainer from '../LedeBanner/LedeBannerContainer';
-import TabbedNavigationContainer from '../Navigation/TabbedNavigationContainer';
 
 import './legacy-quiz.scss';
 
 const LegacyQuiz = (props) => {
-  const { id, fields, data, dashboard, completeQuiz,
-    pickQuizAnswer, trackEvent, showLedeBanner,
-    submitButtonText } = props;
+  const { id, fields, data, completeQuiz,
+    pickQuizAnswer, trackEvent, submitButtonText } = props;
   const { error, shouldSeeResult, selectedResult } = data;
 
   const introduction = shouldSeeResult ? null : (
@@ -75,30 +69,20 @@ const LegacyQuiz = (props) => {
   }
 
   return (
-    <div>
-      { showLedeBanner ? <LedeBannerContainer /> : null }
-      <div className="main clearfix">
-        { dashboard && showLedeBanner ? <DashboardContainer /> : null }
-        { showLedeBanner ? <TabbedNavigationContainer /> : null }
-        <Enclosure className="default-container margin-top-lg margin-bottom-lg">
-          <div className="quiz">
-            <div className="quiz__introduction">
-              <h1 className="quiz__subtitle">{fields.subtitle || LegacyQuiz.defaultProps.fields.subtitle}</h1>
-              <h2 className="quiz__title">{fields.title}</h2>
-              {introduction}
-            </div>
-
-            {questions}
-
-            {quizError}
-
-            {submitConclusion}
-
-            {fields.resultActions && selectedResult ? showResultingAction() : shareConclusion}
-          </div>
-        </Enclosure>
-        { showLedeBanner ? <CallToActionContainer sticky hideIfSignedUp /> : null }
+    <div className="quiz">
+      <div className="quiz__introduction">
+        <h1 className="quiz__subtitle">{fields.subtitle || LegacyQuiz.defaultProps.fields.subtitle}</h1>
+        <h2 className="quiz__title">{fields.title}</h2>
+        {introduction}
       </div>
+
+      {questions}
+
+      {quizError}
+
+      {submitConclusion}
+
+      {fields.resultActions && selectedResult ? showResultingAction() : shareConclusion}
     </div>
   );
 };
@@ -120,14 +104,8 @@ LegacyQuiz.propTypes = {
     questions: PropTypes.object,
     error: PropTypes.string,
   }).isRequired,
-  dashboard: PropTypes.shape({
-    id: PropTypes.string,
-    type: PropTypes.string,
-    fields: PropTypes.object,
-  }),
   completeQuiz: PropTypes.func.isRequired,
   pickQuizAnswer: PropTypes.func.isRequired,
-  showLedeBanner: PropTypes.bool.isRequired,
   submitButtonText: PropTypes.string,
   trackEvent: PropTypes.func.isRequired,
 };
@@ -138,7 +116,6 @@ LegacyQuiz.defaultProps = {
     questions: {},
     error: null,
   },
-  dashboard: null,
   fields: {
     subtitle: 'Quiz',
     introduction: '',

--- a/resources/assets/components/LegacyQuiz/LegacyQuizContainer.js
+++ b/resources/assets/components/LegacyQuiz/LegacyQuizContainer.js
@@ -1,6 +1,6 @@
 import { connect } from 'react-redux';
 import { PuckConnector } from '@dosomething/puck-client';
-import { get, find } from 'lodash';
+import { get } from 'lodash';
 import LegacyQuiz from './LegacyQuiz';
 import {
   pickWinner,
@@ -13,9 +13,7 @@ import { pickQuizAnswer, completeQuiz } from '../../actions/quiz';
  * Provide state from the Redux store as props for this component.
  */
 const mapStateToProps = (state, ownProps) => {
-  const { slug } = ownProps.match.params;
-
-  const quizContent = find(state.campaign.quizzes, { fields: { slug } });
+  const quizContent = ownProps.quizContent;
   const quizId = quizContent.id;
   const quizData = state.quiz[quizId];
   let quizFields = quizContent.fields;
@@ -35,9 +33,7 @@ const mapStateToProps = (state, ownProps) => {
     id: quizId,
     fields: quizFields,
     data: quizData,
-    dashboard: state.campaign.dashboard,
     submitButtonText: get(quizFields, 'additionalContent.submitButtonText'),
-    showLedeBanner: get(quizFields, 'additionalContent.showLedeBanner', true),
   };
 };
 

--- a/resources/assets/components/Page/BlockPage/BlockPageContainer.js
+++ b/resources/assets/components/Page/BlockPage/BlockPageContainer.js
@@ -6,9 +6,9 @@ import { findContentfulEntry } from '../../../helpers';
  * Provide state from the Redux store as props for this component.
  */
 const mapStateToProps = (state, ownProps) => {
-  const { id } = ownProps.match.params;
+  const { id, slug } = ownProps.match.params;
 
-  const json = findContentfulEntry(state, id);
+  const json = findContentfulEntry(state, (id || slug));
 
   return { json };
 };

--- a/resources/assets/components/Page/CampaignPage/CampaignPage.js
+++ b/resources/assets/components/Page/CampaignPage/CampaignPage.js
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 import { Switch, Route, Redirect } from 'react-router-dom';
 
 import { FeedContainer } from '../../Feed'; // @TODO: rename to ActivityFeed or ActivityPage...
+import { LegacyQuizContainer } from '../../LegacyQuiz';
 import BlockPageContainer from '../BlockPage';
 import { isCampaignClosed } from '../../../helpers';
 import { ActionPageContainer } from '../ActionPage';
@@ -63,7 +64,7 @@ const CampaignPage = (props) => {
           />
           <Route path={`${match.url}/pages/:slug`} component={CampaignSubPageContainer} />
           <Route path={`${match.url}/blocks/:id`} component={BlockPageContainer} />
-          <Route path={`${match.url}/quiz/:slug`} component={BlockPageContainer} />
+          <Route path={`${match.url}/quiz/:slug`} component={LegacyQuizContainer} />
           <Route
             path={`${match.url}/modal/:id`}
             render={(routingProps) => {

--- a/resources/assets/components/Page/CampaignPage/CampaignPage.js
+++ b/resources/assets/components/Page/CampaignPage/CampaignPage.js
@@ -4,7 +4,6 @@ import PropTypes from 'prop-types';
 import { Switch, Route, Redirect } from 'react-router-dom';
 
 import { FeedContainer } from '../../Feed'; // @TODO: rename to ActivityFeed or ActivityPage...
-import { LegacyQuizContainer } from '../../LegacyQuiz';
 import BlockPageContainer from '../BlockPage';
 import { isCampaignClosed } from '../../../helpers';
 import { ActionPageContainer } from '../ActionPage';
@@ -64,7 +63,7 @@ const CampaignPage = (props) => {
           />
           <Route path={`${match.url}/pages/:slug`} component={CampaignSubPageContainer} />
           <Route path={`${match.url}/blocks/:id`} component={BlockPageContainer} />
-          <Route path={`${match.url}/quiz/:slug`} component={LegacyQuizContainer} />
+          <Route path={`${match.url}/quiz/:slug`} component={BlockPageContainer} />
           <Route
             path={`${match.url}/modal/:id`}
             render={(routingProps) => {

--- a/resources/assets/helpers/index.js
+++ b/resources/assets/helpers/index.js
@@ -439,17 +439,26 @@ export function query(key, url = window.location) {
 }
 
 /**
- * Find an entry from within the campaign by given ID param.
+ * Find an entry from within the campaign by given ID or Slug param.
  * (Returns false if not found).
  *
  * @param  {Object} state
- * @param  {String} id
+ * @param  {String} identifier
  * @return {Object|Undefined}
  */
-export function findContentfulEntry(state, id) {
-  return find(state.campaign.pages, { id })
-    || find(state.campaign.actionSteps, { id })
-    || find(state.campaign.activityFeed, { id });
+export function findContentfulEntry(state, identifier) {
+  const campaign = state.campaign;
+
+  const contentfulEntries = [].concat(
+    campaign.actionSteps,
+    campaign.activityFeed,
+    campaign.pages,
+    campaign.quizzes,
+  );
+
+  return find(contentfulEntries, entry => (
+    entry.id === identifier || entry.fields.slug === identifier
+  ));
 }
 
 /**


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_


### What does this PR do?
This PR adds rendering support for the brand new Quiz ⚡️

- updating the `FindContentfulEntry` helper method to work with a general `identifier` param, and find either by slug or id
- updating the `BlockPageContainer` to pass both `id` and `slug` from `match` params
- updating the `/quiz` route to render a `BlockPageContainer`
- adding cases to the `ContentfulEntry` to handle rendering a beta/legacy or new/regular Quiz
- updating LegacyQuiz to work with this new format

## Edit:
~Whoops, there are some issues with the `LegacyQuiz` straight up rendering as a `ContentfulEntry` in a BlockPage. Changed things back so that we're rendering the LegacyQuiz from the `/quiz` route.~
Nope. Made some changes to the LegacyQuiz so that it can indeed render nicely through `BlockPagesContainer`, and `ContentfulEntry`. So now we've got backward compatibility and can use either quiz on Contentful.

### What are the relevant tickets/cards?
Refs #780 
[Pivotal #155783121](https://www.pivotaltracker.com/story/show/155783121)
