### PR TITLE
bumping the traffic dist for voter reg modal to 50 percent

### DIFF
--- a/resources/assets/components/Campaign/Campaign.js
+++ b/resources/assets/components/Campaign/Campaign.js
@@ -26,7 +26,7 @@ const Campaign = props => (
     </TrafficDistribution>
 
     { props.featureFlags && props.featureFlags.showVoterRegistrationModal ? (
-      <TrafficDistribution percentage={10} feature="voter_reg_modal">
+      <TrafficDistribution percentage={50} feature="voter_reg_modal">
         <ModalLauncherContainer
           type="voter_reg_modal"
           countdown={30}


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

Bumping up the Traffic Distribution percentage from `10` to `50` percent for the `voter_reg_modal` timed modal feature.

[Slack Convo](https://dosomething.slack.com/archives/C2BPA7M8F/p1522429592000392)