### PR TITLE
Add loading indicator for GraphQL gallery pagination.

### DIFF
--- a/resources/assets/components/CampaignGalleryBlock/CampaignGalleryBlock.js
+++ b/resources/assets/components/CampaignGalleryBlock/CampaignGalleryBlock.js
@@ -10,9 +10,7 @@ import { ReportbackItem } from '../ReportbackItem';
 const CampaignGalleryBlock = (props) => {
   const { loading, postsByCampaignId, loadMorePosts } = props;
 
-  return loading ? (
-    <div className="spinner -centered" />
-  ) : (
+  return (
     <div>
       <Gallery type="triad" className="expand-horizontal-md">
         {postsByCampaignId.map(post => (
@@ -27,8 +25,7 @@ const CampaignGalleryBlock = (props) => {
           </Card>
         ))}
       </Gallery>
-      { /* TODO: Use `networkStatus` to differentiate initial load from subsequent ones? (https://goo.gl/UnWbak) */ }
-      <LoadMore className="padding-lg text-centered" text="view more" onClick={loadMorePosts} isLoading={false} />
+      <LoadMore className="padding-lg text-centered" text="view more" onClick={loadMorePosts} isLoading={loading} />
     </div>
   );
 };

--- a/resources/assets/components/CampaignGalleryBlock/CampaignGalleryBlockContainer.js
+++ b/resources/assets/components/CampaignGalleryBlock/CampaignGalleryBlockContainer.js
@@ -6,6 +6,7 @@ import gql from 'graphql-tag';
 
 import CampaignGalleryBlock from './CampaignGalleryBlock';
 import ErrorBlock from '../ErrorBlock/ErrorBlock';
+import { NetworkStatus } from '../../constants';
 
 /**
  * Provide state from the Redux store as props for this component. (In
@@ -47,7 +48,7 @@ const CampaignGalleryQuery = ({ campaignId }) => (
   >
     {({ data, error, networkStatus, variables, fetchMore }) => {
       // On initial load, just display a loading spinner.
-      if (networkStatus === 1) {
+      if (networkStatus === NetworkStatus.LOADING) {
         return <div className="spinner -centered" />;
       }
 
@@ -59,7 +60,7 @@ const CampaignGalleryQuery = ({ campaignId }) => (
       return (
         <CampaignGalleryBlock
           postsByCampaignId={data.postsByCampaignId}
-          loading={networkStatus === 3}
+          loading={networkStatus === NetworkStatus.FETCH_MORE}
           loadMorePosts={() => fetchMore({
             variables: {
               // The value in `variables.page` doesn't get updated here on

--- a/resources/assets/components/CampaignGalleryBlock/CampaignGalleryBlockContainer.js
+++ b/resources/assets/components/CampaignGalleryBlock/CampaignGalleryBlockContainer.js
@@ -1,8 +1,11 @@
+import React from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { graphql } from 'react-apollo';
+import { Query } from 'react-apollo';
 import gql from 'graphql-tag';
 
 import CampaignGalleryBlock from './CampaignGalleryBlock';
+import ErrorBlock from '../ErrorBlock/ErrorBlock';
 
 /**
  * Provide state from the Redux store as props for this component. (In
@@ -15,7 +18,7 @@ const mapStateToProps = state => ({
 /**
  * The GraphQL query to load data for this component.
  */
-const query = gql`
+const POST_GALLERY_QUERY = gql`
   query PostGallery($campaignId: String!, $count: Int, $page: Int) {
     postsByCampaignId(id: $campaignId, count: $count, page: $page) {
       id
@@ -34,45 +37,58 @@ const query = gql`
 `;
 
 /**
- * Customize the GraphQL query using the given props.
+ * Fetch results via GraphQL using a query component.
  */
-const queryOptions = props => ({
-  variables: {
-    campaignId: props.campaignId,
-    count: 9,
-    page: 1,
-  },
-});
-
-/**
- * Provide results of the GraphQL query as props for this component.
- */
-const mapResultToProps = ({ data: { loading, postsByCampaignId, variables, fetchMore } }) => ({
-  loading,
-  postsByCampaignId,
-  loadMorePosts: () => fetchMore({
-    variables: {
-      // The value in `variables.page` doesn't get updated here on
-      // subsequent clicks, so we have to recalculate each time...
-      page: (postsByCampaignId.length / variables.count) + 1,
-    },
-    updateQuery: (previousResult, { fetchMoreResult }) => {
-      if (! fetchMoreResult.postsByCampaignId) {
-        return previousResult;
+const CampaignGalleryQuery = ({ campaignId }) => (
+  <Query
+    query={POST_GALLERY_QUERY}
+    variables={{ campaignId, count: 9, page: 1 }}
+    notifyOnNetworkStatusChange
+  >
+    {({ data, error, networkStatus, variables, fetchMore }) => {
+      // On initial load, just display a loading spinner.
+      if (networkStatus === 1) {
+        return <div className="spinner -centered" />;
       }
 
-      return {
-        ...previousResult,
-        postsByCampaignId: [
-          ...previousResult.postsByCampaignId,
-          ...fetchMoreResult.postsByCampaignId,
-        ],
-      };
-    },
-  }),
-});
+      if (error) {
+        console.error(`CampaignGalleryQuery ERROR: ${error}`);
+        return <ErrorBlock />;
+      }
+
+      return (
+        <CampaignGalleryBlock
+          postsByCampaignId={data.postsByCampaignId}
+          loading={networkStatus === 3}
+          loadMorePosts={() => fetchMore({
+            variables: {
+              // The value in `variables.page` doesn't get updated here on
+              // subsequent clicks, so we have to recalculate each time...
+              page: (data.postsByCampaignId.length / variables.count) + 1,
+            },
+            updateQuery: (previousResult, { fetchMoreResult }) => {
+              if (! fetchMoreResult.postsByCampaignId) {
+                return previousResult;
+              }
+
+              return {
+                ...previousResult,
+                postsByCampaignId: [
+                  ...previousResult.postsByCampaignId,
+                  ...fetchMoreResult.postsByCampaignId,
+                ],
+              };
+            },
+          })}
+        />
+      );
+    }}
+  </Query>
+);
+
+CampaignGalleryQuery.propTypes = {
+  campaignId: PropTypes.string.isRequired,
+};
 
 // Export the Redux/GraphQL container component.
-export default connect(mapStateToProps)(
-  graphql(query, { options: queryOptions, props: mapResultToProps })(CampaignGalleryBlock),
-);
+export default connect(mapStateToProps)(CampaignGalleryQuery);

--- a/resources/assets/constants/index.js
+++ b/resources/assets/constants/index.js
@@ -8,3 +8,15 @@ import { get } from 'lodash';
 export const MEDIA_MEDIUM_SIZE_MIN = 759;
 
 export const PHOENIX_URL = get(window.ENV, 'PHOENIX_URL', null);
+
+
+// Apollo GraphQL loading states:
+export const NetworkStatus = {
+  LOADING: 1,
+  SET_VARIABLES: 2,
+  FETCH_MORE: 3,
+  REFETCH: 4,
+  POLL: 6,
+  READY: 7,
+  ERROR: 8,
+};


### PR DESCRIPTION
### What does this PR do?
This pull request refactors the GraphQL gallery to use the `Query` component (rather than the `graphql` HOC), which now seems to be the suggested way of doing things in the [Apollo documentation](https://www.apollographql.com/docs/react/features/pagination.html). I think it looks a lil' more readable so seems like a win!

I've also added support for parsing different types of loads from the `networkState` prop - so we show a spinner on initial load, but then just disable & style the "Load More" button when fetching subsequent pages (while the rest of the results stay intact). ⏳ 


### Any background context you want to provide?
It may be helpful to compare [before](https://github.com/DoSomething/phoenix-next/blob/0c57c975d84d022825ad4538a8d5cd6ca5533275/resources/assets/components/CampaignGalleryBlock/CampaignGalleryBlockContainer.js) and [after](https://github.com/DoSomething/phoenix-next/blob/5802c427a8fafb94c758b5b700cdd6bd9d52a330/resources/assets/components/CampaignGalleryBlock/CampaignGalleryBlockContainer.js) when reviewing this!


### What are the relevant tickets/cards?
[#155944555](https://www.pivotaltracker.com/story/show/155944555)


### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
- [ ] Added screenshot to PR description of related front-end updates on **small** screens.
- [ ] Added screenshot to PR description of related front-end updates on **medium** screens.
- [ ] Added screenshot to PR description of related front-end updates on **large** screens.