### PR TITLE
Display reactions in GraphQL gallery.

### DIFF
--- a/resources/assets/components/CampaignGalleryBlock/CampaignGalleryBlock.js
+++ b/resources/assets/components/CampaignGalleryBlock/CampaignGalleryBlock.js
@@ -18,8 +18,8 @@ const CampaignGalleryBlock = (props) => {
             <ReportbackItem
               id={String(post.id)}
               type={post.type}
-              caption={post.media.text}
-              url={post.media.url}
+              caption={post.text}
+              url={post.url}
               firstName={get(post, 'user.firstName') || 'A Doer'}
             />
           </Card>

--- a/resources/assets/components/CampaignGalleryBlock/CampaignGalleryBlock.js
+++ b/resources/assets/components/CampaignGalleryBlock/CampaignGalleryBlock.js
@@ -18,6 +18,9 @@ const CampaignGalleryBlock = (props) => {
             <ReportbackItem
               id={String(post.id)}
               type={post.type}
+              reaction={{ total: post.reactions, reacted: post.reacted }}
+              toggleReactionOn={() => console.log('Coming soon!')}
+              toggleReactionOff={() => console.log('Coming soon!')}
               caption={post.text}
               url={post.url}
               firstName={get(post, 'user.firstName') || 'A Doer'}

--- a/resources/assets/components/CampaignGalleryBlock/CampaignGalleryBlockContainer.js
+++ b/resources/assets/components/CampaignGalleryBlock/CampaignGalleryBlockContainer.js
@@ -24,10 +24,8 @@ const POST_GALLERY_QUERY = gql`
     postsByCampaignId(id: $campaignId, count: $count, page: $page) {
       id
       status
-      media {
-        url
-        text
-      }
+      url
+      text
       user {
         id
         firstName

--- a/resources/assets/components/CampaignGalleryBlock/CampaignGalleryBlockContainer.js
+++ b/resources/assets/components/CampaignGalleryBlock/CampaignGalleryBlockContainer.js
@@ -26,6 +26,8 @@ const POST_GALLERY_QUERY = gql`
       status
       url
       text
+      reactions
+      reacted
       user {
         id
         firstName

--- a/resources/assets/components/CampaignGalleryBlock/CampaignGalleryBlockContainer.js
+++ b/resources/assets/components/CampaignGalleryBlock/CampaignGalleryBlockContainer.js
@@ -1,12 +1,6 @@
-import React from 'react';
-import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { Query } from 'react-apollo';
-import gql from 'graphql-tag';
 
-import CampaignGalleryBlock from './CampaignGalleryBlock';
-import ErrorBlock from '../ErrorBlock/ErrorBlock';
-import { NetworkStatus } from '../../constants';
+import CampaignGalleryBlockQuery from './CampaignGalleryBlockQuery';
 
 /**
  * Provide state from the Redux store as props for this component. (In
@@ -16,80 +10,5 @@ const mapStateToProps = state => ({
   campaignId: String(state.campaign.legacyCampaignId),
 });
 
-/**
- * The GraphQL query to load data for this component.
- */
-const POST_GALLERY_QUERY = gql`
-  query PostGallery($campaignId: String!, $count: Int, $page: Int) {
-    postsByCampaignId(id: $campaignId, count: $count, page: $page) {
-      id
-      status
-      url
-      text
-      reactions
-      reacted
-      user {
-        id
-        firstName
-        lastInitial
-      }
-    }
-  }
-`;
-
-/**
- * Fetch results via GraphQL using a query component.
- */
-const CampaignGalleryQuery = ({ campaignId }) => (
-  <Query
-    query={POST_GALLERY_QUERY}
-    variables={{ campaignId, count: 9, page: 1 }}
-    notifyOnNetworkStatusChange
-  >
-    {({ data, error, networkStatus, variables, fetchMore }) => {
-      // On initial load, just display a loading spinner.
-      if (networkStatus === NetworkStatus.LOADING) {
-        return <div className="spinner -centered" />;
-      }
-
-      if (error) {
-        console.error(`CampaignGalleryQuery ERROR: ${error}`);
-        return <ErrorBlock />;
-      }
-
-      return (
-        <CampaignGalleryBlock
-          postsByCampaignId={data.postsByCampaignId}
-          loading={networkStatus === NetworkStatus.FETCH_MORE}
-          loadMorePosts={() => fetchMore({
-            variables: {
-              // The value in `variables.page` doesn't get updated here on
-              // subsequent clicks, so we have to recalculate each time...
-              page: (data.postsByCampaignId.length / variables.count) + 1,
-            },
-            updateQuery: (previousResult, { fetchMoreResult }) => {
-              if (! fetchMoreResult.postsByCampaignId) {
-                return previousResult;
-              }
-
-              return {
-                ...previousResult,
-                postsByCampaignId: [
-                  ...previousResult.postsByCampaignId,
-                  ...fetchMoreResult.postsByCampaignId,
-                ],
-              };
-            },
-          })}
-        />
-      );
-    }}
-  </Query>
-);
-
-CampaignGalleryQuery.propTypes = {
-  campaignId: PropTypes.string.isRequired,
-};
-
-// Export the Redux/GraphQL container component.
-export default connect(mapStateToProps)(CampaignGalleryQuery);
+// Export the Redux container component.
+export default connect(mapStateToProps)(CampaignGalleryBlockQuery);

--- a/resources/assets/components/CampaignGalleryBlock/CampaignGalleryBlockQuery.js
+++ b/resources/assets/components/CampaignGalleryBlock/CampaignGalleryBlockQuery.js
@@ -1,0 +1,54 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import gql from 'graphql-tag';
+
+import CampaignGalleryBlock from './CampaignGalleryBlock';
+import PaginatedQuery from '../PaginatedQuery';
+
+/**
+ * The GraphQL query to load data for this component.
+ */
+const POST_GALLERY_QUERY = gql`
+  query PostGallery($campaignId: String!, $count: Int, $page: Int) {
+    postsByCampaignId(id: $campaignId, count: $count, page: $page) {
+      id
+      status
+      url
+      text
+      reactions
+      reacted
+      user {
+        id
+        firstName
+        lastInitial
+      }
+    }
+  }
+`;
+
+/**
+ * Fetch results via GraphQL using a query component.
+ */
+const CampaignGalleryQuery = ({ campaignId }) => (
+  <PaginatedQuery
+    query={POST_GALLERY_QUERY}
+    queryName="postsByCampaignId"
+    variables={{ campaignId }}
+    count={9}
+  >
+    {({ result, fetching, fetchMore }) => (
+      <CampaignGalleryBlock
+        postsByCampaignId={result}
+        loading={fetching}
+        loadMorePosts={fetchMore}
+      />
+    )}
+  </PaginatedQuery>
+);
+
+CampaignGalleryQuery.propTypes = {
+  campaignId: PropTypes.string.isRequired,
+};
+
+// Export the GraphQL query component.
+export default CampaignGalleryQuery;

--- a/resources/assets/components/PaginatedQuery.js
+++ b/resources/assets/components/PaginatedQuery.js
@@ -1,0 +1,68 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Query } from 'react-apollo';
+
+import ErrorBlock from './ErrorBlock/ErrorBlock';
+import { NetworkStatus } from '../constants';
+
+/**
+ * Fetch results via GraphQL using a query component.
+ */
+const PaginatedQuery = ({ query, queryName, variables, count, children }) => (
+  <Query
+    query={query}
+    variables={{ ...variables, count, page: 1 }}
+    notifyOnNetworkStatusChange
+  >
+    {(result) => {
+      // On initial load, just display a loading spinner.
+      if (result.networkStatus === NetworkStatus.LOADING) {
+        return <div className="spinner -centered" />;
+      }
+
+      if (result.error) {
+        console.error(`${queryName} ERROR: ${result.error}`);
+        return <ErrorBlock />;
+      }
+
+      return children({
+        result: result.data[queryName],
+        fetching: result.networkStatus === NetworkStatus.FETCH_MORE,
+        fetchMore: () => result.fetchMore({
+          variables: {
+            // The value in `variables.page` doesn't get updated here on
+            // subsequent clicks, so we have to recalculate each time...
+            page: (result.data[queryName].length / result.variables.count) + 1,
+          },
+          updateQuery: (previousResult, { fetchMoreResult }) => {
+            if (! fetchMoreResult[queryName]) {
+              return previousResult;
+            }
+
+            return {
+              ...previousResult,
+              [queryName]: [
+                ...previousResult[queryName],
+                ...fetchMoreResult[queryName],
+              ],
+            };
+          },
+        }),
+      });
+    }}
+  </Query>
+);
+
+PaginatedQuery.propTypes = {
+  query: PropTypes.any.isRequired, // eslint-disable-line react/forbid-prop-types
+  queryName: PropTypes.string.isRequired,
+  variables: PropTypes.object, // eslint-disable-line react/forbid-prop-types
+  count: PropTypes.number.isRequired,
+  children: PropTypes.func.isRequired,
+};
+
+PaginatedQuery.defaultProps = {
+  variables: {},
+};
+
+export default PaginatedQuery;


### PR DESCRIPTION
### What does this PR do?
This PR makes a few additions to the GraphQL-powered gallery:

🥙 I flattened the `url` and `text` properties into the post [in the GraphQL gateway](https://github.com/DoSomething/graphql/commit/65f708fbe0e3bbf4fc6ea227504a3f00f708b08c). This makes more sense to me when querying (since for us `media` isn't a real "thing" with a unique ID, and for a text-only post, the `text` isn't really even media). ddf3256

❤️ Reactions are now displayed on the gallery! 81e8529

🕵️ I split out the container component into `CampaignGalleryBlockContainer` (Redux) and `CampaignGalleryBlockQuery` (GraphQL), and extracted more generalized "paginated query" logic into a `PaginatedQuery` class that gets imported there (based on @mendelB's [feedback](https://github.com/DoSomething/phoenix-next/pull/802#pullrequestreview-108691424)!). I think this feels a little cleaner and nicer to work with, time will tell! 3e7fe6e

🔗 Fixes an issue where the `Authorization` header was not being properly set. 948def39

![screen shot 2018-04-02 at 4 34 45 pm](https://user-images.githubusercontent.com/583202/38214886-017ee234-3694-11e8-9600-3fdbd715e4f5.png)


### Any background context you want to provide?
I'd recommend reviewing things commit-by-commit!


### What are the relevant tickets/cards?
[#155944555](https://www.pivotaltracker.com/story/show/155944555)


### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
- [ ] Added screenshot to PR description of related front-end updates on **small** screens.
- [ ] Added screenshot to PR description of related front-end updates on **medium** screens.
- [ ] Added screenshot to PR description of related front-end updates on **large** screens.