### PR TITLE
Content block content type migration

### DIFF
--- a/contentful/migrations/2018_04_02_001_add_content_block_content_type.js
+++ b/contentful/migrations/2018_04_02_001_add_content_block_content_type.js
@@ -1,0 +1,18 @@
+module.exports = function (migration) {
+  const contentBlock = migration.createContentType('contentBlock')
+    .name('Content Block')
+    .description('')
+    .displayField('internalTitle');
+
+  contentBlock.createField('internalTitle')
+    .name('Internal Title')
+    .type('Symbol')
+    .required(true)
+    .localized(false);
+
+  contentBlock.createField('internalTitle')
+    .name('Internal Title')
+    .type('Symbol')
+    .required(true)
+    .localized(false);
+}

--- a/contentful/migrations/2018_04_02_001_add_content_block_content_type.js
+++ b/contentful/migrations/2018_04_02_001_add_content_block_content_type.js
@@ -1,7 +1,7 @@
 module.exports = function (migration) {
   const contentBlock = migration.createContentType('contentBlock')
     .name('Content Block')
-    .description('')
+    .description('Content block for adding text content with optional titles and single image.')
     .displayField('internalTitle');
 
   contentBlock.createField('internalTitle')
@@ -10,9 +10,40 @@ module.exports = function (migration) {
     .required(true)
     .localized(false);
 
-  contentBlock.createField('internalTitle')
-    .name('Internal Title')
+  contentBlock.createField('superTitle')
+    .name('Supertitle')
+    .type('Symbol')
+    .required(false)
+    .localized(true);
+
+  contentBlock.createField('title')
+    .name('Title')
+    .type('Symbol')
+    .required(false)
+    .localized(true);
+
+  contentBlock.createField('subTitle')
+    .name('Subtitle')
+    .type('Symbol')
+    .required(false)
+    .localized(true);
+
+  contentBlock.createField('content')
+    .name('Content')
     .type('Symbol')
     .required(true)
+    .localized(true);
+
+  contentBlock.createField('image')
+    .name('Image')
+    .type('Link')
+    .linkType('Asset')
+    .required(false)
+    .localized(false);
+
+  contentBlock.createField('additionalContent')
+    .name('Additional Content')
+    .type('Object')
+    .required(false)
     .localized(false);
 }


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_


### What does this PR do?
This PR adds a migration file for `contentBlock` content-types in Contentful (say that 3 times, really fast! 👅🔀)

![screen shot 2018-04-02 at 7 09 47 pm](https://user-images.githubusercontent.com/105849/38220682-87bc1f14-36a9-11e8-9003-652506a2b2ed.png)
