### PR TITLE
Fix for issues with older Safari support of FormData methods.

### DIFF
--- a/resources/assets/actions/post.js
+++ b/resources/assets/actions/post.js
@@ -33,30 +33,32 @@ export function fetchCampaignPosts() {
 /**
  * Store posts for the specified campaign.
  *
- * @param {String} id
- * @param  {FormData} data
+ * @param {String} campaignId
+ * @param  {Object} data
  * @return {function}
  */
-export function storeCampaignPost(id, data) {
-  if (! (data instanceof FormData)) {
-    throw Error(`The supplied data must be an instance of FormData, instead it is an instance of ${data.constructor.name}.`);
+export function storeCampaignPost(campaignId, data) {
+  if (! (data.body instanceof FormData)) {
+    throw Error(`The supplied data.body must be an instance of FormData, instead it is an instance of ${data.body.constructor.name}.`);
   }
+
+  const { body, id, type } = data;
 
   return (dispatch, getState) => {
     const token = getState().user.token;
 
     dispatch(
       apiRequest('POST', {
-        body: data,
+        body,
         failure: POST_SUBMISSION_FAILED,
         meta: {
-          id: data.get('id'),
-          type: data.get('type'),
+          id,
+          type,
         },
         pending: POST_SUBMISSION_PENDING,
         success: POST_SUBMISSION_SUCCESSFUL,
         token,
-        url: `${window.location.origin}/api/v2/campaigns/${id}/posts`,
+        url: `${window.location.origin}/api/v2/campaigns/${campaignId}/posts`,
       }),
     );
   };

--- a/resources/assets/components/actions/TextSubmissionAction/TextSubmissionAction.js
+++ b/resources/assets/components/actions/TextSubmissionAction/TextSubmissionAction.js
@@ -43,7 +43,12 @@ class TextSubmissionAction extends React.Component {
       }));
     }
 
-    this.props.storeCampaignPost(this.props.campaignId, formData);
+    // Send request to store the campaign text submission post.
+    this.props.storeCampaignPost(this.props.campaignId, {
+      body: formData,
+      id: this.props.id,
+      type: this.props.type,
+    });
   }
 
   handleChange = (event) => {


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_


### What does this PR do?
This PR provides a fix for the lack of support in some browsers (*cough* IE, *cough* Safari) for the methods on the `FormData` class. Instead of passing the `FormData` as the data directly to the `storeCampaignPost()` method and trying to use the unsupported `get()` method to grab some of the data to provide better context to the backend, we instead will now pass an object with the data as properties of the object. Makes things a lot easier.


### Any background context you want to provide?
Blessing in disguise? 🤷‍♂️ 


### What are the relevant tickets/cards?
Fixes #