### PR TITLE
Add support for toggling reactions in GraphQL gallery.

### DIFF
--- a/resources/assets/components/Reaction/reaction.scss
+++ b/resources/assets/components/Reaction/reaction.scss
@@ -25,6 +25,12 @@
     }
   }
 
+  .spinner {
+    width: 20px;
+    height: 20px;
+    background-size: 20px;
+  }
+
   .reaction__meta {
     color: $med-gray;
     vertical-align: top;

--- a/resources/assets/components/utilities/PostCard/PostCard.js
+++ b/resources/assets/components/utilities/PostCard/PostCard.js
@@ -23,12 +23,7 @@ export const postCardFragment = gql`
 `;
 
 const PostCard = ({ post, noun }) => {
-  const reactionElement = (
-    <ReactionButton
-      post={post}
-      toggleReaction={() => console.log('this gonna toggle that')}
-    />
-  );
+  const reactionElement = <ReactionButton post={post} />;
 
   return (
     <Figure className="post" image={post.url} alt={`${post.user.firstName}'s photo`}>

--- a/resources/assets/components/utilities/ReactionButton/ReactionButton.js
+++ b/resources/assets/components/utilities/ReactionButton/ReactionButton.js
@@ -23,21 +23,25 @@ const TOGGLE_REACTION = gql`
   }
 `;
 
-const ReactionButton = ({ post }) => {
-  const button = <div className={classnames('reaction__button', { '-reacted': post.reacted })} />;
+const ReactionButton = ({ post }) => (
+  <Mutation mutation={TOGGLE_REACTION} variables={{ postId: post.id }}>
+    {(toggleReaction, { loading }) => {
+      const button = loading ? (
+        <div className="spinner" />
+      ) : (
+        <div className={classnames('reaction__button', { '-reacted': post.reacted })} />
+      );
 
-  return (
-    <Mutation mutation={TOGGLE_REACTION} variables={{ postId: post.id }}>
-      {toggleReaction => (
+      return (
         <button className="reaction" onClick={toggleReaction}>
           <BaseFigure media={button} alignment="left" className="margin-bottom-none">
             <span className="reaction__meta">{post.reactions}</span>
           </BaseFigure>
         </button>
-      )}
-    </Mutation>
-  );
-};
+      );
+    }}
+  </Mutation>
+);
 
 ReactionButton.propTypes = {
   post: propType(reactionButtonFragment).isRequired,

--- a/resources/assets/components/utilities/ReactionButton/ReactionButton.js
+++ b/resources/assets/components/utilities/ReactionButton/ReactionButton.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import gql from 'graphql-tag';
-import PropTypes from 'prop-types';
 import classnames from 'classnames';
+import { Mutation } from 'react-apollo';
 import { propType } from 'graphql-anywhere';
 
 import { BaseFigure } from '../../Figure';
@@ -13,21 +13,34 @@ export const reactionButtonFragment = gql`
   }
 `;
 
-const Reaction = ({ post, toggleReaction }) => {
-  const reactionButton = <div className={classnames('reaction__button', { '-reacted': post.reacted })} />;
+const TOGGLE_REACTION = gql`
+  mutation ToggleReaction($postId: Int!) {
+    toggleReaction(postId: $postId) {
+      id
+      reactions
+      reacted
+    }
+  }
+`;
+
+const ReactionButton = ({ post }) => {
+  const button = <div className={classnames('reaction__button', { '-reacted': post.reacted })} />;
 
   return (
-    <button className="reaction" onClick={toggleReaction}>
-      <BaseFigure media={reactionButton} alignment="left" className="margin-bottom-none">
-        <span className="reaction__meta">{post.reactions}</span>
-      </BaseFigure>
-    </button>
+    <Mutation mutation={TOGGLE_REACTION} variables={{ postId: post.id }}>
+      {toggleReaction => (
+        <button className="reaction" onClick={toggleReaction}>
+          <BaseFigure media={button} alignment="left" className="margin-bottom-none">
+            <span className="reaction__meta">{post.reactions}</span>
+          </BaseFigure>
+        </button>
+      )}
+    </Mutation>
   );
 };
 
-Reaction.propTypes = {
+ReactionButton.propTypes = {
   post: propType(reactionButtonFragment).isRequired,
-  toggleReaction: PropTypes.func.isRequired,
 };
 
-export default Reaction;
+export default ReactionButton;


### PR DESCRIPTION
### What does this PR do?
This PR adds support for toggling reactions in the GraphQL-powered gallery, via [the `toggleReactions` mutation](https://github.com/DoSomething/graphql/pull/4). Still trying to figure out the best way to structure components like this, but this gets us just about* to feature parity with the current implementation!

![reactions-2](https://user-images.githubusercontent.com/583202/38317879-129318c4-37fc-11e8-80a7-ccf1353a899a.gif)

### Any background context you want to provide?
*Still need to add some finishing touches to the anonymous flow!

### What are the relevant tickets/cards?
[#155944555](https://www.pivotaltracker.com/story/show/155944555)

### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
- [ ] Added screenshot to PR description of related front-end updates on **small** screens.
- [ ] Added screenshot to PR description of related front-end updates on **medium** screens.
- [ ] Added screenshot to PR description of related front-end updates on **large** screens.