### PR TITLE
Display text posts in the new campaign gallery.

### DIFF
--- a/resources/assets/components/CampaignGalleryBlock/CampaignGalleryBlock.js
+++ b/resources/assets/components/CampaignGalleryBlock/CampaignGalleryBlock.js
@@ -6,12 +6,14 @@ import Gallery from '../Gallery';
 import LoadMore from '../LoadMore';
 import PostCard from '../utilities/PostCard/PostCard';
 
+import './campaign-gallery.scss';
+
 const CampaignGalleryBlock = (props) => {
   const { loading, postsByCampaignId, loadMorePosts } = props;
 
   return (
     <div>
-      <Gallery type="triad" className="expand-horizontal-md">
+      <Gallery type="triad" className="campaign-gallery expand-horizontal-md">
         {postsByCampaignId.map(post => (
           <Card className="rounded" key={post.id}>
             <PostCard post={post} />

--- a/resources/assets/components/CampaignGalleryBlock/campaign-gallery.scss
+++ b/resources/assets/components/CampaignGalleryBlock/campaign-gallery.scss
@@ -1,0 +1,13 @@
+@import '../../scss/next-toolbox';
+
+.campaign-gallery {
+  // Alternate adjacent 'chat-bubble' colors within a gallery.
+  li:nth-of-type(2n) .chat-bubble{
+    $bright-purple: #563795;
+    background-color: $bright-purple;
+
+    &:before {
+      border-color: $bright-purple transparent transparent $bright-purple;
+    }
+  }
+}

--- a/resources/assets/components/utilities/PostCard/PostCard.js
+++ b/resources/assets/components/utilities/PostCard/PostCard.js
@@ -34,7 +34,7 @@ const PostCard = ({ post, noun }) => {
       media = (
         <div className="chat-bubble -post-bubble flex-center-y margin-bottom-none rounded-top">
           <h4 className="color-yellow caps-lock">I beat bullying by...</h4>
-          <p className="color-white font-size-lg caps-lock">{post.text}</p>
+          <p className="color-white caps-lock">{post.text}</p>
         </div>
       );
       break;

--- a/resources/assets/components/utilities/PostCard/PostCard.js
+++ b/resources/assets/components/utilities/PostCard/PostCard.js
@@ -34,7 +34,7 @@ const PostCard = ({ post, noun }) => {
       media = (
         <div className="chat-bubble -post-bubble flex-center-y margin-bottom-none rounded-top">
           <h4 className="color-yellow caps-lock">I beat bullying by...</h4>
-          <p className="color-white font-size-lg">{post.text}</p>
+          <p className="color-white font-size-lg caps-lock">{post.text}</p>
         </div>
       );
       break;

--- a/resources/assets/components/utilities/PostCard/PostCard.js
+++ b/resources/assets/components/utilities/PostCard/PostCard.js
@@ -3,8 +3,9 @@ import gql from 'graphql-tag';
 import PropTypes from 'prop-types';
 import { propType } from 'graphql-anywhere';
 
+import LazyImage from '../../LazyImage';
+import { BaseFigure } from '../../Figure';
 import { pluralize } from '../../../helpers';
-import { Figure, BaseFigure } from '../../Figure';
 import ReactionButton from '../ReactionButton/ReactionButton';
 
 import './post.scss';
@@ -12,6 +13,7 @@ import './post.scss';
 export const postCardFragment = gql`
   fragment PostCard on Post {
     id
+    type
     status
     url
     text
@@ -24,15 +26,34 @@ export const postCardFragment = gql`
 
 const PostCard = ({ post, noun }) => {
   const reactionElement = <ReactionButton post={post} />;
+  let media = null;
+
+  // Render the appropriate media for this post:
+  switch (post.type) {
+    case 'text':
+      media = (
+        <div className="chat-bubble -post-bubble flex-center-y margin-bottom-none rounded-top">
+          <h4 className="color-yellow caps-lock">I beat bullying by...</h4>
+          <p className="color-white font-size-lg">{post.text}</p>
+        </div>
+      );
+      break;
+    case 'photo':
+      media = <LazyImage alt={`${post.user.firstName}'s photo`} src={post.url} />;
+      break;
+
+    default:
+      media = null;
+  }
 
   return (
-    <Figure className="post" image={post.url} alt={`${post.user.firstName}'s photo`}>
+    <BaseFigure className="post" media={media}>
       <BaseFigure media={reactionElement} alignment="right" className="padded margin-bottom-none">
         <h4>{post.user.firstName}</h4>
         { post.quantity ? <p className="footnote">{post.quantity} {pluralize(post.quantity, noun.singular, noun.plural)}</p> : null }
-        { post.text ? <p>{post.text}</p> : null }
+        { post.type !== 'text' && post.text ? <p>{post.text}</p> : null }
       </BaseFigure>
-    </Figure>
+    </BaseFigure>
   );
 };
 

--- a/resources/assets/components/utilities/PostCard/post.scss
+++ b/resources/assets/components/utilities/PostCard/post.scss
@@ -45,4 +45,12 @@
     border-color: $purple transparent transparent $purple;
     left: 25%;
   }
+
+  p {
+    font-size: $font-medium;
+
+    @include media($large) {
+      font-size: $font-large;
+    }
+  }
 }

--- a/resources/assets/components/utilities/PostCard/post.scss
+++ b/resources/assets/components/utilities/PostCard/post.scss
@@ -32,14 +32,12 @@
 }
 
 .chat-bubble.-post-bubble {
-  $bright-purple: #563795;
-
-  background-color: $bright-purple;
   font-family: $font-league-gothic;
   min-height: 340px; // HACK: short text posts should be same height as photos.
+  background-color: $purple;
 
   &:before {
-    border-color: $bright-purple transparent transparent $bright-purple;
+    border-color: $purple transparent transparent $purple;
     left: 25%;
   }
 }

--- a/resources/assets/components/utilities/PostCard/post.scss
+++ b/resources/assets/components/utilities/PostCard/post.scss
@@ -30,3 +30,16 @@
     overflow: unset;
   }
 }
+
+.chat-bubble.-post-bubble {
+  $bright-purple: #563795;
+
+  background-color: $bright-purple;
+  font-family: $font-league-gothic;
+  min-height: 340px; // HACK: short text posts should be same height as photos.
+
+  &:before {
+    border-color: $bright-purple transparent transparent $bright-purple;
+    left: 25%;
+  }
+}

--- a/resources/assets/components/utilities/PostCard/post.scss
+++ b/resources/assets/components/utilities/PostCard/post.scss
@@ -37,6 +37,11 @@
   background-color: $purple;
 
   &:before {
+    // Offset the 'tail' from bottom with a 1px overlap to avoid
+    // sub-pixel rendering issue w/ slight gap between elements.
+    top: auto;
+    bottom: -19px;
+
     border-color: $purple transparent transparent $purple;
     left: 25%;
   }

--- a/resources/assets/scss/base.scss
+++ b/resources/assets/scss/base.scss
@@ -55,6 +55,14 @@ h1, h2, h3, p {
   background-size: cover;
 }
 
+.color-white {
+  color: $white !important;
+}
+
+.color-yellow {
+  color: $primary-color !important;
+}
+
 .bg-black {
   background-color: $black !important;
 }
@@ -134,6 +142,13 @@ h1, h2, h3, p {
   margin-right: -$half-spacing;
 }
 
+
+.flex-center-y {
+  display: flex;
+  justify-content: center;
+  flex-direction: column;
+}
+
 .flex-center-xy {
   display: flex;
   justify-content: center;
@@ -162,6 +177,10 @@ h1, h2, h3, p {
   p {
     font-size: $font-large;
   }
+}
+
+.caps-lock {
+  text-transform: uppercase;
 }
 
 // TODO: Remove this.
@@ -283,6 +302,14 @@ h1, h2, h3, p {
 
 .rounded {
   border-radius: $lg-border-radius;
+}
+
+.rounded-top {
+  border-radius: $lg-border-radius $lg-border-radius 0 0;
+}
+
+.rounded-bottom {
+  border-radius: 0 0 $lg-border-radius $lg-border-radius;
 }
 
 .faded {


### PR DESCRIPTION
### What does this PR do?
This pull request adds support for text posts in Phoenix's new gallery component.

![screen shot 2018-04-05 at 10 41 38 am](https://user-images.githubusercontent.com/583202/38372920-f1448384-38bd-11e8-9824-2091e8948c2f.png)

### Any background context you want to provide?
For now, "I beat bullying by..." is hard-coded. Let's think on how best to handle this in a follow-up PR!


### What are the relevant tickets/cards?
Closes [#155944555](https://www.pivotaltracker.com/story/show/155944555)!


### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
- [ ] Added screenshot to PR description of related front-end updates on **small** screens.
- [ ] Added screenshot to PR description of related front-end updates on **medium** screens.
- [ ] Added screenshot to PR description of related front-end updates on **large** screens.