### PR TITLE
Basic modals refactor

### DIFF
--- a/app/Entities/TextSubmissionAction.php
+++ b/app/Entities/TextSubmissionAction.php
@@ -21,6 +21,7 @@ class TextSubmissionAction extends Entity implements JsonSerializable
                 'textFieldLabel' => $this->textFieldLabel,
                 'textFieldPlaceholder' => $this->textFieldPlaceholder,
                 'buttonText' => $this->buttonText,
+                'affirmationContent' => $this->affirmationContent ?: null,
                 'additionalContent' => $this->additionalContent,
             ],
         ];

--- a/resources/assets/components/Modal/Modal.js
+++ b/resources/assets/components/Modal/Modal.js
@@ -62,7 +62,7 @@ class Modal extends React.Component {
         onClose={() => chrome.classList.remove('-lock')}
       >
         {({ isOpen, portal }) => (isOpen ? portal((
-          <div className="modal" role="presentation" ref={node => this.node = node} onClick={this.handleOverlayClick}>
+          <div className="modal-v1" role="presentation" ref={node => this.node = node} onClick={this.handleOverlayClick}>
             <div className="modal__container">
               { children }
               { hideCloseButton ? null : <button className="modal__exit" onClick={this.props.closeModal}>×</button> }

--- a/resources/assets/components/Modal/modal.scss
+++ b/resources/assets/components/Modal/modal.scss
@@ -1,6 +1,6 @@
 @import '../../scss/next-toolbox.scss';
 
-.modal {
+.modal-v1 {
   position: fixed;
   overflow-y: scroll;
   height: 100%;

--- a/resources/assets/components/actions/TextSubmissionAction/TextSubmissionAction.js
+++ b/resources/assets/components/actions/TextSubmissionAction/TextSubmissionAction.js
@@ -6,6 +6,7 @@ import PropTypes from 'prop-types';
 import classnames from 'classnames';
 
 import Card from '../../Card';
+import Modal from '../../utilities/Modal/Modal';
 import { getFieldErrors } from '../../../helpers/forms';
 import FormValidation from '../../utilities/Form/FormValidation';
 
@@ -13,6 +14,7 @@ import './text-submission-action.scss';
 
 class TextSubmissionAction extends React.Component {
   state = {
+    showModal: false,
     textValue: '',
   };
 
@@ -24,7 +26,10 @@ class TextSubmissionAction extends React.Component {
     // the submission was successful!
     if (! has(prevResponse, 'status.success') && has(response, 'status.success')) {
       this.resetForm();
-      this.props.openModal('POST_REPORTBACK_MODAL');
+
+      this.setState({
+        showModal: true,
+      });
     }
   }
 
@@ -74,34 +79,53 @@ class TextSubmissionAction extends React.Component {
     const errors = getFieldErrors(formResponse);
 
     return (
-      <Card id={this.props.id} className={classnames('bordered rounded text-submission-action', this.props.className)} title={this.props.title}>
+      <React.Fragment>
+        <Card id={this.props.id} className={classnames('bordered rounded text-submission-action', this.props.className)} title={this.props.title}>
 
-        { formResponse ? <FormValidation response={formResponse} /> : null }
+          { formResponse ? <FormValidation response={formResponse} /> : null }
 
-        <form onSubmit={this.handleSubmit}>
-          <div className="padded">
-            <div className="form-item">
-              <label className={classnames('field-label', { 'has-error': has(errors, 'text') })} htmlFor="text">{this.props.textFieldLabel}</label>
-              <input
-                className={classnames('text-field', { 'has-error shake': has(errors, 'text') })}
-                type="text"
-                id="text"
-                name="text"
-                placeholder={this.props.textFieldPlaceholder}
-                value={this.state.textValue}
-                onChange={this.handleChange}
-              />
+          <form onSubmit={this.handleSubmit}>
+            <div className="padded">
+              <div className="form-item">
+                <label className={classnames('field-label', { 'has-error': has(errors, 'text') })} htmlFor="text">{this.props.textFieldLabel}</label>
+                <input
+                  className={classnames('text-field', { 'has-error shake': has(errors, 'text') })}
+                  type="text"
+                  id="text"
+                  name="text"
+                  placeholder={this.props.textFieldPlaceholder}
+                  value={this.state.textValue}
+                  onChange={this.handleChange}
+                />
+              </div>
+              <p className="footnote">Your submission will be reviewed by a DoSomething.org staffer and added to our public gallery.</p>
             </div>
-            <p className="footnote">Your submission will be reviewed by a DoSomething.org staffer and added to our public gallery.</p>
-          </div>
-          <input type="submit" defaultValue={this.props.buttonText} className="button" disabled={this.props.submissions.isPending} />
-        </form>
-      </Card>
+            <input type="submit" defaultValue={this.props.buttonText} className="button" disabled={this.props.submissions.isPending} />
+          </form>
+        </Card>
+
+        { this.state.showModal ?
+          <Modal onClose={() => this.setState({ showModal: false })}>
+            <Card className="bordered rounded" title="We got your message!">
+              <div className="padded">
+                { this.props.affirmationContent
+                  ||
+                  <p>{TextSubmissionAction.defaultProps.affirmationContent}</p>
+                }
+              </div>
+            </Card>
+
+          </Modal>
+          :
+          null
+        }
+      </React.Fragment>
     );
   }
 }
 
 TextSubmissionAction.propTypes = {
+  affirmationContent: PropTypes.string,
   additionalContent: PropTypes.shape({
     action: PropTypes.string,
   }),
@@ -112,7 +136,6 @@ TextSubmissionAction.propTypes = {
   id: PropTypes.string.isRequired,
   legacyCampaignId: PropTypes.string,
   legacyCampaignRunId: PropTypes.string,
-  openModal: PropTypes.func.isRequired,
   storeCampaignPost: PropTypes.func.isRequired,
   submissions: PropTypes.shape({
     isPending: PropTypes.bool,
@@ -126,6 +149,7 @@ TextSubmissionAction.propTypes = {
 
 TextSubmissionAction.defaultProps = {
   additionalContent: null,
+  affirmationContent: 'Thanks for joining the movement, and submitting your message! After we review your submission, we\'ll add it to the public gallery alongside submissions from all the other members taking action in this campaign.',
   buttonText: 'Submit',
   className: null,
   legacyCampaignId: null,

--- a/resources/assets/components/actions/TextSubmissionAction/TextSubmissionActionContainer.js
+++ b/resources/assets/components/actions/TextSubmissionAction/TextSubmissionActionContainer.js
@@ -1,6 +1,5 @@
 import { connect } from 'react-redux';
 
-import { openModal } from '../../../actions/modal';
 import TextSubmissionAction from './TextSubmissionAction';
 import { clearPostSubmissionItem, storeCampaignPost } from '../../../actions/post';
 
@@ -21,7 +20,6 @@ const mapStateToProps = state => ({
  */
 const actionCreators = {
   clearPostSubmissionItem,
-  openModal,
   storeCampaignPost,
 };
 

--- a/resources/assets/components/utilities/Modal/Modal.js
+++ b/resources/assets/components/utilities/Modal/Modal.js
@@ -1,0 +1,54 @@
+/* global window, document */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import ReactDom from 'react-dom';
+
+import ModalContent from './ModalContent';
+
+import './modal.scss';
+
+class Modal extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.modalPortal = document.getElementById('modal-portal');
+
+    this.chrome = document.getElementById('chrome');
+    this.el = document.createElement('div');
+    this.el.className = 'wrapper';
+    this.scrollOffset = window.scrollY;
+  }
+
+  componentDidMount() {
+    this.chrome.classList.add('-lock');
+    this.chrome.setAttribute('style', `transform: translateY(-${this.scrollOffset}px)`);
+    this.modalPortal.classList.add('is-active');
+    this.modalPortal.appendChild(this.el);
+  }
+
+  componentWillUnmount() {
+    this.chrome.classList.remove('-lock');
+    this.chrome.removeAttribute('style');
+    window.scroll(0, this.scrollOffset);
+    this.modalPortal.classList.remove('is-active');
+    this.modalPortal.removeChild(this.el);
+  }
+
+  render() {
+    const children = (
+      <ModalContent onClose={this.props.onClose}>
+        { this.props.children}
+      </ModalContent>
+    );
+
+    return ReactDom.createPortal(children, this.el);
+  }
+}
+
+Modal.propTypes = {
+  children: PropTypes.node.isRequired,
+  onClose: PropTypes.func.isRequired,
+};
+
+export default Modal;

--- a/resources/assets/components/utilities/Modal/ModalContent.js
+++ b/resources/assets/components/utilities/Modal/ModalContent.js
@@ -1,0 +1,23 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import classnames from 'classnames';
+
+const ModalContent = ({ children, onClose, className }) => (
+  <div className={classnames('modal', className)}>
+    <button className="modal__close" onClick={onClose}>&times;</button>
+
+    { children }
+  </div>
+);
+
+ModalContent.propTypes = {
+  className: PropTypes.string,
+  children: PropTypes.element.isRequired,
+  onClose: PropTypes.func.isRequired,
+};
+
+ModalContent.defaultProps = {
+  className: null,
+};
+
+export default ModalContent;

--- a/resources/assets/components/utilities/Modal/modal.scss
+++ b/resources/assets/components/utilities/Modal/modal.scss
@@ -1,0 +1,52 @@
+@import '../../../scss/next-toolbox.scss';
+
+.modal-portal {
+  background-color: $dark-background-color-transparent;
+  overflow-y: scroll;
+  z-index: 10000;
+
+  &.is-active {
+    height: 100%;
+    left: 0;
+    position: fixed;
+    top: 0;
+    width: 100%;
+  }
+
+  > .wrapper {
+    align-items: center;
+    background-color: rgba(0,0,0,0.3);
+    display: flex;
+    height: 100%;
+    justify-content: center;
+    overflow-y: scroll;
+    padding: $half-spacing;
+    position: relative;
+    width: 100%;
+
+    @include media($medium) {
+      padding: $base-spacing;
+    }
+  }
+}
+
+.modal {
+  margin: auto;
+  max-width: 800px;
+  position: relative;
+}
+
+.modal__close {
+  color: $black;
+  cursor: pointer;
+  display: block;
+  font-size: 34px;
+  height: 50px;
+  line-height: 34px;
+  padding: 0 0 10px;  // bottom padding helps align "X" with titles in card
+  position: absolute;
+  right: 0;
+  text-align: center;
+  top: 0;
+  width: 50px;
+}

--- a/resources/assets/scss/next-toolbox.scss
+++ b/resources/assets/scss/next-toolbox.scss
@@ -23,7 +23,7 @@ $primary-border-color: $light-gray;
 $light-background-color: #F6F6F6;
 $light-background-contrast-color: $off-black;
 $dark-background-color: $off-black;
-$dark-background-color-transparent: rgba(34, 34, 34, 0.9);
+$dark-background-color-transparent: rgba(34, 34, 34, 0.95);
 $dark-background-contrast-color: $white;
 
 // spacing

--- a/resources/assets/scss/next-toolbox.scss
+++ b/resources/assets/scss/next-toolbox.scss
@@ -23,7 +23,7 @@ $primary-border-color: $light-gray;
 $light-background-color: #F6F6F6;
 $light-background-contrast-color: $off-black;
 $dark-background-color: $off-black;
-$dark-background-color-transparent: rgba(34, 34, 34, 0.90);
+$dark-background-color-transparent: rgba(34, 34, 34, 0.9);
 $dark-background-contrast-color: $white;
 
 // spacing

--- a/resources/assets/scss/next-toolbox.scss
+++ b/resources/assets/scss/next-toolbox.scss
@@ -23,7 +23,7 @@ $primary-border-color: $light-gray;
 $light-background-color: #F6F6F6;
 $light-background-contrast-color: $off-black;
 $dark-background-color: $off-black;
-$dark-background-color-transparent: rgba(34, 34, 34, 0.95);
+$dark-background-color-transparent: rgba(34, 34, 34, 0.90);
 $dark-background-contrast-color: $white;
 
 // spacing

--- a/resources/views/layouts/master.blade.php
+++ b/resources/views/layouts/master.blade.php
@@ -32,6 +32,8 @@
         </div>
     </div>
 
+    <div id="modal-portal" class="modal-portal" role="presentation"></div>
+
     @include('partials.analytics')
     {{ isset($state) ? scriptify($state) : scriptify() }}
     {{ scriptify($env, 'ENV') }}


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_


### What does this PR do?
This PR refactors how we execute showing a modal after an event (like an action submission). This uses [React Portals](https://reactjs.org/docs/portals.html) to simplify how to inject components into a container that exists outside the main app container. The aim was to help simplify how we do modals and make it easier to just pop any component inside a modal without needing to add a secondary custom variation on a component that is specific for modals (which is the current process).

It also updates/improves on the styling for the modal so it can be more receptive to whatever components we throw inside of the modal.

This currently only supports injecting _one_ component within a modal.

![new modal experience](https://user-images.githubusercontent.com/105849/38439173-a70afa30-39aa-11e8-9c50-282dd6908ddc.gif)


### Any background context you want to provide?
Prior to this update, the TextSubmissionAction component was forced to use the affirmation content message from the PhotoUploaderAction. However, this update will allow for using a custom affirmation content message specifically for the TSA (once the affirmationContent` field is added to the TSA content-type on Contentful; upcoming PR).


### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
- [ ] Added screenshot to PR description of related front-end updates on **small** screens.
- [ ] Added screenshot to PR description of related front-end updates on **medium** screens.
- [ ] Added screenshot to PR description of related front-end updates on **large** screens.
