### PR TITLE
Adding Quiz Fields Contentful migration

### DIFF
--- a/contentful/migrations/2018_04_09_001_add_fields_to_quiz.js
+++ b/contentful/migrations/2018_04_09_001_add_fields_to_quiz.js
@@ -1,0 +1,16 @@
+module.exports = function (migration) {
+  const quiz = migration.editContentType('quiz');
+
+  quiz.createField('results')
+    .name('Results')
+    .type('Object')
+    .required(true);
+
+  quiz.createField('questions')
+    .name('Questions')
+    .type('Object')
+    .required(true);
+
+  quiz.moveField('results').beforeField('resultBlocks');
+  quiz.moveField('questions').beforeField('resultBlocks');
+}

--- a/contentful/migrations/2018_04_09_001_add_fields_to_quiz.js
+++ b/contentful/migrations/2018_04_09_001_add_fields_to_quiz.js
@@ -12,5 +12,5 @@ module.exports = function (migration) {
     .required(true);
 
   quiz.moveField('results').beforeField('resultBlocks');
-  quiz.moveField('questions').beforeField('resultBlocks');
+  quiz.moveField('questions').beforeField('additionalContent');
 }


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_


### What does this PR do?
This PR adds a Contentful CLI Migration Script to add a `results` and `questions` field to the `Quiz` content type, in anticipation of us utilizing the JSON FOrm Editor extension to allow for these complex JSON fields in Contentful! 🎈 


### What are the relevant tickets/cards?
[Pivotal #155783121](https://www.pivotaltracker.com/story/show/155783121)
#780 

![image](https://user-images.githubusercontent.com/12417657/38513687-f89fbdbe-3bfc-11e8-95f8-af3e53b7376e.png)
