### PR TITLE
Adding some new quiz fields

### DIFF
--- a/app/Entities/Quiz.php
+++ b/app/Entities/Quiz.php
@@ -46,7 +46,7 @@ class Quiz extends Entity implements JsonSerializable
     private function parseResults($results)
     {
         return collect($results)->map(function ($result, $index) {
-            $resultId = chr($index+65);
+            $resultId = chr($index + 65);
             $result['id'] = $resultId;
 
             return $result;

--- a/app/Entities/Quiz.php
+++ b/app/Entities/Quiz.php
@@ -7,6 +7,53 @@ use JsonSerializable;
 class Quiz extends Entity implements JsonSerializable
 {
     /**
+     * Parse choices to add ID based on index.
+     *
+     * @param  array $choices
+     * @return array
+     */
+    private function parseChoices($choices)
+    {
+        return collect($choices)->map(function ($choice, $index) {
+            $choice['id'] = (string) $index;
+
+            return $choice;
+        });
+    }
+
+    /**
+     * Parse questions to add ID based on index and parse through choices.
+     *
+     * @param  array $questions
+     * @return array
+     */
+    private function parseQuestions($questions)
+    {
+        return collect($questions)->map(function ($question, $index) {
+            $question['id'] = (string) $index;
+            $question['choices'] = $this->parseChoices($question['choices']);
+
+            return $question;
+        });
+    }
+
+    /**
+     * Parse results to add an ABC based ID based on the index.
+     *
+     * @param  array $results
+     * @return array
+     */
+    private function parseResults($results)
+    {
+        return collect($results)->map(function ($result, $index) {
+            $resultId = chr($index+65);
+            $result['id'] = $resultId;
+
+            return $result;
+        });
+    }
+
+    /**
      * Convert the object into something JSON serializable.
      *
      * @return array
@@ -19,6 +66,8 @@ class Quiz extends Entity implements JsonSerializable
             'fields' => [
                 'title' => $this->title,
                 'slug' => $this->slug,
+                'results' => $this->parseResults($this->results),
+                'questions' => $this->parseQuestions($this->questions),
                 'resultBlocks' => $this->parseBlocks($this->resultBlocks),
                 'additionalContent' => $this->additionalContent,
             ],

--- a/resources/assets/components/Quiz/Quiz.js
+++ b/resources/assets/components/Quiz/Quiz.js
@@ -77,8 +77,10 @@ class Quiz extends React.Component {
       ) : null;
     }
 
-    // Prepend the "quiz result" text to the specified block.
-    resultBlock.fields.content = `${result.content}\n\n${resultBlock.fields.content}`;
+    if (result) {
+      // Prepend the "quiz result" text to the specified block.
+      resultBlock.fields.content = `${result.content}\n\n${resultBlock.fields.content}`;
+    }
 
     return <ContentfulEntry json={resultBlock} />;
   }

--- a/resources/assets/components/Quiz/Quiz.js
+++ b/resources/assets/components/Quiz/Quiz.js
@@ -28,7 +28,7 @@ class Quiz extends React.Component {
   }
 
   evaluateQuiz() {
-    const questions = this.props.additionalContent.questions;
+    const questions = this.props.questions;
 
     return every(questions, question => (
       !! this.state.choices[question.id]
@@ -43,7 +43,7 @@ class Quiz extends React.Component {
 
       const results = calculateResult(
         this.state.choices,
-        this.props.additionalContent.questions,
+        this.props.questions,
       );
       this.setState({ showResults: true, results });
     }
@@ -59,8 +59,7 @@ class Quiz extends React.Component {
   }
 
   renderResult() {
-    const { resultBlocks } = this.props;
-    const { results } = this.props.additionalContent;
+    const { resultBlocks, results } = this.props;
 
     const resultBlockId = this.state.results.resultBlockId;
     const resultBlock = find(resultBlocks, { id: resultBlockId });
@@ -70,6 +69,7 @@ class Quiz extends React.Component {
 
     if (! resultBlock) {
       // Return the result on it's own when no result block is found.
+
       return result ? (
         <QuizConclusion callToAction={result.content}>
           <ShareContainer className="quiz__share" parentSource="quiz" />
@@ -84,9 +84,9 @@ class Quiz extends React.Component {
   }
 
   render() {
-    const { title, additionalContent } = this.props;
+    const { additionalContent, questions, title } = this.props;
 
-    const { callToAction, introduction, questions, submitButtonText } = (additionalContent || {});
+    const { callToAction, introduction, submitButtonText } = (additionalContent || {});
 
     const { choices, showResults } = this.state;
 
@@ -130,17 +130,17 @@ Quiz.propTypes = {
   additionalContent: PropTypes.shape({
     callToAction: PropTypes.string.isRequired,
     introduction: PropTypes.string.isRequired,
-    questions: PropTypes.arrayOf(PropTypes.shape({
-      id: PropTypes.string.isRequired,
-      title: PropTypes.string.isRequired,
-      choices: PropTypes.arrayOf(PropTypes.object).isRequired,
-    })).isRequired,
-    results: PropTypes.arrayOf(PropTypes.shape({
-      id: PropTypes.string.isRequired,
-      content: PropTypes.string.isRequired,
-    })).isRequired,
     submitButtonText: PropTypes.string,
   }).isRequired,
+  questions: PropTypes.arrayOf(PropTypes.shape({
+    id: PropTypes.string.isRequired,
+    title: PropTypes.string.isRequired,
+    choices: PropTypes.arrayOf(PropTypes.object).isRequired,
+  })).isRequired,
+  results: PropTypes.arrayOf(PropTypes.shape({
+    id: PropTypes.string.isRequired,
+    content: PropTypes.string.isRequired,
+  })).isRequired,
   resultBlocks: PropTypes.arrayOf(PropTypes.object),
   title: PropTypes.string.isRequired,
   trackEvent: PropTypes.func.isRequired,

--- a/resources/assets/components/Quiz/Quiz.test.js
+++ b/resources/assets/components/Quiz/Quiz.test.js
@@ -10,37 +10,20 @@ const props = {
   title: 'This is a cool kids quiz',
   additionalContent: {
     introduction: 'Lets do this',
-    results: [
-      {
-        id: '0',
-        content: 'test question',
-        blockId: '1',
-      },
-      {
-        id: '1',
-        content: 'another one',
-        blockId: '1',
-      },
-      {
-        id: '2',
-        content: 'another one',
-        blockId: '2',
-      },
-    ],
     callToAction: 'Click **"Get Results"** to find out your likelihood for a match',
-    questions: [
-      {
-        id: '0',
-        title: 'title',
-        choices: [sampleChoice],
-      },
-      {
-        id: '1',
-        title: 'title',
-        choices: [sampleChoice],
-      },
-    ],
   },
+  questions: [
+    {
+      id: '0',
+      title: 'title',
+      choices: [sampleChoice],
+    },
+    {
+      id: '1',
+      title: 'title',
+      choices: [sampleChoice],
+    },
+  ],
   resultBlocks: [
     {
       id: '1',
@@ -50,6 +33,23 @@ const props = {
         content: 'Click this link!',
         link: 'https://dosomething.org',
       },
+    },
+  ],
+  results: [
+    {
+      id: '0',
+      content: 'test question',
+      blockId: '1',
+    },
+    {
+      id: '1',
+      content: 'another one',
+      blockId: '1',
+    },
+    {
+      id: '2',
+      content: 'another one',
+      blockId: '2',
     },
   ],
 };


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?
This PR adds some new formalized fields to the Quiz!

- adding `results` and `questions` fields to the Quiz Contentful Entity
- adding parsing functions to add ID's to the contents of `results`, `questions`, and `question.choices`
- using these new fields in the `Quiz` component on the front end
- updating the test data


### Any background context you want to provide?
We've now got these fields formalized in Contentful (#817) and using the UI Extension!


### What are the relevant tickets/cards?
[Pivotal #155783121](https://www.pivotaltracker.com/story/show/155783121)
#780 

