### PR TITLE
Contentful Migration script for ContentBlock 'imageAlignment' field

### DIFF
--- a/contentful/migrations/2018_04_11_001_add_image_alignment_field_to_content_block.js
+++ b/contentful/migrations/2018_04_11_001_add_image_alignment_field_to_content_block.js
@@ -1,0 +1,12 @@
+module.exports = function(migration) {
+  const contentBlock = migration.editContentType('contentBlock');
+
+  contentBlock
+    .createField('imageAlignment')
+    .name('Image Alignment')
+    .type('Symbol')
+    .required(false)
+    .validations([{ in: ['Right', 'Left'] }]);
+
+  contentBlock.moveField('imageAlignment').beforeField('additionalContent');
+};


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR adds a new Contentful Migration script for the `ContentBlock` Content-Type which adds a new `imageAlignment` field

Not married to this naming! So if you have a better suggestion prey tell 😀 

I don't know of any way to mess with the Appearance settings from a migration script, but I will duly add a radio button appearance, as well as a description.

### What are the relevant tickets/cards?
[Pivotal #156473207](https://www.pivotaltracker.com/story/show/156473207)
[Slack](https://dosomething.slack.com/archives/C3ASB4204/p1523392554000097)

![image](https://user-images.githubusercontent.com/12417657/38626975-ce50eab2-3d7b-11e8-923e-d03196de1077.png)

