### PR TITLE
Content block component (skeletal version)

### DIFF
--- a/resources/assets/components/ContentfulEntry/ContentfulEntry.js
+++ b/resources/assets/components/ContentfulEntry/ContentfulEntry.js
@@ -24,6 +24,7 @@ import {
   renderLinkAction,
   renderAffirmation,
   renderTextSubmissionAction,
+  renderContentBlock,
 } from './renderers';
 
 // If no block is passed, just render an empty "placeholder".
@@ -90,11 +91,14 @@ class ContentfulEntry extends React.Component<Props, State> {
       case 'competition':
         return renderCompetitionStep(json);
 
-      case 'legacyContentBlock':
-        return renderLegacyContentBlock(json, stepIndex);
+      case 'contentBlock':
+        return renderContentBlock(json);
 
       case 'gallery':
         return <CampaignGalleryBlockContainer />;
+
+      case 'legacyContentBlock':
+        return renderLegacyContentBlock(json, stepIndex);
 
       case 'linkAction':
         return renderLinkAction(json);

--- a/resources/assets/components/ContentfulEntry/renderers.js
+++ b/resources/assets/components/ContentfulEntry/renderers.js
@@ -245,7 +245,7 @@ export function renderContentBlock(data) {
       key={`content-block-${contentfulId}`}
       className="margin-horizontal-md margin-bottom-lg"
     >
-      <ContentBlock {...data.fields} />
+      <ContentBlock id={contentfulId} {...data.fields} />
     </div>
   );
 }

--- a/resources/assets/components/ContentfulEntry/renderers.js
+++ b/resources/assets/components/ContentfulEntry/renderers.js
@@ -5,6 +5,7 @@ import { LegacyContentBlock } from '../Block';
 import Affirmation from '../Affirmation';
 import { ShareActionContainer } from '../ShareAction';
 import LinkActionContainer from '../actions/LinkAction';
+import ContentBlock from '../blocks/ContentBlock/ContentBlock';
 import { CompetitionBlockContainer } from '../CompetitionBlock';
 import { ReportbackUploaderContainer } from '../ReportbackUploader';
 import { ThirdPartyActionContainer } from '../actions/ThirdPartyAction';
@@ -195,7 +196,7 @@ export function renderLinkAction(step) {
 }
 
 /**
- * Render a link action.
+ * Render a text submission action.
  *
  * @param {Object} data
  * @return {Component}
@@ -228,4 +229,23 @@ export function renderTextSubmissionAction(data) {
  */
 export function renderAffirmation(step) {
   return <Affirmation content={step.fields} />;
+}
+
+/**
+ * Render a content block.
+ *
+ * @param {Object} data ContentBlock
+ * @return {Component}
+ */
+export function renderContentBlock(data) {
+  const contentfulId = data.id;
+
+  return (
+    <div
+      key={`content-block-${contentfulId}`}
+      className="margin-horizontal-md margin-bottom-lg"
+    >
+      <ContentBlock {...data.fields} />
+    </div>
+  );
 }

--- a/resources/assets/components/blocks/ContentBlock/ContentBlock.js
+++ b/resources/assets/components/blocks/ContentBlock/ContentBlock.js
@@ -1,0 +1,6 @@
+import React from 'react';
+
+const ContentBlock = () => <div className="content-block">Content Block!</div>;
+
+export default ContentBlock;
+


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR adds a very basic static version of the ContentBlock component along with a renderer and `ContentfulEntry` case.

### What are the relevant tickets/cards?
[Pivotal #156473207](https://www.pivotaltracker.com/story/show/156473207)

![image](https://user-images.githubusercontent.com/12417657/38690193-8a7b5d60-3e4b-11e8-9d54-f35b89dab1d4.png)
(It's admittedly not looking too hot yet)

### Checklist
* [x] Added screenshot to PR description of related front-end updates on **large** screens.
