### PR TITLE
Simplify how we handle `modal/:id` routes.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -304,6 +304,11 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-9.6.4.tgz",
       "integrity": "sha512-Awg4BcUYiZtNKoveGOu654JVPt11V/KIC77iBz8NweyoOAZpz5rUJfPDwwD+ajfTs2HndbTCEB8IuLfX9m/mmw=="
     },
+    "@types/prop-types": {
+      "version": "15.5.2",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.5.2.tgz",
+      "integrity": "sha512-pQRkAVoxiuUrLq8+CDwiQX4pTCep/PmmNgBbjIwnnsd/HoYjGpR81+FFPE030lvNXgR0haaAU6eoRtztWDE4Xw=="
+    },
     "@types/zen-observable": {
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/@types/zen-observable/-/zen-observable-0.5.3.tgz",
@@ -12868,6 +12873,15 @@
         "prop-types": "15.6.1",
         "react-router": "4.2.0",
         "warning": "3.0.0"
+      }
+    },
+    "react-router-prop-types": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/react-router-prop-types/-/react-router-prop-types-1.0.3.tgz",
+      "integrity": "sha512-dWMgSnh15Yqvh7L4yopVREQCRWvG1IkPBiesVFb5rcioW/x4LWm0f3T/YSDN6PL00kTax8HzLZ19rjjIjUd+Tg==",
+      "requires": {
+        "@types/prop-types": "15.5.2",
+        "prop-types": "15.6.1"
       }
     },
     "react-router-redux": {

--- a/package.json
+++ b/package.json
@@ -22,16 +22,14 @@
     "trailingComma": "all"
   },
   "babel": {
-    "presets": [
-      "@dosomething/babel-config",
-      "flow"
-    ]
+    "presets": ["@dosomething/babel-config", "flow"]
   },
   "jest": {
     "testEnvironment": "jest-environment-jsdom-global",
     "setupTestFrameworkScriptFile": "<rootDir>/jest-setup.js",
     "moduleNameMapper": {
-      "\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$": "<rootDir>/resources/assets/__mocks__/fileMock.js",
+      "\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$":
+        "<rootDir>/resources/assets/__mocks__/fileMock.js",
       "\\.(css|scss)$": "identity-obj-proxy"
     }
   },
@@ -80,6 +78,7 @@
     "react-redux": "^5.0.7",
     "react-router": "^4.2.0",
     "react-router-dom": "^4.2.2",
+    "react-router-prop-types": "^1.0.3",
     "react-router-redux": "5.0.0-alpha.9",
     "react-test-renderer": "^16.3.1",
     "redux": "^3.7.2",

--- a/resources/assets/components/Campaign/Campaign.js
+++ b/resources/assets/components/Campaign/Campaign.js
@@ -8,6 +8,7 @@ import {
 } from '../Modal';
 import NotificationContainer from '../Notification';
 import TrafficDistribution from '../utilities/TrafficDistribution/TrafficDistribution';
+import ModalLayer from '../utilities/ModalLayer/ModalLayer';
 import { CampaignPageContainer, LandingPageContainer } from '../Page';
 import {
   AdminDashboardContainer,
@@ -16,7 +17,11 @@ import {
 import ModalLauncherContainer from '../ModalLauncher';
 
 const Campaign = props => (
-  <div>
+  <ModalLayer
+    history={props.history}
+    location={props.location}
+    match={props.match}
+  >
     <AdminDashboardContainer>
       <CampaignDashboardContainer />
     </AdminDashboardContainer>
@@ -47,12 +52,15 @@ const Campaign = props => (
     ) : (
       <CampaignPageContainer {...props} />
     )}
-  </div>
+  </ModalLayer>
 );
 
 Campaign.propTypes = {
   shouldShowLandingPage: PropTypes.bool.isRequired,
   featureFlags: PropTypes.objectOf(PropTypes.bool),
+  location: PropTypes.any.isRequired, // eslint-disable-line react/forbid-prop-types
+  history: PropTypes.any.isRequired, // eslint-disable-line react/forbid-prop-types
+  match: PropTypes.any.isRequired, // eslint-disable-line react/forbid-prop-types
 };
 
 Campaign.defaultProps = {

--- a/resources/assets/components/Campaign/Campaign.js
+++ b/resources/assets/components/Campaign/Campaign.js
@@ -9,7 +9,7 @@ import {
 } from '../Modal';
 import NotificationContainer from '../Notification';
 import TrafficDistribution from '../utilities/TrafficDistribution/TrafficDistribution';
-import ModalLayer from '../utilities/ModalLayer/ModalLayer';
+import ModalRoute from '../utilities/ModalRoute/ModalRoute';
 import { CampaignPageContainer, LandingPageContainer } from '../Page';
 import {
   AdminDashboardContainer,
@@ -18,7 +18,7 @@ import {
 import ModalLauncherContainer from '../ModalLauncher';
 
 const Campaign = props => (
-  <ModalLayer
+  <ModalRoute
     history={props.history}
     location={props.location}
     match={props.match}
@@ -53,7 +53,7 @@ const Campaign = props => (
     ) : (
       <CampaignPageContainer {...props} />
     )}
-  </ModalLayer>
+  </ModalRoute>
 );
 
 Campaign.propTypes = {

--- a/resources/assets/components/Campaign/Campaign.js
+++ b/resources/assets/components/Campaign/Campaign.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import ReactRouterPropTypes from 'react-router-prop-types';
 
 import {
   ModalSwitchContainer,
@@ -58,9 +59,9 @@ const Campaign = props => (
 Campaign.propTypes = {
   shouldShowLandingPage: PropTypes.bool.isRequired,
   featureFlags: PropTypes.objectOf(PropTypes.bool),
-  location: PropTypes.any.isRequired, // eslint-disable-line react/forbid-prop-types
-  history: PropTypes.any.isRequired, // eslint-disable-line react/forbid-prop-types
-  match: PropTypes.any.isRequired, // eslint-disable-line react/forbid-prop-types
+  location: ReactRouterPropTypes.location.isRequired,
+  history: ReactRouterPropTypes.history.isRequired,
+  match: ReactRouterPropTypes.match.isRequired,
 };
 
 Campaign.defaultProps = {

--- a/resources/assets/components/ContentfulEntry/ContentfulEntryContainer.js
+++ b/resources/assets/components/ContentfulEntry/ContentfulEntryContainer.js
@@ -1,0 +1,15 @@
+import { connect } from 'react-redux';
+
+import ContentfulEntry from './ContentfulEntry';
+import { findContentfulEntry } from '../../helpers';
+
+/**
+ * Provide state from the Redux store as props for this component.
+ *
+ * @return {Object}
+ */
+const mapStateToProps = (state, { id }) => ({
+  json: findContentfulEntry(state, id),
+});
+
+export default connect(mapStateToProps)(ContentfulEntry);

--- a/resources/assets/components/Page/CampaignPage/CampaignPage.js
+++ b/resources/assets/components/Page/CampaignPage/CampaignPage.js
@@ -9,8 +9,6 @@ import { isCampaignClosed } from '../../../helpers';
 import { ActionPageContainer } from '../ActionPage';
 import { CampaignSubPageContainer } from '../CampaignSubPage';
 import CampaignFooter from '../../CampaignFooter';
-import ContentfulEntryContainer from '../../ContentfulEntry/ContentfulEntryContainer';
-import Modal from '../../utilities/Modal/Modal';
 
 // TODO: If they click a modal link from the action page, this takes them to the root /.
 // We should probably make a solution that lets them stay on the page they were already at.
@@ -80,14 +78,6 @@ const CampaignPage = props => {
           <Route
             path={`${match.url}/quiz/:slug`}
             component={BlockPageContainer}
-          />
-          <Route
-            path={`${match.url}/modal/:id`}
-            render={routingProps => (
-              <Modal>
-                <ContentfulEntryContainer id={routingProps.match.params.id} />
-              </Modal>
-            )}
           />
           {/* If no route matches, just redirect back to the main page: */}
           <Redirect from={`${match.url}/:anything`} to={`${match.url}`} />

--- a/resources/assets/components/Page/CampaignPage/CampaignPage.js
+++ b/resources/assets/components/Page/CampaignPage/CampaignPage.js
@@ -9,7 +9,8 @@ import { isCampaignClosed } from '../../../helpers';
 import { ActionPageContainer } from '../ActionPage';
 import { CampaignSubPageContainer } from '../CampaignSubPage';
 import CampaignFooter from '../../CampaignFooter';
-import { BLOCK_MODAL, REPORTBACK_UPLOADER_MODAL } from '../../Modal';
+import ContentfulEntryContainer from '../../ContentfulEntry/ContentfulEntryContainer';
+import Modal from '../../utilities/Modal/Modal';
 
 // TODO: If they click a modal link from the action page, this takes them to the root /.
 // We should probably make a solution that lets them stay on the page they were already at.
@@ -22,7 +23,6 @@ const CampaignPage = props => {
     endDate,
     hasActivityFeed,
     match,
-    openModal,
     shouldShowActionPage,
     template,
   } = props;
@@ -83,20 +83,11 @@ const CampaignPage = props => {
           />
           <Route
             path={`${match.url}/modal/:id`}
-            render={routingProps => {
-              const { id } = routingProps.match.params;
-
-              switch (id) {
-                case 'reportback':
-                  openModal(REPORTBACK_UPLOADER_MODAL);
-                  break;
-                default:
-                  openModal(BLOCK_MODAL, id);
-                  break;
-              }
-
-              return <Redirect to={`${match.url}`} />;
-            }}
+            render={routingProps => (
+              <Modal>
+                <ContentfulEntryContainer id={routingProps.match.params.id} />
+              </Modal>
+            )}
           />
           {/* If no route matches, just redirect back to the main page: */}
           <Redirect from={`${match.url}/:anything`} to={`${match.url}`} />
@@ -126,7 +117,6 @@ CampaignPage.propTypes = {
   affiliatePartners: PropTypes.array.isRequired, // eslint-disable-line react/forbid-prop-types
   match: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
   template: PropTypes.string.isRequired,
-  openModal: PropTypes.func.isRequired,
   shouldShowActionPage: PropTypes.bool.isRequired,
 };
 

--- a/resources/assets/components/utilities/ModalLayer/ModalLayer.js
+++ b/resources/assets/components/utilities/ModalLayer/ModalLayer.js
@@ -4,6 +4,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Route } from 'react-router-dom';
 import { StaticRouter } from 'react-router';
+import ReactRouterPropTypes from 'react-router-prop-types';
 
 import ContentfulEntryContainer from '../../ContentfulEntry/ContentfulEntryContainer';
 import Modal from '../../utilities/Modal/Modal';
@@ -22,16 +23,16 @@ class ModalLayer extends React.Component {
   }
 
   componentWillUpdate(nextProps) {
-    const { location } = this.props;
-
-    // If we're opening a modal, keep track of where we were:
+    // If we're opening a modal, keep track of where we were.
     if (!isModal(this.props.location) && isModal(nextProps.location)) {
-      this.previousLocation = location.pathname;
+      this.previousLocation = this.props.location.pathname;
       this.previousScroll = window.scrollY;
     }
   }
 
   componentDidUpdate(prevProps) {
+    // After closing a modal, restore scroll position. We do this in
+    // `componentDidUpdate` because we need re-rendered page in place.
     if (isModal(prevProps.location) && !isModal(this.props.location)) {
       window.scroll(0, this.previousScroll);
     }
@@ -63,10 +64,10 @@ class ModalLayer extends React.Component {
 }
 
 ModalLayer.propTypes = {
-  history: PropTypes.any.isRequired, // eslint-disable-line react/forbid-prop-types
-  location: PropTypes.any.isRequired, // eslint-disable-line react/forbid-prop-types
-  match: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
-  children: PropTypes.any, // eslint-disable-line react/forbid-prop-types
+  history: ReactRouterPropTypes.history.isRequired,
+  location: ReactRouterPropTypes.location.isRequired,
+  match: ReactRouterPropTypes.match.isRequired,
+  children: PropTypes.node,
 };
 
 ModalLayer.defaultProps = {

--- a/resources/assets/components/utilities/ModalLayer/ModalLayer.js
+++ b/resources/assets/components/utilities/ModalLayer/ModalLayer.js
@@ -1,0 +1,76 @@
+/* global window */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Route } from 'react-router-dom';
+import { StaticRouter } from 'react-router';
+
+import ContentfulEntryContainer from '../../ContentfulEntry/ContentfulEntryContainer';
+import Modal from '../../utilities/Modal/Modal';
+
+// Helpers:
+const isModal = location => location.pathname.includes('/modal/');
+const withoutModal = location =>
+  location.pathname.replace(/\/modal\/[a-zA-Z0-9]*\/?/, '');
+
+class ModalLayer extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.previousLocation = withoutModal(props.location);
+    this.previousScroll = 0;
+  }
+
+  componentWillUpdate(nextProps) {
+    const { location } = this.props;
+
+    // If we're opening a modal, keep track of where we were:
+    if (!isModal(this.props.location) && isModal(nextProps.location)) {
+      this.previousLocation = location.pathname;
+      this.previousScroll = window.scrollY;
+    }
+  }
+
+  componentDidUpdate(prevProps) {
+    if (isModal(prevProps.location) && !isModal(this.props.location)) {
+      window.scroll(0, this.previousScroll);
+    }
+  }
+
+  render() {
+    const { match, history, location, children } = this.props;
+
+    return (
+      <div>
+        <Route
+          path={`${match.url}/modal/:id`}
+          render={routingProps => (
+            <Modal onClose={() => history.push(this.previousLocation)}>
+              <ContentfulEntryContainer id={routingProps.match.params.id} />
+            </Modal>
+          )}
+        />
+        {isModal(location) ? (
+          <StaticRouter location={withoutModal(location)} context={{}}>
+            <div>{children}</div>
+          </StaticRouter>
+        ) : (
+          <div>{children}</div>
+        )}
+      </div>
+    );
+  }
+}
+
+ModalLayer.propTypes = {
+  history: PropTypes.any.isRequired, // eslint-disable-line react/forbid-prop-types
+  location: PropTypes.any.isRequired, // eslint-disable-line react/forbid-prop-types
+  match: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
+  children: PropTypes.any, // eslint-disable-line react/forbid-prop-types
+};
+
+ModalLayer.defaultProps = {
+  children: null,
+};
+
+export default ModalLayer;

--- a/resources/assets/components/utilities/ModalRoute/ModalRoute.js
+++ b/resources/assets/components/utilities/ModalRoute/ModalRoute.js
@@ -6,8 +6,8 @@ import { Route } from 'react-router-dom';
 import { StaticRouter } from 'react-router';
 import ReactRouterPropTypes from 'react-router-prop-types';
 
-import ContentfulEntryContainer from '../../ContentfulEntry/ContentfulEntryContainer';
 import Modal from '../../utilities/Modal/Modal';
+import ContentfulEntryContainer from '../../ContentfulEntry/ContentfulEntryContainer';
 
 // Helpers:
 const isModal = location => location.pathname.includes('/modal/');

--- a/resources/assets/components/utilities/ModalRoute/ModalRoute.js
+++ b/resources/assets/components/utilities/ModalRoute/ModalRoute.js
@@ -14,7 +14,7 @@ const isModal = location => location.pathname.includes('/modal/');
 const withoutModal = location =>
   location.pathname.replace(/\/modal\/[a-zA-Z0-9]*\/?/, '');
 
-class ModalLayer extends React.Component {
+class ModalRoute extends React.Component {
   constructor(props) {
     super(props);
 
@@ -63,15 +63,15 @@ class ModalLayer extends React.Component {
   }
 }
 
-ModalLayer.propTypes = {
+ModalRoute.propTypes = {
   history: ReactRouterPropTypes.history.isRequired,
   location: ReactRouterPropTypes.location.isRequired,
   match: ReactRouterPropTypes.match.isRequired,
   children: PropTypes.node,
 };
 
-ModalLayer.defaultProps = {
+ModalRoute.defaultProps = {
   children: null,
 };
 
-export default ModalLayer;
+export default ModalRoute;


### PR DESCRIPTION
### What does this PR do?

This pull request updates the `/modal/:id` routes to use the new Modal component, and also preserve real URLs! You can now copy-paste the direct link to a modal or use the back/forward buttons in your browser to open and close it! It all works the way you'd expect! 💥 

![screencast](https://user-images.githubusercontent.com/583202/38702785-7f3e2224-3e6f-11e8-8e92-a5c83fd1ad5a.gif)

### Any background context you want to provide?

#### Why are we using `StaticRouter`?
We need to "freeze" the background context so it doesn't change when we open a modal. The [example](https://reacttraining.com/react-router/web/example/modal-gallery) from the docs uses a `Switch` for this, but that only works one level deep - when I tried this, our [nested `Redirect`](https://github.com/DoSomething/phoenix-next/blob/c7ea1392ce314063741b0d7738967c7253c36ea4/resources/assets/components/Page/CampaignPage/CampaignPage.js#L102) would always trigger and close the modal! Oy!

### What are the relevant tickets/cards?

[#156351561](https://www.pivotaltracker.com/story/show/156351561)

### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.
* [ ] Added screenshot to PR description of related front-end updates on **small** screens.
* [ ] Added screenshot to PR description of related front-end updates on **medium** screens.
* [ ] Added screenshot to PR description of related front-end updates on **large** screens.