### PR TITLE
Add the Content Block -- the real deal

### DIFF
--- a/app/Entities/ContentBlock.php
+++ b/app/Entities/ContentBlock.php
@@ -22,7 +22,7 @@ class ContentBlock extends Entity implements JsonSerializable
                 'subTitle' => $this->subTitle,
                 'content' => $this->content,
                 'image' => get_image_url($this->image, 'square'),
-                'imageAlignment' => $this->imageAlignment,
+                'imageAlignment' => $this->imageAlignment ? strtolower($this->imageAlignment) : null,
                 'additionalContent' => $this->additionalContent,
             ],
         ];

--- a/resources/assets/components/ContentfulEntry/renderers.js
+++ b/resources/assets/components/ContentfulEntry/renderers.js
@@ -243,11 +243,10 @@ export function renderContentBlock(data) {
   const contentfulId = data.id;
 
   return (
-    <div
-      key={`content-block-${contentfulId}`}
-      className="margin-horizontal-md margin-bottom-lg"
-    >
-      <ContentBlock id={contentfulId} {...data.fields} />
-    </div>
+    <ContentBlock
+      key={`content-block-${data.id}`}
+      id={data.id}
+      {...data.fields}
+    />
   );
 }

--- a/resources/assets/components/ContentfulEntry/renderers.js
+++ b/resources/assets/components/ContentfulEntry/renderers.js
@@ -240,8 +240,6 @@ export function renderAffirmation(step) {
  * @return {Component}
  */
 export function renderContentBlock(data) {
-  const contentfulId = data.id;
-
   return (
     <ContentBlock
       key={`content-block-${data.id}`}

--- a/resources/assets/components/Figure/figure.scss
+++ b/resources/assets/components/Figure/figure.scss
@@ -48,7 +48,7 @@
   }
 }
 
-.content-block {
+.figure.-one-third {
   &.figure.-right-collapse > .figure__media {
     margin-left: $base-spacing;
   }

--- a/resources/assets/components/Figure/figure.scss
+++ b/resources/assets/components/Figure/figure.scss
@@ -20,18 +20,47 @@
   margin-bottom: 0;
 }
 
-.figure.-left-collapse {
-  text-align: left;
+.figure {
+  &.-right-collapse,
+  &.-left-collapse {
+    text-align: left;
+
+    @include media($tablet) {
+      > .figure__media {
+        margin-right: gutter();
+        margin-bottom: 0;
+      }
+
+      > .figure__body {
+        overflow: hidden;
+      }
+    }
+  }
 
   @include media($tablet) {
-    > .figure__media {
-      float: left;
-      margin-right: gutter();
-      margin-bottom: 0;
+    &.-right-collapse > .figure__media {
+      float: right;
     }
 
-    > .figure__body {
-      overflow: hidden;
+    &.-left-collapse > .figure__media {
+      float: left;
+    }
+  }
+}
+
+.content-block {
+  &.figure.-right-collapse > .figure__media {
+    margin-left: $base-spacing;
+  }
+
+  &.figure.-left-collapse > .figure__media {
+    margin-right: $base-spacing;
+  }
+  &.figure > .figure__media {
+    width: 33%;
+
+    @include media($small) {
+      width: 100%;
     }
   }
 }

--- a/resources/assets/components/Figure/figure.scss
+++ b/resources/assets/components/Figure/figure.scss
@@ -56,6 +56,7 @@
   &.figure.-left-collapse > .figure__media {
     margin-right: $base-spacing;
   }
+
   &.figure > .figure__media {
     width: 33%;
 

--- a/resources/assets/components/Figure/index.js
+++ b/resources/assets/components/Figure/index.js
@@ -35,7 +35,7 @@ BaseFigure.propTypes = {
     'right-collapse',
   ]),
   verticalAlignment: PropTypes.oneOf(['center']),
-  size: PropTypes.oneOf(['small', 'medium', 'large']),
+  size: PropTypes.oneOf(['small', 'medium', 'large', 'one-third']),
   media: PropTypes.node,
 };
 

--- a/resources/assets/components/Figure/index.js
+++ b/resources/assets/components/Figure/index.js
@@ -28,7 +28,12 @@ export const BaseFigure = ({
 BaseFigure.propTypes = {
   className: PropTypes.string,
   children: PropTypes.node,
-  alignment: PropTypes.oneOf(['left', 'right', 'left-collapse']),
+  alignment: PropTypes.oneOf([
+    'left',
+    'right',
+    'left-collapse',
+    'right-collapse',
+  ]),
   verticalAlignment: PropTypes.oneOf(['center']),
   size: PropTypes.oneOf(['small', 'medium', 'large']),
   media: PropTypes.node,

--- a/resources/assets/components/Page/ActionPage/ActionSteps.js
+++ b/resources/assets/components/Page/ActionPage/ActionSteps.js
@@ -87,6 +87,7 @@ const ActionSteps = props => {
     let columnWidth = 'two-thirds';
     if (
       [
+        'contentBlock',
         'photo-uploader',
         'photoUploaderAction',
         'submission-gallery',

--- a/resources/assets/components/SectionHeader/SectionHeader.js
+++ b/resources/assets/components/SectionHeader/SectionHeader.js
@@ -4,24 +4,29 @@ import PropTypes from 'prop-types';
 import { convertNumberToWord } from '../../helpers';
 import './section-header.scss';
 
+// @TODO:
+// - change preTitle prop to superTitle,
+// - remove hideStepNumber prop and associated logic
+
 const SectionHeader = ({ preTitle, title, hideStepNumber, step }) => (
   <div className="flex__cell -two-thirds section-header">
     <span className="heading -emphasized section-header__pre-title">
       {hideStepNumber ? preTitle : `Step ${convertNumberToWord(step)}`}
     </span>
-    <h1 className="section-header__title">{title}</h1>
+    {title ? <h1 className="section-header__title">{title}</h1> : null}
   </div>
 );
 
 SectionHeader.propTypes = {
   preTitle: PropTypes.string,
-  title: PropTypes.string.isRequired,
+  title: PropTypes.string,
   hideStepNumber: PropTypes.bool,
   step: PropTypes.number,
 };
 
 SectionHeader.defaultProps = {
   step: null,
+  title: null,
   preTitle: null,
   hideStepNumber: false,
 };

--- a/resources/assets/components/blocks/ContentBlock/ContentBlock.js
+++ b/resources/assets/components/blocks/ContentBlock/ContentBlock.js
@@ -10,11 +10,7 @@ import './content-block.scss';
 const ContentBlock = props => {
   const { content, image, imageAlignment, superTitle, title } = props;
 
-  const imageAlignmentClass =
-    // ensure proper responsiveness setting for the figure component (only required for 'left')
-    (imageAlignment === 'left' && 'left-collapse') ||
-    imageAlignment ||
-    ContentBlock.defaultProps.imageAlignment;
+  const defaultImageAlignment = ContentBlock.defaultProps.imageAlignment;
 
   const contentNode = content ? <Markdown>{content}</Markdown> : null;
 
@@ -31,8 +27,9 @@ const ContentBlock = props => {
           <Figure
             image={image}
             alt="content-block"
-            alignment={imageAlignmentClass}
+            alignment={`${imageAlignment || defaultImageAlignment}-collapse`}
             size="large"
+            className="content-block"
           >
             {contentNode}
           </Figure>

--- a/resources/assets/components/blocks/ContentBlock/ContentBlock.js
+++ b/resources/assets/components/blocks/ContentBlock/ContentBlock.js
@@ -20,9 +20,11 @@ const ContentBlock = props => {
 
   return (
     <div className="content-block">
-      <div className="margin-horizontal-md">
-        <SectionHeader preTitle={superTitle} title={title} hideStepNumber />
-      </div>
+      {title ? (
+        <div className="margin-horizontal-md">
+          <SectionHeader preTitle={superTitle} title={title} hideStepNumber />
+        </div>
+      ) : null}
 
       <div className="margin-horizontal-md">
         {image ? (

--- a/resources/assets/components/blocks/ContentBlock/ContentBlock.js
+++ b/resources/assets/components/blocks/ContentBlock/ContentBlock.js
@@ -2,8 +2,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import Markdown from '../../Markdown';
-import SectionHeader from '../../SectionHeader';
 import { Figure } from '../../Figure';
+import SectionHeader from '../../SectionHeader';
 
 import './content-block.scss';
 

--- a/resources/assets/components/blocks/ContentBlock/ContentBlock.js
+++ b/resources/assets/components/blocks/ContentBlock/ContentBlock.js
@@ -28,8 +28,7 @@ const ContentBlock = props => {
             image={image}
             alt="content-block"
             alignment={`${imageAlignment || defaultImageAlignment}-collapse`}
-            size="large"
-            className="content-block"
+            size="one-third"
           >
             {contentNode}
           </Figure>

--- a/resources/assets/components/blocks/ContentBlock/ContentBlock.js
+++ b/resources/assets/components/blocks/ContentBlock/ContentBlock.js
@@ -1,6 +1,60 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
-const ContentBlock = () => <div className="content-block">Content Block!</div>;
+import Markdown from '../../Markdown';
+import SectionHeader from '../../SectionHeader';
+import { Figure } from '../../Figure';
+
+import './content-block.scss';
+
+const ContentBlock = props => {
+  const { content, image, imageAlignment, superTitle, title } = props;
+
+  const imageAlignmentClass =
+    // ensure proper responsiveness setting for the figure component (only required for 'left')
+    (imageAlignment === 'left' && 'left-collapse') ||
+    imageAlignment ||
+    ContentBlock.defaultProps.imageAlignment;
+
+  const contentNode = content ? <Markdown>{content}</Markdown> : null;
+
+  return (
+    <div className="content-block">
+      <div className="margin-horizontal-md">
+        <SectionHeader preTitle={superTitle} title={title} hideStepNumber />
+      </div>
+
+      <div className="margin-horizontal-md">
+        {image ? (
+          <Figure
+            image={image}
+            alt="content-block"
+            alignment={imageAlignmentClass}
+            size="large"
+          >
+            {contentNode}
+          </Figure>
+        ) : (
+          contentNode
+        )}
+      </div>
+    </div>
+  );
+};
+
+ContentBlock.propTypes = {
+  content: PropTypes.string.isRequired,
+  image: PropTypes.string,
+  imageAlignment: PropTypes.string,
+  superTitle: PropTypes.string,
+  title: PropTypes.string,
+};
+
+ContentBlock.defaultProps = {
+  image: null,
+  imageAlignment: 'right',
+  superTitle: null,
+  title: null,
+};
 
 export default ContentBlock;
-

--- a/resources/assets/components/blocks/ContentBlock/ContentBlock.test.js
+++ b/resources/assets/components/blocks/ContentBlock/ContentBlock.test.js
@@ -41,16 +41,21 @@ describe('ContentBlock component', () => {
     expect(wrapper.find('Markdown').length).toEqual(1);
   });
 
-  test('it renders the correct alignment class for "left" image prop', () => {
-    const wrapper = shallow(
+  test('it renders the correct alignment class for "left" and "right" image props', () => {
+    let wrapper = shallow(
       <ContentBlock {...props} {...image} imageAlignment="left" />,
     );
     expect(wrapper.find('Figure').props().alignment).toEqual('left-collapse');
+
+    wrapper = shallow(
+      <ContentBlock {...props} {...image} imageAlignment="right" />,
+    );
+    expect(wrapper.find('Figure').props().alignment).toEqual('right-collapse');
   });
 
   test('it defaults to "right" image alignment', () => {
     const wrapper = shallow(<ContentBlock {...props} {...image} />);
-    expect(wrapper.find('Figure').props().alignment).toEqual('right');
+    expect(wrapper.find('Figure').props().alignment).toEqual('right-collapse');
   });
 
   test('it works beautifully with a mere content prop', () => {

--- a/resources/assets/components/blocks/ContentBlock/ContentBlock.test.js
+++ b/resources/assets/components/blocks/ContentBlock/ContentBlock.test.js
@@ -1,6 +1,7 @@
 import React from 'react';
-import { mount, shallow, render } from 'enzyme';
+import { shallow } from 'enzyme';
 import { shallowToJson } from 'enzyme-to-json';
+
 import ContentBlock from './ContentBlock';
 
 const props = {

--- a/resources/assets/components/blocks/ContentBlock/ContentBlock.test.js
+++ b/resources/assets/components/blocks/ContentBlock/ContentBlock.test.js
@@ -1,0 +1,50 @@
+import React from 'react';
+import { mount, shallow, render } from 'enzyme';
+import { shallowToJson } from 'enzyme-to-json';
+import ContentBlock from './ContentBlock';
+
+const props = {
+  superTitle: 'Test Super Title',
+  title: 'Test Title',
+  content: 'Test Content',
+};
+
+const image = { image: 'image.com' };
+
+describe('ContentBlock component', () => {
+  test('is rendered with the proper child components when image is set', () => {
+    const wrapper = shallow(<ContentBlock {...props} {...image} />);
+
+    expect(wrapper.find('SectionHeader').length).toEqual(1);
+    expect(wrapper.find('Figure').length).toEqual(1);
+    expect(wrapper.find('Markdown').length).toEqual(1);
+
+    expect(shallowToJson(wrapper)).toMatchSnapshot();
+  });
+
+  test('is rendered with the proper child components when image is not set', () => {
+    const wrapper = shallow(<ContentBlock {...props} />);
+
+    expect(wrapper.find('SectionHeader').length).toEqual(1);
+    expect(wrapper.find('Figure').length).toEqual(0);
+    expect(wrapper.find('Markdown').length).toEqual(1);
+  });
+
+  test('it renders the correct alignment class for "left" image prop', () => {
+    const wrapper = shallow(
+      <ContentBlock {...props} {...image} imageAlignment="left" />,
+    );
+    expect(wrapper.find('Figure').props().alignment).toEqual('left-collapse');
+  });
+
+  test('it defaults to "right" image alignment', () => {
+    const wrapper = shallow(<ContentBlock {...props} {...image} />);
+    expect(wrapper.find('Figure').props().alignment).toEqual('right');
+  });
+
+  test('it works beautifully with a mere content prop', () => {
+    const wrapper = shallow(<ContentBlock content="hi there" />);
+
+    expect(shallowToJson(wrapper)).toMatchSnapshot();
+  });
+});

--- a/resources/assets/components/blocks/ContentBlock/ContentBlock.test.js
+++ b/resources/assets/components/blocks/ContentBlock/ContentBlock.test.js
@@ -23,6 +23,16 @@ describe('ContentBlock component', () => {
     expect(shallowToJson(wrapper)).toMatchSnapshot();
   });
 
+  test("does not include SectionHeader when there's no title", () => {
+    const wrapper = shallow(
+      <ContentBlock {...props} {...image} title={undefined} />,
+    );
+
+    expect(wrapper.find('SectionHeader').length).toEqual(0);
+
+    expect(shallowToJson(wrapper)).toMatchSnapshot();
+  });
+
   test('is rendered with the proper child components when image is not set', () => {
     const wrapper = shallow(<ContentBlock {...props} />);
 

--- a/resources/assets/components/blocks/ContentBlock/__snapshots__/ContentBlock.test.js.snap
+++ b/resources/assets/components/blocks/ContentBlock/__snapshots__/ContentBlock.test.js.snap
@@ -1,0 +1,61 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ContentBlock component is rendered with the proper child components when image is set 1`] = `
+<div
+  className="content-block"
+>
+  <div
+    className="margin-horizontal-md"
+  >
+    <SectionHeader
+      hideStepNumber={true}
+      preTitle="Test Super Title"
+      step={null}
+      title="Test Title"
+    />
+  </div>
+  <div
+    className="margin-horizontal-md"
+  >
+    <Figure
+      alignment="right"
+      alt="content-block"
+      image="image.com"
+      imageClassName={null}
+      size="large"
+    >
+      <Markdown
+        className={null}
+      >
+        Test Content
+      </Markdown>
+    </Figure>
+  </div>
+</div>
+`;
+
+exports[`ContentBlock component it works beautifully with a mere content prop 1`] = `
+<div
+  className="content-block"
+>
+  <div
+    className="margin-horizontal-md"
+  >
+    <SectionHeader
+      hideStepNumber={true}
+      preTitle={null}
+      step={null}
+      title={null}
+    />
+  </div>
+  <div
+    className="margin-horizontal-md"
+  >
+    <Markdown
+      className={null}
+    >
+      hi there
+    </Markdown>
+  </div>
+</div>
+`;

--- a/resources/assets/components/blocks/ContentBlock/__snapshots__/ContentBlock.test.js.snap
+++ b/resources/assets/components/blocks/ContentBlock/__snapshots__/ContentBlock.test.js.snap
@@ -8,8 +8,9 @@ exports[`ContentBlock component does not include SectionHeader when there's no t
     className="margin-horizontal-md"
   >
     <Figure
-      alignment="right"
+      alignment="right-collapse"
       alt="content-block"
+      className="content-block"
       image="image.com"
       imageClassName={null}
       size="large"
@@ -42,8 +43,9 @@ exports[`ContentBlock component is rendered with the proper child components whe
     className="margin-horizontal-md"
   >
     <Figure
-      alignment="right"
+      alignment="right-collapse"
       alt="content-block"
+      className="content-block"
       image="image.com"
       imageClassName={null}
       size="large"

--- a/resources/assets/components/blocks/ContentBlock/__snapshots__/ContentBlock.test.js.snap
+++ b/resources/assets/components/blocks/ContentBlock/__snapshots__/ContentBlock.test.js.snap
@@ -1,5 +1,29 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`ContentBlock component does not include SectionHeader when there's no title 1`] = `
+<div
+  className="content-block"
+>
+  <div
+    className="margin-horizontal-md"
+  >
+    <Figure
+      alignment="right"
+      alt="content-block"
+      image="image.com"
+      imageClassName={null}
+      size="large"
+    >
+      <Markdown
+        className={null}
+      >
+        Test Content
+      </Markdown>
+    </Figure>
+  </div>
+</div>
+`;
+
 exports[`ContentBlock component is rendered with the proper child components when image is set 1`] = `
 <div
   className="content-block"
@@ -38,16 +62,6 @@ exports[`ContentBlock component it works beautifully with a mere content prop 1`
 <div
   className="content-block"
 >
-  <div
-    className="margin-horizontal-md"
-  >
-    <SectionHeader
-      hideStepNumber={true}
-      preTitle={null}
-      step={null}
-      title={null}
-    />
-  </div>
   <div
     className="margin-horizontal-md"
   >

--- a/resources/assets/components/blocks/ContentBlock/__snapshots__/ContentBlock.test.js.snap
+++ b/resources/assets/components/blocks/ContentBlock/__snapshots__/ContentBlock.test.js.snap
@@ -10,10 +10,9 @@ exports[`ContentBlock component does not include SectionHeader when there's no t
     <Figure
       alignment="right-collapse"
       alt="content-block"
-      className="content-block"
       image="image.com"
       imageClassName={null}
-      size="large"
+      size="one-third"
     >
       <Markdown
         className={null}
@@ -45,10 +44,9 @@ exports[`ContentBlock component is rendered with the proper child components whe
     <Figure
       alignment="right-collapse"
       alt="content-block"
-      className="content-block"
       image="image.com"
       imageClassName={null}
-      size="large"
+      size="one-third"
     >
       <Markdown
         className={null}

--- a/resources/assets/components/blocks/ContentBlock/content-block.scss
+++ b/resources/assets/components/blocks/ContentBlock/content-block.scss
@@ -31,4 +31,15 @@
       }
     }
   }
+  @include media($small) {
+    .figure.-right {
+      > .figure__media {
+        margin-bottom: $half-spacing;
+      }
+
+      > .figure__body {
+        overflow: visible;
+      }
+    }
+  }
 }

--- a/resources/assets/components/blocks/ContentBlock/content-block.scss
+++ b/resources/assets/components/blocks/ContentBlock/content-block.scss
@@ -11,35 +11,4 @@
     color: $black;
     font-family: $primary-font-family;
   }
-
-  .figure > .figure__media {
-    width: 100%;
-  }
-
-  @include media($medium) {
-    .figure {
-      > .figure__media {
-        width: 33.333333% !important;
-      }
-
-      &.-right > .figure__media {
-        margin-left: $base-spacing;
-      }
-
-      &.-left-collapse > .figure__media {
-        margin-right: $base-spacing;
-      }
-    }
-  }
-  @include media($small) {
-    .figure.-right {
-      > .figure__media {
-        margin-bottom: $half-spacing;
-      }
-
-      > .figure__body {
-        overflow: visible;
-      }
-    }
-  }
 }

--- a/resources/assets/components/blocks/ContentBlock/content-block.scss
+++ b/resources/assets/components/blocks/ContentBlock/content-block.scss
@@ -1,0 +1,34 @@
+@import '../../../scss/next-toolbox.scss';
+
+.content-block {
+  width: 100%;
+  margin-bottom: 36px;
+
+  h1,
+  h2,
+  h3,
+  p {
+    color: $black;
+    font-family: $primary-font-family;
+  }
+
+  .figure > .figure__media {
+    width: 100%;
+  }
+
+  @include media($medium) {
+    .figure {
+      > .figure__media {
+        width: 33.333333% !important;
+      }
+
+      &.-right > .figure__media {
+        margin-left: $base-spacing;
+      }
+
+      &.-left-collapse > .figure__media {
+        margin-right: $base-spacing;
+      }
+    }
+  }
+}


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR Adds the fully constructed `ContentBlock` component with styling and some testing!

👉 adjusting the `imageAlignment` field in the `ContentBlock` entity to be lowercased

👉 cleaning the `renderer` function a little bit and removing the styling classes from there (they were interfering with the proper internal styling of the ContentBlock)

👉 adjusting the `SectionHeader` component so that the `title` prop is optional (ContentBlock has an optional title and uses `SectionHeader`)

### Any background context you want to provide?
- I dunno how great these tests are, I tried to focus on the specific tricky variables we had and then just general light content testing.

- Everything's pretty straightforward aside from the `imageAlignment`/`image` balancing act. I *tried* to keep it as clean and rational as I could. Please let me know if there's anything improvable there.

- I had to add some weird styling so that the content wasn't hidden on mobile. (the `overflow: hidden` messed with things as well as a missing `margin-bottom`)

- On mobile, the Image appears *above* the content, contrary to the [current campaign action step](https://user-images.githubusercontent.com/12417657/38754793-2bc201fc-3f31-11e8-844f-f0042adbcd1b.png). Is this a problem for us?

### What are the relevant tickets/cards?
[Pivotal #156473207](https://www.pivotaltracker.com/story/show/156473207)

### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [x] Added appropriate feature/unit tests.
* [x] Added screenshot to PR description of related front-end updates on **small** screens.
* [x] Added screenshot to PR description of related front-end updates on **medium** screens.
* [x] Added screenshot to PR description of related front-end updates on **large** screens.

###PICS

**Large**
![image](https://user-images.githubusercontent.com/12417657/38754085-79ee1cc4-3f2e-11e8-8156-09732350d8c3.png)


**Medium**
![image](https://user-images.githubusercontent.com/12417657/38754207-e1b1ba28-3f2e-11e8-83ea-89e2a79e1aef.png)


**Small**
![image](https://user-images.githubusercontent.com/12417657/38754634-a68eb610-3f30-11e8-8110-c2add4810e89.png)
