### PR TITLE
Remove /pages/ from campaign subpage slugs and redirect existing ones

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -891,7 +891,7 @@
     },
     "babel-eslint": {
       "version": "8.2.2",
-      "resolved": "http://registry.npmjs.org/babel-eslint/-/babel-eslint-8.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-8.2.2.tgz",
       "integrity": "sha512-Qt2lz2egBxNYWqN9JIO2z4NOOf8i4b5JS6CFoYrOZZTDssueiV1jH/jsefyg+86SeNY3rB361/mi3kE1WK2WYQ==",
       "dev": true,
       "requires": {
@@ -4427,7 +4427,7 @@
     },
     "event-stream": {
       "version": "3.3.4",
-      "resolved": "http://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
+      "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
       "integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
       "dev": true,
       "requires": {

--- a/resources/assets/components/App.js
+++ b/resources/assets/components/App.js
@@ -6,11 +6,11 @@ import { ApolloProvider } from 'react-apollo';
 import { ConnectedRouter } from 'react-router-redux';
 import { PuckProvider } from '@dosomething/puck-client';
 
+import { env } from '../helpers';
+import graphqlClient from '../graphql';
+import { getUserId } from '../selectors/user';
 import { CampaignContainer } from './Campaign';
 import { initializeStore } from '../store/store';
-import { getUserId } from '../selectors/user';
-import graphqlClient from '../graphql';
-import { env } from '../helpers';
 
 const App = ({ store, history }) => {
   initializeStore(store);

--- a/resources/assets/components/Campaign/CampaignContainer.js
+++ b/resources/assets/components/Campaign/CampaignContainer.js
@@ -7,10 +7,6 @@ const mapStateToProps = (state, props) => {
   const hasLandingPage = state.campaign.landingPage !== null;
   const isSignedUp = state.signups.thisCampaign;
 
-  console.log('💩');
-  console.log(props.location);
-  console.log(props.match);
-
   // @TODO: Move these into the pages themselves.
   const { location, match } = props;
   const isQuiz = location.pathname.replace(match.url, '').startsWith('/quiz/');

--- a/resources/assets/components/Campaign/CampaignContainer.js
+++ b/resources/assets/components/Campaign/CampaignContainer.js
@@ -7,6 +7,10 @@ const mapStateToProps = (state, props) => {
   const hasLandingPage = state.campaign.landingPage !== null;
   const isSignedUp = state.signups.thisCampaign;
 
+  console.log('💩');
+  console.log(props.location);
+  console.log(props.match);
+
   // @TODO: Move these into the pages themselves.
   const { location, match } = props;
   const isQuiz = location.pathname.replace(match.url, '').startsWith('/quiz/');

--- a/resources/assets/components/Navigation/TabbedNavigationContainer.js
+++ b/resources/assets/components/Navigation/TabbedNavigationContainer.js
@@ -7,11 +7,11 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router-dom';
 
-import NavigationLink from '../Navigation/NavigationLink';
+import SignupButton from '../SignupButton';
+import { isCampaignClosed } from '../../helpers';
 import TabbedNavigation from './TabbedNavigation';
 import { campaignPaths } from '../../helpers/navigation';
-import { isCampaignClosed } from '../../helpers';
-import SignupButton from '../SignupButton';
+import NavigationLink from '../Navigation/NavigationLink';
 
 const mapStateToProps = state => ({
   hasActivityFeed: Boolean(state.campaign.activityFeed.length),

--- a/resources/assets/components/Navigation/TabbedNavigationContainer.js
+++ b/resources/assets/components/Navigation/TabbedNavigationContainer.js
@@ -52,12 +52,7 @@ const TabbedNavigationContainer = props => {
         pageSlug = pageSlug.replace(`${campaignSlug}/`, '');
       }
 
-      const path = join(
-        '/us/campaigns',
-        campaignSlug,
-        campaignPaths.pages,
-        pageSlug,
-      );
+      const path = join('/us/campaigns', campaignSlug, pageSlug);
 
       return (
         <NavigationLink key={page.id} to={path}>

--- a/resources/assets/components/Page/CampaignPage/CampaignPage.js
+++ b/resources/assets/components/Page/CampaignPage/CampaignPage.js
@@ -77,10 +77,6 @@ const CampaignPage = props => {
             }}
           />
           <Route
-            path={`${match.url}/pages/:slug`}
-            component={CampaignSubPageContainer}
-          />
-          <Route
             path={`${match.url}/blocks/:id`}
             component={BlockPageContainer}
           />
@@ -88,8 +84,15 @@ const CampaignPage = props => {
             path={`${match.url}/quiz/:slug`}
             component={BlockPageContainer}
           />
-          {/* If no route matches, just redirect back to the main page: */}
-          <Redirect from={`${match.url}/:anything`} to={`${match.url}`} />
+          {/* @deprecate: remove this Route specification with `/pages/:slug` */}
+          <Route
+            path={`${match.url}/pages/:slug`}
+            component={CampaignSubPageContainer}
+          />
+          <Route
+            path={`${match.url}/:slug`}
+            component={CampaignSubPageContainer}
+          />
         </Switch>
       </div>
       <CampaignFooter

--- a/resources/assets/helpers/navigation.js
+++ b/resources/assets/helpers/navigation.js
@@ -7,7 +7,6 @@ export const campaignPaths = {
   action: '/action',
   blocks: '/blocks/',
   quiz: '/quiz/',
-  pages: '/pages/',
 };
 
 /**

--- a/resources/assets/init.js
+++ b/resources/assets/init.js
@@ -15,6 +15,7 @@ import React from 'react';
 import ReactDom from 'react-dom';
 import thunk from 'redux-thunk';
 import { routerReducer, routerMiddleware } from 'react-router-redux';
+
 import { configureStore } from './store/store';
 import * as reducers from './reducers';
 

--- a/resources/assets/init.js
+++ b/resources/assets/init.js
@@ -16,8 +16,8 @@ import ReactDom from 'react-dom';
 import thunk from 'redux-thunk';
 import { routerReducer, routerMiddleware } from 'react-router-redux';
 
-import { configureStore } from './store/store';
 import * as reducers from './reducers';
+import { configureStore } from './store/store';
 
 // Browser polyfills
 import './polyfills';

--- a/routes/web.php
+++ b/routes/web.php
@@ -29,7 +29,6 @@ $router->get('us/campaigns/{slug}/{clientRoute?}', 'CampaignController@show')
     ->where('clientRoute', '.*');
 $router->redirect('campaigns/{slug}', 'us/campaigns/{slug}');
 
-
 // Campaigns cache clear
 $router->get('next/cache/{cacheId}', 'CacheController');
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -20,9 +20,15 @@ $router->redirect('auth/login', 'next/login'); // Fix for hard-coded redirect in
 $router->get('us/campaigns', 'CampaignController@index');
 $router->redirect('campaigns', 'us/campaigns');
 
+// Redirect routes for campaign specific URLs containing "/pages/".
+$router->get('us/campaigns/{slug}/pages/{clientRoute?}', function ($slug, $clientRoute) {
+    return redirect('/us/campaigns/'.$slug.'/'.$clientRoute);
+});
+
 $router->get('us/campaigns/{slug}/{clientRoute?}', 'CampaignController@show')
     ->where('clientRoute', '.*');
 $router->redirect('campaigns/{slug}', 'us/campaigns/{slug}');
+
 
 // Campaigns cache clear
 $router->get('next/cache/{cacheId}', 'CacheController');


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?
This PR provides the first step in the effort to revise how our system works with slugs for campaign subpages. It removes the `/pages/` from the URLs to campaign subpages and also updates the backend routes to handle redirecting requests to campaigns that contain `/pages/`.

Also, instead of redirecting campaign subpages with a slug that cannot be matched, back to the main campaign root page, we're going to just let the campaign subpage show a NotFound component.

### What are the relevant tickets/cards?
Refs [Pivotal ID #156351793](https://www.pivotaltracker.com/story/show/156351793)


### Checklist
* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.