### PR TITLE
Quick fix to responsiveness issue

### DIFF
--- a/resources/assets/components/Figure/figure.scss
+++ b/resources/assets/components/Figure/figure.scss
@@ -49,12 +49,14 @@
 }
 
 .figure.-one-third {
-  &.figure.-right-collapse > .figure__media {
-    margin-left: $base-spacing;
-  }
+  @include media($tablet) {
+    &.figure.-right-collapse > .figure__media {
+      margin-left: $base-spacing;
+    }
 
-  &.figure.-left-collapse > .figure__media {
-    margin-right: $base-spacing;
+    &.figure.-left-collapse > .figure__media {
+      margin-right: $base-spacing;
+    }
   }
 
   &.figure > .figure__media {


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR fixes an issue where the image for a ContentBlock would still retain it's margin on small screens causing awkwardness
![image](https://user-images.githubusercontent.com/12417657/38831990-19ab602a-418f-11e8-82da-2a928e2d8a74.png)


### Any background context you want to provide?
I was cognizant of this and initially had this `@media` scope. My weary brain must have overlooked that it was missing at some point 😫 

#835 