### PR TITLE
Fix Puck event tracking for ModalLauncher.

### DIFF
--- a/resources/assets/components/ModalLauncher/ModalLauncher.js
+++ b/resources/assets/components/ModalLauncher/ModalLauncher.js
@@ -58,8 +58,19 @@ class ModalLauncher extends React.Component {
   };
 
   render() {
+    // Set the proper Puck "event name" so we can
+    // continue tracking opens of timed modals.
+    let type = this.props.type;
+    if (type === 'voter_reg_modal') {
+      type = 'VOTER_REGISTRATION_MODAL';
+    } else if (type === '') {
+      type = 'SURVEY_MODAL';
+    }
+
     return this.state.showModal ? (
-      <Modal onClose={this.handleClose}>{this.props.render()}</Modal>
+      <Modal trackingId={type} onClose={this.handleClose}>
+        {this.props.render()}
+      </Modal>
     ) : null;
   }
 }

--- a/resources/assets/components/utilities/Modal/Modal.js
+++ b/resources/assets/components/utilities/Modal/Modal.js
@@ -5,6 +5,7 @@ import PropTypes from 'prop-types';
 import ReactDom from 'react-dom';
 
 import ModalContent from './ModalContent';
+import { trackPuckEvent } from '../../../helpers/analytics';
 
 import './modal.scss';
 
@@ -28,6 +29,11 @@ class Modal extends React.Component {
     );
     this.modalPortal.classList.add('is-active');
     this.modalPortal.appendChild(this.el);
+
+    // Track in analytics that the modal opened:
+    if (this.props.trackingId) {
+      trackPuckEvent('open modal', { modalType: this.props.trackingId });
+    }
   }
 
   componentWillUnmount() {
@@ -51,7 +57,12 @@ class Modal extends React.Component {
 
 Modal.propTypes = {
   children: PropTypes.node.isRequired,
+  trackingId: PropTypes.string,
   onClose: PropTypes.func.isRequired,
+};
+
+Modal.defaultProps = {
+  trackingId: null,
 };
 
 export default Modal;


### PR DESCRIPTION
### What does this PR do?

This pull request re-adds the `open modal` Puck event to the two modals launched by the `ModalLauncher`, since we need that event to track conversion on those two flows.

<img width="737" alt="screen shot 2018-04-16 at 4 51 16 pm" src="https://user-images.githubusercontent.com/583202/38834835-9891a130-4197-11e8-84ac-29e62a782002.png">

### Any background context you want to provide?

This event [was triggered](https://github.com/DoSomething/phoenix-next/pull/836/files#diff-dc9bb216b849169350e03ebe7c39bcc2L38) in the old modal implementation, but didn't make it's way over to the new one.

To reduce some noise, I was thinking we'd only track modals that don't appear as part of the normal flow. (Since post-signup and post-reportback modals always appear alongside their associated events, and the `modal/:id` pages should be tracked as normal page views).

### What are the relevant tickets/cards?
N/A

### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.
* [ ] Added screenshot to PR description of related front-end updates on **small** screens.
* [ ] Added screenshot to PR description of related front-end updates on **medium** screens.
* [ ] Added screenshot to PR description of related front-end updates on **large** screens.