### PR TITLE
Ensure 'x' appears above Typeform survey.

### DIFF
--- a/resources/assets/components/utilities/Modal/modal.scss
+++ b/resources/assets/components/utilities/Modal/modal.scss
@@ -50,6 +50,7 @@
   text-align: center;
   top: 0;
   width: 50px;
+  z-index: 9999; // Ensure "x" is above all other elements, like iframes.
 
   &:focus {
     outline: thin dotted;


### PR DESCRIPTION
### What does this PR do?
I noticed a fun little bug when testing the NPS survey for the `ModalLauncher`... you [can't leave](https://user-images.githubusercontent.com/583202/38837050-8365d5a4-419e-11e8-965a-834286f75b9c.png)!! This pull request just makes a _quick_ fix for that by [ensuring the "x" is layered on top](https://user-images.githubusercontent.com/583202/38837061-88f35c62-419e-11e8-895a-6bdc93df0c12.png).

### Any background context you want to provide?
We can also look into making the overlay close the modal again, but this is a good first step!

### What are the relevant tickets/cards?
N/A

### Checklist
* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.
* [ ] Added screenshot to PR description of related front-end updates on **small** screens.
* [ ] Added screenshot to PR description of related front-end updates on **medium** screens.
* [ ] Added screenshot to PR description of related front-end updates on **large** screens.