### PR TITLE
Switching around the logic to prefer campaign slug as part of subpage slug

### DIFF
--- a/resources/assets/components/Navigation/TabbedNavigationContainer.js
+++ b/resources/assets/components/Navigation/TabbedNavigationContainer.js
@@ -45,14 +45,15 @@ const TabbedNavigationContainer = props => {
     .filter(entry => entry.type === 'page')
     .filter(page => !page.fields.hideFromNavigation)
     .map(page => {
-      const pageHasCampaignSlug = page.fields.slug.indexOf(campaignSlug) >= 0;
+      const pageMissingCampaignSlug =
+        page.fields.slug.indexOf(campaignSlug) < 0;
       let pageSlug = page.fields.slug;
 
-      if (pageHasCampaignSlug) {
-        pageSlug = pageSlug.replace(`${campaignSlug}/`, '');
+      if (pageMissingCampaignSlug) {
+        pageSlug = join(campaignSlug, pageSlug);
       }
 
-      const path = join('/us/campaigns', campaignSlug, pageSlug);
+      const path = join('/us/campaigns', pageSlug);
 
       return (
         <NavigationLink key={page.id} to={path}>


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_


### What does this PR do?
This PR switches around the logic when setting the URLs for tabbed navigation links so that it can accommodate page slugs having the campaign slug as part of their value, which is how we aim to make campaign page slugs unique in the CMS.


### What are the relevant tickets/cards?
Refs [Pivotal ID #156351793](https://www.pivotaltracker.com/story/show/156351793)

### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.