### PR TITLE
Contentful slug transform script

### DIFF
--- a/contentful/management-api-scripts/2018_04_17_001_transform_page_slugs.js
+++ b/contentful/management-api-scripts/2018_04_17_001_transform_page_slugs.js
@@ -11,7 +11,7 @@ if (!spaceId || !accessToken) {
   return;
 }
 
-async function transformPageSlugs() {
+async function getEnvironment() {
   const client = contentful.createClient({
     // This is the access token for this space. Normally you get both ID and the token in the Contentful web app
     accessToken: accessToken,
@@ -22,7 +22,11 @@ async function transformPageSlugs() {
 
   // This API call will request the environment with the specified - as of now hardcoded - id
   // (Contentful requires this scoping, as the `space.getEntries` is being deprecated)
-  const environment = await space.getEnvironment('master');
+  return space.getEnvironment('master');
+}
+
+async function transformPageSlugs() {
+  const environment = await getEnvironment();
 
   // Now that we have an environment, we can get entries from that environment
   const campaigns = await environment.getEntries({

--- a/contentful/management-api-scripts/2018_04_17_001_transform_page_slugs.js
+++ b/contentful/management-api-scripts/2018_04_17_001_transform_page_slugs.js
@@ -62,7 +62,12 @@ async function transformPageSlug(campaign, page, environment) {
   const campaignSlug = get(campaign.fields.slug, locale);
   const pageSlug = get(pageEntry.fields.slug, locale);
 
-  if (!campaignSlug || !pageSlug || pageSlug.indexOf(campaignSlug) === 0) {
+  if (
+    !campaignSlug ||
+    !pageSlug ||
+    pageSlug.indexOf(campaignSlug) === 0 ||
+    pageSlug.indexOf(campaignSlug) === 1
+  ) {
     return;
   }
 

--- a/contentful/management-api-scripts/2018_04_17_001_transform_page_slugs.js
+++ b/contentful/management-api-scripts/2018_04_17_001_transform_page_slugs.js
@@ -3,12 +3,19 @@ const contentful = require('contentful-management');
 const spaceId = process.argv[3];
 const accessToken = process.argv[5];
 
+const locale = 'en-US';
+
 if (!spaceId || !accessToken) {
   console.log(
     'Please provide the space-id and access token arguments in the following format:',
   );
   console.log('--space-id [space-id] --access-token [access-token]');
   return;
+}
+
+// Helper Function
+function sleep(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms));
 }
 
 async function getEnvironment() {
@@ -34,20 +41,27 @@ async function transformPageSlugs() {
   });
 
   campaigns.items.forEach(campaign => {
-    const pages = campaign.fields.pages['en-US'];
+    const pages = campaign.fields.pages;
 
-    pages.forEach(page => {
+    if (!pages || !pages[locale]) {
+      return;
+    }
+
+    const campaignPages = campaign.fields.pages[locale];
+
+    campaignPages.forEach(page => {
       transformPageSlug(campaign, page, environment);
     });
 
     console.log(`Updated Campaign! [ID: ${campaign.sys.id}]\n`);
+
+    // API breather room
+    sleep(1000);
   });
 }
 
 async function transformPageSlug(campaign, page, environment) {
   const pageEntry = await environment.getEntry(page.sys.id);
-
-  const locale = 'en-US';
 
   if (!pageEntry.fields.slug || !campaign.fields.slug) {
     return;

--- a/contentful/management-api-scripts/2018_04_17_001_transform_page_slugs.js
+++ b/contentful/management-api-scripts/2018_04_17_001_transform_page_slugs.js
@@ -63,12 +63,7 @@ async function transformPageSlug(campaign, page, environment) {
   const campaignSlug = get(campaign.fields.slug, locale);
   const pageSlug = get(pageEntry.fields.slug, locale);
 
-  if (
-    !campaignSlug ||
-    !pageSlug ||
-    pageSlug.indexOf(campaignSlug) === 0 ||
-    pageSlug.indexOf(campaignSlug) === 1
-  ) {
+  if (!campaignSlug || !pageSlug || pageSlug.indexOf(campaignSlug) >= 0) {
     return;
   }
 

--- a/contentful/management-api-scripts/2018_04_17_001_transform_page_slugs.js
+++ b/contentful/management-api-scripts/2018_04_17_001_transform_page_slugs.js
@@ -76,7 +76,6 @@ async function transformPageSlug(campaign, page, environment) {
   }
 
   pageEntry.fields.slug[locale] = join(campaignSlug, pageSlug);
-  console.log(pageEntry.fields.slug);
 
   pageEntry.update().then(page => page.publish());
 

--- a/contentful/management-api-scripts/2018_04_17_001_transform_page_slugs.js
+++ b/contentful/management-api-scripts/2018_04_17_001_transform_page_slugs.js
@@ -35,17 +35,28 @@ async function transformPageSlugs() {
     pages.forEach(page => {
       transformPageSlug(campaign, page, environment);
     });
+
+    console.log(`Updated Campaign! [ID: ${campaign.sys.id}]\n`);
   });
 }
 
 async function transformPageSlug(campaign, page, environment) {
   const pageEntry = await environment.getEntry(page.sys.id);
 
-  pageEntry.fields.slug['en-US'] = `${campaign.fields.slug['en-US']}/${
-    pageEntry.fields.slug['en-US']
+  const locale = 'en-US';
+
+  if (!pageEntry.fields.slug || !campaign.fields.slug) {
+    return;
+  }
+
+  pageEntry.fields.slug[locale] = `${campaign.fields.slug[locale]}/${
+    pageEntry.fields.slug[locale]
   }`;
 
   pageEntry.update().then(page => page.publish());
+
+  console.log(`Updated Page! [ID: ${pageEntry.sys.id}]`);
+  console.log(`--> ${pageEntry.fields.slug[locale]}\n`);
 }
 
 transformPageSlugs();

--- a/contentful/management-api-scripts/2018_04_17_001_transform_page_slugs.js
+++ b/contentful/management-api-scripts/2018_04_17_001_transform_page_slugs.js
@@ -54,9 +54,6 @@ async function transformPageSlugs() {
     });
 
     console.log(`Processed Campaign! [ID: ${campaign.sys.id}]\n`);
-
-    // API breather room
-    sleep(1000);
   });
 }
 
@@ -83,7 +80,7 @@ async function transformPageSlug(campaign, page, environment) {
   console.log(`--> ${pageEntry.fields.slug[locale]}\n`);
 
   // API breather room
-  sleep(1000);
+  await sleep(1000);
 }
 
 transformPageSlugs();

--- a/contentful/management-api-scripts/2018_04_17_001_transform_page_slugs.js
+++ b/contentful/management-api-scripts/2018_04_17_001_transform_page_slugs.js
@@ -1,0 +1,54 @@
+const contentful = require('contentful-management');
+
+const spaceId = process.argv[3];
+const accessToken = process.argv[5];
+
+if (!spaceId || !accessToken) {
+  console.log(
+    'Please provide the space-id and access token arguments in the following format:',
+  );
+  console.log('--space-id [space-id] --access-token [access-token]');
+  return;
+}
+
+async function transformPageSlugs() {
+  const client = contentful.createClient({
+    // This is the access token for this space. Normally you get both ID and the token in the Contentful web app
+    accessToken: accessToken,
+  });
+
+  // This API call will request a space with the specified ID
+  const space = await client.getSpace(spaceId);
+
+  // This API call will request the environment with the specified - as of now hardcoded - id
+  // (Contentful requires this scoping, as the `space.getEntries` is being deprecated)
+  const environment = await space.getEnvironment('master');
+
+  // Now that we have an environment, we can get entries from that environment
+  const campaigns = await environment.getEntries({
+    content_type: 'campaign',
+  });
+
+  campaigns.items.forEach(campaign => {
+    const pages = campaign.fields.pages['en-US'];
+
+    pages.forEach(page => {
+      transformPageSlug(campaign, page, environment);
+    });
+
+    // give the API a breather
+    sleep(1);
+  });
+}
+
+async function transformPageSlug(campaign, page, environment) {
+  const pageEntry = await environment.getEntry(page.sys.id);
+
+  pageEntry.fields.slug['en-US'] = `${campaign.fields.slug['en-US']}/${
+    pageEntry.fields.slug['en-US']
+  }`;
+
+  pageEntry.update().then(page => page.publish());
+}
+
+transformPageSlugs();

--- a/contentful/management-api-scripts/2018_04_17_001_transform_page_slugs.js
+++ b/contentful/management-api-scripts/2018_04_17_001_transform_page_slugs.js
@@ -72,6 +72,9 @@ async function transformPageSlug(campaign, page, environment) {
 
   console.log(`Updated Page! [ID: ${pageEntry.sys.id}]`);
   console.log(`--> ${pageEntry.fields.slug[locale]}\n`);
+
+  // API breather room
+  sleep(1000);
 }
 
 transformPageSlugs();

--- a/contentful/management-api-scripts/2018_04_17_001_transform_page_slugs.js
+++ b/contentful/management-api-scripts/2018_04_17_001_transform_page_slugs.js
@@ -71,6 +71,10 @@ async function transformPageSlug(campaign, page, environment) {
   const campaignSlug = campaign.fields.slug[locale];
   const pageSlug = pageEntry.fields.slug[locale];
 
+  if (pageSlug.indexOf(campaignSlug) === 0) {
+    return;
+  }
+
   pageEntry.fields.slug[locale] = join(campaignSlug, pageSlug);
   console.log(pageEntry.fields.slug);
 

--- a/contentful/management-api-scripts/2018_04_17_001_transform_page_slugs.js
+++ b/contentful/management-api-scripts/2018_04_17_001_transform_page_slugs.js
@@ -1,5 +1,5 @@
-const contentful = require('contentful-management');
 const { join } = require('path');
+const contentful = require('contentful-management');
 
 const spaceId = process.argv[3];
 const accessToken = process.argv[5];

--- a/contentful/management-api-scripts/2018_04_17_001_transform_page_slugs.js
+++ b/contentful/management-api-scripts/2018_04_17_001_transform_page_slugs.js
@@ -35,9 +35,6 @@ async function transformPageSlugs() {
     pages.forEach(page => {
       transformPageSlug(campaign, page, environment);
     });
-
-    // give the API a breather
-    sleep(1);
   });
 }
 

--- a/contentful/management-api-scripts/2018_04_17_001_transform_page_slugs.js
+++ b/contentful/management-api-scripts/2018_04_17_001_transform_page_slugs.js
@@ -1,11 +1,15 @@
 const { join } = require('path');
 const { get } = require('lodash');
+const parseArgs = require('minimist');
 const contentful = require('contentful-management');
 
-const spaceId = process.argv[3];
-const accessToken = process.argv[5];
-
 const locale = 'en-US';
+
+const args = parseArgs(process.argv, {
+  alias: { 'access-token': 'accessToken', spaceId: 'space-id' },
+});
+
+const { spaceId, accessToken } = args;
 
 if (!spaceId || !accessToken) {
   console.log(

--- a/contentful/management-api-scripts/2018_04_17_001_transform_page_slugs.js
+++ b/contentful/management-api-scripts/2018_04_17_001_transform_page_slugs.js
@@ -1,4 +1,5 @@
 const contentful = require('contentful-management');
+const { join } = require('path');
 
 const spaceId = process.argv[3];
 const accessToken = process.argv[5];
@@ -67,9 +68,11 @@ async function transformPageSlug(campaign, page, environment) {
     return;
   }
 
-  pageEntry.fields.slug[locale] = `${campaign.fields.slug[locale]}/${
-    pageEntry.fields.slug[locale]
-  }`;
+  const campaignSlug = campaign.fields.slug[locale];
+  const pageSlug = pageEntry.fields.slug[locale];
+
+  pageEntry.fields.slug[locale] = join(campaignSlug, pageSlug);
+  console.log(pageEntry.fields.slug);
 
   pageEntry.update().then(page => page.publish());
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -169,6 +169,16 @@
         }
       }
     },
+    "@contentful/axios": {
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/@contentful/axios/-/axios-0.18.0.tgz",
+      "integrity": "sha512-4r4Ww1IJlmRolKgovLTTmdS6CsdvXYVxgXRFwWSh1x36T/0Wg9kTwdaVaApZXcv1DfYyw9RSNdxIGSwTP2/Lag==",
+      "dev": true,
+      "requires": {
+        "follow-redirects": "1.4.1",
+        "is-buffer": "1.1.6"
+      }
+    },
     "@dosomething/analytics": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/@dosomething/analytics/-/analytics-2.1.1.tgz",
@@ -3044,6 +3054,27 @@
       "integrity": "sha1-/ozxhP9mcLa67wGp1IYaXL7EEgo=",
       "dev": true
     },
+    "contentful-management": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/contentful-management/-/contentful-management-5.0.0.tgz",
+      "integrity": "sha512-+KKnYVAuJ0xaDC0jCZJBaMnUAbktK2FbvCvpL8qEE6tU3s1w/N2pXngf3S0YSWRlr7J/yWrYfUhcqJvRkLb3vQ==",
+      "dev": true,
+      "requires": {
+        "@contentful/axios": "0.18.0",
+        "contentful-sdk-core": "6.0.0-beta1",
+        "lodash": "4.17.5"
+      }
+    },
+    "contentful-sdk-core": {
+      "version": "6.0.0-beta1",
+      "resolved": "https://registry.npmjs.org/contentful-sdk-core/-/contentful-sdk-core-6.0.0-beta1.tgz",
+      "integrity": "sha512-X2+pusbgKqgdRzGEZcv5FmA7CkahRtsZXA1ZT/qKjNjal++BhBa4oP0WDSmBZXMl57lZ/LWxca15tpotMEHdYw==",
+      "dev": true,
+      "requires": {
+        "lodash": "4.17.5",
+        "qs": "6.5.1"
+      }
+    },
     "convert-source-map": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.1.tgz",
@@ -4906,6 +4937,15 @@
       "requires": {
         "inherits": "2.0.3",
         "readable-stream": "2.3.6"
+      }
+    },
+    "follow-redirects": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.4.1.tgz",
+      "integrity": "sha512-uxYePVPogtya1ktGnAAXOacnbIuRMB4dkvqeNz2qTtTQsuzSfbDolV+wMMKxAmCx0bLgAKLbBOkjItMbbkR1vg==",
+      "dev": true,
+      "requires": {
+        "debug": "3.1.0"
       }
     },
     "fontfaceobserver": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9869,9 +9869,10 @@
       }
     },
     "minimist": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+      "dev": true
     },
     "mississippi": {
       "version": "2.0.0",
@@ -9934,6 +9935,13 @@
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "requires": {
         "minimist": "0.0.8"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "0.0.8",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+        }
       }
     },
     "modernizr": {
@@ -10677,10 +10685,16 @@
       "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
       "dev": true,
       "requires": {
-        "minimist": "0.0.8",
+        "minimist": "0.0.10",
         "wordwrap": "0.0.3"
       },
       "dependencies": {
+        "minimist": {
+          "version": "0.0.10",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+          "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
+          "dev": true
+        },
         "wordwrap": {
           "version": "0.0.3",
           "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",

--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
     "@dosomething/babel-config": "^2.1.0",
     "@dosomething/eslint-config": "^4.0.0",
     "@dosomething/webpack-config": "^4.0.0",
+    "contentful-management": "^5.0.0",
     "eslint-loader": "^2.0.0",
     "flow-bin": "0.59.0",
     "husky": "^0.14.3",

--- a/package.json
+++ b/package.json
@@ -99,6 +99,7 @@
     "husky": "^0.14.3",
     "identity-obj-proxy": "^3.0.0",
     "jest": "^22.4.3",
+    "minimist": "^1.2.0",
     "modernizr": "^3.6.0",
     "pretty-quick": "^1.4.1",
     "redux-devtools": "^3.4.1",


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR adds a script that uses the [contentful-management-api (js sdk)](https://contentful.github.io/contentful-management.js/contentful-management/5.0.0/) to transform all `Page` - `slug` fields over to the [new format](https://github.com/orgs/DoSomething/teams/team-rocket/discussions/17)

To run this script (in command line from `phoenix-next` project root directory):
```
$ node contentful/management-api-scripts/[transformation-filename] --space-id [contentful space id] --access-token [contentful-access-token]
```


### Any background context you want to provide?
- We tried doing this with our usual transformation process using the Contentful Migration CLI, however, we ran into a roadblock with needing a `Campaign`s own `slug`field  in order to transform it's individual linked `pages` `slug` fields (`campaign-slug/page-slug`). However, the CLI only allows us access to the `Page`s individually when targeting `Page` directly (without any means of knowing the source campaigns slug), or only the `linkEntry` reference to the pages when targeting the `campaign` itself for the transformation. [Slack thread](https://dosomething.slack.com/archives/C3ASB4204/p1523914344000281)

- There would be *way* fewer API calls being made in the script, however, frustratingly, the [`include`](https://www.contentful.com/developers/docs/references/content-delivery-api/#/reference/links) and [`resolveLinks`](https://www.contentful.com/developers/docs/javascript/tutorials/using-js-cda-sdk/#retrieving-entries-with-search-parameters) options don't seem to be working at all with this sdk.

- I tested this all using my personal Contentful space, modeled with Campaigns and pages etc. So this *should* work with our space as well.
![comic](http://i.imgur.com/PnvK7v6.png)

### What are the relevant tickets/cards?
https://www.pivotaltracker.com/story/show/156771576 -- I think

