### PR TITLE
Split vendor files into a separate bundle.

### DIFF
--- a/resources/views/layouts/master.blade.php
+++ b/resources/views/layouts/master.blade.php
@@ -39,6 +39,7 @@
     {{ scriptify($env, 'ENV') }}
     {{ scriptify($auth, 'AUTH') }}
 
+    <script type="text/javascript" src="{{ elixir('vendors~app.js', 'next/assets') }}"></script>
     <script type="text/javascript" src="{{ elixir('app.js', 'next/assets') }}"></script>
 
     @stack('scripts')

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -25,4 +25,10 @@ module.exports = configure({
         '@researchgate/react-intersection-observer/lib/js',
     },
   },
+
+  optimization: {
+    splitChunks: {
+      chunks: 'all',
+    },
+  },
 });

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -13,7 +13,12 @@ module.exports = configure({
 
   module: {
     rules: [
-      { enforce: 'pre', test: /\.js$/, use: 'eslint-loader', include: path.join(__dirname, '/resources/assets') },
+      {
+        enforce: 'pre',
+        test: /\.js$/,
+        use: 'eslint-loader',
+        include: path.join(__dirname, '/resources/assets'),
+      },
     ],
   },
 


### PR DESCRIPTION
### What does this PR do?

This pull request splits out vendor code (stuff in `node_modules` into a separate bundle). The `optimization.splitChunks.chunks = 'all'` setting enables the same bundle-splitting logic for the entry point as for lazy-loaded chunks.

![screen shot 2018-04-18 at 12 15 09 pm](https://user-images.githubusercontent.com/583202/38944542-2aa83af0-4302-11e8-9fc3-d28bfe58a65f.png)

### Any background context you want to provide?

Vendor code changes much less frequently than our app code, so it can be cached by our user's browsers for much longer (i.e. they'd keep the same `vendors~app.js` but get a new smaller `app.js` with changes we deployed to this app).

### What are the relevant tickets/cards?

[Discussion #17](https://github.com/orgs/DoSomething/teams/team-rocket/discussions/17)

### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.
* [ ] Added screenshot to PR description of related front-end updates on **small** screens.
* [ ] Added screenshot to PR description of related front-end updates on **medium** screens.
* [ ] Added screenshot to PR description of related front-end updates on **large** screens.