### PR TITLE
Updating logic to exclude non-page types.

### DIFF
--- a/resources/assets/components/pages/CampaignSubPage/CampaignSubPage.js
+++ b/resources/assets/components/pages/CampaignSubPage/CampaignSubPage.js
@@ -17,8 +17,12 @@ import './campaign-subpage.scss';
 const CampaignSubPageContent = props => {
   const { campaignEndDate, match, noun, pages, tagline, verb } = props;
 
-  const subPage = find(pages, page =>
-    page.fields.slug.endsWith(match.params.slug),
+  const subPage = find(
+    pages,
+    page =>
+      page.type === 'page'
+        ? page.fields.slug.endsWith(match.params.slug)
+        : false,
   );
 
   if (!subPage) {
@@ -69,8 +73,8 @@ CampaignSubPageContent.propTypes = {
   pages: PropTypes.arrayOf(
     PropTypes.shape({
       fields: PropTypes.shape({
-        title: PropTypes.string.isRequired,
-        slug: PropTypes.string.isRequired,
+        title: PropTypes.string,
+        slug: PropTypes.string,
         content: PropTypes.string.isRequired,
       }),
     }),


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?
This PR adds a quick fix when a non-page is linked to a campaigns `pages` reference and when loading a campaign subpage with an incorrect slug, it lets it parse through the list without erroring out and showing the `NotFound` component instead.

Randomly found when trying to fix 404 issues. Moving forward, we might add a separate `LinkedBlocks` reference field on campaigns because we would prefer only _actual_ pages for a campaign to be linked in the `pages` field, but other standalone campaign pages (like for an SMS flow related to a campaign) still need to be able to reference dedicated blocks and those can be linked to in the new field 😄 

### What are the relevant tickets/cards?
N/A

### Checklist
* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.