### PR TITLE
Conditionally load polyfills if browser requires them.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -283,11 +283,6 @@
         "webpack-merge": "4.1.2"
       }
     },
-    "@publica/url-polyfill": {
-      "version": "0.5.8",
-      "resolved": "https://registry.npmjs.org/@publica/url-polyfill/-/url-polyfill-0.5.8.tgz",
-      "integrity": "sha1-EQ0ML/I8LIv4S9yyXFJJTvNsbEw="
-    },
     "@researchgate/react-intersection-observer": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/@researchgate/react-intersection-observer/-/react-intersection-observer-0.6.0.tgz",
@@ -1752,28 +1747,6 @@
       "requires": {
         "babel-runtime": "6.26.0",
         "babel-types": "6.26.0"
-      }
-    },
-    "babel-polyfill": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.26.0.tgz",
-      "integrity": "sha1-N5k3q8Z9eJWXCtxiHyhM2WbPIVM=",
-      "requires": {
-        "babel-runtime": "6.26.0",
-        "core-js": "2.5.5",
-        "regenerator-runtime": "0.10.5"
-      },
-      "dependencies": {
-        "core-js": {
-          "version": "2.5.5",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.5.tgz",
-          "integrity": "sha1-sU3ek2xkDAV5prUMq8wTLdYSfjs="
-        },
-        "regenerator-runtime": {
-          "version": "0.10.5",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
-          "integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg="
-        }
       }
     },
     "babel-preset-env": {
@@ -15494,11 +15467,6 @@
       "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.4.0.tgz",
       "integrity": "sha1-jN2PusTi0uoefi6Al8QvRCKA+Fs=",
       "dev": true
-    },
-    "unfetch": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/unfetch/-/unfetch-3.0.0.tgz",
-      "integrity": "sha1-jR4FE6Ts0OX/LUGmund3Gq6LZII="
     },
     "union-value": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "@dosomething/forge": "^6.8.0",
     "@dosomething/gateway": "^1.3.0",
     "@dosomething/puck-client": "^1.4.0",
-    "@publica/url-polyfill": "^0.5.8",
     "apollo-cache-inmemory": "^1.1.12",
     "apollo-client": "^2.2.8",
     "apollo-link": "^1.2.2",
@@ -53,7 +52,6 @@
     "apollo-link-http": "^1.5.4",
     "babel-jest": "^20.0.3",
     "babel-plugin-graphql-tag": "^1.5.0",
-    "babel-polyfill": "^6.26.0",
     "babel-preset-flow": "^6.23.0",
     "classnames": "^2.2.5",
     "core-js": "^2.5.5",
@@ -92,8 +90,7 @@
     "redux": "^3.7.2",
     "redux-logger": "^2.8.1",
     "redux-thunk": "^2.2.0",
-    "sixpack-client": "^2.1.0",
-    "unfetch": "^3.0.0"
+    "sixpack-client": "^2.1.0"
   },
   "devDependencies": {
     "@dosomething/babel-config": "^2.2.1",

--- a/resources/assets/polyfills.js
+++ b/resources/assets/polyfills.js
@@ -1,16 +1,5 @@
 /* global window */
 
-// Babel polyfill (Promise, Object.assign, etc.)
-// @see: https://babeljs.io/docs/usage/polyfill/
-import 'babel-polyfill';
-
-// `fetch()` polyfill (http://caniuse.com/#feat=fetch)
-import 'unfetch';
-
-// URL constructor polyfill (http://caniuse.com/#feat=url)
-// @see: https://github.com/webcomponents/URL
-import '@publica/url-polyfill';
-
 // `window.location.origin` polyfill for IE 10
 // @see: http://tosbourn.com/a-fix-for-window-location-origin-in-internet-explorer/
 if (!window.location.origin) {

--- a/resources/views/layouts/master.blade.php
+++ b/resources/views/layouts/master.blade.php
@@ -39,6 +39,19 @@
     {{ scriptify($env, 'ENV') }}
     {{ scriptify($auth, 'AUTH') }}
 
+    <script type="text/javascript">
+        var features = [];
+        ('fetch' in window) || features.push('fetch');
+        ('URL' in window) || features.push('URL');
+
+        if (features.length) {
+            features.unshift('default-3.6');
+
+            var s = document.createElement('script');
+            s.src = 'https://cdn.polyfill.io/v2/polyfill.min.js?features='+features.join(',');
+            document.head.appendChild(s);
+        }
+    </script>
     <script type="text/javascript" src="{{ elixir('vendors~app.js', 'next/assets') }}"></script>
     <script type="text/javascript" src="{{ elixir('app.js', 'next/assets') }}"></script>
 


### PR DESCRIPTION
### What does this PR do?
This pull request conditionally loads polyfills using [Polyfill.io](http://polyfill.io), a service created by the Financial Times team that delivers just the polyfills a user's browser needs based on it's user-string. Additionally, we short-circuit and avoid making a request at all for browsers with the newest web platform features (where we can be pretty darn sure they'll have everything else).

### Any background context you want to provide?
This saves most users an additional 71kb – bringing our vendor bundle down to 568kb, 173kb gzipped!

### What are the relevant tickets/cards?
N/A

### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.
* [ ] Added screenshot to PR description of related front-end updates on **small** screens.
* [ ] Added screenshot to PR description of related front-end updates on **medium** screens.
* [ ] Added screenshot to PR description of related front-end updates on **large** screens.