### PR TITLE
Only load the Facebook SDK if we have a share action on the page.

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -36,6 +36,7 @@ class AppServiceProvider extends ServiceProvider
         View::composer('*', function ($view) {
             $view->with('env', [
                 'APP_ENV' => config('app.env'),
+                'FACEBOOK_APP_ID' => config('services.analytics.facebook_id'),
                 'GRAPHQL_URL' => config('services.graphql.url'),
                 'GLADIATOR_URL' => config('services.gladiator.url'),
                 'NORTHSTAR_URL' => config('services.northstar.url'),

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     ]
   },
   "jest": {
+    "clearMocks": true,
     "testEnvironment": "jest-environment-jsdom-global",
     "setupTestFrameworkScriptFile": "<rootDir>/jest-setup.js",
     "moduleNameMapper": {

--- a/resources/assets/components/ContentfulEntry/renderers.js
+++ b/resources/assets/components/ContentfulEntry/renderers.js
@@ -3,12 +3,12 @@ import { PuckWaypoint } from '@dosomething/puck-client';
 
 import Affirmation from '../Affirmation';
 import { LegacyContentBlock } from '../Block';
+import ShareAction from '../actions/ShareAction/ShareAction';
 import ContentBlock from '../blocks/ContentBlock/ContentBlock';
 import { CompetitionBlockContainer } from '../CompetitionBlock';
 import { ReportbackUploaderContainer } from '../ReportbackUploader';
 import { SubmissionGalleryContainer } from '../Gallery/SubmissionGallery';
 import LinkActionContainer from '../actions/LinkAction/LinkActionContainer';
-import ShareActionContainer from '../actions/ShareAction/ShareActionContainer';
 import ThirdPartyActionContainer from '../actions/ThirdPartyAction/ThirdPartyActionContainer';
 import TextSubmissionActionContainer from '../actions/TextSubmissionAction/TextSubmissionActionContainer';
 import SubmissionGalleryBlockContainer from '../blocks/SubmissionGalleryBlock/SubmissionGalleryBlockContainer';
@@ -170,7 +170,7 @@ export function renderShareAction(step) {
   return (
     <div key={`share-action-${contentfulId}`} className="margin-horizontal-md">
       <PuckWaypoint name="share_action-top" waypointData={{ contentfulId }} />
-      <ShareActionContainer id={step.id} {...step.fields} />
+      <ShareAction id={step.id} {...step.fields} />
       <PuckWaypoint
         name="share_action-bottom"
         waypointData={{ contentfulId }}

--- a/resources/assets/components/Share/Share.js
+++ b/resources/assets/components/Share/Share.js
@@ -14,19 +14,11 @@ const Share = props => {
 
   const onFacebookClick = () => {
     trackEvent('clicked facebook share', trackingData);
-
-    showFacebookSharePrompt({ href: link, quote }, response => {
-      if (response) {
-        trackEvent('facebook share posted', trackingData);
-      } else {
-        trackEvent('facebook share cancelled', trackingData);
-      }
-    });
+    showFacebookSharePrompt(link);
   };
 
   const onTwitterClick = () => {
     trackEvent('clicked twitter share', trackingData);
-
     showTwitterSharePrompt(link, quote || '');
   };
 

--- a/resources/assets/components/Share/ShareContainer.js
+++ b/resources/assets/components/Share/ShareContainer.js
@@ -1,10 +1,5 @@
-import { connect } from 'react-redux';
 import { PuckConnector } from '@dosomething/puck-client';
 import Share from './Share';
 
-const mapStateToProps = state => ({
-  user: state.user,
-});
-
-// Export the container component.
-export default connect(mapStateToProps)(PuckConnector(Share));
+// @TODO: Remove PuckConnector.
+export default PuckConnector(Share);

--- a/resources/assets/components/actions/ShareAction/ShareAction.js
+++ b/resources/assets/components/actions/ShareAction/ShareAction.js
@@ -7,8 +7,8 @@ import Card from '../../utilities/Card/Card';
 import Modal from '../../utilities/Modal/Modal';
 import ContentfulEntry from '../../ContentfulEntry';
 import {
-  showFacebookSharePrompt,
   loadFacebookSDK,
+  showFacebookShareDialog,
   showTwitterSharePrompt,
 } from '../../../helpers';
 
@@ -22,29 +22,26 @@ class ShareAction extends React.Component {
     }
   }
 
-  handleFacebookClick = link => {
+  handleFacebookClick = url => {
     const { trackEvent } = this.props;
-    const trackingData = { url: link };
 
-    trackEvent('clicked facebook share action', trackingData);
+    trackEvent('clicked facebook share action', { url });
 
-    showFacebookSharePrompt({ href: link }, response => {
-      if (!response) {
-        trackEvent('share action cancelled', trackingData);
-        return;
-      }
-
-      trackEvent('share action completed', trackingData);
-      this.setState({ showModal: true });
-    });
+    showFacebookShareDialog(url)
+      .then(() => {
+        trackEvent('share action completed', { url });
+        this.setState({ showModal: true });
+      })
+      .catch(() => {
+        trackEvent('share action cancelled', { url });
+      });
   };
 
-  handleTwitterClick = link => {
+  handleTwitterClick = url => {
     const { trackEvent } = this.props;
-    const trackingData = { url: link };
 
-    trackEvent('clicked twitter share action', trackingData);
-    showTwitterSharePrompt(link, '', () => this.setState({ showModal: true }));
+    trackEvent('clicked twitter share action', { url });
+    showTwitterSharePrompt(url, '', () => this.setState({ showModal: true }));
   };
 
   render() {
@@ -57,10 +54,10 @@ class ShareAction extends React.Component {
       title,
     } = this.props;
 
-    const handleShareClick =
-      socialPlatform === 'facebook'
-        ? this.handleFacebookClick
-        : this.handleTwitterClick;
+    const isFacebook = socialPlatform === 'facebook';
+    const handleShareClick = isFacebook
+      ? this.handleFacebookClick
+      : this.handleTwitterClick;
 
     return (
       <React.Fragment>

--- a/resources/assets/components/actions/ShareAction/ShareAction.js
+++ b/resources/assets/components/actions/ShareAction/ShareAction.js
@@ -8,11 +8,19 @@ import Modal from '../../utilities/Modal/Modal';
 import ContentfulEntry from '../../ContentfulEntry';
 import {
   showFacebookSharePrompt,
+  loadFacebookSDK,
   showTwitterSharePrompt,
 } from '../../../helpers';
 
 class ShareAction extends React.Component {
   state = { showModal: false };
+
+  componentDidMount() {
+    // If this is a Facebook share action, make sure we load SDK.
+    if (this.props.socialPlatform === 'facebook') {
+      loadFacebookSDK();
+    }
+  }
 
   handleFacebookClick = link => {
     const { trackEvent } = this.props;

--- a/resources/assets/components/actions/ShareAction/ShareAction.js
+++ b/resources/assets/components/actions/ShareAction/ShareAction.js
@@ -7,6 +7,7 @@ import Button from '../../Button/Button';
 import Card from '../../utilities/Card/Card';
 import Modal from '../../utilities/Modal/Modal';
 import ContentfulEntry from '../../ContentfulEntry';
+import { trackPuckEvent } from '../../../helpers/analytics';
 import {
   loadFacebookSDK,
   showFacebookShareDialog,
@@ -24,24 +25,20 @@ class ShareAction extends React.Component {
   }
 
   handleFacebookClick = url => {
-    const { trackEvent } = this.props;
-
-    trackEvent('clicked facebook share action', { url });
+    trackPuckEvent('clicked facebook share action', { url });
 
     showFacebookShareDialog(url)
       .then(() => {
-        trackEvent('share action completed', { url });
+        trackPuckEvent('share action completed', { url });
         this.setState({ showModal: true });
       })
       .catch(() => {
-        trackEvent('share action cancelled', { url });
+        trackPuckEvent('share action cancelled', { url });
       });
   };
 
   handleTwitterClick = url => {
-    const { trackEvent } = this.props;
-
-    trackEvent('clicked twitter share action', { url });
+    trackPuckEvent('clicked twitter share action', { url });
     showTwitterSharePrompt(url, '', () => this.setState({ showModal: true }));
   };
 
@@ -98,7 +95,6 @@ ShareAction.propTypes = {
   title: PropTypes.string.isRequired,
   content: PropTypes.string,
   link: PropTypes.string.isRequired,
-  trackEvent: PropTypes.func.isRequired,
   socialPlatform: PropTypes.oneOf(['twitter', 'facebook']).isRequired,
   affirmation: PropTypes.string,
   affirmationBlock: PropTypes.object, // eslint-disable-line

--- a/resources/assets/components/actions/ShareAction/ShareAction.js
+++ b/resources/assets/components/actions/ShareAction/ShareAction.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 
 import Embed from '../../Embed';
 import Markdown from '../../Markdown';
+import Button from '../../Button/Button';
 import Card from '../../utilities/Card/Card';
 import Modal from '../../utilities/Modal/Modal';
 import ContentfulEntry from '../../ContentfulEntry';
@@ -67,12 +68,11 @@ class ShareAction extends React.Component {
 
             <Embed className="padded" url={link} />
 
-            <button
-              className="button button-attached"
+            <Button
+              className="button-attached"
               onClick={() => handleShareClick(link)}
-            >
-              Share on {socialPlatform === 'facebook' ? 'Facebook' : 'Twitter'}
-            </button>
+              text={`Share on ${isFacebook ? 'Facebook' : 'Twitter'}`}
+            />
           </Card>
         </div>
         {this.state.showModal ? (

--- a/resources/assets/components/actions/ShareAction/ShareActionContainer.js
+++ b/resources/assets/components/actions/ShareAction/ShareActionContainer.js
@@ -1,5 +1,0 @@
-import { PuckConnector } from '@dosomething/puck-client';
-
-import ShareAction from './ShareAction';
-
-export default PuckConnector(ShareAction);

--- a/resources/assets/components/actions/VoterRegistrationAction/VoterRegistrationAction.test.js
+++ b/resources/assets/components/actions/VoterRegistrationAction/VoterRegistrationAction.test.js
@@ -10,33 +10,40 @@ const trackEventMock = jest.fn();
 
 global.localStorage = new LocalStorageMock();
 
-const wrapper = shallow(
-  <VoterRegistrationAction
-    campaignId="1234"
-    campaignRunId="9876"
-    content="Cras justo odio, dapibus ac facilisis in, egestas eget quam. Duis mollis, est non commodo luctus, nisi erat porttitor ligula."
-    contentfulId="1234"
-    link="http://example.com?campaign={campaignId}&campaingRun={campaignRunId}&user={northstarId}&source={source}"
-    stepIndex={1}
-    title="Register to vote!"
-    userId="551234567890abcdefghijkl"
-    trackEvent={trackEventMock}
-  />,
-);
+const renderVoterRegistration = () =>
+  shallow(
+    <VoterRegistrationAction
+      campaignId="1234"
+      campaignRunId="9876"
+      content="Cras justo odio, dapibus ac facilisis in, egestas eget quam. Duis mollis, est non commodo luctus, nisi erat porttitor ligula."
+      contentfulId="1234"
+      link="http://example.com?campaign={campaignId}&campaingRun={campaignRunId}&user={northstarId}&source={source}"
+      stepIndex={1}
+      title="Register to vote!"
+      userId="551234567890abcdefghijkl"
+      trackEvent={trackEventMock}
+    />,
+  );
 
 test('VoterRegistrationAction is rendered as a card component with a button', () => {
+  const wrapper = renderVoterRegistration();
+
   expect(wrapper.find('Card').length).toEqual(1);
   expect(wrapper.find('.button').length).toEqual(1);
 });
 
 describe('clicking the VoterRegistrationAction button', () => {
-  wrapper.find('.button').simulate('click');
-
   test('calls the event tracker prop function', () => {
+    const wrapper = renderVoterRegistration();
+
+    wrapper.find('.button').simulate('click');
     expect(trackEventMock).toHaveBeenCalled();
   });
 
   test('sets the user to be hidden from voter_reg_modal in local storage', () => {
+    const wrapper = renderVoterRegistration();
+    wrapper.find('.button').simulate('click');
+
     expect(
       get(`${'551234567890abcdefghijkl'}_hide_voter_reg_modal`, 'boolean'),
     ).toBe(true);

--- a/resources/assets/helpers/index.js
+++ b/resources/assets/helpers/index.js
@@ -438,15 +438,7 @@ export function showFacebookShareDialog(href, quote = null) {
   });
 }
 
-/**
- * Share a link by generating a Twitter intent share prompt.
- *
- * @param  {String} href
- * @param  {String} quote
- */
-export function showTwitterSharePrompt(href, quote = '', callback) {
-  const width = 550;
-  const height = 420;
+export function openDialog(href, callback, width = 550, height = 420) {
   const winHeight = window.screen.height;
   const winWidth = window.screen.width;
 
@@ -458,7 +450,7 @@ export function showTwitterSharePrompt(href, quote = '', callback) {
   }
 
   const twitterShareWindow = window.open(
-    `https://twitter.com/intent/tweet?url=${href}&text=${quote}`,
+    href,
     'intent',
     `scrollbars=yes,resizable=yes,toolbar=no,location=yes,width=${width},height=${height},left=${left},top=${top}`,
   );
@@ -475,6 +467,31 @@ export function showTwitterSharePrompt(href, quote = '', callback) {
   if (callback) {
     interval = setInterval(check, 1000);
   }
+}
+
+/**
+ * Share a link by generating a Twitter intent share prompt.
+ *
+ * @param  {String} href
+ * @param  {String} quote
+ */
+export function showFacebookSharePrompt(href, callback) {
+  const appId = env('FACEBOOK_APP_ID');
+  const intent = `https://www.facebook.com/dialog/share?app_id=${appId}&display=popup&href=${href}`;
+
+  openDialog(intent, callback);
+}
+
+/**
+ * Share a link by generating a Twitter intent share prompt.
+ *
+ * @param  {String} href
+ * @param  {String} quote
+ */
+export function showTwitterSharePrompt(href, quote = '', callback) {
+  const intent = `https://twitter.com/intent/tweet?url=${href}&text=${quote}`;
+
+  openDialog(intent, callback);
 }
 
 /**

--- a/resources/assets/helpers/index.js
+++ b/resources/assets/helpers/index.js
@@ -425,17 +425,17 @@ export function loadFacebookSDK() {
  * @param  {Object}   share
  * @param  {Function} callback
  */
-export function showFacebookSharePrompt(share, callback) {
-  const { href, quote } = share;
+export function showFacebookShareDialog(href, quote = null) {
+  const options = {
+    method: 'share',
+    quote,
+    href,
+  };
 
-  FB.ui(
-    {
-      method: 'share',
-      href,
-      quote,
-    },
-    callback,
-  );
+  return new Promise((resolve, reject) => {
+    const handler = success => (success ? resolve() : reject());
+    return window.FB.ui(options, handler);
+  });
 }
 
 /**

--- a/resources/assets/helpers/index.js
+++ b/resources/assets/helpers/index.js
@@ -438,6 +438,14 @@ export function showFacebookShareDialog(href, quote = null) {
   });
 }
 
+/**
+ * Open a dialog and run a callback when it closes.
+ *
+ * @param {String} href
+ * @param {Function} callback
+ * @param {Number} height
+ * @param {Number} width
+ */
 export function openDialog(href, callback, width = 550, height = 420) {
   const winHeight = window.screen.height;
   const winWidth = window.screen.width;
@@ -449,7 +457,7 @@ export function openDialog(href, callback, width = 550, height = 420) {
     top = Math.round(winHeight / 2 - height / 2);
   }
 
-  const twitterShareWindow = window.open(
+  const dialog = window.open(
     href,
     'intent',
     `scrollbars=yes,resizable=yes,toolbar=no,location=yes,width=${width},height=${height},left=${left},top=${top}`,
@@ -458,7 +466,7 @@ export function openDialog(href, callback, width = 550, height = 420) {
   let interval;
 
   const check = () => {
-    if (twitterShareWindow.closed) {
+    if (dialog.closed) {
       clearInterval(interval);
       callback();
     }
@@ -470,7 +478,7 @@ export function openDialog(href, callback, width = 550, height = 420) {
 }
 
 /**
- * Share a link by generating a Twitter intent share prompt.
+ * Share a link by opening a Facebook share prompt.
  *
  * @param  {String} href
  * @param  {String} quote
@@ -483,7 +491,7 @@ export function showFacebookSharePrompt(href, callback) {
 }
 
 /**
- * Share a link by generating a Twitter intent share prompt.
+ * Share a link by opening a Twitter share prompt.
  *
  * @param  {String} href
  * @param  {String} quote

--- a/resources/assets/helpers/index.js
+++ b/resources/assets/helpers/index.js
@@ -1,4 +1,4 @@
-/* global window, document, Blob, FB, URL */
+/* global window, document, Blob, URL */
 
 import { get, find } from 'lodash';
 import MarkdownIt from 'markdown-it';
@@ -393,7 +393,33 @@ export function env(key) {
 }
 
 /**
- * Share a link by generating a Facebook share prompt.
+ * Load and return the Facebook SDK.
+ */
+export function loadFacebookSDK() {
+  return new Promise(resolve => {
+    if (document.getElementById('facebook-jssdk')) {
+      resolve(window.FB);
+    }
+
+    // Set init callback for once we've loaded Facebook's SDK:
+    window.fbAsyncInit = () => {
+      window.FB.init({
+        appId: env('FACEBOOK_APP_ID'),
+        version: 'v2.8',
+      });
+
+      resolve(window.FB);
+    };
+
+    const script = document.createElement('script');
+    script.id = 'facebook-jssdk';
+    script.src = '//connect.facebook.net/en_US/sdk.js';
+    document.head.append(script);
+  });
+}
+
+/**
+ * Share a link by generating a Facebook share dialog.
  * Get a callback if the share is successful or not.
  *
  * @param  {Object}   share

--- a/resources/views/partials/social.blade.php
+++ b/resources/views/partials/social.blade.php
@@ -12,23 +12,3 @@
 <meta property="og:image" content="{{ $socialFields['coverImage'] }}" />
 
 <meta property="fb:app_id" content="{{ $socialFields['facebookAppId'] }}" />
-
-{{-- This is a non-blocking script --}}
-<script>
-  window.fbAsyncInit = function() {
-    FB.init({
-      appId: '{{ $socialFields['facebookAppId'] }}',
-      xfbml: true,
-      version: 'v2.8'
-    });
-    FB.AppEvents.logPageView();
-  };
-
-  (function(d, s, id){
-     var js, fjs = d.getElementsByTagName(s)[0];
-     if (d.getElementById(id)) {return;}
-     js = d.createElement(s); js.id = id;
-     js.src = "//connect.facebook.net/en_US/{{ config('app.debug') ? 'sdk/debug' : 'sdk' }}.js";
-     fjs.parentNode.insertBefore(js, fjs);
-   }(document, 'script', 'facebook-jssdk'));
-</script>


### PR DESCRIPTION
### What does this PR do?

This pull request implements one of my dreams - only loading the flipping huge [Facebook SDK](https://developers.facebook.com/docs/javascript) (215kb, 67kb gzipped) if we actually need it. I've also added a "simplified" share dialog that we use for other shares, which works identically but does not provide `completed` or `cancelled` Puck events.

Finally, I made a few little touch-ups to the `showFacebookShareDialog` helper, with [a new Promise-ified API](https://user-images.githubusercontent.com/583202/39266444-0588c5be-4898-11e8-9799-8216768f876f.png) & removed the need for `ShareActionContainer` by removing an unused prop & replacing `PuckConnector` with the new standalone helper functions.


### Any background context you want to provide?
My original dream was to load the SDK on-demand when a user clicked the "Share on Facebook" button. Unfortunately this dream was squashed by the way browser's pop-up blocks are implemented - calls to `window.open` only work if they were initiated by a user click event. Once we "defer" to make a network request, it's no longer a "user-initiated" action and is blocked. 🙅‍♂️

### What are the relevant tickets/cards?

[Discussion #17](https://github.com/orgs/DoSomething/teams/team-rocket/discussions/17)

### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.
* [ ] Added screenshot to PR description of related front-end updates on **small** screens.
* [ ] Added screenshot to PR description of related front-end updates on **medium** screens.
* [ ] Added screenshot to PR description of related front-end updates on **large** screens.