### PR TITLE
Lazy load Quiz & Legacy Quiz components.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13278,6 +13278,14 @@
         "react-base16-styling": "0.5.3"
       }
     },
+    "react-loadable": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/react-loadable/-/react-loadable-5.3.1.tgz",
+      "integrity": "sha1-lpnpoI/tSbrNacqqKCA0tip2vN0=",
+      "requires": {
+        "prop-types": "15.6.1"
+      }
+    },
     "react-portal": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/react-portal/-/react-portal-4.1.5.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1205,6 +1205,14 @@
         "babel-runtime": "6.26.0"
       }
     },
+    "babel-plugin-dynamic-import-node": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-1.2.0.tgz",
+      "integrity": "sha512-yeDwKaLgGdTpXL7RgGt5r6T4LmnTza/hUn5Ul8uZSGGMtEjYo13Nxai7SQaGCTEzUtg9Zq9qJn0EjEr7SeSlTQ==",
+      "requires": {
+        "babel-plugin-syntax-dynamic-import": "6.18.0"
+      }
+    },
     "babel-plugin-graphql-tag": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-graphql-tag/-/babel-plugin-graphql-tag-1.5.0.tgz",
@@ -1288,8 +1296,7 @@
     "babel-plugin-syntax-dynamic-import": {
       "version": "6.18.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-dynamic-import/-/babel-plugin-syntax-dynamic-import-6.18.0.tgz",
-      "integrity": "sha1-jWomIpyDdFqZgqRBBRVyyqF5sdo=",
-      "dev": true
+      "integrity": "sha1-jWomIpyDdFqZgqRBBRVyyqF5sdo="
     },
     "babel-plugin-syntax-exponentiation-operator": {
       "version": "6.13.0",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
       "flow"
     ],
     "plugins": [
-      "graphql-tag"
+      "graphql-tag",
+      "syntax-dynamic-import"
     ]
   },
   "jest": {
@@ -81,6 +82,7 @@
     "react-addons-update": "^15.6.2",
     "react-apollo": "^2.1.2",
     "react-dom": "^16.3.2",
+    "react-loadable": "^5.3.1",
     "react-portal": "^4.1.5",
     "react-redux": "^5.0.7",
     "react-router": "^4.2.0",
@@ -97,6 +99,7 @@
     "@dosomething/babel-config": "^2.2.1",
     "@dosomething/eslint-config": "^4.0.0",
     "@dosomething/webpack-config": "^4.1.0",
+    "babel-plugin-syntax-dynamic-import": "^6.18.0",
     "contentful-management": "^5.0.0",
     "eslint-loader": "^2.0.0",
     "flow-bin": "0.59.0",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,14 @@
     "plugins": [
       "graphql-tag",
       "syntax-dynamic-import"
-    ]
+    ],
+    "env": {
+      "test": {
+        "plugins": [
+          "babel-plugin-dynamic-import-node"
+        ]
+      }
+    }
   },
   "jest": {
     "clearMocks": true,
@@ -53,6 +60,7 @@
     "apollo-link-error": "^1.0.9",
     "apollo-link-http": "^1.5.4",
     "babel-jest": "^20.0.3",
+    "babel-plugin-dynamic-import-node": "^1.2.0",
     "babel-plugin-graphql-tag": "^1.5.0",
     "babel-preset-flow": "^6.23.0",
     "classnames": "^2.2.5",

--- a/resources/assets/components/ContentfulEntry/ContentfulEntry.js
+++ b/resources/assets/components/ContentfulEntry/ContentfulEntry.js
@@ -3,14 +3,13 @@
 import React from 'react';
 
 import NotFound from '../NotFound';
+import Loader from '../utilities/Loader';
 import StaticBlock from '../StaticBlock';
 import ReportbackBlock from '../ReportbackBlock';
 import ErrorBlock from '../ErrorBlock/ErrorBlock';
-import QuizContainer from '../Quiz/QuizContainer';
 import { ContentfulEntryJson } from '../../types';
 import { parseContentfulType } from '../../helpers';
 import { CampaignUpdateContainer } from '../CampaignUpdate';
-import LegacyQuizContainer from '../LegacyQuiz/LegacyQuizContainer';
 import CallToActionContainer from '../CallToAction/CallToActionContainer';
 import CampaignGalleryBlockContainer from '../blocks/CampaignGalleryBlock/CampaignGalleryBlockContainer';
 import {
@@ -116,11 +115,15 @@ class ContentfulEntry extends React.Component<Props, State> {
       case 'photo-uploader':
         return renderPhotoUploader(json, isSignedUp);
 
-      case 'quiz':
+      case 'quiz': {
+        const QuizContainer = Loader(import('../Quiz/QuizContainer'));
         return <QuizContainer {...json.fields} />;
+      }
 
-      case 'quizBeta':
-        return <LegacyQuizContainer quizContent={json} />;
+      case 'quizBeta': {
+        const LegacyQuiz = Loader(import('../LegacyQuiz/LegacyQuizContainer'));
+        return <LegacyQuiz quizContent={json} />;
+      }
 
       // @TODO: Will be refactored when switching to Rogue!
       case 'reportbacks':

--- a/resources/assets/components/utilities/Loader.js
+++ b/resources/assets/components/utilities/Loader.js
@@ -8,13 +8,10 @@ import Placeholder from './Placeholder';
  * @param {Promise} module
  * @return {React.Component}
  */
-function Loader(module) {
-  const component = Loadable({
+const Loader = module =>
+  Loadable({
     loader: () => module,
     loading: Placeholder,
   });
-
-  return component;
-}
 
 export default Loader;

--- a/resources/assets/components/utilities/Loader.js
+++ b/resources/assets/components/utilities/Loader.js
@@ -1,0 +1,20 @@
+import Loadable from 'react-loadable';
+
+import Placeholder from './Placeholder';
+
+/**
+ * HoC for lazy-loading React components.
+ *
+ * @param {Promise} module
+ * @return {React.Component}
+ */
+function Loader(module) {
+  const component = Loadable({
+    loader: () => module,
+    loading: Placeholder,
+  });
+
+  return component;
+}
+
+export default Loader;

--- a/resources/assets/components/utilities/Placeholder.js
+++ b/resources/assets/components/utilities/Placeholder.js
@@ -1,0 +1,26 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import ErrorBlock from '../ErrorBlock/ErrorBlock';
+
+const Placeholder = ({ error }) => {
+  if (error) {
+    return <ErrorBlock />;
+  }
+
+  return (
+    <div className="placeholder">
+      <div className="spinner" />
+    </div>
+  );
+};
+
+Placeholder.propTypes = {
+  error: PropTypes.bool,
+};
+
+Placeholder.defaultProps = {
+  error: false,
+};
+
+export default Placeholder;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -9,6 +9,7 @@ module.exports = configure({
   output: {
     // Override output path for Laravel's "public" directory.
     path: path.join(__dirname, '/public/next/assets'),
+    publicPath: '/next/assets/',
   },
 
   module: {


### PR DESCRIPTION
### What does this PR do?
This PR uses [react-loadable](https://github.com/jamiebuilds/react-loadable) to split the Quiz & Legacy Quiz components out into separate bundles. This is a simple proof-of-concept for how bundle splitting can work as our application grows bigger, and means we don't have to load code for a feature that doesn't get used on the majority of pages!

### Any background context you want to provide?
🍨

### What are the relevant tickets/cards?
[Discussion #17](https://github.com/orgs/DoSomething/teams/team-rocket/discussions/17)

### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.
* [ ] Added screenshot to PR description of related front-end updates on **small** screens.
* [ ] Added screenshot to PR description of related front-end updates on **medium** screens.
* [ ] Added screenshot to PR description of related front-end updates on **large** screens.