### PR TITLE
Update to only render gallery and view more if posts var contains items.

### DIFF
--- a/resources/assets/components/utilities/PostGallery/PostGallery.js
+++ b/resources/assets/components/utilities/PostGallery/PostGallery.js
@@ -11,7 +11,7 @@ import './post-gallery.scss';
 const PostGallery = props => {
   const { loading, posts, loadMorePosts } = props;
 
-  return (
+  return posts.length ? (
     <div>
       <Gallery type="triad" className="post-gallery expand-horizontal-md">
         {posts.map(post => (
@@ -21,13 +21,14 @@ const PostGallery = props => {
         ))}
       </Gallery>
       <LoadMore
+        buttonClassName="-tertiary"
         className="padding-lg text-centered"
         text="view more"
         onClick={loadMorePosts}
         isLoading={loading}
       />
     </div>
-  );
+  ) : null;
 };
 
 PostGallery.propTypes = {


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?
This PR updates the `PostGallery` to only show if the `posts` variable contains one or more items in it. It also updates the styling of the "view more" link for `PostGallery` to specify using the `-tertiary` style which is a bit more subdued than the current `-secondary` style and thus less distracting.

*Before:*
![image](https://user-images.githubusercontent.com/105849/39381647-cf77839e-4a30-11e8-98df-40dbf1066608.png)

*After:*
![image](https://user-images.githubusercontent.com/105849/39381653-d45d77ce-4a30-11e8-8abe-596249195e0b.png)


### What are the relevant tickets/cards?
Refs [Pivotal ID #157012894](https://www.pivotaltracker.com/story/show/157012894)

### Checklist
* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.

