### PR TITLE
Allow tokens to customize Link & Share Action URLs!

### DIFF
--- a/resources/assets/components/ContentfulEntry/renderers.js
+++ b/resources/assets/components/ContentfulEntry/renderers.js
@@ -3,11 +3,11 @@ import { PuckWaypoint } from '@dosomething/puck-client';
 
 import Affirmation from '../Affirmation';
 import { LegacyContentBlock } from '../Block';
-import ShareAction from '../actions/ShareAction/ShareAction';
 import ContentBlock from '../blocks/ContentBlock/ContentBlock';
 import { ReportbackUploaderContainer } from '../ReportbackUploader';
 import { SubmissionGalleryContainer } from '../Gallery/SubmissionGallery';
 import LinkActionContainer from '../actions/LinkAction/LinkActionContainer';
+import ShareActionContainer from '../actions/ShareAction/ShareActionContainer';
 import ThirdPartyActionContainer from '../actions/ThirdPartyAction/ThirdPartyActionContainer';
 import TextSubmissionActionContainer from '../actions/TextSubmissionAction/TextSubmissionActionContainer';
 import SubmissionGalleryBlockContainer from '../blocks/SubmissionGalleryBlock/SubmissionGalleryBlockContainer';
@@ -149,7 +149,7 @@ export function renderShareAction(step) {
   return (
     <div key={`share-action-${contentfulId}`} className="margin-horizontal-md">
       <PuckWaypoint name="share_action-top" waypointData={{ contentfulId }} />
-      <ShareAction id={step.id} {...step.fields} />
+      <ShareActionContainer id={step.id} {...step.fields} />
       <PuckWaypoint
         name="share_action-bottom"
         waypointData={{ contentfulId }}

--- a/resources/assets/components/actions/LinkAction/LinkAction.js
+++ b/resources/assets/components/actions/LinkAction/LinkAction.js
@@ -5,12 +5,19 @@ import classnames from 'classnames';
 import Embed from '../../Embed';
 import Markdown from '../../Markdown';
 import Card from '../../utilities/Card/Card';
-import { isExternal } from '../../../helpers';
 import SponsorPromotion from '../../SponsorPromotion';
 import { trackPuckEvent } from '../../../helpers/analytics';
+import { isExternal, dynamicString } from '../../../helpers';
 
 const LinkAction = props => {
-  const { content, link, buttonText, affiliateLogo, trackEvent } = props;
+  const {
+    content,
+    link,
+    userId,
+    campaignId,
+    buttonText,
+    affiliateLogo,
+  } = props;
 
   const onLinkClick = () => {
     trackPuckEvent('clicked link action', { link });
@@ -22,6 +29,7 @@ const LinkAction = props => {
   const title = affiliateLogo ? 'See More Be More Do More' : props.title;
 
   const target = isExternal(link) ? '_blank' : '_self';
+  const href = dynamicString(link, { campaignId, userId });
 
   return (
     <div className="link-action margin-bottom-lg">
@@ -40,7 +48,7 @@ const LinkAction = props => {
             onClick={onLinkClick}
             className="link-wrapper"
           >
-            <Embed className="padded" url={link} />
+            <Embed className="padded" url={href} />
           </div>
         )}
 
@@ -55,7 +63,7 @@ const LinkAction = props => {
           <a
             className="button button-attached"
             target={target}
-            href={link}
+            href={href}
             onClick={onLinkClick}
           >
             {buttonText}
@@ -70,15 +78,18 @@ LinkAction.defaultProps = {
   content: null,
   affiliateLogo: null,
   buttonText: null,
+  campaignId: null,
+  userId: null,
 };
 
 LinkAction.propTypes = {
   title: PropTypes.string.isRequired,
   content: PropTypes.string,
   link: PropTypes.string.isRequired,
-  trackEvent: PropTypes.func.isRequired,
   affiliateLogo: PropTypes.string,
   buttonText: PropTypes.string,
+  campaignId: PropTypes.string,
+  userId: PropTypes.string,
 };
 
 export default LinkAction;

--- a/resources/assets/components/actions/LinkAction/LinkAction.js
+++ b/resources/assets/components/actions/LinkAction/LinkAction.js
@@ -7,12 +7,13 @@ import Markdown from '../../Markdown';
 import Card from '../../utilities/Card/Card';
 import { isExternal } from '../../../helpers';
 import SponsorPromotion from '../../SponsorPromotion';
+import { trackPuckEvent } from '../../../helpers/analytics';
 
 const LinkAction = props => {
   const { content, link, buttonText, affiliateLogo, trackEvent } = props;
 
   const onLinkClick = () => {
-    trackEvent('clicked link action', { link });
+    trackPuckEvent('clicked link action', { link });
   };
 
   // The affiliate logo specific text is hard-coded for OZY. Though we can set this title

--- a/resources/assets/components/actions/LinkAction/LinkAction.test.js
+++ b/resources/assets/components/actions/LinkAction/LinkAction.test.js
@@ -4,10 +4,11 @@ import React from 'react';
 import { shallow } from 'enzyme';
 
 import LinkAction from './LinkAction';
+import { trackPuckEvent as trackEventMock } from '../../../helpers/analytics';
+
+jest.mock('../../../helpers/analytics');
 
 describe('LinkAction component', () => {
-  const trackEventMock = jest.fn();
-
   // mocking the window.location.origin for the isExternal helper method called from LinkAction
   jsdom.reconfigure({
     url: 'https://dosomething.org',
@@ -16,7 +17,6 @@ describe('LinkAction component', () => {
   const props = {
     title: 'Click on this link!',
     content: 'This is a great link',
-    trackEvent: trackEventMock,
     link: 'https://dosomething.org',
   };
 

--- a/resources/assets/components/actions/LinkAction/LinkActionContainer.js
+++ b/resources/assets/components/actions/LinkAction/LinkActionContainer.js
@@ -1,4 +1,15 @@
+import { connect } from 'react-redux';
+
 import LinkAction from './LinkAction';
+import { getUserId } from '../../../selectors/user';
+
+/**
+ * Provide state from the Redux store as props for this component.
+ */
+const mapStateToProps = state => ({
+  userId: getUserId(state),
+  campaignId: state.campaign.legacyCampaignId,
+});
 
 // Export the container component.
 export default connect(mapStateToProps)(LinkAction);

--- a/resources/assets/components/actions/LinkAction/LinkActionContainer.js
+++ b/resources/assets/components/actions/LinkAction/LinkActionContainer.js
@@ -1,4 +1,4 @@
-import { PuckConnector } from '@dosomething/puck-client';
 import LinkAction from './LinkAction';
 
-export default PuckConnector(LinkAction);
+// Export the container component.
+export default connect(mapStateToProps)(LinkAction);

--- a/resources/assets/components/actions/ShareAction/ShareAction.js
+++ b/resources/assets/components/actions/ShareAction/ShareAction.js
@@ -1,13 +1,11 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
 
 import Embed from '../../Embed';
 import Markdown from '../../Markdown';
 import Button from '../../Button/Button';
 import Card from '../../utilities/Card/Card';
 import Modal from '../../utilities/Modal/Modal';
-import { getUserId } from '../../../selectors/user';
 import ContentfulEntry from '../../ContentfulEntry';
 import { trackPuckEvent } from '../../../helpers/analytics';
 import {
@@ -17,7 +15,7 @@ import {
   showTwitterSharePrompt,
 } from '../../../helpers';
 
-export class ShareAction extends React.Component {
+class ShareAction extends React.Component {
   state = { showModal: false };
 
   componentDidMount() {
@@ -116,7 +114,4 @@ ShareAction.defaultProps = {
   userId: null,
 };
 
-export default connect(state => ({
-  userId: getUserId(state),
-  campaignId: state.campaign.legacyCampaignId,
-}))(ShareAction);
+export default ShareAction;

--- a/resources/assets/components/actions/ShareAction/ShareAction.test.js
+++ b/resources/assets/components/actions/ShareAction/ShareAction.test.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 
-import ShareAction from './ShareAction';
+import { ShareAction } from './ShareAction';
 import setFBshare from '../../../__mocks__/facebookShareMock';
 import { trackPuckEvent as trackEventMock } from '../../../helpers/analytics';
 

--- a/resources/assets/components/actions/ShareAction/ShareAction.test.js
+++ b/resources/assets/components/actions/ShareAction/ShareAction.test.js
@@ -5,6 +5,8 @@ import ShareAction from './ShareAction';
 import setFBshare from '../../../__mocks__/facebookShareMock';
 import { trackPuckEvent as trackEventMock } from '../../../helpers/analytics';
 
+jest.mock('./ShareActionContainer', () => 'ShareActionContainer');
+
 jest.mock('../../../helpers/analytics');
 jest.useFakeTimers();
 
@@ -93,8 +95,10 @@ describe('ShareAction component', () => {
       wrapper.find('Button').simulate('click');
 
       expect(global.open).toHaveBeenCalled();
-      expect(global.open.mock.calls[0][0]).toEqual(
-        `https://twitter.com/intent/tweet?url=${url}&text=`,
+
+      const intentUrl = String(global.open.mock.calls[0][0]);
+      expect(intentUrl).toEqual(
+        'https://twitter.com/intent/tweet?text=&url=https%3A%2F%2Fdosomething.org',
       );
     });
 

--- a/resources/assets/components/actions/ShareAction/ShareAction.test.js
+++ b/resources/assets/components/actions/ShareAction/ShareAction.test.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 
-import { ShareAction } from './ShareAction';
+import ShareAction from './ShareAction';
 import setFBshare from '../../../__mocks__/facebookShareMock';
 import { trackPuckEvent as trackEventMock } from '../../../helpers/analytics';
 

--- a/resources/assets/components/actions/ShareAction/ShareActionContainer.js
+++ b/resources/assets/components/actions/ShareAction/ShareActionContainer.js
@@ -1,0 +1,15 @@
+import { connect } from 'react-redux';
+
+import ShareAction from './ShareAction';
+import { getUserId } from '../../../selectors/user';
+
+/**
+ * Provide state from the Redux store as props for this component.
+ */
+const mapStateToProps = state => ({
+  userId: getUserId(state),
+  campaignId: state.campaign.legacyCampaignId,
+});
+
+// Export the container component.
+export default connect(mapStateToProps)(ShareAction);

--- a/resources/assets/helpers/analytics.js
+++ b/resources/assets/helpers/analytics.js
@@ -4,7 +4,6 @@ import { Engine as PuckClient } from '@dosomething/puck-client';
 import { dimensionByCookie, init, pageview } from '@dosomething/analytics';
 
 import { PUCK_URL } from '../constants';
-import { getUserId } from '../selectors/user';
 import { get as getHistory } from '../history';
 
 /**
@@ -25,13 +24,12 @@ export function analyzeWithGoogleAnalytics(name, data) {
  *
  * @param  {String} name
  * @param  {Object} data
- * @param  {Object} state
  * @return {void}
  */
-export function analyzeWithPuck(name, data, state) {
+export function analyzeWithPuck(name, data) {
   const Puck = new PuckClient({
     source: 'phoenix-next',
-    getUser: () => getUserId(state),
+    getUser: () => window.AUTH.id,
     puckUrl: PUCK_URL,
     history: getHistory(),
   });
@@ -71,7 +69,7 @@ export function trackAnalyticsEvent(name, data, service) {
       break;
 
     case 'puck':
-      analyzeWithPuck(name, data, window.STATE);
+      analyzeWithPuck(name, data);
       break;
 
     default:

--- a/resources/assets/helpers/index.js
+++ b/resources/assets/helpers/index.js
@@ -393,6 +393,34 @@ export function env(key) {
 }
 
 /**
+ * Construct URL with query params
+ *
+ * @param {String} url
+ * @param {object} query
+ * @return {URL}
+ */
+export function makeUrl(path, queryParameters) {
+  const urlObject = new URL(String(path));
+  urlObject.search = queryString.stringify(queryParameters);
+
+  return urlObject;
+}
+
+/**
+ * Get the query-string value at the given key.
+ *
+ * @param  {String}   key
+ * @param  {URL|Location}   url
+ * @return {String}
+ */
+export function query(key, url = window.location) {
+  // Ensure we have a URL object from the location.
+  const search = queryString.parse(url.search);
+
+  return search[key];
+}
+
+/**
  * Load and return the Facebook SDK.
  */
 export function loadFacebookSDK() {
@@ -500,34 +528,6 @@ export function showTwitterSharePrompt(href, quote = '', callback) {
   const intent = `https://twitter.com/intent/tweet?url=${href}&text=${quote}`;
 
   openDialog(intent, callback);
-}
-
-/**
- * Construct URL with query params
- *
- * @param {String} url
- * @param {object} query
- * @return {URL}
- */
-export function makeUrl(path, queryParameters) {
-  const urlObject = new URL(String(path));
-  urlObject.search = queryString.stringify(queryParameters);
-
-  return urlObject;
-}
-
-/**
- * Get the query-string value at the given key.
- *
- * @param  {String}   key
- * @param  {URL|Location}   url
- * @return {String}
- */
-export function query(key, url = window.location) {
-  // Ensure we have a URL object from the location.
-  const search = queryString.parse(url.search);
-
-  return search[key];
 }
 
 /**

--- a/resources/assets/helpers/index.js
+++ b/resources/assets/helpers/index.js
@@ -513,7 +513,10 @@ export function openDialog(href, callback, width = 550, height = 420) {
  */
 export function showFacebookSharePrompt(href, callback) {
   const appId = env('FACEBOOK_APP_ID');
-  const intent = `https://www.facebook.com/dialog/share?app_id=${appId}&display=popup&href=${href}`;
+  const intent = makeUrl('https://www.facebook.com/dialog/share', {
+    appId,
+    href,
+  });
 
   openDialog(intent, callback);
 }
@@ -525,7 +528,10 @@ export function showFacebookSharePrompt(href, callback) {
  * @param  {String} quote
  */
 export function showTwitterSharePrompt(href, quote = '', callback) {
-  const intent = `https://twitter.com/intent/tweet?url=${href}&text=${quote}`;
+  const intent = makeUrl('https://twitter.com/intent/tweet', {
+    url: href,
+    text: quote,
+  });
 
   openDialog(intent, callback);
 }


### PR DESCRIPTION
### What does this PR do?

This PR adds support for `{userId}` and `{campaignId}` tokens in Link & Share Action URLs.

🔥 Remove `PuckConnector` for LinkAction, in favor of new helpers. 4b46e8f

🔗 Add support for tokens in LinkAction. 9588e0d

🐛 Fix a bug grabbing user state, originally introduced in [this commit](https://github.com/DoSomething/phoenix-next/commit/2499dce20d875d838ccfe156c9992fb4c1373a14). 9e0d66a

🌾 Use `makeUrl` when creating Facebook/Twitter intent URLs so we can safely share URLs with query strings (so it sharing a URL with a query string doesn't get borked like `/share?href=www.example.com?userId=123`). b3dc3a3, a928f79

🦈 Add support for tokens in ShareAction (see note below). 2632ab3

### Any background context you want to provide?

I didn't want to deal with updating imports to once again use a container component on `ShareAction`, so toyed around with wrapping it in the HoC inline inside `ShareAction.js`. The default export is the connected component & a named export is used for importing the "plain" component in tests. Thoughts? 💭

### What are the relevant tickets/cards?

[#156964321](https://www.pivotaltracker.com/story/show/156964321), [#156964338](https://www.pivotaltracker.com/story/show/156964338)

### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.
* [ ] Added screenshot to PR description of related front-end updates on **small** screens.
* [ ] Added screenshot to PR description of related front-end updates on **medium** screens.
* [ ] Added screenshot to PR description of related front-end updates on **large** screens.