### PR TITLE
Photo submission action migration

### DIFF
--- a/contentful/migrations/2018_04_27_001_add_photo_submission_action_content_type.js
+++ b/contentful/migrations/2018_04_27_001_add_photo_submission_action_content_type.js
@@ -1,0 +1,91 @@
+module.exports = function(migration) {
+  const photoSubmissionAction = migration
+    .createContentType('photoSubmissionAction')
+    .name('Photo Submission Action')
+    .description('Action block for submitting photo reportback posts.')
+    .displayField('internalTitle');
+
+  photoSubmissionAction
+    .createField('internalTitle')
+    .name('Internal Title')
+    .type('Symbol')
+    .required(true)
+    .localized(false);
+
+  photoSubmissionAction
+    .createField('title')
+    .name('Title')
+    .type('Symbol')
+    .required(false)
+    .localized(true);
+
+  photoSubmissionAction
+    .createField('captionFieldLabel')
+    .name('Caption Field Label')
+    .type('Symbol')
+    .required(false)
+    .localized(true);
+
+  photoSubmissionAction
+    .createField('captionFieldPlaceholder')
+    .name('Caption Field Placeholder')
+    .type('Symbol')
+    .required(false)
+    .localized(true);
+
+  photoSubmissionAction
+    .createField('showQuantityField')
+    .name('Show Quantity Field')
+    .type('Boolean')
+    .required(false)
+    .localized(false);
+
+  photoSubmissionAction
+    .createField('quantityFieldLabel')
+    .name('Quantity Field Label')
+    .type('Symbol')
+    .required(false)
+    .localized(true);
+
+  photoSubmissionAction
+    .createField('quantityFieldPlaceholder')
+    .name('Quantity Field Placeholder')
+    .type('Symbol')
+    .required(false)
+    .localized(true);
+
+  photoSubmissionAction
+    .createField('whyParticipatedFieldLabel')
+    .name('Why Participated Field Label')
+    .type('Symbol')
+    .required(false)
+    .localized(true);
+
+  photoSubmissionAction
+    .createField('whyParticipatedFieldPlaceholder')
+    .name('Why Participated Field Placeholder')
+    .type('Symbol')
+    .required(false)
+    .localized(true);
+
+  photoSubmissionAction
+    .createField('buttonText')
+    .name('Button Text')
+    .type('Symbol')
+    .required(false)
+    .localized(true);
+
+  photoSubmissionAction
+    .createField('affirmationContent')
+    .name('Affirmation Content')
+    .type('Text')
+    .required(false)
+    .localized(true);
+
+  photoSubmissionAction
+    .createField('additionalContent')
+    .name('Additional Content')
+    .type('Object')
+    .required(false)
+    .localized(false);
+};


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?
This PR adds a migration to create a new `PhotoSubmissionAction` to help with the transition to connect photo posts directly to Rogue. In an effort to avoid breaking the current `PhotoUploadedAction` I chose to create a new content-type that follows more the pattern of that the `TextSubmissionAction` content-type set.

The migration includes a boolean field to indicate whether to show or hide the quantity field, which is something that seems to be needed to be toggled on a per-campaign basis.

![image](https://user-images.githubusercontent.com/105849/39385725-a54cf996-4a3f-11e8-8b72-06b977a792d5.png)


### What are the relevant tickets/cards?
Refs [Pivotal ID #156964358](https://www.pivotaltracker.com/story/show/156964358)
