### PR TITLE
Contentful Migration for ImageMediaBlock content type

### DIFF
--- a/contentful/migrations/2018_05_01_001_add_image_media_block_content_type.js
+++ b/contentful/migrations/2018_05_01_001_add_image_media_block_content_type.js
@@ -1,0 +1,30 @@
+module.exports = function(migration) {
+  const imageMediaBlock = migration
+    .createContentType('imageMediaBlock')
+    .name('Image Media Block')
+    .description('A block of images')
+    .displayField('internalTitle');
+
+  imageMediaBlock
+    .createField('internalTitle')
+    .name('Internal Title')
+    .type('Symbol')
+    .required(true)
+    .localized(false);
+
+  imageMediaBlock
+    .createField('images')
+    .name('Images')
+    .type('Array')
+    .items({
+      type: 'Link',
+      linkType: 'Asset',
+      validations: [
+        {
+          linkMimetypeGroup: ['image'],
+        },
+      ],
+    })
+    .required(true)
+    .localized(false);
+};

--- a/contentful/migrations/2018_05_01_001_add_images_block_content_type.js
+++ b/contentful/migrations/2018_05_01_001_add_images_block_content_type.js
@@ -1,18 +1,18 @@
 module.exports = function(migration) {
-  const imageMediaBlock = migration
-    .createContentType('imageMediaBlock')
-    .name('Image Media Block')
+  const imagesBlock = migration
+    .createContentType('imagesBlock')
+    .name('Images Block')
     .description('A block of images')
     .displayField('internalTitle');
 
-  imageMediaBlock
+  imagesBlock
     .createField('internalTitle')
     .name('Internal Title')
     .type('Symbol')
     .required(true)
     .localized(false);
 
-  imageMediaBlock
+  imagesBlock
     .createField('images')
     .name('Images')
     .type('Array')


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR adds a Contentful CLI Migration script which creates an Image Media Block content type with an `images` media field

### Any background context you want to provide?
The impetus for creating this now is to enable us to port our `CampaignActionStep` entries over to `ContentBlock`s, which do not contain a multiple image reference field as the `CampaignActionStep`s do.

Also importantly, this can serve our new independent articles/pages.

### What are the relevant tickets/cards?
[#156771690](https://www.pivotaltracker.com/story/show/156771690)
[Slack thread](https://dosomething.slack.com/archives/C2BPA7M8F/p1524852405000688)

![image](https://user-images.githubusercontent.com/12417657/39477669-ef13d194-4d2d-11e8-926b-87ab8557e59a.png)


