### PR TITLE
Properly disable submission buttons.

### DIFF
--- a/resources/assets/components/ReportbackUploader/ReportbackUploader.js
+++ b/resources/assets/components/ReportbackUploader/ReportbackUploader.js
@@ -325,7 +325,7 @@ class ReportbackUploader extends React.Component {
                   </div>
                 </div>
 
-                <Button type="submit" disabled={submissions.isStoring} attached>
+                <Button type="submit" loading={submissions.isStoring} attached>
                   Submit a new photo
                 </Button>
               </form>

--- a/resources/assets/components/Revealer/index.js
+++ b/resources/assets/components/Revealer/index.js
@@ -13,7 +13,7 @@ const Revealer = props => {
     <div className="revealer">
       {callToAction ? <h1>{callToAction}</h1> : null}
       {isSignedUp ? (
-        <Button isLoading={isLoading} onClick={onReveal}>
+        <Button loading={isLoading} onClick={onReveal}>
           {title}
         </Button>
       ) : (

--- a/resources/assets/components/actions/TextSubmissionAction/TextSubmissionAction.js
+++ b/resources/assets/components/actions/TextSubmissionAction/TextSubmissionAction.js
@@ -129,7 +129,7 @@ class TextSubmissionAction extends React.Component {
             </div>
             <Button
               type="submit"
-              disabled={this.props.submissions.isPending}
+              loading={this.props.submissions.isPending}
               attached
             >
               {this.props.buttonText}

--- a/resources/assets/components/utilities/Button/Button.js
+++ b/resources/assets/components/utilities/Button/Button.js
@@ -10,15 +10,15 @@ const Button = ({
   className,
   type,
   attached,
-  isDisabled,
-  isLoading,
+  disabled,
+  loading,
   children,
 }) => {
   const classNames = classnames(
     'button',
     {
-      'is-loading': isLoading,
-      'is-disabled': isDisabled,
+      'is-loading': loading,
+      'is-disabled': disabled,
       '-attached': attached,
     },
     className,
@@ -29,7 +29,7 @@ const Button = ({
     <button
       type={type}
       className={classNames}
-      disabled={isDisabled || isLoading}
+      disabled={disabled || loading}
       onClick={onClick}
     >
       {buttonText}
@@ -48,8 +48,8 @@ Button.propTypes = {
   type: PropTypes.string,
   onClick: requiredIf(PropTypes.func, props => props.type !== 'submit'),
   className: PropTypes.string,
-  isDisabled: PropTypes.bool,
-  isLoading: PropTypes.bool,
+  disabled: PropTypes.bool,
+  loading: PropTypes.bool,
   attached: PropTypes.bool,
   children: PropTypes.oneOfType([
     PropTypes.string,
@@ -60,8 +60,8 @@ Button.propTypes = {
 Button.defaultProps = {
   type: null,
   className: null,
-  isDisabled: false,
-  isLoading: false,
+  disabled: false,
+  loading: false,
   attached: false,
 };
 

--- a/resources/assets/components/utilities/LoadMore/LoadMore.js
+++ b/resources/assets/components/utilities/LoadMore/LoadMore.js
@@ -12,7 +12,7 @@ const LoadMore = ({
   text = 'Load More',
 }) => (
   <div className={classnames('loader', className)}>
-    <Button className={buttonClassName} isLoading={isLoading} onClick={onClick}>
+    <Button className={buttonClassName} loading={isLoading} onClick={onClick}>
       {text}
     </Button>
   </div>


### PR DESCRIPTION
### What does this PR do?

This PR fixes the photo uploader & text-submission action to use the `loading` prop so they show a spinner! I've also renamed `disabled` and `loading` so they better match the way the underlying HTML element properties are named (and are less likely to wrap a component to multiple lines! 💅)

![with-spinner](https://user-images.githubusercontent.com/583202/39482666-fa4e5308-4d3d-11e8-8a9b-55610d1f2aac.gif)


### Any background context you want to provide?

Thanks @mendelB for the catch! 👁

### What are the relevant tickets/cards?

Bug introduced in #870.

### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.
* [ ] Added screenshot to PR description of related front-end updates on **small** screens.
* [ ] Added screenshot to PR description of related front-end updates on **medium** screens.
* [ ] Added screenshot to PR description of related front-end updates on **large** screens.
