### PR TITLE
Updating logic to disable access to Action page if the campaign is closed

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -917,7 +917,7 @@
     },
     "babel-eslint": {
       "version": "8.2.2",
-      "resolved": "http://registry.npmjs.org/babel-eslint/-/babel-eslint-8.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-8.2.2.tgz",
       "integrity": "sha512-Qt2lz2egBxNYWqN9JIO2z4NOOf8i4b5JS6CFoYrOZZTDssueiV1jH/jsefyg+86SeNY3rB361/mi3kE1WK2WYQ==",
       "dev": true,
       "requires": {
@@ -4676,7 +4676,7 @@
     },
     "event-stream": {
       "version": "3.3.4",
-      "resolved": "http://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
+      "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
       "integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
       "dev": true,
       "requires": {

--- a/resources/assets/components/pages/CampaignPage/CampaignPage.js
+++ b/resources/assets/components/pages/CampaignPage/CampaignPage.js
@@ -19,6 +19,7 @@ const CampaignPage = props => {
     campaignLead,
     clickedHideAffirmation,
     hasCommunityPage,
+    isAdmin,
     isCampaignClosed,
     match,
     shouldShowSignupAffirmation,
@@ -47,7 +48,13 @@ const CampaignPage = props => {
 
           <Route
             path={join(match.url, 'action')}
-            component={ActionPageContainer}
+            render={() => {
+              if (isAdmin || (!isCampaignClosed && !hasCommunityPage)) {
+                return <ActionPageContainer />;
+              }
+
+              return <Redirect to={join(match.url, 'community')} />;
+            }}
           />
 
           <Route

--- a/resources/assets/components/pages/CampaignPage/CampaignPage.js
+++ b/resources/assets/components/pages/CampaignPage/CampaignPage.js
@@ -108,6 +108,7 @@ CampaignPage.propTypes = {
   }),
   clickedHideAffirmation: PropTypes.func.isRequired,
   hasCommunityPage: PropTypes.bool.isRequired,
+  isAdmin: PropTypes.bool.isRequired,
   isCampaignClosed: PropTypes.bool.isRequired,
   match: ReactRouterPropTypes.match.isRequired,
   shouldShowSignupAffirmation: PropTypes.bool.isRequired,

--- a/resources/assets/components/pages/CampaignPage/CampaignPageContainer.js
+++ b/resources/assets/components/pages/CampaignPage/CampaignPageContainer.js
@@ -3,6 +3,7 @@ import { connect } from 'react-redux';
 
 import CampaignPage from './CampaignPage';
 import { isCampaignClosed } from '../../../helpers';
+import { userHasRole } from '../../../selectors/user';
 import { convertExperiment, clickedHideAffirmation } from '../../../actions';
 
 /**
@@ -14,6 +15,7 @@ const mapStateToProps = state => ({
   campaignLead: get(state, 'campaign.campaignLead.fields', null),
   hasActivityFeed: Boolean(state.campaign.activityFeed.length),
   hasCommunityPage: Boolean(state.campaign.activityFeed.length),
+  isAdmin: userHasRole(state, 'admin'),
   isCampaignClosed: isCampaignClosed(
     get(state.campaign.endDate, 'date', false),
   ),


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?
This PR updates the logic in the `CampaignPage` component to disable access to the Action page if the campaign is closed (and it has a Community page to redirect to). It does not disable access to the Action page if the user is an Admin. cc @ashleybaldwin 😸 

Tested this a bit and seems to work as expected, even if the conditional reads a little odd. We'll likely move this logic to allow pages to decide their "visibility" instead of having a slew of conditionals in the `CampaignPage`, but that's an upcoming change!

### Checklist
* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.