### PR TITLE
Quick fix to simplify logic for Action page.

### DIFF
--- a/resources/assets/components/pages/CampaignPage/CampaignPage.js
+++ b/resources/assets/components/pages/CampaignPage/CampaignPage.js
@@ -49,11 +49,15 @@ const CampaignPage = props => {
           <Route
             path={join(match.url, 'action')}
             render={() => {
-              if (isAdmin || (!isCampaignClosed && !hasCommunityPage)) {
+              if (isAdmin) {
                 return <ActionPageContainer />;
               }
 
-              return <Redirect to={join(match.url, 'community')} />;
+              if (isCampaignClosed && hasCommunityPage) {
+                return <Redirect to={join(match.url, 'community')} />;
+              }
+
+              return <ActionPageContainer />;
             }}
           />
 


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?
This PR fixes logic bug when user is not an admin. Decided to split out the logic so it is a bit simpler and works correctly.

### Any background context you want to provide?
Non-admin users were not able to get to the Action page, when the campaign wasn't closed and it did have a Community page.

