### PR TITLE
Send correct 'app_id' param for Facebook share dialog.

### DIFF
--- a/resources/assets/helpers/index.js
+++ b/resources/assets/helpers/index.js
@@ -512,9 +512,8 @@ export function openDialog(href, callback, width = 550, height = 420) {
  * @param  {String} quote
  */
 export function showFacebookSharePrompt(href, callback) {
-  const appId = env('FACEBOOK_APP_ID');
   const intent = makeUrl('https://www.facebook.com/dialog/share', {
-    appId,
+    app_id: env('FACEBOOK_APP_ID'),
     href,
   });
 


### PR DESCRIPTION
### What does this PR do?

This PR adds a quick fix for the "plain dialog" Facebook shares on the dashboard or campaign update blocks. Previously, we were sending an `?appId=xxx` query param and getting this:

![screen shot 2018-05-01 at 3 40 31 pm](https://user-images.githubusercontent.com/583202/39490326-86927552-4d56-11e8-978e-a6fc8585bf4a.png)

With the expected `app_id`, we're all good again.

### Any background context you want to provide?

N/A

### What are the relevant tickets/cards?

Bug introduced in #856.

### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.
* [ ] Added screenshot to PR description of related front-end updates on **small** screens.
* [ ] Added screenshot to PR description of related front-end updates on **medium** screens.
* [ ] Added screenshot to PR description of related front-end updates on **large** screens.
