### PR TITLE
Add content management script to transform action steps to action page

### DIFF
--- a/contentful/management-api-scripts/2018_05_01_001_transform_campaign_action_steps_to_action_page.js
+++ b/contentful/management-api-scripts/2018_05_01_001_transform_campaign_action_steps_to_action_page.js
@@ -104,7 +104,7 @@ async function addActionPageFromActionSteps(environment, campaign) {
               'imagesBlock',
               withFields({
                 internalTitle: `${internalTitle} - photos`,
-                photos,
+                images: photos,
               }),
             ),
           );

--- a/contentful/management-api-scripts/2018_05_01_001_transform_campaign_action_steps_to_action_page.js
+++ b/contentful/management-api-scripts/2018_05_01_001_transform_campaign_action_steps_to_action_page.js
@@ -1,0 +1,179 @@
+const { join } = require('path');
+const { get } = require('lodash');
+const { contentManagementClient } = require('./contentManagementClient');
+const {
+  attempt,
+  constants,
+  createLogger,
+  getField,
+  processEntries,
+  linkReference,
+  sleep,
+  withFields,
+  run,
+} = require('./helpers');
+
+const { LOCALE } = constants;
+
+const logger = createLogger('action_page_transformation_from_action_steps');
+
+async function addActionPageFromActionSteps(environment, campaign) {
+  const campaignInternalTitle = getField(campaign, 'internalTitle');
+  const campaignSlug = getField(campaign, 'slug');
+  const campaignTitle = getField(campaign, 'title');
+  const campaignActionSteps = getField(campaign, 'actionSteps');
+
+  // No need to transform action steps if they don't exist.
+  if (!campaignActionSteps) {
+    logger.info(`Skipping Campaign! [ID: ${campaign.sys.id}]\n`);
+    logger.info('--------------------------------------------\n');
+    return;
+  }
+
+  logger.info(`Processing Campaign! [ID: ${campaign.sys.id}]\n`);
+
+  // Keep count of the step index so we can manually add the Step Numbers normally generated in PN
+  let stepIndex = 1;
+
+  const actionPageBlocks = [];
+
+  for (var i = 0; i < campaignActionSteps.length; i++) {
+    const campaignActionStep = await attempt(() =>
+      environment.getEntry(campaignActionSteps[i].sys.id),
+    );
+
+    if (!campaignActionStep) {
+      continue;
+    }
+
+    const contentType = get(campaignActionStep.sys, 'contentType.sys.id');
+
+    // If the action step block is a Campaign Action Step, we'll replace it with a Content Block (and ImagesBlock if necessary)
+    if (contentType === 'campaignActionStep') {
+      const actionStepTitle = getField(campaignActionStep, 'title');
+      const content = getField(campaignActionStep, 'content');
+      const hideStepNumber = getField(campaignActionStep, 'hideStepNumber');
+      // If the action step is meant to have a step number attached, we'll manually add it as a superTitle
+      const supertitle =
+        hideStepNumber == null || !hideStepNumber
+          ? `Step ${stepIndex + 1}`
+          : null;
+
+      if (!content) {
+        logger.info(
+          `  - Skipping Campaign Action Step! [ID: ${campaign.sys.id}]\n`,
+        );
+      }
+
+      logger.info(
+        `  - Processing Campaign Action Step! [ID: ${
+          campaignActionStep.sys.id
+        }]\n`,
+      );
+
+      const internalTitle = `${campaignInternalTitle} - Action Step`;
+
+      const contentBlock = await attempt(() =>
+        environment.createEntry(
+          'contentBlock',
+          withFields({
+            internalTitle,
+            supertitle,
+            title: actionStepTitle,
+            content,
+          }),
+        ),
+      );
+
+      const publishedContentBlock = await attempt(() => contentBlock.publish());
+
+      if (publishedContentBlock) {
+        let publishedImagesBlock;
+
+        // If the action step has any photos, we'll add them to a separate Images Block
+        const images = getField(campaignActionStep, 'photos', []);
+
+        if (images.length) {
+          const imagesBlock = await attempt(() =>
+            environment.createEntry(
+              'imagesBlock',
+              withFields({
+                internalTitle: `${internalTitle} - photos`,
+                images,
+              }),
+            ),
+          );
+          publishedImagesBlock = await attempt(() => imagesBlock.publish());
+        }
+
+        actionPageBlocks.push(linkReference(publishedContentBlock.sys.id));
+        stepIndex++;
+        logger.info(
+          `    * Created Content Block! [ID: ${
+            publishedContentBlock.sys.id
+          }]\n`,
+        );
+
+        if (publishedImagesBlock) {
+          actionPageBlocks.push(linkReference(publishedImagesBlock.sys.id));
+          logger.info(
+            `    * Created Images Block! [ID: ${
+              publishedImagesBlock.sys.id
+            }]\n`,
+          );
+        }
+      }
+    } else {
+      actionPageBlocks.push(campaignActionSteps[i]);
+    }
+  }
+
+  const actionPage = await attempt(() =>
+    environment.createEntry(
+      'page',
+      withFields({
+        internalTitle: `${campaignInternalTitle} Action Page`,
+        title: 'Action',
+        slug: join(campaignSlug, 'action'),
+        blocks: actionPageBlocks,
+      }),
+    ),
+  );
+
+  if (actionPage) {
+    const publishedActionPage = attempt(() => actionPage.publish());
+    if (publishedActionPage) {
+      console.log(`  - Created Action Page! [ID: ${actionPage.sys.id}]\n`);
+
+      if (!campaign.fields.pages) {
+        // Ensure the campaign has a pages property with the correct locale
+        campaign.fields.pages = { [LOCALE]: [] };
+      }
+      // Add a Link to the new Page in the campaigns Pages field
+      campaign.fields.pages[LOCALE].push(linkReference(actionPage.sys.id));
+
+      // Update and publish the campaign
+      const updatedCampaign = await attempt(() => campaign.update());
+      if (updatedCampaign) {
+        const publishedCampaign = await attempt(() =>
+          updatedCampaign.publish(),
+        );
+        if (publishedCampaign) {
+          logger.info(
+            `  - Successfully published Campaign! [ID: ${campaign.sys.id}]\n`,
+          );
+        }
+      }
+    }
+  }
+
+  logger.info(`Processed Campaign! [ID: ${campaign.sys.id}]\n`);
+  logger.info('--------------------------------------------\n');
+
+  // API breather room
+  sleep(1000);
+}
+
+contentManagementClient.init((environment, args) =>
+  processEntries(environment, args, 'campaign', addActionPageFromActionSteps),
+);

--- a/contentful/management-api-scripts/2018_05_01_001_transform_campaign_action_steps_to_action_page.js
+++ b/contentful/management-api-scripts/2018_05_01_001_transform_campaign_action_steps_to_action_page.js
@@ -74,7 +74,7 @@ async function addActionPageFromActionSteps(environment, campaign) {
         }]\n`,
       );
 
-      const internalTitle = `${campaignInternalTitle} - Action Step`;
+      const internalTitle = `${campaignInternalTitle} - Action Step ${stepIndex}`;
 
       const contentBlockFields = {
         internalTitle,

--- a/contentful/management-api-scripts/2018_05_01_001_transform_campaign_action_steps_to_action_page.js
+++ b/contentful/management-api-scripts/2018_05_01_001_transform_campaign_action_steps_to_action_page.js
@@ -32,9 +32,10 @@ async function addActionPageFromActionSteps(environment, campaign) {
 
   logger.info(`Processing Campaign! [ID: ${campaign.sys.id}]\n`);
 
-  // Keep count of the step index so we can manually add the Step Numbers normally generated in PN
+  // Keep count of the index of action steps so that we can manually add the correct Step Numbers (normally generated in PN when rendering action steps)
   let stepIndex = 1;
 
+  // This will hold the new set of blocks we'll be adding to the created Action Page.
   const actionPageBlocks = [];
 
   for (var i = 0; i < campaignActionSteps.length; i++) {
@@ -53,7 +54,7 @@ async function addActionPageFromActionSteps(environment, campaign) {
       const actionStepTitle = getField(campaignActionStep, 'title');
       const content = getField(campaignActionStep, 'content');
       const hideStepNumber = getField(campaignActionStep, 'hideStepNumber');
-      const images = getField(campaignActionStep, 'photos', []);
+      const photos = getField(campaignActionStep, 'photos', []);
 
       // If the action step is meant to have a step number attached, we'll manually add it as a superTitle
       const supertitle =
@@ -82,9 +83,9 @@ async function addActionPageFromActionSteps(environment, campaign) {
         content,
       };
 
-      // If there are image on this action step, set the first image on the new content blocks 'image' field
-      if (images.length === 1) {
-        contentBlockFields['image'] = images.shift();
+      // If there is only one photo on this action step, set it to the new content blocks 'image' field
+      if (photos.length === 1) {
+        contentBlockFields['image'] = photos.shift();
       }
 
       const contentBlock = await attempt(() =>
@@ -97,13 +98,13 @@ async function addActionPageFromActionSteps(environment, campaign) {
         let publishedImagesBlock;
 
         // If the action step has multiple photos, we'll add them to a separate Images Block
-        if (images.length) {
+        if (photos.length) {
           const imagesBlock = await attempt(() =>
             environment.createEntry(
               'imagesBlock',
               withFields({
                 internalTitle: `${internalTitle} - photos`,
-                images,
+                photos,
               }),
             ),
           );
@@ -128,6 +129,7 @@ async function addActionPageFromActionSteps(environment, campaign) {
         }
       }
     } else {
+      // If this block is not a Campaign Action Step we can just simply add it to the new Action Page
       actionPageBlocks.push(campaignActionSteps[i]);
     }
   }
@@ -154,7 +156,7 @@ async function addActionPageFromActionSteps(environment, campaign) {
         campaign.fields.pages = { [LOCALE]: [] };
       }
       // Add a Link to the new Page in the campaigns Pages field
-      campaign.fields.pages[LOCALE].push(linkReference(actionPage.sys.id));
+      campaign.fields.pages[LOCALE].unshift(linkReference(actionPage.sys.id));
 
       // Remove actionSteps blocks from campaign
       campaign.fields.actionSteps[LOCALE] = [];


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR adds a Contentful Management API script that creates an 'Action' Page for each campaign based off of it's `actionSteps` field, and transforms the Campaign Action Steps into Content Blocks and ImagesBlocks

To run:
```bash
$ node contentful/management-api-scripts/another.js --space-id [$spaceId] --access-token [$accessToken]
```
Optionally add `--campaign-id [$campaignId]` to run on specific campaign

### Any background context you want to provide?
Part of our ongoing campaign to 'everything is a page'.

The script does the following:
- Grabs all campaigns, or specified campaign
- swaps out it's `campaignActionStep`s for Content Blocks *in a separate reference* (doesn't tamper with the `actionSteps` field itself)
  - if the `campaignActionStep`s have more then one `photos`, it creates an `imagesBlock` as well
- adds new Action page to the campaign with the new set of blocks
- empties the campaign's `actionSteps`

### What are the relevant tickets/cards?
[#156771690](https://www.pivotaltracker.com/story/show/156771690)
#852 
