### PR TITLE
Add migration to create subtitle field in Pages

### DIFF
--- a/contentful/migrations/2018_05_02_001_add_subtitle_to_page_content_type.js
+++ b/contentful/migrations/2018_05_02_001_add_subtitle_to_page_content_type.js
@@ -1,0 +1,12 @@
+module.exports = function(migration) {
+  const page = migration.editContentType('page');
+
+  page
+    .createField('subtitle')
+    .name('Subtitle')
+    .type('Symbol')
+    .required(false)
+    .localized(true);
+
+  page.moveField('subtitle').beforeField('slug');
+};

--- a/contentful/migrations/2018_05_02_001_add_subtitle_to_page_content_type.js
+++ b/contentful/migrations/2018_05_02_001_add_subtitle_to_page_content_type.js
@@ -2,11 +2,11 @@ module.exports = function(migration) {
   const page = migration.editContentType('page');
 
   page
-    .createField('subtitle')
+    .createField('subTitle')
     .name('Subtitle')
     .type('Symbol')
     .required(false)
     .localized(true);
 
-  page.moveField('subtitle').beforeField('slug');
+  page.moveField('subTitle').beforeField('slug');
 };


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR adds a Contentful Migration script to create a `subtitle` field in the `Page` content type.

### What are the relevant tickets/cards?
[#157014308](https://www.pivotaltracker.com/story/show/157014308)