### PR TITLE
Report errors caught by Error Boundaries to New Relic.

### DIFF
--- a/resources/assets/components/ContentfulEntry/ContentfulEntry.js
+++ b/resources/assets/components/ContentfulEntry/ContentfulEntry.js
@@ -8,7 +8,7 @@ import StaticBlock from '../StaticBlock';
 import ReportbackBlock from '../ReportbackBlock';
 import ErrorBlock from '../ErrorBlock/ErrorBlock';
 import { ContentfulEntryJson } from '../../types';
-import { parseContentfulType } from '../../helpers';
+import { parseContentfulType, report } from '../../helpers';
 import { CampaignUpdateContainer } from '../CampaignUpdate';
 import CallToActionContainer from '../CallToAction/CallToActionContainer';
 import CampaignGalleryBlockContainer from '../blocks/CampaignGalleryBlock/CampaignGalleryBlockContainer';
@@ -40,11 +40,9 @@ class ContentfulEntry extends React.Component<Props, State> {
     hasError: false,
   };
 
-  componentDidCatch() {
+  componentDidCatch(error: Error) {
     this.setState({ hasError: true });
-
-    // @TODO: We should report this somewhere!
-    // report(error, info);
+    report(error);
   }
 
   render() {

--- a/resources/assets/helpers/index.js
+++ b/resources/assets/helpers/index.js
@@ -585,3 +585,16 @@ export function parseContentfulType(json, defaultType) {
 
   return type;
 }
+
+/**
+ * Report a caught error to New Relic.
+ *
+ * @param {Error} error
+ */
+export function report(error) {
+  if (!window.newrelic) {
+    return;
+  }
+
+  window.newrelic.noticeError(error);
+}


### PR DESCRIPTION
### What does this PR do?

When we upgraded to React 16, we started catching errors with [Error Boundaries](https://reactjs.org/docs/error-boundaries.html), so now if a block fails it doesn't crash the whole page, a user just sees this!

<p align="center">
<img width="587" alt="screen shot 2018-05-02 at 4 49 54 pm" src="https://user-images.githubusercontent.com/583202/39548523-de602bc6-4e28-11e8-997f-c0909951167c.png">
</p>

But, since the errors are caught they won't be reported to New Relic by default! To do so, I've added a `report` helper (inspired [by Laravel](https://laravel.com/docs/5.6/helpers#method-report), of course) so that these end up in New Relic's "JS Errors" section & alerts.

### Any background context you want to provide?

If you haven't already, take a peek at the [New Relic Browser page](https://rpm.newrelic.com/accounts/108038/browser/68967300) for Phoenix prod!

### What are the relevant tickets/cards?

N/A

### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.
* [ ] Added screenshot to PR description of related front-end updates on **small** screens.
* [ ] Added screenshot to PR description of related front-end updates on **medium** screens.
* [ ] Added screenshot to PR description of related front-end updates on **large** screens.