### PR TITLE
General Page component

### DIFF
--- a/app/Entities/Entity.php
+++ b/app/Entities/Entity.php
@@ -67,7 +67,7 @@ class Entity implements ArrayAccess, JsonSerializable
             case 'linkAction':
                 return new LinkAction($block->entry);
             case 'page':
-                return $block;
+                return new Page($block->entry);
             case 'photoSubmissionAction':
                 return new PhotoSubmissionAction($block->entry);
             case 'photoUploaderAction':
@@ -78,6 +78,8 @@ class Entity implements ArrayAccess, JsonSerializable
                 return new TextSubmissionAction($block->entry);
             case 'voterRegistrationAction':
                 return new VoterRegistrationAction($block->entry);
+            case 'callToAction':
+                return new CallToAction($block->entry);
             default:
                 return new CampaignActionStep($block->entry);
         }

--- a/app/Entities/Page.php
+++ b/app/Entities/Page.php
@@ -36,9 +36,12 @@ class Page extends Entity implements JsonSerializable
             'id' => $this->entry->getId(),
             'type' => $this->getContentType(),
             'fields' => [
+                'slug' => $this->slug,
                 'title' => $this->title,
+                'subTitle' => $this->subTitle,
                 'content' => $this->content,
                 'sidebar' => $this->parseSidebar($this->sidebar),
+                'blocks' => $this->parseBlocks($this->blocks),
             ],
         ];
     }

--- a/resources/assets/components/pages/CampaignPage/CampaignPage.js
+++ b/resources/assets/components/pages/CampaignPage/CampaignPage.js
@@ -11,6 +11,7 @@ import BlockPageContainer from '../BlockPage/BlockPageContainer';
 import ActionPageContainer from '../ActionPage/ActionPageContainer';
 import CampaignSubPageContainer from '../CampaignSubPage/CampaignSubPageContainer';
 import PostSignupModalContainer from '../../pages/PostSignupModal/PostSignupModalContainer';
+import GeneralPageContainer from '../../pages/GeneralPage/GeneralPageContainer';
 
 const CampaignPage = props => {
   const {
@@ -86,7 +87,7 @@ const CampaignPage = props => {
 
           <Route
             path={join(match.url, ':slug')}
-            component={CampaignSubPageContainer}
+            component={GeneralPageContainer}
           />
         </Switch>
       </div>

--- a/resources/assets/components/pages/CampaignPage/CampaignPage.js
+++ b/resources/assets/components/pages/CampaignPage/CampaignPage.js
@@ -85,15 +85,15 @@ const CampaignPage = props => {
             component={CampaignSubPageContainer}
           />
 
-          <Route
-            path={join(match.url, ':slug')}
-            component={CampaignSubPageContainer}
-          />
-
           {/* temporary testing route for general pages */}
           <Route
             path={join(match.url, 'general-page', ':slug')}
             component={GeneralPageContainer}
+          />
+
+          <Route
+            path={join(match.url, ':slug')}
+            component={CampaignSubPageContainer}
           />
         </Switch>
       </div>

--- a/resources/assets/components/pages/CampaignPage/CampaignPage.js
+++ b/resources/assets/components/pages/CampaignPage/CampaignPage.js
@@ -87,6 +87,12 @@ const CampaignPage = props => {
 
           <Route
             path={join(match.url, ':slug')}
+            component={CampaignSubPageContainer}
+          />
+
+          {/* temporary testing route for general pages */}
+          <Route
+            path={join(match.url, 'general-page', ':slug')}
             component={GeneralPageContainer}
           />
         </Switch>

--- a/resources/assets/components/pages/GeneralPage/GeneralPage.js
+++ b/resources/assets/components/pages/GeneralPage/GeneralPage.js
@@ -1,8 +1,6 @@
 import React from 'react';
-import { find } from 'lodash';
 import PropTypes from 'prop-types';
 
-import NotFound from '../../NotFound';
 import Enclosure from '../../Enclosure';
 import ContentfulEntry from '../../ContentfulEntry';
 
@@ -14,21 +12,7 @@ import './general-page.scss';
  * @returns {XML}
  */
 const GeneralPage = props => {
-  const { match, pages } = props;
-
-  const subPage = find(
-    pages,
-    page =>
-      page.type === 'page'
-        ? page.fields.slug.endsWith(match.params.slug)
-        : false,
-  );
-
-  if (!subPage) {
-    return <NotFound />;
-  }
-
-  const { title, subTitle, blocks } = subPage.fields;
+  const { title, subTitle, blocks } = props;
 
   return (
     <div>
@@ -36,8 +20,11 @@ const GeneralPage = props => {
         <Enclosure className="default-container margin-top-lg margin-bottom-lg">
           <div className="general-page__heading text-centered">
             <h1 className="general-page__title caps-lock">{title}</h1>
-            <p className="general-page__subtitle">{subTitle}</p>
+            {subTitle ? (
+              <p className="general-page__subtitle">{subTitle}</p>
+            ) : null}
           </div>
+
           {blocks.map(block => (
             <div className="general-page__block margin-vertical-lg">
               <ContentfulEntry key={block.id} json={block} />
@@ -50,20 +37,13 @@ const GeneralPage = props => {
 };
 
 GeneralPage.propTypes = {
-  match: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
-  pages: PropTypes.arrayOf(
-    PropTypes.shape({
-      fields: PropTypes.shape({
-        title: PropTypes.string,
-        slug: PropTypes.string,
-        blocks: PropTypes.arrayOf(PropTypes.object).isRequired,
-      }),
-    }),
-  ),
+  title: PropTypes.string.isRequired,
+  subTitle: PropTypes.string,
+  blocks: PropTypes.arrayOf(PropTypes.object).isRequired,
 };
 
 GeneralPage.defaultProps = {
-  pages: [],
+  subTitle: null,
 };
 
 export default GeneralPage;

--- a/resources/assets/components/pages/GeneralPage/GeneralPage.js
+++ b/resources/assets/components/pages/GeneralPage/GeneralPage.js
@@ -1,0 +1,63 @@
+import React from 'react';
+import { find } from 'lodash';
+import PropTypes from 'prop-types';
+
+import NotFound from '../../NotFound';
+import Enclosure from '../../Enclosure';
+import ContentfulEntry from '../../ContentfulEntry';
+
+/**
+ * Render a general page
+ *
+ * @returns {XML}
+ */
+const GeneralPage = props => {
+  const { match, pages } = props;
+
+  const subPage = find(
+    pages,
+    page =>
+      page.type === 'page'
+        ? page.fields.slug.endsWith(match.params.slug)
+        : false,
+  );
+
+  if (!subPage) {
+    return <NotFound />;
+  }
+
+  const { title, subTitle, blocks } = subPage.fields;
+
+  return (
+    <div>
+      <div className="main clearfix">
+        <Enclosure className="default-container margin-top-lg margin-bottom-lg">
+          <h1>{title}</h1>
+          <h3>{subTitle}</h3>
+          {subPage.fields.blocks.map(block => {
+            return <ContentfulEntry key={block.id} json={block} />;
+          })}
+        </Enclosure>
+      </div>
+    </div>
+  );
+};
+
+GeneralPage.propTypes = {
+  match: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
+  pages: PropTypes.arrayOf(
+    PropTypes.shape({
+      fields: PropTypes.shape({
+        title: PropTypes.string,
+        slug: PropTypes.string,
+        blocks: PropTypes.arrayOf(PropTypes.object).isRequired,
+      }),
+    }),
+  ),
+};
+
+GeneralPage.defaultProps = {
+  pages: [],
+};
+
+export default GeneralPage;

--- a/resources/assets/components/pages/GeneralPage/GeneralPage.js
+++ b/resources/assets/components/pages/GeneralPage/GeneralPage.js
@@ -38,7 +38,11 @@ const GeneralPage = props => {
             <h1 className="general-page__title caps-lock">{title}</h1>
             <p className="general-page__subtitle">{subTitle}</p>
           </div>
-          {blocks.map(block => <ContentfulEntry key={block.id} json={block} />)}
+          {blocks.map(block => (
+            <div className="general-page__block margin-vertical-lg">
+              <ContentfulEntry key={block.id} json={block} />
+            </div>
+          ))}
         </Enclosure>
       </div>
     </div>

--- a/resources/assets/components/pages/GeneralPage/GeneralPage.js
+++ b/resources/assets/components/pages/GeneralPage/GeneralPage.js
@@ -6,6 +6,8 @@ import NotFound from '../../NotFound';
 import Enclosure from '../../Enclosure';
 import ContentfulEntry from '../../ContentfulEntry';
 
+import './general-page.scss';
+
 /**
  * Render a general page
  *
@@ -32,8 +34,10 @@ const GeneralPage = props => {
     <div>
       <div className="main clearfix">
         <Enclosure className="default-container margin-top-lg margin-bottom-lg">
-          <h1>{title}</h1>
-          <h3>{subTitle}</h3>
+          <div className="general-page__heading text-centered">
+            <h1 className="general-page__title caps-lock">{title}</h1>
+            <p className="general-page__subtitle">{subTitle}</p>
+          </div>
           {blocks.map(block => <ContentfulEntry key={block.id} json={block} />)}
         </Enclosure>
       </div>

--- a/resources/assets/components/pages/GeneralPage/GeneralPage.js
+++ b/resources/assets/components/pages/GeneralPage/GeneralPage.js
@@ -16,7 +16,7 @@ const GeneralPage = props => {
 
   return (
     <div>
-      <div className="main clearfix">
+      <div className="main clearfix general-page">
         <Enclosure className="default-container margin-top-lg margin-bottom-lg">
           <div className="general-page__heading text-centered">
             <h1 className="general-page__title caps-lock">{title}</h1>
@@ -26,10 +26,7 @@ const GeneralPage = props => {
           </div>
 
           {blocks.map(block => (
-            <div
-              className="general-page__block margin-vertical-lg"
-              key={block.id}
-            >
+            <div className="general-page__block margin-vertical" key={block.id}>
               <ContentfulEntry json={block} />
             </div>
           ))}

--- a/resources/assets/components/pages/GeneralPage/GeneralPage.js
+++ b/resources/assets/components/pages/GeneralPage/GeneralPage.js
@@ -17,7 +17,7 @@ const GeneralPage = props => {
   return (
     <div>
       <div className="main clearfix general-page">
-        <Enclosure className="default-container margin-top-lg margin-bottom-lg">
+        <Enclosure className="default-container margin-vertical">
           <div className="general-page__heading text-centered">
             <h1 className="general-page__title caps-lock">{title}</h1>
             {subTitle ? (

--- a/resources/assets/components/pages/GeneralPage/GeneralPage.js
+++ b/resources/assets/components/pages/GeneralPage/GeneralPage.js
@@ -34,7 +34,7 @@ const GeneralPage = props => {
         <Enclosure className="default-container margin-top-lg margin-bottom-lg">
           <h1>{title}</h1>
           <h3>{subTitle}</h3>
-          {subPage.fields.blocks.map(block => {
+          {blocks.map(block => {
             return <ContentfulEntry key={block.id} json={block} />;
           })}
         </Enclosure>

--- a/resources/assets/components/pages/GeneralPage/GeneralPage.js
+++ b/resources/assets/components/pages/GeneralPage/GeneralPage.js
@@ -26,8 +26,11 @@ const GeneralPage = props => {
           </div>
 
           {blocks.map(block => (
-            <div className="general-page__block margin-vertical-lg">
-              <ContentfulEntry key={block.id} json={block} />
+            <div
+              className="general-page__block margin-vertical-lg"
+              key={block.id}
+            >
+              <ContentfulEntry json={block} />
             </div>
           ))}
         </Enclosure>

--- a/resources/assets/components/pages/GeneralPage/GeneralPage.js
+++ b/resources/assets/components/pages/GeneralPage/GeneralPage.js
@@ -34,9 +34,7 @@ const GeneralPage = props => {
         <Enclosure className="default-container margin-top-lg margin-bottom-lg">
           <h1>{title}</h1>
           <h3>{subTitle}</h3>
-          {blocks.map(block => {
-            return <ContentfulEntry key={block.id} json={block} />;
-          })}
+          {blocks.map(block => <ContentfulEntry key={block.id} json={block} />)}
         </Enclosure>
       </div>
     </div>

--- a/resources/assets/components/pages/GeneralPage/GeneralPageContainer.js
+++ b/resources/assets/components/pages/GeneralPage/GeneralPageContainer.js
@@ -9,13 +9,11 @@ import GeneralPage from './GeneralPage';
 const mapStateToProps = (state, ownProps) => {
   // @todo This setup is temporary to test general pages
   // this container should just be fetching the props from state
-  const { match, pages } = ownProps;
-
   const subPage = find(
-    pages,
+    state.campaign.pages,
     page =>
       page.type === 'page'
-        ? page.fields.slug.endsWith(match.params.slug)
+        ? page.fields.slug.endsWith(ownProps.match.params.slug)
         : false,
   );
 

--- a/resources/assets/components/pages/GeneralPage/GeneralPageContainer.js
+++ b/resources/assets/components/pages/GeneralPage/GeneralPageContainer.js
@@ -1,14 +1,36 @@
 import { connect } from 'react-redux';
+import { find } from 'lodash';
 
 import GeneralPage from './GeneralPage';
 
 /**
  * Provide state from the Redux store as props for this component.
  */
-const mapStateToProps = (state, ownProps) => ({
-  pages: state.campaign.pages,
-  route: ownProps.match.params,
-});
+const mapStateToProps = (state, ownProps) => {
+  // @todo This setup is temporary to test general pages
+  // this container should just be fetching the props from state
+  const { match, pages } = ownProps;
+
+  const subPage = find(
+    pages,
+    page =>
+      page.type === 'page'
+        ? page.fields.slug.endsWith(match.params.slug)
+        : false,
+  );
+
+  if (!subPage) {
+    return null;
+  }
+
+  const { title, subTitle, blocks } = subPage.fields;
+
+  return {
+    title,
+    subTitle,
+    block,
+  };
+};
 
 // Export the container component.
 export default connect(mapStateToProps)(GeneralPage);

--- a/resources/assets/components/pages/GeneralPage/GeneralPageContainer.js
+++ b/resources/assets/components/pages/GeneralPage/GeneralPageContainer.js
@@ -1,0 +1,14 @@
+import { connect } from 'react-redux';
+
+import GeneralPage from './GeneralPage';
+
+/**
+ * Provide state from the Redux store as props for this component.
+ */
+const mapStateToProps = (state, ownProps) => ({
+  pages: state.campaign.pages,
+  route: ownProps.match.params,
+});
+
+// Export the container component.
+export default connect(mapStateToProps)(GeneralPage);

--- a/resources/assets/components/pages/GeneralPage/GeneralPageContainer.js
+++ b/resources/assets/components/pages/GeneralPage/GeneralPageContainer.js
@@ -28,7 +28,7 @@ const mapStateToProps = (state, ownProps) => {
   return {
     title,
     subTitle,
-    block,
+    blocks,
   };
 };
 

--- a/resources/assets/components/pages/GeneralPage/general-page.scss
+++ b/resources/assets/components/pages/GeneralPage/general-page.scss
@@ -50,8 +50,8 @@
     margin-left: 10%;
   }
 
-  @include media($large) {
-    width: 65%;
-    margin-left: 17.5%;
+  @include media($larger) {
+    width: 50%;
+    margin-left: 25%;
   }
 }

--- a/resources/assets/components/pages/GeneralPage/general-page.scss
+++ b/resources/assets/components/pages/GeneralPage/general-page.scss
@@ -1,0 +1,56 @@
+@import '../../../scss/next-toolbox';
+
+.general-page__heading {
+  .general-page__title {
+    font-family: $secondary-font-family;
+    font-size: $font-superhero;
+    font-weight: $weight-normal;
+
+    @include media($medium) {
+      font-size: $font-gigantic;
+    }
+  }
+
+  .general-page__subtitle {
+    font-family: $primary-font-family;
+    font-weight: $weight-bold;
+
+    @include media($medium) {
+      font-size: $font-large;
+    }
+  }
+
+  &:after {
+    content: '';
+    display: block;
+    width: 100%;
+    height: 5px;
+    background: $blue;
+    background: linear-gradient(
+      to right,
+      $blue 0%,
+      $blue 33.3%,
+      $purple 33.3%,
+      $purple 66.6%,
+      $yellow 66.6%,
+      $yellow 100%
+    );
+    margin-top: 40px;
+    margin-bottom: 40px;
+  }
+}
+
+.default-container {
+  width: 95%;
+  margin-left: 2.5%;
+
+  @include media($medium) {
+    width: 80%;
+    margin-left: 10%;
+  }
+
+  @include media($large) {
+    width: 65%;
+    margin-left: 17.5%;
+  }
+}

--- a/resources/assets/components/pages/GeneralPage/general-page.scss
+++ b/resources/assets/components/pages/GeneralPage/general-page.scss
@@ -1,5 +1,9 @@
 @import '../../../scss/next-toolbox';
 
+.general-page {
+  background: $white;
+}
+
 .general-page__heading {
   .general-page__title {
     font-family: $secondary-font-family;

--- a/resources/assets/components/pages/GeneralPage/general-page.scss
+++ b/resources/assets/components/pages/GeneralPage/general-page.scss
@@ -23,9 +23,7 @@
   &:after {
     content: '';
     display: block;
-    width: 100%;
     height: 5px;
-    background: $blue;
     background: linear-gradient(
       to right,
       $blue 0%,
@@ -35,8 +33,7 @@
       $yellow 66.6%,
       $yellow 100%
     );
-    margin-top: 40px;
-    margin-bottom: 40px;
+    margin: $section-spacing 10px;
   }
 }
 

--- a/resources/assets/scss/base.scss
+++ b/resources/assets/scss/base.scss
@@ -310,11 +310,6 @@ p {
   margin-bottom: $base-spacing;
 }
 
-.margin-vertical-lg {
-  margin-top: $base-spacing;
-  margin-bottom: $base-spacing;
-}
-
 .margin-vertical-md {
   margin-top: $half-spacing;
   margin-bottom: $half-spacing;

--- a/resources/assets/scss/base.scss
+++ b/resources/assets/scss/base.scss
@@ -310,6 +310,11 @@ p {
   margin-bottom: $base-spacing;
 }
 
+.margin-vertical-lg {
+  margin-top: $base-spacing;
+  margin-bottom: $base-spacing;
+}
+
 .margin-vertical-md {
   margin-top: $half-spacing;
   margin-bottom: $half-spacing;


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR adds a 'General Page' for rendering Pages (e.g. 'Article' pages) in an (ultimately) campaign independent manner.

Right now it's still tied to a campaign since we don't have the top level `/:slug` [route](https://github.com/DoSomething/phoenix-next/blob/master/routes/web.php#L30) implemented.

I added a `general-page/:slug` route in `CampaignPages` to render this GeneralPage component for testing, and set up a test page [here](https://app.contentful.com/spaces/81iqaqpfd8fy/entries/6w1ss8sJ44kUCcOQSWMmS) on [this](https://app.contentful.com/spaces/81iqaqpfd8fy/entries/3GftDuJy2kCIyymQ8ayGCW) campaign.




### What are the relevant tickets/cards?
[#156998603](https://www.pivotaltracker.com/story/show/156998603)

### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.
* [x] Added screenshot to PR description of related front-end updates on **small** screens.
* [x] Added screenshot to PR description of related front-end updates on **medium** screens.
* [x] Added screenshot to PR description of related front-end updates on **large** screens.

**LARGE**
![image](https://user-images.githubusercontent.com/12417657/39724739-9bed693c-5217-11e8-804f-ef3311c6ad4f.png)


**MEDIUM**
![image](https://user-images.githubusercontent.com/12417657/39723092-afd7442c-5212-11e8-884b-1384d7627fdd.png)


**SMALL**
![image](https://user-images.githubusercontent.com/12417657/39723657-85d578cc-5214-11e8-8d40-7521af280390.png)


**NO SUBTITLE**
![image](https://user-images.githubusercontent.com/12417657/39724800-c383e26e-5217-11e8-89d7-2222f0f5b1b8.png)


