### PR TITLE
Add linting rule to enforce import grouping.

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -11,5 +11,17 @@ module.exports = {
     // Require multi-line curly braces for all conditionals.
     curly: ['error', 'all'],
     'brace-style': ['error', '1tbs', { allowSingleLine: false }],
+
+    // Require imports to be grouped by type (packages, then internal files).
+    'import/order': [
+      'error',
+      {
+        'newlines-between': 'always',
+        groups: [
+          ['builtin', 'external'],
+          ['parent', 'sibling', 'internal', 'index'],
+        ],
+      },
+    ],
   },
 };

--- a/resources/assets/actions/event.js
+++ b/resources/assets/actions/event.js
@@ -1,5 +1,4 @@
 import * as actions from '../actions';
-
 import { isTimestampValid } from '../helpers';
 import { getArray, EVENT_STORAGE_KEY } from '../helpers/storage';
 import { isAuthenticated } from '../selectors/user';

--- a/resources/assets/actions/reportback.js
+++ b/resources/assets/actions/reportback.js
@@ -2,6 +2,7 @@
 
 import { Phoenix } from '@dosomething/gateway';
 import { has, get } from 'lodash';
+
 import { normalizeReportbackItemResponse } from '../normalizers';
 import { isAuthenticated } from '../selectors/user';
 import {

--- a/resources/assets/actions/signup.js
+++ b/resources/assets/actions/signup.js
@@ -1,8 +1,8 @@
 import { join } from 'path';
 import { get } from 'lodash';
 import { push } from 'react-router-redux';
-
 import { Phoenix } from '@dosomething/gateway';
+
 import { isCampaignClosed } from '../helpers';
 import { isAuthenticated } from '../selectors/user';
 import { isSignedUp } from '../selectors/signup';

--- a/resources/assets/components/AdminDashboard/AdminDashboardContainer.js
+++ b/resources/assets/components/AdminDashboard/AdminDashboardContainer.js
@@ -1,4 +1,5 @@
 import { connect } from 'react-redux';
+
 import AdminDashboard from './AdminDashboard';
 import { userHasRole } from '../../selectors/user';
 

--- a/resources/assets/components/AffiliateOption/AffiliateOptionContainer.js
+++ b/resources/assets/components/AffiliateOption/AffiliateOptionContainer.js
@@ -1,5 +1,6 @@
 import { connect } from 'react-redux';
 import { get } from 'lodash';
+
 import AffiliateOption from './AffiliateOption';
 import { clickedOptOut } from '../../actions/signup';
 

--- a/resources/assets/components/Block/BlockWrapper.test.js
+++ b/resources/assets/components/Block/BlockWrapper.test.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { mount, shallow } from 'enzyme';
 import { shallowToJson } from 'enzyme-to-json';
 import { MemoryRouter } from 'react-router';
+
 import BlockWrapper from './BlockWrapper';
 
 test('it renders correctly with children', () => {

--- a/resources/assets/components/CallToAction/CallToAction.test.js
+++ b/resources/assets/components/CallToAction/CallToAction.test.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 import { shallowToJson } from 'enzyme-to-json';
+
 import CallToAction from './CallToAction';
 
 // @TODO: Test was failing without having the mock, although it is

--- a/resources/assets/components/CampaignUpdate/CampaignUpdate.test.js
+++ b/resources/assets/components/CampaignUpdate/CampaignUpdate.test.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 import { shallowToJson } from 'enzyme-to-json';
+
 import CampaignUpdate from './CampaignUpdate';
 
 const author = {

--- a/resources/assets/components/CampaignUpdate/CampaignUpdateContainer.js
+++ b/resources/assets/components/CampaignUpdate/CampaignUpdateContainer.js
@@ -1,6 +1,7 @@
 /* global window */
 
 import { connect } from 'react-redux';
+
 import CampaignUpdate from './CampaignUpdate';
 import { makeShareLink } from '../../helpers';
 

--- a/resources/assets/components/ContentfulEntry/ContentfulEntry.test.js
+++ b/resources/assets/components/ContentfulEntry/ContentfulEntry.test.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { shallow } from 'enzyme';
+
 import ContentfulEntry from './ContentfulEntry';
 
 // Mock Redux containers so we don't need Provider context.

--- a/resources/assets/components/Embed/index.js
+++ b/resources/assets/components/Embed/index.js
@@ -8,9 +8,9 @@ import { truncate } from 'lodash';
 
 import { Figure } from '../Figure';
 import { isExternal } from '../../helpers';
+import linkIcon from './linkIcon.svg';
 
 import './embed.scss';
-import linkIcon from './linkIcon.svg';
 
 class Embed extends React.Component {
   constructor(props) {

--- a/resources/assets/components/Experiment/ExperimentContainer.js
+++ b/resources/assets/components/Experiment/ExperimentContainer.js
@@ -1,4 +1,5 @@
 import { connect } from 'react-redux';
+
 import Experiment from './Experiment';
 import { participateInExperiment } from '../../actions';
 

--- a/resources/assets/components/Flex/index.js
+++ b/resources/assets/components/Flex/index.js
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import classnames from 'classnames';
+
 import { modifiers } from '../../helpers';
 import './flex.scss';
 

--- a/resources/assets/components/Gallery/SubmissionGallery/SubmissionGallery.test.js
+++ b/resources/assets/components/Gallery/SubmissionGallery/SubmissionGallery.test.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 import { shallowToJson } from 'enzyme-to-json';
+
 import SubmissionGallery from './SubmissionGallery';
 
 const mediaItem = {

--- a/resources/assets/components/LegacyQuiz/LegacyQuiz.test.js
+++ b/resources/assets/components/LegacyQuiz/LegacyQuiz.test.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { mount } from 'enzyme';
+
 import LegacyQuiz from './LegacyQuiz';
 
 // Mock Redux containers so we don't need Provider context.

--- a/resources/assets/components/LegacyQuiz/LegacyQuizContainer.js
+++ b/resources/assets/components/LegacyQuiz/LegacyQuizContainer.js
@@ -1,6 +1,7 @@
 import { connect } from 'react-redux';
 import { PuckConnector } from '@dosomething/puck-client';
 import { get } from 'lodash';
+
 import LegacyQuiz from './LegacyQuiz';
 import {
   pickWinner,

--- a/resources/assets/components/ModalLauncher/ModalLauncher.test.js
+++ b/resources/assets/components/ModalLauncher/ModalLauncher.test.js
@@ -6,7 +6,6 @@ import { getTime } from 'date-fns';
 
 import { set } from '../../helpers/storage';
 import LocalStorageMock from '../../__mocks__/localStorageMock';
-
 import ModalLauncher from './ModalLauncher';
 
 // Faking timers to be able to interact with and mock our timed modal launcher component

--- a/resources/assets/components/Notification/NotificationContainer.js
+++ b/resources/assets/components/Notification/NotificationContainer.js
@@ -1,4 +1,5 @@
 import { connect } from 'react-redux';
+
 import NotificationList from './NotificationList';
 import { removeNotification } from '../../actions';
 

--- a/resources/assets/components/Quiz/Quiz.test.js
+++ b/resources/assets/components/Quiz/Quiz.test.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { render, shallow } from 'enzyme';
+
 import Quiz from './Quiz';
 import QuizQuestion from './QuizQuestion';
 

--- a/resources/assets/components/Quiz/QuizQuestion.js
+++ b/resources/assets/components/Quiz/QuizQuestion.js
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 
 import QuizChoice from './QuizChoice';
 import SectionHeader from '../SectionHeader';
-
 import { convertNumberToWord } from '../../helpers';
 
 const QuizQuestion = props => {

--- a/resources/assets/components/Reaction/index.js
+++ b/resources/assets/components/Reaction/index.js
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import classnames from 'classnames';
+
 import { BaseFigure } from '../Figure';
 import './reaction.scss';
 

--- a/resources/assets/components/ReportbackBlock/index.js
+++ b/resources/assets/components/ReportbackBlock/index.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+
 import BlockWrapper from '../Block/BlockWrapper';
 import ReportbackItemContainer from '../ReportbackItem';
 import './reportback-block.scss';

--- a/resources/assets/components/ReportbackItem/ReportbackItemContainer.js
+++ b/resources/assets/components/ReportbackItem/ReportbackItemContainer.js
@@ -1,5 +1,6 @@
 import { connect } from 'react-redux';
 import { get } from 'lodash';
+
 import ReportbackItem from './ReportbackItem';
 import { isAuthenticated } from '../../selectors/user';
 import { toggleReactionOn, toggleReactionOff } from '../../actions';

--- a/resources/assets/components/ReportbackItem/test.js
+++ b/resources/assets/components/ReportbackItem/test.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 import { shallowToJson } from 'enzyme-to-json';
+
 import ReportbackItem from './ReportbackItem';
 
 test('Reportback Item basic snapshot test', () => {

--- a/resources/assets/components/ReportbackUploader/ReportbackUploaderContainer.js
+++ b/resources/assets/components/ReportbackUploader/ReportbackUploaderContainer.js
@@ -1,6 +1,7 @@
 import { connect } from 'react-redux';
 import { get } from 'lodash';
 import { PuckConnector } from '@dosomething/puck-client';
+
 import ReportbackUploader from './ReportbackUploader';
 import {
   addSubmissionItemToList,

--- a/resources/assets/components/ScrollConcierge/index.js
+++ b/resources/assets/components/ScrollConcierge/index.js
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { scrollToElement } from '../../helpers/scroll';
 
 /**

--- a/resources/assets/components/Slideshow/SlideshowContainer.js
+++ b/resources/assets/components/Slideshow/SlideshowContainer.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { connect } from 'react-redux';
+
 import { nextSlide } from '../../actions/slideshow';
 import Slideshow from './Slideshow';
 

--- a/resources/assets/components/actions/VoterRegistrationAction/VoterRegistrationAction.test.js
+++ b/resources/assets/components/actions/VoterRegistrationAction/VoterRegistrationAction.test.js
@@ -2,7 +2,6 @@ import React from 'react';
 import { shallow } from 'enzyme';
 
 import { get } from '../../../helpers/storage';
-
 import VoterRegistrationAction from './VoterRegistrationAction';
 import LocalStorageMock from '../../../__mocks__/localStorageMock';
 

--- a/resources/assets/components/pages/ActionPage/ActionStepsContainer.js
+++ b/resources/assets/components/pages/ActionPage/ActionStepsContainer.js
@@ -1,4 +1,5 @@
 import { connect } from 'react-redux';
+
 import ActionSteps from './ActionSteps';
 import { isSignedUp } from '../../../selectors/signup';
 

--- a/resources/assets/components/pages/BlockPage/BlockPage.js
+++ b/resources/assets/components/pages/BlockPage/BlockPage.js
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+
 import Enclosure from '../../Enclosure';
 import ContentfulEntry from '../../ContentfulEntry';
 

--- a/resources/assets/components/pages/BlockPage/BlockPageContainer.js
+++ b/resources/assets/components/pages/BlockPage/BlockPageContainer.js
@@ -1,4 +1,5 @@
 import { connect } from 'react-redux';
+
 import BlockPage from './BlockPage';
 import { findContentfulEntry } from '../../../helpers';
 

--- a/resources/assets/components/pages/PostSignupModal/PostSignupModal.js
+++ b/resources/assets/components/pages/PostSignupModal/PostSignupModal.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+
 import SlideshowContainer from '../../Slideshow';
 import ContentfulEntry from '../../ContentfulEntry';
 

--- a/resources/assets/components/pages/PostSignupModal/PostSignupModalContainer.js
+++ b/resources/assets/components/pages/PostSignupModal/PostSignupModalContainer.js
@@ -1,4 +1,5 @@
 import { connect } from 'react-redux';
+
 import PostSignupModal from './PostSignupModal';
 
 /**

--- a/resources/assets/components/pages/SurveyModal/SurveyModalContainer.js
+++ b/resources/assets/components/pages/SurveyModal/SurveyModalContainer.js
@@ -1,4 +1,5 @@
 import { connect } from 'react-redux';
+
 import SurveyModal from './SurveyModal';
 import { getUserId } from '../../../selectors/user';
 

--- a/resources/assets/components/utilities/ContentfulImage/index.js
+++ b/resources/assets/components/utilities/ContentfulImage/index.js
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+
 import { contentfulImageUrl } from '../../../helpers';
 
 const ContentfulImage = ({ url, width, height, fit }) => (

--- a/resources/assets/components/utilities/Gallery/Gallery.test.js
+++ b/resources/assets/components/utilities/Gallery/Gallery.test.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import renderer from 'react-test-renderer';
+
 import Gallery from './Gallery';
 
 test('it renders correctly with children', () => {

--- a/resources/assets/components/utilities/LazyImage.js
+++ b/resources/assets/components/utilities/LazyImage.js
@@ -1,7 +1,8 @@
-import PropTypes from 'prop-types';
 /* global Image */
 
 import React from 'react';
+import PropTypes from 'prop-types';
+
 import { EMPTY_IMAGE } from '../../helpers';
 
 class LazyImage extends React.Component {

--- a/resources/assets/components/utilities/MediaUploader/test.js
+++ b/resources/assets/components/utilities/MediaUploader/test.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 import { shallowToJson } from 'enzyme-to-json';
+
 import MediaUploader from './index';
 
 test('MediaUploader snapshot test', () => {

--- a/resources/assets/helpers/experiments.js
+++ b/resources/assets/helpers/experiments.js
@@ -1,6 +1,7 @@
 /* eslint-disable import/prefer-default-export */
 
 import { get } from 'lodash';
+
 import experimentsDefinitions from '../experiments.json';
 
 /**

--- a/resources/assets/helpers/sixpack.js
+++ b/resources/assets/helpers/sixpack.js
@@ -1,6 +1,7 @@
 /* global window */
 
 import client from 'sixpack-client';
+
 import experiments from '../experiments.json';
 
 export function sixpack() {

--- a/resources/assets/history.js
+++ b/resources/assets/history.js
@@ -1,4 +1,5 @@
 import createHistory from 'history/createBrowserHistory';
+
 import createHistoryHashObserver from './helpers/createHistoryHashObserver';
 
 let history = null;

--- a/resources/assets/init.js
+++ b/resources/assets/init.js
@@ -1,4 +1,5 @@
 /* global window, document */
+/* eslint-disable import/order */
 
 /*
  |--------------------------------------------------------------------------

--- a/resources/assets/reducers/events.js
+++ b/resources/assets/reducers/events.js
@@ -1,7 +1,6 @@
 /* global window */
 
 import { QUEUE_EVENT, COMPLETED_EVENT } from '../actions';
-
 import {
   append as storageAppend,
   splice as storageSplice,

--- a/resources/assets/reducers/reportbacks.js
+++ b/resources/assets/reducers/reportbacks.js
@@ -1,5 +1,6 @@
 import { merge } from 'lodash';
 import update from 'react-addons-update';
+
 import {
   REQUESTED_REPORTBACKS,
   RECEIVED_REPORTBACKS,


### PR DESCRIPTION
### What does this PR do?

This PR adds an [import/order](https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/order.md) rule to enforce grouping of imports. Unfortunately this plugin doesn't also support ordering within those groups, but it's one less thing to think about & manually fix!

### Any background context you want to provide?
Prompted by a comment by @katiecrane in #884!

### What are the relevant tickets/cards?
N/A

### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.
* [ ] Added screenshot to PR description of related front-end updates on **small** screens.
* [ ] Added screenshot to PR description of related front-end updates on **medium** screens.
* [ ] Added screenshot to PR description of related front-end updates on **large** screens.