### PR TITLE
A few touch-ups to Embed edge cases.

### DIFF
--- a/app/Http/Controllers/EmbedController.php
+++ b/app/Http/Controllers/EmbedController.php
@@ -26,7 +26,7 @@ class EmbedController extends Controller
             CURLOPT_TIMEOUT => 3,
         ]);
 
-        $info = remember('embed.' . md5($url), 60, function () use ($url, $dispatcher) {
+        $info = remember('embed.' . md5($url), 60 * 48, function () use ($url, $dispatcher) {
             try {
                 return Embed::create($url, null, $dispatcher);
             } catch (\Exception $exception) {

--- a/resources/assets/components/utilities/Embed/Embed.js
+++ b/resources/assets/components/utilities/Embed/Embed.js
@@ -51,14 +51,14 @@ class Embed extends React.Component {
             <div className="margin-vertical-md margin-right-md">
               <h3>
                 {data ? (
-                  truncate(data.title, { length: 140 })
+                  truncate(data.title, { length: 60 })
                 ) : (
                   <PlaceholderText size="medium" />
                 )}
               </h3>
               <p className="color-gray">
                 {data ? (
-                  truncate(data.description, { length: 300 })
+                  truncate(data.description, { length: 240 })
                 ) : (
                   <PlaceholderText size="large" />
                 )}

--- a/resources/assets/components/utilities/Embed/Embed.js
+++ b/resources/assets/components/utilities/Embed/Embed.js
@@ -49,7 +49,7 @@ class Embed extends React.Component {
           <LazyImage className="embed__image" src={image} background />
           <div className="embed__content padded">
             <div className="margin-vertical-md margin-right-md">
-              <h3>
+              <h3 className="line-break">
                 {data ? (
                   truncate(data.title, { length: 60 })
                 ) : (

--- a/resources/assets/scss/base.scss
+++ b/resources/assets/scss/base.scss
@@ -153,6 +153,10 @@ p {
   margin-right: -$half-spacing;
 }
 
+.line-break {
+  line-break: normal;
+}
+
 .flex-center-y {
   display: flex;
   justify-content: center;


### PR DESCRIPTION
### What does this PR do?

This pull request has two super tiny tweaks to embeds after doing a lil' more QA on some of our campaigns. It reduces character counts before content is truncated, and allows the browser to more aggressively break long strings (for example, a URL to a PDF):

![screen shot 2018-05-08 at 3 31 49 pm](https://user-images.githubusercontent.com/583202/39778820-68dddda6-52d5-11e8-84e3-1eb1f75004e4.png)

### Any background context you want to provide?

This just fixes up some edge cases on the new embed implementation!

### What are the relevant tickets/cards?

[#156276586](https://www.pivotaltracker.com/story/show/156276586)

### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.
* [ ] Added screenshot to PR description of related front-end updates on **small** screens.
* [ ] Added screenshot to PR description of related front-end updates on **medium** screens.
* [ ] Added screenshot to PR description of related front-end updates on **large** screens.