### PR TITLE
Community campaign subpage

### DIFF
--- a/app/Entities/Entity.php
+++ b/app/Entities/Entity.php
@@ -80,6 +80,16 @@ class Entity implements ArrayAccess, JsonSerializable
                 return new VoterRegistrationAction($block->entry);
             case 'callToAction':
                 return new CallToAction($block->entry);
+            case 'customBlock':
+                if ($block->entry->getType() === 'join_cta') {
+                    return new CallToAction($block->entry);
+                }
+
+                if ($block->entry->getType() === 'campaign_update') {
+                    return new CampaignUpdate($block->entry);
+                }
+
+                return new CustomBlock($block->entry);
             default:
                 return new CampaignActionStep($block->entry);
         }

--- a/app/Entities/Page.php
+++ b/app/Entities/Page.php
@@ -31,7 +31,8 @@ class Page extends Entity implements JsonSerializable
      * @param  array $blocks
      * @return array
      */
-    public function parseBlocks($blocks) {
+    public function parseBlocks($blocks)
+    {
         $parsedBlocks = parent::parseBlocks($blocks);
 
         if (ends_with($this->slug, 'community')) {

--- a/app/Entities/Page.php
+++ b/app/Entities/Page.php
@@ -26,6 +26,22 @@ class Page extends Entity implements JsonSerializable
     }
 
     /**
+     * Parse blocks, and reverse parsed blocks for community pages.
+     *
+     * @param  array $blocks
+     * @return array
+     */
+    public function parseBlocks($blocks) {
+        $parsedBlocks = parent::parseBlocks($blocks);
+
+        if (ends_with($this->slug, 'community')) {
+            return $parsedBlocks->reverse()->values();
+        }
+
+        return $parsedBlocks;
+    }
+
+    /**
      * Convert the object into something JSON serializable.
      *
      * @return array

--- a/app/Entities/Page.php
+++ b/app/Entities/Page.php
@@ -42,6 +42,9 @@ class Page extends Entity implements JsonSerializable
                 'content' => $this->content,
                 'sidebar' => $this->parseSidebar($this->sidebar),
                 'blocks' => $this->parseBlocks($this->blocks),
+                // @TODO: we want to eventually remove the need for hideFromNavigation field
+                // in favor of always linking to pages referenced in the `pages` field.
+                'hideFromNavigation' => $this->hideFromNavigation,
             ],
         ];
     }

--- a/app/Entities/Page.php
+++ b/app/Entities/Page.php
@@ -35,7 +35,7 @@ class Page extends Entity implements JsonSerializable
     {
         $parsedBlocks = parent::parseBlocks($blocks);
 
-        if (ends_with($this->slug, 'community')) {
+        if (ends_with(rtrim($this->slug, '/'), 'community')) {
             return $parsedBlocks->reverse()->values();
         }
 

--- a/resources/assets/components/pages/CampaignPage/CampaignPage.js
+++ b/resources/assets/components/pages/CampaignPage/CampaignPage.js
@@ -19,6 +19,7 @@ const CampaignPage = props => {
     affiliateSponsors,
     campaignLead,
     clickedHideAffirmation,
+    hasActivityFeed,
     hasCommunityPage,
     isAdmin,
     isCampaignClosed,
@@ -65,7 +66,11 @@ const CampaignPage = props => {
                 return <Redirect to={join(match.url, 'action')} />;
               }
 
-              return <FeedContainer />;
+              return hasActivityFeed ? (
+                <FeedContainer />
+              ) : (
+                <CampaignSubPageContainer isCommunity />
+              );
             }}
           />
 
@@ -114,6 +119,7 @@ CampaignPage.propTypes = {
     email: PropTypes.string,
   }),
   clickedHideAffirmation: PropTypes.func.isRequired,
+  hasActivityFeed: PropTypes.bool.isRequired,
   hasCommunityPage: PropTypes.bool.isRequired,
   isAdmin: PropTypes.bool.isRequired,
   isCampaignClosed: PropTypes.bool.isRequired,

--- a/resources/assets/components/pages/CampaignPage/CampaignPageContainer.js
+++ b/resources/assets/components/pages/CampaignPage/CampaignPageContainer.js
@@ -14,7 +14,10 @@ const mapStateToProps = state => ({
   affiliatePartners: state.campaign.affiliatePartners,
   campaignLead: get(state, 'campaign.campaignLead.fields', null),
   hasActivityFeed: Boolean(state.campaign.activityFeed.length),
-  hasCommunityPage: Boolean(state.campaign.activityFeed.length),
+  hasCommunityPage: Boolean(
+    state.campaign.activityFeed.length ||
+      state.campaign.pages.find(page => page.fields.slug.endsWith('community')),
+  ),
   isAdmin: userHasRole(state, 'admin'),
   isCampaignClosed: isCampaignClosed(
     get(state.campaign.endDate, 'date', false),

--- a/resources/assets/components/pages/CampaignSubPage/CampaignSubPage.js
+++ b/resources/assets/components/pages/CampaignSubPage/CampaignSubPage.js
@@ -6,6 +6,7 @@ import NotFound from '../../NotFound';
 import Enclosure from '../../Enclosure';
 import { isCampaignClosed } from '../../../helpers';
 import ScrollConcierge from '../../ScrollConcierge';
+import ContentfulEntry from '../../ContentfulEntry';
 import Markdown from '../../utilities/Markdown/Markdown';
 import { CallToActionContainer } from '../../CallToAction';
 import DashboardContainer from '../../Dashboard/DashboardContainer';
@@ -15,14 +16,22 @@ import CampaignPageNavigationContainer from '../../CampaignPageNavigation/Campai
 import './campaign-subpage.scss';
 
 const CampaignSubPageContent = props => {
-  const { campaignEndDate, match, noun, pages, tagline, verb } = props;
+  const {
+    campaignEndDate,
+    isCommunity,
+    match,
+    noun,
+    pages,
+    tagline,
+    verb,
+  } = props;
+
+  const pageSlug = isCommunity ? 'community' : match.params.slug;
 
   const subPage = find(
     pages,
     page =>
-      page.type === 'page'
-        ? page.fields.slug.endsWith(match.params.slug)
-        : false,
+      page.type === 'page' ? page.fields.slug.endsWith(pageSlug) : false,
   );
 
   if (!subPage) {
@@ -34,6 +43,21 @@ const CampaignSubPageContent = props => {
   const ctaContent = `${tagline} Join hundreds of members and ${verb.plural} ${
     noun.plural
   }!`;
+
+  if (isCommunity) {
+    return (
+      <div className="clearfix padded campaign-subpage" id={subPage.id}>
+        <div>
+          <ScrollConcierge />
+          {subPage.fields.blocks.map(block => (
+            <div className="margin-vertical" key={block.id} id={block.id}>
+              <ContentfulEntry json={block} />
+            </div>
+          ))}
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className="clearfix padded campaign-subpage" id={subPage.id}>
@@ -65,7 +89,8 @@ const CampaignSubPageContent = props => {
 
 CampaignSubPageContent.propTypes = {
   campaignEndDate: PropTypes.string.isRequired,
-  match: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
+  isCommunity: PropTypes.bool,
+  match: PropTypes.object, // eslint-disable-line react/forbid-prop-types
   noun: PropTypes.shape({
     singular: PropTypes.string,
     plural: PropTypes.string,
@@ -87,7 +112,11 @@ CampaignSubPageContent.propTypes = {
 };
 
 CampaignSubPageContent.defaultProps = {
+  isCommunity: false,
   pages: [],
+  match: {
+    params: {},
+  },
   noun: {
     singular: 'action',
     plural: 'action',

--- a/resources/assets/components/pages/CampaignSubPage/CampaignSubPage.js
+++ b/resources/assets/components/pages/CampaignSubPage/CampaignSubPage.js
@@ -50,7 +50,7 @@ const CampaignSubPageContent = props => {
         <div>
           <ScrollConcierge />
           {subPage.fields.blocks.map(block => (
-            <div className="margin-vertical" key={block.id} id={block.id}>
+            <div className="margin-vertical" key={block.id}>
               <ContentfulEntry json={block} />
             </div>
           ))}

--- a/resources/assets/components/pages/CampaignSubPage/CampaignSubPageContainer.js
+++ b/resources/assets/components/pages/CampaignSubPage/CampaignSubPageContainer.js
@@ -6,7 +6,7 @@ import CampaignSubPage from './CampaignSubPage';
 /**
  * Provide state from the Redux store as props for this component.
  */
-const mapStateToProps = (state, ownProps) => ({
+const mapStateToProps = state => ({
   pages: state.campaign.pages,
   dashboard: state.campaign.dashboard,
   noun: get(state.campaign.additionalContent, 'noun'),

--- a/resources/assets/components/pages/CampaignSubPage/CampaignSubPageContainer.js
+++ b/resources/assets/components/pages/CampaignSubPage/CampaignSubPageContainer.js
@@ -9,7 +9,6 @@ import CampaignSubPage from './CampaignSubPage';
 const mapStateToProps = (state, ownProps) => ({
   pages: state.campaign.pages,
   dashboard: state.campaign.dashboard,
-  route: ownProps.match.params,
   noun: get(state.campaign.additionalContent, 'noun'),
   verb: get(state.campaign.additionalContent, 'verb'),
   tagline: get(state.campaign.additionalContent, 'tagline'),


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR adds support for routing to a  'Community' Page (`/community`) on a campaign (which has a Community Page but not an `activityFeed` field).

- Adding parsing for a `customBlock` content type to the contentful Entity `parseBlocks` method (to enable handling custom blocks which exist in many an `activityFeed` and will be ported to the community pages)
- Accounting for a Community page in the `page`s field when setting the `hasCommunityPage` boolean for `CampaignPage` routing
- Adding community page specific rendering in `campaignSubPage` to render the community page with blocks. (Will be implemented for pages in general down the line)
- Rendering the `campaignSubPage` from the `/community` route on campaigns which have a community page and no activity feed
- Adding the `hideFromNavigation` field to the `Page` Entity (temporary as we want to get rid of that logic in the future)

### Any background context you want to provide?
The setup is somewhat intensely specific to the weird world we have now with balancing community pages and `activityFeed`s. Once we sunset `activityFeed` entirely and move over to pages for everything, this will be able to be cleaned up majorly!

The `isCommunity` prop is to circumvent the general methodoligy the `campaignSubPage` uses to find the appropriate page. We also don't have access to the `match` prop (and anyways don't have a `:slug`) when on the `/community` route.

### What are the relevant tickets/cards?
[#156771690](https://www.pivotaltracker.com/story/show/156771690)