### PR TITLE
Update ActivityFeed to Community Page transformation script

### DIFF
--- a/contentful/management-api-scripts/2018_04_20_001_campaign_activity_feed_to_community_page.js
+++ b/contentful/management-api-scripts/2018_04_20_001_campaign_activity_feed_to_community_page.js
@@ -21,6 +21,7 @@ async function addCommunityPageFromActivityFeed(environment, campaign) {
   const campaignSlug = getField(campaign, 'slug');
   const campaignActivityFeed = getField(campaign, 'activity_feed');
   const campaignPages = getField(campaign, 'pages', []);
+  const campaignAdditionalContent = getField(campaign, 'additionalContent');
 
   if (!campaignPages.length) {
     // Ensure the campaign has a pages property with the correct locale
@@ -36,9 +37,9 @@ async function addCommunityPageFromActivityFeed(environment, campaign) {
 
   logger.info(`Processing Campaign! [ID: ${campaign.sys.id}]\n`);
 
-  const communityPageBlocks = [];
+  let communityPageBlocks = [];
 
-  // Copy over all block link references from activityFeed besides for `reportbacks` custom blocks
+  // Copy over all block link references from activity_feed besides for `reportbacks` custom blocks
   for (let i = 0; i < campaignActivityFeed.length; i++) {
     const block = campaignActivityFeed[i];
     const blockEntry = await attempt(() => environment.getEntry(block.sys.id));
@@ -58,6 +59,15 @@ async function addCommunityPageFromActivityFeed(environment, campaign) {
     }
 
     communityPageBlocks.push(block);
+  }
+
+  // Reverse the community page blocks for activity_feeds which were still ordered top to bottom
+  const reverseActivityFeedOrder = get(
+    campaignAdditionalContent,
+    'reverseActivityFeedOrder',
+  );
+  if (reverseActivityFeedOrder === false) {
+    communityPageBlocks = communityPageBlocks.reverse();
   }
 
   // Create a new community 'Page' with the activity_feed blocks from the source campaign


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR includes some updates to the Contentful Management API script for updating Campaigns `activity_feed`s to Community Pages:

- ignores any custom blocks of `type` `reportbacks`
- empties the `activity_feed` field of the transformed campaign
- reverse the block ordering for any campaign specified as `reverseActivityFeedOrder: false` in `additionalContent`. (so that we can blanket reverse all community pages, and not have to migrate this logic to pages)

With the support on the front end from #892, we'll be able to run this script and transition campaigns to the new path one by one.

### What are the relevant tickets/cards?
[#156771690](https://www.pivotaltracker.com/story/show/156771690)