### PR TITLE
Add a badge to unpublished posts.

### DIFF
--- a/resources/assets/components/utilities/PostCard/PostBadge.js
+++ b/resources/assets/components/utilities/PostCard/PostBadge.js
@@ -1,0 +1,21 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const PostBadge = ({ status, tags }) =>
+  status !== 'ACCEPTED' || tags.includes('hide-in-gallery') ? (
+    <div
+      className="post-badge"
+      title="This post is awaiting review or hidden in the gallery."
+    />
+  ) : null;
+
+PostBadge.propTypes = {
+  status: PropTypes.bool.isRequired,
+  tags: PropTypes.arrayOf(PropTypes.string),
+};
+
+PostBadge.defaultProps = {
+  tags: [],
+};
+
+export default PostBadge;

--- a/resources/assets/components/utilities/PostCard/PostBadge.js
+++ b/resources/assets/components/utilities/PostCard/PostBadge.js
@@ -1,13 +1,27 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-const PostBadge = ({ status, tags }) =>
-  status !== 'ACCEPTED' || tags.includes('hide-in-gallery') ? (
-    <div
-      className="post-badge"
-      title="This post is awaiting review or hidden in the gallery."
-    />
-  ) : null;
+const PostBadge = ({ status, tags }) => {
+  if (status === 'REJECTED') {
+    return (
+      <div
+        className="post-badge -rejected"
+        title="This post has been marked as rejected."
+      />
+    );
+  }
+
+  if (status !== 'ACCEPTED' || tags.includes('hide-in-gallery')) {
+    return (
+      <div
+        className="post-badge"
+        title="This post is awaiting review or hidden in the gallery."
+      />
+    );
+  }
+
+  return null;
+};
 
 PostBadge.propTypes = {
   status: PropTypes.bool.isRequired,

--- a/resources/assets/components/utilities/PostCard/PostCard.js
+++ b/resources/assets/components/utilities/PostCard/PostCard.js
@@ -3,6 +3,7 @@ import gql from 'graphql-tag';
 import PropTypes from 'prop-types';
 import { propType } from 'graphql-anywhere';
 
+import PostBadge from './PostBadge';
 import { BaseFigure } from '../../Figure';
 import { pluralize } from '../../../helpers';
 import LazyImage from '../../utilities/LazyImage';
@@ -17,6 +18,7 @@ export const postCardFragment = gql`
     status
     url
     text
+    tags
     quantity
     user {
       firstName
@@ -54,6 +56,7 @@ const PostCard = ({ post, noun }) => {
         alignment="right"
         className="padded margin-bottom-none"
       >
+        <PostBadge status={post.status} tags={post.tags} />
         <h4>{firstName}</h4>
         {post.quantity ? (
           <p className="footnote">

--- a/resources/assets/components/utilities/PostCard/post.scss
+++ b/resources/assets/components/utilities/PostCard/post.scss
@@ -73,3 +73,7 @@
   color: #fff;
   transform: rotate(-45deg);
 }
+
+.post-badge.-rejected {
+  color: $error-color;
+}

--- a/resources/assets/components/utilities/PostCard/post.scss
+++ b/resources/assets/components/utilities/PostCard/post.scss
@@ -1,6 +1,7 @@
 @import '../../../scss/next-toolbox.scss';
 
 .post {
+  position: relative;
   font-family: $primary-font-family;
   margin-bottom: 0;
 
@@ -59,4 +60,16 @@
       font-size: $font-medium;
     }
   }
+}
+
+.post-badge {
+  display: block;
+  position: absolute;
+  top: -15px;
+  left: -15px;
+  width: 30px;
+  height: 30px;
+  background: $yellow;
+  color: #fff;
+  transform: rotate(-45deg);
 }


### PR DESCRIPTION
### What does this PR do?

This PR just adds a lil' badge to unpublished & rejected posts, so it's clear to staff members (who can see everything) or users (whose posts may be awaiting review) that it won't be visible in the public gallery.

![screen shot 2018-05-09 at 1 17 02 pm](https://user-images.githubusercontent.com/583202/39829087-4ae680a8-538b-11e8-80e3-4fbb76142256.png)


### Any background context you want to provide?

This was prompted by some confusion earlier today around how Phoenix Next galleries worked.

### What are the relevant tickets/cards?

N/A

### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.
* [ ] Added screenshot to PR description of related front-end updates on **small** screens.
* [ ] Added screenshot to PR description of related front-end updates on **medium** screens.
* [ ] Added screenshot to PR description of related front-end updates on **large** screens.
