### PR TITLE
Quick fix for change in required prop type.

### DIFF
--- a/resources/assets/components/utilities/PostCard/PostBadge.js
+++ b/resources/assets/components/utilities/PostCard/PostBadge.js
@@ -43,7 +43,7 @@ const PostBadge = ({ status, tags }) => {
 };
 
 PostBadge.propTypes = {
-  status: PropTypes.bool.isRequired,
+  status: PropTypes.string.isRequired,
   tags: PropTypes.arrayOf(PropTypes.string),
 };
 


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?
This PR fixes a quick issue with the specified prop type for the `status` property; from a `bool` to a `string`.

### Any background context you want to provide?
![screen shot 2018-05-09 at 3 43 14 pm](https://user-images.githubusercontent.com/105849/39836019-0e83b364-53a0-11e8-897d-e2dde74da374.png)
