### PR TITLE
Allow embeds to be hidden in Share Actions.

### DIFF
--- a/app/Entities/ShareAction.php
+++ b/app/Entities/ShareAction.php
@@ -20,6 +20,7 @@ class ShareAction extends Entity implements JsonSerializable
                 'title' => $this->title,
                 'content' => $this->content,
                 'link' => $this->link,
+                'hideEmbed' => $this->hideEmbed,
                 'affirmation' => $this->affirmation,
                 'affirmationBlock' => $this->parseBlock($this->affirmationBlock),
                 'socialPlatform' => $this->socialPlatform->first() ?: 'facebook',

--- a/resources/assets/components/actions/ShareAction/ShareAction.js
+++ b/resources/assets/components/actions/ShareAction/ShareAction.js
@@ -47,12 +47,12 @@ class ShareAction extends React.Component {
     const {
       affirmation, // @TODO: Rename me to 'affirmationText'?
       affirmationBlock,
+      campaignId,
       content,
       hideEmbed,
       link,
       socialPlatform,
       title,
-      campaignId,
       userId,
     } = this.props;
 
@@ -98,23 +98,23 @@ class ShareAction extends React.Component {
 }
 
 ShareAction.propTypes = {
-  title: PropTypes.string.isRequired,
-  content: PropTypes.string,
-  link: PropTypes.string.isRequired,
-  socialPlatform: PropTypes.oneOf(['twitter', 'facebook']).isRequired,
   affirmation: PropTypes.string,
   affirmationBlock: PropTypes.object, // eslint-disable-line
   campaignId: PropTypes.string,
-  userId: PropTypes.string,
+  content: PropTypes.string,
   hideEmbed: PropTypes.bool,
+  link: PropTypes.string.isRequired,
+  socialPlatform: PropTypes.oneOf(['twitter', 'facebook']).isRequired,
+  title: PropTypes.string.isRequired,
+  userId: PropTypes.string,
 };
 
 ShareAction.defaultProps = {
-  content: null,
   affirmation: 'Thanks for rallying your friends on Facebook!',
   campaignId: null,
-  userId: null,
+  content: null,
   hideEmbed: false,
+  userId: null,
 };
 
 export default ShareAction;

--- a/resources/assets/components/actions/ShareAction/ShareAction.js
+++ b/resources/assets/components/actions/ShareAction/ShareAction.js
@@ -48,6 +48,7 @@ class ShareAction extends React.Component {
       affirmation, // @TODO: Rename me to 'affirmationText'?
       affirmationBlock,
       content,
+      hideEmbed,
       link,
       socialPlatform,
       title,
@@ -67,9 +68,11 @@ class ShareAction extends React.Component {
         <div className="share-action margin-bottom-lg">
           <Card title={title} className="rounded bordered">
             {content ? <Markdown className="padded">{content}</Markdown> : null}
-            <div className="padded">
-              <Embed url={href} />
-            </div>
+            {hideEmbed ? null : (
+              <div className="padded">
+                <Embed url={href} />
+              </div>
+            )}
             <Button attached onClick={() => handleShareClick(href)}>
               Share on {isFacebook ? 'Facebook' : 'Twitter'}
             </Button>
@@ -103,6 +106,7 @@ ShareAction.propTypes = {
   affirmationBlock: PropTypes.object, // eslint-disable-line
   campaignId: PropTypes.string,
   userId: PropTypes.string,
+  hideEmbed: PropTypes.bool,
 };
 
 ShareAction.defaultProps = {
@@ -110,6 +114,7 @@ ShareAction.defaultProps = {
   affirmation: 'Thanks for rallying your friends on Facebook!',
   campaignId: null,
   userId: null,
+  hideEmbed: false,
 };
 
 export default ShareAction;


### PR DESCRIPTION
### What does this PR do?

This pull request adds the ability to hide the embed preview in Share Actions, by checking the "Hide Embed" field on the [content model](https://app.contentful.com/spaces/81iqaqpfd8fy/content_types/shareAction/fields). This field is not required & by default, embeds will continue to be shown. When hidden, they look like this:

<img width="630" alt="screen shot 2018-05-10 at 11 31 08 am" src="https://user-images.githubusercontent.com/583202/39878161-a83fb142-5445-11e8-8c42-d02135826e02.png">

### Any background context you want to provide?

The interesting change is in 013218a, and I just sorted things in 763640c. 🔃 

### What are the relevant tickets/cards?

[#157402866](https://www.pivotaltracker.com/story/show/157402866)

### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.
* [ ] Added screenshot to PR description of related front-end updates on **small** screens.
* [ ] Added screenshot to PR description of related front-end updates on **medium** screens.
* [ ] Added screenshot to PR description of related front-end updates on **large** screens.