### PR TITLE
Adjust modal min width for small screens

### DIFF
--- a/resources/assets/components/utilities/Modal/modal.scss
+++ b/resources/assets/components/utilities/Modal/modal.scss
@@ -32,9 +32,13 @@
 
 .modal {
   margin: auto;
-  min-width: 400px;
+  min-width: 250px;
   max-width: 800px;
   position: relative;
+
+  @include media($medium) {
+    min-width: 400px;
+  }
 }
 
 .modal__close {


### PR DESCRIPTION
Quick adjustment to the min-width sizing to address some bugginess we were seeing on small screens stretching too far for the viewport.

![image](https://user-images.githubusercontent.com/12417657/39878363-2d4cd522-5446-11e8-8979-033da80af644.png)
)


[Slack convo](https://dosomething.slack.com/archives/C2BPA7M8F/p1525965512000365)
