### PR TITLE
Performing loader functionality on mount as well as on update

### DIFF
--- a/resources/assets/components/utilities/LazyImage.js
+++ b/resources/assets/components/utilities/LazyImage.js
@@ -14,10 +14,7 @@ class LazyImage extends React.Component {
     this.state = { loaded: false };
   }
 
-  /**
-   * Perform actions after receiving new props.
-   */
-  componentDidUpdate() {
+  setLoader = () => {
     this.loader = new Image();
 
     // Load image and set `loaded: true` state when ready.
@@ -25,6 +22,20 @@ class LazyImage extends React.Component {
     if (this.props.src) {
       this.loader.src = this.props.src;
     }
+  };
+
+  /**
+   * Perform actions after component is mounted.
+   */
+  componentDidMount() {
+    this.setLoader();
+  }
+
+  /**
+   * Perform actions after receiving new props.
+   */
+  componentDidUpdate() {
+    this.setLoader();
   }
 
   componentWillUnmount() {

--- a/resources/assets/components/utilities/LazyImage.js
+++ b/resources/assets/components/utilities/LazyImage.js
@@ -14,16 +14,6 @@ class LazyImage extends React.Component {
     this.state = { loaded: false };
   }
 
-  setLoader = () => {
-    this.loader = new Image();
-
-    // Load image and set `loaded: true` state when ready.
-    this.loader.onload = () => this.setState({ loaded: true });
-    if (this.props.src) {
-      this.loader.src = this.props.src;
-    }
-  };
-
   /**
    * Perform actions after component is mounted.
    */
@@ -41,6 +31,16 @@ class LazyImage extends React.Component {
   componentWillUnmount() {
     this.loader = null;
   }
+
+  setLoader = () => {
+    this.loader = new Image();
+
+    // Load image and set `loaded: true` state when ready.
+    this.loader.onload = () => this.setState({ loaded: true });
+    if (this.props.src) {
+      this.loader.src = this.props.src;
+    }
+  };
 
   /**
    * Render the image.


### PR DESCRIPTION
Update to set the loader on the LazyImage component both after mounting *and* updating props. (Quick bug fix to address RBs never rendering their images.)