### PR TITLE
Fix issue when tags are not returned.

### DIFF
--- a/resources/assets/components/utilities/PostCard/PostBadge.js
+++ b/resources/assets/components/utilities/PostCard/PostBadge.js
@@ -28,7 +28,8 @@ const PostBadge = ({ status, tags }) => {
     );
   }
 
-  if (tags.includes('hide-in-gallery')) {
+  // If we can see tags for this post, and one is 'hide in gallery'.
+  if (tags && tags.includes('hide-in-gallery')) {
     return (
       <img
         className="post-badge"


### PR DESCRIPTION
### What does this PR do?

This pull request fixes an issue with the `PostBadge` component for non-staffers. Rogue only includes the `tags` property for owners/staffers, so normal users will often see this field as null. That makes `[].includes` not a safe bet. Adding an existence check clears things up.

### Any background context you want to provide?

N/A

### What are the relevant tickets/cards?

N/A

### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.
* [ ] Added screenshot to PR description of related front-end updates on **small** screens.
* [ ] Added screenshot to PR description of related front-end updates on **medium** screens.
* [ ] Added screenshot to PR description of related front-end updates on **large** screens.
