### PR TITLE
Standalone 'Page' backend setup

### DIFF
--- a/app/Http/Controllers/PageController.php
+++ b/app/Http/Controllers/PageController.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Repositories\PageRepository;
+
+class PageController extends Controller
+{
+    /**
+     * The page repository.
+     *
+     * @var PageRepository
+     */
+    protected $pageRepository;
+
+    /**
+     * Make a new PageController, inject dependencies,
+     * and set middleware for this controller's methods.
+     *
+     * @param PageRepository $pageRepository
+     */
+    public function __construct(PageRepository $pageRepository)
+    {
+        $this->pageRepository = $pageRepository;
+    }
+
+    /**
+     * Display the specified resource.
+     *
+     * @param  string  $slug
+     * @return \Illuminate\View\View
+     */
+    public function show($slug)
+    {
+        $page = $this->pageRepository->findBySlug($slug);
+
+        return view('app')->with('state', [
+            'page' => $page,
+        ]);
+    }
+}

--- a/app/Http/Controllers/PageController.php
+++ b/app/Http/Controllers/PageController.php
@@ -34,8 +34,11 @@ class PageController extends Controller
     {
         $page = $this->pageRepository->findBySlug($slug);
 
-        return view('app')->with('state', [
-            'page' => $page,
-        ]);
+        // return view('app')->with('state', [
+        //     'page' => $page,
+        // ]);
+
+        return response('Hang Tight! We\'ll have static pages up and running in a jiffy!', 501)
+            ->header('Content-Type', 'text/plain');
     }
 }

--- a/app/Repositories/PageRepository.php
+++ b/app/Repositories/PageRepository.php
@@ -43,8 +43,8 @@ class PageRepository
 
         if (! $pages->count()) {
             throw new ModelNotFoundException;
-        } else {
-            return new Page($pages[0]);
         }
+
+        return new Page($pages[0]);
     }
 }

--- a/app/Repositories/PageRepository.php
+++ b/app/Repositories/PageRepository.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\Repositories;
+
+use App\Entities\Page;
+use Contentful\Delivery\Query;
+use Contentful\Delivery\Client as Contentful;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+
+class PageRepository
+{
+    /**
+     * Contentful client instance.
+     */
+    private $contentful;
+
+    /**
+     * PageRepository constructor.
+     *
+     * @param Contentful $contentful
+     */
+    public function __construct(Contentful $contentful)
+    {
+        $this->contentful = $contentful;
+    }
+
+    /**
+     * Find a page by its slug.
+     *
+     * @param  string $slug
+     * @return stdClass
+     * @throws \Illuminate\Database\Eloquent\ModelNotFoundException
+     */
+    public function findBySlug($slug)
+    {
+        $query = (new Query)
+            ->setContentType('page')
+            ->where('fields.slug', $slug)
+            ->setInclude(1)
+            ->setLimit(1);
+
+        $pages = $this->contentful->getEntries($query);
+
+        if (! $pages->count()) {
+            throw new ModelNotFoundException;
+        } else {
+            return new Page($pages[0]);
+        }
+    }
+}

--- a/routes/web.php
+++ b/routes/web.php
@@ -27,10 +27,7 @@ $router->redirect('campaigns', 'us/campaigns');
 
 // Non campaign pages
 $router->redirect('/{slug}', 'us/{slug}');
-$router->get('/us/{slug}', function ($slug) {
-    return response('Hang Tight! We\'ll have static pages up and running in a jiffy!', 501)
-        ->header('Content-Type', 'text/plain');
-});
+$router->get('/us/{slug}', 'PageController@show');
 
 // Redirect routes for campaign specific URLs containing "/pages/".
 $router->get('us/campaigns/{slug}/pages/{clientRoute?}', function ($slug, $clientRoute) {


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR adds the initial setup for our standalone Pages (static pages, article pages) on the backend.

- Adds a `PageRepository` with a findBySlug method for fetching the proper page entry from Contentful
- Adds a `PageController` with a `show` method still stubbed to the `501` but fetching the page using the `PageRepository` (so if the entry is not found we'd return a `404` #progress).
- Routing `us/{slug}` to the `PageController@show`

### Any background context you want to provide?
This is the first half of implementation for standalone Page support.

Q: Should we add caching to the PageRepository@findBySlug à la the [CampaignRepository](https://github.com/DoSomething/phoenix-next/blob/page-backend/app/Repositories/CampaignRepository.php#L128) or is that overkill for this?

### What are the relevant tickets/cards?
[#157006215](https://www.pivotaltracker.com/story/show/157006215)
