### PR TITLE
Community migration updates

### DIFF
--- a/contentful/management-api-scripts/2018_04_20_001_campaign_activity_feed_to_community_page.js
+++ b/contentful/management-api-scripts/2018_04_20_001_campaign_activity_feed_to_community_page.js
@@ -90,7 +90,7 @@ async function addCommunityPageFromActivityFeed(environment, campaign) {
       logger.info(`  - Created Community Page! [ID: ${id}]\n`);
 
       // Add a Link to the new Page to the campaigns Pages field
-      campaign.fields.pages[LOCALE].push(linkReference(id));
+      campaign.fields.pages[LOCALE].unshift(linkReference(id));
       // Remove activity_feed blocks from campaign
       campaign.fields.activity_feed[LOCALE] = [];
 

--- a/docs/content-publishing/community/campaign-update.md
+++ b/docs/content-publishing/community/campaign-update.md
@@ -2,7 +2,7 @@
 
 ## Campaign Update (default)
 
-The `CampaignUpdate` component renders a visual component which can feature campaign updates, announcements and informational content rendered in Markdown format, as well as an embedded link (this can be to an article, a video, any valid URL will do!). In the right hand side of the footer of the Campaign Update we add a Facebook and Twitter social share icon. (The metadata for the content of the share can be customized, but will default to be a share of the link to the Campaign Update). A Byline featuring the author of the Campaign Update (another customizable setting), will be set on the left hand side of the Campaign Update footer.
+The `CampaignUpdate` component renders a visual component which can feature campaign updates, announcements and informational content rendered in Markdown format, as well as an embedded link (this can be to an article, a video, any valid URL will do!). ~In the right hand side of the footer of the Campaign Update we add a Facebook and Twitter social share icon. (The metadata for the content of the share can be customized, but will default to be a share of the link to the Campaign Update).~ (social share -temporarily disabled), A Byline featuring the author of the Campaign Update (another customizable setting), will be set on the left hand side of the Campaign Update footer.
 
 ![Campaign Update component](../_assets/campaign-update-component.png)
 
@@ -16,7 +16,7 @@ The Campaign Update can also be equipped with an affiliate logo. If this field i
 
 The Campaign Update consists of five fields:
 
-* **displayOptions (required)**: the amount of width accross the page that the campaign update should occupy ('two-thirds', or 'full')
+* ~**displayOptions (required)**: the amount of width across the page that the campaign update should occupy ('two-thirds', or 'full')~ - All campaign updates are now displayed at full width across the page.
 * **content (optional)**: content in Markdown format that will appear within the campaign update (on top of the link, if provided).
 * **link (required)**: a valid URL which will be embedded within the card.
 * **author** (optional)\*\*: a reference to the Contentful Entry of the author to be displayed on the campaign update. (This will be overriden by the affiliateLogo field, if provided)

--- a/docs/content-publishing/community/community-update.md
+++ b/docs/content-publishing/community/community-update.md
@@ -13,7 +13,7 @@ Updates in the _Community Feed_ currently consist of [Campaign Updates](./campai
 
 * **Internal Title**: this is the title for the content within the Contentful system and will not be displayed on the website.
   * Format: `Campaign Name - Date - Short Description`.
-* **Display Options**: this refers to how wide you want the block to be - recommended width for campaign updates is `two-thirds` or `full`.
+* ~**Display Options**: this refers to how wide you want the block to be - recommended width for campaign updates is `two-thirds` or `full`.~ - All campaign updates are now displayed at full width across the page.
 * **Content**: use markdown to fill in and format whatever you want.
 * **Link**: if you want the campaign update to have an external link that is highlighted in its own card, you should put the link in this field. This is also where you should drop a YouTube link for a video update.
 

--- a/docs/content-publishing/community/feed-order.md
+++ b/docs/content-publishing/community/feed-order.md
@@ -1,6 +1,6 @@
 # Feed Order
 
-1.  The feed is ordered _earlies_ on the bottom to _latest_ at the top.
+1.  The feed is ordered _earliest_ on the bottom to _latest_ at the top.
 
 2.  To change this order, just hover over one of the blocks in the **Activity Feed** section and just drag and drop things in whatever order you want!
 
@@ -8,5 +8,5 @@
 
 4.  _One thing to keep in mind though - you should look at the published feed to make sure all of the slots are filling in correctly. One row in the feed is 3 columns, or `two-thirds` of a display option._
 
-5.  If the pieces of the feed do not fill the entire space, reportbacks will fill in the space in between.
+5.  ~If the pieces of the feed do not fill the entire space, reportbacks will fill in the space in between.~ Reportbacks will no longer auto fill spacing. All campaign updates will display at full width across the page.
     ![Activity Feed](../_assets/activity-feed.png)

--- a/resources/assets/components/CampaignUpdate/CampaignUpdate.js
+++ b/resources/assets/components/CampaignUpdate/CampaignUpdate.js
@@ -5,7 +5,7 @@ import { get } from 'lodash';
 
 import Card from '../utilities/Card/Card';
 import Embed from '../utilities/Embed/Embed';
-// @see line 82 *1
+// @see line 81 *1
 // import Share from '../utilities/Share/Share';
 import Byline from '../utilities/Byline/Byline';
 import SponsorPromotion from '../SponsorPromotion';
@@ -20,7 +20,7 @@ const CampaignUpdate = props => {
     content,
     link,
     bordered,
-    // @see line 82 *1
+    // @see line 81 *1
     // shareLink,
     // titleLink,
   } = props;
@@ -40,7 +40,7 @@ const CampaignUpdate = props => {
         bordered,
         'affiliate-content': affiliateLogo,
       })}
-      // @see line 82 *1
+      // @see line 81 *1
       // link={titleLink}
       title={title}
       onClose={closeModal}
@@ -66,7 +66,7 @@ const CampaignUpdate = props => {
             className="float-left"
           />
         )}
-        {/* @see line 82 *1
+        {/* @see line 81 *1
           <Share
             link={shareLink}
             variant="icon"

--- a/resources/assets/components/CampaignUpdate/CampaignUpdate.js
+++ b/resources/assets/components/CampaignUpdate/CampaignUpdate.js
@@ -5,7 +5,8 @@ import { get } from 'lodash';
 
 import Card from '../utilities/Card/Card';
 import Embed from '../utilities/Embed/Embed';
-import Share from '../utilities/Share/Share';
+// @see line 82 *1
+// import Share from '../utilities/Share/Share';
 import Byline from '../utilities/Byline/Byline';
 import SponsorPromotion from '../SponsorPromotion';
 import Markdown from '../utilities/Markdown/Markdown';
@@ -18,9 +19,10 @@ const CampaignUpdate = props => {
     closeModal,
     content,
     link,
-    shareLink,
     bordered,
-    titleLink,
+    // @see line 82 *1
+    // shareLink,
+    // titleLink,
   } = props;
 
   const authorFields = get(author, 'fields', {});
@@ -38,7 +40,8 @@ const CampaignUpdate = props => {
         bordered,
         'affiliate-content': affiliateLogo,
       })}
-      link={titleLink}
+      // @see line 82 *1
+      // link={titleLink}
       title={title}
       onClose={closeModal}
     >
@@ -63,16 +66,23 @@ const CampaignUpdate = props => {
             className="float-left"
           />
         )}
-        <Share
-          link={shareLink}
-          variant="icon"
-          parentSource="campaignUpdate"
-          className="clear-none -right-icon"
-        />
+        {/* @see line 82 *1
+          <Share
+            link={shareLink}
+            variant="icon"
+            parentSource="campaignUpdate"
+            className="clear-none -right-icon"
+          /> */}
       </footer>
     </Card>
   );
 };
+
+// *1:
+// Temporarily sunsetting sharing and linking since
+// moving campaign updates from `activity_feed` to page removes the entry as a direct descendent of
+// the campaigns, thus disabling our helpers#findContentfulEntry from finding it for rendering.
+// @todo implement routing for individual entries.
 
 CampaignUpdate.propTypes = {
   id: PropTypes.string.isRequired,
@@ -85,8 +95,9 @@ CampaignUpdate.propTypes = {
   closeModal: PropTypes.func,
   content: PropTypes.string,
   link: PropTypes.string,
-  shareLink: PropTypes.string.isRequired,
-  titleLink: PropTypes.string.isRequired,
+  // @see line 81 *1
+  // shareLink: PropTypes.string.isRequired,
+  // titleLink: PropTypes.string.isRequired,
   bordered: PropTypes.bool,
 };
 

--- a/resources/assets/components/CampaignUpdate/CampaignUpdate.js
+++ b/resources/assets/components/CampaignUpdate/CampaignUpdate.js
@@ -79,9 +79,10 @@ const CampaignUpdate = props => {
 };
 
 // *1:
-// Temporarily sunsetting sharing and linking since
-// moving campaign updates from `activity_feed` to page removes the entry as a direct descendent of
-// the campaigns, thus disabling our helpers#findContentfulEntry from finding it for rendering.
+// Temporarily sunsetting sharing and title links due to affects of running
+// /content/management-api-scripts/2018_04_20_001_campaign_activity_feed_to_community_page
+// (Moving Campaign##activity_feed blocks to a Page prevents us from finding and displaying the entries locally
+// at the /block and /modal routes)
 // @todo implement routing for individual entries.
 
 CampaignUpdate.propTypes = {

--- a/resources/assets/components/CampaignUpdate/__snapshots__/CampaignUpdate.test.js.snap
+++ b/resources/assets/components/CampaignUpdate/__snapshots__/CampaignUpdate.test.js.snap
@@ -4,7 +4,7 @@ exports[`it generates a campaign update in affiliate mode snapshot 1`] = `
 <Card
   className="rounded bordered affiliate-content"
   id="1234567890"
-  link="http://example.com/link-to-content"
+  link={null}
   onClose={null}
   title="See More Be More Do More"
 >
@@ -20,13 +20,6 @@ exports[`it generates a campaign update in affiliate mode snapshot 1`] = `
       className="affiliate-logo"
       imgUrl="http://example.com/avatar-aang.jpg"
       title="Campaign Sponsor Logo"
-    />
-    <Share
-      className="clear-none -right-icon"
-      link="http://example.com/link-to-content"
-      parentSource="campaignUpdate"
-      quote={null}
-      variant="icon"
     />
   </footer>
 </Card>
@@ -36,7 +29,7 @@ exports[`it generates a campaign update snapshot 1`] = `
 <Card
   className="rounded bordered affiliate-content"
   id="1234567890"
-  link="http://example.com/link-to-content"
+  link={null}
   onClose={null}
   title="See More Be More Do More"
 >
@@ -52,13 +45,6 @@ exports[`it generates a campaign update snapshot 1`] = `
       className="affiliate-logo"
       imgUrl="http://example.com/avatar-aang.jpg"
       title="Campaign Sponsor Logo"
-    />
-    <Share
-      className="clear-none -right-icon"
-      link="http://example.com/link-to-content"
-      parentSource="campaignUpdate"
-      quote={null}
-      variant="icon"
     />
   </footer>
 </Card>


### PR DESCRIPTION
2 quick last minute additions for the `activity_feed` --> community page migration:

- Adding the newly generated Community Page to the *top* of the Campaign's Pages field so that the 'community' tab is at the beginning of the navigation (or at least directly following the 'action' tab).
- Disabling title link and sharing for Campaign Updates, since moving the blocks from the campaigns activity feed hides them from our Contentful Entry finding method (which means the links don't work anymore).