### PR TITLE
Standalone Page - frontend

### DIFF
--- a/app/Http/Controllers/PageController.php
+++ b/app/Http/Controllers/PageController.php
@@ -34,11 +34,8 @@ class PageController extends Controller
     {
         $page = $this->pageRepository->findBySlug($slug);
 
-        // return view('app')->with('state', [
-        //     'page' => $page,
-        // ]);
-
-        return response('Hang Tight! We\'ll have static pages up and running in a jiffy!', 501)
-            ->header('Content-Type', 'text/plain');
+        return view('app')->with('state', [
+            'page' => $page,
+        ]);
     }
 }

--- a/resources/assets/components/App.js
+++ b/resources/assets/components/App.js
@@ -12,6 +12,7 @@ import { getUserId } from '../selectors/user';
 import { initializeStore } from '../store/store';
 import ProfilePage from './pages/ProfilePage/ProfilePage';
 import CampaignContainer from './Campaign/CampaignContainer';
+import GeneralPageContainer from './pages/GeneralPage/GeneralPageContainer';
 
 const App = ({ store, history }) => {
   initializeStore(store);
@@ -29,6 +30,7 @@ const App = ({ store, history }) => {
             <Switch>
               <Route path="/us/profile" component={ProfilePage} />
               <Route path="/us/campaigns/:slug" component={CampaignContainer} />
+              <Route path="/us/:slug" component={GeneralPageContainer} />
             </Switch>
           </ConnectedRouter>
         </ApolloProvider>

--- a/resources/assets/components/pages/GeneralPage/GeneralPageContainer.js
+++ b/resources/assets/components/pages/GeneralPage/GeneralPageContainer.js
@@ -5,11 +5,15 @@ import GeneralPage from './GeneralPage';
 /**
  * Provide state from the Redux store as props for this component.
  */
-const mapStateToProps = state => ({
-  title: state.page.title,
-  subTitle: state.page.subTitle,
-  blocks: state.page.blocks,
-});
+const mapStateToProps = state => {
+  const { title, subTitle, blocks } = state.page.fields;
+
+  return {
+    title,
+    subTitle,
+    blocks,
+  };
+};
 
 // Export the container component.
 export default connect(mapStateToProps)(GeneralPage);

--- a/resources/assets/components/pages/GeneralPage/GeneralPageContainer.js
+++ b/resources/assets/components/pages/GeneralPage/GeneralPageContainer.js
@@ -1,34 +1,15 @@
 import { connect } from 'react-redux';
-import { find } from 'lodash';
 
 import GeneralPage from './GeneralPage';
 
 /**
  * Provide state from the Redux store as props for this component.
  */
-const mapStateToProps = (state, ownProps) => {
-  // @todo This setup is temporary to test general pages
-  // this container should just be fetching the props from state
-  const subPage = find(
-    state.campaign.pages,
-    page =>
-      page.type === 'page'
-        ? page.fields.slug.endsWith(ownProps.match.params.slug)
-        : false,
-  );
-
-  if (!subPage) {
-    return null;
-  }
-
-  const { title, subTitle, blocks } = subPage.fields;
-
-  return {
-    title,
-    subTitle,
-    blocks,
-  };
-};
+const mapStateToProps = state => ({
+  title: state.page.title,
+  subTitle: state.page.subTitle,
+  blocks: state.page.blocks,
+});
 
 // Export the container component.
 export default connect(mapStateToProps)(GeneralPage);

--- a/resources/assets/components/pages/GeneralPage/general-page.scss
+++ b/resources/assets/components/pages/GeneralPage/general-page.scss
@@ -2,6 +2,7 @@
 
 .general-page {
   background: $white;
+  position: inherit;
 
   .general-page__heading {
     .general-page__title {

--- a/resources/assets/reducers/index.js
+++ b/resources/assets/reducers/index.js
@@ -13,3 +13,4 @@ export slideshow from './slideshow';
 export submissions from './submissions';
 export uploads from './uploads';
 export user from './user';
+export page from './page';

--- a/resources/assets/reducers/page.js
+++ b/resources/assets/reducers/page.js
@@ -1,0 +1,3 @@
+const page = (state = {}) => state;
+
+export default page;

--- a/resources/assets/store/initialState.js
+++ b/resources/assets/store/initialState.js
@@ -22,6 +22,8 @@ const initialState = {
   notifications: {
     items: [],
   },
+  // standalone (campaign independent) pages
+  page: {},
   posts: {},
   postSubmissions: {
     isPending: false,


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR adds basic support for standalone pages (`/us/:slug`) on the React side of things.

- Adds a `us/:slug` route to our top-level React router in `/App` 
- Adds `page` state to our initial state as well as a `page` reducer.
- Adjusts the `GeneralPage` component to work directly with the `page` state
- Small scss adjustment to ensure the navigation profile dropdown doesn't get hidden behind the `GeneralPage` due to us setting the background color to white

### Any background context you want to provide?
Part 2 of Standalone page implementation.


### What are the relevant tickets/cards?
#902 
#883 
[#157006215](https://www.pivotaltracker.com/story/show/157006215)

### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.

😱 

![image](https://user-images.githubusercontent.com/12417657/39931445-6e8a2a88-550b-11e8-9415-f8f43ecf1777.png)

