### PR TITLE
Images block component

### DIFF
--- a/app/Entities/Entity.php
+++ b/app/Entities/Entity.php
@@ -64,6 +64,8 @@ class Entity implements ArrayAccess, JsonSerializable
                 return new CampaignUpdate($block->entry);
             case 'contentBlock':
                 return new ContentBlock($block->entry);
+            case 'imagesBlock':
+                return new ImagesBlock($block->entry);
             case 'linkAction':
                 return new LinkAction($block->entry);
             case 'page':

--- a/app/Entities/Entity.php
+++ b/app/Entities/Entity.php
@@ -60,10 +60,22 @@ class Entity implements ArrayAccess, JsonSerializable
         switch ($block->getContentType()) {
             case 'affirmation':
                 return new Affirmation($block->entry);
+            case 'callToAction':
+                return new CallToAction($block->entry);
             case 'campaignUpdate':
                 return new CampaignUpdate($block->entry);
             case 'contentBlock':
                 return new ContentBlock($block->entry);
+            case 'customBlock':
+                if ($block->entry->getType() === 'join_cta') {
+                    return new CallToAction($block->entry);
+                }
+
+                if ($block->entry->getType() === 'campaign_update') {
+                    return new CampaignUpdate($block->entry);
+                }
+
+                return new CustomBlock($block->entry);
             case 'imagesBlock':
                 return new ImagesBlock($block->entry);
             case 'linkAction':
@@ -80,18 +92,6 @@ class Entity implements ArrayAccess, JsonSerializable
                 return new TextSubmissionAction($block->entry);
             case 'voterRegistrationAction':
                 return new VoterRegistrationAction($block->entry);
-            case 'callToAction':
-                return new CallToAction($block->entry);
-            case 'customBlock':
-                if ($block->entry->getType() === 'join_cta') {
-                    return new CallToAction($block->entry);
-                }
-
-                if ($block->entry->getType() === 'campaign_update') {
-                    return new CampaignUpdate($block->entry);
-                }
-
-                return new CustomBlock($block->entry);
             default:
                 return new CampaignActionStep($block->entry);
         }

--- a/app/Entities/ImagesBlock.php
+++ b/app/Entities/ImagesBlock.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Entities;
+
+use JsonSerializable;
+
+class ImagesBlock extends Entity implements JsonSerializable
+{
+    /**
+     * Parse and extract images data.
+     *
+     * @param  array $images
+     * @return array
+     */
+    public function parseImages($images)
+    {
+        return collect($images)->map(function ($image) {
+            return get_image_url($image, 'square');
+        });
+    }
+
+    /**
+     * Convert the object into something JSON serializable.
+     *
+     * @return array
+     */
+    public function jsonSerialize()
+    {
+        return [
+            'id' => $this->entry->getId(),
+            'type' => $this->getContentType(),
+            'fields' => [
+                'images' => $this->parseImages($this->images),
+            ],
+        ];
+    }
+}

--- a/resources/assets/components/ContentfulEntry/ContentfulEntry.js
+++ b/resources/assets/components/ContentfulEntry/ContentfulEntry.js
@@ -10,6 +10,7 @@ import ErrorBlock from '../ErrorBlock/ErrorBlock';
 import { ContentfulEntryJson } from '../../types';
 import { parseContentfulType, report } from '../../helpers';
 import { CampaignUpdateContainer } from '../CampaignUpdate';
+import ImagesBlock from '../blocks/ImagesBlock/ImagesBlock';
 import CallToActionContainer from '../CallToAction/CallToActionContainer';
 import CampaignGalleryBlockContainer from '../blocks/CampaignGalleryBlock/CampaignGalleryBlockContainer';
 import {
@@ -94,6 +95,9 @@ class ContentfulEntry extends React.Component<Props, State> {
             <CampaignGalleryBlockContainer />
           </div>
         );
+
+      case 'imagesBlock':
+        return <ImagesBlock images={json.fields.images} />;
 
       case 'legacyContentBlock':
         return renderLegacyContentBlock(json, stepIndex);

--- a/resources/assets/components/blocks/ImagesBlock/ImagesBlock.js
+++ b/resources/assets/components/blocks/ImagesBlock/ImagesBlock.js
@@ -1,0 +1,16 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import Gallery from '../../utilities/Gallery/Gallery';
+
+const ImagesBlock = ({ images }) => (
+  <Gallery type="triad" className="expand-horizontal-md">
+    {images.map(image => <img alt="Images Block" src={image} key={image} />)}
+  </Gallery>
+);
+
+ImagesBlock.propTypes = {
+  images: PropTypes.arrayOf(PropTypes.string).isRequired,
+};
+
+export default ImagesBlock;


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR adds the infrastructure for rendering `ImagesBlock`s in Phoenix (next?!).

- `ImagesBlock` Entity
- case for `imagesBlock` in Entity#parseBlock method
- `ImagesBlock` React component (renders as a simple `Gallery`!)
- case for `imagesBlock` entry type in `ContentfulEntries` component

### What are the relevant tickets/cards?
[#157015690](https://www.pivotaltracker.com/story/show/157015690)
#871 

### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.
* [x] Added screenshot to PR description of related front-end updates on **small** screens.
* [ ] Added screenshot to PR description of related front-end updates on **medium** screens.
* [x] Added screenshot to PR description of related front-end updates on **large** screens.

**Large**
![screen shot 2018-05-11 at 2 47 23 pm](https://user-images.githubusercontent.com/12417657/39941415-7c632cf8-552a-11e8-9aba-d4fec87d11eb.png)


**Small**
![image](https://user-images.githubusercontent.com/12417657/39941536-d78e4cca-552a-11e8-9c21-fc87f71704ff.png)
