### PR TITLE
Make sure we load polyfills before app dependencies.

### DIFF
--- a/resources/views/layouts/master.blade.php
+++ b/resources/views/layouts/master.blade.php
@@ -29,7 +29,7 @@
 
         if (features.length) scripts.unshift('https://cdn.polyfill.io/v2/polyfill.min.js?features='+ features.join(','));
 
-        // Script loader, from <goo.gl/wez2dP>
+        // Script loader, from <goo.gl/wez2dP>. More context at <https://git.io/vpywh>.
         !function(e,t,r){function n(){for(;d[0]&&"loaded"==d[0][f];)c=d.shift(),c[o]=!i.parentNode.insertBefore(c,i)}
         for(var s,a,c,d=[],i=e.scripts[0],o="onreadystatechange",f="readyState";s=r.shift();)a=e.createElement(t),
         "async" in i?(a.async=!1,e.head.appendChild(a)):i[f]?(d.push(a),a[o]=n):e.write("<"+t+'src="'+s

--- a/resources/views/layouts/master.blade.php
+++ b/resources/views/layouts/master.blade.php
@@ -8,6 +8,34 @@
     <meta name="csrf-token" content="{{ csrf_token() }}">
     <title>DoSomething.org</title>
 
+    <link rel="preload" href="{{ elixir('vendors~app.js', 'next/assets') }}" as="script" />
+    <link rel="preload" href="{{ elixir('app.js', 'next/assets') }}" as="script" />
+
+    <script type="text/javascript">
+        var hasWorkingUrl = false; // https://git.io/vpzRA
+        try { var u = new URL('b', 'http://a'); u.pathname = 'c%20d'; hasWorkingUrl = u.href === 'http://a/c%20d'; } catch(e) {}
+
+        var features = [];
+        if (!('Map' in window) || !('WeakSet' in window)) features.push('es2015')
+        if (!('includes' in Array.prototype)) features.push('es2016')
+        if (!('values' in Object)) features.push('Object.values');
+        if (!('fetch' in window)) features.push('fetch');
+        if (!hasWorkingUrl) features.push('URL');
+
+        const scripts = [
+            '{{ elixir("vendors~app.js", "next/assets") }}',
+            '{{ elixir("app.js", "next/assets") }}',
+        ];
+
+        if (features.length) scripts.unshift('https://cdn.polyfill.io/v2/polyfill.min.js?features='+ features.join(','));
+
+        // Script loader, from <goo.gl/wez2dP>
+        !function(e,t,r){function n(){for(;d[0]&&"loaded"==d[0][f];)c=d.shift(),c[o]=!i.parentNode.insertBefore(c,i)}
+        for(var s,a,c,d=[],i=e.scripts[0],o="onreadystatechange",f="readyState";s=r.shift();)a=e.createElement(t),
+        "async" in i?(a.async=!1,e.head.appendChild(a)):i[f]?(d.push(a),a[o]=n):e.write("<"+t+'src="'+s
+        +'" defer></'+t+">"),a.src=s}(document,"script",scripts)
+    </script>
+
     <link rel="icon" type="image/ico" href={{config('app.url') . "/favicon.ico?v1" }}>
     <link rel="stylesheet" href="{{ elixir('app.css', 'next/assets') }}" media="screen, projection" type="text/css">
 
@@ -38,27 +66,6 @@
     {{ isset($state) ? scriptify($state) : scriptify() }}
     {{ scriptify($env, 'ENV') }}
     {{ scriptify($auth, 'AUTH') }}
-
-    <script type="text/javascript">
-        var hasWorkingUrl = false; // https://git.io/vpzRA
-        try { var u = new URL('b', 'http://a'); u.pathname = 'c%20d'; hasWorkingUrl = u.href === 'http://a/c%20d'; } catch(e) {}
-
-        var features = [];
-        if (!('Map' in window) || !('WeakSet' in window)) features.push('es2015')
-        if (!('includes' in Array.prototype)) features.push('es2016')
-        if (!('values' in Object)) features.push('Object.values');
-        if (!('fetch' in window)) features.push('fetch');
-        if (!hasWorkingUrl) features.push('URL');
-
-        if (features.length) {
-            var s = document.createElement('script');
-            s.src = 'https://cdn.polyfill.io/v2/polyfill.min.js?features='+features.join(',');
-            document.head.appendChild(s);
-        }
-    </script>
-
-    <script type="text/javascript" src="{{ elixir('vendors~app.js', 'next/assets') }}"></script>
-    <script type="text/javascript" src="{{ elixir('app.js', 'next/assets') }}"></script>
 
     @stack('scripts')
 </body>

--- a/resources/views/layouts/master.blade.php
+++ b/resources/views/layouts/master.blade.php
@@ -22,7 +22,7 @@
         if (!('fetch' in window)) features.push('fetch');
         if (!hasWorkingUrl) features.push('URL');
 
-        const scripts = [
+        var scripts = [
             '{{ elixir("vendors~app.js", "next/assets") }}',
             '{{ elixir("app.js", "next/assets") }}',
         ];


### PR DESCRIPTION
### What does this PR do?

This pull request addresses some intermittent error reports we've gotten where polyfills aren't loaded (e.g. [`fetch is not found globally`](https://rpm.newrelic.com/accounts/108038/browser/68967300/js_errors#id=-1612396049) or [`Object.values is not a function`](https://rpm.newrelic.com/accounts/108038/browser/68967300/js_errors#id=-1111673818). These would occur because we didn't always fully load & parse the polyfill.io bundle before our app/vendor code.

To ensure scripts load in the proper order while still getting good performance, I've pulled the script loader from this [Jake Archibald deep dive](https://www.html5rocks.com/en/tutorials/speed/script-loading/) (while still marking our app code with `link rel=preload`s at the top). It's a little ugly at first glance, but it does seem to work reliably.

### Any background context you want to provide?

This is a kinda weird situation, so I want to make sure we're thinking everything through! Here's some questions I thought through while working on this:

#### Were browsers that relied on polyfills like `fetch` and `Object.values` always broken?
No, this seemed to only happen on the first load. Once the `polyfill.min.js` file was in cache, the scripts would load in the expected order on subsequent loads. Hopefully most users just reloaded the page and continued to report back! 🤞

#### What's this crazy script block, anyways?
The [unminified source](https://www.html5rocks.com/en/tutorials/speed/script-loading/#toc-enough) is printed here.

#### Why don't we just have a callback on the polyfill script?
The [polyfill.io documentation](https://polyfill.io/v2/docs/examples) suggests using the `&callback=main` query param to run a `main()` callback once polyfills are loaded. Unfortunately, this would only let us delay our application itself. Vendor code [like this line in Apollo Client](https://github.com/apollographql/apollo-link/blob/a79f47e8ae81ee2444d547315be61dbafea37dcb/packages/apollo-link-http-common/src/index.ts#L175-L185) could still execute before our callback.

#### Why is the script tag moved to the `head`?
The "loader" adds async script tags into the document. We want to do this as soon as possible since the browser delays script execution & rendering until it has finished downloading and parsing any CSS files it's encountered (so if we had this "loader script" below the CSS, it wouldn't start downloading things till after the CSS is downloaded and parsed).

#### Wait wait, the article says to use `link rel=subresource`. What's with that?
That was a [deprecated feature](https://stackoverflow.com/a/35104388) in Chrome. From what I can tell, `link rel=preload` is the modern equivalent. Things move fast!

### What are the relevant tickets/cards?

[#157410960](https://www.pivotaltracker.com/story/show/157410960)

### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.
* [ ] Added screenshot to PR description of related front-end updates on **small** screens.
* [ ] Added screenshot to PR description of related front-end updates on **medium** screens.
* [ ] Added screenshot to PR description of related front-end updates on **large** screens.