### PR TITLE
Finalizing photo submission action

### DIFF
--- a/app/Entities/PhotoSubmissionAction.php
+++ b/app/Entities/PhotoSubmissionAction.php
@@ -21,6 +21,8 @@ class PhotoSubmissionAction extends Entity implements JsonSerializable
                 'whyParticipatedFieldLabel' => $this->whyParticipatedFieldLabel,
                 'whyParticipatedFieldPlaceholder' => $this->whyParticipatedFieldPlaceholder,
                 'buttonText' => $this->buttonText,
+                'informationTitle' => $this->informationTitle,
+                'informationContent' => $this->informationContent,
                 'affirmationContent' => $this->affirmationContent,
                 'additionalContent' => $this->additionalContent,
             ],

--- a/contentful/migrations/2018_04_27_001_add_photo_submission_action_content_type.js
+++ b/contentful/migrations/2018_04_27_001_add_photo_submission_action_content_type.js
@@ -76,6 +76,20 @@ module.exports = function(migration) {
     .localized(true);
 
   photoSubmissionAction
+    .createField('informationTitle')
+    .name('Information Title')
+    .type('Symbol')
+    .required(false)
+    .localized(true);
+
+  photoSubmissionAction
+    .createField('informationContent')
+    .name('Information Content')
+    .type('Text')
+    .required(false)
+    .localized(true);
+
+  photoSubmissionAction
     .createField('affirmationContent')
     .name('Affirmation Content')
     .type('Text')

--- a/resources/assets/components/actions/PhotoSubmissionAction/PhotoSubmissionAction.js
+++ b/resources/assets/components/actions/PhotoSubmissionAction/PhotoSubmissionAction.js
@@ -5,8 +5,9 @@ import { get, has, invert, mapValues } from 'lodash';
 
 import Card from '../../utilities/Card/Card';
 import Modal from '../../utilities/Modal/Modal';
-import { withoutUndefined } from '../../../helpers';
 import Button from '../../utilities/Button/Button';
+import { withoutUndefined } from '../../../helpers';
+import Markdown from '../../utilities/Markdown/Markdown';
 import MediaUploader from '../../utilities/MediaUploader';
 import FormValidation from '../../utilities/Form/FormValidation';
 import { getFieldErrors, setFormData } from '../../../helpers/forms';
@@ -14,8 +15,25 @@ import { getFieldErrors, setFormData } from '../../../helpers/forms';
 import './photo-submission-action.scss';
 
 class PhotoSubmissionAction extends React.Component {
+  static getDerivedStateFromProps(nextProps) {
+    const response = nextProps.submissions.items[nextProps.id] || null;
+
+    const responseSuccessful = has(response, 'status.success');
+
+    if (responseSuccessful) {
+      return {
+        shouldResetForm: true,
+        showModal: responseSuccessful,
+      };
+    }
+
+    return null;
+  }
+
   constructor(props) {
     super(props);
+
+    console.log(this.props);
 
     // @TODO: Update the MediaUploader component and remove need
     // for this object.
@@ -28,13 +46,16 @@ class PhotoSubmissionAction extends React.Component {
       captionValue: '',
       mediaValue: this.defaultMediaState,
       quantityValue: '',
+      shouldResetForm: false,
       showModal: false,
       whyParticipatedValue: '',
     };
   }
 
-  componentDidUpdate(prevProps) {
-    console.log(prevProps);
+  componentDidUpdate() {
+    if (this.state.shouldResetForm) {
+      this.resetForm();
+    }
   }
 
   fields = {
@@ -91,6 +112,7 @@ class PhotoSubmissionAction extends React.Component {
       captionValue: '',
       mediaValue: this.defaultMediaState,
       quantityValue: '',
+      shouldResetForm: false,
       whyParticipatedValue: '',
     });
   };
@@ -109,115 +131,144 @@ class PhotoSubmissionAction extends React.Component {
 
     return (
       <React.Fragment>
-        <Card
-          className={classnames('bordered rounded', this.props.className)}
-          title={this.props.title}
-        >
-          {formResponse ? <FormValidation response={formResponse} /> : null}
-
-          <form
-            className="photo-submission-action"
-            onSubmit={this.handleSubmit}
-          >
-            <div className="wrapper">
-              <div className="form-section">
-                <div className="wrapper">
-                  <MediaUploader
-                    label="Add your photo here"
-                    media={this.state.mediaValue}
-                    onChange={this.handleFileUpload}
-                    hasError={has(errors, 'media')}
-                  />
-
-                  <div className="form-item">
-                    <label
-                      className={classnames('field-label', {
-                        'has-error': has(errors, 'caption'),
-                      })}
-                      htmlFor="caption"
-                    >
-                      {this.props.captionFieldLabel}
-                    </label>
-                    <input
-                      className={classnames('text-field', {
-                        'has-error shake': has(errors, 'caption'),
-                      })}
-                      type="text"
-                      id="caption"
-                      name="caption"
-                      placeholder={this.props.captionFieldPlaceholder}
-                      value={this.state.captionValue}
-                      onChange={this.handleChange}
-                    />
-                  </div>
-                </div>
-              </div>
-
-              <div className="form-section">
-                <div className="wrapper">
-                  <div className="form-item">
-                    <label
-                      className={classnames('field-label', {
-                        'has-error': has(errors, 'quantity'),
-                      })}
-                      htmlFor="quantity"
-                    >
-                      {this.props.quantityFieldLabel}
-                    </label>
-                    <input
-                      className={classnames('text-field', {
-                        'has-error shake': has(errors, 'quantity'),
-                      })}
-                      type="text"
-                      id="quantity"
-                      name="quantity"
-                      placeholder={this.props.quantityFieldPlaceholder}
-                      value={this.state.quantityValue}
-                      onChange={this.handleChange}
-                    />
-                  </div>
-
-                  <div className="form-item stretched">
-                    <label
-                      className={classnames('field-label', {
-                        'has-error': has(errors, 'whyParticipated'),
-                      })}
-                      htmlFor="whyParticipated"
-                    >
-                      {this.props.whyParticipatedFieldLabel}
-                    </label>
-                    <textarea
-                      className={classnames('text-field', {
-                        'has-error shake': has(errors, 'whyParticipated'),
-                      })}
-                      id="whyParticipated"
-                      name="whyParticipated"
-                      placeholder={this.props.whyParticipatedFieldPlaceholder}
-                      value={this.state.whyParticipatedValue}
-                      onChange={this.handleChange}
-                    />
-                  </div>
-                </div>
-              </div>
-            </div>
-
-            <Button
-              type="submit"
-              loading={this.props.submissions.isPending}
-              attached
+        <div className="clearfix">
+          <div className="photo-submission-action">
+            <Card
+              className={classnames('bordered rounded', this.props.className)}
+              title={this.props.title}
             >
-              {this.props.buttonText}
-            </Button>
-          </form>
-        </Card>
+              {formResponse ? <FormValidation response={formResponse} /> : null}
 
-        {this.state.showModal ? <Modal /> : null}
+              <form
+                className="photo-submission-form"
+                onSubmit={this.handleSubmit}
+              >
+                <div className="wrapper">
+                  <div className="form-section">
+                    <div className="wrapper">
+                      <MediaUploader
+                        label="Add your photo here"
+                        media={this.state.mediaValue}
+                        onChange={this.handleFileUpload}
+                        hasError={has(errors, 'media')}
+                      />
+
+                      <div className="form-item">
+                        <label
+                          className={classnames('field-label', {
+                            'has-error': has(errors, 'caption'),
+                          })}
+                          htmlFor="caption"
+                        >
+                          {this.props.captionFieldLabel}
+                        </label>
+                        <input
+                          className={classnames('text-field', {
+                            'has-error shake': has(errors, 'caption'),
+                          })}
+                          type="text"
+                          id="caption"
+                          name="caption"
+                          placeholder={this.props.captionFieldPlaceholder}
+                          value={this.state.captionValue}
+                          onChange={this.handleChange}
+                        />
+                      </div>
+                    </div>
+                  </div>
+
+                  <div className="form-section">
+                    <div className="wrapper">
+                      <div className="form-item">
+                        <label
+                          className={classnames('field-label', {
+                            'has-error': has(errors, 'quantity'),
+                          })}
+                          htmlFor="quantity"
+                        >
+                          {this.props.quantityFieldLabel}
+                        </label>
+                        <input
+                          className={classnames('text-field', {
+                            'has-error shake': has(errors, 'quantity'),
+                          })}
+                          type="text"
+                          id="quantity"
+                          name="quantity"
+                          placeholder={this.props.quantityFieldPlaceholder}
+                          value={this.state.quantityValue}
+                          onChange={this.handleChange}
+                        />
+                      </div>
+
+                      <div className="form-item stretched">
+                        <label
+                          className={classnames('field-label', {
+                            'has-error': has(errors, 'whyParticipated'),
+                          })}
+                          htmlFor="whyParticipated"
+                        >
+                          {this.props.whyParticipatedFieldLabel}
+                        </label>
+                        <textarea
+                          className={classnames('text-field', {
+                            'has-error shake': has(errors, 'whyParticipated'),
+                          })}
+                          id="whyParticipated"
+                          name="whyParticipated"
+                          placeholder={
+                            this.props.whyParticipatedFieldPlaceholder
+                          }
+                          value={this.state.whyParticipatedValue}
+                          onChange={this.handleChange}
+                        />
+                      </div>
+                    </div>
+                  </div>
+                </div>
+
+                <Button
+                  type="submit"
+                  loading={this.props.submissions.isPending}
+                  attached
+                >
+                  {this.props.buttonText}
+                </Button>
+              </form>
+            </Card>
+          </div>
+
+          {this.props.informationContent ? (
+            <div className="photo-submission-information">
+              <Card
+                title={this.props.informationTitle}
+                className="bordered rounded"
+              >
+                <Markdown className="padding-md">
+                  {this.props.informationContent}
+                </Markdown>
+              </Card>
+            </div>
+          ) : null}
+        </div>
+
+        {this.state.showModal ? (
+          <Modal onClose={() => this.setState({ showModal: false })}>
+            <Card className="bordered rounded" title="We got your photo!">
+              <Markdown className="padded">
+                {this.props.affirmationContent ||
+                  PhotoSubmissionAction.defaultProps.affirmationContent}
+              </Markdown>
+            </Card>
+          </Modal>
+        ) : null}
       </React.Fragment>
     );
   }
 }
 
 PhotoSubmissionAction.propTypes = {
+  affirmationContent: PropTypes.string,
   additionalContent: PropTypes.shape({
     action: PropTypes.string,
   }),
@@ -228,6 +279,8 @@ PhotoSubmissionAction.propTypes = {
   className: PropTypes.string,
   clearPostSubmissionItem: PropTypes.func.isRequired,
   id: PropTypes.string.isRequired,
+  informationContent: PropTypes.string,
+  informationTitle: PropTypes.string,
   quantityFieldLabel: PropTypes.string,
   quantityFieldPlaceholder: PropTypes.string,
   storeCampaignPost: PropTypes.func.isRequired,
@@ -242,10 +295,15 @@ PhotoSubmissionAction.propTypes = {
 
 PhotoSubmissionAction.defaultProps = {
   additionalContent: null,
+  affirmationContent:
+    "Thanks for joining the movement, and submitting your photo! After we review your submission, we'll add it to the public gallery alongside submissions from all the other members taking action in this campaign.",
   buttonText: 'Submit a new photo',
   captionFieldLabel: 'Add a caption to your photo.',
   captionFieldPlaceholder: '60 characters or less',
   className: null,
+  informationContent:
+    'A DoSomething staffer will review and approve your photo.',
+  informationTitle: 'More Info',
   quantityFieldLabel: 'How many items are in this photo?',
   quantityFieldPlaceholder: 'Quantity # (300)',
   title: 'Submit your photo',

--- a/resources/assets/components/actions/PhotoSubmissionAction/PhotoSubmissionAction.js
+++ b/resources/assets/components/actions/PhotoSubmissionAction/PhotoSubmissionAction.js
@@ -23,7 +23,7 @@ class PhotoSubmissionAction extends React.Component {
     if (responseSuccessful) {
       return {
         shouldResetForm: true,
-        showModal: responseSuccessful,
+        showModal: true,
       };
     }
 
@@ -32,8 +32,6 @@ class PhotoSubmissionAction extends React.Component {
 
   constructor(props) {
     super(props);
-
-    console.log(this.props);
 
     // @TODO: Update the MediaUploader component and remove need
     // for this object.

--- a/resources/assets/components/actions/PhotoSubmissionAction/PhotoSubmissionAction.js
+++ b/resources/assets/components/actions/PhotoSubmissionAction/PhotoSubmissionAction.js
@@ -18,9 +18,7 @@ class PhotoSubmissionAction extends React.Component {
   static getDerivedStateFromProps(nextProps) {
     const response = nextProps.submissions.items[nextProps.id] || null;
 
-    const responseSuccessful = has(response, 'status.success');
-
-    if (responseSuccessful) {
+    if (has(response, 'status.success')) {
       return {
         shouldResetForm: true,
         showModal: true,

--- a/resources/assets/components/actions/PhotoSubmissionAction/PhotoSubmissionAction.test.js
+++ b/resources/assets/components/actions/PhotoSubmissionAction/PhotoSubmissionAction.test.js
@@ -8,7 +8,11 @@ describe('PhotoSubmissionAction component', () => {
 
   const wrapper = shallow(
     <PhotoSubmissionAction
+      campaignId="1234"
+      campaignRunId="6789"
+      clearPostSubmissionItem={jest.fn()}
       id={id}
+      storeCampaignPost={jest.fn()}
       submissions={{
         isPending: false,
         items: {},
@@ -17,7 +21,7 @@ describe('PhotoSubmissionAction component', () => {
   );
 
   test('is rendered as a card component with a form, MediaUploader and a submit button', () => {
-    expect(wrapper.find('Card').length).toEqual(1);
+    expect(wrapper.find('Card').length).toBeGreaterThanOrEqual(1);
     expect(wrapper.find('form').length).toEqual(1);
     expect(wrapper.find('MediaUploader').length).toEqual(1);
     expect(wrapper.find('Button').length).toEqual(1);

--- a/resources/assets/components/actions/PhotoSubmissionAction/photo-submission-action.scss
+++ b/resources/assets/components/actions/PhotoSubmissionAction/photo-submission-action.scss
@@ -1,6 +1,25 @@
 @import '../../../scss/next-toolbox.scss';
 
 .photo-submission-action {
+  @include media($large) {
+    float: left;
+    padding-right: $half-spacing;
+    width: 66.6666666666666%;
+  }
+}
+
+.photo-submission-information {
+  margin-top: $base-spacing;
+
+  @include media($large) {
+    float: right;
+    margin-top: 0;
+    padding-left: $half-spacing;
+    width: 33.3333333333333%;
+  }
+}
+
+.photo-submission-form {
   > .wrapper {
     @include media($medium) {
       display: flex;


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?
This PR finalizes most of the intended behavior and appearance for the new `PhotoSubmissionAction`. It enables the affirmation to show when a successful submission is made and also adds the styles to showcase the information card underneath or alongside the PSA depending on device size.

![psa](https://user-images.githubusercontent.com/105849/40004570-f5659f10-5763-11e8-9112-eed509ccc65f.jpg)


### Any background context you want to provide?
I manually added the information title and information content fields to the PSA content type on Contentful, but backfilled the code into the original migration for the PSA. 🤠 

### What are the relevant tickets/cards?
Refs [Pivotal ID #156964358](https://www.pivotaltracker.com/story/show/156964358)
Refs #562 


### Checklist
* [x] Added screenshot to PR description of related front-end updates on **small** screens.
* [x] Added screenshot to PR description of related front-end updates on **medium** screens.
* [x] Added screenshot to PR description of related front-end updates on **large** screens.
