### PR TITLE
Double gallery bug fix

### DIFF
--- a/resources/assets/components/pages/ActionPage/ActionSteps.js
+++ b/resources/assets/components/pages/ActionPage/ActionSteps.js
@@ -52,7 +52,6 @@ const ActionSteps = props => {
     actionSteps,
     callToAction,
     campaignId,
-    hasActivityFeed,
     hasPendingSignup,
     isSignedUp,
     template,
@@ -130,7 +129,6 @@ ActionSteps.propTypes = {
   actionSteps: PropTypes.array.isRequired, // eslint-disable-line react/forbid-prop-types
   callToAction: PropTypes.string.isRequired,
   campaignId: PropTypes.string.isRequired,
-  hasActivityFeed: PropTypes.bool.isRequired,
   hasPendingSignup: PropTypes.bool.isRequired,
   isSignedUp: PropTypes.bool.isRequired,
   template: PropTypes.string.isRequired,

--- a/resources/assets/components/pages/ActionPage/ActionSteps.js
+++ b/resources/assets/components/pages/ActionPage/ActionSteps.js
@@ -119,7 +119,7 @@ const ActionSteps = props => {
     );
   }
 
-  if (isSignedUp && (template === 'legacy' || !hasActivityFeed)) {
+  if (isSignedUp && template === 'legacy') {
     stepComponents.push(renderLegacyGallery());
   }
 

--- a/resources/assets/components/pages/ActionPage/ActionStepsContainer.js
+++ b/resources/assets/components/pages/ActionPage/ActionStepsContainer.js
@@ -9,7 +9,6 @@ import { isSignedUp } from '../../../selectors/signup';
 const mapStateToProps = state => ({
   campaignId: state.campaign.legacyCampaignId,
   callToAction: state.campaign.callToAction,
-  hasActivityFeed: Boolean(state.campaign.activityFeed.length),
   hasPendingSignup: state.signups.isPending,
   isSignedUp: isSignedUp(state),
   template: state.campaign.template,


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?
This PR fixes a bug where there are two member reportback galleries being rendered on a page. We have a conditional that decides whether to include the member gallery onto the action page, but we can end up with multiple galleries if a gallery is added manually as an item in the Contentful campaign.

This auto-adding of the gallery was done in #640 to address the following issue:

> It adds the LegacyGallery to the bottom of the Action page in a campaign, if the campaign does not have an activity feed - which would mean it does not have a community tab.

However, I think in hindsight, the preferred approach would be for editors to add a member gallery manually. Additionally, we're getting rid of the activity feed in favor of a community page, so this conditional won't be working correctly in the near future. So instead of adding a more convoluted logic conditional, I'm just restoring it back to only addressing legacy templates, and otherwise the gallery needs to be added as a component in Contentful.

### What are the relevant tickets/cards?
Refs [Pivotal ID #157012852](https://www.pivotaltracker.com/story/show/157012852)
