### PR TITLE
Ensure page is fully loaded before starting app.

### DIFF
--- a/resources/assets/components/App.js
+++ b/resources/assets/components/App.js
@@ -25,7 +25,7 @@ const App = ({ store, history }) => {
         history={history}
         puckUrl={env('PUCK_URL')}
       >
-        <ApolloProvider client={graphqlClient}>
+        <ApolloProvider client={graphqlClient(env('GRAPHQL_URL'))}>
           <ConnectedRouter history={history}>
             <Switch>
               <Route path="/us/profile" component={ProfilePage} />

--- a/resources/assets/graphql.js
+++ b/resources/assets/graphql.js
@@ -7,8 +7,6 @@ import { setContext } from 'apollo-link-context';
 import { InMemoryCache } from 'apollo-cache-inmemory';
 import { onError } from 'apollo-link-error';
 
-import { env } from './helpers';
-
 // Create an authentication link with the user's access token.
 const authenticationLink = setContext((request, context) => {
   const accessToken = window.AUTH.token;
@@ -38,13 +36,13 @@ const errorLink = onError(({ graphQLErrors, networkError }) => {
   }
 });
 
-// Create the HTTP link! This is our terminating link that makes actual requests.
-const httpLink = new HttpLink({ uri: env('GRAPHQL_URL') });
-
 // Configure Apollo Client.
-const client = new ApolloClient({
-  link: ApolloLink.from([errorLink, authenticationLink, httpLink]),
-  cache: new InMemoryCache(),
-});
+export default uri => {
+  // Create the HTTP link! This is our terminating link that makes actual requests.
+  const httpLink = new HttpLink({ uri });
 
-export default client;
+  return new ApolloClient({
+    link: ApolloLink.from([errorLink, authenticationLink, httpLink]),
+    cache: new InMemoryCache(),
+  });
+};

--- a/resources/assets/init.js
+++ b/resources/assets/init.js
@@ -35,28 +35,31 @@ import './scss/fonts.scss';
 import App from './components/App';
 
 // DOM Helpers
+import { ready } from './helpers';
 import { init as historyInit } from './history';
 import { googleAnalyticsInit } from './helpers/analytics';
 import { bindNavigationEvents } from './helpers/navigation';
 
 // Configure store & history.
-const history = historyInit();
-const middleware = [thunk, routerMiddleware(history)];
-const preloadedState = window.STATE || {};
-const store = configureStore(
-  { ...reducers, routing: routerReducer },
-  middleware,
-  { ...preloadedState, user: window.AUTH },
-);
+ready(() => {
+  const history = historyInit();
+  const middleware = [thunk, routerMiddleware(history)];
+  const preloadedState = window.STATE || {};
+  const store = configureStore(
+    { ...reducers, routing: routerReducer },
+    middleware,
+    { ...preloadedState, user: window.AUTH },
+  );
 
-// Add event listeners for top-level navigation.
-bindNavigationEvents();
+  // Add event listeners for top-level navigation.
+  bindNavigationEvents();
 
-// Add event listeners for GA.
-googleAnalyticsInit(history);
+  // Add event listeners for GA.
+  googleAnalyticsInit(history);
 
-// Render the application!
-const appElement = document.getElementById('app');
-if (appElement) {
-  ReactDom.render(<App store={store} history={history} />, appElement);
-}
+  // Render the application!
+  const appElement = document.getElementById('app');
+  if (appElement) {
+    ReactDom.render(<App store={store} history={history} />, appElement);
+  }
+});


### PR DESCRIPTION
### What does this PR do?

This pull request fixes up a bug I introduced in #910. Since we now kick off network requests for scripts in the header, there's a chance that they'll load before the rest of the DOM has been parsed and run into issues (for example, not being able to find `window.ENV`). To avoid that, I've delayed our "initial render" until the DOM is ready and delayed an `env()` call that would happen before initial render.

### Any background context you want to provide?

We didn't have to do this before because the scripts were located at the very end of the body, after our `window.STATE`, `window.AUTH` and `window.ENV` scripts.

### What are the relevant tickets/cards?

I'll write one up!

### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.
* [ ] Added screenshot to PR description of related front-end updates on **small** screens.
* [ ] Added screenshot to PR description of related front-end updates on **medium** screens.
* [ ] Added screenshot to PR description of related front-end updates on **large** screens.
