### PR TITLE
Add migration for new campaign fields

### DIFF
--- a/contentful/migrations/2018_05_15_001_add_fields_to_campaign.js
+++ b/contentful/migrations/2018_05_15_001_add_fields_to_campaign.js
@@ -1,0 +1,49 @@
+module.exports = function(migration) {
+  const campaign = migration.editContentType('campaign');
+
+  campaign
+    .createField('staffPick')
+    .name('Staff Pick')
+    .type('Boolean')
+    .required(false)
+    .localized(true);
+
+  campaign
+    .createField('cause')
+    .name('Cause')
+    .type('Array')
+    .items({
+      type: 'Symbol',
+      validations: [
+        {
+          in: [
+            'Animals',
+            'Bullying',
+            'Disasters',
+            'Discrimination',
+            'Education',
+            'Environment',
+            'Homelessness',
+            'Mental Health',
+            'Physical Health',
+            'Poverty',
+            'Relationships',
+            'Sex',
+            'Violence',
+          ],
+        },
+      ],
+    })
+    .required(false)
+    .localized(true);
+
+  campaign.changeEditorInterface('cause', 'checkbox');
+
+  campaign
+    .createField('scholarshipAmount')
+    .name('Scholarship Amount')
+    .type('Integer')
+    .required(false);
+
+  campaign.moveField('additionalContent').afterField('scholarshipAmount');
+};


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR adds a Contentful CLI Migration script which adds new fields to the Campaign Content Type

- Staff Pick
- Cause (checklist of specified causes)
- Scholarship Amount

### Any background context you want to provide?
A cool thing is we can [change the editor interface for a field directly from the migration](https://github.com/contentful/contentful-migration#changeeditorinterface-fieldid-widgetid-settings--void)! (We do it here for cause. I stopped short of adding helper text - which we can also do). You just need to update your contentful-cli to be able to run this.

I set Scholarship Amount as an integer, please LMK if it should be a Symbol instead. (I ask bc it was specified in the card as `number?`)

### What are the relevant tickets/cards?
[#157006958](https://www.pivotaltracker.com/story/show/157006958)

![image](https://user-images.githubusercontent.com/12417657/40068169-fb473eb6-5835-11e8-9682-abceac57ea68.png)

