### PR TITLE
Make quantity field optional

### DIFF
--- a/app/Http/Requests/PostRequest.php
+++ b/app/Http/Requests/PostRequest.php
@@ -28,6 +28,7 @@ class PostRequest extends FormRequest
             case 'photo':
                 return [
                     'file.required' => 'An uploaded photo is required.',
+                    'quantity.required_if' => 'The quantity field is required.',
                     'text.max' => 'The caption field may not be greater than :max characters.',
                     'text.min' => 'The caption field may not be less than :min characters.',
                     'text.required' => 'The caption field for your photo is required.',
@@ -56,7 +57,8 @@ class PostRequest extends FormRequest
             case 'photo':
                 return [
                     'file' => 'required|file|image',
-                    'quantity' => 'required|integer|min:1',
+                    'quantity' => 'required_if:show_quantity,1|integer|min:1',
+                    'show_quantity' => 'required|boolean',
                     'text' => 'required|min:4|max:60',
                     'why_participated' => 'required',
                 ];

--- a/resources/assets/components/actions/PhotoSubmissionAction/PhotoSubmissionAction.js
+++ b/resources/assets/components/actions/PhotoSubmissionAction/PhotoSubmissionAction.js
@@ -54,11 +54,18 @@ class PhotoSubmissionAction extends React.Component {
     }
   }
 
-  fields = {
-    file: 'media',
-    text: 'caption',
-    quantity: 'quantity',
-    why_participated: 'whyParticipated',
+  fields = () => {
+    const items = {
+      file: 'media',
+      text: 'caption',
+      why_participated: 'whyParticipated',
+    };
+
+    if (this.props.showQuantityField) {
+      items.quantity = 'quantity';
+    }
+
+    return items;
   };
 
   handleChange = event => {
@@ -88,8 +95,9 @@ class PhotoSubmissionAction extends React.Component {
         type,
         id: this.props.id,
         // Associate state values to fields.
-        ...mapValues(this.fields, value => this.state[`${value}Value`]),
+        ...mapValues(this.fields(), value => this.state[`${value}Value`]),
         file: this.state.mediaValue.file || '',
+        show_quantity: this.props.showQuantityField ? 1 : 0,
       },
       this.props,
     );
@@ -121,7 +129,7 @@ class PhotoSubmissionAction extends React.Component {
     // Associate errors to component field names.
     const errors = withoutUndefined(
       formErrors
-        ? mapValues(invert(this.fields), value => formErrors[value])
+        ? mapValues(invert(this.fields()), value => formErrors[value])
         : null,
     );
 
@@ -175,27 +183,29 @@ class PhotoSubmissionAction extends React.Component {
 
                   <div className="form-section">
                     <div className="wrapper">
-                      <div className="form-item">
-                        <label
-                          className={classnames('field-label', {
-                            'has-error': has(errors, 'quantity'),
-                          })}
-                          htmlFor="quantity"
-                        >
-                          {this.props.quantityFieldLabel}
-                        </label>
-                        <input
-                          className={classnames('text-field', {
-                            'has-error shake': has(errors, 'quantity'),
-                          })}
-                          type="text"
-                          id="quantity"
-                          name="quantity"
-                          placeholder={this.props.quantityFieldPlaceholder}
-                          value={this.state.quantityValue}
-                          onChange={this.handleChange}
-                        />
-                      </div>
+                      {this.props.showQuantityField ? (
+                        <div className="form-item">
+                          <label
+                            className={classnames('field-label', {
+                              'has-error': has(errors, 'quantity'),
+                            })}
+                            htmlFor="quantity"
+                          >
+                            {this.props.quantityFieldLabel}
+                          </label>
+                          <input
+                            className={classnames('text-field', {
+                              'has-error shake': has(errors, 'quantity'),
+                            })}
+                            type="text"
+                            id="quantity"
+                            name="quantity"
+                            placeholder={this.props.quantityFieldPlaceholder}
+                            value={this.state.quantityValue}
+                            onChange={this.handleChange}
+                          />
+                        </div>
+                      ) : null}
 
                       <div className="form-item stretched">
                         <label
@@ -279,6 +289,7 @@ PhotoSubmissionAction.propTypes = {
   informationTitle: PropTypes.string,
   quantityFieldLabel: PropTypes.string,
   quantityFieldPlaceholder: PropTypes.string,
+  showQuantityField: PropTypes.bool,
   storeCampaignPost: PropTypes.func.isRequired,
   submissions: PropTypes.shape({
     isPending: PropTypes.bool,
@@ -301,7 +312,8 @@ PhotoSubmissionAction.defaultProps = {
     'A DoSomething staffer will review and approve your photo.',
   informationTitle: 'More Info',
   quantityFieldLabel: 'How many items are in this photo?',
-  quantityFieldPlaceholder: 'Quantity # (300)',
+  quantityFieldPlaceholder: 'Quantity # (e.g. 300)',
+  showQuantityField: true,
   title: 'Submit your photo',
   whyParticipatedFieldLabel: 'Why is this campaign important to you?',
   whyParticipatedFieldPlaceholder:

--- a/tests/Feature/StorePhotoReportbackPostTest.php
+++ b/tests/Feature/StorePhotoReportbackPostTest.php
@@ -68,12 +68,13 @@ class StorePhotoReportbackPostTest extends BrowserKitTestCase
     }
 
     /** @test */
-    public function quantity_is_required_to_submit_photo_post()
+    public function quantity_is_required_if_field_is_displayed_to_submit_photo_post()
     {
         $this->storePhotoPost([
             'type' => 'photo',
             'text' => 'Great text caption!',
             'file' => 'not-a-file-upload',
+            'show_quantity' => '1',
             'why_participated' => 'Because testing is very important.',
         ]);
 


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?
This PR updates the `PhotoSubmissionAction` to allow campaign leads to decide whether to show or hide the `quantity` field on the form. It also makes sure to validate the `quantity` field _if_ it is set to show up on the form using the `showQuantityField` option in the Contentful PSA content type.

**With Quantity Field**
![kapture 2018-05-15 at 12 15 10](https://user-images.githubusercontent.com/105849/40069710-160fcfd4-583a-11e8-8166-51a4f0a28657.gif)

**Without Quantity Field**
![kapture 2018-05-15 at 12 16 58](https://user-images.githubusercontent.com/105849/40069733-27579ec0-583a-11e8-835c-1eb410fcd436.gif)


### Any background context you want to provide?
I initially approached this by adding a bunch of logic to the `PostRequest` to deal with only validating the `quantity` if the `show_quantity` was set to `true`. This logic needed to be in place because I was still submitting a value for the `quantity` via the front-end `FormData` submission, and thus even though not required it would still validate against the `int` and `min:1` rules for the `quantity` since it was still present in the form data. 

Upon that realization, it made it more obvious that this could be significantly simplified by just not including a `quantity` property in the `FormData` if the `showQuantityField` was `false`. This turned out to be the better, and simpler approach via adding a little bit of logic in the `PhotoSubmissionAction` to not include the `quantity` property.


### What are the relevant tickets/cards?
Refs [Pivotal ID #156964358](https://www.pivotaltracker.com/story/show/156964358)
Refs #562 


### Checklist
* [x] Added appropriate feature/unit tests.

