### PR TITLE
Add additional tokens to Link Action and Share Action.

### DIFF
--- a/resources/assets/components/actions/LinkAction/LinkActionContainer.js
+++ b/resources/assets/components/actions/LinkAction/LinkActionContainer.js
@@ -9,6 +9,7 @@ import { getUserId } from '../../../selectors/user';
 const mapStateToProps = state => ({
   userId: getUserId(state),
   campaignId: state.campaign.legacyCampaignId,
+  campaignRunId: state.campaign.legacyCampaignRunId,
 });
 
 // Export the container component.

--- a/resources/assets/components/actions/LinkAction/templates/DefaultTemplate.js
+++ b/resources/assets/components/actions/LinkAction/templates/DefaultTemplate.js
@@ -23,6 +23,7 @@ const DefaultTemplate = props => {
     link,
     userId,
     campaignId,
+    campaignRunId,
     buttonText,
     affiliateLogo,
   } = props;
@@ -32,7 +33,13 @@ const DefaultTemplate = props => {
   // so this ensures consistency until we make this part of the content editing process.
   const title = affiliateLogo ? 'See More Be More Do More' : props.title;
 
-  const href = dynamicString(link, { campaignId, userId });
+  const href = dynamicString(link, {
+    userId,
+    northstarId: userId, // @TODO: Remove!
+    campaignId,
+    campaignRunId,
+    source: 'web',
+  });
 
   // If no content is provided, show as an embed.
   if (!content) {
@@ -40,10 +47,10 @@ const DefaultTemplate = props => {
       <div
         role="button"
         tabIndex="0"
-        onClick={() => onLinkClick(link)}
+        onClick={() => onLinkClick(href)}
         className="link-wrapper margin-bottom-lg"
       >
-        <Embed url={href} badged />
+        <Embed url={link} badged />
         {affiliateLogo ? (
           <SponsorPromotion
             className="affiliate-logo -padded"
@@ -84,6 +91,7 @@ DefaultTemplate.defaultProps = {
   affiliateLogo: null,
   buttonText: 'Visit Link',
   campaignId: null,
+  campaignRunId: null,
   userId: null,
 };
 
@@ -94,6 +102,7 @@ DefaultTemplate.propTypes = {
   affiliateLogo: PropTypes.string,
   buttonText: PropTypes.string,
   campaignId: PropTypes.string,
+  campaignRunId: PropTypes.string,
   userId: PropTypes.string,
 };
 

--- a/resources/assets/components/actions/LinkAction/templates/DefaultTemplate.js
+++ b/resources/assets/components/actions/LinkAction/templates/DefaultTemplate.js
@@ -78,7 +78,7 @@ const DefaultTemplate = props => {
           />
         ) : null}
 
-        <Button attached onClick={() => onLinkClick(link)}>
+        <Button attached onClick={() => onLinkClick(href)}>
           {buttonText}
         </Button>
       </Card>

--- a/resources/assets/components/actions/ShareAction/ShareAction.js
+++ b/resources/assets/components/actions/ShareAction/ShareAction.js
@@ -48,6 +48,7 @@ class ShareAction extends React.Component {
       affirmation, // @TODO: Rename me to 'affirmationText'?
       affirmationBlock,
       campaignId,
+      campaignRunId,
       content,
       hideEmbed,
       link,
@@ -61,7 +62,13 @@ class ShareAction extends React.Component {
       ? this.handleFacebookClick
       : this.handleTwitterClick;
 
-    const href = dynamicString(link, { campaignId, userId });
+    const href = dynamicString(link, {
+      userId,
+      northstarId: userId, // @TODO: Remove!
+      campaignId,
+      campaignRunId,
+      source: 'web',
+    });
 
     return (
       <React.Fragment>
@@ -101,6 +108,7 @@ ShareAction.propTypes = {
   affirmation: PropTypes.string,
   affirmationBlock: PropTypes.object, // eslint-disable-line
   campaignId: PropTypes.string,
+  campaignRunId: PropTypes.string.isRequired,
   content: PropTypes.string,
   hideEmbed: PropTypes.bool,
   link: PropTypes.string.isRequired,

--- a/resources/assets/components/actions/ShareAction/ShareAction.js
+++ b/resources/assets/components/actions/ShareAction/ShareAction.js
@@ -77,7 +77,7 @@ class ShareAction extends React.Component {
             {content ? <Markdown className="padded">{content}</Markdown> : null}
             {hideEmbed ? null : (
               <div className="padded">
-                <Embed url={href} />
+                <Embed url={link} />
               </div>
             )}
             <Button attached onClick={() => handleShareClick(href)}>

--- a/resources/assets/components/actions/ShareAction/ShareActionContainer.js
+++ b/resources/assets/components/actions/ShareAction/ShareActionContainer.js
@@ -9,6 +9,7 @@ import { getUserId } from '../../../selectors/user';
 const mapStateToProps = state => ({
   userId: getUserId(state),
   campaignId: state.campaign.legacyCampaignId,
+  campaignRunId: state.campaign.legacyCampaignRunId,
 });
 
 // Export the container component.

--- a/resources/assets/components/actions/VoterRegistrationAction/VoterRegistrationAction.js
+++ b/resources/assets/components/actions/VoterRegistrationAction/VoterRegistrationAction.js
@@ -21,7 +21,8 @@ const VoterRegistrationAction = props => {
   } = props;
 
   const tokens = {
-    northstarId: userId,
+    userId,
+    northstarId: userId, // @TODO: Remove!
     campaignId,
     campaignRunId,
     source: 'web',

--- a/resources/assets/components/utilities/Embed/Embed.js
+++ b/resources/assets/components/utilities/Embed/Embed.js
@@ -7,7 +7,7 @@ import classnames from 'classnames';
 import { Phoenix } from '@dosomething/gateway';
 
 import linkIcon from './linkIcon.svg';
-import { isExternal } from '../../../helpers';
+import { isExternal, withoutTokens } from '../../../helpers';
 import LazyImage from '../LazyImage';
 import PlaceholderText from '../PlaceholderText/PlaceholderText';
 
@@ -23,7 +23,7 @@ class Embed extends React.Component {
 
   componentDidMount() {
     this.phoenix
-      .get('next/embed', { url: this.props.url })
+      .get('next/embed', { url: withoutTokens(this.props.url) })
       .then(data => this.setState({ data }));
   }
 

--- a/resources/assets/helpers/index.js
+++ b/resources/assets/helpers/index.js
@@ -76,6 +76,19 @@ export function dynamicString(string, tokens = {}) {
 }
 
 /**
+ * Return a string with tokens removed.
+ *
+ * @param  {String} string
+ * @param  {Object} tokens
+ * @return {String}
+ */
+export function withoutTokens(string) {
+  const regex = new RegExp(`{[A-Za-z]*}`, 'g');
+
+  return string.replace(regex, 'x');
+}
+
+/**
  * Ensure a user is authenticated. If not, redirect them
  * to log in via the OpenID Connect flow.
  * @param isAuthenticated


### PR DESCRIPTION
### What does this PR do?

This PR adds a few extra dynamic tokens to the Link Action and Share Action:

 - `{northstarId}` - this is an alias for `{userId}`, which we should use instead.
 - `{campaignRunId}` - the legacy campaign run ID for the current campaign.
 - `{source}` - like the voter registration action, this is hard-coded to `web`.

### Any background context you want to provide?

🗼 

### What are the relevant tickets/cards?

[#157515339](https://www.pivotaltracker.com/story/show/157515339)

### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.
* [ ] Added screenshot to PR description of related front-end updates on **small** screens.
* [ ] Added screenshot to PR description of related front-end updates on **medium** screens.
* [ ] Added screenshot to PR description of related front-end updates on **large** screens.