### PR TITLE
implement basic index action

### DIFF
--- a/app/Http/Controllers/Api/CampaignsController.php
+++ b/app/Http/Controllers/Api/CampaignsController.php
@@ -31,7 +31,9 @@ class CampaignsController extends Controller
      */
     public function index()
     {
-        abort(501, 'Currently not implemented.');
+        $data = $this->campaignRepository->getAll();
+
+        return response()->json(['data' => $data]);
     }
 
     /**

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -11,7 +11,7 @@
 * [Architecture](development/architecture.md)
 * [Deployments](development/deployments/README.md)
   * [Contentful Migrations](development/deployments/contentful-migrations.md)
-  * [Contentful Content Management API Scripts](contentful-content-management-api.md)
+  * [Contentful Content Management API Scripts](development/deployments/contentful-content-management-api.md)
   * [Heroku](development/deployments/heroku.md)
 * [Features](development/features/README.md)
   * [Routing](development/features/routing.md)

--- a/docs/api-reference/v2/campaigns.md
+++ b/docs/api-reference/v2/campaigns.md
@@ -1,5 +1,45 @@
 # Campaigns
 
+## Retrieve all Campaigns
+
+This returns an abridged set of primary campaign fields to reduce the data load.
+
+```
+GET /api/v2/campaigns
+```
+
+Example Request:
+
+```
+https://next.dosomething.org/api/v2/campaigns
+```
+
+Example Response:
+
+```json
+{
+  "data": [
+    {
+      "id": "6LQzMvDNQcYQYwso8qSkQ8",
+      "slug": "test-teens-for-jeans",
+      "title": "[Test] Teens for Jeans",
+      "callToAction": "Let's collect another million jeans TOGETHER.",
+      "coverImage":
+        "https://images.ctfassets.net/81iqaqpfd8fy/4k8rv5sN0kii0AoCawc6UQ/c22c3c132d1bb43055b6bafc248fcea5/vn7gpbosm9rx.jpg?w=600&h=600&fm=jpg&fit=fill"
+    },
+    {
+      "id": "5bUfbCp98sicAKSoscqUUO",
+      "slug": "legacy-test-thumb-wars",
+      "title": "[LegacyTest] Thumb Wars",
+      "callToAction":
+        "Share Thumb Socks with a friend to remind them not to text and drive.",
+      "coverImage":
+        "https://images.ctfassets.net/81iqaqpfd8fy/56IbQd5sBGSSASAA8a6oQ4/e0a772998ec2e1e183f6cbee843ed032/thumb_wars.jpg?w=600&h=600&fm=jpg&fit=fill"
+    }
+  ]
+}
+```
+
 ## Retrieve a Campaign
 
 ```


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR adds basic implementation for the `CampaignsController#index` for the `/api/v2/campaigns` endpoint.
(also includes a tiny unrelated doc link fix)

### Any background context you want to provide?
All this does as of now is return the value of the `CampaignRepository`'s `getAll` method which queries for all Contentful campaigns.

I believe though that we do need to return Ashes campaigns as well from this endpoint to fully backfill support for the ashes campaigns index. [More context in this thread](https://dosomething.slack.com/archives/C3ASB4204/p1526496169000595)

Also, this doesn't include params for filtering of any kind as of yet. Hopefully will be able to utilize [some existing code](https://dosomething.slack.com/archives/C3ASB4204/p1526481348000338) from Northstar to implement that next.
### What are the relevant tickets/cards?
[#157410894](https://www.pivotaltracker.com/story/show/157410894)

### Checklist

* [x] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.
