### PR TITLE
Add contentful migration for ReferralSubmissionAction content type

### DIFF
--- a/contentful/migrations/2018_05_18_001_add_referral_submission_action_content_type.js
+++ b/contentful/migrations/2018_05_18_001_add_referral_submission_action_content_type.js
@@ -1,0 +1,42 @@
+module.exports = function(migration) {
+  const referralSubmissionAction = migration
+    .createContentType('referralSubmissionAction')
+    .name('Referral Submission Action')
+    .description('Action block for submitting friend referral posts.')
+    .displayField('internalTitle');
+
+  referralSubmissionAction
+    .createField('internalTitle')
+    .name('Internal Title')
+    .type('Symbol')
+    .required(true)
+    .localized(false);
+
+  referralSubmissionAction
+    .createField('title')
+    .name('Title')
+    .type('Symbol')
+    .required(false)
+    .localized(true);
+
+  referralSubmissionAction
+    .createField('buttonText')
+    .name('Button Text')
+    .type('Symbol')
+    .required(false)
+    .localized(true);
+
+  referralSubmissionAction
+    .createField('affirmationContent')
+    .name('Affirmation Content')
+    .type('Text')
+    .required(false)
+    .localized(true);
+
+  referralSubmissionAction
+    .createField('additionalContent')
+    .name('Additional Content')
+    .type('Object')
+    .required(false)
+    .localized(false);
+};


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR adds a Contentful Migration Script to create a ReferralSubmissionAction Content Type with some basic fields.

I only added the fields that felt like a given deal for this action, following a similar format to the text and photo submission actions. 

### What are the relevant tickets/cards?
[#157363643](https://www.pivotaltracker.com/story/show/157363643)

![image](https://user-images.githubusercontent.com/12417657/40249180-2e851b4c-5aa0-11e8-990c-300a88465bda.png)
