### PR TITLE
Referrals backend

### DIFF
--- a/app/Http/Controllers/ReferralController.php
+++ b/app/Http/Controllers/ReferralController.php
@@ -5,31 +5,20 @@ namespace App\Http\Controllers;
 use Carbon\Carbon;
 use App\Models\Referral;
 use Illuminate\Http\Request;
-use App\Services\PhoenixLegacy;
-use App\Services\UploadedMedia;
-use Illuminate\Support\Facades\Log;
 
 class ReferralController extends Controller
 {
-    /**
-     * The legacy Phoenix API.
-     *
-     * @var PhoenixLegacy
-     */
-    private $phoenixLegacy;
 
     /**
      * ReferralController constructor.
      */
-    public function __construct(PhoenixLegacy $phoenixLegacy)
+    public function __construct()
     {
-        $this->phoenixLegacy = $phoenixLegacy;
-
         $this->middleware('auth');
     }
 
     /**
-     * Store 'Refer a Friend' RB fields locally, then store regular reportback fields through the PhoenixLegacy API.
+     * Store 'referral' action fields locally.
      *
      * @param  \App\Http\Requests\StorePostRequest  $request
      * @return \Illuminate\Http\Response
@@ -48,7 +37,7 @@ class ReferralController extends Controller
             'referrer_northstar_id' => auth()->id(),
         ]);
 
-        return response()->json($referral, 201);;
+        return response()->json($referral, 201);
     }
 
     public function csvExport()

--- a/app/Http/Controllers/ReferralController.php
+++ b/app/Http/Controllers/ReferralController.php
@@ -8,7 +8,6 @@ use Illuminate\Http\Request;
 
 class ReferralController extends Controller
 {
-
     /**
      * ReferralController constructor.
      */
@@ -25,7 +24,6 @@ class ReferralController extends Controller
      */
     public function store(Request $request)
     {
-
         $this->validate($request, [
             'firstName' => 'required',
             'email' => 'required|email',

--- a/database/migrations/2018_05_18_180529_add_default_value_to_friend_story_field.php
+++ b/database/migrations/2018_05_18_180529_add_default_value_to_friend_story_field.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddDefaultValueToFriendStoryField extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('referrals', function (Blueprint $table) {
+            $table->text('friend_story')->nullable()->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('referrals', function (Blueprint $table) {
+            $table->text('friend_story')->change();
+        });
+    }
+}

--- a/database/migrations/2018_05_18_180529_add_default_value_to_friend_story_field.php
+++ b/database/migrations/2018_05_18_180529_add_default_value_to_friend_story_field.php
@@ -26,7 +26,7 @@ class AddDefaultValueToFriendStoryField extends Migration
     public function down()
     {
         Schema::table('referrals', function (Blueprint $table) {
-            $table->text('friend_story')->change();
+            $table->text('friend_story')->nullable(false)->change();
         });
     }
 }


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR updates the 'Referral' situation on the backend for the new ReferralSubmissionAction format

- adds a migration to change the `referrals` table's `friend_story` field to `nullable()`. (Should we just drop this field entirely? This is specific to the old team-dream friend referral setup)
- updates the `ReferralsController@store` to validate properly, and not send anything to Rogue.
- updates the `csvExport` function to stop using the `friend_story` field.

### Any background context you want to provide?
For the LYVC campaign, we decided on utilizing the old referrals set up temporarily as we flesh out and test this feature.

### What are the relevant tickets/cards?
[#157363643](https://www.pivotaltracker.com/story/show/157363643)
