### PR TITLE
Action page navigation setup

### DIFF
--- a/resources/assets/components/CampaignPageNavigation/CampaignPageNavigation.js
+++ b/resources/assets/components/CampaignPageNavigation/CampaignPageNavigation.js
@@ -38,8 +38,10 @@ const CampaignPageNavigation = ({
     });
   }
 
+  const hasActionPage = pages.find(page => page.fields.slug.endsWith('action'));
+
   // Conditional whether to include Action page.
-  if (campaignPages.length && !isCampaignClosed) {
+  if (campaignPages.length && !isCampaignClosed && !hasActionPage) {
     campaignPages.unshift({
       id: 'action-page',
       slug: 'action',

--- a/resources/assets/components/CampaignPageNavigation/CampaignPageNavigation.js
+++ b/resources/assets/components/CampaignPageNavigation/CampaignPageNavigation.js
@@ -38,7 +38,9 @@ const CampaignPageNavigation = ({
     });
   }
 
-  const hasActionPage = pages.find(page => page.fields.slug.endsWith('action'));
+  const hasActionPage = pages.find(
+    page => page.type === 'page' && page.fields.slug.endsWith('action'),
+  );
 
   // Conditional whether to include Action page.
   if (campaignPages.length && !isCampaignClosed && !hasActionPage) {

--- a/resources/assets/components/pages/ActionPage/ActionPageContainer.js
+++ b/resources/assets/components/pages/ActionPage/ActionPageContainer.js
@@ -14,7 +14,7 @@ const mapStateToProps = state => {
 
   const steps = state.campaign.actionSteps.length
     ? state.campaign.actionSteps
-    : actionPage.fields.blocks;
+    : get(actionPage, 'fields.blocks', []);
 
   return {
     steps,

--- a/resources/assets/components/pages/ActionPage/ActionPageContainer.js
+++ b/resources/assets/components/pages/ActionPage/ActionPageContainer.js
@@ -7,12 +7,22 @@ import { isSignedUp } from '../../../selectors/signup';
 /**
  * Provide state from the Redux store as props for this component.
  */
-const mapStateToProps = state => ({
-  steps: state.campaign.actionSteps,
-  dashboard: state.campaign.dashboard,
-  signedUp: isSignedUp(state),
-  featureFlags: get(state.campaign.additionalContent, 'featureFlags'),
-});
+const mapStateToProps = state => {
+  const actionPage = state.campaign.pages.find(page =>
+    page.fields.slug.endsWith('action'),
+  );
+
+  const steps = state.campaign.actionSteps.length
+    ? state.campaign.actionSteps
+    : actionPage.fields.blocks;
+
+  return {
+    steps,
+    dashboard: state.campaign.dashboard,
+    signedUp: isSignedUp(state),
+    featureFlags: get(state.campaign.additionalContent, 'featureFlags'),
+  };
+};
 
 // Export the container component.
 export default connect(mapStateToProps)(ActionPage);

--- a/resources/assets/components/pages/ActionPage/ActionPageContainer.js
+++ b/resources/assets/components/pages/ActionPage/ActionPageContainer.js
@@ -8,8 +8,8 @@ import { isSignedUp } from '../../../selectors/signup';
  * Provide state from the Redux store as props for this component.
  */
 const mapStateToProps = state => {
-  const actionPage = state.campaign.pages.find(page =>
-    page.fields.slug.endsWith('action'),
+  const actionPage = state.campaign.pages.find(
+    page => page.type === 'page' && page.fields.slug.endsWith('action'),
   );
 
   const steps = state.campaign.actionSteps.length

--- a/resources/assets/components/pages/ActionPage/ActionSteps.js
+++ b/resources/assets/components/pages/ActionPage/ActionSteps.js
@@ -93,6 +93,7 @@ const ActionSteps = props => {
         'submission-gallery',
         'legacyContentBlock',
         'gallery',
+        'imagesBlock',
       ].includes(type)
     ) {
       columnWidth = 'full';

--- a/resources/assets/components/pages/CampaignPage/CampaignPageContainer.js
+++ b/resources/assets/components/pages/CampaignPage/CampaignPageContainer.js
@@ -16,7 +16,9 @@ const mapStateToProps = state => ({
   hasActivityFeed: Boolean(state.campaign.activityFeed.length),
   hasCommunityPage: Boolean(
     state.campaign.activityFeed.length ||
-      state.campaign.pages.find(page => page.fields.slug.endsWith('community')),
+      state.campaign.pages.find(
+        page => page.type === 'page' && page.fields.slug.endsWith('community'),
+      ),
   ),
   isAdmin: userHasRole(state, 'admin'),
   isCampaignClosed: isCampaignClosed(


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR adds some logic to enable rendering the `ActionPage` for migrated Campaigns, using the action Page instead of Campaign `actionSteps`.

- don't manually add an `action` tab if there's an action page
- render the action page blocks as the action steps if it exists and there are no `actionSteps`

This means we've got backfilled support for `actionSteps` as well as support for the new action Pages, so we can migrate piecemeal and ensure everything is working before pulling the switch on `actionSteps`

### Any background context you want to provide?
I went with simply replacing the `steps` prop but still maintaining the use of the regular flow for action steps (using the `ActionPage` component etc.) since there are a bunch of moving pieces involved in rendering the action page which simply rendering the blocks in a `campaignSubPage` would lose. (described more thoroughly in #925) 
Q: was this the right move? Or do we want to focus on moving this over completely to a regular page setup now - or perhaps after we migrate?

### What are the relevant tickets/cards?
[#156771690](https://www.pivotaltracker.com/story/show/156771690)
