### PR TITLE
Fix rendering issue in Chrome 41.

### DIFF
--- a/resources/views/partials/script_loading.blade.php
+++ b/resources/views/partials/script_loading.blade.php
@@ -4,6 +4,7 @@
 
     var features = [];
     if (!('Map' in window) || !('WeakSet' in window)) features.push('es2015')
+    if (!('find' in Array.prototype)) features.push('Array.prototype.find')
     if (!('includes' in Array.prototype)) features.push('es2016')
     if (!('values' in Object)) features.push('Object.values');
     if (!('fetch' in window)) features.push('fetch');


### PR DESCRIPTION
### What does this PR do?

This pull request fixes [the `TypeError: undefined is not a function` error in Chrome 41](https://rpm.newrelic.com/accounts/108038/browser/68967300/js_errors#id=445189017&tab_index=1), which is crashing on [this usage of `Array.prototype.find`](https://github.com/DoSomething/puck-client/blob/d8c55ee9ed3a15b6e835d12760fc07b087464ea5/lib/helpers.js#L98). This is particularly important because it is [causing Google to be unable to crawl pages on Phoenix](https://dosomething.slack.com/archives/C3ASB4204/p1527010491000209).

#### Before:

![before](https://user-images.githubusercontent.com/583202/40389544-bb23c8e4-5de0-11e8-9669-f0534cfcab03.png)


#### After:

![after](https://user-images.githubusercontent.com/583202/40389549-bd3d27f6-5de0-11e8-80a3-cb6112649d20.png)

### Any background context you want to provide?
I wonder if we can set up a monitoring task to see how a couple of popular pages render in Chrome 41 so we'd catch future regressions more easily? Does BrowserStack offer that as a service?

### What are the relevant tickets/cards?

I'll write up a quick card!

### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.
* [ ] Added screenshot to PR description of related front-end updates on **small** screens.
* [ ] Added screenshot to PR description of related front-end updates on **medium** screens.
* [ ] Added screenshot to PR description of related front-end updates on **large** screens.