### PR TITLE
Content block update

### DIFF
--- a/resources/assets/components/ContentfulEntry/renderers.js
+++ b/resources/assets/components/ContentfulEntry/renderers.js
@@ -242,11 +242,9 @@ export function renderAffirmation(step) {
  * @return {Component}
  */
 export function renderContentBlock(data) {
+  const fields = withoutNulls(data.fields);
+
   return (
-    <ContentBlock
-      key={`content-block-${data.id}`}
-      id={data.id}
-      {...data.fields}
-    />
+    <ContentBlock key={`content-block-${data.id}`} id={data.id} {...fields} />
   );
 }

--- a/resources/assets/components/blocks/ContentBlock/ContentBlock.js
+++ b/resources/assets/components/blocks/ContentBlock/ContentBlock.js
@@ -10,10 +10,6 @@ import './content-block.scss';
 const ContentBlock = props => {
   const { content, image, imageAlignment, superTitle, title } = props;
 
-  const defaultImageAlignment = ContentBlock.defaultProps.imageAlignment;
-
-  const contentNode = content ? <Markdown>{content}</Markdown> : null;
-
   return (
     <div className="content-block">
       {title ? (
@@ -26,10 +22,10 @@ const ContentBlock = props => {
         <Figure
           image={image}
           alt="content-block"
-          alignment={`${imageAlignment || defaultImageAlignment}-collapse`}
+          alignment={`${imageAlignment}-collapse`}
           size="one-third"
         >
-          {contentNode}
+          {content ? <Markdown>{content}</Markdown> : null}
         </Figure>
       </div>
     </div>

--- a/resources/assets/components/blocks/ContentBlock/ContentBlock.js
+++ b/resources/assets/components/blocks/ContentBlock/ContentBlock.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import { Figure } from '../../Figure';
+import { Flex, FlexCell } from '../../Flex';
 import SectionHeader from '../../SectionHeader';
 import Markdown from '../../utilities/Markdown/Markdown';
 
@@ -9,6 +10,10 @@ import './content-block.scss';
 
 const ContentBlock = props => {
   const { content, image, imageAlignment, superTitle, title } = props;
+
+  const defaultImageAlignment = ContentBlock.defaultProps.imageAlignment;
+
+  const contentNode = content ? <Markdown>{content}</Markdown> : null;
 
   return (
     <div className="content-block">
@@ -19,14 +24,20 @@ const ContentBlock = props => {
       ) : null}
 
       <div className="margin-horizontal-md">
-        <Figure
-          image={image}
-          alt="content-block"
-          alignment={`${imageAlignment}-collapse`}
-          size="one-third"
-        >
-          {content ? <Markdown>{content}</Markdown> : null}
-        </Figure>
+        {image ? (
+          <Figure
+            image={image}
+            alt="content-block"
+            alignment={`${imageAlignment || defaultImageAlignment}-collapse`}
+            size="one-third"
+          >
+            {contentNode}
+          </Figure>
+        ) : (
+          <Flex>
+            <FlexCell width="two-thirds">{contentNode}</FlexCell>
+          </Flex>
+        )}
       </div>
     </div>
   );

--- a/resources/assets/components/blocks/ContentBlock/ContentBlock.js
+++ b/resources/assets/components/blocks/ContentBlock/ContentBlock.js
@@ -23,18 +23,14 @@ const ContentBlock = props => {
       ) : null}
 
       <div className="margin-horizontal-md">
-        {image ? (
-          <Figure
-            image={image}
-            alt="content-block"
-            alignment={`${imageAlignment || defaultImageAlignment}-collapse`}
-            size="one-third"
-          >
-            {contentNode}
-          </Figure>
-        ) : (
-          contentNode
-        )}
+        <Figure
+          image={image}
+          alt="content-block"
+          alignment={`${imageAlignment || defaultImageAlignment}-collapse`}
+          size="one-third"
+        >
+          {contentNode}
+        </Figure>
       </div>
     </div>
   );

--- a/resources/assets/components/blocks/ContentBlock/ContentBlock.js
+++ b/resources/assets/components/blocks/ContentBlock/ContentBlock.js
@@ -1,8 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import classnames from 'classnames';
 
 import { Figure } from '../../Figure';
-import { Flex, FlexCell } from '../../Flex';
 import SectionHeader from '../../SectionHeader';
 import Markdown from '../../utilities/Markdown/Markdown';
 
@@ -21,7 +21,9 @@ const ContentBlock = props => {
         </div>
       ) : null}
 
-      <div className="margin-horizontal-md">
+      <div
+        className={classnames('margin-horizontal-md', { 'two-thirds': !image })}
+      >
         {image ? (
           <Figure
             image={image}
@@ -32,9 +34,7 @@ const ContentBlock = props => {
             {contentNode}
           </Figure>
         ) : (
-          <Flex>
-            <FlexCell width="two-thirds">{contentNode}</FlexCell>
-          </Flex>
+          contentNode
         )}
       </div>
     </div>

--- a/resources/assets/components/blocks/ContentBlock/ContentBlock.js
+++ b/resources/assets/components/blocks/ContentBlock/ContentBlock.js
@@ -11,8 +11,6 @@ import './content-block.scss';
 const ContentBlock = props => {
   const { content, image, imageAlignment, superTitle, title } = props;
 
-  const defaultImageAlignment = ContentBlock.defaultProps.imageAlignment;
-
   const contentNode = content ? <Markdown>{content}</Markdown> : null;
 
   return (
@@ -28,7 +26,7 @@ const ContentBlock = props => {
           <Figure
             image={image}
             alt="content-block"
-            alignment={`${imageAlignment || defaultImageAlignment}-collapse`}
+            alignment={`${imageAlignment}-collapse`}
             size="one-third"
           >
             {contentNode}

--- a/resources/assets/components/blocks/ContentBlock/ContentBlock.test.js
+++ b/resources/assets/components/blocks/ContentBlock/ContentBlock.test.js
@@ -37,7 +37,7 @@ describe('ContentBlock component', () => {
     const wrapper = shallow(<ContentBlock {...props} />);
 
     expect(wrapper.find('SectionHeader').length).toEqual(1);
-    expect(wrapper.find('Figure').length).toEqual(0);
+    expect(wrapper.find('Figure').length).toEqual(1);
     expect(wrapper.find('Markdown').length).toEqual(1);
   });
 

--- a/resources/assets/components/blocks/ContentBlock/ContentBlock.test.js
+++ b/resources/assets/components/blocks/ContentBlock/ContentBlock.test.js
@@ -37,7 +37,7 @@ describe('ContentBlock component', () => {
     const wrapper = shallow(<ContentBlock {...props} />);
 
     expect(wrapper.find('SectionHeader').length).toEqual(1);
-    expect(wrapper.find('Figure').length).toEqual(1);
+    expect(wrapper.find('Figure').length).toEqual(0);
     expect(wrapper.find('Markdown').length).toEqual(1);
   });
 

--- a/resources/assets/components/blocks/ContentBlock/__snapshots__/ContentBlock.test.js.snap
+++ b/resources/assets/components/blocks/ContentBlock/__snapshots__/ContentBlock.test.js.snap
@@ -65,11 +65,19 @@ exports[`ContentBlock component it works beautifully with a mere content prop 1`
   <div
     className="margin-horizontal-md"
   >
-    <Markdown
-      className={null}
+    <Figure
+      alignment="right-collapse"
+      alt="content-block"
+      image={null}
+      imageClassName={null}
+      size="one-third"
     >
-      hi there
-    </Markdown>
+      <Markdown
+        className={null}
+      >
+        hi there
+      </Markdown>
+    </Figure>
   </div>
 </div>
 `;

--- a/resources/assets/components/blocks/ContentBlock/__snapshots__/ContentBlock.test.js.snap
+++ b/resources/assets/components/blocks/ContentBlock/__snapshots__/ContentBlock.test.js.snap
@@ -63,23 +63,13 @@ exports[`ContentBlock component it works beautifully with a mere content prop 1`
   className="content-block"
 >
   <div
-    className="margin-horizontal-md"
+    className="margin-horizontal-md two-thirds"
   >
-    <Flex
+    <Markdown
       className={null}
-      id={null}
     >
-      <FlexCell
-        className={null}
-        width="two-thirds"
-      >
-        <Markdown
-          className={null}
-        >
-          hi there
-        </Markdown>
-      </FlexCell>
-    </Flex>
+      hi there
+    </Markdown>
   </div>
 </div>
 `;

--- a/resources/assets/components/blocks/ContentBlock/__snapshots__/ContentBlock.test.js.snap
+++ b/resources/assets/components/blocks/ContentBlock/__snapshots__/ContentBlock.test.js.snap
@@ -65,19 +65,21 @@ exports[`ContentBlock component it works beautifully with a mere content prop 1`
   <div
     className="margin-horizontal-md"
   >
-    <Figure
-      alignment="right-collapse"
-      alt="content-block"
-      image={null}
-      imageClassName={null}
-      size="one-third"
+    <Flex
+      className={null}
+      id={null}
     >
-      <Markdown
+      <FlexCell
         className={null}
+        width="two-thirds"
       >
-        hi there
-      </Markdown>
-    </Figure>
+        <Markdown
+          className={null}
+        >
+          hi there
+        </Markdown>
+      </FlexCell>
+    </Flex>
   </div>
 </div>
 `;

--- a/resources/assets/components/blocks/ContentBlock/content-block.scss
+++ b/resources/assets/components/blocks/ContentBlock/content-block.scss
@@ -11,4 +11,10 @@
     color: $black;
     font-family: $primary-font-family;
   }
+
+  .two-thirds {
+    @include media($medium) {
+      width: 66.6666666666666%;
+    }
+  }
 }


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR adds a quick refactor and a touch of clean up to the `ContentBlock` component:

- ~Always return a `Figure` component even~ Style content ~with `Flex`~ when there is no `image` prop to ensure proper formatting of the content
- Use the `withoutNulls` helper in the renderer so that we can do away with explicitly grabbing the `defaultProp`for `imageAlignment` and let React handle that work ☺️ 

### Any background context you want to provide?
I was testing out the action navigation changes with a new action 'page' and noticed that the ContentBlock was spreading across the entire page when there was no image:
![image](https://user-images.githubusercontent.com/12417657/40496605-291489ca-5f48-11e8-844a-a456b60bd831.png)

But by ~always returning `Figure`~ styling properly:
![image](https://user-images.githubusercontent.com/12417657/40496718-741a99aa-5f48-11e8-97cd-f354563d9a1e.png)



### What are the relevant tickets/cards?
[#156771690](https://www.pivotaltracker.com/story/show/156771690)