### PR TITLE
Add additional fields to the LegacyCampaign Entity

### DIFF
--- a/app/Entities/LegacyCampaign.php
+++ b/app/Entities/LegacyCampaign.php
@@ -45,6 +45,12 @@ class LegacyCampaign implements JsonSerializable
                 'url' => $this->legacyCampaign['cover_image']['default']['uri'],
                 'landscapeUrl' => $this->legacyCampaign['cover_image']['default']['sizes']['landscape']['uri'],
             ],
+            'staffPick' => $this->legacyCampaign['staff_pick'],
+            'cause' => $this->legacyCampaign['causes']['primary']['name'],
+            'additionalContent' => [
+                'noun' => $this->legacyCampaign['reportback_info']['noun'],
+                'verb' => $this->legacyCampaign['reportback_info']['verb'],
+            ]
         ];
     }
 }

--- a/app/Entities/LegacyCampaign.php
+++ b/app/Entities/LegacyCampaign.php
@@ -48,8 +48,14 @@ class LegacyCampaign implements JsonSerializable
             'staffPick' => $this->legacyCampaign['staff_pick'],
             'cause' => $this->legacyCampaign['causes']['primary']['name'],
             'additionalContent' => [
-                'noun' => $this->legacyCampaign['reportback_info']['noun'],
-                'verb' => $this->legacyCampaign['reportback_info']['verb'],
+                'noun' => [
+                    'singular' => null,
+                    'plural' => $this->legacyCampaign['reportback_info']['noun'],
+                ],
+                'verb' => [
+                    'singular' => null,
+                    'plural' => $this->legacyCampaign['reportback_info']['verb'],
+                ],
             ],
         ];
     }

--- a/app/Entities/LegacyCampaign.php
+++ b/app/Entities/LegacyCampaign.php
@@ -50,7 +50,7 @@ class LegacyCampaign implements JsonSerializable
             'additionalContent' => [
                 'noun' => $this->legacyCampaign['reportback_info']['noun'],
                 'verb' => $this->legacyCampaign['reportback_info']['verb'],
-            ]
+            ],
         ];
     }
 }


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR adds some additional fields to the `LegacyCampaign` Entity.

### Any background context you want to provide?
I had been under the mistaken impression that the new fields from #922 only needed to be added to the `Campaign` Entity. This will add -the available ones- to the `LegacyCampaign` as well.

### What are the relevant tickets/cards?
[#157010624](https://www.pivotaltracker.com/story/show/157010624)