### PR TITLE
Fetch index of Legacy Campaigns By ID

### DIFF
--- a/app/Entities/LegacyCampaign.php
+++ b/app/Entities/LegacyCampaign.php
@@ -20,7 +20,7 @@ class LegacyCampaign implements JsonSerializable
      */
     public function __construct($legacyCampaign)
     {
-        $this->legacyCampaign = $legacyCampaign['data'];
+        $this->legacyCampaign = $legacyCampaign;
     }
 
     /**

--- a/app/Repositories/CampaignRepository.php
+++ b/app/Repositories/CampaignRepository.php
@@ -120,7 +120,8 @@ class CampaignRepository
      * @param  array $ids
      * @return \Illuminate\Support\Collection
      */
-    public function findByLegacyCampaignIds($ids) {
+    public function findByLegacyCampaignIds($ids)
+    {
         $query['ids'] = implode(',', $ids);
 
         $legacyCampaigns = $this->phoenixLegacy->getCampaigns($query);
@@ -128,7 +129,6 @@ class CampaignRepository
         return collect($legacyCampaigns['data'])->map(function ($legacyCampaign) {
             return new LegacyCampaign($legacyCampaign);
         });
-
     }
 
     /**

--- a/app/Repositories/CampaignRepository.php
+++ b/app/Repositories/CampaignRepository.php
@@ -115,6 +115,23 @@ class CampaignRepository
     }
 
     /**
+     * Find a list of campaigns by their legacy IDs.
+     *
+     * @param  array $ids
+     * @return \Illuminate\Support\Collection
+     */
+    public function findByLegacyCampaignIds($ids) {
+        $query['ids'] = implode(',', $ids);
+
+        $legacyCampaigns = $this->phoenixLegacy->getCampaigns($query);
+
+        return collect($legacyCampaigns['data'])->map(function ($legacyCampaign) {
+            return new LegacyCampaign($legacyCampaign);
+        });
+
+    }
+
+    /**
      * Find a campaign by its slug.
      *
      * @param  string $slug

--- a/app/Repositories/CampaignRepository.php
+++ b/app/Repositories/CampaignRepository.php
@@ -108,7 +108,7 @@ class CampaignRepository
                 throw new ModelNotFoundException;
             }
 
-            return new LegacyCampaign($legacyCampaign);
+            return new LegacyCampaign($legacyCampaign['data']);
         }
 
         return new Campaign($campaigns[0]);

--- a/app/Services/PhoenixLegacy.php
+++ b/app/Services/PhoenixLegacy.php
@@ -41,6 +41,20 @@ class PhoenixLegacy extends RestApiClient
     }
 
     /**
+     * Get details for (optionally filtered) campaigns from Phoenix.
+     * @see: https://github.com/DoSomething/phoenix/blob/dev/documentation/endpoints/campaigns.md#retrieve-all-campaigns
+     *
+     * @param array $query - query string for filtering results
+     * @return array - JSON response
+     */
+    public function getCampaigns(array $query = [])
+    {
+        $path = 'v1/campaigns';
+
+        return $this->get($path, $query);
+    }
+
+    /**
      * Get an index of (optionally filtered) campaign signups from Phoenix.
      * @see: https://github.com/DoSomething/phoenix/wiki/API#retrieve-a-signup-collection
      *

--- a/app/Services/PhoenixLegacy.php
+++ b/app/Services/PhoenixLegacy.php
@@ -41,7 +41,7 @@ class PhoenixLegacy extends RestApiClient
     }
 
     /**
-     * Get details for (optionally filtered) campaigns from Phoenix.
+     * Get an index of (optionally filtered) campaigns from Phoenix.
      * @see: https://github.com/DoSomething/phoenix/blob/dev/documentation/endpoints/campaigns.md#retrieve-all-campaigns
      *
      * @param array $query - query string for filtering results


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR adds basic setup to enable fetching an index of legacy campaigns from Ashes.

- Adds a `getCampaigns` method to the `PhoenixLegacy` Service [4140f43](https://github.com/DoSomething/phoenix-next/commit/4140f43ff5232404dd66ffcf002546908c0415c4)
- Adds a `findByLegacyCampaignIds` method to the `CampaignRepository` [299a6c5](https://github.com/DoSomething/phoenix-next/commit/299a6c56f7ef614e24b5cd0bbe5788cc15fcbf06)
- Removes `data` index in the `LegacyCampaign` Entity constructor so that an index of campaign `data` can be used to construct `LegacyCampaigns`s as well

### Any background context you want to provide?
This is the first step towards the #942 feature.

Qs:
- Should the `findByLegacyCampaignIds` or `getCampaigns` methods be doing any validation to ensure that there aren't more than n `$ids` provided? (Since we discussed limiting this call to 10-15 IDs)
  - or also, in the case of `getCampaigns` should we only be allowing calls with an `ids` query param?
- How's the naming? I simply used the plural of the two existing 'show' methods we had in use.

### What are the relevant tickets/cards?
#942 
[#157410894](https://www.pivotaltracker.com/story/show/157410894)
