### PR TITLE
Switching to use Pivotal ID reference.

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -14,7 +14,7 @@ This PR ...
 
 ### What are the relevant tickets/cards?
 
-Fixes #
+Refs [Pivotal ID #]()
 
 ### Checklist
 


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR updates the PR template to use a Pivotal ID reference since we're typically attributing PRs to PT tickets.
