### PR TITLE
SocialDriveAction Content Type setup

### DIFF
--- a/app/Entities/Entity.php
+++ b/app/Entities/Entity.php
@@ -90,6 +90,8 @@ class Entity implements ArrayAccess, JsonSerializable
                 return new ReferralSubmissionAction($block->entry);
             case 'shareAction':
                 return new ShareAction($block->entry);
+            case 'socialDriveAction':
+                return new SocialDriveAction($block->entry);
             case 'textSubmissionAction':
                 return new TextSubmissionAction($block->entry);
             case 'voterRegistrationAction':

--- a/app/Entities/SocialDriveAction.php
+++ b/app/Entities/SocialDriveAction.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Entities;
+
+use JsonSerializable;
+
+class SocialDriveAction extends Entity implements JsonSerializable
+{
+    /**
+     * Convert the object into something JSON serializable.
+     *
+     * @return array
+     */
+    public function jsonSerialize()
+    {
+        return [
+            'id' => $this->entry->getId(),
+            'type' => $this->getContentType(),
+            'fields' => [
+                'link' => $this->link,
+            ],
+        ];
+    }
+}

--- a/contentful/migrations/2018_05_31_001_add_social_drive_action_content_type.js
+++ b/contentful/migrations/2018_05_31_001_add_social_drive_action_content_type.js
@@ -1,0 +1,23 @@
+module.exports = function(migration) {
+  const socialDriveAction = migration
+    .createContentType('socialDriveAction')
+    .name('Social Drive Action')
+    .description(
+      'An Action block for social drives for link sharing and page view tracking.',
+    )
+    .displayField('internalTitle');
+
+  socialDriveAction
+    .createField('internalTitle')
+    .name('Internal Title')
+    .type('Symbol')
+    .required(true)
+    .localized(false);
+
+  socialDriveAction
+    .createField('link')
+    .name('Link')
+    .type('Symbol')
+    .required(true)
+    .localized(false);
+};

--- a/resources/assets/components/ContentfulEntry/ContentfulEntry.js
+++ b/resources/assets/components/ContentfulEntry/ContentfulEntry.js
@@ -12,6 +12,7 @@ import { parseContentfulType, report } from '../../helpers';
 import { CampaignUpdateContainer } from '../CampaignUpdate';
 import ImagesBlock from '../blocks/ImagesBlock/ImagesBlock';
 import CallToActionContainer from '../CallToAction/CallToActionContainer';
+import SocialDriveActionContainer from '../actions/SocialDriveAction/SocialDriveActionContainer';
 import CampaignGalleryBlockContainer from '../blocks/CampaignGalleryBlock/CampaignGalleryBlockContainer';
 import {
   renderLinkAction,
@@ -141,6 +142,13 @@ class ContentfulEntry extends React.Component<Props, State> {
 
       case 'shareAction':
         return renderShareAction(json);
+
+      case 'socialDriveAction':
+        return (
+          <div className="margin-horizontal-md margin-bottom-lg">
+            <SocialDriveActionContainer {...json.fields} />
+          </div>
+        );
 
       case 'static':
         return (

--- a/resources/assets/components/ContentfulEntry/ContentfulEntry.js
+++ b/resources/assets/components/ContentfulEntry/ContentfulEntry.js
@@ -12,7 +12,6 @@ import { parseContentfulType, report } from '../../helpers';
 import { CampaignUpdateContainer } from '../CampaignUpdate';
 import ImagesBlock from '../blocks/ImagesBlock/ImagesBlock';
 import CallToActionContainer from '../CallToAction/CallToActionContainer';
-import SocialDriveActionContainer from '../actions/SocialDriveAction/SocialDriveActionContainer';
 import CampaignGalleryBlockContainer from '../blocks/CampaignGalleryBlock/CampaignGalleryBlockContainer';
 import {
   renderLinkAction,
@@ -142,13 +141,6 @@ class ContentfulEntry extends React.Component<Props, State> {
 
       case 'shareAction':
         return renderShareAction(json);
-
-      case 'socialDriveAction':
-        return (
-          <div className="margin-horizontal-md margin-bottom-lg">
-            <SocialDriveActionContainer {...json.fields} />
-          </div>
-        );
 
       case 'static':
         return (


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR adds the setup for a SocialDriveAction Contentful Content Type/Entity

- Contentful CLI migration script to create the content type
- SocialDriveAction Entity
- block parsing case for content type

### Any background context you want to provide?
The Content-Type fields purposefully meager for now, as we shall continue to add fields once this is more fleshed out

### What are the relevant tickets/cards?
Refs [Pivotal ID #157741116](https://www.pivotaltracker.com/story/show/157741116)

![image](https://user-images.githubusercontent.com/12417657/40805263-b48d69a6-64eb-11e8-869d-f3a54e4035c8.png)

