### PR TITLE
Add Bertly shortened link to SocialDriveAction component

### DIFF
--- a/resources/assets/components/actions/SocialDriveAction/SocialDriveAction.js
+++ b/resources/assets/components/actions/SocialDriveAction/SocialDriveAction.js
@@ -8,7 +8,6 @@ import linkIcon from './linkIcon.svg';
 import Card from '../../utilities/Card/Card';
 import Embed from '../../utilities/Embed/Embed';
 import { postRequest } from '../../../helpers/api';
-import { setFormData } from '../../../helpers/forms';
 import {
   dynamicString,
   handleFacebookShareClick,
@@ -28,10 +27,8 @@ class SocialDriveAction extends React.Component {
 
     const href = dynamicString(this.props.link, { userId });
 
-    const formData = setFormData({ url: withoutTokens(href) });
-
-    postRequest('api/v2/links', formData, token).then(response =>
-      this.setState({ shortenedLink: response.url }),
+    postRequest('api/v2/links', { url: withoutTokens(href) }, token).then(
+      response => this.setState({ shortenedLink: response.url }),
     );
   }
 

--- a/resources/assets/components/actions/SocialDriveAction/SocialDriveAction.js
+++ b/resources/assets/components/actions/SocialDriveAction/SocialDriveAction.js
@@ -2,112 +2,142 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
+import classnames from 'classnames';
 
 import linkIcon from './linkIcon.svg';
+import { postRequest } from '../../../helpers/api';
+import { setFormData } from '../../../helpers/forms';
 import Card from '../../utilities/Card/Card';
 import Embed from '../../utilities/Embed/Embed';
 import {
   dynamicString,
   handleFacebookShareClick,
   handleTwitterShareClick,
+  withoutTokens,
 } from '../../../helpers';
 
 import './social-drive.scss';
 
-const SocialDriveAction = props => {
-  const { link, showPageViews, userId } = props;
+class SocialDriveAction extends React.Component {
+  state = {
+    shortenedLink: null,
+  };
 
-  const href = dynamicString(link, { userId });
+  componentDidMount() {
+    const { userId, token } = this.props;
 
-  const handleCopyLinkClick = () => {
+    const href = dynamicString(this.props.link, { userId });
+
+    const formData = setFormData({ url: withoutTokens(href) });
+
+    postRequest('api/v2/links', formData, token).then(response =>
+      this.setState({ shortenedLink: response.url }),
+    );
+  }
+
+  handleCopyLinkClick = () => {
     const linkInput = document.querySelector('#social-drive-link');
     linkInput.select();
     document.execCommand('copy');
   };
 
-  return (
-    <Card
-      title="Your Online Drive"
-      className="social-drive-action rounded bordered"
-    >
-      <div className="padded">
-        <Embed url={link} />
-      </div>
+  render() {
+    const { link, showPageViews } = this.props;
+    const shortenedLink = this.state.shortenedLink;
 
-      <div className="padded link-area">
-        <div className="share-text">
-          <p>Share your link:</p>
+    return (
+      <Card
+        title="Your Online Drive"
+        className="social-drive-action rounded bordered"
+      >
+        <div className="padded">
+          <Embed url={link} />
         </div>
 
-        <div className="link-bar">
-          <input
-            readOnly
-            type="text"
-            id="social-drive-link"
-            className="text-field link"
-            value={href}
-          />
-          <button
-            className="text-field link-copy-button"
-            onClick={handleCopyLinkClick}
-          >
-            <img src={linkIcon} alt="link" />
-            <p>Copy link</p>
-          </button>
-        </div>
-      </div>
-
-      <div className="share-buttons">
-        <div className="share-button padded">
-          <button
-            className="button padding-vertical-md bg-dark-blue"
-            onClick={() => handleFacebookShareClick(href)}
-          >
-            <i className="social-icon -facebook" />
-            Share on Facebook
-          </button>
-        </div>
-
-        <div className="share-button padded">
-          <button
-            className="button padding-vertical-md"
-            onClick={() => handleTwitterShareClick(href)}
-          >
-            <i className="social-icon -twitter" />
-            <span>Share on Twitter</span>
-          </button>
-        </div>
-      </div>
-
-      {showPageViews ? (
-        <div>
-          <div className="padding-horizontal-md">
-            <hr className="border" />
+        <div className="padded link-area">
+          <div className="share-text">
+            <p>Share your link:</p>
           </div>
 
-          <div className="link-info padded">
-            <p className="info__title">What happens next?</p>
-
-            <p className="info__text">
-              As you share your voter registration page, we&#39;ll keep track of
-              how many people you bring in. Check back often and try to get as
-              many views as possible!
-            </p>
-          </div>
-
-          <div className="padded page-views">
-            <span className="page-views__text caps-lock">total page views</span>
-            <h1 className="page-views__amount">5</h1>
+          <div className="link-bar">
+            <input
+              readOnly
+              type="text"
+              id="social-drive-link"
+              className="text-field link"
+              value={shortenedLink || 'Loading...'}
+              disabled={!shortenedLink}
+            />
+            <button
+              className="text-field link-copy-button"
+              onClick={this.handleCopyLinkClick}
+              disabled={!shortenedLink}
+            >
+              <img src={linkIcon} alt="link" />
+              <p>Copy link</p>
+            </button>
           </div>
         </div>
-      ) : null}
-    </Card>
-  );
-};
+
+        <div className="share-buttons">
+          <div className="share-button padded">
+            <button
+              className={classnames('button padding-vertical-md', {
+                'bg-dark-blue': shortenedLink,
+              })}
+              onClick={() => handleFacebookShareClick(shortenedLink)}
+              disabled={!shortenedLink}
+            >
+              <i className="social-icon -facebook" />
+              Share on Facebook
+            </button>
+          </div>
+
+          <div className="share-button padded">
+            <button
+              className="button padding-vertical-md"
+              onClick={() => handleTwitterShareClick(shortenedLink)}
+              disabled={!shortenedLink}
+            >
+              <i className="social-icon -twitter" />
+              <span>Share on Twitter</span>
+            </button>
+          </div>
+        </div>
+
+        {showPageViews ? (
+          <div>
+            <div className="padding-horizontal-md">
+              <hr className="border" />
+            </div>
+
+            <div className="link-info padded">
+              <p className="info__title">What happens next?</p>
+
+              <p className="info__text">
+                As you share your voter registration page, we&#39;ll keep track
+                of how many people you bring in. Check back often and try to get
+                as many views as possible!
+              </p>
+            </div>
+
+            <div className="padded page-views">
+              <span className="page-views__text caps-lock">
+                total page views
+              </span>
+              <h1 className="page-views__amount">5</h1>
+            </div>
+          </div>
+        ) : null}
+      </Card>
+    );
+  }
+}
 
 SocialDriveAction.propTypes = {
   link: PropTypes.string.isRequired,
   showPageViews: PropTypes.bool,
+  token: PropTypes.string.isRequired,
   userId: PropTypes.string.isRequired,
 };
 

--- a/resources/assets/components/actions/SocialDriveAction/SocialDriveAction.js
+++ b/resources/assets/components/actions/SocialDriveAction/SocialDriveAction.js
@@ -18,9 +18,15 @@ import {
 import './social-drive.scss';
 
 class SocialDriveAction extends React.Component {
-  state = {
-    shortenedLink: null,
-  };
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      shortenedLink: null,
+    };
+
+    this.linkInput = React.createRef();
+  }
 
   componentDidMount() {
     const { userId, token } = this.props;
@@ -33,8 +39,7 @@ class SocialDriveAction extends React.Component {
   }
 
   handleCopyLinkClick = () => {
-    const linkInput = document.querySelector('#social-drive-link');
-    linkInput.select();
+    this.linkInput.current.select();
     document.execCommand('copy');
   };
 
@@ -60,7 +65,7 @@ class SocialDriveAction extends React.Component {
             <input
               readOnly
               type="text"
-              id="social-drive-link"
+              ref={this.linkInput}
               className="text-field link"
               value={shortenedLink || 'Loading...'}
               disabled={!shortenedLink}

--- a/resources/assets/components/actions/SocialDriveAction/SocialDriveAction.js
+++ b/resources/assets/components/actions/SocialDriveAction/SocialDriveAction.js
@@ -5,10 +5,10 @@ import PropTypes from 'prop-types';
 import classnames from 'classnames';
 
 import linkIcon from './linkIcon.svg';
-import { postRequest } from '../../../helpers/api';
-import { setFormData } from '../../../helpers/forms';
 import Card from '../../utilities/Card/Card';
 import Embed from '../../utilities/Embed/Embed';
+import { postRequest } from '../../../helpers/api';
+import { setFormData } from '../../../helpers/forms';
 import {
   dynamicString,
   handleFacebookShareClick,

--- a/resources/assets/components/actions/SocialDriveAction/SocialDriveAction.js
+++ b/resources/assets/components/actions/SocialDriveAction/SocialDriveAction.js
@@ -8,10 +8,12 @@ import linkIcon from './linkIcon.svg';
 import Card from '../../utilities/Card/Card';
 import Embed from '../../utilities/Embed/Embed';
 import { postRequest } from '../../../helpers/api';
+import { trackPuckEvent } from '../../../helpers/analytics';
 import {
   dynamicString,
-  handleFacebookShareClick,
   handleTwitterShareClick,
+  loadFacebookSDK,
+  showFacebookShareDialog,
   withoutTokens,
 } from '../../../helpers';
 
@@ -29,6 +31,8 @@ class SocialDriveAction extends React.Component {
   }
 
   componentDidMount() {
+    loadFacebookSDK();
+
     const { userId, token } = this.props;
 
     const href = dynamicString(this.props.link, { userId });
@@ -41,6 +45,18 @@ class SocialDriveAction extends React.Component {
   handleCopyLinkClick = () => {
     this.linkInput.current.select();
     document.execCommand('copy');
+  };
+
+  handleFacebookShareClick = url => {
+    trackPuckEvent('clicked facebook share action', { url });
+
+    showFacebookShareDialog(url)
+      .then(() => {
+        trackPuckEvent('share action completed', { url });
+      })
+      .catch(() => {
+        trackPuckEvent('share action cancelled', { url });
+      });
   };
 
   render() {
@@ -87,7 +103,7 @@ class SocialDriveAction extends React.Component {
               className={classnames('button padding-vertical-md', {
                 'bg-dark-blue': shortenedLink,
               })}
-              onClick={() => handleFacebookShareClick(shortenedLink)}
+              onClick={() => this.handleFacebookShareClick(shortenedLink)}
               disabled={!shortenedLink}
             >
               <i className="social-icon -facebook" />

--- a/resources/assets/components/actions/SocialDriveAction/SocialDriveActionContainer.js
+++ b/resources/assets/components/actions/SocialDriveAction/SocialDriveActionContainer.js
@@ -8,6 +8,7 @@ import { getUserId } from '../../../selectors/user';
  */
 const mapStateToProps = state => ({
   userId: getUserId(state),
+  token: state.user.token,
 });
 
 // Export the container component.

--- a/resources/assets/helpers/api.js
+++ b/resources/assets/helpers/api.js
@@ -22,6 +22,25 @@ export function getRequest(url, query) {
 }
 
 /**
+ * Send a POST request.
+ *
+ * @param  {String} url
+ * @param  {Object} query
+ * @param  {String} token
+ * @return {Object}
+ */
+export function postRequest(url, query, token) {
+  const client = new RestApiClient(PHOENIX_URL, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'multipart/form-data',
+    },
+  });
+
+  return client.post(url, query);
+}
+
+/**
  * Get campaign signups for a user.
  *
  * @param  {String} userId

--- a/resources/assets/helpers/api.js
+++ b/resources/assets/helpers/api.js
@@ -33,7 +33,7 @@ export function postRequest(url, query, token) {
   const client = new RestApiClient(PHOENIX_URL, {
     headers: {
       Authorization: `Bearer ${token}`,
-      'Content-Type': 'multipart/form-data',
+      'Content-Type': 'application/json',
     },
   });
 


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR adds an API call to the `SocialDriveAction` component to fetch a shortened Bertly link via our Phoenix Bertly proxy endpoint.

What happens is we make the API call once the component mounts, and have all the buttons disabled until the state has it's `shortenedLink` property set (which happens as a callback once the API response is returned)

**UPDATE** I snuck in some changes to the Facebook share link handler to use the more robust share action flow. (I know it's completely repetitive of the `ShareAction`. Hoping we can clean this up as we refactor. Ashley really wanted this in. #blameCanada)

### Any background context you want to provide?
I added a new `postRequest` method to the `/helpers/api` so that we can avoid setting the authentication headers and `PHOENIX_URL` and whatnot from the `socialDriveAction` component.

I'm not sure that my `token` param approach was the right one for this method, but it seemed like an easy way to pass along the needed user token from state.

I also did not add an error `catch` to the API call, since if it errors out it'll just stay in the 'disabled' state forever. (wasn't sure of a better way for now, but I'm sure we can tweak this as we continue fleshing this out)

The git diffs for the actual `render()` markup is all kaboodled and thus gonna be annoying to review. You can just look out for some `disabled` attributes on `button`s, a [utility class name](157741116) and the [link bar value](https://github.com/DoSomething/phoenix-next/pull/954/files#diff-6fa015ab9fa63a40da148508a9827503R68) being conditioned on the `shortenedLink` state property being 'truthy'.
 
### What are the relevant tickets/cards?

Refs [Pivotal ID #157741116](https://www.pivotaltracker.com/story/show/157741116)

![jun-04-2018 14-31-31](https://user-images.githubusercontent.com/12417657/40934826-0e6c85e0-6804-11e8-90cc-02b9e96b5e8b.gif)

