### PR TITLE
Fix for validation issue when not using quantity field.

### DIFF
--- a/app/Http/Requests/PostRequest.php
+++ b/app/Http/Requests/PostRequest.php
@@ -28,8 +28,7 @@ class PostRequest extends FormRequest
             case 'photo':
                 return [
                     'file.required' => 'An uploaded photo is required.',
-                    'quantity.required_if' => 'The quantity field is required.',
-                    'quantity.min' => $this->setMinQuantityMessage(),
+                    'quantity.min' => $this->getMinQuantityMessage(),
                     'text.max' => 'The caption field may not be greater than :max characters.',
                     'text.min' => 'The caption field may not be less than :min characters.',
                     'text.required' => 'The caption field for your photo is required.',
@@ -56,13 +55,7 @@ class PostRequest extends FormRequest
         // Custom validation rules based on the type of post action.
         switch ($this->input('type')) {
             case 'photo':
-                return [
-                    'file' => 'required|file|image',
-                    'quantity' => 'required_if:show_quantity,1|integer|min:1',
-                    'show_quantity' => 'required|boolean',
-                    'text' => 'required|min:4|max:60',
-                    'why_participated' => 'required',
-                ];
+                return $this->getPhotoRules();
 
             case 'text':
                 return [
@@ -75,9 +68,32 @@ class PostRequest extends FormRequest
     }
 
     /**
-     * Set validation message for min quantity rule.
+     * Get the validation rules for a photo post.
+     *
+     * @return array
      */
-    private function setMinQuantityMessage()
+    private function getPhotoRules()
+    {
+        $rules = [
+            'file' => 'required|file|image',
+            'show_quantity' => 'required|boolean',
+            'text' => 'required|min:4|max:60',
+            'why_participated' => 'required',
+        ];
+
+        if (filter_var($this->input('show_quantity'), FILTER_VALIDATE_BOOLEAN)) {
+            $rules += [
+                'quantity' => 'required|integer|min:1',
+            ];
+        }
+
+        return $rules;
+    }
+
+    /**
+     * Get validation message for min quantity rule.
+     */
+    private function getMinQuantityMessage()
     {
         $previousQuantity = (int) $this->input('previousQuantity');
 

--- a/tests/Feature/StorePhotoReportbackPostTest.php
+++ b/tests/Feature/StorePhotoReportbackPostTest.php
@@ -89,6 +89,7 @@ class StorePhotoReportbackPostTest extends BrowserKitTestCase
             'text' => 'Great text caption!',
             'quantity' => 'not-an-integer',
             'file' => 'not-a-file-upload',
+            'show_quantity' => '1',
             'why_participated' => 'Because testing is very important.',
         ]);
 
@@ -103,6 +104,7 @@ class StorePhotoReportbackPostTest extends BrowserKitTestCase
             'caption' => 'Great text caption!',
             'quantity' => '3.5',
             'file' => 'not-a-file-upload',
+            'show_quantity' => '1',
             'why_participated' => 'Because testing is very important.',
         ]);
 
@@ -117,6 +119,7 @@ class StorePhotoReportbackPostTest extends BrowserKitTestCase
             'caption' => 'Great text caption!',
             'quantity' => '0',
             'file' => 'not-a-file-upload',
+            'show_quantity' => '1',
             'why_participated' => 'Because testing is very important.',
         ]);
 


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR fixes a bug when the quantity field is not displayed on the Photo Submission Action. While the `quantity` field would _not be validated as "required"_ if the `show_quantity` field value was `false`, the form request would still validate that the quantity value needed to both be an integer and a minimum value of 1. Thus, the PSA form, without a quantity field would never be able to be successfully submitted.

To solve this issue, I set up a separate `getPhotoRules()` method which checks against the `show_quantity` boolean value to see if it should add any validation rules for the `quantity` and all seems to work great 🍸 

### Any background context you want to provide?

I encountered this bug when switching some older Contentful Campaigns to use the new PSA instead of the old Photo Uploader.

### What are the relevant tickets/cards?
🌵 

