### PR TITLE
Fix PageNavigation ghost tab bug

### DIFF
--- a/resources/assets/components/CampaignPageNavigation/CampaignPageNavigation.js
+++ b/resources/assets/components/CampaignPageNavigation/CampaignPageNavigation.js
@@ -56,7 +56,7 @@ const CampaignPageNavigation = ({
     slug: prepareCampaignPageSlug(campaignSlug, page.slug),
   }));
 
-  return (
+  return campaignPages.length ? (
     <PageNavigation pages={campaignPages}>
       {isAffiliated ? null : (
         <SignupButtonContainer
@@ -65,7 +65,7 @@ const CampaignPageNavigation = ({
         />
       )}
     </PageNavigation>
-  );
+  ) : null;
 };
 
 CampaignPageNavigation.propTypes = {


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR adds a touch of logic to ensure that we don't render `PageNavigation` if there aren't multiple pages

### Any background context you want to provide?
Similiar to #777 
[Slack](https://dosomething.slack.com/files/U025G4PTC/FB1MF1468/screen_shot_2018-06-05_at_9.46.31_am.png)
[Slack 2](https://dosomething.slack.com/archives/C3ASB4204/p1528206946000430)