### PR TITLE
Display clicks in the Social Drive Action.

### DIFF
--- a/app/Http/Controllers/Api/LinkController.php
+++ b/app/Http/Controllers/Api/LinkController.php
@@ -44,10 +44,10 @@ class LinkController extends Controller
 
         $url = $request->input('url');
         $host = parse_url($url, PHP_URL_HOST);
-        if (in_array($host, $whitelist)) {
-            $url = $this->bertly->shorten($url);
+        if (! in_array($host, $whitelist)) {
+            return ['url' => $url, 'count' => '0'];
         }
 
-        return response()->json(['url' => $url]);
+        return $this->bertly->shorten($url);
     }
 }

--- a/app/Services/Bertly.php
+++ b/app/Services/Bertly.php
@@ -43,12 +43,27 @@ class Bertly extends RestApiClient
      */
     public function shorten($url)
     {
-        $response = $this->send('POST', '/', [
-            'form_params' => [
-                'url' => $url,
-            ],
-        ]);
+        $shortlink = $this->postForm('/', compact('url'));
 
-        return $response['url'];
+        return [
+            'url' => $shortlink['url'],
+        ];
+    }
+
+    /**
+     * Send a POST request to the given URL.
+     *
+     * @param string $path - URL to make request to (relative to base URL)
+     * @param array $payload - Body of the POST request
+     * @param bool $withAuthorization - Should this request be authorized?
+     * @return array
+     */
+    public function postForm($path, $payload = [], $withAuthorization = true)
+    {
+        $options = [
+            'form_params' => $payload,
+        ];
+
+        return $this->send('POST', $path, $options, $withAuthorization);
     }
 }

--- a/app/Services/Bertly.php
+++ b/app/Services/Bertly.php
@@ -44,9 +44,11 @@ class Bertly extends RestApiClient
     public function shorten($url)
     {
         $shortlink = $this->postForm('/', compact('url'));
+        $stats = $this->get($shortlink['url'] . '/clicks');
 
         return [
             'url' => $shortlink['url'],
+            'count' => $stats['count'],
         ];
     }
 

--- a/resources/assets/components/actions/SocialDriveAction/SocialDriveAction.js
+++ b/resources/assets/components/actions/SocialDriveAction/SocialDriveAction.js
@@ -37,8 +37,8 @@ class SocialDriveAction extends React.Component {
 
     const href = dynamicString(this.props.link, { userId });
 
-    postRequest('api/v2/links', { url: withoutTokens(href) }, token).then(
-      response => this.setState({ shortenedLink: response.url }),
+    postRequest('/api/v2/links', { url: withoutTokens(href) }, token).then(
+      ({ url, count }) => this.setState({ shortenedLink: url, count }),
     );
   }
 
@@ -143,7 +143,7 @@ class SocialDriveAction extends React.Component {
               <span className="page-views__text caps-lock">
                 total page views
               </span>
-              <h1 className="page-views__amount">5</h1>
+              <h1 className="page-views__amount">{this.state.count || 0}</h1>
             </div>
           </div>
         ) : null}
@@ -160,7 +160,7 @@ SocialDriveAction.propTypes = {
 };
 
 SocialDriveAction.defaultProps = {
-  showPageViews: false,
+  showPageViews: true,
 };
 
 export default SocialDriveAction;

--- a/resources/assets/components/actions/SocialDriveAction/SocialDriveAction.js
+++ b/resources/assets/components/actions/SocialDriveAction/SocialDriveAction.js
@@ -37,9 +37,9 @@ class SocialDriveAction extends React.Component {
 
     const href = dynamicString(this.props.link, { userId });
 
-    postRequest('/api/v2/links', { url: withoutTokens(href) }, token).then(
-      ({ url, count }) => this.setState({ shortenedLink: url, count }),
-    );
+    postRequest('/api/v2/links', { url: withoutTokens(href) }, token)
+      .then(({ url, count }) => this.setState({ shortenedLink: url, count }))
+      .catch(() => this.setState({ shortenedLink: href, count: 0 }));
   }
 
   handleCopyLinkClick = () => {

--- a/resources/assets/components/actions/SocialDriveAction/SocialDriveAction.js
+++ b/resources/assets/components/actions/SocialDriveAction/SocialDriveAction.js
@@ -39,7 +39,7 @@ class SocialDriveAction extends React.Component {
 
     postRequest('/api/v2/links', { url: withoutTokens(href) }, token)
       .then(({ url, count }) => this.setState({ shortenedLink: url, count }))
-      .catch(() => this.setState({ shortenedLink: href, count: 0 }));
+      .catch(() => this.setState({ shortenedLink: href, count: 'N/A' }));
   }
 
   handleCopyLinkClick = () => {
@@ -143,7 +143,9 @@ class SocialDriveAction extends React.Component {
               <span className="page-views__text caps-lock">
                 total page views
               </span>
-              <h1 className="page-views__amount">{this.state.count || 0}</h1>
+              <h1 className="page-views__amount">
+                {shortenedLink ? this.state.count : '?'}
+              </h1>
             </div>
           </div>
         ) : null}


### PR DESCRIPTION
### What does this PR do?

This pull request adds the "total clicks" interface to the Social Drive Action, using Bertly's `/clicks` endpoint. This allows users to see how many people have clicked on their personalized share link!

At the moment, this is done using a chained HTTP request in our LinkController proxy, but could probably be added as a query-string option to that `POST /` route in Bertly.

![screen shot 2018-06-05 at 12 15 21 pm](https://user-images.githubusercontent.com/583202/40988847-25a42acc-68ba-11e8-8304-302beb585743.png)


### Any background context you want to provide?

For now, any failures will gracefully display the unshortened link and zero clicks. We can consider other fallback options in a follow-up PR as well.

### What are the relevant tickets/cards?

Refs [Pivotal ID #157741138](https://www.pivotaltracker.com/story/show/157741138).

### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.
* [ ] Added screenshot to PR description of related front-end updates on **small** screens.
* [ ] Added screenshot to PR description of related front-end updates on **medium** screens.
* [ ] Added screenshot to PR description of related front-end updates on **large** screens.