### PR TITLE
Psa validation bug fix part deux

### DIFF
--- a/resources/assets/components/actions/PhotoSubmissionAction/PhotoSubmissionAction.js
+++ b/resources/assets/components/actions/PhotoSubmissionAction/PhotoSubmissionAction.js
@@ -136,8 +136,6 @@ class PhotoSubmissionAction extends React.Component {
    * @return {void}
    */
   handleFileUpload = media => {
-    console.log(media);
-
     this.setState({
       mediaValue: media,
     });

--- a/resources/assets/components/actions/PhotoSubmissionAction/PhotoSubmissionAction.js
+++ b/resources/assets/components/actions/PhotoSubmissionAction/PhotoSubmissionAction.js
@@ -164,9 +164,9 @@ class PhotoSubmissionAction extends React.Component {
     );
 
     if (this.props.showQuantityField) {
-      values['previousQuantity'] = get(this.state.signup, 'quantity', 0);
+      values.previousQuantity = get(this.state.signup, 'quantity', 0);
 
-      values['quantity'] = calculateDifference(
+      values.quantity = calculateDifference(
         get(this.state.signup, 'quantity', null),
         this.state.quantityValue,
       );

--- a/resources/assets/components/actions/PhotoSubmissionAction/PhotoSubmissionAction.js
+++ b/resources/assets/components/actions/PhotoSubmissionAction/PhotoSubmissionAction.js
@@ -22,6 +22,12 @@ import {
 import './photo-submission-action.scss';
 
 class PhotoSubmissionAction extends React.Component {
+  /**
+   * Lifecycle method invoked before every render.
+   *
+   * @param  {Object} nextProps
+   * @return {Object|null}
+   */
   static getDerivedStateFromProps(nextProps) {
     const response = nextProps.submissions.items[nextProps.id] || null;
 
@@ -35,6 +41,11 @@ class PhotoSubmissionAction extends React.Component {
     return null;
   }
 
+  /**
+   * Create a new instance.
+   *
+   * @param  {Object} props
+   */
   constructor(props) {
     super(props);
 
@@ -58,6 +69,11 @@ class PhotoSubmissionAction extends React.Component {
     this.props.initPostSubmissionItem(this.props.id);
   }
 
+  /**
+   * Lifecylce method invoked immediately after a component is mounted.
+   *
+   * @return {void}
+   */
   componentDidMount() {
     const request = getUserCampaignSignups(
       this.props.userId,
@@ -71,12 +87,22 @@ class PhotoSubmissionAction extends React.Component {
     });
   }
 
+  /**
+   * Lifecyle method invoked immediately after updating occurs.
+   *
+   * @return {void}
+   */
   componentDidUpdate() {
     if (this.state.shouldResetForm) {
       this.resetForm();
     }
   }
 
+  /**
+   * Fields for the form and their associated references.
+   *
+   * @return {Array}
+   */
   fields = () => {
     const items = {
       file: 'media',
@@ -91,18 +117,38 @@ class PhotoSubmissionAction extends React.Component {
     return items;
   };
 
+  /**
+   * Handle form input change events.
+   *
+   * @param  {Object} event
+   * @return {void}
+   */
   handleChange = event => {
     this.setState({
       [`${event.target.name}Value`]: event.target.value,
     });
   };
 
+  /**
+   * Handle file upload event.
+   *
+   * @param  {Object} media
+   * @return {void}
+   */
   handleFileUpload = media => {
+    console.log(media);
+
     this.setState({
       mediaValue: media,
     });
   };
 
+  /**
+   * Handle form submit event.
+   *
+   * @param  {Object} event
+   * @return {void}
+   */
   handleSubmit = event => {
     event.preventDefault();
 
@@ -152,12 +198,23 @@ class PhotoSubmissionAction extends React.Component {
     });
   };
 
+  /**
+   * Handle receiving a signup response.
+   *
+   * @param  {Object} data
+   * @return {void}
+   */
   handleSignupResponse = data => {
     this.setState({
       signup: data,
     });
   };
 
+  /**
+   * Rest the form fields.
+   *
+   * @return {void}
+   */
   resetForm = () => {
     const signup = get(
       this.props.submissions.items[this.props.id],
@@ -175,6 +232,11 @@ class PhotoSubmissionAction extends React.Component {
     });
   };
 
+  /**
+   * Render the component.
+   *
+   * @return {ReactComponent}
+   */
   render() {
     const submissionItem = this.props.submissions.items[this.props.id];
 

--- a/resources/assets/components/actions/PhotoSubmissionAction/PhotoSubmissionAction.js
+++ b/resources/assets/components/actions/PhotoSubmissionAction/PhotoSubmissionAction.js
@@ -112,10 +112,19 @@ class PhotoSubmissionAction extends React.Component {
 
     const action = get(this.props.additionalContent, 'action', 'default');
 
-    const quantity = calculateDifference(
-      get(this.state.signup, 'quantity', null),
-      this.state.quantityValue,
+    const values = mapValues(
+      this.fields(),
+      value => this.state[`${value}Value`],
     );
+
+    if (this.props.showQuantityField) {
+      values['previousQuantity'] = get(this.state.signup, 'quantity', 0);
+
+      values['quantity'] = calculateDifference(
+        get(this.state.signup, 'quantity', null),
+        this.state.quantityValue,
+      );
+    }
 
     const formData = setFormData(
       {
@@ -123,10 +132,8 @@ class PhotoSubmissionAction extends React.Component {
         type,
         id: this.props.id,
         // Associate state values to fields.
-        ...mapValues(this.fields(), value => this.state[`${value}Value`]),
+        ...values,
         file: this.state.mediaValue.file || '',
-        previousQuantity: get(this.state.signup, 'quantity', 0),
-        quantity,
         show_quantity: this.props.showQuantityField ? 1 : 0,
       },
       {


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR fixes a bug when the quantity field is not displayed on the Photo Submission Action. 

While the `quantity` field would _not be validated as "required"_ if the `show_quantity` field value was `false`, the form request would still validate that the quantity value needed to both be an integer and a minimum value of 1. This was because after the updates happened to add logic to show a member's prior quantity, the changes resulted in a value for quantity _always_ being passed even if indicated that the field should not show. The value being passed was `null` and thus the validation rules, upon seeing an existing property for `quantity`, would appropriately validate them.

To solve this issue, I updated the `PhotoSubmissionAction` to include some logic and _only_ include values for `quanity` and `previousQuantity` if `showQuantity` is `true`, and all seems to work great 🍸 

### Any background context you want to provide?

I encountered this bug when switching some older Contentful Campaigns to use the new PSA instead of the old Photo Uploader.

### What are the relevant tickets/cards?
🌵 

