### PR TITLE
Adjustments to the `parseBlock` method

### DIFF
--- a/app/Entities/Entity.php
+++ b/app/Entities/Entity.php
@@ -63,6 +63,7 @@ class Entity implements ArrayAccess, JsonSerializable
             case 'callToAction':
                 return new CallToAction($block->entry);
             case 'campaignActionStep':
+            case 'componentActionStep':
                 return new CampaignActionStep($block->entry);
             case 'campaignUpdate':
                 return new CampaignUpdate($block->entry);

--- a/app/Entities/Entity.php
+++ b/app/Entities/Entity.php
@@ -86,6 +86,8 @@ class Entity implements ArrayAccess, JsonSerializable
                 return new PhotoSubmissionAction($block->entry);
             case 'photoUploaderAction':
                 return new PhotoUploaderAction($block->entry);
+            case 'quiz':
+                return new Quiz($block->entry);
             case 'referralSubmissionAction':
                 return new ReferralSubmissionAction($block->entry);
             case 'shareAction':

--- a/app/Entities/Entity.php
+++ b/app/Entities/Entity.php
@@ -62,6 +62,8 @@ class Entity implements ArrayAccess, JsonSerializable
                 return new Affirmation($block->entry);
             case 'callToAction':
                 return new CallToAction($block->entry);
+            case 'campaignActionStep':
+                return new CampaignActionStep($block->entry);
             case 'campaignUpdate':
                 return new CampaignUpdate($block->entry);
             case 'contentBlock':
@@ -99,7 +101,7 @@ class Entity implements ArrayAccess, JsonSerializable
             case 'voterRegistrationAction':
                 return new VoterRegistrationAction($block->entry);
             default:
-                return new CampaignActionStep($block->entry);
+                return $block->entry;
         }
     }
 


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR adds some cases to the `parseBlock` method to account for `quiz`es and `campaignActionStep`s.

Also swapped the default case to merely return the `$block->entry` to avoid parsing some unknown block as a `campaignActionStep`

Threw in the Quiz case as a first step towards [Pivotal ID #157750196](https://www.pivotaltracker.com/story/show/157750196)

### Any background context you want to provide?
We were bumping into errors anytime we had an unrecognized block in a Contentful reference where it's be rendered as a `campaignActionStep` and [break down the system](https://i.ytimg.com/vi/RSAbLRnGiWg/maxresdefault.jpg)

### What are the relevant tickets/cards?
[Slack](https://dosomething.slack.com/archives/C3ASB4204/p1528222293000020)
[also Slack](https://dosomething.slack.com/archives/C3ASB4204/p1528156878000035)
[Slack as well](https://dosomething.slack.com/archives/C3ASB4204/p1528131998000440)

 [Pivotal ID #157750196](https://www.pivotaltracker.com/story/show/157750196)