### PR TITLE
Adding migration to add field for quiz auto submit.

### DIFF
--- a/contentful/migrations/2018_06_05_001_add_auto_submit_field_to_quiz.js
+++ b/contentful/migrations/2018_06_05_001_add_auto_submit_field_to_quiz.js
@@ -1,0 +1,12 @@
+module.exports = function(migration) {
+  const quiz = migration.editContentType('quiz');
+
+  quiz
+    .createField('autoSubmit')
+    .name('Auto Submit Quiz')
+    .type('Boolean')
+    .required(true)
+    .localized(false);
+
+  quiz.moveField('autoSubmit').afterField('slug');
+};


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR adds a migration to add the `autoSubmit` boolean field for the quiz.
![image](https://user-images.githubusercontent.com/105849/40999413-c601f7ce-68d8-11e8-9943-ff136285a207.png)


### What are the relevant tickets/cards?

Refs [Pivotal ID #157744645](https://www.pivotaltracker.com/story/show/157744645)
