### PR TITLE
Implement Quizzes as `resultBlocks`

### DIFF
--- a/resources/assets/components/Quiz/Quiz.js
+++ b/resources/assets/components/Quiz/Quiz.js
@@ -71,8 +71,8 @@ class Quiz extends React.Component {
 
       // Retain the current pathname while replacing the active quiz's slug with the resultBlocks slug
       const newPath = location.pathname.replace(
-        `quiz/${slug}`,
-        `quiz/${resultBlockSlug}`,
+        new RegExp(`/quiz/${slug}$`),
+        `/quiz/${resultBlockSlug}`,
       );
 
       history.push(newPath);

--- a/resources/assets/components/Quiz/Quiz.js
+++ b/resources/assets/components/Quiz/Quiz.js
@@ -1,6 +1,6 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import { every } from 'lodash';
+import PropTypes from 'prop-types';
 import ReactRouterPropTypes from 'react-router-prop-types';
 
 import calculateResult from './helpers';

--- a/resources/assets/components/Quiz/Quiz.js
+++ b/resources/assets/components/Quiz/Quiz.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { every } from 'lodash';
+import ReactRouterPropTypes from 'react-router-prop-types';
 
 import calculateResult from './helpers';
 import { Flex, FlexCell } from '../Flex';
@@ -8,6 +9,7 @@ import QuizQuestion from './QuizQuestion';
 import Share from '../utilities/Share/Share';
 import QuizConclusion from './QuizConclusion';
 import ContentfulEntry from '../ContentfulEntry';
+import ScrollConcierge from '../ScrollConcierge';
 
 import './quiz.scss';
 
@@ -54,9 +56,28 @@ class Quiz extends React.Component {
         this.props.resultBlocks,
       );
 
+      this.quizResultBlockHandler(results.resultBlock);
+
       this.setState({ showResults: true, results });
     }
   };
+
+  // If the winning resultBlock is a Quiz, navigates to the new resultBlock's slug
+  quizResultBlockHandler(resultBlock) {
+    if (resultBlock && resultBlock.type === 'quiz') {
+      const { location, history, slug } = this.props;
+
+      const resultBlockSlug = resultBlock.fields.slug;
+
+      // Retain the current pathname while replacing the active quiz's slug with the resultBlocks slug
+      const newPath = location.pathname.replace(
+        `quiz/${slug}`,
+        `quiz/${resultBlockSlug}`,
+      );
+
+      history.push(newPath);
+    }
+  }
 
   selectChoice = (questionId, choiceId) => {
     this.setState({
@@ -128,6 +149,8 @@ class Quiz extends React.Component {
   render() {
     return (
       <Flex className="quiz">
+        <ScrollConcierge />
+
         <FlexCell width="two-thirds">
           <h1 className="quiz__heading">Quiz</h1>
           <h2 className="quiz__title">{this.props.title}</h2>
@@ -146,6 +169,8 @@ Quiz.propTypes = {
     introduction: PropTypes.string.isRequired,
     submitButtonText: PropTypes.string,
   }).isRequired,
+  history: ReactRouterPropTypes.history.isRequired,
+  location: ReactRouterPropTypes.location.isRequired,
   questions: PropTypes.arrayOf(
     PropTypes.shape({
       id: PropTypes.string.isRequired,
@@ -160,6 +185,7 @@ Quiz.propTypes = {
     }),
   ).isRequired,
   resultBlocks: PropTypes.arrayOf(PropTypes.object),
+  slug: PropTypes.string.isRequired,
   title: PropTypes.string.isRequired,
   trackEvent: PropTypes.func.isRequired,
 };

--- a/resources/assets/components/Quiz/Quiz.js
+++ b/resources/assets/components/Quiz/Quiz.js
@@ -63,7 +63,7 @@ class Quiz extends React.Component {
   };
 
   // If the winning resultBlock is a Quiz, navigates to the new resultBlock's slug
-  quizResultBlockHandler(resultBlock) {
+  quizResultBlockHandler = resultBlock => {
     if (resultBlock && resultBlock.type === 'quiz') {
       const { location, history, slug } = this.props;
 
@@ -77,7 +77,7 @@ class Quiz extends React.Component {
 
       history.push(newPath);
     }
-  }
+  };
 
   selectChoice = (questionId, choiceId) => {
     this.setState({

--- a/resources/assets/components/Quiz/Quiz.js
+++ b/resources/assets/components/Quiz/Quiz.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { every, find } from 'lodash';
+import { every } from 'lodash';
 
 import calculateResult from './helpers';
 import { Flex, FlexCell } from '../Flex';
@@ -18,8 +18,8 @@ class Quiz extends React.Component {
     this.state = {
       choices: {},
       results: {
-        resultId: null,
-        resultBlockId: null,
+        result: null,
+        resultBlock: null,
       },
       showResults: false,
     };
@@ -47,7 +47,12 @@ class Quiz extends React.Component {
         responses: this.state.choices,
       });
 
-      const results = calculateResult(this.state.choices, this.props.questions);
+      const results = calculateResult(
+        this.state.choices,
+        this.props.questions,
+        this.props.results,
+        this.props.resultBlocks,
+      );
 
       this.setState({ showResults: true, results });
     }
@@ -99,17 +104,10 @@ class Quiz extends React.Component {
   };
 
   renderResult = () => {
-    const { resultBlocks, results } = this.props;
-
-    const resultBlockId = this.state.results.resultBlockId;
-    const resultBlock = find(resultBlocks, { id: resultBlockId });
-
-    const resultId = this.state.results.resultId;
-    const result = find(results, { id: resultId });
+    const { result, resultBlock } = this.state.results;
 
     if (!resultBlock) {
       // Return the result on it's own when no result block is found.
-
       return result ? (
         <QuizConclusion callToAction={result.content}>
           <Share className="quiz__share" parentSource="quiz" />

--- a/resources/assets/components/Quiz/Quiz.test.js
+++ b/resources/assets/components/Quiz/Quiz.test.js
@@ -81,6 +81,7 @@ const props = {
   slug: 'quiz-slug',
   history,
   location,
+  autoSubmit: false,
 };
 
 test('it should display a placeholder quiz', () => {

--- a/resources/assets/components/Quiz/Quiz.test.js
+++ b/resources/assets/components/Quiz/Quiz.test.js
@@ -1,15 +1,30 @@
+/* global location, jsdom */
+
 import React from 'react';
 import { render, shallow } from 'enzyme';
+import { createMemoryHistory } from 'history';
 
 import Quiz from './Quiz';
 import QuizQuestion from './QuizQuestion';
 
-const sampleChoice = {
-  id: '0',
-  title: 'title',
-  results: ['0'],
-  resultBlock: '1',
-};
+const history = createMemoryHistory();
+
+history.push = jest.fn();
+
+const sampleChoices = [
+  {
+    id: '0',
+    title: 'title',
+    results: ['0'],
+    resultBlock: '1',
+  },
+  {
+    id: '1',
+    title: 'title',
+    results: ['0'],
+    resultBlock: '2',
+  },
+];
 
 const props = {
   id: '1',
@@ -23,12 +38,12 @@ const props = {
     {
       id: '0',
       title: 'title',
-      choices: [sampleChoice],
+      choices: sampleChoices,
     },
     {
       id: '1',
       title: 'title',
-      choices: [sampleChoice],
+      choices: sampleChoices,
     },
   ],
   resultBlocks: [
@@ -41,24 +56,31 @@ const props = {
         link: 'https://dosomething.org',
       },
     },
+    {
+      id: '2',
+      type: 'quiz',
+      fields: {
+        slug: 'quiz-slug-2',
+      },
+    },
   ],
   results: [
     {
       id: '0',
       content: 'test question',
-      blockId: '1',
     },
     {
       id: '1',
       content: 'another one',
-      blockId: '1',
     },
     {
       id: '2',
       content: 'another one',
-      blockId: '2',
     },
   ],
+  slug: 'quiz-slug',
+  history,
+  location,
 };
 
 test('it should display a placeholder quiz', () => {
@@ -95,6 +117,26 @@ test('clicking the button hides the quiz, shows the conclusion, and tracks the c
   wrapper.find('button').simulate('click');
 
   expect(tracker).toHaveBeenCalled();
+  expect(history.push).toHaveBeenCalledTimes(0);
   expect(wrapper.find(QuizQuestion)).toHaveLength(0);
   expect(wrapper.find('ContentfulEntry')).toHaveLength(1);
+});
+
+test('a winning quiz resultBlock causes a redirect to the new quiz', () => {
+  const tracker = jest.fn();
+
+  jsdom.reconfigure({
+    url: 'https://phoenix.test/us/campaigns/test-campaign/quiz/quiz-slug',
+  });
+
+  const wrapper = shallow(<Quiz trackEvent={tracker} {...props} />);
+
+  wrapper.setState({ choices: { 0: '1', 1: '1' } });
+
+  wrapper.find('button').simulate('click');
+
+  expect(history.push).toHaveBeenCalled();
+  expect(history.push.mock.calls[0][0]).toEqual(
+    '/us/campaigns/test-campaign/quiz/quiz-slug-2',
+  );
 });

--- a/resources/assets/components/Quiz/QuizContainer.js
+++ b/resources/assets/components/Quiz/QuizContainer.js
@@ -1,6 +1,7 @@
 import { connect } from 'react-redux';
+import { withRouter } from 'react-router';
 import { PuckConnector } from '@dosomething/puck-client';
 
 import Quiz from './Quiz';
 
-export default connect()(PuckConnector(Quiz));
+export default withRouter(connect()(PuckConnector(Quiz)));

--- a/resources/assets/components/Quiz/helpers.js
+++ b/resources/assets/components/Quiz/helpers.js
@@ -1,3 +1,5 @@
+import { find } from 'lodash';
+
 /**
  * Tally the amount of times a quiz result content and result block
  * have been opted for via a users choice selection for quiz questions, and
@@ -7,7 +9,7 @@
  * @param  {Array}   questions
  * @return {Object}
  */
-const calculateResult = (selections, questions) => {
+const calculateResult = (selections, questions, results, resultBlocks) => {
   const talliedResults = {};
   const talliedResultBlocks = {};
 
@@ -17,8 +19,8 @@ const calculateResult = (selections, questions) => {
     const selectedChoice = question.choices[selectedChoiceId];
 
     // increment the counter for each result of the selected choice
-    const results = selectedChoice.results;
-    results.forEach(
+    const resultIds = selectedChoice.results;
+    resultIds.forEach(
       resultId =>
         // ensuring a default value of zero for unset result properties
         (talliedResults[resultId] = (talliedResults[resultId] || 0) + 1),
@@ -37,13 +39,19 @@ const calculateResult = (selections, questions) => {
     (resultA, resultB) => talliedResults[resultB] - talliedResults[resultA],
   )[0];
 
+  const result = resultId ? find(results, { id: resultId }) : null;
+
   // sorts results by their selection counter in descending order
   const resultBlockId = Object.keys(talliedResultBlocks).sort(
     (blockA, blockB) =>
       talliedResultBlocks[blockB] - talliedResultBlocks[blockA],
   )[0];
 
-  return { resultId, resultBlockId };
+  const resultBlock = resultBlockId
+    ? find(resultBlocks, { id: resultBlockId })
+    : null;
+
+  return { result, resultBlock };
 };
 
 export default calculateResult;

--- a/resources/assets/components/Quiz/helpers.test.js
+++ b/resources/assets/components/Quiz/helpers.test.js
@@ -21,7 +21,13 @@ const questions = [
 
 const selections = { 0: '0', 1: '1' };
 
-test('it tallies the results and returns the one with the most selections', () => {
-  const expectedResult = { resultId: '1', resultBlockId: '1234' };
-  expect(calculateResult(selections, questions)).toEqual(expectedResult);
+const results = [{ id: '0' }, { id: '1' }, { id: '2' }];
+
+const resultBlocks = [{ id: '1234' }];
+
+test('it tallies the results and returns the ones with the most selections', () => {
+  const expectedResult = { result: results[1], resultBlock: resultBlocks[0] };
+  expect(calculateResult(selections, questions, results, resultBlocks)).toEqual(
+    expectedResult,
+  );
 });


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR adds the ability to set a Quiz as a potential `resultBlock` for a Quiz (for Logic jumping etc.).

- Added a bit of work to the `/helpers#calculateResult`, so that it finds the winning `resultBlock` and `result` and returns those rather than just the IDs. (also changed Quiz state to store them instead of IDs as well) [3457548](https://github.com/DoSomething/phoenix-next/commit/3457548915077f402f9499589908300a92052b30)
- Added a `quizResultBlockHandler` function which gets called on quiz completion, to see if the winning resultBlock is a Quiz, and if so, to redirect to that Quiz's `slug`. [78beff9](https://github.com/DoSomething/phoenix-next/commit/78beff91503ea7d304e24b8b8d5ec7f30dc88777)
  - tightened the `replace` logic a bit to ensure we only replace the quiz slug at the end of the URL [41639d9](https://github.com/DoSomething/phoenix-next/commit/41639d996771c61a213d986cae90783ff3cb12c9)
- update those tests! Including adding a new case for the quiz result block redirect, adding support for the location and history, and updating the helper's test for its new functionality [409ecbe](https://github.com/DoSomething/phoenix-next/commit/409ecbe7a326cc18594343c1cb5e0f7873c1166e)

### Any background context you want to provide?
I initially tried just adding another logic case to the `renderResult` function, but that was problematic since it gets called within the `render` function and thus React would cry if we'd redirect during a render, so I added the lil `quizResultBlockHandler` function to be called right before updating the `state` with the quiz results.

### What are the relevant tickets/cards?

Refs [Pivotal ID #157750196](https://www.pivotaltracker.com/story/show/157750196)

### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [x] Added appropriate feature/unit tests.

![jun-06-2018 14-33-46](https://user-images.githubusercontent.com/12417657/41058006-a84f6a0e-6996-11e8-9967-fd5afd504d61.gif)

