### PR TITLE
Updating the quiz to allow auto submitting if designated via Contentful.

### DIFF
--- a/app/Entities/Quiz.php
+++ b/app/Entities/Quiz.php
@@ -66,6 +66,7 @@ class Quiz extends Entity implements JsonSerializable
             'fields' => [
                 'title' => $this->title,
                 'slug' => $this->slug,
+                'autoSubmit' => $this->autoSubmit,
                 'results' => $this->parseResults($this->results),
                 'questions' => $this->parseQuestions($this->questions),
                 'resultBlocks' => $this->parseBlocks($this->resultBlocks),

--- a/resources/assets/components/Quiz/Quiz.js
+++ b/resources/assets/components/Quiz/Quiz.js
@@ -142,6 +142,7 @@ class Quiz extends React.Component {
 }
 
 Quiz.propTypes = {
+  autoSubmit: PropTypes.bool.isRequired,
   additionalContent: PropTypes.shape({
     callToAction: PropTypes.string.isRequired,
     introduction: PropTypes.string.isRequired,

--- a/resources/assets/components/Quiz/Quiz.js
+++ b/resources/assets/components/Quiz/Quiz.js
@@ -21,38 +21,84 @@ class Quiz extends React.Component {
         resultId: null,
         resultBlockId: null,
       },
+      showResults: false,
     };
-
-    this.selectChoice = this.selectChoice.bind(this);
   }
 
-  evaluateQuiz() {
+  componentDidUpdate() {
+    if (!this.props.autoSubmit) {
+      return;
+    }
+
+    if (!this.state.showResults && this.evaluateQuiz()) {
+      this.completeQuiz();
+    }
+  }
+
+  evaluateQuiz = () => {
     const questions = this.props.questions;
 
     return every(questions, question => !!this.state.choices[question.id]);
-  }
+  };
 
-  completeQuiz() {
+  completeQuiz = () => {
     if (this.evaluateQuiz()) {
       this.props.trackEvent('converted on quiz', {
         responses: this.state.choices,
       });
 
       const results = calculateResult(this.state.choices, this.props.questions);
+
       this.setState({ showResults: true, results });
     }
-  }
+  };
 
-  selectChoice(questionId, choiceId) {
+  selectChoice = (questionId, choiceId) => {
     this.setState({
       choices: {
         ...this.state.choices,
         [questionId]: choiceId,
       },
     });
-  }
+  };
 
-  renderResult() {
+  renderQuiz = () => {
+    const { questions } = this.props;
+
+    const { callToAction, introduction, submitButtonText } =
+      this.props.additionalContent || {};
+
+    return (
+      <React.Fragment>
+        {introduction}
+
+        {questions.map(question => (
+          <QuizQuestion
+            key={question.id}
+            id={question.id}
+            title={question.title}
+            choices={question.choices}
+            selectChoice={this.selectChoice}
+            activeChoiceId={this.state.choices[question.id]}
+          />
+        ))}
+
+        {this.props.autoSubmit ? null : (
+          <QuizConclusion callToAction={callToAction}>
+            <button
+              onClick={() => this.completeQuiz()}
+              className="button quiz__submit"
+              disabled={!this.evaluateQuiz()}
+            >
+              {submitButtonText || Quiz.defaultProps.submitButtonText}
+            </button>
+          </QuizConclusion>
+        )}
+      </React.Fragment>
+    );
+  };
+
+  renderResult = () => {
     const { resultBlocks, results } = this.props;
 
     const resultBlockId = this.state.results.resultBlockId;
@@ -79,50 +125,16 @@ class Quiz extends React.Component {
     }
 
     return <ContentfulEntry json={resultBlock} />;
-  }
+  };
 
   render() {
-    const { additionalContent, questions, title } = this.props;
-
-    const { callToAction, introduction, submitButtonText } =
-      additionalContent || {};
-
-    const { choices, showResults } = this.state;
-
     return (
       <Flex className="quiz">
         <FlexCell width="two-thirds">
           <h1 className="quiz__heading">Quiz</h1>
-          <h2 className="quiz__title">{title}</h2>
+          <h2 className="quiz__title">{this.props.title}</h2>
 
-          {showResults ? null : introduction}
-
-          {showResults
-            ? null
-            : questions.map(question => (
-                <QuizQuestion
-                  key={question.id}
-                  id={question.id}
-                  title={question.title}
-                  choices={question.choices}
-                  selectChoice={this.selectChoice}
-                  activeChoiceId={choices[question.id]}
-                />
-              ))}
-
-          {showResults ? (
-            this.renderResult()
-          ) : (
-            <QuizConclusion callToAction={callToAction}>
-              <button
-                onClick={() => this.completeQuiz()}
-                className="button quiz__submit"
-                disabled={!this.evaluateQuiz()}
-              >
-                {submitButtonText || Quiz.defaultProps.submitButtonText}
-              </button>
-            </QuizConclusion>
-          )}
+          {this.state.showResults ? this.renderResult() : this.renderQuiz()}
         </FlexCell>
       </Flex>
     );

--- a/resources/assets/components/Quiz/QuizChoice.js
+++ b/resources/assets/components/Quiz/QuizChoice.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import classnames from 'classnames';
 
 import Card from '../utilities/Card/Card';
+import { contentfulImageUrl } from '../../helpers';
 
 const QuizChoice = props => {
   const {
@@ -29,7 +30,10 @@ const QuizChoice = props => {
     >
       <Card className={cardClasses}>
         {backgroundImage ? (
-          <img src={backgroundImage} alt="quiz choice background" />
+          <img
+            src={contentfulImageUrl(backgroundImage, 300)}
+            alt="quiz choice background"
+          />
         ) : null}
         <p className="padding-md">{title}</p>
       </Card>


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_


### What does this PR do?

This PR updates the quiz to enable allowing Campaign Leads to select (via a toggle on Contentful) whether the quiz can be auto-submitted upon selecting a choice for the last question to be answered. Otherwise the classic submit button becomes disabled and allows the member to click to submit the quiz.

I also added a quick fix so that images in the question choices are sized down to a max width of 300 px wide. We weren't doing any resizing and using the images at their full size which is not good for performance!

![example](https://dzwonsemrish7.cloudfront.net/items/3X1W2G2v3N1C0y3r142N/Screen%20Recording%202018-06-06%20at%2003.13%20PM.gif?v=8bd239e0)

### What are the relevant tickets/cards?

Refs [Pivotal ID #157744645](https://www.pivotaltracker.com/story/show/157744645)

### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.
* [ ] Added screenshot to PR description of related front-end updates on **small** screens.
* [ ] Added screenshot to PR description of related front-end updates on **medium** screens.
* [ ] Added screenshot to PR description of related front-end updates on **large** screens.
