### PR TITLE
Add gating and signup conversion functionality to the Quiz

### DIFF
--- a/resources/assets/actions/event.js
+++ b/resources/assets/actions/event.js
@@ -1,7 +1,7 @@
 import * as actions from '../actions';
-import { isTimestampValid } from '../helpers';
-import { getArray, EVENT_STORAGE_KEY } from '../helpers/storage';
 import { isAuthenticated } from '../selectors/user';
+import { getArray, EVENT_STORAGE_KEY } from '../helpers/storage';
+import { isTimestampValid, contentfulImageUrl } from '../helpers';
 
 // Action: remove completed event from storage.
 export function completedEvent(index) {
@@ -52,7 +52,9 @@ export function queueEvent(actionCreatorName, ...args) {
       const { callToAction, coverImage, title } = getState().campaign;
 
       northstarOptions.title = encodeURIComponent(title);
-      northstarOptions.coverImage = coverImage.url;
+      northstarOptions.coverImage = encodeURIComponent(
+        contentfulImageUrl(coverImage.url, '800', '600', 'fill'),
+      );
       northstarOptions.callToAction = encodeURIComponent(callToAction);
     }
 

--- a/resources/assets/actions/signup.js
+++ b/resources/assets/actions/signup.js
@@ -171,12 +171,15 @@ export function clickedSignUp(
           // If Drupal denied our signup request, check if we already had a signup.
           dispatch(checkForSignup(campaignId));
         } else {
-          // Create signup and track any data before redirects.
-          dispatch(signupCreated(campaignId));
-
-          // Take user to the action page if campaign is open.
           const endDate = get(state.campaign.endDate, 'date', null);
           const isClosed = isCampaignClosed(endDate);
+
+          // Create signup and track any data before redirects.
+          dispatch(
+            signupCreated(campaignId, shouldRedirectToActionTab && !isClosed),
+          );
+
+          // Take user to the action page if campaign is open.
           if (shouldRedirectToActionTab && !isClosed) {
             dispatch({ type: OPENED_POST_SIGNUP_MODAL });
             dispatch(push(campaignActionUrl));

--- a/resources/assets/actions/signup.js
+++ b/resources/assets/actions/signup.js
@@ -141,7 +141,14 @@ export function clickedSignUp(
 
     // If the user is not logged in, handle this action later.
     if (!isAuthenticated(state)) {
-      return dispatch(queueEvent('clickedSignUp', campaignId, details));
+      return dispatch(
+        queueEvent(
+          'clickedSignUp',
+          campaignId,
+          details,
+          shouldRedirectToActionTab,
+        ),
+      );
     }
 
     // If we already have a signup, just go to the action page.

--- a/resources/assets/actions/signup.js
+++ b/resources/assets/actions/signup.js
@@ -26,7 +26,7 @@ import {
  */
 
 // Action: a new signup was created for a campaign.
-export function signupCreated(campaignId) {
+export function signupCreated(campaignId, shouldShowAffirmation = true) {
   return (dispatch, getState) => {
     const { user } = getState();
 
@@ -34,6 +34,7 @@ export function signupCreated(campaignId) {
       type: SIGNUP_CREATED,
       campaignId,
       userId: user.id,
+      shouldShowAffirmation,
     });
   };
 }

--- a/resources/assets/components/Quiz/Quiz.js
+++ b/resources/assets/components/Quiz/Quiz.js
@@ -1,29 +1,47 @@
+/* global window */
 import React from 'react';
-import { every } from 'lodash';
 import PropTypes from 'prop-types';
+import { find, every } from 'lodash';
 import ReactRouterPropTypes from 'react-router-prop-types';
 
-import calculateResult from './helpers';
+import { query } from '../../helpers';
 import { Flex, FlexCell } from '../Flex';
 import QuizQuestion from './QuizQuestion';
 import Share from '../utilities/Share/Share';
 import QuizConclusion from './QuizConclusion';
 import ContentfulEntry from '../ContentfulEntry';
 import ScrollConcierge from '../ScrollConcierge';
+import { calculateResult, resultsParam, appendResultParams } from './helpers';
 
 import './quiz.scss';
 
 class Quiz extends React.Component {
-  constructor() {
-    super();
+  constructor(props) {
+    super(props);
+
+    // grab state overrides from the query parameters
+    const resultId = query('resultId');
+    const resultBlockId = query('resultBlockId');
+    // Also ensuring user authentication before applying the showResults query param override
+    const showResults = query('showResults') && props.isAuthenticated;
+
+    // Scrub the result override parameter from the current URL
+    const scrubbedParam = window.location.search.replace(
+      resultsParam(resultId, resultBlockId),
+      '',
+    );
+    window.history.pushState(window.location.state, '', scrubbedParam);
+
+    const result = find(props.results, { id: resultId });
+    const resultBlock = find(props.resultBlocks, { id: resultBlockId });
 
     this.state = {
       choices: {},
       results: {
-        result: null,
-        resultBlock: null,
+        result,
+        resultBlock,
       },
-      showResults: false,
+      showResults,
     };
   }
 
@@ -44,22 +62,47 @@ class Quiz extends React.Component {
   };
 
   completeQuiz = () => {
-    if (this.evaluateQuiz()) {
-      this.props.trackEvent('converted on quiz', {
-        responses: this.state.choices,
-      });
-
-      const results = calculateResult(
-        this.state.choices,
-        this.props.questions,
-        this.props.results,
-        this.props.resultBlocks,
-      );
-
-      this.quizResultBlockHandler(results.resultBlock);
-
-      this.setState({ showResults: true, results });
+    // Ensure all quiz questions have been answered
+    if (!this.evaluateQuiz()) {
+      return;
     }
+
+    const {
+      trackEvent,
+      questions,
+      resultBlocks,
+      autoSubmit,
+      isAuthenticated,
+      clickedSignUp,
+      legacyCampaignId,
+    } = this.props;
+
+    const results = calculateResult(
+      this.state.choices,
+      questions,
+      this.props.results,
+      resultBlocks,
+    );
+
+    trackEvent('converted on quiz', {
+      responses: this.state.choices,
+    });
+
+    // Run a quiz conversion (campaign signup) if this quiz is not set to auto submit
+    if (!autoSubmit) {
+      if (!isAuthenticated) {
+        appendResultParams(results);
+
+        clickedSignUp(legacyCampaignId, null, false);
+        return;
+      }
+
+      clickedSignUp(legacyCampaignId, null, false);
+    }
+
+    this.quizResultBlockHandler(results.resultBlock);
+
+    this.setState({ showResults: true, results });
   };
 
   // If the winning resultBlock is a Quiz, navigates to the new resultBlock's slug
@@ -169,7 +212,10 @@ Quiz.propTypes = {
     introduction: PropTypes.string.isRequired,
     submitButtonText: PropTypes.string,
   }).isRequired,
+  clickedSignUp: PropTypes.func.isRequired,
   history: ReactRouterPropTypes.history.isRequired,
+  isAuthenticated: PropTypes.bool.isRequired,
+  legacyCampaignId: PropTypes.string.isRequired,
   location: ReactRouterPropTypes.location.isRequired,
   questions: PropTypes.arrayOf(
     PropTypes.shape({

--- a/resources/assets/components/Quiz/Quiz.js
+++ b/resources/assets/components/Quiz/Quiz.js
@@ -11,7 +11,7 @@ import Share from '../utilities/Share/Share';
 import QuizConclusion from './QuizConclusion';
 import ContentfulEntry from '../ContentfulEntry';
 import ScrollConcierge from '../ScrollConcierge';
-import { calculateResult, resultsParam, appendResultParams } from './helpers';
+import { calculateResult, resultParams, appendResultParams } from './helpers';
 
 import './quiz.scss';
 
@@ -27,7 +27,7 @@ class Quiz extends React.Component {
 
     // Scrub the result override parameter from the current URL
     const scrubbedParam = window.location.search.replace(
-      resultsParam(resultId, resultBlockId),
+      resultParam(resultId, resultBlockId),
       '',
     );
     window.history.pushState(window.location.state, '', scrubbedParam);

--- a/resources/assets/components/Quiz/Quiz.js
+++ b/resources/assets/components/Quiz/Quiz.js
@@ -91,9 +91,11 @@ class Quiz extends React.Component {
     // Run a quiz conversion (campaign signup) if this quiz is not set to auto submit
     if (!autoSubmit) {
       if (!isAuthenticated) {
+        // Append result and resultBlock IDs to URL, so that upon redirect from login flow, we can show their results
         appendResultParams(results);
 
         clickedSignUp(legacyCampaignId, null, false);
+        // Hard return so the results won't display before the login redirect
         return;
       }
 

--- a/resources/assets/components/Quiz/Quiz.js
+++ b/resources/assets/components/Quiz/Quiz.js
@@ -27,7 +27,7 @@ class Quiz extends React.Component {
 
     // Scrub the result override parameter from the current URL
     const scrubbedParam = window.location.search.replace(
-      resultParam(resultId, resultBlockId),
+      resultParams(resultId, resultBlockId),
       '',
     );
     window.history.pushState(window.location.state, '', scrubbedParam);

--- a/resources/assets/components/Quiz/Quiz.js
+++ b/resources/assets/components/Quiz/Quiz.js
@@ -19,7 +19,7 @@ class Quiz extends React.Component {
   constructor(props) {
     super(props);
 
-    // grab state overrides from the query parameters
+    // Grab state overrides from the query parameters
     const resultId = query('resultId');
     const resultBlockId = query('resultBlockId');
     // Also ensuring user authentication before applying the showResults query param override

--- a/resources/assets/components/Quiz/Quiz.test.js
+++ b/resources/assets/components/Quiz/Quiz.test.js
@@ -11,6 +11,10 @@ const history = createMemoryHistory();
 
 history.push = jest.fn();
 
+jsdom.reconfigure({
+  url: 'https://phoenix.test/us/campaigns/test-campaign/quiz/quiz-slug',
+});
+
 const sampleChoices = [
   {
     id: '0',
@@ -82,6 +86,9 @@ const props = {
   history,
   location,
   autoSubmit: false,
+  clickedSignUp: () => {},
+  isAuthenticated: true,
+  legacyCampaignId: '1',
 };
 
 test('it should display a placeholder quiz', () => {
@@ -125,10 +132,6 @@ test('clicking the button hides the quiz, shows the conclusion, and tracks the c
 
 test('a winning quiz resultBlock causes a redirect to the new quiz', () => {
   const tracker = jest.fn();
-
-  jsdom.reconfigure({
-    url: 'https://phoenix.test/us/campaigns/test-campaign/quiz/quiz-slug',
-  });
 
   const wrapper = shallow(<Quiz trackEvent={tracker} {...props} />);
 

--- a/resources/assets/components/Quiz/QuizContainer.js
+++ b/resources/assets/components/Quiz/QuizContainer.js
@@ -3,5 +3,25 @@ import { withRouter } from 'react-router';
 import { PuckConnector } from '@dosomething/puck-client';
 
 import Quiz from './Quiz';
+import { clickedSignUp } from '../../actions/signup';
+import { isAuthenticated } from '../../selectors/user';
 
-export default withRouter(connect()(PuckConnector(Quiz)));
+/**
+ * Provide state from the Redux store as props for this component.
+ */
+const mapStateToProps = state => ({
+  isAuthenticated: isAuthenticated(state),
+  legacyCampaignId: state.campaign.legacyCampaignId,
+});
+
+/**
+ * Provide pre-bound functions that allow the component to dispatch
+ * actions to the Redux store as props for this component.
+ */
+const actionCreators = {
+  clickedSignUp,
+};
+
+export default withRouter(
+  connect(mapStateToProps, actionCreators)(PuckConnector(Quiz)),
+);

--- a/resources/assets/components/Quiz/helpers.js
+++ b/resources/assets/components/Quiz/helpers.js
@@ -1,4 +1,5 @@
-import { find } from 'lodash';
+/* global window */
+import { find, get } from 'lodash';
 
 /**
  * Tally the amount of times a quiz result content and result block
@@ -9,7 +10,12 @@ import { find } from 'lodash';
  * @param  {Array}   questions
  * @return {Object}
  */
-const calculateResult = (selections, questions, results, resultBlocks) => {
+export const calculateResult = (
+  selections,
+  questions,
+  results,
+  resultBlocks,
+) => {
   const talliedResults = {};
   const talliedResultBlocks = {};
 
@@ -54,4 +60,16 @@ const calculateResult = (selections, questions, results, resultBlocks) => {
   return { result, resultBlock };
 };
 
-export default calculateResult;
+export const resultsParam = (resultId, resultBlockId) =>
+  `resultId=${resultId}&resultBlockId=${resultBlockId}&showResults=true`;
+
+export const appendResultParams = results => {
+  const resultId = get(results, 'result.id');
+  const resultBlockId = get(results, 'resultBlock.id');
+
+  // Add result params to persist the quiz results to follow an unauthenticated user login flow
+  const params = window.location.search ? `${window.location.search}&` : '?';
+  const quizResultParams = params + resultsParam(resultId, resultBlockId);
+
+  window.history.pushState(window.history.state, '', quizResultParams);
+};

--- a/resources/assets/components/Quiz/helpers.js
+++ b/resources/assets/components/Quiz/helpers.js
@@ -60,7 +60,7 @@ export const calculateResult = (
   return { result, resultBlock };
 };
 
-export const resultsParam = (resultId, resultBlockId) =>
+export const resultParams = (resultId, resultBlockId) =>
   `resultId=${resultId}&resultBlockId=${resultBlockId}&showResults=true`;
 
 export const appendResultParams = results => {

--- a/resources/assets/components/Quiz/helpers.js
+++ b/resources/assets/components/Quiz/helpers.js
@@ -69,7 +69,7 @@ export const appendResultParams = results => {
 
   // Add result params to persist the quiz results to follow an unauthenticated user login flow
   const params = window.location.search ? `${window.location.search}&` : '?';
-  const quizResultParams = params + resultsParam(resultId, resultBlockId);
+  const quizResultParams = params + resultParams(resultId, resultBlockId);
 
   window.history.pushState(window.history.state, '', quizResultParams);
 };

--- a/resources/assets/components/Quiz/helpers.test.js
+++ b/resources/assets/components/Quiz/helpers.test.js
@@ -1,4 +1,4 @@
-import calculateResult from './helpers';
+import { calculateResult } from './helpers';
 
 const questions = [
   {

--- a/resources/assets/helpers/index.js
+++ b/resources/assets/helpers/index.js
@@ -420,7 +420,7 @@ export function makeUrl(path, queryParameters) {
  *
  * @param  {String}   key
  * @param  {URL|Location}   url
- * @return {String}
+ * @return {String|Undefined}
  */
 export function query(key, url = window.location) {
   // Ensure we have a URL object from the location.

--- a/resources/assets/reducers/signups.js
+++ b/resources/assets/reducers/signups.js
@@ -30,7 +30,7 @@ const signupReducer = (state = {}, action) => {
         data: signups,
         isPending: false,
         thisCampaign: true,
-        shouldShowAffirmation: true,
+        shouldShowAffirmation: action.shouldShowAffirmation,
         total: state.total + 1,
       };
 


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR adds functionality to auto signup users on quiz submission (for non auto-submit quizzes), as well as support to ensure unauthenticated users can see their quiz result after going through the Northstar authentication flow.

### background context:
There are some moving parts to this, so I'll attempt to summarize what in tarnation is going on here:

#### ⚜️Our Task 
<image src="https://user-images.githubusercontent.com/12417657/41127185-07cdadf6-6a78-11e8-88a5-5ac40d348825.jpg" width="40%" />
We want to auto sign-up users for the current campaign when they submit a completed quiz. 
The simple idea is that In the `completeQuiz` function - if the Quiz is not set to `autoSubmit`- (we don't want to auto sign up users for a quiz if there is no explicit submit button with some context) - than we will sign up the user for the current campaign before showing them their quiz results. 

#### ⚜️It's complicated 😬 
<image src="https://user-images.githubusercontent.com/12417657/41128383-0080016c-6a7c-11e8-844d-2269531ce01a.jpg" width="40%"/>

This becomes slightly complicated for unauthenticated users -- who in order to be signed up for the campaign need to first go through the login flow on Northstar, which means they're leaving our domain with only the [current URL](https://github.com/DoSomething/phoenix-next/blob/quiz-gating-and-signup-conversion/app/Http/Controllers/AuthController.php#L47) to guide them back. Once they're redirected back to the quiz it just starts over and they need to re-take the quiz to see their results. LAME.

#### ⚜️Diego's bright idea 💡 
<image src="https://user-images.githubusercontent.com/12417657/41128440-2cecfa8e-6a7c-11e8-8009-03728c090621.gif" width="40%" />
@weerd helped (well, more like I helped, he did) craft a solution whereby - before we trigger the signup - we equip the current URL with some helpful query parameters based on the results they should be seeing. Then we can simply check the query params whenever we render a Quiz and alter the state accordingly! Setting the appropriate `result` and `resultBlock` and then scrubbing the URL of these extra params.

I also had to finagle the `signupCreated` action and reducer to ensure that we wouldn't be popping up a post signup affirmation modal and ruining the zen. (This is something that may require some more refactoring/discussion as there seems to be an `OPENED_POST_SIGNUP_MODAL` action type hanging about which'd trigger the affirmation modal, as well as the `shouldShowAffirmation` being set from the `signupCreated` reducer case).

#### ⚜️Matt 🖖 
<image src="https://user-images.githubusercontent.com/12417657/41129235-1a0b701e-6a7f-11e8-8ad4-7e10aaeebd81.png" />
We also snuck in a fix for an issue @mshmsh5000 flagged regarding us not formatting the cover image URL passed from campaigns to Northstar for login flow, causing Yuge images to be rendered on Login pages [21088ee](https://github.com/DoSomething/phoenix-next/commit/21088ee14448ed7efe870c7c9ec406c7812d256f)

[Slack convo](https://dosomething.slack.com/archives/C2BPA7M8F/p1528408079000550)


### What are the relevant tickets/cards?

Refs [Pivotal ID #157751720](https://www.pivotaltracker.com/story/show/157751720)

![jun-07-2018 18-26-13](https://user-images.githubusercontent.com/12417657/41129541-8f45bf00-6a80-11e8-81e6-a70aa63a051f.gif)

