### PR TITLE
Quick fix for the Quiz constructor

### DIFF
--- a/resources/assets/components/Quiz/Quiz.js
+++ b/resources/assets/components/Quiz/Quiz.js
@@ -30,7 +30,7 @@ class Quiz extends React.Component {
       resultParams(resultId, resultBlockId),
       '',
     );
-    window.history.pushState(window.location.state, '', scrubbedParam);
+    window.history.replaceState(window.location.state, '', scrubbedParam);
 
     const result = find(props.results, { id: resultId });
     const resultBlock = find(props.resultBlocks, { id: resultBlockId });


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_


### What does this PR do?

This PR will adjust our Quiz URL scrubbing method to use `replaceState` instead of `pushState` so that if we are indeed scrubbing params from the URL, the user won't be stuck in a history loop. (where you'd click back, hit the old URL with the params, but then we'd scrub them again pushing you forward......)