### PR TITLE
Filter out action page if campaign is closed

### DIFF
--- a/resources/assets/components/CampaignPageNavigation/CampaignPageNavigation.js
+++ b/resources/assets/components/CampaignPageNavigation/CampaignPageNavigation.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
+import { isActionPage } from '../../helpers';
 import { prepareCampaignPageSlug } from '../../helpers/campaign';
 import PageNavigation from '../utilities/PageNavigation/PageNavigation';
 import SignupButtonContainer from '../SignupButton/SignupButtonContainer';
@@ -16,9 +17,6 @@ const CampaignPageNavigation = ({
   if (isLegacyTemplate) {
     return null;
   }
-
-  const isActionPage = page =>
-    page.type === 'page' && page.fields.slug.endsWith('action');
 
   const linkablePages = pages
     .filter(page => page.type === 'page')

--- a/resources/assets/components/CampaignPageNavigation/CampaignPageNavigation.js
+++ b/resources/assets/components/CampaignPageNavigation/CampaignPageNavigation.js
@@ -17,11 +17,16 @@ const CampaignPageNavigation = ({
     return null;
   }
 
+  const isActionPage = page =>
+    page.type === 'page' && page.fields.slug.endsWith('action');
+
   const linkablePages = pages
     .filter(page => page.type === 'page')
     // @TODO: we want to eventually remove the need for hideFromNavigation field
     // in favor of always linking to pages referenced in the `pages` field.
-    .filter(page => !page.fields.hideFromNavigation);
+    .filter(page => !page.fields.hideFromNavigation)
+    // Remove action page from navigaition list if campaign is closed.
+    .filter(page => !isCampaignClosed || !isActionPage(page));
 
   let campaignPages = linkablePages.map(page => ({
     id: page.id,
@@ -38,9 +43,7 @@ const CampaignPageNavigation = ({
     });
   }
 
-  const hasActionPage = pages.find(
-    page => page.type === 'page' && page.fields.slug.endsWith('action'),
-  );
+  const hasActionPage = pages.find(page => isActionPage(page));
 
   // Conditional whether to include Action page.
   if (campaignPages.length && !isCampaignClosed && !hasActionPage) {

--- a/resources/assets/helpers/index.js
+++ b/resources/assets/helpers/index.js
@@ -651,3 +651,13 @@ export function withoutNulls(data) {
 export function withoutUndefined(data) {
   return omitBy(data, isUndefined);
 }
+
+/**
+ * Determine if a page is an 'Action' page.
+ *
+ * @param  {Object} dpage
+ * @return {Boolean}
+ */
+export function isActionPage(page) {
+  return page.type === 'page' && page.fields.slug.endsWith('action');
+}


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR ensures that any Action Page would be filtered out of the Campaign Page Navigation when a campaign is closed

### Any background context you want to provide?
Last bit of work to ensure we're all set up for the grand Action Page Migration™£¢¡∞§¶£ºª 

### What are the relevant tickets/cards?

Refs [Pivotal ID #156771690](https://www.pivotaltracker.com/story/show/156771690)
