### PR TITLE
Action Page Transformation Script Addendum

### DIFF
--- a/contentful/management-api-scripts/2018_05_01_001_transform_campaign_action_steps_to_action_page.js
+++ b/contentful/management-api-scripts/2018_05_01_001_transform_campaign_action_steps_to_action_page.js
@@ -4,6 +4,7 @@ const { contentManagementClient } = require('./contentManagementClient');
 const {
   attempt,
   constants,
+  convertNumberToWord,
   createLogger,
   getField,
   processEntries,
@@ -67,7 +68,7 @@ async function addActionPageFromActionSteps(environment, campaign) {
 
       // If the action step is meant to have a step number attached, we'll manually add it as the superTitle
       if (hideStepNumber == null || !hideStepNumber) {
-        superTitle = `Step ${stepIndex}`;
+        superTitle = `Step ${convertNumberToWord(stepIndex)}`;
       }
 
       if (!content) {

--- a/contentful/management-api-scripts/helpers.js
+++ b/contentful/management-api-scripts/helpers.js
@@ -3,6 +3,36 @@ const winston = require('winston');
 
 const LOCALE = 'en-US';
 
+// Convert an int to a string. (Supports 0-10)
+function convertNumberToWord(number) {
+  switch (number) {
+    case 0:
+      return 'zero';
+    case 1:
+      return 'one';
+    case 2:
+      return 'two';
+    case 3:
+      return 'three';
+    case 4:
+      return 'four';
+    case 5:
+      return 'five';
+    case 6:
+      return 'six';
+    case 7:
+      return 'seven';
+    case 8:
+      return 'eight';
+    case 9:
+      return 'nine';
+    case 10:
+      return 'ten';
+    default:
+      throw new Error('Number out of range');
+  }
+}
+
 function sleep(ms) {
   return new Promise(resolve => setTimeout(resolve, ms));
 }
@@ -92,6 +122,7 @@ module.exports = {
   processEntries,
   createLogger,
   withFields,
+  convertNumberToWord,
   constants: {
     LOCALE,
   },


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR adds a quick fix to the Action Page transformation script

- adds `convertNumberToWord` helper method and uses it to properly set newly created content blocks `preTitle`s

### Any background context you want to provide?
We, unfortunately, can't use the existing helper method since it's in a NodeJS incompatible file so I figured I'd copy it over into the management-api-scripts local helpers file. 
If you think it's overkill, we can just paste it into the actual action page script file and call it a day

### What are the relevant tickets/cards?

Refs [Pivotal ID #156771690](https://www.pivotaltracker.com/story/show/156771690)