### PR TITLE
Add SocialOverride functionality for Pages

### DIFF
--- a/app/Entities/Page.php
+++ b/app/Entities/Page.php
@@ -62,6 +62,7 @@ class Page extends Entity implements JsonSerializable
                 // @TODO: we want to eventually remove the need for hideFromNavigation field
                 // in favor of always linking to pages referenced in the `pages` field.
                 'hideFromNavigation' => $this->hideFromNavigation,
+                'socialOverride' => $this->socialOverride ? new SocialOverride($this->socialOverride->entry) : null,
             ],
         ];
     }

--- a/app/Http/Controllers/CampaignController.php
+++ b/app/Http/Controllers/CampaignController.php
@@ -53,7 +53,7 @@ class CampaignController extends Controller
             'campaign' => $campaign,
             // We render social metatags server-side because Facebook & Twitter
             // do not render JavaScript when crawling pages like Google does.
-            'socialFields' => get_social_fields($campaign, $request->url()),
+            'socialFields' => get_campaign_social_fields($campaign, $request->url()),
         ])->with('state', [
             'campaign' => $campaign,
         ]);

--- a/app/Http/Controllers/PageController.php
+++ b/app/Http/Controllers/PageController.php
@@ -34,7 +34,9 @@ class PageController extends Controller
     {
         $page = $this->pageRepository->findBySlug($slug);
 
-        return view('app')->with('state', [
+        return view('app', [
+            'socialFields' => get_social_fields($page),
+        ])->with('state', [
             'page' => $page,
         ]);
     }

--- a/app/Repositories/PageRepository.php
+++ b/app/Repositories/PageRepository.php
@@ -28,7 +28,7 @@ class PageRepository
      * Find a page by its slug.
      *
      * @param  string $slug
-     * @return object
+     * @return \Contentful\Delivery\DynamicEntry
      * @throws \Illuminate\Database\Eloquent\ModelNotFoundException
      */
     public function findBySlug($slug)

--- a/app/Repositories/PageRepository.php
+++ b/app/Repositories/PageRepository.php
@@ -28,7 +28,7 @@ class PageRepository
      * Find a page by its slug.
      *
      * @param  string $slug
-     * @return stdClass
+     * @return object
      * @throws \Illuminate\Database\Eloquent\ModelNotFoundException
      */
     public function findBySlug($slug)

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -279,7 +279,7 @@ function get_social_fields($entry)
     if (! $socialOverride) {
         return;
     }
- 
+    
     return [
         'title' => $socialOverride->title,
         'callToAction' => $socialOverride->callToAction,

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -262,7 +262,7 @@ function useOverrideIfSet($field, $base, $override)
 /**
  * Determine the fields to display in the social share.
  *
- * @param  stdClass|object $entry
+ * @param  \Contentful\Delivery\DynamicEntry|stdClass $entry
  * @return array|null
  */
 function get_social_fields($entry)

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -279,7 +279,7 @@ function get_social_fields($entry)
     if (! $socialOverride) {
         return;
     }
-    
+
     return [
         'title' => $socialOverride->title,
         'callToAction' => $socialOverride->callToAction,

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -262,11 +262,39 @@ function useOverrideIfSet($field, $base, $override)
 /**
  * Determine the fields to display in the social share.
  *
+ * @param  stdClass $entry
+ * @return array|null
+ */
+function get_social_fields($entry)
+{
+    if (get_class($entry) === 'stdClass') {
+        $socialOverride = object_get($entry->fields, 'socialOverride.fields');
+    } else {
+        $socialOverride = $entry->socialOverride;
+        $socialOverride->coverImage = get_image_url($socialOverride->coverImage, 'landscape');
+    }
+
+    if (!$socialOverride) {
+        return;
+    }
+ 
+    return [
+        'title' => $socialOverride->title,
+        'callToAction' => $socialOverride->callToAction,
+        'coverImage' => $socialOverride->coverImage,
+        'facebookAppId' => config('services.analytics.facebook_id'),
+        'quote' => $socialOverride->quote,  
+    ];
+}
+
+/**
+ * Determine the fields to display in the social share for a campaign.
+ *
  * @param  stdClass $campaign
  * @param  string   $uri
  * @return array
  */
-function get_social_fields($campaign, $uri)
+function get_campaign_social_fields($campaign, $uri)
 {
     $socialOverride = $campaign->socialOverride ? $campaign->socialOverride->fields : null;
     $blockPath = $campaign->slug . '/blocks';

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -274,7 +274,7 @@ function get_social_fields($entry)
         $socialOverride->coverImage = get_image_url($socialOverride->coverImage, 'landscape');
     }
 
-    if (!$socialOverride) {
+    if (! $socialOverride) {
         return;
     }
  
@@ -283,7 +283,7 @@ function get_social_fields($entry)
         'callToAction' => $socialOverride->callToAction,
         'coverImage' => $socialOverride->coverImage,
         'facebookAppId' => config('services.analytics.facebook_id'),
-        'quote' => $socialOverride->quote,  
+        'quote' => $socialOverride->quote,
     ];
 }
 

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -262,13 +262,15 @@ function useOverrideIfSet($field, $base, $override)
 /**
  * Determine the fields to display in the social share.
  *
- * @param  stdClass $entry
+ * @param  stdClass|object $entry
  * @return array|null
  */
 function get_social_fields($entry)
 {
+    // If this is an Entry which has been cast as JSON and thus completely JSON serialized.
     if (get_class($entry) === 'stdClass') {
         $socialOverride = object_get($entry->fields, 'socialOverride.fields');
+    // Otherwise, It should be a non-cast Contentful Entity object.
     } else {
         $socialOverride = $entry->socialOverride;
         $socialOverride->coverImage = get_image_url($socialOverride->coverImage, 'landscape');

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -267,6 +267,8 @@ function useOverrideIfSet($field, $base, $override)
  */
 function get_social_fields($entry)
 {
+    // @TODO We'll want to re-assess the following once we re-work caching Contentful queries.
+
     // If this is an Entry which has been cast as JSON and thus completely JSON serialized.
     if (get_class($entry) === 'stdClass') {
         $socialOverride = object_get($entry->fields, 'socialOverride.fields');


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR enables `socialOverride` functionality for General Pages (guides/articles/static-pages)

- adds `socialOverride` field to the `Page` Entity's `jsonSerialize`
- adds a general `get_social_fields` helper method for Contentful entries / changes the campaign-specific method name to `get_campaign_social_fields`
- sets the `socialFields` variable when rendering a page from the `PageController` using the `get_social_fields` helper method

### Any background context you want to provide?
The `get_social_fields` helper is pretty specific to campaigns, so switched up the naming to make room for this more general `get_social_fields` method.

I ran into some issues since contrary to the [`CampaignRepository#findBySlug`](https://github.com/DoSomething/phoenix-next/blob/page-social-override/app/Repositories/CampaignRepository.php#L168), in the [`PageRepository#findBySlug`](https://github.com/DoSomething/phoenix-next/blob/page-social-override/app/Repositories/PageRepository.php#L48) we're not returning the JSON `encode/decode`d object. But being that we probably might end up adding caching in the near future, it felt like a good idea to enable this `get_social_fields` method to comply with either the decoded object or a `DynamicEntry` (Which is the current case with Pages)

### What are the relevant tickets/cards?

Refs [Pivotal ID #158163700](https://www.pivotaltracker.com/story/show/158163700)
