### PR TITLE
Hide question number quiz

### DIFF
--- a/app/Entities/Quiz.php
+++ b/app/Entities/Quiz.php
@@ -70,6 +70,7 @@ class Quiz extends Entity implements JsonSerializable
                 'results' => $this->parseResults($this->results),
                 'questions' => $this->parseQuestions($this->questions),
                 'resultBlocks' => $this->parseBlocks($this->resultBlocks),
+                'hideQuestionNumber' => $this->hideQuestionNumber,
                 'additionalContent' => $this->additionalContent,
             ],
         ];

--- a/contentful/migrations/2018_06_12_002_add_hide_question_number_to_quiz.js
+++ b/contentful/migrations/2018_06_12_002_add_hide_question_number_to_quiz.js
@@ -1,0 +1,12 @@
+module.exports = function(migration) {
+  const quiz = migration.editContentType('quiz');
+
+  quiz
+    .createField('hideQuestionNumber')
+    .name('Hide Question Number')
+    .type('Boolean')
+    .required(false)
+    .localized(false);
+
+  quiz.moveField('hideQuestionNumber').afterField('autoSubmit');
+};

--- a/resources/assets/components/Quiz/Quiz.js
+++ b/resources/assets/components/Quiz/Quiz.js
@@ -134,7 +134,7 @@ class Quiz extends React.Component {
   };
 
   renderQuiz = () => {
-    const { questions } = this.props;
+    const { questions, hideQuestionNumber } = this.props;
 
     const { callToAction, introduction, submitButtonText } =
       this.props.additionalContent || {};
@@ -150,6 +150,7 @@ class Quiz extends React.Component {
             title={question.title}
             choices={question.choices}
             selectChoice={this.selectChoice}
+            hideQuestionNumber={hideQuestionNumber}
             activeChoiceId={this.state.choices[question.id]}
           />
         ))}
@@ -234,12 +235,14 @@ Quiz.propTypes = {
   ).isRequired,
   resultBlocks: PropTypes.arrayOf(PropTypes.object),
   slug: PropTypes.string.isRequired,
+  hideQuestionNumber: PropTypes.bool,
   title: PropTypes.string.isRequired,
   trackEvent: PropTypes.func.isRequired,
 };
 
 Quiz.defaultProps = {
   resultBlocks: null,
+  hideQuestionNumber: false,
   submitButtonText: 'Get Results',
 };
 

--- a/resources/assets/components/Quiz/QuizQuestion.js
+++ b/resources/assets/components/Quiz/QuizQuestion.js
@@ -6,7 +6,14 @@ import SectionHeader from '../SectionHeader';
 import { convertNumberToWord } from '../../helpers';
 
 const QuizQuestion = props => {
-  const { activeChoiceId, choices, id, selectChoice, title } = props;
+  const {
+    activeChoiceId,
+    choices,
+    hideQuestionNumber,
+    id,
+    selectChoice,
+    title,
+  } = props;
 
   const quizChoices = choices.map(choice => (
     <QuizChoice
@@ -19,13 +26,13 @@ const QuizQuestion = props => {
     />
   ));
 
+  const preTitle = hideQuestionNumber
+    ? null
+    : `Question ${convertNumberToWord(Number(id) + 1)}`;
+
   return (
     <div className="question">
-      <SectionHeader
-        preTitle={`Question ${convertNumberToWord(Number(id) + 1)}`}
-        title={title}
-        hideStepNumber
-      />
+      <SectionHeader preTitle={preTitle} title={title} hideStepNumber />
       <div className="question__choices">{quizChoices}</div>
     </div>
   );
@@ -36,11 +43,13 @@ QuizQuestion.propTypes = {
   choices: PropTypes.arrayOf(PropTypes.object).isRequired,
   id: PropTypes.string.isRequired,
   selectChoice: PropTypes.func.isRequired,
+  hideQuestionNumber: PropTypes.bool,
   title: PropTypes.string.isRequired,
 };
 
 QuizQuestion.defaultProps = {
   activeChoiceId: null,
+  hideQuestionNumber: false,
 };
 
 export default QuizQuestion;


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR adds a `hideQuestionNumber` toggle to the quiz to enable hiding the `preTitle` on `QuizQuestions`s with the `Question #`.

### Any background context you want to provide?
This is especially useful for logic jumped / nested quizzes where the question numbers would awkwardly begin again from 1

### What are the relevant tickets/cards?

Refs [Pivotal ID #158307276](https://www.pivotaltracker.com/story/show/158307276)


![image](https://user-images.githubusercontent.com/12417657/41357355-fa7656be-6ef3-11e8-9282-038c8e89fb03.png)
