### PR TITLE
Using campaign sub page to render the quiz with lede banner.

### DIFF
--- a/resources/assets/components/LedeBanner/templates/MosaicTemplate.js
+++ b/resources/assets/components/LedeBanner/templates/MosaicTemplate.js
@@ -17,6 +17,7 @@ const MosaicTemplate = props => {
     affiliatedActionText,
     affiliatedActionLink,
     affiliateSponsors,
+    displaySignup,
     title,
     subtitle,
     blurb,
@@ -35,7 +36,7 @@ const MosaicTemplate = props => {
     )})`,
   };
 
-  const signupButton = (
+  const signupButton = displaySignup ? (
     <div className="mosaic-lede-banner__signup">
       <SignupButton
         className={classnames({ '-float': affiliateSponsors.length })}
@@ -49,7 +50,7 @@ const MosaicTemplate = props => {
       ) : null}
       {showPartnerMsgOptIn ? <AffiliateOptionContainer /> : null}
     </div>
-  );
+  ) : null;
 
   const actionButton = affiliatedActionLink ? (
     <div className="mosaic-lede-banner__signup">
@@ -108,6 +109,7 @@ MosaicTemplate.propTypes = {
     description: PropTypes.string,
     url: PropTypes.string,
   }).isRequired,
+  displaySignup: PropTypes.bool,
   isAffiliated: PropTypes.bool.isRequired,
   subtitle: PropTypes.string.isRequired,
   title: PropTypes.string.isRequired,
@@ -119,6 +121,7 @@ MosaicTemplate.defaultProps = {
   affiliatedActionText: null,
   affiliatedActionLink: null,
   blurb: null,
+  displaySignup: true,
   showPartnerMsgOptIn: false,
   signupArrowContent: null,
 };

--- a/resources/assets/components/Quiz/Quiz.js
+++ b/resources/assets/components/Quiz/Quiz.js
@@ -193,6 +193,12 @@ class Quiz extends React.Component {
   render() {
     return (
       <Flex className="quiz">
+        {/*
+          @TODO: removed the ScrollConcierge because with the lede banner, the scroll would
+          always go past the banner to the content of the quiz. Initially, added so after a
+          potential logic jump with nested quiz, the quiz would scroll back up to see the
+          first question in the next, connected quiz. Need to find a better solution.
+        */}
         <FlexCell width="two-thirds">
           <h1 className="quiz__heading">Quiz</h1>
           <h2 className="quiz__title">{this.props.title}</h2>

--- a/resources/assets/components/Quiz/Quiz.js
+++ b/resources/assets/components/Quiz/Quiz.js
@@ -10,7 +10,6 @@ import QuizQuestion from './QuizQuestion';
 import Share from '../utilities/Share/Share';
 import QuizConclusion from './QuizConclusion';
 import ContentfulEntry from '../ContentfulEntry';
-import ScrollConcierge from '../ScrollConcierge';
 import { calculateResult, resultParams, appendResultParams } from './helpers';
 
 import './quiz.scss';
@@ -194,8 +193,6 @@ class Quiz extends React.Component {
   render() {
     return (
       <Flex className="quiz">
-        <ScrollConcierge />
-
         <FlexCell width="two-thirds">
           <h1 className="quiz__heading">Quiz</h1>
           <h2 className="quiz__title">{this.props.title}</h2>
@@ -211,7 +208,7 @@ Quiz.propTypes = {
   autoSubmit: PropTypes.bool.isRequired,
   additionalContent: PropTypes.shape({
     callToAction: PropTypes.string.isRequired,
-    introduction: PropTypes.string.isRequired,
+    introduction: PropTypes.string,
     submitButtonText: PropTypes.string,
   }).isRequired,
   clickedSignUp: PropTypes.func.isRequired,
@@ -239,6 +236,9 @@ Quiz.propTypes = {
 };
 
 Quiz.defaultProps = {
+  additionalContent: {
+    introduction: null,
+  },
   resultBlocks: null,
   submitButtonText: 'Get Results',
 };

--- a/resources/assets/components/pages/CampaignPage/CampaignPage.js
+++ b/resources/assets/components/pages/CampaignPage/CampaignPage.js
@@ -80,7 +80,7 @@ const CampaignPage = props => {
 
           <Route
             path={join(match.url, 'quiz/:slug')}
-            component={BlockPageContainer}
+            component={CampaignSubPageContainer}
           />
 
           {/* @deprecate: remove this Route specification with `/pages/:slug` */}

--- a/resources/assets/components/pages/CampaignSubPage/CampaignSubPage.js
+++ b/resources/assets/components/pages/CampaignSubPage/CampaignSubPage.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import Enclosure from '../../Enclosure';
+import ContentfulEntry from '../../ContentfulEntry';
 import { CallToActionContainer } from '../../CallToAction';
 import CampaignSubPageContent from './CampaignSubPageContent';
 import DashboardContainer from '../../Dashboard/DashboardContainer';
@@ -15,19 +16,31 @@ import './campaign-subpage.scss';
  *
  * @returns {XML}
  */
-const CampaignSubPage = props => (
-  <div>
-    <LedeBannerContainer />
-    <div className="main clearfix">
-      {props.dashboard ? <DashboardContainer /> : null}
-      <CampaignPageNavigationContainer />
-      <Enclosure className="default-container margin-top-lg margin-bottom-lg">
-        <CampaignSubPageContent {...props} />
-      </Enclosure>
-      <CallToActionContainer sticky hideIfSignedUp />
+const CampaignSubPage = props => {
+  // @TODO: after Action page migration, determine a better solution (Page has own gate toggle? etc).
+  const displaySignup = !props.json ? true : false; // eslint-disable-line no-unneeded-ternary
+
+  return (
+    <div>
+      <LedeBannerContainer displaySignup={displaySignup} />
+      <div className="main clearfix">
+        {props.dashboard ? <DashboardContainer /> : null}
+
+        {!props.json ? <CampaignPageNavigationContainer /> : null}
+
+        <Enclosure className="default-container margin-top-lg margin-bottom-lg">
+          {/* @TODO: after Action page migration, refactor and combine CampaignPage & CampaignSubPage and render Contentful Entry within CampaignPage component */}
+          {!props.json ? (
+            <CampaignSubPageContent {...props} />
+          ) : (
+            <ContentfulEntry json={props.json} />
+          )}
+        </Enclosure>
+        <CallToActionContainer sticky hideIfSignedUp />
+      </div>
     </div>
-  </div>
-);
+  );
+};
 
 CampaignSubPage.propTypes = {
   dashboard: PropTypes.shape({
@@ -35,10 +48,12 @@ CampaignSubPage.propTypes = {
     type: PropTypes.string,
     fields: PropTypes.object,
   }),
+  json: PropTypes.object, // eslint-disable-line react/forbid-prop-types
 };
 
 CampaignSubPage.defaultProps = {
   dashboard: null,
+  json: null,
 };
 
 export default CampaignSubPage;

--- a/resources/assets/components/pages/CampaignSubPage/CampaignSubPage.js
+++ b/resources/assets/components/pages/CampaignSubPage/CampaignSubPage.js
@@ -16,31 +16,26 @@ import './campaign-subpage.scss';
  *
  * @returns {XML}
  */
-const CampaignSubPage = props => {
-  // @TODO: after Action page migration, determine a better solution (Page has own gate toggle? etc).
-  const displaySignup = !props.json ? true : false; // eslint-disable-line no-unneeded-ternary
+const CampaignSubPage = props => (
+  <div>
+    <LedeBannerContainer displaySignup={Boolean(props.entryContent)} />
+    <div className="main clearfix">
+      {props.dashboard ? <DashboardContainer /> : null}
 
-  return (
-    <div>
-      <LedeBannerContainer displaySignup={displaySignup} />
-      <div className="main clearfix">
-        {props.dashboard ? <DashboardContainer /> : null}
+      {!props.entryContent ? <CampaignPageNavigationContainer /> : null}
 
-        {!props.json ? <CampaignPageNavigationContainer /> : null}
-
-        <Enclosure className="default-container margin-top-lg margin-bottom-lg">
-          {/* @TODO: after Action page migration, refactor and combine CampaignPage & CampaignSubPage and render Contentful Entry within CampaignPage component */}
-          {!props.json ? (
-            <CampaignSubPageContent {...props} />
-          ) : (
-            <ContentfulEntry json={props.json} />
-          )}
-        </Enclosure>
-        <CallToActionContainer sticky hideIfSignedUp />
-      </div>
+      <Enclosure className="default-container margin-top-lg margin-bottom-lg">
+        {/* @TODO: after Action page migration, refactor and combine CampaignPage & CampaignSubPage and render Contentful Entry within CampaignPage component */}
+        {!props.entryContent ? (
+          <CampaignSubPageContent {...props} />
+        ) : (
+          <ContentfulEntry entryContent={props.entryContent} />
+        )}
+      </Enclosure>
+      <CallToActionContainer sticky hideIfSignedUp />
     </div>
-  );
-};
+  </div>
+);
 
 CampaignSubPage.propTypes = {
   dashboard: PropTypes.shape({
@@ -48,12 +43,12 @@ CampaignSubPage.propTypes = {
     type: PropTypes.string,
     fields: PropTypes.object,
   }),
-  json: PropTypes.object, // eslint-disable-line react/forbid-prop-types
+  entryContent: PropTypes.object, // eslint-disable-line react/forbid-prop-types
 };
 
 CampaignSubPage.defaultProps = {
   dashboard: null,
-  json: null,
+  entryContent: null,
 };
 
 export default CampaignSubPage;

--- a/resources/assets/components/pages/CampaignSubPage/CampaignSubPage.js
+++ b/resources/assets/components/pages/CampaignSubPage/CampaignSubPage.js
@@ -29,7 +29,7 @@ const CampaignSubPage = props => (
         {!props.entryContent ? (
           <CampaignSubPageContent {...props} />
         ) : (
-          <ContentfulEntry entryContent={props.entryContent} />
+          <ContentfulEntry json={props.entryContent} />
         )}
       </Enclosure>
       <CallToActionContainer sticky hideIfSignedUp />

--- a/resources/assets/components/pages/CampaignSubPage/CampaignSubPageContainer.js
+++ b/resources/assets/components/pages/CampaignSubPage/CampaignSubPageContainer.js
@@ -2,19 +2,27 @@ import { get } from 'lodash';
 import { connect } from 'react-redux';
 
 import CampaignSubPage from './CampaignSubPage';
+import { findContentfulEntry } from '../../../helpers';
 
 /**
  * Provide state from the Redux store as props for this component.
  */
-const mapStateToProps = state => ({
-  pages: state.campaign.pages,
-  dashboard: state.campaign.dashboard,
-  noun: get(state.campaign.additionalContent, 'noun'),
-  verb: get(state.campaign.additionalContent, 'verb'),
-  tagline: get(state.campaign.additionalContent, 'tagline'),
-  title: state.campaign.title,
-  campaignEndDate: get(state.campaign.endDate, 'date', null),
-});
+const mapStateToProps = (state, ownProps) => {
+  const { id, slug } = ownProps.match.params;
+
+  const json = findContentfulEntry(state, id || slug);
+
+  return {
+    campaignEndDate: get(state.campaign.endDate, 'date', null),
+    dashboard: state.campaign.dashboard,
+    json,
+    noun: get(state.campaign.additionalContent, 'noun'),
+    pages: state.campaign.pages,
+    tagline: get(state.campaign.additionalContent, 'tagline'),
+    title: state.campaign.title,
+    verb: get(state.campaign.additionalContent, 'verb'),
+  };
+};
 
 // Export the container component.
 export default connect(mapStateToProps)(CampaignSubPage);

--- a/resources/assets/components/pages/CampaignSubPage/CampaignSubPageContainer.js
+++ b/resources/assets/components/pages/CampaignSubPage/CampaignSubPageContainer.js
@@ -10,12 +10,13 @@ import { findContentfulEntry } from '../../../helpers';
 const mapStateToProps = (state, ownProps) => {
   const { id, slug } = ownProps.match.params;
 
-  const json = findContentfulEntry(state, id || slug);
+  // @TODO: temporary retrieval of single camapaign page (quiz) based on matched id or slug.
+  const entryContent = findContentfulEntry(state, id || slug);
 
   return {
     campaignEndDate: get(state.campaign.endDate, 'date', null),
     dashboard: state.campaign.dashboard,
-    json,
+    entryContent,
     noun: get(state.campaign.additionalContent, 'noun'),
     pages: state.campaign.pages,
     tagline: get(state.campaign.additionalContent, 'tagline'),

--- a/resources/assets/components/pages/CampaignSubPage/CampaignSubPageContent.js
+++ b/resources/assets/components/pages/CampaignSubPage/CampaignSubPageContent.js
@@ -60,7 +60,9 @@ const CampaignSubPageContent = props => {
         <article className="padded bordered rounded bg-white">
           <h2 className="visually-hidden">{subPage.fields.title}</h2>
 
-          <Markdown>{subPage.fields.content}</Markdown>
+          {subPage.fields.content ? (
+            <Markdown>{subPage.fields.content}</Markdown>
+          ) : null}
         </article>
       </div>
 

--- a/resources/assets/components/pages/CampaignSubPage/CampaignSubPageContent.js
+++ b/resources/assets/components/pages/CampaignSubPage/CampaignSubPageContent.js
@@ -94,7 +94,7 @@ CampaignSubPageContent.propTypes = {
       fields: PropTypes.shape({
         title: PropTypes.string,
         slug: PropTypes.string,
-        content: PropTypes.string.isRequired,
+        content: PropTypes.string,
       }),
     }),
   ),


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR switches to using the `CampaignSubPage` for rendering out the Quiz, so that it gets access to the `LedeBanner`. It also does a little cleanup and a sort-of hacky update to pass along a prop to tell the Lede Banner not to show the signup button.

![image](https://user-images.githubusercontent.com/105849/41367339-bb85386c-6f0c-11e8-8c52-fb8ddff633d5.png)


### Any background context you want to provide?

I'm not a big fan of this solution,  BUT it brings us part-way to moving to where we want to be and eventually using the same component to render all "pages" for a campaign. Some refactor work will address the `@TODO`'s I've included _after_ the migration is run to move `Actions` into their own page for the final step of everything a page. Then the real work begins ™

### What are the relevant tickets/cards?

Refs [Pivotal ID #158261002](https://www.pivotaltracker.com/story/show/158261002)

### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.