### PR TITLE
Auto scroll positioning for nested quizzes and quiz results

### DIFF
--- a/resources/assets/components/Quiz/Quiz.js
+++ b/resources/assets/components/Quiz/Quiz.js
@@ -1,7 +1,7 @@
 /* global window */
 import React from 'react';
 import PropTypes from 'prop-types';
-import { find, every } from 'lodash';
+import { find, every, get } from 'lodash';
 import ReactRouterPropTypes from 'react-router-prop-types';
 
 import { query } from '../../helpers';
@@ -10,6 +10,7 @@ import QuizQuestion from './QuizQuestion';
 import Share from '../utilities/Share/Share';
 import QuizConclusion from './QuizConclusion';
 import ContentfulEntry from '../ContentfulEntry';
+import ScrollConcierge from '../ScrollConcierge';
 import { calculateResult, resultParams, appendResultParams } from './helpers';
 
 import './quiz.scss';
@@ -41,7 +42,12 @@ class Quiz extends React.Component {
         resultBlock,
       },
       showResults,
+      // Show the scroll concierge for nested quizzes
+      renderScrollConcierge: get(props.additionalContent, 'isNestedQuiz'),
     };
+
+    // Quickly hide scroll concierge so that we can re-render it when showing the quiz results
+    setTimeout(() => this.setState({ renderScrollConcierge: false }), 500);
   }
 
   componentDidUpdate() {
@@ -103,7 +109,7 @@ class Quiz extends React.Component {
 
     this.quizResultBlockHandler(results.resultBlock);
 
-    this.setState({ showResults: true, results });
+    this.setState({ showResults: true, results, renderScrollConcierge: true });
   };
 
   // If the winning resultBlock is a Quiz, navigates to the new resultBlock's slug
@@ -194,12 +200,7 @@ class Quiz extends React.Component {
   render() {
     return (
       <Flex className="quiz">
-        {/*
-          @TODO: removed the ScrollConcierge because with the lede banner, the scroll would
-          always go past the banner to the content of the quiz. Initially, added so after a
-          potential logic jump with nested quiz, the quiz would scroll back up to see the
-          first question in the next, connected quiz. Need to find a better solution.
-        */}
+        {this.state.renderScrollConcierge ? <ScrollConcierge /> : null}
         <FlexCell width="two-thirds">
           <h1 className="quiz__heading">Quiz</h1>
           {this.props.title ? (
@@ -219,6 +220,7 @@ Quiz.propTypes = {
     callToAction: PropTypes.string.isRequired,
     introduction: PropTypes.string,
     submitButtonText: PropTypes.string,
+    isNestedQuiz: PropTypes.bool,
   }).isRequired,
   clickedSignUp: PropTypes.func.isRequired,
   history: ReactRouterPropTypes.history.isRequired,
@@ -248,6 +250,7 @@ Quiz.propTypes = {
 Quiz.defaultProps = {
   additionalContent: {
     introduction: null,
+    isNestedQuiz: false,
   },
   resultBlocks: null,
   hideQuestionNumber: false,


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR adds ScrollConcierge capability to the Quiz to ensure proper screen positioning for nested quizzes and quiz results

### Any background context you want to provide?
*Imma try and document the train of thought here since this is a bit of a weird scenario:*

The idea is to ensure that users are scrolled to proper screen positioning when moving from one quiz to another (since presumably, they've scrolled down a bit to complete the first quiz and now need to be nudged back to the top (and this needs to happen *only* for a nested quiz, since we don't want to skip over the `LedeBanner` for the initial quiz)).

The catch is that when rendering the quiz results - where, once again, the screen may need to be nudged to the top - the `ScrollConcierge` may already have been set to show if we're on a nested quiz and if so it wouldn't re-render for the results - thus sadly keeping the user scrolled a bit past the result block.

![jun-14-2018 11-14-15](https://user-images.githubusercontent.com/12417657/41421170-24872b88-6fc4-11e8-928d-3b1594f24c28.gif)

😢 


So to prevent this, we set a timer in the constructor to almost immediately reset the `renderScrollConcierge` to `false`, so that once we get to render the results we'll simply be able to toggle it to `true` again and properly re-render the ScrollConcierge.

![jun-14-2018 11-16-35](https://user-images.githubusercontent.com/12417657/41421273-6a972286-6fc4-11e8-9c40-c5a82aac2328.gif)

🍺 😄 
 
### What are the relevant tickets/cards?
[Slack](https://dosomething.slack.com/archives/C3ASB4204/p1528983096000473)
