### PR TITLE
Fixing bug when missing match prop and breaking community page.

### DIFF
--- a/resources/assets/components/pages/CampaignSubPage/CampaignSubPage.js
+++ b/resources/assets/components/pages/CampaignSubPage/CampaignSubPage.js
@@ -32,7 +32,9 @@ const CampaignSubPage = props => (
           <ContentfulEntry json={props.entryContent} />
         )}
       </Enclosure>
-      <CallToActionContainer sticky hideIfSignedUp />
+      {!props.entryContent ? (
+        <CallToActionContainer sticky hideIfSignedUp />
+      ) : null}
     </div>
   </div>
 );

--- a/resources/assets/components/pages/CampaignSubPage/CampaignSubPageContainer.js
+++ b/resources/assets/components/pages/CampaignSubPage/CampaignSubPageContainer.js
@@ -1,4 +1,4 @@
-import { get } from 'lodash';
+import { get, has } from 'lodash';
 import { connect } from 'react-redux';
 
 import CampaignSubPage from './CampaignSubPage';
@@ -8,10 +8,14 @@ import { findContentfulEntry } from '../../../helpers';
  * Provide state from the Redux store as props for this component.
  */
 const mapStateToProps = (state, ownProps) => {
-  const { id, slug } = ownProps.match.params;
+  let entryContent = null;
 
-  // @TODO: temporary retrieval of single camapaign page (quiz) based on matched id or slug.
-  const entryContent = findContentfulEntry(state, id || slug);
+  if (has(ownProps, 'match.props', null)) {
+    const { id, slug } = ownProps.match.params;
+
+    // @TODO: temporary retrieval of single campaign page (quiz) based on matched id or slug.
+    entryContent = findContentfulEntry(state, id || slug);
+  }
 
   return {
     campaignEndDate: get(state.campaign.endDate, 'date', null),

--- a/resources/assets/components/pages/CampaignSubPage/CampaignSubPageContainer.js
+++ b/resources/assets/components/pages/CampaignSubPage/CampaignSubPageContainer.js
@@ -10,7 +10,7 @@ import { findContentfulEntry } from '../../../helpers';
 const mapStateToProps = (state, ownProps) => {
   let entryContent = null;
 
-  if (has(ownProps, 'match.props', null)) {
+  if (has(ownProps, 'match.params', null)) {
     const { id, slug } = ownProps.match.params;
 
     // @TODO: temporary retrieval of single campaign page (quiz) based on matched id or slug.

--- a/resources/assets/components/pages/CampaignSubPage/CampaignSubPageContent.js
+++ b/resources/assets/components/pages/CampaignSubPage/CampaignSubPageContent.js
@@ -84,7 +84,7 @@ const CampaignSubPageContent = props => {
 };
 
 CampaignSubPageContent.propTypes = {
-  campaignEndDate: PropTypes.string.isRequired,
+  campaignEndDate: PropTypes.string,
   isCommunity: PropTypes.bool,
   match: PropTypes.object, // eslint-disable-line react/forbid-prop-types
   noun: PropTypes.shape({
@@ -108,6 +108,7 @@ CampaignSubPageContent.propTypes = {
 };
 
 CampaignSubPageContent.defaultProps = {
+  campaignEndDate: null,
   isCommunity: false,
   pages: [],
   match: {


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR fixes a bug which would break Community pages on Campaigns due to a missing property when setting things up in the `CampaignSubPageContainer`.

Also does not make the end date on a campaign required in the `CampaignSubPageContent` component and defaults the value to `null`. This was showing up as a warning on Grab The Mic which does not have an end date!

### What are the relevant tickets/cards?

Refs [Pivotal ID #158261002](https://www.pivotaltracker.com/story/show/158261002)
