### PR TITLE
Add migration script for deleting activity feed from campaign

### DIFF
--- a/contentful/migrations/2018_06_15_001_remove_activity_feed_field_from_campaign.js
+++ b/contentful/migrations/2018_06_15_001_remove_activity_feed_field_from_campaign.js
@@ -1,0 +1,5 @@
+module.exports = function(migration) {
+  const campaign = migration.editContentType('campaign');
+
+  campaign.deleteField('activity_feed');
+};


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR adds a Contentful migration script to delete the `activity_feed` field from the `Campaign` content type 🎊 

### Any background context you want to provide?
We switched to Community Pages so we no longer need this field!

### What are the relevant tickets/cards?
Refs [Pivotal ID #](https://www.pivotaltracker.com/story/show/156771690)

![image](https://user-images.githubusercontent.com/12417657/41477923-dcce4d3c-7093-11e8-8c36-74b4c17b47a7.png)
