### PR TITLE
Add Contentful Querying by Legacy Campaign IDs

### DIFF
--- a/app/Repositories/CampaignRepository.php
+++ b/app/Repositories/CampaignRepository.php
@@ -93,9 +93,9 @@ class CampaignRepository
     {
         $query['ids'] = implode(',', $ids);
 
-        $campaigns = $this->phoenixLegacy->getCampaigns($query);
+        $results = $this->phoenixLegacy->getCampaigns($query);
 
-        $campaigns = collect($campaigns['data'])->map(function ($campaign) {
+        $campaigns = collect($results['data'])->map(function ($campaign) {
             return new LegacyCampaign($campaign);
         });
     }

--- a/app/Repositories/CampaignRepository.php
+++ b/app/Repositories/CampaignRepository.php
@@ -145,9 +145,9 @@ class CampaignRepository
             ->where('fields.legacyCampaignId', $ids, 'in')
             ->setInclude(1);
 
-        $campaignsArray = iterator_to_array($this->contentful->getEntries($query));
+        $results = $this->contentful->getEntries($query);
 
-        $contentfulCampaigns = collect($campaignsArray)->map(function ($campaign) {
+        $contentfulCampaigns = collect($results->getIterator())->map(function ($campaign) {
             return new Campaign($campaign);
         });
 

--- a/app/Repositories/CampaignRepository.php
+++ b/app/Repositories/CampaignRepository.php
@@ -84,6 +84,23 @@ class CampaignRepository
     }
 
     /**
+     * Get a list of campaigns by IDs from Phoenix Ashes.
+     *
+     * @param  array $ids
+     * @return \Illuminate\Support\Collection
+     */
+    public function getLegacyCampaigns($ids)
+    {
+        $query['ids'] = implode(',', $ids);
+
+        $campaigns = $this->phoenixLegacy->getCampaigns($query);
+
+        $campaigns = collect($campaigns['data'])->map(function ($campaign) {
+            return new LegacyCampaign($campaign);
+        });
+    }
+
+    /**
      * Find a campaign by its legacy ID.
      *
      * @param  string $id


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR updates our lovely `CampaignRepository#findByLegacyCampaignIds ` function to query Contentful first in its quest to return campaigns by a list of Legacy IDs.

### Any background context you want to provide?
We'll first ask Contentful for all campaigns it can find using the `legacyCampaignId` field, and only pass along the remaining non-found IDs to Ashes.

This is another step towards a `/index` endpoint for Campaigns, supporting the batched `filter[id]=1,2,3` query.

### Question:
We probably don't want to be returning the fully constructed Contentful `Campaign` entity from this endpoint, correct? Do we perhaps want to create a mini or truncated Campaign entity which we could use for this scenario as well as in the `getAll` method?

### What are the relevant tickets/cards?

Refs [Pivotal ID #157410894](https://www.pivotaltracker.com/story/show/157410894)
#942 
