### PR TITLE
Migration to remove the Photo Uploader Action.

### DIFF
--- a/contentful/migrations/2018_06_18_001_delete_photo_uploader_action_content_type.js
+++ b/contentful/migrations/2018_06_18_001_delete_photo_uploader_action_content_type.js
@@ -1,0 +1,3 @@
+module.exports = function(migration) {
+  migration.deleteContentType('photoUploaderAction');
+};


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR runs a migration to remove the `PhotoUploaderAction` content type, since we've introduced a new and improved `PhotoSubmissionAction`✨ to replace it.

![image](https://user-images.githubusercontent.com/105849/41561622-66f43d9c-7318-11e8-96b7-f5e050602623.png)
