### PR TITLE
Add method to find Campaigns from Contentful by IDs

### DIFF
--- a/app/Repositories/CampaignRepository.php
+++ b/app/Repositories/CampaignRepository.php
@@ -160,6 +160,26 @@ class CampaignRepository
     }
 
     /**
+     * Find a list of campaigns by their IDs.
+     *
+     * @param  array $ids
+     * @return \Illuminate\Support\Collection
+     */
+    public function findByIds($ids)
+    {
+        $query = (new Query)
+            ->setContentType('campaign')
+            ->where('sys.id', $ids, 'in')
+            ->setInclude(1);
+
+        $results = $this->contentful->getEntries($query);
+
+        return collect($results->getIterator())->map(function ($campaign) {
+            return new Campaign($campaign);
+        });
+    }
+
+    /**
      * Find a campaign by its slug.
      *
      * @param  string $slug


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR adds a new method to the `CampaignRepository` to batch query campaigns from Contentful by a list of IDs

### Any background context you want to provide?
**Q**:
I wasn't sure whether to name this `findByContentfulIds` or if we wanted this to be implied as the de-facto primary ID by calling it `findByIds`?

### What are the relevant tickets/cards?

Refs [Pivotal ID #157410894](https://www.pivotaltracker.com/story/show/157410894)
#942 