### PR TITLE
Add migration to remove ComponentActionStep content type.

### DIFF
--- a/contentful/migrations/2018_06_19_001_delete_component_action_step_content_type.js
+++ b/contentful/migrations/2018_06_19_001_delete_component_action_step_content_type.js
@@ -1,0 +1,3 @@
+module.exports = function(migration) {
+  migration.deleteContentType('componentActionStep');
+};


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_


### What does this PR do?

This PR adds a migration to remove the `ComponentActionStep` content type which we no longer use.

![image](https://user-images.githubusercontent.com/105849/41613824-b9221c54-73c4-11e8-88be-607a9e6ad0e0.png)
