### PR TITLE
Updated Campaigns Index Action

### DIFF
--- a/app/Entities/TruncatedCampaign.php
+++ b/app/Entities/TruncatedCampaign.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Entities;
+
+use JsonSerializable;
+
+class TruncatedCampaign extends Campaign implements JsonSerializable
+{
+    /**
+     * Convert the object into something JSON serializable.
+     *
+     * @return array
+     */
+    public function jsonSerialize()
+    {
+        return [
+            'id' => $this->entry->getId(),
+            'legacyCampaignId' => $this->legacyCampaignId,
+            'legacyCampaignRunId' => get_legacy_campaign_data($this->legacyCampaignId, 'campaign_runs.current.en.id'),
+            'type' => $this->entry->getContentType()->getId(),
+            'title' => $this->title,
+            'slug' => $this->slug,
+            'status' => null, // @TODO: calculate status based on the endDate!
+            'endDate' => $this->endDate,
+            'callToAction' => $this->callToAction, //@TODO: deprecate in favor of tagline.
+            'tagline' => $this->callToAction,
+            'coverImage' => [
+                'description' => $this->coverImage ? $this->coverImage->getDescription() : '',
+                'url' => get_image_url($this->coverImage),
+                'landscapeUrl' => get_image_url($this->coverImage, 'landscape'),
+            ],
+            'actionText' => array_get($this->campaignSettings, 'actionText') ?: 'Join Us',
+            'staffPick' => $this->staffPick,
+            'cause' => $this->cause,
+            'scholarshipAmount' => $this->scholarshipAmount,
+            'additionalContent' => $this->additionalContent,
+        ];
+    }
+}

--- a/app/Http/Controllers/Api/CampaignsController.php
+++ b/app/Http/Controllers/Api/CampaignsController.php
@@ -51,9 +51,9 @@ class CampaignsController extends Controller
         // All remaining IDs are presumed to be Contentful IDs.
         $contentfulIds = array_diff($idsArray, $legacyIds);
 
-        $legacyCampaigns = count($legacyIds) ? $this->campaignRepository->findByLegacyCampaignIds($legacyIds) : collect();
+        $legacyCampaigns = $this->campaignRepository->findByLegacyCampaignIds($legacyIds);
 
-        $contentfulCampaigns = count($contentfulIds) ? $this->campaignRepository->findByIds($contentfulIds) : collect();
+        $contentfulCampaigns = $this->campaignRepository->findByIds($contentfulIds);
 
         $campaigns = $contentfulCampaigns->merge($legacyCampaigns);
 

--- a/app/Http/Controllers/Api/CampaignsController.php
+++ b/app/Http/Controllers/Api/CampaignsController.php
@@ -40,10 +40,11 @@ class CampaignsController extends Controller
 
         $idsArray = explode(',', $ids);
 
-        // We limit filter[id] requests to a maximum of 10 IDs.
-        if (count($idsArray) > 10) {
-            return response()->json('Exceeded limit of 10 IDs', 422);
-        }
+        $request->query('filter')['id'] = $idsArray;
+
+        $this->validate($request, [
+            'filter.id' => 'max:10'
+        ]);
 
         // Extract the legacy IDs.
         $legacyIds = array_filter($idsArray, 'is_legacy_id');

--- a/app/Http/Controllers/Api/CampaignsController.php
+++ b/app/Http/Controllers/Api/CampaignsController.php
@@ -34,7 +34,7 @@ class CampaignsController extends Controller
     {
         $ids = array_get($request->query('filter'), 'id');
 
-        if (!$ids) {
+        if (! $ids) {
             return response()->json(['data' => []]);
         }
 
@@ -54,7 +54,7 @@ class CampaignsController extends Controller
         // All remaining IDs are presumed to be Contentful IDs.
         $contentfulIds = array_diff($idsArray, $legacyIds);
 
-        $legacyCampaigns = count($legacyIds) ? $this->campaignRepository->findByLegacyCampaignIds($legacyIds): collect();
+        $legacyCampaigns = count($legacyIds) ? $this->campaignRepository->findByLegacyCampaignIds($legacyIds) : collect();
 
         $contentfulCampaigns = count($contentfulIds) ? $this->campaignRepository->findByIds($contentfulIds) : collect();
 

--- a/app/Http/Controllers/Api/CampaignsController.php
+++ b/app/Http/Controllers/Api/CampaignsController.php
@@ -40,6 +40,7 @@ class CampaignsController extends Controller
 
         $idsArray = explode(',', $ids);
 
+        // Resetting the filter[id] param value to an array so that we can properly validate.
         $request->query('filter')['id'] = $idsArray;
 
         $this->validate($request, [

--- a/app/Http/Controllers/Api/CampaignsController.php
+++ b/app/Http/Controllers/Api/CampaignsController.php
@@ -42,7 +42,6 @@ class CampaignsController extends Controller
 
         // We limit filter[id] requests to a maximum of 10 IDs.
         if (count($idsArray) > 10) {
-            // Not sure that this is the right thing to do here:
             return response()->json('Exceeded limit of 10 IDs', 422);
         }
 

--- a/app/Http/Controllers/Api/CampaignsController.php
+++ b/app/Http/Controllers/Api/CampaignsController.php
@@ -55,9 +55,9 @@ class CampaignsController extends Controller
         // All remaining IDs are presumed to be Contentful IDs.
         $contentfulIds = array_diff($idsArray, $legacyIds);
 
-        $contentfulCampaigns = $this->campaignRepository->findByLegacyCampaignIds($legacyIds);
+        $legacyCampaigns = $this->campaignRepository->findByLegacyCampaignIds($legacyIds);
 
-        $legacyCampaigns = $this->campaignRepository->findByIds($contentfulIds);
+        $contentfulCampaigns = $this->campaignRepository->findByIds($contentfulIds);
 
         $campaigns = $contentfulCampaigns->merge($legacyCampaigns);
 

--- a/app/Http/Controllers/Api/CampaignsController.php
+++ b/app/Http/Controllers/Api/CampaignsController.php
@@ -34,6 +34,9 @@ class CampaignsController extends Controller
     {
         $ids = array_get($request->query('filter'), 'id');
 
+        if (!$ids) {
+            return response()->json(['data' => []]);
+        }
 
         $idsArray = explode(',', $ids);
 
@@ -44,16 +47,16 @@ class CampaignsController extends Controller
         }
 
         // Extract the legacy IDs.
-        $legacyIds = collect($idsArray)->filter(function($id) {
+        $legacyIds = collect($idsArray)->filter(function ($id) {
             return is_legacy_id($id);
         })->all();
 
         // All remaining IDs are presumed to be Contentful IDs.
         $contentfulIds = array_diff($idsArray, $legacyIds);
 
-        $legacyCampaigns = $this->campaignRepository->findByLegacyCampaignIds($legacyIds);
+        $legacyCampaigns = count($legacyIds) ? $this->campaignRepository->findByLegacyCampaignIds($legacyIds): collect();
 
-        $contentfulCampaigns = $this->campaignRepository->findByIds($contentfulIds);
+        $contentfulCampaigns = count($contentfulIds) ? $this->campaignRepository->findByIds($contentfulIds) : collect();
 
         $campaigns = $contentfulCampaigns->merge($legacyCampaigns);
 

--- a/app/Http/Controllers/Api/CampaignsController.php
+++ b/app/Http/Controllers/Api/CampaignsController.php
@@ -34,11 +34,7 @@ class CampaignsController extends Controller
     {
         $ids = array_get($request->query('filter'), 'id');
 
-        if (! $ids) {
-            return response()->json(['data' => []]);
-        }
-
-        $idsArray = explode(',', $ids);
+        $idsArray = count($ids) ? explode(',', $ids) : [];
 
         // Resetting the filter[id] param value to an array so that we can properly validate.
         $request->query('filter')['id'] = $idsArray;

--- a/app/Http/Controllers/Api/CampaignsController.php
+++ b/app/Http/Controllers/Api/CampaignsController.php
@@ -32,12 +32,8 @@ class CampaignsController extends Controller
      */
     public function index(Request $request)
     {
-        $this->validate($request, [
-            // We're only supporting requests with an ID filter query.
-            'filter.id' => 'required',
-        ]);
+        $ids = array_get($request->query('filter'), 'id');
 
-        $ids = $request->query('filter')['id'];
 
         $idsArray = explode(',', $ids);
 

--- a/app/Http/Controllers/Api/CampaignsController.php
+++ b/app/Http/Controllers/Api/CampaignsController.php
@@ -43,7 +43,7 @@ class CampaignsController extends Controller
         $request->query('filter')['id'] = $idsArray;
 
         $this->validate($request, [
-            'filter.id' => 'max:10'
+            'filter.id' => 'max:10',
         ]);
 
         // Extract the legacy IDs.

--- a/app/Http/Controllers/Api/CampaignsController.php
+++ b/app/Http/Controllers/Api/CampaignsController.php
@@ -46,9 +46,7 @@ class CampaignsController extends Controller
         }
 
         // Extract the legacy IDs.
-        $legacyIds = collect($idsArray)->filter(function ($id) {
-            return is_legacy_id($id);
-        })->all();
+        $legacyIds = array_filter($idsArray, 'is_legacy_id');
 
         // All remaining IDs are presumed to be Contentful IDs.
         $contentfulIds = array_diff($idsArray, $legacyIds);

--- a/app/Repositories/CampaignRepository.php
+++ b/app/Repositories/CampaignRepository.php
@@ -6,6 +6,7 @@ use App\Entities\Campaign;
 use Contentful\Delivery\Query;
 use App\Services\PhoenixLegacy;
 use App\Entities\LegacyCampaign;
+use App\Entities\TruncatedCampaign;
 use Contentful\Delivery\Client as Contentful;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 
@@ -49,13 +50,7 @@ class CampaignRepository
             // Transform & cast as JSON so we can cache this. One little gotcha -
             // we don't want full campaigns, that'd be a monstrous object!
             $results = collect($array)->map(function ($entity) {
-                return [
-                    'id' => $entity->getId(),
-                    'slug' => $entity->getSlug(),
-                    'title' => $entity->getTitle(),
-                    'callToAction' => $entity->getCallToAction(),
-                    'coverImage' => get_image_url($entity->getCoverImage(), 'square'),
-                ];
+                return new TruncatedCampaign($entity);
             });
 
             return $results->toJson();
@@ -152,7 +147,7 @@ class CampaignRepository
         $results = $this->contentful->getEntries($query);
 
         $contentfulCampaigns = collect($results->getIterator())->map(function ($campaign) {
-            return new Campaign($campaign);
+            return new TruncatedCampaign($campaign);
         });
 
         // List of IDs returned from Contentful.
@@ -183,7 +178,7 @@ class CampaignRepository
         $results = $this->contentful->getEntries($query);
 
         return collect($results->getIterator())->map(function ($campaign) {
-            return new Campaign($campaign);
+            return new TruncatedCampaign($campaign);
         });
     }
 

--- a/app/Repositories/CampaignRepository.php
+++ b/app/Repositories/CampaignRepository.php
@@ -140,6 +140,10 @@ class CampaignRepository
      */
     public function findByLegacyCampaignIds($ids)
     {
+        if (empty($ids)) {
+            return collect();
+        }
+
         $query = (new Query)
             ->setContentType('campaign')
             ->where('fields.legacyCampaignId', $ids, 'in')
@@ -167,6 +171,10 @@ class CampaignRepository
      */
     public function findByIds($ids)
     {
+        if (empty($ids)) {
+            return collect();
+        }
+
         $query = (new Query)
             ->setContentType('campaign')
             ->where('sys.id', $ids, 'in')


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR updates the `Campaigns#index` action to process a `filter[id]=1,2,3` query.

### Any background context you want to provide?
This is a bit of a hefty action. I imagine that once we bring this action fully up to speed (full index support, pagination etc.) we can get to clean this up some more 🙏

### What are the relevant tickets/cards?

Refs [Pivotal ID #157410894](https://www.pivotaltracker.com/story/show/157410894)
#942 
