### PR TITLE
Fixes to the Campaign Index action

### DIFF
--- a/app/Http/Controllers/Api/CampaignsController.php
+++ b/app/Http/Controllers/Api/CampaignsController.php
@@ -34,7 +34,7 @@ class CampaignsController extends Controller
     {
         $ids = array_get($request->query('filter'), 'id');
 
-        $idsArray = count($ids) ? explode(',', $ids) : [];
+        $idsArray = $ids ? explode(',', $ids) : [];
 
         // Resetting the filter[id] param value to an array so that we can properly validate.
         $request->query('filter')['id'] = $idsArray;

--- a/app/Http/Controllers/Api/CampaignsController.php
+++ b/app/Http/Controllers/Api/CampaignsController.php
@@ -37,7 +37,7 @@ class CampaignsController extends Controller
         $idsArray = $ids ? explode(',', $ids) : [];
 
         // Resetting the filter[id] param value to an array so that we can properly validate.
-        $request->query('filter')['id'] = $idsArray;
+        $request->request->add(['filter' => ['id' => $idsArray]]);
 
         $this->validate($request, [
             'filter.id' => 'max:10',


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR fixes a couple of silly mistakes I made in the zero hour of #989 

- Fixed an improperly defined ternary to ensure we weren't exploding an empty string
- Properly reset the `filter[id]` query parameter

🤦‍♂️ 