### PR TITLE
Quick fix for the index endpoint

### DIFF
--- a/app/Http/Controllers/Api/CampaignsController.php
+++ b/app/Http/Controllers/Api/CampaignsController.php
@@ -37,7 +37,7 @@ class CampaignsController extends Controller
         $idsArray = $ids ? explode(',', $ids) : [];
 
         // Resetting the filter[id] param value to an array so that we can properly validate.
-        $request->request->add(['filter' => ['id' => $idsArray]]);
+        $request->merge(['filter' => ['id' => $idsArray]]);
 
         $this->validate($request, [
             'filter.id' => 'max:10',


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR fixes the insanely awkward method we were using to reset the `filter[id]` param for the Campaign Index action
#990 

🤦‍♂️ 🤕 🤒 