### PR TITLE
Attach query params to the nested quiz path

### DIFF
--- a/resources/assets/components/Quiz/Quiz.js
+++ b/resources/assets/components/Quiz/Quiz.js
@@ -120,10 +120,11 @@ class Quiz extends React.Component {
       const resultBlockSlug = resultBlock.fields.slug;
 
       // Retain the current pathname while replacing the active quiz's slug with the resultBlocks slug
-      const newPath = location.pathname.replace(
-        new RegExp(`/quiz/${slug}$`),
-        `/quiz/${resultBlockSlug}`,
-      );
+      const newPath =
+        location.pathname.replace(
+          new RegExp(`/quiz/${slug}$`),
+          `/quiz/${resultBlockSlug}`,
+        ) + location.search;
 
       history.push(newPath);
     }


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR ensures we retain query parameters when redirecting a user to a nested Quiz

### Any background context you want to provide?
This is specifically important for SMS quizzes, where we'd like to keep the quiz un-gated while retaining User identity through the `user_id=` query parameter.

### What are the relevant tickets/cards?

Refs [Pivotal ID #157751760](https://www.pivotaltracker.com/story/show/157751760)