### PR TITLE
Remove activityFeed related fields and props

### DIFF
--- a/resources/assets/components/pages/CampaignPage/CampaignPage.js
+++ b/resources/assets/components/pages/CampaignPage/CampaignPage.js
@@ -18,7 +18,6 @@ const CampaignPage = props => {
     affiliateSponsors,
     campaignLead,
     clickedHideAffirmation,
-    hasActivityFeed,
     hasCommunityPage,
     isAdmin,
     isCampaignClosed,
@@ -65,11 +64,7 @@ const CampaignPage = props => {
                 return <Redirect to={join(match.url, 'action')} />;
               }
 
-              return hasActivityFeed ? (
-                <FeedContainer />
-              ) : (
-                <CampaignSubPageContainer isCommunity />
-              );
+              return <CampaignSubPageContainer isCommunity />;
             }}
           />
 
@@ -112,7 +107,6 @@ CampaignPage.propTypes = {
     email: PropTypes.string,
   }),
   clickedHideAffirmation: PropTypes.func.isRequired,
-  hasActivityFeed: PropTypes.bool.isRequired,
   hasCommunityPage: PropTypes.bool.isRequired,
   isAdmin: PropTypes.bool.isRequired,
   isCampaignClosed: PropTypes.bool.isRequired,

--- a/resources/assets/components/pages/CampaignPage/CampaignPage.js
+++ b/resources/assets/components/pages/CampaignPage/CampaignPage.js
@@ -4,7 +4,6 @@ import PropTypes from 'prop-types';
 import ReactRouterPropTypes from 'react-router-prop-types';
 import { Switch, Route, Redirect } from 'react-router-dom';
 
-import { FeedContainer } from '../../Feed'; // @TODO: rename to ActivityFeed or ActivityPage...
 import Modal from '../../utilities/Modal/Modal';
 import CampaignFooter from '../../CampaignFooter';
 import BlockPageContainer from '../BlockPage/BlockPageContainer';

--- a/resources/assets/components/pages/CampaignPage/CampaignPageContainer.js
+++ b/resources/assets/components/pages/CampaignPage/CampaignPageContainer.js
@@ -13,12 +13,10 @@ const mapStateToProps = state => ({
   affiliateSponsors: state.campaign.affiliateSponsors,
   affiliatePartners: state.campaign.affiliatePartners,
   campaignLead: get(state, 'campaign.campaignLead.fields', null),
-  hasActivityFeed: Boolean(state.campaign.activityFeed.length),
   hasCommunityPage: Boolean(
-    state.campaign.activityFeed.length ||
-      state.campaign.pages.find(
-        page => page.type === 'page' && page.fields.slug.endsWith('community'),
-      ),
+    state.campaign.pages.find(
+      page => page.type === 'page' && page.fields.slug.endsWith('community'),
+    ),
   ),
   isAdmin: userHasRole(state, 'admin'),
   isCampaignClosed: isCampaignClosed(


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR removes the deprecated `activityFeed` field and props from our application

### Any background context you want to provide?
Since we've moved over to 'Community Page's, the Campaign `activityFeed` is deprecated and no longer in use so:

- removed the `Campaign` Entity `activityFeed` field, and `parseActivityField` method
- removed the defunct `fillReportbackPosts ` method
- trashed the `activityFeed` props and logic from `CampaignPage`

### What are the relevant tickets/cards?

Refs [Pivotal ID #158394949](https://www.pivotaltracker.com/story/show/158394949)
#982 