### PR TITLE
Migration script to delete campaign actionSteps field

### DIFF
--- a/contentful/migrations/2018_06_28_001_delete_action_steps_field_from_campaigns.js
+++ b/contentful/migrations/2018_06_28_001_delete_action_steps_field_from_campaigns.js
@@ -1,0 +1,5 @@
+module.exports = function(migration) {
+  const campaign = migration.editContentType('campaign');
+
+  campaign.deleteField('actionSteps');
+};


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR adds a Contentful Migration CLI script to delete the `actionSteps` field from the Campaign Content Type

### What are the relevant tickets/cards?

Refs [Pivotal ID #158394949](https://www.pivotaltracker.com/story/show/158394949)