### PR TITLE
Action Steps and  Activity Feed cleanup

### DIFF
--- a/app/Entities/Campaign.php
+++ b/app/Entities/Campaign.php
@@ -106,7 +106,6 @@ class Campaign extends Entity implements JsonSerializable
             'campaignLead' => $this->parseCampaignLead($this->campaignLead, $this->additionalContent),
             'affiliateSponsors' => $this->parseAffiliates($this->affiliateSponsors),
             'affiliatePartners' => $this->parseAffiliates($this->affiliatePartners),
-            'actionSteps' => $this->parseBlocks($this->actionSteps),
             'quizzes' => $this->parseQuizzes($this->quizzes),
             'dashboard' => $this->dashboard,
             'affirmation' => $this->parseBlock($this->affirmation),

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -311,7 +311,7 @@ function get_campaign_social_fields($campaign, $uri)
 
     if (str_contains($uri, [$blockPath, $modalPath])) {
         $blockId = last(explode('/', $uri));
-
+        // @TODO with the activityFeed field now deprecated, we need to re-visit this.
         $block = array_first($campaign->activityFeed, function ($value) use ($blockId) {
             return $value->id === $blockId;
         });

--- a/docs/api-reference/v2/campaigns.md
+++ b/docs/api-reference/v2/campaigns.md
@@ -149,8 +149,6 @@ Example Response:
     },
     "affiliateSponsors": [],
     "affiliatePartners": [],
-    "activityFeed": [],
-    "actionSteps": [],
     "quizzes": [],
     "dashboard": null,
     "affirmation": null,

--- a/resources/assets/components/CampaignPageNavigation/CampaignPageNavigation.js
+++ b/resources/assets/components/CampaignPageNavigation/CampaignPageNavigation.js
@@ -8,7 +8,6 @@ import SignupButtonContainer from '../SignupButton/SignupButtonContainer';
 
 const CampaignPageNavigation = ({
   campaignSlug,
-  hasCommunityPage,
   isAffiliated,
   isCampaignClosed,
   isLegacyTemplate,
@@ -26,35 +25,10 @@ const CampaignPageNavigation = ({
     // Remove action page from navigaition list if campaign is closed.
     .filter(page => !isCampaignClosed || !isActionPage(page));
 
-  let campaignPages = linkablePages.map(page => ({
+  const campaignPages = linkablePages.map(page => ({
     id: page.id,
-    slug: page.fields.slug,
+    slug: prepareCampaignPageSlug(campaignSlug, page.fields.slug),
     title: page.fields.title,
-  }));
-
-  // Conditional whether to include Community page.
-  if (hasCommunityPage) {
-    campaignPages.unshift({
-      id: 'community-page',
-      slug: 'community',
-      title: 'Community',
-    });
-  }
-
-  const hasActionPage = pages.find(page => isActionPage(page));
-
-  // Conditional whether to include Action page.
-  if (campaignPages.length && !isCampaignClosed && !hasActionPage) {
-    campaignPages.unshift({
-      id: 'action-page',
-      slug: 'action',
-      title: 'Action',
-    });
-  }
-
-  campaignPages = campaignPages.map(page => ({
-    ...page,
-    slug: prepareCampaignPageSlug(campaignSlug, page.slug),
   }));
 
   return campaignPages.length ? (
@@ -71,7 +45,6 @@ const CampaignPageNavigation = ({
 
 CampaignPageNavigation.propTypes = {
   campaignSlug: PropTypes.string.isRequired,
-  hasCommunityPage: PropTypes.bool.isRequired,
   isAffiliated: PropTypes.bool.isRequired,
   isCampaignClosed: PropTypes.bool.isRequired,
   isLegacyTemplate: PropTypes.bool.isRequired,

--- a/resources/assets/components/CampaignPageNavigation/CampaignPageNavigationContainer.js
+++ b/resources/assets/components/CampaignPageNavigation/CampaignPageNavigationContainer.js
@@ -7,7 +7,6 @@ import { isSignedUp } from '../../selectors/signup';
 import CampaignPageNavigation from './CampaignPageNavigation';
 
 const mapStateToProps = state => ({
-  hasCommunityPage: Boolean(state.campaign.activityFeed.length),
   isAffiliated: isSignedUp(state),
   isCampaignClosed: isCampaignClosed(get(state.campaign.endDate, 'date', null)),
   isLegacyTemplate: Boolean(state.campaign.template === 'legacy'),

--- a/resources/assets/components/pages/ActionPage/ActionPageContainer.js
+++ b/resources/assets/components/pages/ActionPage/ActionPageContainer.js
@@ -2,22 +2,17 @@ import { get } from 'lodash';
 import { connect } from 'react-redux';
 
 import ActionPage from './ActionPage';
+import { isActionPage } from '../../../helpers';
 import { isSignedUp } from '../../../selectors/signup';
 
 /**
  * Provide state from the Redux store as props for this component.
  */
 const mapStateToProps = state => {
-  const actionPage = state.campaign.pages.find(
-    page => page.type === 'page' && page.fields.slug.endsWith('action'),
-  );
-
-  const steps = state.campaign.actionSteps.length
-    ? state.campaign.actionSteps
-    : get(actionPage, 'fields.blocks', []);
+  const actionPage = state.campaign.pages.find(isActionPage);
 
   return {
-    steps,
+    steps: get(actionPage, 'fields.blocks', []),
     dashboard: state.campaign.dashboard,
     signedUp: isSignedUp(state),
     featureFlags: get(state.campaign.additionalContent, 'featureFlags'),

--- a/resources/assets/helpers/index.js
+++ b/resources/assets/helpers/index.js
@@ -578,12 +578,7 @@ export function handleTwitterShareClick(href, trackingData, quote = '') {
 export function findContentfulEntry(state, identifier) {
   const campaign = state.campaign;
 
-  const contentfulEntries = [].concat(
-    campaign.actionSteps,
-    campaign.activityFeed,
-    campaign.pages,
-    campaign.quizzes,
-  );
+  const contentfulEntries = [].concat(campaign.pages, campaign.quizzes);
 
   return find(
     contentfulEntries,


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR removes an assortment of fields, logic, and React props related to the now deprecated `actionSteps` and `activityFeed` Campaign fields.

### What are the relevant tickets/cards?

Refs [Pivotal ID #158394949](https://www.pivotaltracker.com/story/show/158394949)
