### PR TITLE
Removing Gladiator vars since the service has been retired.

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,9 +28,6 @@ CONTENTFUL_CACHE=
 
 GRAPHQL_URL=https://graphql-qa.dosomething.org/graphql
 
-GLADIATOR_URL=
-GLADIATOR_API_KEY=
-
 NORTHSTAR_URL=https://identity-qa.dosomething.org
 NORTHSTAR_AUTHORIZATION_ID=dev-oauth
 NORTHSTAR_AUTHORIZATION_SECRET=

--- a/app.json
+++ b/app.json
@@ -2,11 +2,7 @@
   "name": "phoenix",
   "description": ":sparkles:",
   "formation": {},
-  "addons": [
-    "jawsdb-maria",
-    "heroku-redis",
-    "papertrail"
-  ],
+  "addons": ["jawsdb-maria", "heroku-redis", "papertrail"],
   "buildpacks": [
     {
       "url": "heroku/php"
@@ -36,12 +32,6 @@
       "required": true
     },
     "FACEBOOK_APP_ID": {
-      "required": true
-    },
-    "GLADIATOR_URL": {
-      "required": true
-    },
-    "GLADIATOR_API_KEY": {
       "required": true
     },
     "GOOGLE_ANALYTICS_ID": {

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -27,7 +27,6 @@ class AppServiceProvider extends ServiceProvider
                 'APP_ENV' => config('app.env'),
                 'FACEBOOK_APP_ID' => config('services.analytics.facebook_id'),
                 'GRAPHQL_URL' => config('services.graphql.url'),
-                'GLADIATOR_URL' => config('services.gladiator.url'),
                 'NORTHSTAR_URL' => config('services.northstar.url'),
                 'NPS_SURVEY_ENABLED' => config('services.timed_modals.nps_survey.enabled'),
                 'PHOENIX_LEGACY_URL' => config('services.phoenix-legacy.url'),

--- a/config/services.php
+++ b/config/services.php
@@ -26,11 +26,6 @@ return [
         'url' => env('GRAPHQL_URL', 'https://graphql-qa.dosomething.org/graphql'),
     ],
 
-    'gladiator' => [
-        'url' => env('GLADIATOR_URL', 'https://gladiator-qa.dosomething.org'),
-        'key' => env('GLADIATOR_API_KEY'),
-    ],
-
     'rogue' => [
         'url' => env('ROGUE_URL', 'https://rogue-qa.dosomething.org'),
         'key' => env('ROGUE_API_KEY'),


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR removes any old references to Gladiator related variables. The Gladiator service is now officially retired and archived, so we no longer need to set any variables for it.


### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.