### PR TITLE
Removing total signups output in Dashboard and related code.

### DIFF
--- a/app/Http/Controllers/SignupController.php
+++ b/app/Http/Controllers/SignupController.php
@@ -33,18 +33,6 @@ class SignupController extends Controller
     }
 
     /**
-     * Get the total signups for this campaign.
-     *
-     * @param  int $campaignId
-     * @return \Illuminate\Http\Response
-     */
-    public function total($campaignId)
-    {
-        // Count = 1 is a hack to make the API actually return something. Don't ask.
-        return response()->json($this->phoenixLegacy->getAllSignupsCached(['campaigns' => $campaignId, 'count' => 1]));
-    }
-
-    /**
      * Store a newly created resource in storage.
      *
      * @param  \Illuminate\Http\Request  $request

--- a/app/Services/PhoenixLegacy.php
+++ b/app/Services/PhoenixLegacy.php
@@ -69,26 +69,6 @@ class PhoenixLegacy extends RestApiClient
     }
 
     /**
-     * Get a cached index of (optionally filtered) campaign signups from Phoenix.
-     * @see: https://github.com/DoSomething/phoenix/wiki/API#retrieve-a-signup-collection
-     *
-     * @param array $query - query string, for filtering results
-     * @return array - JSON response
-     */
-    public function getAllSignupsCached(array $query = [])
-    {
-        $path = 'v1/signups';
-
-        // Use a lower expiration on this.
-        $customCacheExpiration = 10;
-        $cacheKey = 'legacy-' . $path . '-' . implode($query);
-
-        return remember(make_cache_key($cacheKey), $customCacheExpiration, function () use ($path, $query) {
-            return $this->get($path, $query);
-        });
-    }
-
-    /**
      * Get details for a particular campaign signup from Phoenix.
      * @see: https://github.com/DoSomething/phoenix/wiki/API#retrieve-a-specific-signup
      *

--- a/resources/assets/actions/signup.js
+++ b/resources/assets/actions/signup.js
@@ -93,25 +93,6 @@ export function setTotalSignups(total) {
   return { type: SET_TOTAL_SIGNUPS, total };
 }
 
-// Async Action: get the total signups for this campaign.
-export function getTotalSignups(campaignId) {
-  return (dispatch, getState) => {
-    new Phoenix().get(`next/signups/total/${campaignId}`).then(response => {
-      if (!response || !response.meta || !response.meta.pagination) {
-        throw new Error('no signup metadata found');
-      }
-
-      let total = response.meta.pagination.total;
-      // @TODO: Not ideal, but the browser doesn't know if this is an old cached response or not.
-      if (isSignedUp(getState())) {
-        total += 1;
-      }
-
-      dispatch(setTotalSignups(total));
-    });
-  };
-}
-
 // Async Action: send signup to phoenix and
 // check if the user is logged in or has an existing signup.
 export function clickedSignUp(

--- a/resources/assets/actions/signup.js
+++ b/resources/assets/actions/signup.js
@@ -5,7 +5,6 @@ import { Phoenix } from '@dosomething/gateway';
 
 import { isCampaignClosed } from '../helpers';
 import { isAuthenticated } from '../selectors/user';
-import { isSignedUp } from '../selectors/signup';
 import {
   SIGNUP_CREATED,
   SIGNUP_FOUND,

--- a/resources/assets/components/Dashboard/DashboardContainer.js
+++ b/resources/assets/components/Dashboard/DashboardContainer.js
@@ -1,24 +1,14 @@
 import { connect } from 'react-redux';
 
 import Dashboard from './index';
-import { getTotalSignups } from '../../actions';
 
 /**
  * Provide state from the Redux store as props for this component.
  */
 const mapStateToProps = state => ({
-  legacyCampaignId: state.campaign.legacyCampaignId,
-  totalCampaignSignups: state.signups.total,
   content: state.campaign.dashboard,
   endDate: state.campaign.endDate,
 });
 
-/**
- * Bind Redux actions as props.
- */
-const actionCreators = {
-  getTotalSignups,
-};
-
 // Export the container component.
-export default connect(mapStateToProps, actionCreators)(Dashboard);
+export default connect(mapStateToProps)(Dashboard);

--- a/resources/assets/components/Dashboard/index.js
+++ b/resources/assets/components/Dashboard/index.js
@@ -8,12 +8,6 @@ import { getDaysBetween } from '../../helpers';
 import './dashboard.scss';
 
 class Dashboard extends React.Component {
-  componentDidMount() {
-    if (this.props.totalCampaignSignups === 0) {
-      this.props.getTotalSignups(this.props.legacyCampaignId);
-    }
-  }
-
   /**
    * Replace the given text with variables from the props.
    * @TODO: This should not be defined in the render function.
@@ -22,16 +16,10 @@ class Dashboard extends React.Component {
    * @return {String}
    */
   replaceTemplateVars(text) {
-    const totalCampaignSignups = (
-      this.props.totalCampaignSignups || 0
-    ).toLocaleString();
-
-    return text
-      .replace('{totalSignups}', totalCampaignSignups)
-      .replace(
-        '{endDate}',
-        getDaysBetween(new Date(), new Date(this.props.endDate.date)),
-      );
+    return text.replace(
+      '{endDate}',
+      getDaysBetween(new Date(), new Date(this.props.endDate.date)),
+    );
   }
 
   /**
@@ -94,9 +82,6 @@ class Dashboard extends React.Component {
 }
 
 Dashboard.propTypes = {
-  totalCampaignSignups: PropTypes.number,
-  getTotalSignups: PropTypes.func.isRequired,
-  legacyCampaignId: PropTypes.string.isRequired,
   endDate: PropTypes.shape({
     date: PropTypes.string,
   }).isRequired,
@@ -113,7 +98,6 @@ Dashboard.propTypes = {
 };
 
 Dashboard.defaultProps = {
-  totalCampaignSignups: 0,
   content: {
     fields: {
       // ...!

--- a/routes/web.php
+++ b/routes/web.php
@@ -66,7 +66,6 @@ $router->resource('next/reportbackItems', 'ReportbackItemsController', ['only' =
 $router->resource('next/referrals', 'ReferralController', ['only' => ['store']]);
 
 // Signups
-$router->get('next/signups/total/{campaignId}', 'SignupController@total');
 $router->resource('next/signups', 'SignupController', ['except' => ['create', 'edit', 'destroy']]);
 
 // Activity


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR removes the total signups output from the Dashboard (which wasn't really used anyhoo), and gets rid of a lot of the related code for getting the total signups.

To get the total signups for a campaign to potentially showcase in the Dashboard, we make a call to Ashes for the information. Turns out we make the call _even if we're not showing the total signups_ in the Dashboard, which is not idea. Plus the call has started failing for whatever reason, responding with `500` server error codes. Since we can't currently get the total signups for a campaign from Rogue directly, we decided it best to just remove this and any associated code given that it's not really being used.

### Any background context you want to provide?

The error I was seeing:
![screen shot 2018-07-03 at 2 43 48 pm](https://user-images.githubusercontent.com/105849/42238692-bcefd98c-7ecf-11e8-84e0-ca2d4ea399f4.png)

### What are the relevant tickets/cards?

🌵 

### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.