### PR TITLE
Update to fix errors with referencing property no longer availble.

### DIFF
--- a/app/helpers.php
+++ b/app/helpers.php
@@ -321,7 +321,7 @@ function get_campaign_social_fields($campaign, $uri)
         if ($communityPage) {
             // Find the block within the community page block if available.
             $block = array_first($communityPage->fields->blocks, function ($value) use ($blockId) {
-                return $value->id = $blockId;
+                return $value->id === $blockId;
             });
         }
 

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -310,11 +310,20 @@ function get_campaign_social_fields($campaign, $uri)
     $modalPath = $campaign->slug . '/modal';
 
     if (str_contains($uri, [$blockPath, $modalPath])) {
+        $block = null;
         $blockId = last(explode('/', $uri));
-        // @TODO with the activityFeed field now deprecated, we need to re-visit this.
-        $block = array_first($campaign->activityFeed, function ($value) use ($blockId) {
-            return $value->id === $blockId;
+
+        // Find the community page.
+        $communityPage = array_first($campaign->pages, function ($value) {
+            return ends_with($value->fields->slug, 'community');
         });
+
+        if ($communityPage) {
+            // Find the block within the community page block if available.
+            $block = array_first($communityPage->fields->blocks, function ($value) use ($blockId) {
+                return $value->id = $blockId;
+            });
+        }
 
         if ($block && isset($block->fields->socialOverride)) {
             $socialOverride = $block->fields->socialOverride->fields;


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR fixes an issue where the code for the `get_campaign_social_fields()` (which we really need to revisit) was referencing the `activityFeed` property on the `campaign` object, but that property was recently removed in favor of having a dedicated Community page.

So this just does a quick update to look inside the `$campaign->pages` property, find the Community page if it is available and then if it is, we search for a social override block thing, inside of the Community page blocks! Should resolve the errors!

### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.