### PR TITLE
ActionStep and SectionHeader component cleanup

### DIFF
--- a/resources/assets/components/ContentfulEntry/ContentfulEntry.js
+++ b/resources/assets/components/ContentfulEntry/ContentfulEntry.js
@@ -30,7 +30,6 @@ const DEFAULT_BLOCK: ContentfulEntryJson = { fields: { type: null } };
 
 type Props = {
   json: ContentfulEntryJson,
-  stepIndex: number,
 };
 type State = { hasError: boolean };
 
@@ -51,7 +50,7 @@ class ContentfulEntry extends React.Component<Props, State> {
     }
 
     // Otherwise, find the corresponding component & render it!
-    const { json = DEFAULT_BLOCK, stepIndex = 1 } = this.props;
+    const { json = DEFAULT_BLOCK } = this.props;
     const type = parseContentfulType(json);
 
     switch (type) {
@@ -151,7 +150,7 @@ class ContentfulEntry extends React.Component<Props, State> {
         return renderTextSubmissionAction(json);
 
       case 'voterRegistrationAction':
-        return renderVoterRegistrationAction(json, stepIndex);
+        return renderVoterRegistrationAction(json);
 
       default:
         return <NotFound />;

--- a/resources/assets/components/ContentfulEntry/renderers.js
+++ b/resources/assets/components/ContentfulEntry/renderers.js
@@ -17,7 +17,7 @@ import ReferralSubmissionActionContainer from '../actions/ReferralSubmissionActi
  *
  * @return {Component}
  */
-export function renderVoterRegistrationAction(step, stepIndex) {
+export function renderVoterRegistrationAction(step) {
   const { title, content, link } = step.fields;
   const key = `voter-registration-action-${step.id}`;
 
@@ -29,7 +29,6 @@ export function renderVoterRegistrationAction(step, stepIndex) {
         content={content}
         title={title}
         link={link}
-        stepIndex={stepIndex}
       />
       <PuckWaypoint name="voter_registration_action-bottom" />
     </div>

--- a/resources/assets/components/LegacyQuiz/Question.js
+++ b/resources/assets/components/LegacyQuiz/Question.js
@@ -13,7 +13,7 @@ const Question = props => {
 
   return (
     <div className="question">
-      <SectionHeader title={title} hideStepNumber />
+      <SectionHeader title={title} />
       <div className="question__choices">
         {answers.map(answer => (
           <Answer

--- a/resources/assets/components/Quiz/QuizQuestion.js
+++ b/resources/assets/components/Quiz/QuizQuestion.js
@@ -32,7 +32,7 @@ const QuizQuestion = props => {
 
   return (
     <div className="question">
-      <SectionHeader preTitle={preTitle} title={title} hideStepNumber />
+      <SectionHeader preTitle={preTitle} title={title} />
       <div className="question__choices">{quizChoices}</div>
     </div>
   );

--- a/resources/assets/components/SectionHeader/SectionHeader.js
+++ b/resources/assets/components/SectionHeader/SectionHeader.js
@@ -4,14 +4,12 @@ import PropTypes from 'prop-types';
 import { convertNumberToWord } from '../../helpers';
 import './section-header.scss';
 
-// @TODO:
-// - change preTitle prop to superTitle,
-// - remove hideStepNumber prop and associated logic
+// @TODO: change preTitle prop to superTitle.
 
-const SectionHeader = ({ preTitle, title, hideStepNumber, step }) => (
+const SectionHeader = ({ preTitle, title }) => (
   <div className="flex__cell -two-thirds section-header">
     <span className="heading -emphasized section-header__pre-title">
-      {hideStepNumber ? preTitle : `Step ${convertNumberToWord(step)}`}
+      {preTitle}
     </span>
     {title ? <h1 className="section-header__title">{title}</h1> : null}
   </div>
@@ -20,15 +18,11 @@ const SectionHeader = ({ preTitle, title, hideStepNumber, step }) => (
 SectionHeader.propTypes = {
   preTitle: PropTypes.string,
   title: PropTypes.string,
-  hideStepNumber: PropTypes.bool,
-  step: PropTypes.number,
 };
 
 SectionHeader.defaultProps = {
-  step: null,
   title: null,
   preTitle: null,
-  hideStepNumber: false,
 };
 
 export default SectionHeader;

--- a/resources/assets/components/SectionHeader/SectionHeader.js
+++ b/resources/assets/components/SectionHeader/SectionHeader.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import { convertNumberToWord } from '../../helpers';
 import './section-header.scss';
 
 // @TODO: change preTitle prop to superTitle.

--- a/resources/assets/components/actions/VoterRegistrationAction/VoterRegistrationAction.test.js
+++ b/resources/assets/components/actions/VoterRegistrationAction/VoterRegistrationAction.test.js
@@ -17,7 +17,6 @@ const renderVoterRegistration = () =>
       content="Cras justo odio, dapibus ac facilisis in, egestas eget quam. Duis mollis, est non commodo luctus, nisi erat porttitor ligula."
       contentfulId="1234"
       link="http://example.com?campaign={campaignId}&campaingRun={campaignRunId}&user={northstarId}&source={source}"
-      stepIndex={1}
       title="Register to vote!"
       userId="551234567890abcdefghijkl"
       trackEvent={trackEventMock}

--- a/resources/assets/components/blocks/ContentBlock/ContentBlock.js
+++ b/resources/assets/components/blocks/ContentBlock/ContentBlock.js
@@ -16,7 +16,7 @@ const ContentBlock = props => {
     <div className="content-block">
       {title ? (
         <div className="margin-horizontal-md">
-          <SectionHeader preTitle={superTitle} title={title} hideStepNumber />
+          <SectionHeader preTitle={superTitle} title={title} />
         </div>
       ) : null}
 

--- a/resources/assets/components/blocks/ContentBlock/__snapshots__/ContentBlock.test.js.snap
+++ b/resources/assets/components/blocks/ContentBlock/__snapshots__/ContentBlock.test.js.snap
@@ -32,9 +32,7 @@ exports[`ContentBlock component is rendered with the proper child components whe
     className="margin-horizontal-md"
   >
     <SectionHeader
-      hideStepNumber={true}
       preTitle="Test Super Title"
-      step={null}
       title="Test Title"
     />
   </div>

--- a/resources/assets/components/pages/ActionPage/ActionSteps.js
+++ b/resources/assets/components/pages/ActionPage/ActionSteps.js
@@ -57,8 +57,6 @@ const ActionSteps = props => {
     template,
   } = props;
 
-  const stepIndex = 0;
-
   const stepComponents = actionSteps.map(json => {
     const type = parseContentfulType(json);
 
@@ -66,16 +64,7 @@ const ActionSteps = props => {
     // @TODO: These should be split out into separate "content" blocks.
     let prefixComponent = null;
     if (['voterRegistrationAction'].includes(type)) {
-      const title = get(json, 'fields.title', '');
-
-      // @HACK: We have some blank titles " "... just hide those.
-      prefixComponent = title.trim().length ? (
-        <SectionHeader
-          title={title}
-          hideStepNumber={get(json, 'fields.hideStepNumber', true)}
-          step={stepIndex}
-        />
-      ) : null;
+      prefixComponent = <SectionHeader title={get(json, 'fields.title', '')} />;
     }
 
     let columnWidth = 'two-thirds';
@@ -92,7 +81,7 @@ const ActionSteps = props => {
       <Flex id={`step-${json.id}`} key={json.id}>
         {prefixComponent}
         <FlexCell width={columnWidth}>
-          <ContentfulEntry json={json} stepIndex={stepIndex} />
+          <ContentfulEntry json={json} />
         </FlexCell>
       </Flex>
     );

--- a/resources/assets/components/pages/ActionPage/ActionSteps.js
+++ b/resources/assets/components/pages/ActionPage/ActionSteps.js
@@ -1,10 +1,8 @@
 import React from 'react';
-import { get } from 'lodash';
 import PropTypes from 'prop-types';
 
 import Revealer from '../../Revealer';
 import { Flex, FlexCell } from '../../Flex';
-import SectionHeader from '../../SectionHeader';
 import ContentfulEntry from '../../ContentfulEntry';
 import { parseContentfulType } from '../../../helpers';
 import { PostGalleryContainer } from '../../Gallery/PostGallery';
@@ -60,13 +58,6 @@ const ActionSteps = props => {
   const stepComponents = actionSteps.map(json => {
     const type = parseContentfulType(json);
 
-    // Some components have built-in section headers. For those, append it.
-    // @TODO: These should be split out into separate "content" blocks.
-    let prefixComponent = null;
-    if (['voterRegistrationAction'].includes(type)) {
-      prefixComponent = <SectionHeader title={get(json, 'fields.title', '')} />;
-    }
-
     let columnWidth = 'two-thirds';
     if (['photoSubmissionAction', 'gallery', 'imagesBlock'].includes(type)) {
       columnWidth = 'full';
@@ -79,7 +70,6 @@ const ActionSteps = props => {
 
     return (
       <Flex id={`step-${json.id}`} key={json.id}>
-        {prefixComponent}
         <FlexCell width={columnWidth}>
           <ContentfulEntry json={json} />
         </FlexCell>


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR 

- simplifies some ActionStep component logic, ~specifically in regards to the `preFixComponent` (all VoterRegistrationActions have titles)~
- removes the `step` and `hideStepNumber` logic from the `SectionHeader` component and all the various references around the app
- removes the `prefixComponent` in `ActionSteps`

### Any background context you want to provide?
We no longer make use of the `hideStepNumber` prop, thanks to our migration away from `CampaignActionSteps` #925  This finally eradicates all reference to this much-beloved functionality.

### What are the relevant tickets/cards?

Refs [Pivotal ID #158394949](https://www.pivotaltracker.com/story/show/158394949)