### PR TITLE
Add reset submission call to fix looping bug

### DIFF
--- a/resources/assets/components/actions/PhotoSubmissionAction/PhotoSubmissionAction.js
+++ b/resources/assets/components/actions/PhotoSubmissionAction/PhotoSubmissionAction.js
@@ -32,6 +32,8 @@ class PhotoSubmissionAction extends React.Component {
     const response = nextProps.submissions.items[nextProps.id] || null;
 
     if (has(response, 'status.success')) {
+      nextProps.resetPostSubmissionItem(nextProps.id);
+
       return {
         shouldResetForm: true,
         showModal: true,

--- a/resources/assets/components/actions/PhotoSubmissionAction/PhotoSubmissionAction.js
+++ b/resources/assets/components/actions/PhotoSubmissionAction/PhotoSubmissionAction.js
@@ -32,6 +32,7 @@ class PhotoSubmissionAction extends React.Component {
     const response = nextProps.submissions.items[nextProps.id] || null;
 
     if (has(response, 'status.success')) {
+      // Resetting the submission item so that this won't be triggered continually for further renders.
       nextProps.resetPostSubmissionItem(nextProps.id);
 
       return {

--- a/resources/assets/components/actions/ReferralSubmissionAction/ReferralSubmissionAction.js
+++ b/resources/assets/components/actions/ReferralSubmissionAction/ReferralSubmissionAction.js
@@ -16,6 +16,7 @@ class ReferralSubmissionAction extends React.Component {
     const response = nextProps.submissions.items[nextProps.id] || null;
 
     if (has(response, 'status.success')) {
+      // Resetting the submission item so that this won't be triggered continually for further renders.
       nextProps.resetPostSubmissionItem(nextProps.id);
 
       return {

--- a/resources/assets/components/actions/ReferralSubmissionAction/ReferralSubmissionAction.js
+++ b/resources/assets/components/actions/ReferralSubmissionAction/ReferralSubmissionAction.js
@@ -16,6 +16,8 @@ class ReferralSubmissionAction extends React.Component {
     const response = nextProps.submissions.items[nextProps.id] || null;
 
     if (has(response, 'status.success')) {
+      nextProps.resetPostSubmissionItem(nextProps.id);
+
       return {
         showModal: true,
         firstNameValue: '',

--- a/resources/assets/components/actions/TextSubmissionAction/TextSubmissionAction.js
+++ b/resources/assets/components/actions/TextSubmissionAction/TextSubmissionAction.js
@@ -16,6 +16,8 @@ class TextSubmissionAction extends React.Component {
     const response = nextProps.submissions.items[nextProps.id] || null;
 
     if (has(response, 'status.success')) {
+      nextProps.resetPostSubmissionItem(nextProps.id);
+
       return {
         showModal: true,
         textValue: '',

--- a/resources/assets/components/actions/TextSubmissionAction/TextSubmissionAction.js
+++ b/resources/assets/components/actions/TextSubmissionAction/TextSubmissionAction.js
@@ -16,6 +16,7 @@ class TextSubmissionAction extends React.Component {
     const response = nextProps.submissions.items[nextProps.id] || null;
 
     if (has(response, 'status.success')) {
+      // Resetting the submission item so that this won't be triggered continually for further renders.
       nextProps.resetPostSubmissionItem(nextProps.id);
 
       return {


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_


### What does this PR do?

This PR is a proposed fix to an infinite loop we were experiencing in our RB Submission Forms.

### Any background context you want to provide?
[This thread here](https://dosomething.slack.com/archives/C2BPA7M8F/p1531331017000136)
> So to recap:
It seems that with the updated version of React, the `getDerivedStateFromProps` lifecycle method is invoked for *every* re-render.
This seems not to have been the case in earlier versions, which was why, although we still maintained a successful submission in our store, we still weren’t getting caught in this infinite loop.
Now that it is happening though, what we could do is simply call the `resetPostSubmissionItem` method once we register a successful post, ensuring that the next time `getDerivedStateFromProps` is invoked, we will no longer reset the state to `shouldResetForm: true` causing the cycle to begin all over again. 
Like so https://git.io/fNI4H