### PR TITLE
Update to reflect new contentful asset domains

### DIFF
--- a/resources/assets/components/utilities/Markdown/Markdown.js
+++ b/resources/assets/components/utilities/Markdown/Markdown.js
@@ -8,7 +8,7 @@ import { markdown, contentfulImageUrl } from '../../../helpers';
 
 import './markdown.scss';
 
-const pattern = /\/\/images\.contentful\.com.+\.(jpg|png)/g;
+const pattern = /\/\/images\.ctfassets\.net.+\.(jpg|png)/g;
 const contentfulImageFormat = url => contentfulImageUrl(url, '1000');
 const formatImageUrls = string =>
   string.replace(pattern, contentfulImageFormat);


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR updates our `Markdown` components asset domain pattern, so we can auto-format Contentful asset images embedded in markdown content

### Any background context you want to provide?
More info in the linked issue! https://github.com/DoSomething/phoenix-next/issues/1002#issuecomment-405364588

### What are the relevant tickets/cards?
#1002 