### PR TITLE
Update Markdown image formatting -- patch

### DIFF
--- a/resources/assets/components/utilities/Markdown/Markdown.js
+++ b/resources/assets/components/utilities/Markdown/Markdown.js
@@ -8,7 +8,7 @@ import { markdown, contentfulImageUrl } from '../../../helpers';
 
 import './markdown.scss';
 
-const pattern = /\/\/images\.ctfassets\.net.+\.(jpg|png)/g;
+const pattern = /\/\/images\.(ctfassets\.net|contentful\.com).+\.(jpg|png)/g;
 const contentfulImageFormat = url => contentfulImageUrl(url, '1000');
 const formatImageUrls = string =>
   string.replace(pattern, contentfulImageFormat);


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?
This PR updates the markdown image url formatter to include the legacy contentful asset domain.

### Any background context you want to provide?
In my utter excitement and joy at patching the Markdown formatter, the thought that we might have many legacy Content entries using the legacy domain asset escaped me.
(A quick rough script estimated it at 55 blocks that include the use of the legacy domain)

### What are the relevant tickets/cards?
#1032 

![haste makes waste](http://www.paraart.com/wp-content/themes/PA_theme2/images/game-img/haste-makes-waste.jpg)

![car](http://sbt.blob.core.windows.net/storyboards/michaelbrecht/haste-makes-waste.png)
