### PR TITLE
Facebook Share Action to Rogue

### DIFF
--- a/resources/assets/components/actions/ShareAction/ShareAction.js
+++ b/resources/assets/components/actions/ShareAction/ShareAction.js
@@ -61,8 +61,11 @@ class ShareAction extends React.Component {
 
     showFacebookShareDialog(url)
       .then(() => {
-        // @TODO: Once Rogue is ready to accept this post we'll activate.
-        this.storeSharePost();
+        // Send share post to Rogue for authenticated users
+        if (this.props.isAuthenticated && this.props.campaignId) {
+          this.storeSharePost();
+        }
+
         trackPuckEvent('share action completed', { url });
         this.setState({ showModal: true });
       })

--- a/resources/assets/components/actions/ShareAction/ShareAction.js
+++ b/resources/assets/components/actions/ShareAction/ShareAction.js
@@ -29,6 +29,7 @@ class ShareAction extends React.Component {
 
   storeSharePost = url => {
     const type = '?';
+    const type = 'share-social';
 
     const action = get(this.props.additionalContent, 'action', 'default');
 
@@ -42,6 +43,7 @@ class ShareAction extends React.Component {
       },
       {
         url,
+        platform: 'facebook',
         campaign_id: campaignId,
         legacy_campaign_id: legacyCampaignId,
         legacy_campaign_run_id: campaignRunId,

--- a/resources/assets/components/actions/ShareAction/ShareAction.js
+++ b/resources/assets/components/actions/ShareAction/ShareAction.js
@@ -148,6 +148,7 @@ ShareAction.propTypes = {
   content: PropTypes.string,
   hideEmbed: PropTypes.bool,
   id: PropTypes.string.isRequired,
+  isAuthenticated: PropTypes.func.isRequired,
   legacyCampaignId: PropTypes.string,
   link: PropTypes.string.isRequired,
   socialPlatform: PropTypes.oneOf(['twitter', 'facebook']).isRequired,

--- a/resources/assets/components/actions/ShareAction/ShareAction.js
+++ b/resources/assets/components/actions/ShareAction/ShareAction.js
@@ -27,8 +27,7 @@ class ShareAction extends React.Component {
     }
   }
 
-  storeSharePost = url => {
-    const type = '?';
+  storeSharePost = () => {
     const type = 'share-social';
 
     const action = get(this.props.additionalContent, 'action', 'default');
@@ -42,7 +41,6 @@ class ShareAction extends React.Component {
         id,
       },
       {
-        url,
         platform: 'facebook',
         campaign_id: campaignId,
         legacy_campaign_id: legacyCampaignId,
@@ -64,7 +62,7 @@ class ShareAction extends React.Component {
     showFacebookShareDialog(url)
       .then(() => {
         // @TODO: Once Rogue is ready to accept this post we'll activate.
-        // this.storeSharePost(url);
+        this.storeSharePost();
         trackPuckEvent('share action completed', { url });
         this.setState({ showModal: true });
       })

--- a/resources/assets/components/actions/ShareAction/ShareActionContainer.js
+++ b/resources/assets/components/actions/ShareAction/ShareActionContainer.js
@@ -2,15 +2,25 @@ import { connect } from 'react-redux';
 
 import ShareAction from './ShareAction';
 import { getUserId } from '../../../selectors/user';
+import { storeCampaignPost } from '../../../actions/post';
 
 /**
  * Provide state from the Redux store as props for this component.
  */
 const mapStateToProps = state => ({
   userId: getUserId(state),
-  campaignId: state.campaign.legacyCampaignId,
+  campaignId: state.campaign.id,
   campaignRunId: state.campaign.legacyCampaignRunId,
+  legacyCampaignId: state.campaign.legacyCampaignId,
 });
 
+/**
+ * Provide pre-bound functions that allow the component to dispatch
+ * actions to the Redux store as props for this component.
+ */
+const actionCreators = {
+  storeCampaignPost,
+};
+
 // Export the container component.
-export default connect(mapStateToProps)(ShareAction);
+export default connect(mapStateToProps, actionCreators)(ShareAction);

--- a/resources/assets/components/actions/ShareAction/ShareActionContainer.js
+++ b/resources/assets/components/actions/ShareAction/ShareActionContainer.js
@@ -1,7 +1,7 @@
 import { connect } from 'react-redux';
 
 import ShareAction from './ShareAction';
-import { getUserId } from '../../../selectors/user';
+import { getUserId, isAuthenticated } from '../../../selectors/user';
 import { storeCampaignPost } from '../../../actions/post';
 
 /**
@@ -11,6 +11,7 @@ const mapStateToProps = state => ({
   userId: getUserId(state),
   campaignId: state.campaign.id,
   campaignRunId: state.campaign.legacyCampaignRunId,
+  isAuthenticated: isAuthenticated(state),
   legacyCampaignId: state.campaign.legacyCampaignId,
 });
 
@@ -23,4 +24,7 @@ const actionCreators = {
 };
 
 // Export the container component.
-export default connect(mapStateToProps, actionCreators)(ShareAction);
+export default connect(
+  mapStateToProps,
+  actionCreators,
+)(ShareAction);


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR adds a call to post successful Facebook share actions to Rogue for authenticated users on a campaign Share Action.

### Any background context you want to provide?
I got the `type` and `details.platform` fields as well as more context from this doc https://github.com/DoSomething/chompy/wiki/How-Historic-FB-Share-Records-are-Imported

### What are the relevant tickets/cards?

Refs [Pivotal ID #158772936](https://www.pivotaltracker.com/story/show/158772936)
