### PR TITLE
Quick fix for errors on PaginatedQuery graphql requests

### DIFF
--- a/resources/assets/components/PaginatedQuery.js
+++ b/resources/assets/components/PaginatedQuery.js
@@ -33,7 +33,10 @@ const PaginatedQuery = ({ query, queryName, variables, count, children }) => (
             variables: {
               // The value in `variables.page` doesn't get updated here on
               // subsequent clicks, so we have to recalculate each time...
-              page: result.data[queryName].length / result.variables.count + 1,
+              page:
+                Math.ceil(
+                  result.data[queryName].length / result.variables.count,
+                ) + 1,
             },
             updateQuery: (previousResult, { fetchMoreResult }) => {
               if (!fetchMoreResult[queryName]) {

--- a/resources/assets/components/PaginatedQuery.js
+++ b/resources/assets/components/PaginatedQuery.js
@@ -34,6 +34,7 @@ const PaginatedQuery = ({ query, queryName, variables, count, children }) => (
               // The value in `variables.page` doesn't get updated here on
               // subsequent clicks, so we have to recalculate each time...
               page:
+                // Use ceil to force an integer in case we have less results data than the count!
                 Math.ceil(
                   result.data[queryName].length / result.variables.count,
                 ) + 1,


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR adds a quick fix for some errors we were seeing in graphql queries made from Phoenix.

### Any background context you want to provide?
TL;DR: use `Math.ceil` to force an integer value and stop the errors!

#### Down By the Quarry 🗿 
We were seeing a bunch of errors from our `CampaignGalleryQuery` and `SubmissionGalleryQuery`s due to a faulty `$page` variable. e.g.:
![image](https://user-images.githubusercontent.com/12417657/42902013-28f204d0-8a9b-11e8-8b8f-b140d3483362.png)

(See [Apollo Engine's errors page](https://engine.apollographql.com/service/DoSomething-GraphQL?query=2ec7a5f0a414a8419292342349dfc935913a4ddb&range=lastDay&tab=errors).)

#### [Napoleon's  Page](http://www.sparknotes.com/lit/idiot/section16/) 🇫🇷 
Turns out, our `PaginatedQuery` component (used by both error-prone components) re-calculates it's `page` query variable (which is used to determine the offset for the query on the backend) using the total amount of results thus far divided by the `count` variable (used to determine amount of items to load per page), which could end up being more than the actual amount of results! (If the `count` is 5 but we only have 1 result, we'd end up with 0.2 plus the incremented value of 1 === 1.2 which is not a valid Integer! Hence the errors).

Frustratingly, we cannot simply increment the page by one for each `fetchMore` request, since the `variables` prop does **not** get dynamically updated for each additional request. (I believe [this open issue](https://github.com/apollographql/apollo-client/issues/2285) expresses this point).

#### [No Ceilings](https://g.co/kgs/y5g6Z4) 🎧 
So finally this PR proposes to ensure we always have a valid int by using the ole `Math.ceil`, so that the 0.2 become a 1 + 1 == 2. 🍰 

### What are the relevant tickets/cards?

Refs [Pivotal ID #158730573](https://www.pivotaltracker.com/story/show/158730573)
