### PR TITLE
Bug fix for get_campaign_social_fields helper method

### DIFF
--- a/app/helpers.php
+++ b/app/helpers.php
@@ -315,7 +315,7 @@ function get_campaign_social_fields($campaign, $uri)
 
         // Find the community page.
         $communityPage = array_first($campaign->pages, function ($value) {
-            return ends_with($value->fields->slug, 'community');
+            return isset($value->fields->slug) && ends_with($value->fields->slug, 'community');
         });
 
         if ($communityPage) {


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR adds a quick patch to a bug we encountered from the `get_campaign_social_fields` helper method.

Ensuring the `slug` field is set on the page, before running the string check for `community`.

### Any background context you want to provide?
When attempting to check for a `SocialOverride` when rendering a campaign block route (`/blocks/:id`), we try and find the `/community` page in each of the campaigns `pages` by the `slug` field. Problem is some `pages` aren't actually Page content types and do not have a `slug` field, causing our application to throw a tantrum.

![image](https://user-images.githubusercontent.com/12417657/42961320-7d277cb2-8b5c-11e8-8f62-96ef9fe913fd.png)


### What are the relevant tickets/cards?
Refs [Pivotal ID #159176993](https://www.pivotaltracker.com/story/show/159176993)
[Slack thread here](https://dosomething.slack.com/archives/C2BPA7M8F/p1532021548000240)
