### PR TITLE
Error logging for failed POST requests to Phoenix backend

### DIFF
--- a/resources/assets/middleware/api.js
+++ b/resources/assets/middleware/api.js
@@ -2,9 +2,11 @@
 
 import { RestApiClient } from '@dosomething/gateway';
 
+import { report } from '../helpers';
 import { PHOENIX_URL } from '../constants';
 import { getRequest } from '../helpers/api';
 import { API } from '../constants/action-types';
+import { trackPuckEvent } from '../helpers/analytics';
 
 /**
  * Send a GET request and dispatch actions.
@@ -68,7 +70,14 @@ const postRequest = (payload, dispatch) => {
       });
     })
     .catch(error => {
+      report(error);
+      trackPuckEvent('phoenix_failed_post_request', {
+        url: payload.url,
+        body: payload.body,
+        error,
+      });
       console.log('🚫 failed response; caught the error!');
+
       const response = error.response;
 
       dispatch({


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR adds error logging for failed POST requests made to the Phoenix backend from our API middleware using the Gateway `RestApiClient`.

### Any background context you want to provide?
We want to be able to analyze and recognize when one of our calls is failing, specifically regarding the Share action post to Rogue #1035 where we don't have any failure handling exposed to the user.

### What are the relevant tickets/cards?

Refs [Pivotal ID #158772936](https://www.pivotaltracker.com/story/show/158772936/comments/192093651)


<img src="http://scoutdigitalmarketing.com.au/wp-content/uploads/2017/04/willy-wonka-google-analytics-meme.png" width="25%" />