### PR TITLE
Social drive Puck Events

### DIFF
--- a/resources/assets/components/actions/SocialDriveAction/SocialDriveAction.js
+++ b/resources/assets/components/actions/SocialDriveAction/SocialDriveAction.js
@@ -45,6 +45,9 @@ class SocialDriveAction extends React.Component {
   handleCopyLinkClick = () => {
     this.linkInput.current.select();
     document.execCommand('copy');
+    trackPuckEvent('phoenix_clicked_copy_to_clipboard', {
+      url: this.props.link,
+    });
   };
 
   handleFacebookShareClick = url => {

--- a/resources/assets/components/actions/SocialDriveAction/SocialDriveAction.js
+++ b/resources/assets/components/actions/SocialDriveAction/SocialDriveAction.js
@@ -119,7 +119,9 @@ class SocialDriveAction extends React.Component {
           <div className="share-button padded">
             <button
               className="button padding-vertical-md"
-              onClick={() => handleTwitterShareClick(shortenedLink)}
+              onClick={() =>
+                handleTwitterShareClick(shortenedLink, { url: link })
+              }
               disabled={!shortenedLink}
             >
               <i className="social-icon -twitter" />

--- a/resources/assets/components/actions/SocialDriveAction/SocialDriveAction.js
+++ b/resources/assets/components/actions/SocialDriveAction/SocialDriveAction.js
@@ -51,14 +51,16 @@ class SocialDriveAction extends React.Component {
   };
 
   handleFacebookShareClick = url => {
-    trackPuckEvent('clicked facebook share action', { url });
+    const trackingData = { url: this.props.link };
+
+    trackPuckEvent('clicked facebook share action', trackingData);
 
     showFacebookShareDialog(url)
       .then(() => {
-        trackPuckEvent('share action completed', { url });
+        trackPuckEvent('share action completed', trackingData);
       })
       .catch(() => {
-        trackPuckEvent('share action cancelled', { url });
+        trackPuckEvent('share action cancelled', trackingData);
       });
   };
 


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR edits the Puck event tracking for the `SocialDriveAction` component
- adds a new puck event `phoenix_clicked_copy_to_clipboard` on copy link to clipboard clicks
- updates the puck event tracking `data` fields to use the original `link` prop instead of the shortened link
- adds a tracking `data.url` field for twitter share clicks

### What are the relevant tickets/cards?

Refs [Pivotal ID #159035714](https://www.pivotaltracker.com/story/show/159035714)
