### PR TITLE
Fix typo and import declaration.

### DIFF
--- a/resources/assets/polyfills.js
+++ b/resources/assets/polyfills.js
@@ -1,7 +1,7 @@
 /* global window */
 
 // Regenerator runtime, for async/await.
-import 'regenerator-runtime';
+import 'regenerator-runtime/runtime';
 
 // `window.location.origin` polyfill for IE 10
 // @see: http://tosbourn.com/a-fix-for-window-location-origin-in-internet-explorer/

--- a/resources/assets/store/middlewares.js
+++ b/resources/assets/store/middlewares.js
@@ -2,6 +2,6 @@ import apiMiddleware from '../middleware/api';
 import analyticsMiddleware from '../middleware/analytics';
 import experimentsMiddleware from '../middleware/experiments';
 
-const middlwares = [analyticsMiddleware, apiMiddleware, experimentsMiddleware];
+const middlewares = [analyticsMiddleware, apiMiddleware, experimentsMiddleware];
 
-export default middlwares;
+export default middlewares;


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR fixes a typo and import declaration encountered while working on the new Sixpack component.

With the import declaration fix, I was having trouble working with async/await, which this import provides polyfill support for, but it was not working since it was not importing the `runtime`.