### PR TITLE
Adding Row utility component 

### DIFF
--- a/resources/assets/components/pages/CampaignPage/CampaignPageContent.js
+++ b/resources/assets/components/pages/CampaignPage/CampaignPageContent.js
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 import classnames from 'classnames';
 
 import NotFound from '../../NotFound';
+import Row from '../../utilities/Row/Row';
 import ScrollConcierge from '../../ScrollConcierge';
 import ContentfulEntry from '../../ContentfulEntry';
 import Markdown from '../../utilities/Markdown/Markdown';
@@ -59,18 +60,16 @@ const CampaignPageContent = props => {
     <div className="campaign-page" id={subPage.id}>
       <ScrollConcierge />
       {content ? (
-        <div className="row">
-          <div className="primary">
-            <Markdown className="margin-horizontal-md">{content}</Markdown>
-          </div>
-          <div className="secondary">
+        <Row>
+          <Markdown className="margin-horizontal-md">{content}</Markdown>
+          <div className="blocks">
             {sidebar.map(block => (
               <div className="margin-bottom-lg" key={block.id}>
                 <ContentfulEntry json={block} />
               </div>
             ))}
           </div>
-        </div>
+        </Row>
       ) : null}
 
       <div className="blocks clear-both">

--- a/resources/assets/components/pages/CampaignPage/campaign-page.scss
+++ b/resources/assets/components/pages/CampaignPage/campaign-page.scss
@@ -5,28 +5,6 @@
   font-size: $font-regular;
   line-height: 1.4;
 
-  .primary {
-    margin: 0 0 $base-spacing;
-
-    @include media($large) {
-      float: left;
-      padding-right: $half-spacing;
-      width: 66.6666666666666%;
-    }
-  }
-
-  .secondary {
-    display: none;
-
-    @include media($large) {
-      display: block;
-      float: right;
-      padding-left: $half-spacing;
-      margin: 0 0 $base-spacing;
-      width: 33.3333333333333%;
-    }
-  }
-
   > div {
     margin: $base-spacing 0;
   }

--- a/resources/assets/components/utilities/Row/Row.js
+++ b/resources/assets/components/utilities/Row/Row.js
@@ -1,0 +1,26 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import './row.scss';
+
+const Row = ({ children }) => {
+  // Ensure we have an array, even if a single child was passed through.
+  const childArray = React.Children.toArray(children);
+
+  return (
+    <div className="row">
+      <div className="primary">{childArray[0]}</div>
+
+      <div className="secondary">{childArray[1]}</div>
+    </div>
+  );
+};
+
+Row.propTypes = {
+  children: PropTypes.oneOfType([
+    PropTypes.node,
+    PropTypes.arrayOf(PropTypes.node),
+  ]).isRequired,
+};
+
+export default Row;

--- a/resources/assets/components/utilities/Row/row.scss
+++ b/resources/assets/components/utilities/Row/row.scss
@@ -1,0 +1,25 @@
+@import '../../../scss/next-toolbox';
+
+.row {
+  .primary {
+    margin: 0 0 $base-spacing;
+
+    @include media($large) {
+      float: left;
+      padding-right: $half-spacing;
+      width: 66.6666666666666%;
+    }
+  }
+
+  .secondary {
+    display: none;
+
+    @include media($large) {
+      display: block;
+      float: right;
+      padding-left: $half-spacing;
+      margin: 0 0 $base-spacing;
+      width: 33.3333333333333%;
+    }
+  }
+}


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR adds a new `Row` utility component to abstract the functionality of laying out and styling a row of content.

### Any background context you want to provide?
We had a neat little setup in [`CampaignPageContent`](https://github.com/DoSomething/phoenix-next/blob/master/resources/assets/components/pages/CampaignPage/CampaignPageContent.js#L62...L73) with [styling](https://github.com/DoSomething/phoenix-next/blob/master/resources/assets/components/pages/CampaignPage/campaign-page.scss#L8..L28) applied to lay out a row of 'primary' (two thirds) and 'secondary' (remaining third) content on a page like so:
<img width="1552" alt="screen shot 2018-07-30 at 4 18 26 pm" src="https://user-images.githubusercontent.com/12417657/43421292-5cab144c-9414-11e8-9424-60795ac7b349.png">

📱: 

<img width="433" alt="screen shot 2018-07-30 at 4 31 48 pm" src="https://user-images.githubusercontent.com/12417657/43421954-36370864-9416-11e8-97ac-f2e474ff4443.png">


In anticipation of utilizing this pattern across other components, this proposes an abstracted utility component called `Row`, which when supplied with one or two children, will take care of laying out and styling the content the same way.

### Thinking Face 🤔 
Somethings about this component bug me:

- the way we're statically grabbing two children into the `.primary` and `.secondary` classes, quietly abandoning the rest
- the components actions seem a bit obstructed from the user (on mobile the `.secondary` content will casually disappear without warning)

Could it be that a better method of abstraction is to simply create global styling rules in `base.scss`?
Or is this a good soft-implementation of [CSS-in-JS](https://reactjs.org/docs/faq-styling.html#what-is-css-in-js)? (we do have similiar such components like the [`Flex`](https://github.com/DoSomething/phoenix-next/blob/master/resources/assets/components/Flex/flex.scss) component)