### PR TITLE
Remove body field from failed event data

### DIFF
--- a/resources/assets/components/actions/ShareAction/ShareAction.js
+++ b/resources/assets/components/actions/ShareAction/ShareAction.js
@@ -151,7 +151,7 @@ ShareAction.propTypes = {
   content: PropTypes.string,
   hideEmbed: PropTypes.bool,
   id: PropTypes.string.isRequired,
-  isAuthenticated: PropTypes.func.isRequired,
+  isAuthenticated: PropTypes.bool.isRequired,
   legacyCampaignId: PropTypes.string,
   link: PropTypes.string.isRequired,
   socialPlatform: PropTypes.oneOf(['twitter', 'facebook']).isRequired,

--- a/resources/assets/middleware/api.js
+++ b/resources/assets/middleware/api.js
@@ -7,7 +7,6 @@ import { PHOENIX_URL } from '../constants';
 import { getRequest } from '../helpers/api';
 import { API } from '../constants/action-types';
 import { trackPuckEvent } from '../helpers/analytics';
-import { getFormData } from '../helpers/forms';
 
 /**
  * Send a GET request and dispatch actions.

--- a/resources/assets/middleware/api.js
+++ b/resources/assets/middleware/api.js
@@ -74,7 +74,6 @@ const postRequest = (payload, dispatch) => {
       report(error);
       trackPuckEvent('phoenix_failed_post_request', {
         url: payload.url,
-        body: getFormData(payload.body),
         error,
       });
       console.log('🚫 failed response; caught the error!');


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR removes the `body` field (containing the form data) from Puck events fired for failed POST requests to Phoenix from our front  end

(Also snuck in a quick adjustment to a faulty prop type in the ShareAction)

### Any background context you want to provide?
While testing the new `phoenix_failed_post_request` event on staging, I noticed that though the events were firing correctly and hitting Puck, they were not showing up on Keen.io. 

Turns out that for PhotoSubmissionActions, when the form data contains a File blob, the content type header becomes `application/octet-stream`. So something there is making someone unhappy. (I wasn't able to get to the absolute bottom of this.)

At @weerd's recommendation, this will simply remove the `body` field from this Puck event, since we already pass through the `error` anyways, which should give us all the info we need. If we do feel that we're missing data, we can circle back to this, and add a parser to clean out the form data before submission.

#1040 
