### PR TITLE
Add General page content and sidebar fields

### DIFF
--- a/resources/assets/components/pages/CampaignPage/CampaignPageContent.js
+++ b/resources/assets/components/pages/CampaignPage/CampaignPageContent.js
@@ -63,13 +63,15 @@ const CampaignPageContent = props => {
           <div className="primary">
             <Markdown className="margin-horizontal-md">{content}</Markdown>
           </div>
-          <div className="secondary">
-            {sidebar.map(block => (
-              <div className="margin-bottom-lg" key={block.id}>
-                <ContentfulEntry json={block} />
-              </div>
-            ))}
-          </div>
+          {sidebar.length ? (
+            <div className="secondary">
+              {sidebar.map(block => (
+                <div className="margin-bottom-lg" key={block.id}>
+                  <ContentfulEntry json={block} />
+                </div>
+              ))}
+            </div>
+          ) : null}
         </div>
       ) : null}
 

--- a/resources/assets/components/pages/GeneralPage/GeneralPage.js
+++ b/resources/assets/components/pages/GeneralPage/GeneralPage.js
@@ -1,8 +1,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import classnames from 'classnames';
 
 import Enclosure from '../../Enclosure';
 import ContentfulEntry from '../../ContentfulEntry';
+import Markdown from '../../utilities/Markdown/Markdown';
 
 import './general-page.scss';
 
@@ -12,7 +14,7 @@ import './general-page.scss';
  * @returns {XML}
  */
 const GeneralPage = props => {
-  const { title, subTitle, blocks } = props;
+  const { title, subTitle, content, sidebar, blocks } = props;
 
   return (
     <div>
@@ -24,6 +26,22 @@ const GeneralPage = props => {
               <p className="general-page__subtitle">{subTitle}</p>
             ) : null}
           </div>
+
+          {content ? (
+            <div className={classnames({ row: sidebar.length })}>
+              <div className="primary">
+                <Markdown className="margin-horizontal-md">{content}</Markdown>
+              </div>
+
+              <div className="secondary">
+                {sidebar.map(block => (
+                  <div className="margin-bottom-lg" key={block.id}>
+                    <ContentfulEntry json={block} />
+                  </div>
+                ))}
+              </div>
+            </div>
+          ) : null}
 
           {blocks.map(block => (
             <div className="general-page__block margin-vertical" key={block.id}>
@@ -39,11 +57,15 @@ const GeneralPage = props => {
 GeneralPage.propTypes = {
   title: PropTypes.string.isRequired,
   subTitle: PropTypes.string,
+  content: PropTypes.string,
+  sidebar: PropTypes.arrayOf(PropTypes.object),
   blocks: PropTypes.arrayOf(PropTypes.object).isRequired,
 };
 
 GeneralPage.defaultProps = {
   subTitle: null,
+  content: null,
+  sidebar: [],
 };
 
 export default GeneralPage;

--- a/resources/assets/components/pages/GeneralPage/GeneralPage.js
+++ b/resources/assets/components/pages/GeneralPage/GeneralPage.js
@@ -33,13 +33,15 @@ const GeneralPage = props => {
                 <Markdown className="margin-horizontal-md">{content}</Markdown>
               </div>
 
-              <div className="secondary">
-                {sidebar.map(block => (
-                  <div className="margin-bottom-lg" key={block.id}>
-                    <ContentfulEntry json={block} />
-                  </div>
-                ))}
-              </div>
+              {sidebar.length ? (
+                <div className="secondary">
+                  {sidebar.map(block => (
+                    <div className="margin-bottom-lg" key={block.id}>
+                      <ContentfulEntry json={block} />
+                    </div>
+                  ))}
+                </div>
+              ) : null}
             </div>
           ) : null}
 

--- a/resources/assets/components/pages/GeneralPage/GeneralPageContainer.js
+++ b/resources/assets/components/pages/GeneralPage/GeneralPageContainer.js
@@ -5,15 +5,7 @@ import GeneralPage from './GeneralPage';
 /**
  * Provide state from the Redux store as props for this component.
  */
-const mapStateToProps = state => {
-  const { title, subTitle, blocks } = state.page.fields;
-
-  return {
-    title,
-    subTitle,
-    blocks,
-  };
-};
+const mapStateToProps = state => state.page.fields;
 
 // Export the container component.
 export default connect(mapStateToProps)(GeneralPage);

--- a/resources/assets/components/pages/GeneralPage/general-page.scss
+++ b/resources/assets/components/pages/GeneralPage/general-page.scss
@@ -55,4 +55,28 @@
       margin-left: 25%;
     }
   }
+
+  .row {
+    .primary {
+      margin: 0 0 $base-spacing;
+
+      @include media($large) {
+        float: left;
+        padding-right: $half-spacing;
+        width: 66.6666666666666%;
+      }
+    }
+
+    .secondary {
+      display: none;
+
+      @include media($large) {
+        display: block;
+        float: right;
+        padding-left: $half-spacing;
+        margin: 0 0 $base-spacing;
+        width: 33.3333333333333%;
+      }
+    }
+  }
 }


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR adds the `content` and `sidebar` fields to the `GeneralPage` component.

- refactors `GeneralPageContainer` to pass over *all* page fields. (it's way cleaner too! ⚡️)
- formats the content and sidebar using the same scheme as the [`CampaignContentPage`](https://github.com/DoSomething/phoenix-next/blob/master/resources/assets/components/pages/CampaignPage/CampaignPageContent.js#L61...L74), wherein the fields will only be rendered *if* there is `content` provided. And then arranged in a two-thirds/one-third format.


### Any background context you want to provide?
👇 
One deviation from the arrangement in `CampaignContentPage` is that we'll only apply the `.row` class along with its `.primary`/`.secondary` partitioned styling *if* there are `sidebar ` blocks provided, if there aren't, the `content` will stretch full width, as unlike campaign pages, I thought it looked pretty silly to have the content across only two-thirds of the alotted space if there are no blocks provided:
![image](https://user-images.githubusercontent.com/12417657/43546892-bb98b394-95a7-11e8-9dff-d7423e933323.png)
(Pls lemme know if you think otherwise!)

👇 
Another point: I don't think anyone will want to be attaching sidebar blocks yet, since, the two blocks allowed for the `sidebar` field -- `customBlock` and `callToAction`, both error out on General Pages (see attached screenshots below). I think this is due to us not having a Campaign in state for `callToAction`s, and `customBlock` static blocks only being [rendered properly for Pitch Pages](https://github.com/DoSomething/phoenix-next/blob/master/resources/assets/components/pages/LandingPage/templates/PitchTemplate.js#L12...L17) (which incedentally @weerd, is another example use case of the `.primary .secondary` that I totally missed -and I probably missed it because- it makes use of the CSS from the Campaign Page 😬 )
✌️ 
But in any case, `sidebar` blocks will technically be rendered out on the page if added!

### What are the relevant tickets/cards?

Refs [Pivotal ID #159110916](https://www.pivotaltracker.com/story/show/159110916)

### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.
* [x] Added screenshot to PR description of related front-end updates on **small** screens.
* [ ] Added screenshot to PR description of related front-end updates on **medium** screens.
* [x] Added screenshot to PR description of related front-end updates on **large** screens.


💻 
[With Content  - and Sidebar Blocks](https://user-images.githubusercontent.com/12417657/43551239-5641ec42-95b4-11e8-9c28-0c3dfe4ac124.png)
[With Content - Without Sidebar Blocks](https://user-images.githubusercontent.com/12417657/43551278-7d07f632-95b4-11e8-97d1-a98e89d473ae.png)


📱 
[With, and without sidebar (sidebar blocks are hidden on medium/small screens)](https://user-images.githubusercontent.com/12417657/43551362-bb6a4588-95b4-11e8-9113-a1763a2be587.png)

