### PR TITLE
Move Landing Page Logic to Campaign Page / Closed Campaign State Logic

### DIFF
--- a/resources/assets/components/Campaign/Campaign.js
+++ b/resources/assets/components/Campaign/Campaign.js
@@ -6,7 +6,6 @@ import NotificationContainer from '../Notification';
 import ModalLauncherContainer from '../ModalLauncher';
 import ModalRoute from '../utilities/ModalRoute/ModalRoute';
 import CampaignRouteContainer from './CampaignRoute/CampaignRouteContainer';
-import LandingPageContainer from '../pages/LandingPage/LandingPageContainer';
 import SurveyModalContainer from '../pages/SurveyModal/SurveyModalContainer';
 import TrafficDistribution from '../utilities/TrafficDistribution/TrafficDistribution';
 import VoterRegistrationModal from '../pages/VoterRegistrationModal/VoterRegistrationModal';
@@ -45,16 +44,11 @@ const Campaign = props => (
       </TrafficDistribution>
     ) : null}
 
-    {props.shouldShowLandingPage ? (
-      <LandingPageContainer {...props} />
-    ) : (
-      <CampaignRouteContainer {...props} />
-    )}
+    <CampaignRouteContainer {...props} />
   </ModalRoute>
 );
 
 Campaign.propTypes = {
-  shouldShowLandingPage: PropTypes.bool.isRequired,
   featureFlags: PropTypes.objectOf(PropTypes.bool),
   location: ReactRouterPropTypes.location.isRequired,
   history: ReactRouterPropTypes.history.isRequired,

--- a/resources/assets/components/Campaign/CampaignContainer.js
+++ b/resources/assets/components/Campaign/CampaignContainer.js
@@ -2,32 +2,9 @@ import { connect } from 'react-redux';
 import { get } from 'lodash';
 
 import Campaign from './Campaign';
-import { isSignedUp } from '../../selectors/signup';
 
-const mapStateToProps = (state, props) => {
-  const hasLandingPage = state.campaign.landingPage !== null;
-
-  // @TODO: Move these into the pages themselves.
-  const { location, match } = props;
-  const isQuiz = location.pathname.replace(match.url, '').startsWith('/quiz/');
-  const isBlock = location.pathname
-    .replace(match.url, '')
-    .startsWith('/blocks/');
-
-  const ignoreLandingPage =
-    state.admin.shouldShowActionPage || isQuiz || isBlock;
-  let shouldShowLandingPage = false;
-
-  if (state.admin.shouldShowLandingPage) {
-    shouldShowLandingPage = true;
-  } else if (hasLandingPage && !ignoreLandingPage) {
-    shouldShowLandingPage = !isSignedUp(state);
-  }
-
-  return {
-    shouldShowLandingPage,
-    featureFlags: get(state.campaign.additionalContent, 'featureFlags'),
-  };
-};
+const mapStateToProps = state => ({
+  featureFlags: get(state.campaign.additionalContent, 'featureFlags'),
+});
 
 export default connect(mapStateToProps)(Campaign);

--- a/resources/assets/components/pages/CampaignPage/CampaignPage.js
+++ b/resources/assets/components/pages/CampaignPage/CampaignPage.js
@@ -8,6 +8,7 @@ import CampaignPageContent from './CampaignPageContent';
 import DashboardContainer from '../../Dashboard/DashboardContainer';
 import LedeBannerContainer from '../../LedeBanner/LedeBannerContainer';
 import CampaignPageNavigationContainer from '../../CampaignPageNavigation/CampaignPageNavigationContainer';
+import LandingPageContainer from '../../pages/LandingPage/LandingPageContainer';
 
 import './campaign-page.scss';
 
@@ -16,28 +17,31 @@ import './campaign-page.scss';
  *
  * @returns {XML}
  */
-const CampaignPage = props => (
-  <div>
-    <LedeBannerContainer displaySignup={Boolean(!props.entryContent)} />
-    <div className="main clearfix">
-      {props.dashboard ? <DashboardContainer /> : null}
+const CampaignPage = props =>
+  props.shouldShowLandingPage ? (
+    <LandingPageContainer {...props} />
+  ) : (
+    <div>
+      <LedeBannerContainer displaySignup={Boolean(!props.entryContent)} />
+      <div className="main clearfix">
+        {props.dashboard ? <DashboardContainer /> : null}
 
-      {!props.entryContent ? <CampaignPageNavigationContainer /> : null}
+        {!props.entryContent ? <CampaignPageNavigationContainer /> : null}
 
-      <Enclosure className="default-container margin-top-lg margin-bottom-lg">
-        {/* @TODO: after Action page migration, refactor and combine CampaignPage & CampaignSubPage and render Contentful Entry within CampaignPage component */}
+        <Enclosure className="default-container margin-top-lg margin-bottom-lg">
+          {/* @TODO: after Action page migration, refactor and combine CampaignPage & CampaignSubPage and render Contentful Entry within CampaignPage component */}
+          {!props.entryContent ? (
+            <CampaignPageContent {...props} />
+          ) : (
+            <ContentfulEntry json={props.entryContent} />
+          )}
+        </Enclosure>
         {!props.entryContent ? (
-          <CampaignPageContent {...props} />
-        ) : (
-          <ContentfulEntry json={props.entryContent} />
-        )}
-      </Enclosure>
-      {!props.entryContent ? (
-        <CallToActionContainer sticky hideIfSignedUp />
-      ) : null}
+          <CallToActionContainer sticky hideIfSignedUp />
+        ) : null}
+      </div>
     </div>
-  </div>
-);
+  );
 
 CampaignPage.propTypes = {
   dashboard: PropTypes.shape({
@@ -46,6 +50,7 @@ CampaignPage.propTypes = {
     fields: PropTypes.object,
   }),
   entryContent: PropTypes.object, // eslint-disable-line react/forbid-prop-types
+  shouldShowLandingPage: PropTypes.bool.isRequired,
 };
 
 CampaignPage.defaultProps = {

--- a/resources/assets/components/pages/CampaignPage/CampaignPageContainer.js
+++ b/resources/assets/components/pages/CampaignPage/CampaignPageContainer.js
@@ -2,7 +2,7 @@ import { get, has } from 'lodash';
 import { connect } from 'react-redux';
 
 import CampaignPage from './CampaignPage';
-import { findContentfulEntry } from '../../../helpers';
+import { findContentfulEntry, shouldShowLandingPage } from '../../../helpers';
 
 /**
  * Provide state from the Redux store as props for this component.
@@ -18,6 +18,7 @@ const mapStateToProps = (state, ownProps) => {
   }
 
   return {
+    shouldShowLandingPage: shouldShowLandingPage(state, entryContent),
     campaignEndDate: get(state.campaign.endDate, 'date', null),
     dashboard: state.campaign.dashboard,
     entryContent,

--- a/resources/assets/helpers/index.js
+++ b/resources/assets/helpers/index.js
@@ -382,7 +382,7 @@ export function isCampaignClosed(endDate) {
 }
 
 /**
- * Check if the Landing Page should be shown for campaign
+ * Check if the Landing Page should be shown for campaign.
  *
  * @param  {Object}       state
  * @param  {Boolean|null} shouldIgnore

--- a/resources/assets/helpers/index.js
+++ b/resources/assets/helpers/index.js
@@ -384,8 +384,8 @@ export function isCampaignClosed(endDate) {
 /**
  * Check if the Landing Page should be shown for campaign.
  *
- * @param  {Object}       state
- * @param  {Boolean|null} ignoreLandingPage
+ * @param  {Object}  state
+ * @param  {Boolean} ignoreLandingPage - optional additional boolean to ignore landing page.
  * @return {Boolean}
  */
 export function shouldShowLandingPage(state, ignoreLandingPage) {

--- a/resources/assets/helpers/index.js
+++ b/resources/assets/helpers/index.js
@@ -385,18 +385,19 @@ export function isCampaignClosed(endDate) {
  * Check if the Landing Page should be shown for campaign.
  *
  * @param  {Object}       state
- * @param  {Boolean|null} shouldIgnore
+ * @param  {Boolean|null} ignoreLandingPage
  * @return {Boolean}
  */
-export function shouldShowLandingPage(state, shouldIgnore) {
+export function shouldShowLandingPage(state, ignoreLandingPage) {
   const hasLandingPage = state.campaign.landingPage !== null;
 
-  const ignoreLandingPage = state.admin.shouldShowActionPage || shouldIgnore;
+  const shouldIgnoreLandingPage =
+    state.admin.shouldShowActionPage || ignoreLandingPage;
   let shouldShow = false;
 
   if (state.admin.shouldShowLandingPage) {
     shouldShow = true;
-  } else if (hasLandingPage && !ignoreLandingPage) {
+  } else if (hasLandingPage && !shouldIgnoreLandingPage) {
     shouldShow =
       !isSignedUp(state) &&
       !isCampaignClosed(get(state.campaign.endDate, 'date', null));

--- a/resources/assets/helpers/index.js
+++ b/resources/assets/helpers/index.js
@@ -8,6 +8,7 @@ import markdownItFootnote from 'markdown-it-footnote';
 import { get, find, isNull, isUndefined, omitBy } from 'lodash';
 
 import { trackPuckEvent } from './analytics';
+import { isSignedUp } from '../selectors/signup';
 
 // Helper Constants
 export const EMPTY_IMAGE =
@@ -378,6 +379,30 @@ export function isCampaignClosed(endDate) {
   }
 
   return isBefore(endDate, new Date());
+}
+
+/**
+ * Check if the Landing Page should be shown for campaign
+ *
+ * @param  {Object}       state
+ * @param  {Boolean|null} shouldIgnore
+ * @return {Boolean}
+ */
+export function shouldShowLandingPage(state, shouldIgnore) {
+  const hasLandingPage = state.campaign.landingPage !== null;
+
+  const ignoreLandingPage = state.admin.shouldShowActionPage || shouldIgnore;
+  let shouldShow = false;
+
+  if (state.admin.shouldShowLandingPage) {
+    shouldShow = true;
+  } else if (hasLandingPage && !ignoreLandingPage) {
+    shouldShow =
+      !isSignedUp(state) &&
+      !isCampaignClosed(get(state.campaign.endDate, 'date', null));
+  }
+
+  return shouldShow;
 }
 
 /**


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR

- moves the logic determining whether to show the Landing Page over to the `CampaignPage` component
- ensures Landing Page won't show up for closed campaigns
- abstracts the logic into a helper function called ...`shouldShowLandingPage`! 💡 

### Any background context you want to provide?
I was adding the logic to ensure landing pages did not show for closed campaigns and bumped into a helpful `@TODO` comment begging us to move the logic from the `CampaignContainer` into the respective pages themselves, so took the opportunity to do so!

It did feel like a good idea to throw the whole mess of logic into a helper method to clean the container and so that we can easily pull it into other components if needed in the future.
![helper](http://joshowens.me/content/images/2015/Jun/collection-helpers-meme.jpg)

### What are the relevant tickets/cards?

Refs [Pivotal ID #159476747](https://www.pivotaltracker.com/story/show/159476747)
