### PR TITLE
Provide fallbacks and better logic for a couple Legacy Campaign fields.

### DIFF
--- a/app/Entities/LegacyCampaign.php
+++ b/app/Entities/LegacyCampaign.php
@@ -47,6 +47,18 @@ class LegacyCampaign implements JsonSerializable
     }
 
     /**
+     * Parse the campaign run ID.
+     *
+     * @param  array $campaignRuns
+     * @return string
+     */
+    public function parseCampaignRunId($campaignRuns) {
+        $current = array_shift($campaignRuns['current']);
+
+        return $current['id'];
+    }
+
+    /**
      * Convert the object into something JSON serializable.
      *
      * @return array
@@ -56,7 +68,7 @@ class LegacyCampaign implements JsonSerializable
         return [
             'id' => null,
             'legacyCampaignId' => $this->legacyCampaign['id'],
-            'legacyCampaignRunId' => $this->legacyCampaign['campaign_runs']['current']['en']['id'],
+            'legacyCampaignRunId' => $this->parseCampaignRunId($this->legacyCampaign['campaign_runs']),
             'type' => 'campaign',
             'title' => $this->legacyCampaign['title'],
             'slug' => null,

--- a/app/Entities/LegacyCampaign.php
+++ b/app/Entities/LegacyCampaign.php
@@ -52,7 +52,8 @@ class LegacyCampaign implements JsonSerializable
      * @param  array $campaignRuns
      * @return string
      */
-    public function parseCampaignRunId($campaignRuns) {
+    public function parseCampaignRunId($campaignRuns)
+    {
         $current = array_shift($campaignRuns['current']);
 
         return $current['id'];

--- a/app/Entities/LegacyCampaign.php
+++ b/app/Entities/LegacyCampaign.php
@@ -24,6 +24,29 @@ class LegacyCampaign implements JsonSerializable
     }
 
     /**
+     * Parse the cover image data.
+     *
+     * @param  array $coverImage
+     * @return array
+     */
+    public function parseCoverImage($coverImage)
+    {
+        $url = null;
+        $landscapeUrl = null;
+
+        if (isset($coverImage['default'])) {
+            $url = $coverImage['default']['uri'];
+            $landscapeUrl = isset($coverImage['default']['sizes']['landscape']) ? $coverImage['default']['sizes']['landscape']['uri'] : null;
+        }
+
+        return [
+            'description' => null,
+            'url' => $url,
+            'landscapeUrl' => $landscapeUrl,
+        ];
+    }
+
+    /**
      * Convert the object into something JSON serializable.
      *
      * @return array
@@ -40,11 +63,7 @@ class LegacyCampaign implements JsonSerializable
             'status' => $this->legacyCampaign['status'],
             'callToAction' => $this->legacyCampaign['tagline'],
             'tagline' => $this->legacyCampaign['tagline'],
-            'coverImage' => [
-                'description' => null,
-                'url' => $this->legacyCampaign['cover_image']['default']['uri'],
-                'landscapeUrl' => $this->legacyCampaign['cover_image']['default']['sizes']['landscape']['uri'],
-            ],
+            'coverImage' => $this->parseCoverImage($this->legacyCampaign['cover_image']),
             'staffPick' => $this->legacyCampaign['staff_pick'],
             'cause' => $this->legacyCampaign['causes']['primary']['name'],
             'additionalContent' => [

--- a/app/Entities/LegacyCampaign.php
+++ b/app/Entities/LegacyCampaign.php
@@ -31,18 +31,10 @@ class LegacyCampaign implements JsonSerializable
      */
     public function parseCoverImage($coverImage)
     {
-        $url = null;
-        $landscapeUrl = null;
-
-        if (isset($coverImage['default'])) {
-            $url = $coverImage['default']['uri'];
-            $landscapeUrl = isset($coverImage['default']['sizes']['landscape']) ? $coverImage['default']['sizes']['landscape']['uri'] : null;
-        }
-
         return [
             'description' => null,
-            'url' => $url,
-            'landscapeUrl' => $landscapeUrl,
+            'url' => array_get($coverImage, 'default.uri', null),
+            'landscapeUrl' => array_get($coverImage, 'default.sizes.landscape.uri', null),
         ];
     }
 


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_


### What does this PR do?
This PR updates the LegacyCampaign Entity to handle data from Ashes regarding cover images a little better. We found there may be some campaigns that don't have a cover image, or don't have a cover image with a "landscape" crop assigned and thus breaks the parsing of the data.

It also updates handling in the LegacyCampaign Entity for the Ashes run ID. Thanks to global, not all campaigns will have a value under `en` for the current run. Since there are a couple different languages Ashes supported, instead of adding logic to address each one, I figured it would be easier to just take the first item in the `current` array and grab the ID from it, instead of dealing with each potential index of `en`, `es-mx`, `pt-br`, etc... Thanks to @mendelB for flagging this one! 🏅 


### What are the relevant tickets/cards?
🌵 


### Checklist
- [ ] Documentation included in `/docs` for added/updated API endpoints.
- [ ] Added appropriate feature/unit tests.
- [ ] Added relevant Runscope API monitoring tests.
