### PR TITLE
Don't show SubmissionGalleryBlock when there is no user ID

### DIFF
--- a/resources/assets/components/blocks/SubmissionGalleryBlock/SubmissionGalleryBlockQuery.js
+++ b/resources/assets/components/blocks/SubmissionGalleryBlock/SubmissionGalleryBlockQuery.js
@@ -37,27 +37,32 @@ const SUBMISSION_GALLERY_QUERY = gql`
 /**
  * Fetch results via GraphQL using a query component.
  */
-const SubmissionGalleryBlockQuery = ({ campaignId, userId, type }) => (
-  <PaginatedQuery
-    query={SUBMISSION_GALLERY_QUERY}
-    queryName="posts"
-    variables={{ campaignId, userId, type }}
-    count={6}
-  >
-    {({ result, fetching, fetchMore }) => (
-      <PostGallery
-        posts={result}
-        loading={fetching}
-        loadMorePosts={fetchMore}
-      />
-    )}
-  </PaginatedQuery>
-);
+const SubmissionGalleryBlockQuery = ({ campaignId, userId, type }) =>
+  userId ? (
+    <PaginatedQuery
+      query={SUBMISSION_GALLERY_QUERY}
+      queryName="posts"
+      variables={{ campaignId, userId, type }}
+      count={6}
+    >
+      {({ result, fetching, fetchMore }) => (
+        <PostGallery
+          posts={result}
+          loading={fetching}
+          loadMorePosts={fetchMore}
+        />
+      )}
+    </PaginatedQuery>
+  ) : null;
 
 SubmissionGalleryBlockQuery.propTypes = {
   campaignId: PropTypes.string.isRequired,
   type: PropTypes.string.isRequired,
-  userId: PropTypes.string.isRequired,
+  userId: PropTypes.string,
+};
+
+SubmissionGalleryBlockQuery.defaultProps = {
+  userId: null,
 };
 
 // Export the GraphQL query component.


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR ensures a User ID is provided to the `SubmissionGalleryBlockQuery` before attempting to run the query and return a submission gallery!

### Any background context you want to provide?
This is part of the intermittent effort to enable showing Action pages on closed campaigns / un-authed users.

We were seeing errors crop up in GraphQl/Apollo due to closed campaigns (ungated due to removed landing pages), allowing access to action pages which generally contain Photo/Text Submission Actions and corresponding user submission galleries, which error out when there is no User ID in state!

Here, we'll ensure the ID exists, (whether from proper or soft authentication) before displaying the Query/Gallery

### Grapples, Tussles, and Scuffles  🤼‍♂️ 🤼‍♀️ 
I grappled with how to do this since we're rendering these galleries from our [`/renderers`](https://github.com/DoSomething/phoenix-next/blob/submission-gallery-gate/resources/assets/components/ContentfulEntry/renderers.js#L94) from whence it'd be awkward to try and determine user ID status from state. So I went with the actual component taking care of rendering itself or just `null` while making the `userId` prop optional.

(The submission forms themselves are going to be [gated eventually as well](https://www.pivotaltracker.com/story/show/159476740) (at least for closed campaigns for now))

### What are the relevant tickets/cards?

Refs [Pivotal ID #159476970](https://www.pivotaltracker.com/story/show/159476970)
