### PR TITLE
Share Action Link Tracking

### DIFF
--- a/resources/assets/components/actions/ShareAction/ShareAction.js
+++ b/resources/assets/components/actions/ShareAction/ShareAction.js
@@ -64,7 +64,9 @@ class ShareAction extends React.Component {
   };
 
   handleFacebookClick = url => {
-    trackPuckEvent('clicked facebook share action', { url });
+    const { link } = this.props;
+
+    trackPuckEvent('clicked facebook share action', { url: link });
 
     showFacebookShareDialog(url)
       .then(() => {
@@ -73,16 +75,16 @@ class ShareAction extends React.Component {
           this.storeSharePost();
         }
 
-        trackPuckEvent('share action completed', { url });
+        trackPuckEvent('share action completed', { url: link });
         this.setState({ showModal: true });
       })
       .catch(() => {
-        trackPuckEvent('share action cancelled', { url });
+        trackPuckEvent('share action cancelled', { url: link });
       });
   };
 
   handleTwitterClick = url => {
-    trackPuckEvent('clicked twitter share action', { url });
+    trackPuckEvent('clicked twitter share action', { url: this.props.link });
     showTwitterSharePrompt(url, '', () => this.setState({ showModal: true }));
   };
 

--- a/resources/assets/components/actions/ShareAction/ShareAction.js
+++ b/resources/assets/components/actions/ShareAction/ShareAction.js
@@ -32,7 +32,13 @@ class ShareAction extends React.Component {
 
     const action = get(this.props.additionalContent, 'action', 'default');
 
-    const { id, campaignId, campaignRunId, legacyCampaignId } = this.props;
+    const {
+      id,
+      campaignId,
+      campaignRunId,
+      legacyCampaignId,
+      link,
+    } = this.props;
 
     const formData = setFormData(
       {
@@ -41,6 +47,7 @@ class ShareAction extends React.Component {
         id,
       },
       {
+        url: link,
         platform: 'facebook',
         campaign_id: campaignId,
         legacy_campaign_id: legacyCampaignId,


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR 

- adds the `link` to the `details` field POSTed to Rogue for successfully completed Facebook shares
- updates the puck tracking data for shares to be the *original* unprocessed link

### Any background context you want to provide?
The consensus seems to be that data-wise it'd be better for us to track the original link so we have uniform link data across a specific Share Action.


### What are the relevant tickets/cards?

Refs [Pivotal ID #158772936](https://www.pivotaltracker.com/story/show/158772936)