### PR TITLE
Switching to Sixpack class and enabling conversion.

### DIFF
--- a/resources/assets/constants/index.js
+++ b/resources/assets/constants/index.js
@@ -20,3 +20,7 @@ export const NetworkStatus = {
   READY: 7,
   ERROR: 8,
 };
+
+export const SIXPACK_EXPERIMENT_SIGNUP_ACTION = 'signup';
+export const SIXPACK_EXPERIMENT_REPORTBACK_POST_ACTION = 'reportbackPost';
+export const SIXPACK_EXPERIMENT_CLICKED_BUTTON_ACTION = 'clickedButton';

--- a/resources/assets/helpers/index.js
+++ b/resources/assets/helpers/index.js
@@ -7,6 +7,7 @@ import iterator from 'markdown-it-for-inline';
 import markdownItFootnote from 'markdown-it-footnote';
 import { get, find, isNull, isUndefined, omitBy } from 'lodash';
 
+import Sixpack from '../services/Sixpack';
 import { trackPuckEvent } from './analytics';
 
 // Helper Constants
@@ -617,6 +618,24 @@ export function report(error) {
   }
 
   window.newrelic.noticeError(error);
+}
+
+/*
+ * Variable that stores single instance of Sixpack.
+ */
+let sixpackInstance = null;
+
+/**
+ * Get instance of Sixpack class.
+ *
+ * @return {Sixpack}
+ */
+export function sixpack() {
+  if (!sixpackInstance) {
+    sixpackInstance = new Sixpack();
+  }
+
+  return sixpackInstance;
 }
 
 /**

--- a/resources/assets/helpers/loggers.js
+++ b/resources/assets/helpers/loggers.js
@@ -1,0 +1,19 @@
+/* eslint-ignore import/prefer-default-export */
+
+export function sixpackLog(client, action, experimentName, experiment) {
+  console.groupCollapsed(
+    '%c SIXPACK: %c %c %s %c▷%c %s %c',
+    'background-color: rgba(151,103,36,0.5); color: rgba(105,72,26,1); display: inline-block; font-weight: bold; line-height: 1.5;',
+    'background-color: transparent; color: rgba(165, 162, 162, 1); font-weight: normal; letter-spacing: 3px; line-height: 1.5;',
+    'color: black; font-weight: bold; letter-spacing: normal; line-height: 1.5;',
+    action,
+    'color: rgba(165, 162, 162, 0.8); font-weight: normal;',
+    'color: black; font-weight: bold;',
+    experimentName,
+    'background-color: rgba(105,157,215,0.5);',
+  );
+  console.log('Experiment:', experiment);
+  console.log('Client ID: %s', client.client_id);
+  console.log('Sixpack URL: %s', client.base_url);
+  console.groupEnd();
+}

--- a/resources/assets/helpers/loggers.js
+++ b/resources/assets/helpers/loggers.js
@@ -1,4 +1,4 @@
-/* eslint-ignore import/prefer-default-export */
+/* eslint-disable import/prefer-default-export */
 
 export function sixpackLog(client, action, experimentName, experiment) {
   console.groupCollapsed(

--- a/resources/assets/services/Sixpack.js
+++ b/resources/assets/services/Sixpack.js
@@ -1,0 +1,140 @@
+/* global window */
+
+import client from 'sixpack-client';
+
+import {
+  SIXPACK_EXPERIMENT_SIGNUP_ACTION,
+  SIXPACK_EXPERIMENT_REPORTBACK_POST_ACTION,
+  SIXPACK_EXPERIMENT_CLICKED_BUTTON_ACTION,
+} from '../constants';
+import { sixpackLog } from '../helpers/loggers';
+
+class Sixpack {
+  constructor() {
+    this.reset();
+
+    const env = window.ENV || {};
+
+    if (!env.SIXPACK_BASE_URL) {
+      throw new Error('Missing Sixpack configuration settings.');
+    }
+
+    this.client = new client.Session({
+      base_url: env.SIXPACK_BASE_URL,
+      cookie_name: env.SIXPACK_COOKIE_PREFIX || 'sixpack',
+    });
+  }
+
+  conversions = [
+    SIXPACK_EXPERIMENT_SIGNUP_ACTION,
+    SIXPACK_EXPERIMENT_REPORTBACK_POST_ACTION,
+    SIXPACK_EXPERIMENT_CLICKED_BUTTON_ACTION,
+  ];
+
+  experiments = {};
+
+  /**
+   * Add experiment and supplied values to the experiments list.
+   *
+   * @param {String} experimentName
+   * @param {Object} experimentSettings
+   */
+  addExperiment(experimentName, experimentSettings) {
+    const values = experimentSettings;
+
+    if (!values.convertableActions || !values.convertableActions.length) {
+      values.convertableActions = this.conversions;
+    }
+
+    this.experiments[experimentName] = { ...values };
+  }
+
+  /**
+   * Convert on specified experiment name.
+   *
+   * @param  {String} experimentName
+   * @return {Promise}
+   */
+  convert(experimentName) {
+    const kpi = this.experiments[experimentName].kpi;
+
+    return new Promise((resolve, reject) => {
+      this.client.convert(experimentName, kpi, (error, response) => {
+        if (error) {
+          reject(error);
+        }
+
+        sixpackLog(
+          this.client,
+          'convert',
+          experimentName,
+          this.experiments[experimentName],
+        );
+
+        resolve(response);
+      });
+    });
+  }
+
+  /**
+   * Convert all available experiments that match a specified convertable action.
+   *
+   * @param  {String} action
+   * @return {Void}
+   */
+  convertOnAction(action) {
+    const matchingExperiments = Object.keys(this.experiments).filter(
+      experimentName =>
+        this.experiments[experimentName].convertOn.includes(action),
+    );
+
+    matchingExperiments.forEach(experimentName => this.convert(experimentName));
+  }
+
+  /**
+   * Participate in specified experiment.
+   *
+   * @param  {String} experimentName
+   * @param  {Array}  testAlternatives
+   * @param  {Object} options
+   * @return {Promise}
+   */
+  participate(experimentName, testAlternatives = [], options = {}) {
+    return new Promise((resolve, reject) => {
+      this.client.participate(
+        experimentName,
+        testAlternatives,
+        (error, response) => {
+          if (error) {
+            reject(error);
+          }
+
+          this.addExperiment(experimentName, {
+            selectedAlternative: response.alternative.name,
+            ...options,
+          });
+
+          sixpackLog(
+            this.client,
+            'participate',
+            experimentName,
+            this.experiments[experimentName],
+          );
+
+          resolve(response.alternative.name);
+        },
+      );
+    });
+  }
+
+  /**
+   * Reset the list of experiments.
+   *
+   * @return {Void}
+   */
+  reset() {
+    this.experiments = {};
+  }
+}
+
+export default Sixpack;

--- a/resources/assets/services/Sixpack.js
+++ b/resources/assets/services/Sixpack.js
@@ -85,7 +85,7 @@ class Sixpack {
   convertOnAction(action) {
     const matchingExperiments = Object.keys(this.experiments).filter(
       experimentName =>
-        this.experiments[experimentName].convertOn.includes(action),
+        this.experiments[experimentName].convertableActions.includes(action),
     );
 
     matchingExperiments.forEach(experimentName => this.convert(experimentName));


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_


### What does this PR do?

This PR creates a new `Sixpack` class to help handle all experiments on a page. I worked with @DFurnes to initially stub out the idea. He had suggested trying to move away from storing the experiments in the Redux store and instead having a dedicated singleton class to handle experiments on a page and from this initial pass it seems to work rather well.

Being a singleton, the`Sixpack` class can only be instantiated once and will house all the experiments on a page (that means it keeps track of experiments on a page load, OR switching to another page (like a tabbed nav page, but still need to test this out a bit).

Experiments can be setup via Contentful and will activate an alternative when the page is loaded. In Contentful, an editor can select what "actions" or events to convert the experiment on; if none are specified, then it will convert on any of the possible actions.

### Any background context you want to provide?

This PR only adds the changes to include the `Sixpack` class, some constants, and also adds some new console logging for when a Sixpack test is participated or converted:

![sixpack console log](https://user-images.githubusercontent.com/105849/43799855-a25a0f18-9a5c-11e8-8310-bd0669365d60.png)

The capacity to execute the conversions will happen in middleware (upcoming PR) which will listen for actions related to signups, posts, etc.

### What are the relevant tickets/cards?

Refs [Pivotal ID #159468419](https://www.pivotaltracker.com/story/show/159468419)
