### PR TITLE
Migration to add the sixpack experiment content type.

### DIFF
--- a/contentful/migrations/2018_08_08_001_add_sixpack_experiment_content_type.js
+++ b/contentful/migrations/2018_08_08_001_add_sixpack_experiment_content_type.js
@@ -1,0 +1,47 @@
+module.exports = function(migration) {
+  const sixpackExperiment = migration
+    .createContentType('sixpackExperiment')
+    .name('Sixpack Experiment')
+    .description('Used to help set up A/B testing experiments.')
+    .displayField('internalTitle');
+
+  sixpackExperiment
+    .createField('internalTitle')
+    .name('Internal Title')
+    .type('Symbol')
+    .required(true)
+    .localized(false);
+
+  sixpackExperiment
+    .createField('title')
+    .name('Title')
+    .type('Symbol')
+    .required(true)
+    .localized(true);
+
+  sixpackExperiment
+    .createField('alternatives')
+    .name('Test Alternatives')
+    .type('Array')
+    .items({
+      type: 'Link',
+      linkType: 'Entry',
+    })
+    .validations([{ size: { min: 2 } }])
+    .required(true)
+    .localized(false);
+
+  sixpackExperiment
+    .createField('trafficFraction')
+    .name('Traffic Fraction')
+    .type('Integer')
+    .required(false)
+    .localized(false);
+
+  sixpackExperiment
+    .createField('kpi')
+    .name('Key Performance Indicator (KPI)')
+    .type('Symbol')
+    .required(false)
+    .localized(true);
+};

--- a/contentful/migrations/2018_08_08_001_add_sixpack_experiment_content_type.js
+++ b/contentful/migrations/2018_08_08_001_add_sixpack_experiment_content_type.js
@@ -35,6 +35,7 @@ module.exports = function(migration) {
     .createField('trafficFraction')
     .name('Traffic Fraction')
     .type('Integer')
+    .validations([{ range: { min: 1, max: 100 } }])
     .required(false)
     .localized(false);
 


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR adds a migration to add the new Sixpack Experiments content type into the system:

![image](https://user-images.githubusercontent.com/105849/43855059-92e77794-9b12-11e8-9f1e-8e1aab222583.png)


### What are the relevant tickets/cards?

Refs [Pivotal ID #159468419](https://www.pivotaltracker.com/story/show/159468419)