### PR TITLE
Page Entity Sidebar Block Parsing Bug Fix

### DIFF
--- a/app/Entities/Page.php
+++ b/app/Entities/Page.php
@@ -14,13 +14,15 @@ class Page extends Entity implements JsonSerializable
      */
     public function parseSidebar($sidebarItems)
     {
-        return collect($sidebarItems)->filter(function ($sidebarItem) {
+        return collect($sidebarItems)->map(function ($sidebarItem) {
             switch ($sidebarItem->getContentType()) {
                 case 'callToAction':
                     return new CallToAction($sidebarItem->entry);
 
                 case 'customBlock':
                     return new CustomBlock($sidebarItem->entry);
+                default:
+                    return $sidebarItem->entry;
             }
         });
     }

--- a/app/Entities/Page.php
+++ b/app/Entities/Page.php
@@ -7,27 +7,6 @@ use JsonSerializable;
 class Page extends Entity implements JsonSerializable
 {
     /**
-     * Parse and extract data for the sidebar.
-     *
-     * @param  array $sidebarItems
-     * @return array
-     */
-    public function parseSidebar($sidebarItems)
-    {
-        return collect($sidebarItems)->map(function ($sidebarItem) {
-            switch ($sidebarItem->getContentType()) {
-                case 'callToAction':
-                    return new CallToAction($sidebarItem->entry);
-
-                case 'customBlock':
-                    return new CustomBlock($sidebarItem->entry);
-                default:
-                    return $sidebarItem->entry;
-            }
-        });
-    }
-
-    /**
      * Parse blocks, and reverse parsed blocks for community pages.
      *
      * @param  array $blocks
@@ -59,7 +38,7 @@ class Page extends Entity implements JsonSerializable
                 'title' => $this->title,
                 'subTitle' => $this->subTitle,
                 'content' => $this->content,
-                'sidebar' => $this->parseSidebar($this->sidebar),
+                'sidebar' => $this->parseBlocks($this->sidebar),
                 'blocks' => $this->parseBlocks($this->blocks),
                 // @TODO: we want to eventually remove the need for hideFromNavigation field
                 // in favor of always linking to pages referenced in the `pages` field.


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR fixes the sidebar block parsing method used in the `Page` Contentful Entity to ensure we properly return the parsed blocks.

### Any background context you want to provide?
We were using a `filter` method to ensure we only parsed specified content types. The issue is this caused us to never properly return the parsed date since `filter` does not `map` but only filters on some condition 💡

Once fixing this, I figured, heck, why not just use the `parseBlocks` method we use all over the place. Validations are defined and can be customized in Contentful to ensure we only get the correct blocks.

### What are the relevant tickets/cards?

Refs [Pivotal ID #159037991](https://www.pivotaltracker.com/story/show/159037991)
