### PR TITLE
Sixpack component fixes and updates

### DIFF
--- a/app/Entities/SixpackExperiment.php
+++ b/app/Entities/SixpackExperiment.php
@@ -6,13 +6,20 @@ use JsonSerializable;
 
 class SixpackExperiment extends Entity implements JsonSerializable
 {
-    public function jsonSerializable()
+    /**
+     * Convert the object into something JSON serializable.
+     *
+     * @return array
+     */
+    public function jsonSerialize()
     {
         return [
             'id' => $this->entry->getId(),
             'type' => $this->getContentType(),
             'fields' => [
                 'alternatives' => $this->parseBlocks($this->alternatives),
+                'convertableActions' => $this->convertableActions,
+                'kpi' => $this->kpi,
                 'title' => $this->title,
                 'trafficFraction' => $this->trafficFraction, // @TODO: divide number by 100 for decimal indication.
             ],

--- a/contentful/migrations/2018_08_09_add_convertable_actions_field_to_sixpack_experiment.js
+++ b/contentful/migrations/2018_08_09_add_convertable_actions_field_to_sixpack_experiment.js
@@ -1,0 +1,21 @@
+module.exports = function(migration) {
+  const sixpackExperiment = migration.editContentType('sixpackExperiment');
+
+  sixpackExperiment
+    .createField('convertableActions')
+    .name('Actions To Convert Experiment')
+    .type('Array')
+    .items({
+      type: 'Symbol',
+      validations: [
+        {
+          in: ['signup', 'reportbackPost', 'clickedButton'],
+        },
+      ],
+    })
+    .validations([{ size: { min: 1 } }]);
+    .required(true)
+    .localized(false)
+
+  sixpackExperiment.moveField('convertableActions').afterField('alternatives');
+};

--- a/contentful/migrations/2018_08_09_add_convertable_actions_field_to_sixpack_experiment.js
+++ b/contentful/migrations/2018_08_09_add_convertable_actions_field_to_sixpack_experiment.js
@@ -13,9 +13,8 @@ module.exports = function(migration) {
         },
       ],
     })
-    .validations([{ size: { min: 1 } }]);
     .required(true)
-    .localized(false)
+    .localized(false);
 
   sixpackExperiment.moveField('convertableActions').afterField('alternatives');
 };


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR fixes a bug with the `SixpackExperiment` entity file, and adds a migration to include the `convertableActions` field to the `sixpackExperiment` content type!

### Any background context you want to provide?

Successfully run on `dev` env!
![image](https://user-images.githubusercontent.com/105849/43907469-7a3da202-9bc3-11e8-9e00-4b0a65e4ce02.png)


### What are the relevant tickets/cards?

Refs [Pivotal ID #159468419](https://www.pivotaltracker.com/story/show/159468419)
