### PR TITLE
Sixpack component cleanup

### DIFF
--- a/app/Entities/SixpackExperiment.php
+++ b/app/Entities/SixpackExperiment.php
@@ -7,6 +7,16 @@ use JsonSerializable;
 class SixpackExperiment extends Entity implements JsonSerializable
 {
     /**
+     * Parse traffic fraction to set as decimal value.
+     *
+     * @return int
+     */
+    private function parseTrafficFraction($trafficFraction)
+    {
+        return ($trafficFraction ?: 100) / 100;
+    }
+
+    /**
      * Convert the object into something JSON serializable.
      *
      * @return array
@@ -21,7 +31,7 @@ class SixpackExperiment extends Entity implements JsonSerializable
                 'convertableActions' => $this->convertableActions,
                 'kpi' => $this->kpi,
                 'title' => $this->title,
-                'trafficFraction' => $this->trafficFraction, // @TODO: divide number by 100 for decimal indication.
+                'trafficFraction' => $this->parseTrafficFraction($this->trafficFraction),
             ],
         ];
     }

--- a/resources/assets/components/utilities/SixpackExperiment/SixpackExperiment.js
+++ b/resources/assets/components/utilities/SixpackExperiment/SixpackExperiment.js
@@ -2,9 +2,9 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { snakeCase } from 'lodash';
 
+import { sixpack } from '../../../helpers';
 import ContentfulEntry from '../../ContentfulEntry';
 import Placeholder from '../../utilities/Placeholder';
-import { participateBeta } from '../../../helpers/experiments';
 
 class SixpackExperiment extends React.Component {
   constructor(props) {
@@ -13,18 +13,33 @@ class SixpackExperiment extends React.Component {
     this.state = {
       selectedAlternative: null,
     };
+
+    this.experimentName =
+      snakeCase(this.props.campaignSlug) + '_' + snakeCase(this.props.title);
   }
 
   componentDidMount() {
-    const { alternatives, title } = this.props;
+    const {
+      alternatives,
+      convertableActions,
+      kpi,
+      trafficFraction,
+    } = this.props;
 
     const alternativeOptions = alternatives.map(item =>
-      snakeCase(item.fields.title),
+      // @TODO: probably want to use internalTitle but not all entities expose that.
+      // Defaults to title field, but we should aim to start exposing internalTitle on entities!
+      snakeCase(item.fields.internalTitle || item.fields.title),
     );
 
-    const selectedAlternative = participateBeta(
-      snakeCase(title),
+    const selectedAlternative = sixpack().participate(
+      this.experimentName,
       alternativeOptions,
+      {
+        convertableActions,
+        kpi,
+        trafficFraction,
+      },
     );
 
     selectedAlternative
@@ -43,6 +58,10 @@ class SixpackExperiment extends React.Component {
       });
   }
 
+  componentWillUnmount() {
+    sixpack().removeExperiment(this.experimentName);
+  }
+
   render() {
     return this.state.selectedAlternative ? (
       <ContentfulEntry json={this.state.selectedAlternative} />
@@ -53,8 +72,18 @@ class SixpackExperiment extends React.Component {
 }
 
 SixpackExperiment.propTypes = {
-  title: PropTypes.string.isRequired,
   alternatives: PropTypes.arrayOf(PropTypes.object).isRequired,
+  campaignSlug: PropTypes.string,
+  convertableActions: PropTypes.arrayOf(PropTypes.string).isRequired,
+  kpi: PropTypes.string,
+  title: PropTypes.string.isRequired,
+  trafficFraction: PropTypes.number,
+};
+
+SixpackExperiment.defaultProps = {
+  campaignSlug: '',
+  kpi: null,
+  trafficFraction: 1,
 };
 
 export default SixpackExperiment;

--- a/resources/assets/components/utilities/SixpackExperiment/SixpackExperiment.js
+++ b/resources/assets/components/utilities/SixpackExperiment/SixpackExperiment.js
@@ -14,8 +14,11 @@ class SixpackExperiment extends React.Component {
       selectedAlternative: null,
     };
 
-    this.experimentName =
-      snakeCase(this.props.campaignSlug) + '_' + snakeCase(this.props.title); // eslint-disable-line prefer-template
+    const { campaignSlug, title } = this.props;
+
+    this.experimentName = campaignSlug
+      ? `${snakeCase(campaignSlug)}_${snakeCase(title)}`
+      : `${snakeCase(title)}`;
   }
 
   componentDidMount() {

--- a/resources/assets/components/utilities/SixpackExperiment/SixpackExperiment.js
+++ b/resources/assets/components/utilities/SixpackExperiment/SixpackExperiment.js
@@ -84,7 +84,7 @@ SixpackExperiment.propTypes = {
 };
 
 SixpackExperiment.defaultProps = {
-  campaignSlug: '',
+  campaignSlug: null,
   kpi: null,
   trafficFraction: 1,
 };

--- a/resources/assets/components/utilities/SixpackExperiment/SixpackExperiment.js
+++ b/resources/assets/components/utilities/SixpackExperiment/SixpackExperiment.js
@@ -15,7 +15,7 @@ class SixpackExperiment extends React.Component {
     };
 
     this.experimentName =
-      snakeCase(this.props.campaignSlug) + '_' + snakeCase(this.props.title);
+      snakeCase(this.props.campaignSlug) + '_' + snakeCase(this.props.title); // eslint-disable-line prefer-template
   }
 
   componentDidMount() {

--- a/resources/assets/components/utilities/SixpackExperiment/SixpackExperimentContainer.js
+++ b/resources/assets/components/utilities/SixpackExperiment/SixpackExperimentContainer.js
@@ -1,3 +1,4 @@
+import { get } from 'lodash';
 import { connect } from 'react-redux';
 
 import SixpackExperiment from './SixpackExperiment';
@@ -6,7 +7,7 @@ import SixpackExperiment from './SixpackExperiment';
  * Provide state from the Redux store as props for this component.
  */
 const mapStateToProps = state => ({
-  campaignSlug: state.campaign.slug,
+  campaignSlug: get(state.campaign, 'slugy', null),
 });
 
 /**

--- a/resources/assets/components/utilities/SixpackExperiment/SixpackExperimentContainer.js
+++ b/resources/assets/components/utilities/SixpackExperiment/SixpackExperimentContainer.js
@@ -7,7 +7,7 @@ import SixpackExperiment from './SixpackExperiment';
  * Provide state from the Redux store as props for this component.
  */
 const mapStateToProps = state => ({
-  campaignSlug: get(state.campaign, 'slugy', null),
+  campaignSlug: get(state.campaign, 'slug', null),
 });
 
 /**

--- a/resources/assets/components/utilities/SixpackExperiment/SixpackExperimentContainer.js
+++ b/resources/assets/components/utilities/SixpackExperiment/SixpackExperimentContainer.js
@@ -6,8 +6,7 @@ import SixpackExperiment from './SixpackExperiment';
  * Provide state from the Redux store as props for this component.
  */
 const mapStateToProps = state => ({
-  campaignId: state.campaign.id,
-  slug: state.campaign.slug,
+  campaignSlug: state.campaign.slug,
 });
 
 /**

--- a/resources/assets/helpers/experiments.js
+++ b/resources/assets/helpers/experiments.js
@@ -84,27 +84,6 @@ export function participate(name) {
 }
 
 /**
- * Participate current client to specified experiment. (Beta)
- *
- * @param  {String} experimentName
- * @param  {Array}  alternatives
- * @return {Promise} The promise returns the string name of the selected alternative.
- *
- * @todo   Include trafficFraction as optional argument!
- */
-export function participateBeta(experimentName, alternatives = []) {
-  return new Promise((resolve, reject) => {
-    sixpack().participate(experimentName, alternatives, (error, response) => {
-      if (error) {
-        reject(error);
-      }
-
-      resolve(response.alternative.name);
-    });
-  });
-}
-
-/**
  * Convert current client on specified experiment.
  *
  * @param  {String} name

--- a/resources/assets/services/Sixpack.js
+++ b/resources/assets/services/Sixpack.js
@@ -2,11 +2,6 @@
 
 import client from 'sixpack-client';
 
-import {
-  SIXPACK_EXPERIMENT_SIGNUP_ACTION,
-  SIXPACK_EXPERIMENT_REPORTBACK_POST_ACTION,
-  SIXPACK_EXPERIMENT_CLICKED_BUTTON_ACTION,
-} from '../constants';
 import { sixpackLog } from '../helpers/loggers';
 
 class Sixpack {
@@ -23,14 +18,17 @@ class Sixpack {
       base_url: env.SIXPACK_BASE_URL,
       cookie_name: env.SIXPACK_COOKIE_PREFIX || 'sixpack',
     });
+
+    if (window.ENV.APP_ENV !== 'production') {
+      window.SixpackExperiment = this;
+    }
   }
 
-  conversions = [
-    SIXPACK_EXPERIMENT_SIGNUP_ACTION,
-    SIXPACK_EXPERIMENT_REPORTBACK_POST_ACTION,
-    SIXPACK_EXPERIMENT_CLICKED_BUTTON_ACTION,
-  ];
-
+  /**
+   * Key-value store of current experiments.
+   *
+   * @type {Object}
+   */
   experiments = {};
 
   /**
@@ -40,13 +38,7 @@ class Sixpack {
    * @param {Object} experimentSettings
    */
   addExperiment(experimentName, experimentSettings) {
-    const values = experimentSettings;
-
-    if (!values.convertableActions || !values.convertableActions.length) {
-      values.convertableActions = this.conversions;
-    }
-
-    this.experiments[experimentName] = { ...values };
+    this.experiments[experimentName] = { ...experimentSettings };
   }
 
   /**
@@ -125,6 +117,16 @@ class Sixpack {
         },
       );
     });
+  }
+
+  /**
+   * Remove specified experiment from the experiments list.
+   *
+   * @param  {String} experimentName
+   * @return {Void}
+   */
+  removeExperiment(experimentName) {
+    delete this.experiments[experimentName];
   }
 
   /**


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR updates the `SixpackExperiment` entity, the `Sixpack` service class and the `SixpackExperiment` component and enables participation in experiments created on Contentful using the new `sixpackExperiment` content type! Converting on experiments via middleware is coming in next PR.

### Any background context you want to provide?

I found it helpful to have a `window.SixpackExperiment` object available in the console for troubleshooting, seeing what are the active experiments on a page, etc. I decided to only expose it on `local` or `staging` env, but if we feel it's fine to expose on the window, I can remove the conditional :)

It also makes sure to remove experiments from the `Sixpack` experiment key/value store, only when a `SixpackExperiment` component is unmounted. This helps to keep from converting experiments that are no longer visible if a user changes a page without a full browser page reload (like the campaign tabbed nav). If they didn't get removed, then it could possible convert on experiments that aren't visible, but exist in the experiments store list. This also keep from losing experiments that have been added by devs that exist "outside" the campaign page internals like a lede banner test. If we were to `reset()` the complete list of experiments non-reloaded page changes, then a lede banner style change wouldn't get re-inserted into the experiments store. (Just making a note of this here to address our initial approach we considered where we would just reset the entire experiments list on any page type change).

### What are the relevant tickets/cards?

Refs [Pivotal ID #159468419](https://www.pivotaltracker.com/story/show/159468419)

### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.