### PR TITLE
Fixing bug with signup conversion.

### DIFF
--- a/resources/assets/actions/signup.js
+++ b/resources/assets/actions/signup.js
@@ -24,6 +24,41 @@ import {
  * to the state tree (either as a result of application logic or user input).
  */
 
+// Action: no existing signup was found for the campaign.
+export function clickedHideAffirmation() {
+  return { type: CLOSED_POST_SIGNUP_MODAL };
+}
+
+export function clickedSignupButton() {
+  return {
+    type: 'CLICKED_SIGNUP_BUTTON',
+    payload: {
+      meta: {
+        sixpackExperiments: {
+          conversion: 'signup',
+        },
+      },
+    },
+  };
+}
+
+// Action: triggers the post signup affirmation modal.
+// This is for admin usage.
+export function clickedShowAffirmation() {
+  return { type: OPENED_POST_SIGNUP_MODAL };
+}
+
+// Action: sends whether the user opted out of affiliate messaging.
+export function clickedOptOut() {
+  return { type: SIGNUP_CLICKED_OPT_OUT };
+}
+
+// Action: removes the current signup from campaign
+// for admin to preview content
+export function clickedRemoveSignUp(campaignId) {
+  return { type: CLICKED_REMOVE_SIGN_UP, campaignId };
+}
+
 // Action: a new signup was created for a campaign.
 export function signupCreated(campaignId, shouldShowAffirmation = true) {
   return (dispatch, getState) => {
@@ -59,16 +94,7 @@ export function signupNotFound() {
 // Action: waiting on a signup response.
 // @TODO: cleanup the signup actions to use approach established in "post" action.
 export function signupPending() {
-  return {
-    type: SIGNUP_PENDING,
-    payload: {
-      meta: {
-        sixpackExperiments: {
-          conversion: 'signup',
-        },
-      },
-    },
-  };
+  return { type: SIGNUP_PENDING };
 }
 
 // Async Action: check if user already signed up for the campaign
@@ -130,6 +156,10 @@ export function clickedSignUp(
         : null;
     }
 
+    // @TODO: Once we refactor this file, hopefully will not need this action
+    // dispatch any longer, or flow will be more logical!
+    dispatch(clickedSignupButton());
+
     // If the user is not logged in, handle this action later.
     if (!isAuthenticated(state)) {
       return dispatch(
@@ -177,26 +207,4 @@ export function clickedSignUp(
         }
       });
   };
-}
-
-// Action: removes the current signup from campaign
-// for admin to preview content
-export function clickedRemoveSignUp(campaignId) {
-  return { type: CLICKED_REMOVE_SIGN_UP, campaignId };
-}
-
-// Action: triggers the post signup affirmation modal.
-// This is for admin usage.
-export function clickedShowAffirmation() {
-  return { type: OPENED_POST_SIGNUP_MODAL };
-}
-
-// Action: no existing signup was found for the campaign.
-export function clickedHideAffirmation() {
-  return { type: CLOSED_POST_SIGNUP_MODAL };
-}
-
-// Action: sends whether the user opted out of affiliate messaging.
-export function clickedOptOut() {
-  return { type: SIGNUP_CLICKED_OPT_OUT };
 }


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR fixes a bug with converting Sixpack Experiments on campaign signup. The signup action code is pretty convoluted and hard to follow and could use some refactor love. In the meantime, the easiest solution I found was to add another action creator in the `actions/signup.js` that can be dispatched called `clickedSignupButton()` and merely triggers an action that can be caught in the middleware.

Main change is [here](https://github.com/DoSomething/phoenix-next/pull/1067/files#diff-9e724eddc3f7ebfa3cb156868580310aR32) and the call to [dispatch](https://github.com/DoSomething/phoenix-next/pull/1067/files#diff-9e724eddc3f7ebfa3cb156868580310aR161) the action. Otherwise the rest of the changes is alphabetizing the methods.

When signing up for a campaign when not logged in, a user is taken to Northstar to log in and then returned back to the action page of the campaign. There's a bit of convoluted logic when this happens and I previously added the meta-data for the `sixpackExperiments` middleware to catch in the `signupPending()` action creator, but apparently this doesn't always get called. Thus we weren't converting experiments when a signup lead to a login via Northstar.

### Any background context you want to provide?
I also re-sorted the action creators up to and alphabetized them! 💅 

### What are the relevant tickets/cards?

Refs [Pivotal ID #158806897](https://www.pivotaltracker.com/story/show/158806897)
