### PR TITLE
Disable nginx access log.

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -1,9 +1,13 @@
-# Increase request size limit.
-client_max_body_size 10M;
-
 # Serve application with Laravel.
 # see: https://laravel.com/docs/5.5/installation#web-server-configuration
 location / {
     index index.php;
     try_files $uri $uri/ /index.php?$query_string;
 }
+
+# Increase request size limit.
+client_max_body_size 10M;
+
+# Disable nginx's access log since we get the same information
+# from Heroku's router (and can more easily filter that).
+access_log off;


### PR DESCRIPTION
#### What's this PR do?
This pull request disable's nginx's access logs for Phoenix, since we get similar information in a more readable format from [Heroku's router](https://devcenter.heroku.com/articles/http-routing#heroku-router-log-format). This should help trim down log usage even further.

#### How should this be reviewed?
I've made the same change to Northstar, Rogue, Aurora & verified it works.

#### Relevant Tickets
References DoSomething/devops#432.

#### Checklist
- [ ] Documentation added for changed endpoints.
- [ ] Tests added for new features/bug fixes.
- [ ] Post a message in #api if this includes something that causes a rebuild!  