### PR TITLE
Facebook Messenger share logic

### DIFF
--- a/resources/assets/components/utilities/SocialShareTray/SocialShareTray.js
+++ b/resources/assets/components/utilities/SocialShareTray/SocialShareTray.js
@@ -42,23 +42,20 @@ class SocialShareTray extends React.Component {
   handleFacebookMessengerClick = (shareLink, trackLink) => {
     const trackingData = { url: trackLink };
 
-    trackPuckEvent(
-      'phoenix_clicked_share_facebook_messenger_action',
-      trackingData,
-    );
+    trackPuckEvent('phoenix_clicked_share_facebook_messenger', trackingData);
 
     if (getFormattedScreenSize() === 'large') {
       // Show Send Dialog for Desktop clients.
       showFacebookSendDialog(shareLink)
         .then(() => {
           trackPuckEvent(
-            'phoenix_completed_share_facebook_messenger_action',
+            'phoenix_completed_share_facebook_messenger',
             trackingData,
           );
         })
         .catch(() => {
           trackPuckEvent(
-            'phoenix_cancelled_share_facebook_messenger_action',
+            'phoenix_cancelled_share_facebook_messenger',
             trackingData,
           );
         });
@@ -67,13 +64,13 @@ class SocialShareTray extends React.Component {
       facebookMessengerShare(shareLink)
         .then(() => {
           trackPuckEvent(
-            'phoenix_redirected_facebook_messenger_app_share',
+            'phoenix_redirected_share_facebook_messenger_app',
             trackingData,
           );
         })
         .catch(() => {
           trackPuckEvent(
-            'phoenix_failed_facebook_messenger_app_share',
+            'phoenix_failed_share_facebook_messenger_app',
             trackingData,
           );
         });

--- a/resources/assets/components/utilities/SocialShareTray/SocialShareTray.js
+++ b/resources/assets/components/utilities/SocialShareTray/SocialShareTray.js
@@ -64,13 +64,13 @@ class SocialShareTray extends React.Component {
       facebookMessengerShare(shareLink)
         .then(() => {
           trackPuckEvent(
-            'phoenix_redirected_share_facebook_messenger_app',
+            'phoenix_successful_redirect_facebook_messenger_app',
             trackingData,
           );
         })
         .catch(() => {
           trackPuckEvent(
-            'phoenix_failed_share_facebook_messenger_app',
+            'phoenix_failed_redirect_facebook_messenger_app',
             trackingData,
           );
         });

--- a/resources/assets/components/utilities/SocialShareTray/SocialShareTray.js
+++ b/resources/assets/components/utilities/SocialShareTray/SocialShareTray.js
@@ -42,25 +42,40 @@ class SocialShareTray extends React.Component {
   handleFacebookMessengerClick = (shareLink, trackLink) => {
     const trackingData = { url: trackLink };
 
-    trackPuckEvent('clicked ??', trackingData);
+    trackPuckEvent(
+      'phoenix_clicked_share_facebook_messenger_action',
+      trackingData,
+    );
 
     if (getFormattedScreenSize() === 'large') {
       // Show Send Dialog for Desktop clients.
       showFacebookSendDialog(shareLink)
         .then(() => {
-          trackPuckEvent('??', trackingData);
+          trackPuckEvent(
+            'phoenix_completed_share_facebook_messenger_action',
+            trackingData,
+          );
         })
         .catch(() => {
-          trackPuckEvent('??', trackingData);
+          trackPuckEvent(
+            'phoenix_cancelled_share_facebook_messenger_action',
+            trackingData,
+          );
         });
     } else {
       // Redirect mobile / tablet clients to the Messenger app.
       facebookMessengerShare(shareLink)
         .then(() => {
-          trackPuckEvent('??');
+          trackPuckEvent(
+            'phoenix_redirected_facebook_messenger_app_share',
+            trackingData,
+          );
         })
         .catch(() => {
-          trackPuckEvent('??');
+          trackPuckEvent(
+            'phoenix_failed_facebook_messenger_app_share',
+            trackingData,
+          );
         });
     }
   };

--- a/resources/assets/components/utilities/SocialShareTray/SocialShareTray.js
+++ b/resources/assets/components/utilities/SocialShareTray/SocialShareTray.js
@@ -13,6 +13,9 @@ import {
   loadFacebookSDK,
   handleTwitterShareClick,
   showFacebookShareDialog,
+  showFacebookSendDialog,
+  facebookMessengerShare,
+  getFormattedScreenSize,
 } from '../../../helpers';
 
 import './social-share-tray.scss';
@@ -34,6 +37,32 @@ class SocialShareTray extends React.Component {
       .catch(() => {
         trackPuckEvent('share action cancelled', trackingData);
       });
+  };
+
+  handleFacebookMessengerClick = (shareLink, trackLink) => {
+    const trackingData = { url: trackLink };
+
+    trackPuckEvent('clicked ??', trackingData);
+
+    if (getFormattedScreenSize() === 'large') {
+      // Show Send Dialog for Desktop clients.
+      showFacebookSendDialog(shareLink)
+        .then(() => {
+          trackPuckEvent('??', trackingData);
+        })
+        .catch(() => {
+          trackPuckEvent('??', trackingData);
+        });
+    } else {
+      // Redirect mobile / tablet clients to the Messenger app.
+      facebookMessengerShare(shareLink)
+        .then(() => {
+          trackPuckEvent('??');
+        })
+        .catch(() => {
+          trackPuckEvent('??');
+        });
+    }
   };
 
   handleEmailShareClick = shareLink =>
@@ -71,7 +100,9 @@ class SocialShareTray extends React.Component {
             disabled={!shareLink}
             icon={messengerIcon}
             text="Send"
-            // @TODO add onClick prop with click handler
+            onClick={() =>
+              this.handleFacebookMessengerClick(shareLink, trackLink)
+            }
           />
 
           <ShareButton

--- a/resources/assets/components/utilities/SocialShareTray/SocialShareTray.js
+++ b/resources/assets/components/utilities/SocialShareTray/SocialShareTray.js
@@ -77,8 +77,10 @@ class SocialShareTray extends React.Component {
     }
   };
 
-  handleEmailShareClick = shareLink =>
+  handleEmailShareClick = (shareLink, trackLink) => {
+    trackPuckEvent('phoenix_clicked_share_email', { url: trackLink });
     window.open(`mailto:?body=${encodeURIComponent(shareLink)}`);
+  };
 
   render() {
     const { shareLink } = this.props;
@@ -122,7 +124,7 @@ class SocialShareTray extends React.Component {
             disabled={!shareLink}
             icon={emailIcon}
             text="Email"
-            onClick={() => this.handleEmailShareClick(shareLink)}
+            onClick={() => this.handleEmailShareClick(shareLink, trackLink)}
           />
         </div>
       </div>

--- a/resources/assets/helpers/index.js
+++ b/resources/assets/helpers/index.js
@@ -483,19 +483,39 @@ export function loadFacebookSDK() {
 }
 
 /**
- * Share a link by generating a Facebook share dialog.
- * Get a callback if the share is successful or not.
+ * Generate a Facebook Share Dialog
  *
- * @param  {Object}   share
- * @param  {Function} callback
+ * @param {String} href
+ * @param {String} quote
  */
 export function showFacebookShareDialog(href, quote = null) {
-  const options = {
+  return showFacebookDialog({
     method: 'share',
     quote,
     href,
-  };
+  });
+}
 
+/**
+ * Generate a Facebook Send Dialog
+ *
+ * @param {String} href
+ */
+export function showFacebookSendDialog(href) {
+  return showFacebookDialog({
+    method: 'send',
+    link: href,
+  });
+}
+
+/**
+ * Share a link by generating a Facebook dialog.
+ * Get a callback if the share is successful or not.
+ *
+ * @param  {Object}  options
+ * @return {Promise}
+ */
+export function showFacebookDialog(options) {
   return new Promise((resolve, reject) => {
     const handler = success => (success ? resolve() : reject());
     return window.FB.ui(options, handler);

--- a/resources/assets/helpers/index.js
+++ b/resources/assets/helpers/index.js
@@ -547,6 +547,7 @@ export function facebookMessengerShare(href) {
       // they presumably don't have the Messenger app.
       if (!switchedToApp && window.document.hasFocus()) {
         reject();
+        // eslint-disable-next-line no-alert
         window.alert(
           'Sorry, you need to have the Facebook Messenger app installed, to send a message.',
         );

--- a/resources/assets/helpers/index.js
+++ b/resources/assets/helpers/index.js
@@ -483,6 +483,20 @@ export function loadFacebookSDK() {
 }
 
 /**
+ * Share a link by generating a Facebook dialog.
+ * Get a callback if the share is successful or not.
+ *
+ * @param  {Object}  options
+ * @return {Promise}
+ */
+export function showFacebookDialog(options) {
+  return new Promise((resolve, reject) => {
+    const handler = success => (success ? resolve() : reject());
+    return window.FB.ui(options, handler);
+  });
+}
+
+/**
  * Generate a Facebook Share Dialog
  *
  * @param {String} href
@@ -505,20 +519,6 @@ export function showFacebookSendDialog(href) {
   return showFacebookDialog({
     method: 'send',
     link: href,
-  });
-}
-
-/**
- * Share a link by generating a Facebook dialog.
- * Get a callback if the share is successful or not.
- *
- * @param  {Object}  options
- * @return {Promise}
- */
-export function showFacebookDialog(options) {
-  return new Promise((resolve, reject) => {
-    const handler = success => (success ? resolve() : reject());
-    return window.FB.ui(options, handler);
   });
 }
 

--- a/resources/assets/helpers/index.js
+++ b/resources/assets/helpers/index.js
@@ -523,6 +523,42 @@ export function showFacebookDialog(options) {
 }
 
 /**
+ * Share a link via the Facebook Messenger app (for mobile devices).
+ * Get a callback if the user is presumed to have been redirected to the
+ * application or not.
+ *
+ * @param  {String}  href
+ * @return {Promise}
+ */
+export function facebookMessengerShare(href) {
+  // Capture if the user leaves the page (presumably meaning they've been successfully redirected to the Messenger app.)
+  let switchedToApp = false;
+  window.onblur = () => (switchedToApp = true);
+
+  return new Promise((resolve, reject) => {
+    const messengerAppUrl = makeUrl('fb-messenger://share', {
+      link: href,
+      app_id: env('FACEBOOK_APP_ID'),
+    });
+    window.location = messengerAppUrl.href;
+
+    setTimeout(() => {
+      // If our client still has not left the page, and the page is still in focus,
+      // they presumably don't have the Messenger app.
+      if (!switchedToApp && window.document.hasFocus()) {
+        reject();
+        window.alert(
+          'Sorry, you need to have the Facebook Messenger app installed, to send a message.',
+        );
+      } else {
+        window.onblur = null;
+        resolve();
+      }
+    }, 1500);
+  });
+}
+
+/**
  * Open a dialog and run a callback when it closes.
  *
  * @param {String} href


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR adds logic to handle a Facebook Messenger link share.

### Any background context you want to provide?
*Oh heck yes there is.*

🆘So Facebook Messenger sharing turned out to be a hell hole and a half.
⚱️For some light fun reading about the ins and outs of our quandary you can read this [Slack thread](https://dosomething.slack.com/archives/C2BPA7M8F/p1534948720000100) 

#### The Issue 🤦‍♂️ 
Essentially, the issue boils down to the elegant [Facebook Send Dialog](https://github.com/DoSomething/phoenix-next/pull/1075#issue-210808711) (quite similar to the Facebook Share dialog we know, love, and use), which allows sharing links via direct messages on Facebook, being supported only on Desktop clients. 

For our Mobile clients, Facebook wants us to direct users to the Facebook Messenger app [via a hard link](https://developers.facebook.com/docs/sharing/messenger/web).
The issue being (well firstly that we lose the cool functionality of the dialog (primarily the callback informing us of successful/canceled shares.) But also) that folks may not have the app, in which case nothing will happen for them. Blank screen. Ugh.

So here we come to the (controversial? Daring? Heroic? Insane? Obnoxious? All-Around-Terrible?) proposal for dealing with Messenger sharing on Mobile / Tablet:
[f7fe0d4](https://github.com/DoSomething/phoenix-next/commit/f7fe0d4044dbbf2218d8a865ba917991ff816329)
😲 😱 👎 🤞 🙌 ☠️ 🚬 🥃 

- We attempt to send the user to the messenger app via setting the `window.location` to a deep link
- We set a listener for an [`onblur`](https://developer.mozilla.org/en-US/docs/Web/API/GlobalEventHandlers/onblur) event, so we can track if the user indeed leaves the page
- We set a timer, giving a reasonable cushion for the app to open (I ran through this on my phone in a bunch of ways to gauge some approximation)
- We check to see if the user has left the page (based on the `onblur` we tracked this status)
  - If they did. 🎊We presume they've been redirected to the app and return `resolve` the returned Promise
  - If not, we presume they do not have the app installed, so we `alert` them to this issue, and `reject` the Promise.

I based this on several suggestions [here](https://stackoverflow.com/questions/13044805/how-to-check-if-an-app-is-installed-from-a-web-page-on-an-iphone/16720093#16720093) and some other places on the web. But diverged a bit from the consensus there to deal with our context and to keep this somewhat sane.

### Damn Danial Back At It Again With The Hacky Code 👟 
Please let me know your thoughts on this. I feel (hope?) this is an OK way to deal with a somewhat 💩  situation, and is not too dangerous?




### Puck Events  🏒 
We have a bunch of new events to track here:
1. clicked messenger share desktop (dialog)
2. successful messenger share desktop (dialog)
3. failed messenger share desktop (dialog)
4. clicked messenger share mobile
5. successful redirect to messenger app mobile
6. failed redirect to messenger app mobile

I added suggested naming, but please let me know thoughts. Then I can get final approval from 🌧 

Also, one thought I had was - do we want to split each of these events out into a brand new unique event, or might we want to use a more general Facebook share event, and rely on categorization through more `data` or something? (I guess a more general question might be - are we cool making a whole bunch of new events, or should we be sparing about it?)

### What are the relevant tickets/cards?

Refs [Pivotal ID #159445991](https://www.pivotaltracker.com/story/show/159445991)

### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.
* [ ] Added screenshot to PR description of related front-end updates on **small** screens.
* [ ] Added screenshot to PR description of related front-end updates on **medium** screens.
* [ ] Added screenshot to PR description of related front-end updates on **large** screens.


![image](https://user-images.githubusercontent.com/12417657/44599828-8c4b7d00-a7a5-11e8-885f-11810c84214f.png)

![image](https://user-images.githubusercontent.com/12417657/44599861-a2593d80-a7a5-11e8-88f3-786bbe52db13.png)
