### PR TITLE
Moving editor interface change line to bottom.

### DIFF
--- a/contentful/content-types/person.js
+++ b/contentful/content-types/person.js
@@ -24,8 +24,6 @@ module.exports = function(migration) {
     .required(true)
     .localized(true);
 
-  person.changeEditorInterface('type', 'radio');
-
   person
     .createField('active')
     .name('Active')
@@ -69,4 +67,6 @@ module.exports = function(migration) {
     .type('Text')
     .required(false)
     .localized(true);
+
+  person.changeEditorInterface('type', 'radio');
 };


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR just moves the line to change the editor interface for the `type` field. I found when running the script, if the line happens right after the field, the rest of the script field additions run as "updates" to the content type, instead of "creating" the fields. Which I think is technically fine, but could be a little confusing when reading through the updates that happened. If placed at end then the script runs with everything is a field creation call, and lastly updates the one field to change the interface.

### Any background context you want to provide?

💅 

