### PR TITLE
Adding Landing Page content type.

### DIFF
--- a/contentful/content-types/landingPage.js
+++ b/contentful/content-types/landingPage.js
@@ -1,0 +1,74 @@
+module.exports = function(migration) {
+  const landingPage = migration
+    .createContentType('landingPage')
+    .name('Landing Page')
+    .description('A custom landing page for a DoSomething.org campaign.')
+    .displayField('internalTitle');
+
+  landingPage
+    .createField('internalTitle')
+    .name('Internal Title')
+    .type('Symbol')
+    .required(true)
+    .localized(false);
+
+  landingPage
+    .createField('title')
+    .name('Title')
+    .type('Symbol')
+    .required(true)
+    .localized(true);
+
+  landingPage
+    .createField('subTitle')
+    .name('Subtitle')
+    .type('Symbol')
+    .required(false)
+    .localized(true);
+
+  landingPage
+    .createField('content')
+    .name('Content')
+    .type('Text')
+    .required(false)
+    .localized(true);
+
+  landingPage
+    .createField('sidebar')
+    .name('Sidebar')
+    .type('Array')
+    .items({
+      type: 'Link',
+      linkType: 'Entry',
+      validations: [
+        {
+          linkContentType: ['callToAction', 'customBlock'],
+        },
+      ],
+    })
+    .required(false)
+    .localized(false);
+
+  landingPage
+    .createField('blocks')
+    .name('Blocks')
+    .type('Array')
+    .items({
+      type: 'Link',
+      linkType: 'Entry',
+      validations: [
+        {
+          linkContentType: ['callToAction', 'contentBlock', 'customBlock'],
+        },
+      ],
+    })
+    .required(false)
+    .localized(false);
+
+  landingPage
+    .createField('additionalContent')
+    .name('Additional Content')
+    .type('Object')
+    .required(false)
+    .localized(false);
+};


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR adds a new `landingPage` content type migration for Contentful. 

### Any background context you want to provide?

While doing some bug fixing to get Sixpack Experiments working on Landing Pages for campaigns, it has highlighted a need for Landing Pages to get their own content type. They are different enough from default `page`s with their requirements and how they work in campaigns. It's useful to know when we're dealing with a type of `page` or `landingPage` to be able to treat them as intended in their different use cases (this issue came up with Sixpack), but also for things like the slug field which is technically required but can't match the campaign slug, etc due to uniqueness collisions and also never actually gets used for landing pages. So it was about time to create a dedicated content type. We'll be moving current landing pages to use this new type in the future.

### What are the relevant tickets/cards?

Refs [Pivotal ID #159907997](https://www.pivotaltracker.com/story/show/159907997)

### Checklist

* [ ] Documentation added for new features/changed endpoints.