### PR TITLE
Update to restore window.sixpack.

### DIFF
--- a/resources/assets/services/Sixpack.js
+++ b/resources/assets/services/Sixpack.js
@@ -19,10 +19,8 @@ class Sixpack {
       cookie_name: env.SIXPACK_COOKIE_PREFIX || 'sixpack',
     });
 
-    // Unsetting the default sixpack object added to the window by the sixpack package.
-    delete window.sixpack;
-
-    window.Sixpack = this;
+    window.DS = window.DS || {};
+    window.DS.Sixpack = this;
   }
 
   /**


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR fixes a bug introduced when we removed the `window.sixpack` object and replaced it with a `window.Sixpack`. Turns out the JS Sixpack client still needs to have access to the `window.sixpack` that it sets up (we thought it wasn't being used).

However, we also want access to our own Sixpack object on the window and figured it would be nice to have a distinct `window.DS` object that could contain all the things™ related to DS. Nice little name spacing.


### What are the relevant tickets/cards?

Refs [Pivotal ID #159907997](https://www.pivotaltracker.com/story/show/159907997)

### Checklist

* [ ] Documentation added for new features/changed endpoints.
