### PR TITLE
Landing page entity and logic

### DIFF
--- a/app/Entities/Campaign.php
+++ b/app/Entities/Campaign.php
@@ -86,7 +86,7 @@ class Campaign extends Entity implements JsonSerializable
      */
     public function parseLandingPage($landingPage)
     {
-        if (!$landingPage) {
+        if (! $landingPage) {
             return null;
         }
 

--- a/app/Entities/Campaign.php
+++ b/app/Entities/Campaign.php
@@ -79,6 +79,30 @@ class Campaign extends Entity implements JsonSerializable
     }
 
     /**
+     * Parse the landing page for the campaign.
+     *
+     * @param  DynamicEntry $landingPage
+     * @return array
+     */
+    public function parseLandingPage($landingPage)
+    {
+        if (!$landingPage) {
+            return null;
+        }
+
+        if ($landingPage->entry->getContentType()->getId() === 'sixpackExperiment') {
+            return new SixpackExperiment($landingPage->entry);
+        }
+
+        // @TODO: remove once all landing pages use the LandingPage content type.
+        if ($landingPage->entry->getContentType()->getId() === 'page') {
+            return new Page($landingPage->entry);
+        }
+
+        return new LandingPage($landingPage->entry);
+    }
+
+    /**
      * Convert the object into something JSON serializable.
      *
      * @return array
@@ -110,7 +134,7 @@ class Campaign extends Entity implements JsonSerializable
             'dashboard' => $this->dashboard,
             'affirmation' => $this->parseBlock($this->affirmation),
             'pages' => $this->parseBlocks($this->pages),
-            'landingPage' => $this->landingPage ? new Page($this->landingPage->entry) : null,
+            'landingPage' => $this->parseLandingPage($this->landingPage),
             'socialOverride' => $this->socialOverride ? new SocialOverride($this->socialOverride->entry) : null,
             'additionalContent' => $this->additionalContent,
             'allowExperiments' => $this->campaignSettings ? $this->campaignSettings->allowExperiments : null,

--- a/app/Entities/Campaign.php
+++ b/app/Entities/Campaign.php
@@ -90,12 +90,12 @@ class Campaign extends Entity implements JsonSerializable
             return null;
         }
 
-        if ($landingPage->entry->getContentType()->getId() === 'sixpackExperiment') {
+        if ($landingPage->getContentType() === 'sixpackExperiment') {
             return new SixpackExperiment($landingPage->entry);
         }
 
         // @TODO: remove once all landing pages use the LandingPage content type.
-        if ($landingPage->entry->getContentType()->getId() === 'page') {
+        if ($landingPage->getContentType() === 'page') {
             return new Page($landingPage->entry);
         }
 

--- a/app/Entities/LandingPage.php
+++ b/app/Entities/LandingPage.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Entities;
+
+use JsonSerializable;
+
+class LandingPage extends Entity implements JsonSerializable
+{
+    /**
+     * Convert the object into something JSON serializable.
+     *
+     * @return array
+     */
+    public function jsonSerialize()
+    {
+        return [
+            'id' => $this->entry->getId(),
+            'type' => $this->getContentType(),
+            'fields' => [
+                'internalTitle' => $this->internalTitle,
+                'title' => $this->title,
+                'subTitle' => $this->subTitle,
+                'content' => $this->content,
+                'sidebar' => $this->parseBlocks($this->sidebar),
+                'blocks' => $this->parseBlocks($this->blocks),
+                'additionalContent' => $this->additionalContent,
+            ],
+        ];
+    }
+}

--- a/app/Entities/Page.php
+++ b/app/Entities/Page.php
@@ -34,9 +34,10 @@ class Page extends Entity implements JsonSerializable
             'id' => $this->entry->getId(),
             'type' => $this->getContentType(),
             'fields' => [
-                'slug' => $this->slug,
+                'internalTitle' => $this->internalTitle,
                 'title' => $this->title,
                 'subTitle' => $this->subTitle,
+                'slug' => $this->slug,
                 'content' => $this->content,
                 'sidebar' => $this->parseBlocks($this->sidebar),
                 'blocks' => $this->parseBlocks($this->blocks),

--- a/resources/assets/components/ContentfulEntry/ContentfulEntry.js
+++ b/resources/assets/components/ContentfulEntry/ContentfulEntry.js
@@ -13,6 +13,7 @@ import { CampaignUpdateContainer } from '../CampaignUpdate';
 import ImagesBlock from '../blocks/ImagesBlock/ImagesBlock';
 import { parseContentfulType, report, withoutNulls } from '../../helpers';
 import CallToActionContainer from '../CallToAction/CallToActionContainer';
+import LandingPageContainer from '../pages/LandingPage/LandingPageContainer';
 import SocialDriveActionContainer from '../actions/SocialDriveAction/SocialDriveActionContainer';
 import SixpackExperimentContainer from '../utilities/SixpackExperiment/SixpackExperimentContainer';
 import CampaignGalleryBlockContainer from '../blocks/CampaignGalleryBlock/CampaignGalleryBlockContainer';
@@ -99,6 +100,9 @@ class ContentfulEntry extends React.Component<Props, State> {
 
       case 'linkAction':
         return renderLinkAction(json);
+
+      case 'landingPage':
+        return <LandingPageContainer {...json.fields} />;
 
       case 'page':
         return (

--- a/resources/assets/components/pages/CampaignPage/CampaignPage.js
+++ b/resources/assets/components/pages/CampaignPage/CampaignPage.js
@@ -18,9 +18,9 @@ import './campaign-page.scss';
  * @returns {XML}
  */
 const CampaignPage = props => {
-  // @TODO: temporary variable to select component to use based on type.
+  // @TODO: temporary fucntion to select component to use based on type.
   // Will be removed once all landing pages use the LandingPage content type.
-  const landingPageComponent =
+  const landingPageComponent = () =>
     props.landingPage.type === 'page' ? (
       <LandingPageContainer {...props} />
     ) : (
@@ -28,7 +28,7 @@ const CampaignPage = props => {
     );
 
   return props.shouldShowLandingPage ? (
-    landingPageComponent
+    landingPageComponent()
   ) : (
     <div>
       <LedeBannerContainer displaySignup={Boolean(!props.entryContent)} />

--- a/resources/assets/components/pages/CampaignPage/CampaignPage.js
+++ b/resources/assets/components/pages/CampaignPage/CampaignPage.js
@@ -3,12 +3,12 @@ import PropTypes from 'prop-types';
 
 import Enclosure from '../../Enclosure';
 import ContentfulEntry from '../../ContentfulEntry';
-import { CallToActionContainer } from '../../CallToAction';
 import CampaignPageContent from './CampaignPageContent';
+import { CallToActionContainer } from '../../CallToAction';
 import DashboardContainer from '../../Dashboard/DashboardContainer';
 import LedeBannerContainer from '../../LedeBanner/LedeBannerContainer';
-import CampaignPageNavigationContainer from '../../CampaignPageNavigation/CampaignPageNavigationContainer';
 import LandingPageContainer from '../../pages/LandingPage/LandingPageContainer';
+import CampaignPageNavigationContainer from '../../CampaignPageNavigation/CampaignPageNavigationContainer';
 
 import './campaign-page.scss';
 
@@ -17,9 +17,18 @@ import './campaign-page.scss';
  *
  * @returns {XML}
  */
-const CampaignPage = props =>
-  props.shouldShowLandingPage ? (
-    <LandingPageContainer {...props} />
+const CampaignPage = props => {
+  // @TODO: temporary variable to select component to use based on type.
+  // Will be removed once all landing pages use the LandingPage content type.
+  const landingPageComponent =
+    props.landingPage.type === 'page' ? (
+      <LandingPageContainer {...props} />
+    ) : (
+      <ContentfulEntry json={props.landingPage} />
+    );
+
+  return props.shouldShowLandingPage ? (
+    landingPageComponent
   ) : (
     <div>
       <LedeBannerContainer displaySignup={Boolean(!props.entryContent)} />
@@ -42,6 +51,7 @@ const CampaignPage = props =>
       </div>
     </div>
   );
+};
 
 CampaignPage.propTypes = {
   dashboard: PropTypes.shape({
@@ -50,12 +60,18 @@ CampaignPage.propTypes = {
     fields: PropTypes.object,
   }),
   entryContent: PropTypes.object, // eslint-disable-line react/forbid-prop-types
+  landingPage: PropTypes.shape({
+    id: PropTypes.string,
+    type: PropTypes.string,
+    fields: PropTypes.object,
+  }),
   shouldShowLandingPage: PropTypes.bool.isRequired,
 };
 
 CampaignPage.defaultProps = {
   dashboard: null,
   entryContent: null,
+  landingPage: null,
 };
 
 export default CampaignPage;

--- a/resources/assets/components/pages/CampaignPage/CampaignPageContainer.js
+++ b/resources/assets/components/pages/CampaignPage/CampaignPageContainer.js
@@ -18,12 +18,13 @@ const mapStateToProps = (state, ownProps) => {
   }
 
   return {
-    shouldShowLandingPage: shouldShowLandingPage(state, entryContent),
     campaignEndDate: get(state.campaign.endDate, 'date', null),
     dashboard: state.campaign.dashboard,
     entryContent,
+    landingPage: get(state.campaign, 'landingPage', null),
     noun: get(state.campaign.additionalContent, 'noun'),
     pages: state.campaign.pages,
+    shouldShowLandingPage: shouldShowLandingPage(state, entryContent),
     tagline: get(state.campaign.additionalContent, 'tagline'),
     title: state.campaign.title,
     verb: get(state.campaign.additionalContent, 'verb'),

--- a/resources/assets/components/pages/LandingPage/LandingPage.js
+++ b/resources/assets/components/pages/LandingPage/LandingPage.js
@@ -15,13 +15,14 @@ import './landing-page.scss';
 const LandingPage = props => {
   const {
     campaignId,
-    pitchContent,
+    content,
     showPartnerMsgOptIn,
     sidebar,
     signupArrowContent,
     tagline,
   } = props;
 
+  // @TODO: allow outputting multiple blocks in the sidebar.
   const sidebarCTA = sidebar[0] && sidebar[0].fields;
 
   return (
@@ -51,7 +52,7 @@ const LandingPage = props => {
 
       <div className="clearfix bg-white">
         <Enclosure className="default-container margin-lg pitch-landing-page">
-          <PitchTemplate pitchContent={pitchContent} sidebarCTA={sidebarCTA} />
+          <PitchTemplate content={content} sidebarCTA={sidebarCTA} />
         </Enclosure>
 
         <CallToActionContainer content={tagline} sticky />
@@ -76,7 +77,7 @@ const LandingPage = props => {
 
 LandingPage.propTypes = {
   campaignId: PropTypes.string.isRequired,
-  pitchContent: PropTypes.string.isRequired,
+  content: PropTypes.string.isRequired,
   showPartnerMsgOptIn: PropTypes.bool,
   sidebar: PropTypes.arrayOf(PropTypes.object),
   signupArrowContent: PropTypes.string,

--- a/resources/assets/components/pages/LandingPage/LandingPageContainer.js
+++ b/resources/assets/components/pages/LandingPage/LandingPageContainer.js
@@ -11,7 +11,7 @@ const mapStateToProps = state => {
 
   return {
     campaignId: state.campaign.id,
-    pitchContent: landingPage.content,
+    content: landingPage.content,
     showPartnerMsgOptIn: get(
       state.campaign.additionalContent,
       'displayAffilitateOptOut',

--- a/resources/assets/components/pages/LandingPage/templates/PitchTemplate.js
+++ b/resources/assets/components/pages/LandingPage/templates/PitchTemplate.js
@@ -4,10 +4,10 @@ import PropTypes from 'prop-types';
 import Card from '../../../utilities/Card/Card';
 import Markdown from '../../../utilities/Markdown/Markdown';
 
-const PitchTemplate = ({ pitchContent, sidebarCTA }) => (
+const PitchTemplate = ({ content, sidebarCTA }) => (
   <div className="campaign-page">
     <div className="primary">
-      <Markdown>{pitchContent}</Markdown>
+      <Markdown>{content}</Markdown>
     </div>
     <div className="secondary">
       <Card title={sidebarCTA.title} className="rounded bordered">
@@ -18,7 +18,7 @@ const PitchTemplate = ({ pitchContent, sidebarCTA }) => (
 );
 
 PitchTemplate.propTypes = {
-  pitchContent: PropTypes.string.isRequired,
+  content: PropTypes.string.isRequired,
   sidebarCTA: PropTypes.shape({
     title: PropTypes.string,
     content: PropTypes.string,


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR updates how we render out Landing Pages for a campaign. It adds a new `LandingPage` entity to take advantage of the new `landingPage` content type on Contentful. Moving forward we want to use this content type instead of the `page` content type so we can know better when we're dealing with the uniqueness of a landing page.

If a landing page is of type `page` it will render out using the old approach, otherwise if it is of type `landingPage` it will render using the new approach.

It now uses the `ContentfulEntry` component to render out the landing page (which sets things up for an upcoming Sixpack bug fix for landing pages). This PR also fixes some naming to rename the `pitchContent` variable to just be `content`.


### What are the relevant tickets/cards?

Refs [Pivotal ID #159907997](https://www.pivotaltracker.com/story/show/159907997)

### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.