### PR TITLE
Social Drive Action visual update

### DIFF
--- a/resources/assets/components/actions/SocialDriveAction/SocialDriveAction.js
+++ b/resources/assets/components/actions/SocialDriveAction/SocialDriveAction.js
@@ -69,94 +69,93 @@ class SocialDriveAction extends React.Component {
     const shortenedLink = this.state.shortenedLink;
 
     return (
-      <Card
-        title="Your Online Drive"
-        className="social-drive-action rounded bordered"
-      >
-        <div className="padded">
-          <Embed url={link} />
-        </div>
+      <div className="clearfix padding-bottom-lg">
+        <div className="social-drive-action">
+          <Card title="Your Online Drive" className="rounded bordered">
+            <div className="padded">
+              <Embed url={link} />
+            </div>
 
-        <div className="padded link-area">
-          <div className="share-text">
-            <p>Share your link:</p>
-          </div>
+            <div className="padded link-area">
+              <div className="share-text">
+                <p>Share your link:</p>
+              </div>
 
-          <div className="link-bar">
-            <input
-              readOnly
-              type="text"
-              ref={this.linkInput}
-              className="text-field link"
-              value={shortenedLink || 'Loading...'}
-              disabled={!shortenedLink}
-            />
-            <button
-              className="text-field link-copy-button"
-              onClick={this.handleCopyLinkClick}
-              disabled={!shortenedLink}
-            >
-              <img src={linkIcon} alt="link" />
-              <p>Copy link</p>
-            </button>
-          </div>
-        </div>
+              <div className="link-bar">
+                <input
+                  readOnly
+                  type="text"
+                  ref={this.linkInput}
+                  className="text-field link"
+                  value={shortenedLink || 'Loading...'}
+                  disabled={!shortenedLink}
+                />
+                <button
+                  className="text-field link-copy-button"
+                  onClick={this.handleCopyLinkClick}
+                  disabled={!shortenedLink}
+                >
+                  <img src={linkIcon} alt="link" />
+                  <p>Copy link</p>
+                </button>
+              </div>
+            </div>
 
-        <div className="share-buttons">
-          <div className="share-button padded">
-            <button
-              className={classnames('button padding-vertical-md', {
-                'bg-dark-blue': shortenedLink,
-              })}
-              onClick={() => this.handleFacebookShareClick(shortenedLink)}
-              disabled={!shortenedLink}
-            >
-              <i className="social-icon -facebook" />
-              Share on Facebook
-            </button>
-          </div>
+            <div className="share-buttons">
+              <div className="share-button padded">
+                <button
+                  className={classnames('button padding-vertical-md', {
+                    'bg-dark-blue': shortenedLink,
+                  })}
+                  onClick={() => this.handleFacebookShareClick(shortenedLink)}
+                  disabled={!shortenedLink}
+                >
+                  <i className="social-icon -facebook" />
+                  Share on Facebook
+                </button>
+              </div>
 
-          <div className="share-button padded">
-            <button
-              className="button padding-vertical-md"
-              onClick={() =>
-                handleTwitterShareClick(shortenedLink, { url: link })
-              }
-              disabled={!shortenedLink}
-            >
-              <i className="social-icon -twitter" />
-              <span>Share on Twitter</span>
-            </button>
-          </div>
+              <div className="share-button padded">
+                <button
+                  className="button padding-vertical-md"
+                  onClick={() =>
+                    handleTwitterShareClick(shortenedLink, { url: link })
+                  }
+                  disabled={!shortenedLink}
+                >
+                  <i className="social-icon -twitter" />
+                  <span>Share on Twitter</span>
+                </button>
+              </div>
+            </div>
+          </Card>
         </div>
 
         {showPageViews ? (
-          <div>
-            <div className="padding-horizontal-md">
-              <hr className="border" />
-            </div>
+          <div className="social-drive-information">
+            <Card className="bordered rounded" title="More info">
+              <div className="link-info padded">
+                <p className="info__title">What happens next?</p>
 
-            <div className="link-info padded">
-              <p className="info__title">What happens next?</p>
+                <p className="info__text">
+                  As you share your voter registration page, we&#39;ll keep
+                  track of how many people you bring in. Check back often and
+                  try to get as many views as possible!
+                </p>
+              </div>
 
-              <p className="info__text">
-                As you share your voter registration page, we&#39;ll keep track
-                of how many people you bring in. Check back often and try to get
-                as many views as possible!
-              </p>
-            </div>
-
-            <div className="padded page-views">
-              <span className="page-views__text caps-lock">
-                total page views
-              </span>
-              <h1 className="page-views__amount">
-                {shortenedLink ? this.state.count : '?'}
-              </h1>
-            </div>
+              <div className="padded page-views">
+                <span className="page-views__text caps-lock">
+                  total page views
+                </span>
+                <h1 className="page-views__amount">
+                  {shortenedLink ? this.state.count : '?'}
+                </h1>
+              </div>
+            </Card>
           </div>
         ) : null}
-      </Card>
+      </div>
     );
   }
 }

--- a/resources/assets/components/actions/SocialDriveAction/social-drive.scss
+++ b/resources/assets/components/actions/SocialDriveAction/social-drive.scss
@@ -1,6 +1,12 @@
 @import '../../../scss/next-toolbox.scss';
 
 .social-drive-action {
+  @include media($large) {
+    float: left;
+    padding-right: $half-spacing;
+    width: 66.6666666666666%;
+  }
+
   .link-area {
     @include media($large) {
       display: flex;
@@ -61,6 +67,41 @@
     border: 0.5px solid $light-gray;
   }
 
+  .share-buttons {
+    @include media($large) {
+      display: flex;
+
+      .share-button {
+        flex: 1;
+      }
+    }
+
+    .share-button button {
+      width: 100%;
+      text-transform: none;
+      font-size: $font-regular;
+    }
+
+    .social-icon {
+      margin-right: 8px;
+    }
+  }
+
+  .bg-dark-blue {
+    background-color: #39579a;
+  }
+}
+
+.social-drive-information {
+  margin-top: $base-spacing;
+
+  @include media($large) {
+    float: right;
+    margin-top: 0;
+    padding-left: $half-spacing;
+    width: 33.3333333333333%;
+  }
+
   .link-info {
     .info__title {
       font-family: $primary-font-family;
@@ -88,29 +129,5 @@
       font-weight: $weight-normal;
       line-height: $font-hero;
     }
-  }
-
-  .share-buttons {
-    @include media($large) {
-      display: flex;
-
-      .share-button {
-        flex: 1;
-      }
-    }
-
-    .share-button button {
-      width: 100%;
-      text-transform: none;
-      font-size: $font-regular;
-    }
-
-    .social-icon {
-      margin-right: 8px;
-    }
-  }
-
-  .bg-dark-blue {
-    background-color: #39579a;
   }
 }

--- a/resources/assets/components/pages/CampaignPage/CampaignPageContent.js
+++ b/resources/assets/components/pages/CampaignPage/CampaignPageContent.js
@@ -31,7 +31,14 @@ const CampaignPageContent = props => {
     const type = parseContentfulType(json);
 
     let fullWidth = false;
-    if (['photoSubmissionAction', 'gallery', 'imagesBlock'].includes(type)) {
+    if (
+      [
+        'photoSubmissionAction',
+        'gallery',
+        'imagesBlock',
+        'socialDriveAction',
+      ].includes(type)
+    ) {
       fullWidth = true;
     }
 


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR updates the styling for the `SocialDriveAction` rendering the additional info for the action on a separate card.

### Any background context you want to provide?
The styling is pretty much copied over from the [`PhotoSubmissionAction`](https://github.com/DoSomething/phoenix-next/blob/master/resources/assets/components/actions/PhotoSubmissionAction/photo-submission-action.scss#L3...#L20), it's also a pretty similar format to the [`.row > .primary / .secondary`](https://github.com/DoSomething/phoenix-next/blob/master/resources/assets/components/pages/GeneralPage/general-page.scss#L59...#L81) that we use in a few places. But I figured we'd leave the refactoring or abstracting this to another time (if we so desire).


### What are the relevant tickets/cards?

Refs [Pivotal ID #](https://www.pivotaltracker.com/story/show/159445991)

### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.
* [x] Added screenshot to PR description of related front-end updates on **small** screens.
* [x] Added screenshot to PR description of related front-end updates on **medium** screens.
* [x] Added screenshot to PR description of related front-end updates on **large** screens.

**LARGE**
![image](https://user-images.githubusercontent.com/12417657/44858196-76273c00-ac3f-11e8-9074-b8af13cfe243.png)

**Medium**
![image](https://user-images.githubusercontent.com/12417657/44858240-8dfec000-ac3f-11e8-8e96-f39915c80a7a.png)

**Small**
![image](https://user-images.githubusercontent.com/12417657/44858312-aec71580-ac3f-11e8-9924-736152b3b147.png)
