### PR TITLE
Social Drive Action - updates!

### DIFF
--- a/resources/assets/components/actions/SocialDriveAction/SocialDriveAction.js
+++ b/resources/assets/components/actions/SocialDriveAction/SocialDriveAction.js
@@ -2,20 +2,14 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import classnames from 'classnames';
 
 import linkIcon from './linkIcon.svg';
 import Card from '../../utilities/Card/Card';
 import Embed from '../../utilities/Embed/Embed';
 import { postRequest } from '../../../helpers/api';
 import { trackPuckEvent } from '../../../helpers/analytics';
-import {
-  dynamicString,
-  handleTwitterShareClick,
-  loadFacebookSDK,
-  showFacebookShareDialog,
-  withoutTokens,
-} from '../../../helpers';
+import { dynamicString, withoutTokens } from '../../../helpers';
+import SocialShareTray from '../../utilities/SocialShareTray/SocialShareTray';
 
 import './social-drive.scss';
 
@@ -31,8 +25,6 @@ class SocialDriveAction extends React.Component {
   }
 
   componentDidMount() {
-    loadFacebookSDK();
-
     const { userId, token } = this.props;
 
     const href = dynamicString(this.props.link, { userId });
@@ -48,20 +40,6 @@ class SocialDriveAction extends React.Component {
     trackPuckEvent('phoenix_clicked_copy_to_clipboard', {
       url: this.props.link,
     });
-  };
-
-  handleFacebookShareClick = url => {
-    const trackingData = { url: this.props.link };
-
-    trackPuckEvent('clicked facebook share action', trackingData);
-
-    showFacebookShareDialog(url)
-      .then(() => {
-        trackPuckEvent('share action completed', trackingData);
-      })
-      .catch(() => {
-        trackPuckEvent('share action cancelled', trackingData);
-      });
   };
 
   render() {
@@ -101,33 +79,7 @@ class SocialDriveAction extends React.Component {
               </div>
             </div>
 
-            <div className="share-buttons">
-              <div className="share-button padded">
-                <button
-                  className={classnames('button padding-vertical-md', {
-                    'bg-dark-blue': shortenedLink,
-                  })}
-                  onClick={() => this.handleFacebookShareClick(shortenedLink)}
-                  disabled={!shortenedLink}
-                >
-                  <i className="social-icon -facebook" />
-                  Share on Facebook
-                </button>
-              </div>
-
-              <div className="share-button padded">
-                <button
-                  className="button padding-vertical-md"
-                  onClick={() =>
-                    handleTwitterShareClick(shortenedLink, { url: link })
-                  }
-                  disabled={!shortenedLink}
-                >
-                  <i className="social-icon -twitter" />
-                  <span>Share on Twitter</span>
-                </button>
-              </div>
-            </div>
+            <SocialShareTray shareLink={shortenedLink} trackLink={link} />
           </Card>
         </div>
 

--- a/resources/assets/components/actions/SocialDriveAction/social-drive.scss
+++ b/resources/assets/components/actions/SocialDriveAction/social-drive.scss
@@ -62,34 +62,6 @@
       }
     }
   }
-
-  hr {
-    border: 0.5px solid $light-gray;
-  }
-
-  .share-buttons {
-    @include media($large) {
-      display: flex;
-
-      .share-button {
-        flex: 1;
-      }
-    }
-
-    .share-button button {
-      width: 100%;
-      text-transform: none;
-      font-size: $font-regular;
-    }
-
-    .social-icon {
-      margin-right: 8px;
-    }
-  }
-
-  .bg-dark-blue {
-    background-color: #39579a;
-  }
 }
 
 .social-drive-information {

--- a/resources/assets/components/utilities/SocialShareTray/SocialShareTray.js
+++ b/resources/assets/components/utilities/SocialShareTray/SocialShareTray.js
@@ -79,7 +79,7 @@ class SocialShareTray extends React.Component {
 
   handleEmailShareClick = (shareLink, trackLink) => {
     trackPuckEvent('phoenix_clicked_share_email', { url: trackLink });
-    window.open(`mailto:?body=${encodeURIComponent(shareLink)}`);
+    window.location = `mailto:?body=${encodeURIComponent(shareLink)}`;
   };
 
   render() {

--- a/resources/assets/helpers/index.js
+++ b/resources/assets/helpers/index.js
@@ -549,7 +549,7 @@ export function facebookMessengerShare(href) {
         reject();
         // eslint-disable-next-line no-alert
         window.alert(
-          'Sorry, you need to have the Facebook Messenger app installed, to send a message.',
+          'Sorry, you need to have the Facebook Messenger app installed to send a message.',
         );
       } else {
         window.onblur = null;


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR replaces the button in the `SocialDriveAction` with the `SocialShareTray` and its assorted button-ary.

### Any background context you want to provide?
At Long Last. The `SocialDriveAction` visual refactor should be complete!

Also updated the mailto redirect for email clicks in the SocailShareTray so we don't open a blank new tab. And removed a comma from our Facebook Messenger mobile failure alert.

### What are the relevant tickets/cards?

Refs [Pivotal ID #](https://www.pivotaltracker.com/story/show/159445991)

### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.

For more visual previews see #1072 and #1087 
![image](https://user-images.githubusercontent.com/12417657/44864683-47fd2880-ac4e-11e8-8a26-6260986d7e44.png)
