### PR TITLE
Updates to address using default URL in both Person and Staff.

### DIFF
--- a/app/Entities/Affirmation.php
+++ b/app/Entities/Affirmation.php
@@ -23,7 +23,7 @@ class Affirmation extends Entity implements JsonSerializable
                 'fields' => [
                     'name' => $authorValue,
                     'jobTitle' => 'Campaign Lead',
-                    'avatar' => null,
+                    'photo' => null,
                 ],
             ];
         } else {

--- a/app/Entities/CampaignUpdate.php
+++ b/app/Entities/CampaignUpdate.php
@@ -15,12 +15,18 @@ class CampaignUpdate extends Entity implements JsonSerializable
     {
         switch ($this->getContentType()) {
             case 'campaignUpdate':
+                $author = null;
+
+                if ($this->author) {
+                    $author = $this->author->getContentType() === 'staff' ? new Staff($this->author->entry) : new Person($this->author->entry);
+                }
+
                 $type = $this->getContentType();
-                $author = $this->author ? new Staff($this->author->entry) : null;
                 $content = $this->content;
                 $socialOverride = $this->socialOverride ? new SocialOverride($this->socialOverride->entry) : null;
                 break;
 
+            // @TODO (2018-08-30): We should aim to remove the old campaign update customBlocks.
             case 'customBlock':
                 $type = 'campaignUpdate';
                 $author = [
@@ -29,7 +35,7 @@ class CampaignUpdate extends Entity implements JsonSerializable
                     'fields' => [
                         'name' => isset($this->additionalContent['author']) ? $this->additionalContent['author'] : null,
                         'jobTitle' => isset($this->additionalContent['jobTitle']) ? $this->additionalContent['jobTitle'] : null,
-                        'avatar' => null,
+                        'photo' => null,
                     ],
                 ];
                 $content = "## {$this->title}\n\n {$this->content}";

--- a/app/Entities/Staff.php
+++ b/app/Entities/Staff.php
@@ -19,7 +19,7 @@ class Staff extends Entity implements JsonSerializable
             'fields' => [
                 'name' => $this->name,
                 'jobTitle' => $this->jobTitle,
-                'avatar' => get_image_url($this->avatar, 'square'),
+                'photo' => get_image_url($this->avatar),
                 'email' => $this->email,
             ],
         ];

--- a/resources/assets/__mocks__/fileMock.js
+++ b/resources/assets/__mocks__/fileMock.js
@@ -1,1 +1,1 @@
-module.exports = {};
+module.exports = 'http://placekitten.com/300/300';

--- a/resources/assets/components/CampaignUpdate/CampaignUpdate.js
+++ b/resources/assets/components/CampaignUpdate/CampaignUpdate.js
@@ -9,6 +9,7 @@ import Embed from '../utilities/Embed/Embed';
 // import Share from '../utilities/Share/Share';
 import Byline from '../utilities/Byline/Byline';
 import SponsorPromotion from '../SponsorPromotion';
+import { contentfulImageUrl } from '../../helpers';
 import Markdown from '../utilities/Markdown/Markdown';
 
 const CampaignUpdate = props => {
@@ -26,6 +27,7 @@ const CampaignUpdate = props => {
   } = props;
 
   const authorFields = get(author, 'fields', {});
+  const authorPhoto = authorFields.photo || undefined;
 
   const isTweet = content && content.length < 144;
 
@@ -61,7 +63,11 @@ const CampaignUpdate = props => {
         ) : (
           <Byline
             author={authorFields.name}
-            avatar={authorFields.avatar || undefined}
+            photo={
+              authorPhoto
+                ? contentfulImageUrl(authorPhoto, 175, 175, 'fill')
+                : undefined
+            }
             jobTitle={authorFields.jobTitle || undefined}
             className="float-left"
           />

--- a/resources/assets/components/CampaignUpdate/CampaignUpdate.test.js
+++ b/resources/assets/components/CampaignUpdate/CampaignUpdate.test.js
@@ -6,7 +6,7 @@ import CampaignUpdate from './CampaignUpdate';
 
 const author = {
   fields: {
-    avatar: 'http://example.com/avatar-aang.jpg',
+    photo: 'http://example.com/avatar-aang.jpg',
     jobTitle: 'The Last Airbender',
     name: 'Aang',
   },

--- a/resources/assets/components/utilities/Byline/Byline.js
+++ b/resources/assets/components/utilities/Byline/Byline.js
@@ -12,12 +12,12 @@ import './byline.scss';
  * about an author and the option to add a
  * Facebook share.
  */
-const Byline = ({ author, jobTitle, avatar, share, className }) => (
+const Byline = ({ author, jobTitle, photo, share, className }) => (
   <div className={classnames('byline', className)}>
     <Figure
       size="small"
       alignment="left"
-      image={avatar}
+      image={photo}
       alt={`picture of ${author}`}
       imageClassName="avatar"
       className="margin-bottom-none"
@@ -34,7 +34,7 @@ Byline.propTypes = {
   author: PropTypes.string,
   className: PropTypes.string,
   jobTitle: PropTypes.string,
-  avatar: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
+  photo: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
   share: PropTypes.node,
 };
 
@@ -42,7 +42,7 @@ Byline.defaultProps = {
   author: 'Puppet Sloth',
   className: null,
   jobTitle: 'DoSomething.org Staff',
-  avatar: DEFAULT_AVATAR,
+  photo: DEFAULT_AVATAR,
   share: null,
 };
 

--- a/resources/assets/components/utilities/Byline/Byline.js
+++ b/resources/assets/components/utilities/Byline/Byline.js
@@ -34,7 +34,7 @@ Byline.propTypes = {
   author: PropTypes.string,
   className: PropTypes.string,
   jobTitle: PropTypes.string,
-  photo: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
+  photo: PropTypes.string,
   share: PropTypes.node,
 };
 

--- a/resources/assets/components/utilities/Byline/Byline.test.js
+++ b/resources/assets/components/utilities/Byline/Byline.test.js
@@ -15,7 +15,7 @@ test('Byline with props snapshot test', () => {
     <Byline
       author="Braümhilda Snosages"
       jobTitle="Campaign Tester"
-      avatar="http://placeimg.com/150/150/people"
+      photo="http://placeimg.com/150/150/people"
     />,
   );
   const tree = shallowToJson(component);

--- a/resources/assets/components/utilities/Byline/__snapshots__/Byline.test.js.snap
+++ b/resources/assets/components/utilities/Byline/__snapshots__/Byline.test.js.snap
@@ -8,7 +8,7 @@ exports[`Byline default snapshot test 1`] = `
     alignment="left"
     alt="picture of Puppet Sloth"
     className="margin-bottom-none"
-    image={Object {}}
+    image="http://placekitten.com/300/300"
     imageClassName="avatar"
     size="small"
   >


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_


### What does this PR do?

This PR updates the `Staff` entity to return the default author photo URL and not a pre-formatted one. Instead we want the front-end React components to decide what sizing of a photo they want using the Contentful Image API.

It also makes it so that Campaign Updates and Affirmations support either using a `staff` or `person` content type. The `staff` content type will be deprecated but to make the transition easier, we are supporting both until everyone is shift over to be a `person`.

This PR also updates references to use `photo` instead of `avatar` which is the new name for the person's photo in the `person` content type.

### What are the relevant tickets/cards?

Refs [Pivotal ID #159740120](https://www.pivotaltracker.com/story/show/159740120)

### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.