### PR TITLE
Contentful SDK update - 3.0

### DIFF
--- a/app/Entities/Campaign.php
+++ b/app/Entities/Campaign.php
@@ -3,7 +3,7 @@
 namespace App\Entities;
 
 use JsonSerializable;
-use Contentful\Delivery\Asset;
+use Contentful\Delivery\Resource\Asset;
 
 /**
  * The Campaign entity.

--- a/app/Entities/Campaign.php
+++ b/app/Entities/Campaign.php
@@ -53,7 +53,7 @@ class Campaign extends Entity implements JsonSerializable
     /**
      * Parse the campaign lead from other
      *
-     * @param  DynamicEntry $campaignlead
+     * @param  Entry $campaignlead
      * @param  array $additionalContent
      * @return array
      */
@@ -84,7 +84,7 @@ class Campaign extends Entity implements JsonSerializable
     /**
      * Parse the landing page for the campaign.
      *
-     * @param  DynamicEntry $landingPage
+     * @param  Entry $landingPage
      * @return array
      */
     public function parseLandingPage($landingPage)

--- a/app/Entities/Campaign.php
+++ b/app/Entities/Campaign.php
@@ -7,15 +7,6 @@ use Contentful\Delivery\Asset;
 
 /**
  * The Campaign entity.
- *
- * @property string $title
- * @property string $callToAction
- * @property Asset $coverImage
- * @property array $problemFact
- * @property array $solutionFact
- * @property array $solutionStatement
- * @property array $facts
- * @property string $faqs
  */
 class Campaign extends Entity implements JsonSerializable
 {

--- a/app/Entities/Campaign.php
+++ b/app/Entities/Campaign.php
@@ -3,7 +3,6 @@
 namespace App\Entities;
 
 use JsonSerializable;
-use Contentful\Delivery\Resource\Asset;
 
 /**
  * The Campaign entity.

--- a/app/Entities/CustomBlock.php
+++ b/app/Entities/CustomBlock.php
@@ -14,7 +14,7 @@ class CustomBlock extends Entity implements JsonSerializable
     public function jsonSerialize()
     {
         // Custom Block type field, which -if set- overrides the Content Type's type.
-        $type = $this->entry->type();
+        $type = $this->entry->type;
 
         return [
             'id' => $this->entry->getId(),

--- a/app/Entities/CustomBlock.php
+++ b/app/Entities/CustomBlock.php
@@ -13,9 +13,11 @@ class CustomBlock extends Entity implements JsonSerializable
      */
     public function jsonSerialize()
     {
+        // Custom Block type field, which -if set- overrides the Content Type's type.
+        $type = $this->entry->type();
         return [
             'id' => $this->entry->getId(),
-            'type' => (is_string($this->type) || ! $this->type) ? $this->type : $this->type->first(),
+            'type' => (is_string($type) || ! $type) ? $type : $type->first(),
             'fields' => [
                 'title' => $this->title,
                 'content' => $this->content,

--- a/app/Entities/CustomBlock.php
+++ b/app/Entities/CustomBlock.php
@@ -15,6 +15,7 @@ class CustomBlock extends Entity implements JsonSerializable
     {
         // Custom Block type field, which -if set- overrides the Content Type's type.
         $type = $this->entry->type();
+
         return [
             'id' => $this->entry->getId(),
             'type' => (is_string($type) || ! $type) ? $type : $type->first(),

--- a/app/Entities/Entity.php
+++ b/app/Entities/Entity.php
@@ -5,7 +5,7 @@ namespace App\Entities;
 use ArrayAccess;
 use JsonSerializable;
 use InvalidArgumentException;
-use Contentful\Delivery\Asset;
+use Contentful\Delivery\Resource\Asset;
 use Contentful\Delivery\Resource\Entry;
 
 /**

--- a/app/Entities/Entity.php
+++ b/app/Entities/Entity.php
@@ -6,7 +6,7 @@ use ArrayAccess;
 use JsonSerializable;
 use InvalidArgumentException;
 use Contentful\Delivery\Asset;
-use Contentful\Delivery\DynamicEntry;
+use Contentful\Delivery\Resource\Entry;
 
 /**
  * A convenience wrapper for Contentful's DynamicEntity.
@@ -16,16 +16,16 @@ class Entity implements ArrayAccess, JsonSerializable
     /**
      * The Contentful entry.
      *
-     * @var \Contentful\Delivery\DynamicEntry
+     * @var \Contentful\Delivery\Resource\Entry
      */
     protected $entry;
 
     /**
      * Create instance of the Campaign class.
      *
-     * @param \Contentful\Delivery\DynamicEntry $entry
+     * @param \Contentful\Delivery\Resource\Entry $entry
      */
-    public function __construct(DynamicEntry $entry)
+    public function __construct(Entry $entry)
     {
         $this->entry = $entry;
 
@@ -117,7 +117,7 @@ class Entity implements ArrayAccess, JsonSerializable
             return null;
         }
 
-        // @see: DynamicEntry's __call implementation.
+        // @see: Entry's __call implementation.
         try {
             $value = $this->entry->{'get'.ucwords($property)}();
         } catch (\Contentful\Exception\NotFoundException $error) {
@@ -133,13 +133,13 @@ class Entity implements ArrayAccess, JsonSerializable
             return $value;
         }
 
-        if ($value instanceof DynamicEntry) {
+        if ($value instanceof Entry) {
             return new self($value);
         }
 
         if (is_array($value)) {
             return collect($value)->map(function ($value) {
-                if ($value instanceof DynamicEntry) {
+                if ($value instanceof Entry) {
                     return new self($value);
                 } else {
                     return $value;
@@ -151,7 +151,7 @@ class Entity implements ArrayAccess, JsonSerializable
     }
 
     /**
-     * Get the ContentType for the DynamicEntry.
+     * Get the ContentType for the Entry.
      *
      * @return string
      */

--- a/app/Entities/Entity.php
+++ b/app/Entities/Entity.php
@@ -225,7 +225,7 @@ class Entity implements ArrayAccess, JsonSerializable
         return (object) [
             'id' => $this->entry->getId(),
             'type' => $this->entry->getContentType()->getId(),
-            'fields' => $json->fields,
+            'fields' => $json['fields'],
         ];
     }
 }

--- a/app/Entities/Entity.php
+++ b/app/Entities/Entity.php
@@ -67,11 +67,11 @@ class Entity implements ArrayAccess, JsonSerializable
             case 'contentBlock':
                 return new ContentBlock($block->entry);
             case 'customBlock':
-                if ($block->entry->getType() === 'join_cta') {
+                if ($block->entry->type() === 'join_cta') {
                     return new CallToAction($block->entry);
                 }
 
-                if ($block->entry->getType() === 'campaign_update') {
+                if ($block->entry->type() === 'campaign_update') {
                     return new CampaignUpdate($block->entry);
                 }
 

--- a/app/Entities/Entity.php
+++ b/app/Entities/Entity.php
@@ -120,7 +120,7 @@ class Entity implements ArrayAccess, JsonSerializable
         // @see: Entry's __call implementation.
         try {
             $value = $this->entry->{'get'.ucwords($property)}();
-        } catch (\Contentful\Exception\NotFoundException $error) {
+        } catch (\Contentful\Core\Exception\NotFoundException $error) {
             // If the linked resource is not published, return null.
             $value = null;
         } catch (\ErrorException $error) {

--- a/app/Entities/Entity.php
+++ b/app/Entities/Entity.php
@@ -67,11 +67,11 @@ class Entity implements ArrayAccess, JsonSerializable
             case 'contentBlock':
                 return new ContentBlock($block->entry);
             case 'customBlock':
-                if ($block->entry->type() === 'join_cta') {
+                if ($block->entry->type === 'join_cta') {
                     return new CallToAction($block->entry);
                 }
 
-                if ($block->entry->type() === 'campaign_update') {
+                if ($block->entry->type === 'campaign_update') {
                     return new CampaignUpdate($block->entry);
                 }
 

--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -3,9 +3,9 @@
 namespace App\Exceptions;
 
 use Exception;
-use Contentful\Exception\NotFoundException;
 use Illuminate\Auth\AuthenticationException;
 use Illuminate\Validation\ValidationException;
+use Contentful\Core\Exception\NotFoundException;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 use Illuminate\Foundation\Exceptions\Handler as ExceptionHandler;

--- a/app/Repositories/PageRepository.php
+++ b/app/Repositories/PageRepository.php
@@ -28,7 +28,7 @@ class PageRepository
      * Find a page by its slug.
      *
      * @param  string $slug
-     * @return \Contentful\Delivery\DynamicEntry
+     * @return \Contentful\Delivery\Resource\Entry
      * @throws \Illuminate\Database\Eloquent\ModelNotFoundException
      */
     public function findBySlug($slug)

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -1,10 +1,10 @@
 <?php
 
 use App\Entities\Campaign;
-use Contentful\Delivery\Asset;
 use App\Services\PhoenixLegacy;
 use Contentful\File\ImageOptions;
 use Illuminate\Support\HtmlString;
+use Contentful\Delivery\Resource\Asset;
 
 /**
  * Get Heroku database configuration variables from supplied

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -2,8 +2,8 @@
 
 use App\Entities\Campaign;
 use App\Services\PhoenixLegacy;
-use Contentful\File\ImageOptions;
 use Illuminate\Support\HtmlString;
+use Contentful\Core\File\ImageOptions;
 use Contentful\Delivery\Resource\Asset;
 
 /**
@@ -138,10 +138,10 @@ function get_image_url($asset, $style = null)
         return null;
     }
 
-    /** @var \Contentful\File\ImageFile $file */
+    /** @var \Contentful\Core\File\ImageFile $file */
     $file = $asset->getFile();
 
-    if (! $file instanceof \Contentful\File\ImageFile) {
+    if (! $file instanceof \Contentful\Core\File\ImageFile) {
         throw new \InvalidArgumentException('Cannot use file ' . $file->getFileName() . ' as an image.');
     }
 

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -222,7 +222,7 @@ function useOverrideIfSet($field, $base, $override)
 /**
  * Determine the fields to display in the social share.
  *
- * @param  \Contentful\Delivery\DynamicEntry|stdClass $entry
+ * @param  \Contentful\Delivery\Resource\Entry|stdClass $entry
  * @return array|null
  */
 function get_social_fields($entry)

--- a/composer.json
+++ b/composer.json
@@ -4,8 +4,8 @@
   "require": {
     "php": ">=7.0.0",
     "barryvdh/laravel-debugbar": "^2.3",
-    "contentful/contentful": "2.0.*",
-    "contentful/laravel": "2.0.*",
+    "contentful/contentful": "3.3.*",
+    "contentful/laravel": "3.0.*",
     "dfurnes/environmentalist": "^0.0.2",
     "doctrine/dbal": "^2.5",
     "dosomething/gateway": "^1.14.7",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "521d76c05912b49f4c6535ab9b325db9",
+    "content-hash": "12759f69ce3519963a01280642831bcd",
     "packages": [
         {
             "name": "barryvdh/laravel-debugbar",
@@ -54,6 +54,252 @@
                 "webprofiler"
             ],
             "time": "2017-07-21T11:56:48+00:00"
+        },
+        {
+            "name": "cache/adapter-common",
+            "version": "1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-cache/adapter-common.git",
+                "reference": "6320bb5f5574cb88438059b59f8708da6b6f1d32"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-cache/adapter-common/zipball/6320bb5f5574cb88438059b59f8708da6b6f1d32",
+                "reference": "6320bb5f5574cb88438059b59f8708da6b6f1d32",
+                "shasum": ""
+            },
+            "require": {
+                "cache/tag-interop": "^1.0",
+                "php": "^5.6 || ^7.0",
+                "psr/cache": "^1.0",
+                "psr/log": "^1.0",
+                "psr/simple-cache": "^1.0"
+            },
+            "require-dev": {
+                "cache/integration-tests": "^0.16",
+                "phpunit/phpunit": "^5.7.21"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Cache\\Adapter\\Common\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Aaron Scherer",
+                    "email": "aequasi@gmail.com",
+                    "homepage": "https://github.com/aequasi"
+                },
+                {
+                    "name": "Tobias Nyholm",
+                    "email": "tobias.nyholm@gmail.com",
+                    "homepage": "https://github.com/nyholm"
+                }
+            ],
+            "description": "Common classes for PSR-6 adapters",
+            "homepage": "http://www.php-cache.com/en/latest/",
+            "keywords": [
+                "cache",
+                "psr-6",
+                "tag"
+            ],
+            "time": "2018-07-08T13:04:33+00:00"
+        },
+        {
+            "name": "cache/hierarchical-cache",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-cache/hierarchical-cache.git",
+                "reference": "97173a5115765f72ccdc90dbc01132a3786ef5fd"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-cache/hierarchical-cache/zipball/97173a5115765f72ccdc90dbc01132a3786ef5fd",
+                "reference": "97173a5115765f72ccdc90dbc01132a3786ef5fd",
+                "shasum": ""
+            },
+            "require": {
+                "cache/adapter-common": "^1.0",
+                "php": "^5.6 || ^7.0",
+                "psr/cache": "^1.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^5.7.21"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Cache\\Hierarchy\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Aaron Scherer",
+                    "email": "aequasi@gmail.com",
+                    "homepage": "https://github.com/aequasi"
+                },
+                {
+                    "name": "Tobias Nyholm",
+                    "email": "tobias.nyholm@gmail.com",
+                    "homepage": "https://github.com/nyholm"
+                }
+            ],
+            "description": "A helper trait and interface to your PSR-6 cache to support hierarchical keys.",
+            "homepage": "http://www.php-cache.com/en/latest/",
+            "keywords": [
+                "cache",
+                "hierarchical",
+                "hierarchy",
+                "psr-6"
+            ],
+            "time": "2017-07-16T21:58:17+00:00"
+        },
+        {
+            "name": "cache/tag-interop",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-cache/tag-interop.git",
+                "reference": "c7496dd81530f538af27b4f2713cde97bc292832"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-cache/tag-interop/zipball/c7496dd81530f538af27b4f2713cde97bc292832",
+                "reference": "c7496dd81530f538af27b4f2713cde97bc292832",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.5 || ^7.0",
+                "psr/cache": "^1.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Cache\\TagInterop\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Tobias Nyholm",
+                    "email": "tobias.nyholm@gmail.com",
+                    "homepage": "https://github.com/nyholm"
+                },
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com",
+                    "homepage": "https://github.com/nicolas-grekas"
+                }
+            ],
+            "description": "Framework interoperable interfaces for tags",
+            "homepage": "http://www.php-cache.com/en/latest/",
+            "keywords": [
+                "cache",
+                "psr",
+                "psr6",
+                "tag"
+            ],
+            "time": "2017-03-13T09:14:27+00:00"
+        },
+        {
+            "name": "cache/void-adapter",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-cache/void-adapter.git",
+                "reference": "a0554f661cf9f1498a2afe72d077f3c35d797161"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-cache/void-adapter/zipball/a0554f661cf9f1498a2afe72d077f3c35d797161",
+                "reference": "a0554f661cf9f1498a2afe72d077f3c35d797161",
+                "shasum": ""
+            },
+            "require": {
+                "cache/adapter-common": "^1.0",
+                "cache/hierarchical-cache": "^1.0",
+                "php": "^5.6 || ^7.0",
+                "psr/cache": "^1.0",
+                "psr/simple-cache": "^1.0"
+            },
+            "provide": {
+                "psr/cache-implementation": "^1.0"
+            },
+            "require-dev": {
+                "cache/integration-tests": "^0.16",
+                "phpunit/phpunit": "^5.7.21"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Cache\\Adapter\\Void\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Aaron Scherer",
+                    "email": "aequasi@gmail.com",
+                    "homepage": "https://github.com/aequasi"
+                },
+                {
+                    "name": "Tobias Nyholm",
+                    "email": "tobias.nyholm@gmail.com",
+                    "homepage": "https://github.com/nyholm"
+                }
+            ],
+            "description": "A PSR-6 cache implementation using Void. This implementation supports tags",
+            "homepage": "http://www.php-cache.com/en/latest/",
+            "keywords": [
+                "cache",
+                "psr-6",
+                "tag",
+                "void"
+            ],
+            "time": "2017-07-16T21:09:25+00:00"
         },
         {
             "name": "composer/ca-bundle",
@@ -113,30 +359,33 @@
         },
         {
             "name": "contentful/contentful",
-            "version": "2.0.1",
+            "version": "3.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/contentful/contentful.php.git",
-                "reference": "1719880365edc08ca2da026dbd2e0b2174298b0a"
+                "reference": "bc6773e50b0ddf62c4dcc470dafbc6eea7feee3b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/contentful/contentful.php/zipball/1719880365edc08ca2da026dbd2e0b2174298b0a",
-                "reference": "1719880365edc08ca2da026dbd2e0b2174298b0a",
+                "url": "https://api.github.com/repos/contentful/contentful.php/zipball/bc6773e50b0ddf62c4dcc470dafbc6eea7feee3b",
+                "reference": "bc6773e50b0ddf62c4dcc470dafbc6eea7feee3b",
                 "shasum": ""
             },
             "require": {
-                "guzzlehttp/guzzle": "^6.2.1",
-                "guzzlehttp/psr7": "~1.4",
-                "php": "^5.5.9|^7.0",
-                "psr/http-message": "~1.0",
-                "symfony/console": "~2.7|~3.0",
-                "symfony/filesystem": "~2.7|~3.0"
+                "cache/void-adapter": "^1.0",
+                "contentful/core": "^1.0",
+                "php": "^5.6|^7.0",
+                "psr/cache": "^1.0",
+                "symfony/console": "~2.7|~3.0|~4.0",
+                "symfony/filesystem": "~2.7|~3.0|~4.0"
             },
             "require-dev": {
-                "jakub-onderka/php-console-highlighter": "^0.3.2",
-                "jakub-onderka/php-parallel-lint": "^0.9.2",
-                "php-vcr/phpunit-testlistener-vcr": "^2.0"
+                "cache/array-adapter": "^1.0",
+                "php-vcr/phpunit-testlistener-vcr": "^2.0",
+                "phpunit/phpunit": "^4.8|^5.7"
+            },
+            "suggest": {
+                "symfony/cache": "A PSR-6 compatible cache component"
             },
             "bin": [
                 "bin/contentful"
@@ -144,12 +393,12 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.1.0-dev"
+                    "dev-master": "3.3.0-dev"
                 }
             },
             "autoload": {
                 "psr-4": {
-                    "Contentful\\": "src/"
+                    "Contentful\\Delivery\\": "src/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -157,35 +406,88 @@
                 "MIT"
             ],
             "description": "SDK for the Contentful Content Delivery API",
-            "time": "2017-06-16T11:22:13+00:00"
+            "time": "2018-06-18T08:38:53+00:00"
         },
         {
-            "name": "contentful/laravel",
-            "version": "2.0.0",
+            "name": "contentful/core",
+            "version": "1.5.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/contentful/contentful-laravel.git",
-                "reference": "bd9873ab609f1bb505fa2b027064bbf3a6d66fe1"
+                "url": "https://github.com/contentful/contentful-core.php.git",
+                "reference": "a55b24250000222e45f018a860b39f815d4754cd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/contentful/contentful-laravel/zipball/bd9873ab609f1bb505fa2b027064bbf3a6d66fe1",
-                "reference": "bd9873ab609f1bb505fa2b027064bbf3a6d66fe1",
+                "url": "https://api.github.com/repos/contentful/contentful-core.php/zipball/a55b24250000222e45f018a860b39f815d4754cd",
+                "reference": "a55b24250000222e45f018a860b39f815d4754cd",
                 "shasum": ""
             },
             "require": {
-                "contentful/contentful": "^2.0.0",
-                "illuminate/support": "~5.0",
-                "php": ">=5.5.9"
+                "ext-json": "*",
+                "guzzlehttp/guzzle": "^6.3",
+                "guzzlehttp/psr7": "^1.4",
+                "php": "^5.6|^7.0",
+                "psr/http-message": "^1.0",
+                "psr/log": "^1.0"
             },
             "require-dev": {
-                "jakub-onderka/php-console-highlighter": "^0.3.2",
-                "jakub-onderka/php-parallel-lint": "^0.9.2"
+                "monolog/monolog": "^1.23",
+                "phpunit/phpunit": "^5.7",
+                "symfony/finder": "^3.0|^4.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.1.0-dev"
+                    "dev-master": "1.5.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Contentful\\Core\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Foundation library for Contentful PHP SDKs",
+            "time": "2018-08-30T16:31:39+00:00"
+        },
+        {
+            "name": "contentful/laravel",
+            "version": "3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/contentful/contentful-laravel.git",
+                "reference": "c352d4cf48e6e13877d8863f194075486fee422b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/contentful/contentful-laravel/zipball/c352d4cf48e6e13877d8863f194075486fee422b",
+                "reference": "c352d4cf48e6e13877d8863f194075486fee422b",
+                "shasum": ""
+            },
+            "require": {
+                "contentful/contentful": "^3.0.0",
+                "laravel/framework": "~5.4",
+                "php": "^7.0"
+            },
+            "require-dev": {
+                "orchestra/testbench": "^3.5",
+                "phpunit/phpunit": "^6.0|^7.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0.0-dev"
+                },
+                "laravel": {
+                    "providers": [
+                        "Contentful\\Laravel\\ContentfulServiceProvider"
+                    ],
+                    "aliases": {
+                        "ContentfulDelivery": "Contentful\\Laravel\\Facades\\ContentfulDelivery"
+                    }
                 }
             },
             "autoload": {
@@ -198,7 +500,7 @@
                 "MIT"
             ],
             "description": "Integrates the Contentful PHP SDK with Laravel.",
-            "time": "2017-06-13T15:08:27+00:00"
+            "time": "2018-06-25T10:33:39+00:00"
         },
         {
             "name": "dfurnes/environmentalist",
@@ -2332,6 +2634,52 @@
             "time": "2016-06-16T16:22:20+00:00"
         },
         {
+            "name": "psr/cache",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/cache.git",
+                "reference": "d11b50ad223250cf17b86e38383413f5a6764bf8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/cache/zipball/d11b50ad223250cf17b86e38383413f5a6764bf8",
+                "reference": "d11b50ad223250cf17b86e38383413f5a6764bf8",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Cache\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for caching libraries",
+            "keywords": [
+                "cache",
+                "psr",
+                "psr-6"
+            ],
+            "time": "2016-08-06T20:24:11+00:00"
+        },
+        {
             "name": "psr/container",
             "version": "1.0.0",
             "source": {
@@ -3490,34 +3838,35 @@
         },
         {
             "name": "symfony/psr-http-message-bridge",
-            "version": "v1.0.2",
+            "version": "v1.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/psr-http-message-bridge.git",
-                "reference": "c2b757934f2d9681a287e662efbc27c41fe8ef86"
+                "reference": "53c15a6a7918e6c2ab16ae370ea607fb40cab196"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/psr-http-message-bridge/zipball/c2b757934f2d9681a287e662efbc27c41fe8ef86",
-                "reference": "c2b757934f2d9681a287e662efbc27c41fe8ef86",
+                "url": "https://api.github.com/repos/symfony/psr-http-message-bridge/zipball/53c15a6a7918e6c2ab16ae370ea607fb40cab196",
+                "reference": "53c15a6a7918e6c2ab16ae370ea607fb40cab196",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3",
-                "psr/http-message": "~1.0",
-                "symfony/http-foundation": "~2.3|~3.0|~4.0"
+                "php": "^5.3.3 || ^7.0",
+                "psr/http-message": "^1.0",
+                "symfony/http-foundation": "^2.3.42 || ^3.4 || ^4.0"
             },
             "require-dev": {
-                "symfony/phpunit-bridge": "~3.2|4.0"
+                "symfony/phpunit-bridge": "^3.4 || 4.0"
             },
             "suggest": {
+                "psr/http-factory-implementation": "To use the PSR-17 factory",
                 "psr/http-message-implementation": "To use the HttpFoundation factory",
                 "zendframework/zend-diactoros": "To use the Zend Diactoros factory"
             },
             "type": "symfony-bridge",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0-dev"
+                    "dev-master": "1.1-dev"
                 }
             },
             "autoload": {
@@ -3546,7 +3895,7 @@
                 "http-message",
                 "psr-7"
             ],
-            "time": "2017-12-19T00:31:44+00:00"
+            "time": "2018-08-30T16:28:28+00:00"
         },
         {
             "name": "symfony/routing",

--- a/config/contentful.php
+++ b/config/contentful.php
@@ -16,6 +16,11 @@ return [
     'delivery.token' => env('CONTENTFUL_CONTENT_API_KEY'),
 
     /*
+     * Controls which Contentful Environment is accessed (defaults to 'master')
+     */
+    'delivery.environment' => env('CONTENTFUL_ENVIRONMENT_ID', 'master'),
+
+    /*
      * Controls whether Contentful's Delivery or Preview API is accessed
      */
     'delivery.preview' => env('CONTENTFUL_USE_PREVIEW_API', false),


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR updates our Contentful SDK from 2.0 -> 3.0 (well 3.3 to be precise but who's counting) and updates code for breaking package changes.

- 📦[5d4f0e8](https://github.com/DoSomething/phoenix-next/commit/5d4f0e824df6b5095b7e93bc5ffc4bb8259bffab) is the package update itself -- easy! (It was also necessary to update the contentful/laravel package.)
- 💰There were multiple [namespace changes](https://github.com/contentful/contentful.php/blob/master/UPGRADE-3.0.md#change-of-namespace-of-some-classes):
  - [181a0a2](https://github.com/DoSomething/phoenix-next/commit/181a0a29e336613d2ccb2d6f233dbada728d7eab) changes all `Contentful\Delivery\DynamicEntry` to `Contentful\Delivery\Resource\Entry` 
  - [4628e33](https://github.com/DoSomething/phoenix-next/commit/4628e33dd2b7ee9046e2676858d589d269a5c087) `Contentful\Delivery\Asset` to `Contentful\Delivery\Resource\Asset`
  - [765c61e](https://github.com/DoSomething/phoenix-next/commit/765c61e006e874dc4b34ea2fb935a2e28d56d183) `Contentful\Exception\NotFoundException` to `Contentful\Core\Exception\NotFoundException` 
  - [e65b49f](https://github.com/DoSomething/phoenix-next/commit/e65b49fd1369949c038599eb15c20542328dd676) `Contentful\File\ImageOptions` to `Contentful\Core\File\ImageOptions`
- ♻️[4345a13](https://github.com/DoSomething/phoenix-next/commit/4345a1396eaa58ceac69959bf438f6da0ac9f337) Adds the `environmentId` key for the [Contentful Client constructor changes](https://github.com/contentful/contentful.php/blob/master/UPGRADE-3.0.md#change-of-signature-of-client-constructor) 🎊 
- ⌨️[7ce6fab](https://github.com/DoSomething/phoenix-next/commit/7ce6fab5b3bdbd0df03d68a280fc9c29aae363ed) This is an interesting one: The new `Entry` class (taking over the old `DynamicEntry` class) returns it's `"Entry"` type when you call `Entity->entry->getType()`. Bad news for Custom Blocks where we need to access the entries `type` field. Good news is we can use the field name as a [magic function](https://github.com/contentful/contentful.php/blob/master/CHANGELOG.md#changed) itself to access the actual entry fields for `type`. (Something perhaps to look into. But this works just fine for now.)
  - [e51c7ea](https://github.com/DoSomething/phoenix-next/commit/e51c7ea750501b3513ff7d3329ebff640f8ffd49) similiar issue for Custom Block `type` field.
  - [d3d4b4c](https://github.com/DoSomething/phoenix-next/commit/d3d4b4c5b05fda8fb34e1cd96cf7fd7cfe50c8ef) wherein I realize - why call a magic method when you can just access the field directly?
- 🏰[b4bc207](https://github.com/DoSomething/phoenix-next/commit/b4bc207d5d269ba9075feb44ffb43a0985428372) The new `Entry` also [stopped](https://github.com/contentful/contentful.php/commit/5674c135b9bc2900f7700d8c177c337fa19cd911#diff-94a17d898d5f92215a4f65b1c7b36ab3R310) casting the return value of its `jsonSerialize` method as an `object`. So we needed to change the way we access the `fields` field. (This one was a doozy to trace down.)

### Any background context you want to provide?
~One thing to note. As of right now. I haven't been able to get any Environment to work beside for `master` which works just fine. Still investigating.~
Figured out the above issue. We just needed to whitelist the `dev` environment (or whichever environment) in the Access Tokens [permissions](https://app.contentful.com/spaces/81iqaqpfd8fy/api/keys/23e544OyTTkrf0fQ5rfYnc). So setting a `CONTENTFUL_ENVIRONMENT_ID=` in `.env` to e.g. `dev` works wonderfully!

There are a couple of new changes in `3.4.0` but the `contentful/laravel` package doesn't seem ready for the update yet.

There were some notable changes from where we were at in 1.0 prior to #1085 I tried to take note of some of the notable ones in this [gist](https://gist.github.com/mendelB/c4d3ac9d39117279a5c1fd89bdc7cd49)

[Here's](https://github.com/contentful/contentful.php/blob/master/CHANGELOG.md) the full ChangeLog and [here's](https://github.com/contentful/contentful.php/blob/master/UPGRADE-3.0.md#change-of-signature-of-client-constructor) the 2.x -> 3.x upgrade guide
### What are the relevant tickets/cards?

Refs [Pivotal ID #158440484](https://www.pivotaltracker.com/story/show/158440484)