### PR TITLE
Add management API scripts to derive Persons from Staff entries

### DIFF
--- a/contentful/content-types/person.js
+++ b/contentful/content-types/person.js
@@ -18,7 +18,13 @@ module.exports = function(migration) {
     .type('Symbol')
     .validations([
       {
-        in: ['staff', 'intern', 'board member', 'advisory board member'],
+        in: [
+          'staff',
+          'intern',
+          'board member',
+          'advisory board member',
+          'member',
+        ],
       },
     ])
     .required(true)

--- a/contentful/management-api-scripts/2018_09_07_001_derive_person_from_staff.js
+++ b/contentful/management-api-scripts/2018_09_07_001_derive_person_from_staff.js
@@ -34,7 +34,7 @@ async function derivePersonFromStaff(environment, staff) {
   );
 
   if (person) {
-    console.log(`-   Created  Person! [ID: ${person.sys.id}]\n`);
+    logger.info(`-   Created  Person! [ID: ${person.sys.id}]\n`);
   }
 
   logger.info(`Processed Staff! [ID: ${staff.sys.id}]\n`);

--- a/contentful/management-api-scripts/2018_09_07_001_derive_person_from_staff.js
+++ b/contentful/management-api-scripts/2018_09_07_001_derive_person_from_staff.js
@@ -1,0 +1,49 @@
+const { contentManagementClient } = require('./contentManagementClient');
+const {
+  attempt,
+  createLogger,
+  getField,
+  processEntries,
+  sleep,
+  withFields,
+} = require('./helpers');
+
+const logger = createLogger('derive_person_from_staff');
+
+async function derivePersonFromStaff(environment, staff) {
+  const staffInternalTitle = getField(staff, 'internalTitle');
+  const staffName = getField(staff, 'name');
+  const staffJobTitle = getField(staff, 'jobTitle');
+  const staffAvatar = getField(staff, 'avatar');
+  const staffEmail = getField(staff, 'email');
+
+  logger.info(`Processing Staff! [ID: ${staff.sys.id}]\n`);
+
+  const person = await attempt(() =>
+    environment.createEntry(
+      'person',
+      withFields({
+        name: staffName,
+        jobTitle: staffJobTitle,
+        photo: staffAvatar,
+        email: staffEmail,
+        // Persist Internal Title info, in case it contains anything of note.
+        description: staffInternalTitle,
+      }),
+    ),
+  );
+
+  if (person) {
+    console.log(`-   Created  Person! [ID: ${person.sys.id}]\n`);
+  }
+
+  logger.info(`Processed Staff! [ID: ${staff.sys.id}]\n`);
+  logger.info('--------------------------------------------\n');
+
+  // API breather room
+  sleep(1000);
+}
+
+contentManagementClient.init((environment, args) =>
+  processEntries(environment, args, 'staff', derivePersonFromStaff),
+);

--- a/contentful/management-api-scripts/2018_09_07_002_replace_staff_linked_entries_with_person.js
+++ b/contentful/management-api-scripts/2018_09_07_002_replace_staff_linked_entries_with_person.js
@@ -20,21 +20,11 @@ async function replaceStaffLinkedEntriesWithPerson(environment, staff) {
 
   logger.info(`Processing Staff! [ID: ${staff.sys.id}] [Name: ${staffName}]\n`);
 
-  let people;
-
-  if (staffName === 'Margot') {
-    // Special case to account for two Staff entries for Margot.
-    people = await environment.getEntries({
-      content_type: 'person',
-      'fields.name[match]': 'Margot Harris',
-    });
-  } else {
-    // Find the Person entries of the same name.
-    people = await environment.getEntries({
-      content_type: 'person',
-      'fields.name[match]': staffName,
-    });
-  }
+  // Find the Person entries of the same name.
+  const people = await environment.getEntries({
+    content_type: 'person',
+    'fields.name[match]': staffName,
+  });
 
   // Hard return if there is no Person equivalent.
   if (!people.items.length) {

--- a/contentful/management-api-scripts/2018_09_07_002_replace_staff_linked_entries_with_person.js
+++ b/contentful/management-api-scripts/2018_09_07_002_replace_staff_linked_entries_with_person.js
@@ -1,0 +1,138 @@
+const { get } = require('lodash');
+const { contentManagementClient } = require('./contentManagementClient');
+const {
+  attempt,
+  createLogger,
+  getField,
+  processEntries,
+  sleep,
+  withFields,
+  linkReference,
+  constants,
+} = require('./helpers');
+
+const { LOCALE } = constants;
+
+const logger = createLogger('replace_staff_linked_entries_with_person');
+
+async function replaceStaffLinkedEntriesWithPerson(environment, staff) {
+  const staffName = getField(staff, 'name');
+
+  logger.info(`Processing Staff! [ID: ${staff.sys.id}] [Name: ${staffName}]\n`);
+
+  let people;
+
+  if (staffName === 'Margot') {
+    // Special case to account for two Staff entries for Margot.
+    people = await environment.getEntries({
+      content_type: 'person',
+      'fields.name[match]': 'Margot Harris',
+    });
+  } else {
+    // Find the Person entries of the same name.
+    people = await environment.getEntries({
+      content_type: 'person',
+      'fields.name[match]': staffName,
+    });
+  }
+
+  // Hard return if there is no Person equivalent.
+  if (!people.items.length) {
+    return;
+  }
+
+  // Our Staff names are unique, so there shouldn't be more then one match.
+  const person = people.items[0];
+
+  // Generate Link Reference to the Person.
+  const personLink = linkReference(person.sys.id);
+
+  // Find all Entries which link to the Staff entry.
+  const linkedEntries = await environment.getEntries({
+    links_to_entry: staff.sys.id,
+  });
+
+  logger.info(
+    `Processing links to ${staffName}. There are ${
+      linkedEntries.items.length
+    } links.`,
+  );
+
+  for (let i = 0; i < linkedEntries.items.length; i++) {
+    const linkedEntry = linkedEntries.items[i];
+
+    logger.info(
+      `Processing Link ${i + 1} OF ${linkedEntries.items.length} [ID: ${
+        linkedEntry.sys.id
+      }]\n`,
+    );
+
+    const linkedEntryType = get(linkedEntry, 'sys.contentType.sys.id');
+
+    // Default 'Staff' field should be 'author'. Special cases are Campaigns and Affirmations.
+    let authorField = 'author';
+    switch (linkedEntryType) {
+      case 'campaign':
+        authorField = 'campaignLead';
+        break;
+      case 'affirmation':
+        authorField = 'newAuthor';
+        break;
+    }
+
+    // Determine if the linked entry was already published to prevent publishing a draft entry.
+    const wasLinkedEntryPublished = await linkedEntry.isPublished();
+
+    // If the linked entry is archived, we can't update it.
+    const isLinkedEntryArchived = await linkedEntry.isArchived();
+    if (isLinkedEntryArchived) {
+      logger.info(`-- Skipping Archived Link! [ID: ${linkedEntry.sys.id}]\n`);
+    }
+
+    // Replace the link to Staff entry with a link to the Person.
+    linkedEntry.fields[authorField][LOCALE] = personLink;
+
+    // Attempt to update the entry.
+    const updatedLinkedEntry = await attempt(() => linkedEntry.update());
+
+    if (updatedLinkedEntry) {
+      logger.info(`-- Updated Link! [ID: ${linkedEntry.sys.id}]\n`);
+    }
+
+    if (updatedLinkedEntry && wasLinkedEntryPublished) {
+      // Attempt to publish the entry.
+      const publishedLinkedEntry = await attempt(() =>
+        updatedLinkedEntry.publish(),
+      );
+
+      if (publishedLinkedEntry) {
+        logger.info(`-- Published Link! [ID: ${linkedEntry.sys.id}]\n`);
+      }
+    }
+  }
+
+  // Determine if there's a mismatch in linked entries for the original Staff and the person.
+  // If there is, we'll log it so we can manually debug.
+  const personLinkedEntries = await environment.getEntries({
+    links_to_entry: person.sys.id,
+  });
+  if (personLinkedEntries.items.length !== linkedEntries.items.length) {
+    logger.error(
+      `There are less entries linking to the Person then to the Staff!! [Person ID: ${
+        person.sys.id
+      }] [Staff ID: ${staff.sys.id}]`,
+    );
+  }
+
+  logger.info(`Processed Staff! [ID: ${staff.sys.id}] [Name: ${staffName}]\n`);
+  logger.info('--------------------------------------------\n');
+}
+
+contentManagementClient.init((environment, args) =>
+  processEntries(
+    environment,
+    args,
+    'staff',
+    replaceStaffLinkedEntriesWithPerson,
+  ),
+);

--- a/contentful/management-api-scripts/2018_09_07_002_replace_staff_linked_entries_with_person.js
+++ b/contentful/management-api-scripts/2018_09_07_002_replace_staff_linked_entries_with_person.js
@@ -80,14 +80,15 @@ async function replaceStaffLinkedEntriesWithPerson(environment, staff) {
         break;
     }
 
-    // Determine if the linked entry was already published to prevent publishing a draft entry.
-    const wasLinkedEntryPublished = await linkedEntry.isPublished();
-
     // If the linked entry is archived, we can't update it.
     const isLinkedEntryArchived = await linkedEntry.isArchived();
     if (isLinkedEntryArchived) {
       logger.info(`-- Skipping Archived Link! [ID: ${linkedEntry.sys.id}]\n`);
+      continue;
     }
+
+    // Determine if the linked entry was already published to prevent publishing a draft entry.
+    const wasLinkedEntryPublished = await linkedEntry.isPublished();
 
     // Replace the link to Staff entry with a link to the Person.
     linkedEntry.fields[authorField][LOCALE] = personLink;

--- a/contentful/management-api-scripts/contentManagementClient.js
+++ b/contentful/management-api-scripts/contentManagementClient.js
@@ -6,10 +6,14 @@ const LOCALE = 'en-US';
 
 async function initContentManagementClient(callback) {
   const args = parseArgs(process.argv, {
-    alias: { accessToken: 'access-token', spaceId: 'space-id' },
+    alias: {
+      accessToken: 'access-token',
+      spaceId: 'space-id',
+      environmentId: 'environment-id',
+    },
   });
 
-  const { spaceId, accessToken } = args;
+  const { spaceId, accessToken, environmentId } = args;
 
   if (!spaceId || !accessToken) {
     console.log(
@@ -18,11 +22,11 @@ async function initContentManagementClient(callback) {
     console.log('--space-id [space-id] --access-token [access-token]');
     return;
   }
-  const environment = await getEnvironment(spaceId, accessToken);
+  const environment = await getEnvironment(spaceId, accessToken, environmentId);
   callback(environment, args);
 }
 
-async function getEnvironment(spaceId, accessToken) {
+async function getEnvironment(spaceId, accessToken, environmentId = 'dev') {
   const client = contentful.createClient({
     // This is the access token for this space. Normally you get both ID and the token in the Contentful web app
     accessToken: accessToken,
@@ -33,7 +37,7 @@ async function getEnvironment(spaceId, accessToken) {
 
   // This API call will request the environment with the specified - as of now hardcoded - id
   // (Contentful requires this scoping, as the `space.getEntries` is being deprecated)
-  return space.getEnvironment('master');
+  return space.getEnvironment(environmentId);
 }
 
 module.exports = {


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR adds a contentful-migration-api script that simply creates new `Person` entries for each of our existing legacy `Staff` entries. **This was successfully run on Master**

It also adds a script to replace any link to the legacy Staff, with a link to its equivalent Person entry. **This was not run yet. This is actually consequential, so pending approval** (Ran it on a `test` environment and it executed successfully.)

Also:
- updates the client to accept an `environment-id` argument to specify environment (and defaults to `dev` for safety)
- Adds `member` option to list of validations for `Person.type` (we have a few `Staff` entries that seem to be members (wasn't sure whether to characterize as MC or VIP or Partner, so just went with `member` for now))

### Any background context you want to provide?
Figured we can split the Staff -> Person migration into a few parts:
1. simply script to create Person copies of existing Staff **DONE**
2. update the Person entries to add the additional new fields. (`type`, `active`) **DONE using Contentful UI** (PR updates migration file accordingly. (If we don't like the `member` choice we can totally change to wtvr.))
3. find all entries linking to staff entries and swap those for the person entry of the same name. **Pending Approval**

### What are the relevant tickets/cards?

Refs [Pivotal ID #159740120](https://www.pivotaltracker.com/story/show/159740120)