### PR TITLE
Add parsing for Person $author type

### DIFF
--- a/app/Entities/Affirmation.php
+++ b/app/Entities/Affirmation.php
@@ -27,7 +27,7 @@ class Affirmation extends Entity implements JsonSerializable
                 ],
             ];
         } else {
-            $author = new Staff($authorValue->entry);
+            $author = $authorValue->getContentType() === 'staff' ? new Staff($authorValue->entry) : new Person($authorValue->entry);
         }
 
         return [


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR accounts for `Person` `$author` types in the `Affirmation` Entity

### Any background context you want to provide?
As part of our migration from `Staff` to `Person`, this accounts for one remaining `author` field (or in this case `newAuthor`), to ensure we can parse out the `Person` entity if it is the linked reference.

### What are the relevant tickets/cards?

Refs [Pivotal ID #159740120](https://www.pivotaltracker.com/story/show/159740120)