### PR TITLE
Adding Default Result Block field for Quiz

### DIFF
--- a/app/Entities/Quiz.php
+++ b/app/Entities/Quiz.php
@@ -70,6 +70,7 @@ class Quiz extends Entity implements JsonSerializable
                 'results' => $this->parseResults($this->results),
                 'questions' => $this->parseQuestions($this->questions),
                 'resultBlocks' => $this->parseBlocks($this->resultBlocks),
+                'defaultResultBlock' => $this->parseBlock($this->defaultResultBlock),
                 'hideQuestionNumber' => $this->hideQuestionNumber,
                 'additionalContent' => $this->additionalContent,
             ],

--- a/contentful/migrations/2018_09_13_001_add_default_result_block_field_to_quiz.js
+++ b/contentful/migrations/2018_09_13_001_add_default_result_block_field_to_quiz.js
@@ -1,0 +1,13 @@
+module.exports = function(migration) {
+  const quiz = migration.editContentType('quiz');
+
+  quiz
+    .createField('defaultResultBlock')
+    .name('Default Result Block')
+    .type('Link')
+    .linkType('Entry')
+    .validations([{ linkContentType: ['shareAction', 'linkAction', 'quiz'] }])
+    .required(false);
+
+  quiz.moveField('defaultResultBlock').afterField('resultBlocks');
+};

--- a/docs/content-publishing/quiz.md
+++ b/docs/content-publishing/quiz.md
@@ -182,6 +182,7 @@ The Quiz consists of the following fields:
 - **results** _\(required\)_: the list of results for the quiz.
   - **content** _\(required\)_: The content field for the results
 - **resultBlocks** _\(optional\)_: the entries within which the results will be returned.
+- **defaultResultBlock** _\(optional\)_: the default entry to be rendered if none of the `results` or `resultBlocks` are determined as the winning result based on the user selections.
 - **questions** _\(required\)_: the questions for the quiz.
   - **title** _\(required\)_: the question title.
   - **choices** _\(required\)_: the available choices for the question.

--- a/resources/assets/components/Quiz/Quiz.js
+++ b/resources/assets/components/Quiz/Quiz.js
@@ -235,7 +235,7 @@ Quiz.propTypes = {
     isNestedQuiz: PropTypes.bool,
   }).isRequired,
   clickedSignUp: PropTypes.func.isRequired,
-  defaultResultBlock: PropTypes.object,
+  defaultResultBlock: PropTypes.object, // eslint-disable-line react/forbid-prop-types
   history: ReactRouterPropTypes.history.isRequired,
   isAuthenticated: PropTypes.bool.isRequired,
   legacyCampaignId: PropTypes.string.isRequired,

--- a/resources/assets/components/Quiz/Quiz.js
+++ b/resources/assets/components/Quiz/Quiz.js
@@ -178,15 +178,23 @@ class Quiz extends React.Component {
   };
 
   renderResult = () => {
+    const { defaultResultBlock } = this.props;
     const { result, resultBlock } = this.state.results;
 
+    const defaultResult = defaultResultBlock ? (
+      <ContentfulEntry json={defaultResultBlock} />
+    ) : null;
+
     if (!resultBlock) {
-      // Return the result on it's own when no result block is found.
+      // Return the result on it's own when no result block is found,
+      // or the 'default result block' if no result is determined.
       return result ? (
         <QuizConclusion callToAction={result.content}>
           <Share className="quiz__share" parentSource="quiz" />
         </QuizConclusion>
-      ) : null;
+      ) : (
+        defaultResult
+      );
     }
 
     if (result) {
@@ -227,6 +235,7 @@ Quiz.propTypes = {
     isNestedQuiz: PropTypes.bool,
   }).isRequired,
   clickedSignUp: PropTypes.func.isRequired,
+  defaultResultBlock: PropTypes.object,
   history: ReactRouterPropTypes.history.isRequired,
   isAuthenticated: PropTypes.bool.isRequired,
   legacyCampaignId: PropTypes.string.isRequired,
@@ -257,6 +266,7 @@ Quiz.defaultProps = {
     isNestedQuiz: false,
   },
   resultBlocks: null,
+  defaultResultBlock: null,
   hideQuestionNumber: false,
   submitButtonText: 'Get Results',
   title: null,


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR adds a new `defaultResultBlock` field to the Quiz, and renders the block when no `results` or `resultBlocks` are determined as 'winners'.

- adds a Contentful migration script to add the `defaultResultBlock` single reference field
- adds the `defaultResultBlock` field to the Quiz Entity on Phoenix
- adds `defaultResultBlock` as a Quiz `prop` and adds its rendering logic to the component

### Any background context you want to provide?
There is a potential Quiz scenario where none of the results of Result Blocks are determined as winners to be rendered based on the users selections. This will allow setting some default Result Block to be rendered out instead.

### What are the relevant tickets/cards?

Refs [Pivotal ID #160464497](https://www.pivotaltracker.com/story/show/160464497)

### Checklist

* [x] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.
* [ ] Added screenshot to PR description of related front-end updates on **small** screens.
* [ ] Added screenshot to PR description of related front-end updates on **medium** screens.
* [ ] Added screenshot to PR description of related front-end updates on **large** screens.

![image](https://user-images.githubusercontent.com/12417657/45503239-46565900-b754-11e8-962f-aee4f5b33d3c.png)
