### PR TITLE
Updates for campaign endDate formatting

### DIFF
--- a/resources/assets/actions/signup.js
+++ b/resources/assets/actions/signup.js
@@ -1,5 +1,4 @@
 import { join } from 'path';
-import { get } from 'lodash';
 import { push } from 'react-router-redux';
 import { Phoenix } from '@dosomething/gateway';
 
@@ -191,8 +190,7 @@ export function clickedSignUp(
           // If Drupal denied our signup request, check if we already had a signup.
           dispatch(checkForSignup(campaignId));
         } else {
-          const endDate = get(state.campaign.endDate, 'date', null);
-          const isClosed = isCampaignClosed(endDate);
+          const isClosed = isCampaignClosed(state.campaign.endDate);
 
           // Create signup and track any data before redirects.
           dispatch(

--- a/resources/assets/components/Campaign/CampaignRoute/CampaignRouteContainer.js
+++ b/resources/assets/components/Campaign/CampaignRoute/CampaignRouteContainer.js
@@ -17,9 +17,7 @@ const mapStateToProps = state => ({
       page => page.type === 'page' && page.fields.slug.endsWith('community'),
     ),
   ),
-  isCampaignClosed: isCampaignClosed(
-    get(state.campaign.endDate, 'date', false),
-  ),
+  isCampaignClosed: isCampaignClosed(state.campaign.endDate),
   legacyCampaignId: state.campaign.legacyCampaignId,
   shouldShowSignupAffirmation: state.signups.shouldShowAffirmation,
 });

--- a/resources/assets/components/CampaignPageNavigation/CampaignPageNavigationContainer.js
+++ b/resources/assets/components/CampaignPageNavigation/CampaignPageNavigationContainer.js
@@ -1,4 +1,3 @@
-import { get } from 'lodash';
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router-dom';
 
@@ -8,7 +7,7 @@ import CampaignPageNavigation from './CampaignPageNavigation';
 
 const mapStateToProps = state => ({
   isAffiliated: isSignedUp(state),
-  isCampaignClosed: isCampaignClosed(get(state.campaign.endDate, 'date', null)),
+  isCampaignClosed: isCampaignClosed(state.campaign.endDate),
   isLegacyTemplate: Boolean(state.campaign.template === 'legacy'),
   pages: state.campaign.pages,
   campaignSlug: state.campaign.slug,

--- a/resources/assets/components/pages/CampaignPage/CampaignPageContainer.js
+++ b/resources/assets/components/pages/CampaignPage/CampaignPageContainer.js
@@ -18,7 +18,7 @@ const mapStateToProps = (state, ownProps) => {
   }
 
   return {
-    campaignEndDate: get(state.campaign.endDate, 'date', null),
+    campaignEndDate: state.campaign.endDate,
     dashboard: state.campaign.dashboard,
     entryContent,
     landingPage: get(state.campaign, 'landingPage', null),

--- a/resources/assets/helpers/index.js
+++ b/resources/assets/helpers/index.js
@@ -400,8 +400,7 @@ export function shouldShowLandingPage(state, ignoreLandingPage) {
     shouldShow = true;
   } else if (hasLandingPage && !shouldIgnoreLandingPage) {
     shouldShow =
-      !isSignedUp(state) &&
-      !isCampaignClosed(get(state.campaign.endDate, 'date', null));
+      !isSignedUp(state) && !isCampaignClosed(state.campaign.endDate);
   }
 
   return shouldShow;


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR updates the way we fetch the `campaign.endDate` field to reflect some format changes

### Any background context you want to provide?
The `campaign.endDate` property used to be returned as an object, so we'd nest into the `date` field to fetch the actual date string.

Now, presumably due to some Contentful SDK JSON parsing changes (#1090) - the field is returned as a plain string.

![cats](https://pics.me.me/my-main-area-of-expertise-is-of-course-string-theory-24543641.png)

### What are the relevant tickets/cards?
https://dosomething.slack.com/archives/C3ASB4204/p1537195383000100
