### PR TITLE
Un-bold Markdown Paragraph Links

### DIFF
--- a/resources/assets/components/utilities/Markdown/markdown.scss
+++ b/resources/assets/components/utilities/Markdown/markdown.scss
@@ -69,6 +69,10 @@
     font-weight: 700;
   }
 
+  p a {
+    font-weight: $weight-normal;
+  }
+
   h2,
   h3 {
     font-family: $primary-font-family;


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR ensures `<a>` tags in paragraphs have a 'normal' `font-weight`

### Any background context you want to provide?
I assumed the `markdown.scss` file was the correct place for this rule. I left in the old rule declaring plain `<a>` as bolded, since this card specified 'links in paragraph elements'.

### What are the relevant tickets/cards?

Refs [Pivotal ID #159745386](https://www.pivotaltracker.com/story/show/159745386)

**BEFORE**
![image](https://user-images.githubusercontent.com/12417657/45641172-b7fb1380-ba82-11e8-9303-6b0557aacf1f.png)

**AFTER**
![image](https://user-images.githubusercontent.com/12417657/45641197-d234f180-ba82-11e8-9168-18278fb0fcf9.png)

