### PR TITLE
Update Markdown headers styling

### DIFF
--- a/resources/assets/components/blocks/ContentBlock/content-block.scss
+++ b/resources/assets/components/blocks/ContentBlock/content-block.scss
@@ -3,12 +3,4 @@
 .content-block {
   width: 100%;
   margin-bottom: 36px;
-
-  h1,
-  h2,
-  h3,
-  p {
-    color: $black;
-    font-family: $primary-font-family;
-  }
 }

--- a/resources/assets/components/utilities/Markdown/markdown.scss
+++ b/resources/assets/components/utilities/Markdown/markdown.scss
@@ -1,9 +1,6 @@
 @import '../../../scss/next-toolbox.scss';
 
 .markdown {
-  h1,
-  h2,
-  h3,
   p {
     color: inherit;
   }

--- a/resources/assets/components/utilities/Markdown/markdown.scss
+++ b/resources/assets/components/utilities/Markdown/markdown.scss
@@ -75,7 +75,7 @@
     font-size: 41px;
     font-weight: $weight-normal;
     text-transform: uppercase;
-    color: #000000;
+    color: $black;
   }
 
   h2,

--- a/resources/assets/components/utilities/Markdown/markdown.scss
+++ b/resources/assets/components/utilities/Markdown/markdown.scss
@@ -70,17 +70,32 @@
     font-weight: $weight-normal;
   }
 
+  h1 {
+    font-family: $secondary-font-family;
+    font-size: 41px;
+    font-weight: $weight-normal;
+    text-transform: uppercase;
+    color: #000000;
+  }
+
   h2,
-  h3 {
+  h3,
+  h4 {
     font-family: $primary-font-family;
+    font-weight: $weight-bold;
+    color: $black;
   }
 
   h2 {
-    font-size: 28px;
+    font-size: 41px;
   }
 
   h3 {
-    font-size: 22px;
+    font-size: 27px;
+  }
+
+  h4 {
+    font-size: 18px;
   }
 
   table {


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR updates the styling of our Markdown header tags.

### Any background context you want to provide?
I also removed some ruling from the Content Block styling that wasn't being used (since we use a `SectionHeader` component to take care of the title) but was affecting the Markdown headers.

**MOCKS**
![md classes](https://user-images.githubusercontent.com/12417657/45648307-34e3b880-ba96-11e8-9c54-bb62b9087234.png)


**BEFORE**
![image](https://user-images.githubusercontent.com/12417657/45648338-4a58e280-ba96-11e8-9621-715999402f3d.png)



**AFTER**
![image](https://user-images.githubusercontent.com/12417657/45648249-f64dfe00-ba95-11e8-9183-695ad6c83af3.png)


### What are the relevant tickets/cards?

Refs [Pivotal ID #159745211](https://www.pivotaltracker.com/story/show/159745211)
