### PR TITLE
Migration to add authors to page content type.

### DIFF
--- a/contentful/migrations/2018_09_19_001_add_authors_field_to_page_content_type.js
+++ b/contentful/migrations/2018_09_19_001_add_authors_field_to_page_content_type.js
@@ -1,0 +1,20 @@
+module.exports = function(migration) {
+  const page = migration.editContentType('page');
+
+  page
+    .createField('authors')
+    .name('Authors')
+    .type('Array')
+    .items({
+      type: 'Link',
+      linkType: 'Entry',
+      validations: [
+        {
+          linkContentType: ['person'],
+        },
+      ],
+    })
+    .required(false);
+
+  page.moveField('authors').afterField('slug');
+};


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR updates the `page` content type to add a new `authors` field to allow editors to specify the author(s) for a page.

![image](https://user-images.githubusercontent.com/105849/45773109-7354b100-bc17-11e8-8b16-56e1b56f60d4.png)

### What are the relevant tickets/cards?

Refs [Pivotal ID #159745156](https://www.pivotaltracker.com/story/show/159745156)
