### PR TITLE
Social Share Tray in Content Pages (and updates)

### DIFF
--- a/resources/assets/components/pages/GeneralPage/GeneralPage.js
+++ b/resources/assets/components/pages/GeneralPage/GeneralPage.js
@@ -1,3 +1,5 @@
+/* global window */
+
 import React from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';

--- a/resources/assets/components/pages/GeneralPage/GeneralPage.js
+++ b/resources/assets/components/pages/GeneralPage/GeneralPage.js
@@ -5,6 +5,7 @@ import classnames from 'classnames';
 import Enclosure from '../../Enclosure';
 import ContentfulEntry from '../../ContentfulEntry';
 import Markdown from '../../utilities/Markdown/Markdown';
+import SocialShareTray from '../../utilities/SocialShareTray/SocialShareTray';
 
 import './general-page.scss';
 
@@ -50,6 +51,12 @@ const GeneralPage = props => {
               <ContentfulEntry json={block} />
             </div>
           ))}
+
+          <SocialShareTray
+            shareLink={window.location.href}
+            platforms={['facebook', 'twitter']}
+            title="found this useful?"
+          />
         </Enclosure>
       </div>
     </div>

--- a/resources/assets/components/utilities/SocialShareTray/SocialShareTray.js
+++ b/resources/assets/components/utilities/SocialShareTray/SocialShareTray.js
@@ -83,7 +83,7 @@ class SocialShareTray extends React.Component {
   };
 
   render() {
-    const { shareLink } = this.props;
+    const { shareLink, platforms } = this.props;
     const trackLink = this.props.trackLink || this.props.shareLink;
 
     return (
@@ -91,41 +91,51 @@ class SocialShareTray extends React.Component {
         <p className="title caps-lock font-bold">Share on Social Media</p>
 
         <div className="share-buttons">
-          <ShareButton
-            className="facebook"
-            onClick={() => this.handleFacebookShareClick(shareLink, trackLink)}
-            disabled={!shareLink}
-            icon={facebookIcon}
-            text="Share"
-          />
+          {platforms.includes('facebook') ? (
+            <ShareButton
+              className="facebook"
+              onClick={() =>
+                this.handleFacebookShareClick(shareLink, trackLink)
+              }
+              disabled={!shareLink}
+              icon={facebookIcon}
+              text="Share"
+            />
+          ) : null}
 
-          <ShareButton
-            className="twitter"
-            onClick={() =>
-              handleTwitterShareClick(shareLink, { url: trackLink })
-            }
-            disabled={!shareLink}
-            icon={twitterIcon}
-            text="Tweet"
-          />
+          {platforms.includes('twitter') ? (
+            <ShareButton
+              className="twitter"
+              onClick={() =>
+                handleTwitterShareClick(shareLink, { url: trackLink })
+              }
+              disabled={!shareLink}
+              icon={twitterIcon}
+              text="Tweet"
+            />
+          ) : null}
 
-          <ShareButton
-            className="messenger"
-            disabled={!shareLink}
-            icon={messengerIcon}
-            text="Send"
-            onClick={() =>
-              this.handleFacebookMessengerClick(shareLink, trackLink)
-            }
-          />
+          {platforms.includes('messenger') ? (
+            <ShareButton
+              className="messenger"
+              disabled={!shareLink}
+              icon={messengerIcon}
+              text="Send"
+              onClick={() =>
+                this.handleFacebookMessengerClick(shareLink, trackLink)
+              }
+            />
+          ) : null}
 
-          <ShareButton
-            className="email"
-            disabled={!shareLink}
-            icon={emailIcon}
-            text="Email"
-            onClick={() => this.handleEmailShareClick(shareLink, trackLink)}
-          />
+          {platforms.includes('email') ? (
+            <ShareButton
+              className="email"
+              disabled={!shareLink}
+              icon={emailIcon}
+              text="Email"
+              onClick={() => this.handleEmailShareClick(shareLink, trackLink)}
+            />
+          ) : null}
         </div>
       </div>
     );
@@ -135,11 +145,13 @@ class SocialShareTray extends React.Component {
 SocialShareTray.propTypes = {
   shareLink: PropTypes.string,
   trackLink: PropTypes.string,
+  platforms: PropTypes.arrayOf(PropTypes.string),
 };
 
 SocialShareTray.defaultProps = {
   shareLink: null,
   trackLink: null,
+  platforms: ['facebook', 'twitter', 'messenger', 'email'],
 };
 
 export default SocialShareTray;

--- a/resources/assets/components/utilities/SocialShareTray/SocialShareTray.js
+++ b/resources/assets/components/utilities/SocialShareTray/SocialShareTray.js
@@ -83,12 +83,12 @@ class SocialShareTray extends React.Component {
   };
 
   render() {
-    const { shareLink, platforms } = this.props;
+    const { shareLink, platforms, title } = this.props;
     const trackLink = this.props.trackLink || this.props.shareLink;
 
     return (
       <div className="social-share-tray padded text-centered">
-        <p className="title caps-lock font-bold">Share on Social Media</p>
+        <p className="title caps-lock font-bold">{title}</p>
 
         <div className="share-buttons">
           {platforms.includes('facebook') ? (
@@ -146,12 +146,14 @@ SocialShareTray.propTypes = {
   shareLink: PropTypes.string,
   trackLink: PropTypes.string,
   platforms: PropTypes.arrayOf(PropTypes.string),
+  title: PropTypes.string,
 };
 
 SocialShareTray.defaultProps = {
   shareLink: null,
   trackLink: null,
   platforms: ['facebook', 'twitter', 'messenger', 'email'],
+  title: 'Share on Social Media',
 };
 
 export default SocialShareTray;


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR adds the `SocialShareTray` component to `GeneralPage`s!

- 🔘 [5af656a](https://github.com/DoSomething/phoenix-next/commit/5af656a84d855f91279f87cea9d4ee8e25100ed8) Adds `platforms` prop so that we can specify platforms for the tray (defaults to all of 'em)
- 🎋[1c09553](https://github.com/DoSomething/phoenix-next/commit/1c0955363410154a0b34ed7545f1b90ad7381b39) Adds `title` prop so we can customize the title (defaults to 'Share on social media').

### Any background context you want to provide?
The logic I used for rendering the buttons based on `platform` prop seems somewhat non-DRY but it was the best I could think of without going too crazy about this.


### What are the relevant tickets/cards?

Refs [Pivotal ID #159745577](https://www.pivotaltracker.com/story/show/159745577)

![image](https://user-images.githubusercontent.com/12417657/45843020-66ee5800-bcec-11e8-935c-14da4a48ff04.png)


![image](https://user-images.githubusercontent.com/12417657/45847954-c6ebfb00-bcfa-11e8-9d90-2fcec1ea28d4.png)
