### PR TITLE
Wrap author image in contentfulImageUrl helper function.

### DIFF
--- a/resources/assets/components/pages/GeneralPage/GeneralPage.js
+++ b/resources/assets/components/pages/GeneralPage/GeneralPage.js
@@ -5,10 +5,10 @@ import PropTypes from 'prop-types';
 import classnames from 'classnames';
 
 import Enclosure from '../../Enclosure';
-import { withoutNulls } from '../../../helpers';
 import Byline from '../../utilities/Byline/Byline';
 import ContentfulEntry from '../../ContentfulEntry';
 import Markdown from '../../utilities/Markdown/Markdown';
+import { contentfulImageUrl, withoutNulls } from '../../../helpers';
 import SocialShareTray from '../../utilities/SocialShareTray/SocialShareTray';
 
 import './general-page.scss';
@@ -37,6 +37,12 @@ const GeneralPage = props => {
                   <Byline
                     author={author.fields.name}
                     {...withoutNulls(author.fields)}
+                    photo={contentfulImageUrl(
+                      author.fields.photo,
+                      175,
+                      175,
+                      'fill',
+                    )}
                     className="byline--page-author"
                     key={author.id}
                   />


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR updates the author output on Pages to make sure the image used is a thumbnail and we're not requesting the full size image!

### Any background context you want to provide?

🌂

### What are the relevant tickets/cards?

☂️

