### PR TITLE
Explore Campaigns Page Updates

### DIFF
--- a/app/Http/Controllers/CampaignController.php
+++ b/app/Http/Controllers/CampaignController.php
@@ -32,7 +32,7 @@ class CampaignController extends Controller
      */
     public function index()
     {
-        $campaigns = $this->campaignRepository->getAll();
+        $campaigns = $this->campaignRepository->getAllCampaignsSorted();
 
         return view('campaigns.index', ['campaigns' => $campaigns]);
     }

--- a/app/Repositories/CampaignRepository.php
+++ b/app/Repositories/CampaignRepository.php
@@ -52,6 +52,11 @@ class CampaignRepository
         return json_decode($campaigns);
     }
 
+    /**
+     * Get all campaigns sorted by open status, and staff pick status.
+     *
+     * @return \Illuminate\Support\Collection
+     */
     public function getAllCampaignsSorted()
     {
         $campaigns = $this->getAll();

--- a/app/Repositories/CampaignRepository.php
+++ b/app/Repositories/CampaignRepository.php
@@ -2,6 +2,7 @@
 
 namespace App\Repositories;
 
+use Carbon\Carbon;
 use App\Entities\Campaign;
 use Contentful\Delivery\Query;
 use App\Services\PhoenixLegacy;
@@ -61,6 +62,21 @@ class CampaignRepository
         });
 
         return json_decode($flattenedCampaign);
+    }
+
+    public function getAllCampaignsSorted()
+    {
+        $campaigns = $this->getAll();
+
+        // Partition into list of open and closed campaigns for sorting.
+        list($openCampaigns, $closedCampaigns) = collect($campaigns)->partition(function($campaign) {
+            return ((!$campaign->endDate) || $campaign->endDate > Carbon::now());
+        });
+
+        // Sort open campaigns by staff pick.
+        $sortedOpenCampaigns = $openCampaigns->sortByDesc('staffPick');
+
+        return $sortedOpenCampaigns->merge($closedCampaigns);
     }
 
     /**

--- a/app/Repositories/CampaignRepository.php
+++ b/app/Repositories/CampaignRepository.php
@@ -45,11 +45,11 @@ class CampaignRepository
      */
     public function getAll()
     {
-        $flattenedCampaigns = remember('campaigns', 15, function () {
+        $campaigns = remember('campaigns', 15, function () {
             return $this->getEntriesAsJson('campaign');
         });
 
-        return json_decode($flattenedCampaigns);
+        return json_decode($campaigns);
     }
 
     public function getAllCampaignsSorted()

--- a/app/Repositories/CampaignRepository.php
+++ b/app/Repositories/CampaignRepository.php
@@ -152,11 +152,9 @@ class CampaignRepository
             ->where('fields.legacyCampaignId', $ids, 'in')
             ->setInclude(1);
 
-        $results = $this->contentful->getEntries($query);
+        $results = $this->contentful->getEntries($query)->getItems();
 
-        $contentfulCampaigns = collect($results->getIterator())->map(function ($campaign) {
-            return new TruncatedCampaign($campaign);
-        });
+        $contentfulCampaigns = collect($results)->mapInto(TruncatedCampaign::class);
 
         // List of IDs returned from Contentful.
         $foundIds = $contentfulCampaigns->pluck('legacyCampaignId')->all();
@@ -183,11 +181,9 @@ class CampaignRepository
             ->where('sys.id', $ids, 'in')
             ->setInclude(1);
 
-        $results = $this->contentful->getEntries($query);
+        $results = $this->contentful->getEntries($query)->getItems();
 
-        return collect($results->getIterator())->map(function ($campaign) {
-            return new TruncatedCampaign($campaign);
-        });
+        return collect($results)->mapInto(TruncatedCampaign::class);
     }
 
     /**

--- a/app/Repositories/CampaignRepository.php
+++ b/app/Repositories/CampaignRepository.php
@@ -55,9 +55,7 @@ class CampaignRepository
 
             // Transform & cast as JSON so we can cache this. One little gotcha -
             // we don't want full campaigns, that'd be a monstrous object!
-            $results = collect($array)->map(function ($entity) {
-                return new TruncatedCampaign($entity);
-            });
+            $results = collect($array)->mapInto(TruncatedCampaign::class);
 
             return $results->toJson();
         });

--- a/app/Repositories/CampaignRepository.php
+++ b/app/Repositories/CampaignRepository.php
@@ -69,8 +69,8 @@ class CampaignRepository
         $campaigns = $this->getAll();
 
         // Partition into list of open and closed campaigns for sorting.
-        list($openCampaigns, $closedCampaigns) = collect($campaigns)->partition(function($campaign) {
-            return ((!$campaign->endDate) || $campaign->endDate > Carbon::now());
+        list($openCampaigns, $closedCampaigns) = collect($campaigns)->partition(function ($campaign) {
+            return ! $campaign->endDate || $campaign->endDate > Carbon::now();
         });
 
         // Sort open campaigns by staff pick.

--- a/app/Repositories/CampaignRepository.php
+++ b/app/Repositories/CampaignRepository.php
@@ -45,7 +45,11 @@ class CampaignRepository
     public function getAll()
     {
         $flattenedCampaign = remember('campaigns', 15, function () {
-            $query = (new Query)->setContentType('campaign')->setInclude(0);
+            $query = (new Query)
+                ->setContentType('campaign')
+                ->setInclude(0)
+                ->orderBy('sys.updatedAt', true);
+
             $campaigns = $this->contentful->getEntries($query);
             $array = iterator_to_array($campaigns);
 

--- a/app/Repositories/CampaignRepository.php
+++ b/app/Repositories/CampaignRepository.php
@@ -98,9 +98,7 @@ class CampaignRepository
 
         $results = $this->phoenixLegacy->getCampaigns($query);
 
-        return collect($results['data'])->map(function ($campaign) {
-            return new LegacyCampaign($campaign);
-        });
+        return collect($results['data'])->mapInto(LegacyCampaign::class);
     }
 
     /**

--- a/app/Repositories/CampaignRepository.php
+++ b/app/Repositories/CampaignRepository.php
@@ -46,19 +46,7 @@ class CampaignRepository
     public function getAll()
     {
         $flattenedCampaign = remember('campaigns', 15, function () {
-            $query = (new Query)
-                ->setContentType('campaign')
-                ->setInclude(0)
-                ->orderBy('sys.updatedAt', true);
-
-            $campaigns = $this->contentful->getEntries($query);
-            $array = iterator_to_array($campaigns);
-
-            // Transform & cast as JSON so we can cache this. One little gotcha -
-            // we don't want full campaigns, that'd be a monstrous object!
-            $results = collect($array)->mapInto(TruncatedCampaign::class);
-
-            return $results->toJson();
+            return $this->getEntriesAsJson('campaign');
         });
 
         return json_decode($flattenedCampaign);

--- a/app/Repositories/CampaignRepository.php
+++ b/app/Repositories/CampaignRepository.php
@@ -45,11 +45,11 @@ class CampaignRepository
      */
     public function getAll()
     {
-        $flattenedCampaign = remember('campaigns', 15, function () {
+        $flattenedCampaigns = remember('campaigns', 15, function () {
             return $this->getEntriesAsJson('campaign');
         });
 
-        return json_decode($flattenedCampaign);
+        return json_decode($flattenedCampaigns);
     }
 
     public function getAllCampaignsSorted()

--- a/app/Repositories/QueriesContentful.php
+++ b/app/Repositories/QueriesContentful.php
@@ -5,9 +5,33 @@ namespace App\Repositories;
 use App\Entities\Page;
 use App\Entities\Campaign;
 use Contentful\Delivery\Query;
+use App\Entities\TruncatedCampaign;
 
 trait QueriesContentful
 {
+    /**
+     * Get entries from a Contentful Query and return data as JSON.
+     *
+     * @param  string $type
+     * @return string
+     */
+    protected function getEntriesAsJson($type)
+    {
+        $query = (new Query)
+                ->setContentType($type)
+                ->setInclude(0)
+                ->orderBy('sys.updatedAt', true);
+
+        $entries = app('contentful.delivery')->getEntries($query)->getItems();
+
+        switch ($type) {
+            case 'campaign':
+                // Using the TruncatedCampaign Entity to avoid returning a monstrous object.
+                $results = collect($entries)->mapInto(TruncatedCampaign::class);
+                return $results->toJson();
+        }
+    }
+
     /**
      * Get a single entry from a Contentful Query and return data as JSON.
      *

--- a/app/Repositories/QueriesContentful.php
+++ b/app/Repositories/QueriesContentful.php
@@ -28,6 +28,7 @@ trait QueriesContentful
             case 'campaign':
                 // Using the TruncatedCampaign Entity to avoid returning a monstrous object.
                 $results = collect($entries)->mapInto(TruncatedCampaign::class);
+
                 return $results->toJson();
         }
     }

--- a/resources/views/campaigns/index.blade.php
+++ b/resources/views/campaigns/index.blade.php
@@ -3,36 +3,29 @@
 @section('content')
     <div class="container -padded">
         <div class="wrapper">
-            @if(auth()->user() && auth()->user()->isStaff())
-                <div class="container__block">
-                    <h1>Campaigns</h1>
-                    <p>Here's all the campaigns available on <strong>Phoenix Next</strong>, the new DoSomething.org
-                        web experience.</p>
-                </div>
-                <ul class="gallery -quartet">
-                    @foreach($campaigns as $item)
-                        <li>
-                            <article class="tile">
-                                <a class="wrapper" href="{{ url('us/campaigns/'.$item->slug) }}">
-                                    <div class="tile__meta">
-                                        <h1 class="tile__title">{{ $item->title }}</h1>
-                                    </div>
-                                    @if ($item->coverImage)
-                                        <img alt="{{ $item->title }}" src="{{ $item->coverImage->url }}?w=400&h=400&fit=fill" />
-                                    @else
-                                        <img alt="No cover image!" src="data:image/gif;base64,R0lGODlhAQABAIAAAAUEBAAAACwAAAAAAQABAAACAkQBADs=" />
-                                    @endif
-                                </a>
-                            </article>
-                        </li>
-                    @endforeach
-                </ul>
-            @else
-                <div class="container__block">
-                    <h1>Permission Denied</h1>
-                    How'd you get here? This is only for staff members.
-                </div>
-            @endif
+            <div class="container__block">
+                <h1>Campaigns</h1>
+                <p>Here's all the campaigns available on <strong>Phoenix Next</strong>, the new DoSomething.org
+                    web experience.</p>
+            </div>
+            <ul class="gallery -quartet">
+                @foreach($campaigns as $item)
+                    <li>
+                        <article class="tile">
+                            <a class="wrapper" href="{{ url('us/campaigns/'.$item->slug) }}">
+                                <div class="tile__meta">
+                                    <h1 class="tile__title">{{ $item->title }}</h1>
+                                </div>
+                                @if ($item->coverImage)
+                                    <img alt="{{ $item->title }}" src="{{ $item->coverImage->url }}?w=400&h=400&fit=fill" />
+                                @else
+                                    <img alt="No cover image!" src="data:image/gif;base64,R0lGODlhAQABAIAAAAUEBAAAACwAAAAAAQABAAACAkQBADs=" />
+                                @endif
+                            </a>
+                        </article>
+                    </li>
+                @endforeach
+            </ul>
         </div>
     </div>
 @stop

--- a/resources/views/campaigns/index.blade.php
+++ b/resources/views/campaigns/index.blade.php
@@ -4,9 +4,7 @@
     <div class="container -padded">
         <div class="wrapper">
             <div class="container__block">
-                <h1>Campaigns</h1>
-                <p>Here's all the campaigns available on <strong>Phoenix Next</strong>, the new DoSomething.org
-                    web experience.</p>
+                <h1>Explore Campaigns</h1>
             </div>
             <ul class="gallery -quartet">
                 @foreach($campaigns as $item)


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR updates the Explore Campaigns page on Phoenix.

- [dea641f](https://github.com/DoSomething/phoenix-next/commit/dea641f44a0013b505e8a8feee3418175f7ce30e) for the `getAll` campaigns method - orders campaigns by `sys.updatedAt` field
- [abe9d6b](https://github.com/DoSomething/phoenix-next/commit/abe9d6b019ff94ab82e7acfffdac83680d0a7406) adds a new `CampaignRepository` method called `getAllCampaignsSorted`(?) which sorts campaigns as follows:
  1. Open campaigns that are staff picks
  2. Open campaigns that are not staff picks
  3. Rest of campaigns
- [085b87c](https://github.com/DoSomething/phoenix-next/commit/085b87c66c9745e417455ba12035134a09371bee) Ungate the campaigns index list on the page
- [5c588e0](https://github.com/DoSomething/phoenix-next/commit/5c588e0aa48e010179a19dea36c3ed921535d886) Update the text / title content on the page to align with Ashes

**UPDATES**:
- [e47b46b](https://github.com/DoSomething/phoenix-next/pull/1110/commits/e47b46bbb8b7227da7bef584624ae3ca26a2398c) adds the index campaigns method to the `QueriesContentful` Trait as a more abstract method to be applied to more types (pages, etc.)
- [945ba92](https://github.com/DoSomething/phoenix-next/pull/1110/commits/945ba9207dc9b5a2985f22529e77121fbaecd49b) Use the new method in `CampaignsRepository#getAll`
- tidy up some of the other methods -- we were finally able to implement @DFurnes [words](https://github.com/DoSomething/phoenix-next/pull/983#discussion_r196186478) for some of the methods due to our Contentful SDK update, as well as some general `mapInto` abstractions.


### What are the relevant tickets/cards?

Refs [Pivotal ID #160603200](https://www.pivotaltracker.com/story/show/160603200)

![image](https://user-images.githubusercontent.com/12417657/46173187-957fac00-c273-11e8-9caa-59903c65320c.png)
