### PR TITLE
Using .length cause this is not PHP.

### DIFF
--- a/resources/assets/components/pages/GeneralPage/GeneralPage.js
+++ b/resources/assets/components/pages/GeneralPage/GeneralPage.js
@@ -32,7 +32,7 @@ const GeneralPage = props => {
               <p className="general-page__subtitle">{subTitle}</p>
             ) : null}
 
-            {authors ? (
+            {authors.length ? (
               <div className="general-page__authors">
                 {authors.map(author => (
                   <Byline
@@ -82,7 +82,7 @@ const GeneralPage = props => {
             title="found this useful?"
           />
 
-          {authors ? (
+          {authors.length ? (
             <ul className="general-page__author-bios">
               {authors.map(author => (
                 <li className="padding-vertical-md">


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR switches to use `authors.length` for the ternary check if any authors have been added. @mendelB realized that just checking against `authors` is truthy and leads to an empty div with spacing. 

I was stuck in PHP world, where empty arrays are falsey 🤦‍♂️ 

### What are the relevant tickets/cards?

Refs [Pivotal ID #159745156](https://www.pivotaltracker.com/story/show/159745156)
