### PR TITLE
Add 'campaign_' cache key name prefix

### DIFF
--- a/app/Repositories/CampaignRepository.php
+++ b/app/Repositories/CampaignRepository.php
@@ -201,7 +201,7 @@ class CampaignRepository
         if (! config('services.contentful.cache')) {
             $campaign = $this->getEntryFromSlugAsJson('campaign', $slug);
         } else {
-            $campaign = remember($slug, 15, function () use ($slug) {
+            $campaign = remember('campaign_'.$slug, 15, function () use ($slug) {
                 return $this->getEntryFromSlugAsJson('campaign', $slug);
             });
         }


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do

This PR adds `'campaign_'` as a prefix to the Campaign Entity cache key

### Any background context you want to provide?
We rely on this prefix in the Clear Cache button in `CampaignDashboard`s https://github.com/DoSomething/phoenix-next/blob/master/resources/assets/components/AdminDashboard/CampaignDashboard/CampaignDashboard.js#L41