### PR TITLE
Better to not require jobTitle and instead add default.

### DIFF
--- a/resources/assets/components/utilities/Author/AuthorBio.js
+++ b/resources/assets/components/utilities/Author/AuthorBio.js
@@ -27,7 +27,7 @@ export default AuthorBio;
 AuthorBio.propTypes = {
   className: PropTypes.string,
   description: PropTypes.string,
-  jobTitle: PropTypes.string.isRequired,
+  jobTitle: PropTypes.string,
   name: PropTypes.string.isRequired,
   photo: PropTypes.string,
 };
@@ -35,5 +35,6 @@ AuthorBio.propTypes = {
 AuthorBio.defaultProps = {
   className: null,
   description: null,
+  jobTitle: 'Staff',
   photo: DEFAULT_AVATAR,
 };


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR removes the need to require a `jobTitle` in the Author Bio, especially since the field is not required on the `Person` content type, better to just use a smart default value.

### Any background context you want to provide?

🌵 

