### PR TITLE
Page social share tray toggle

### DIFF
--- a/app/Entities/Page.php
+++ b/app/Entities/Page.php
@@ -42,6 +42,7 @@ class Page extends Entity implements JsonSerializable
                 'content' => $this->content,
                 'sidebar' => $this->parseBlocks($this->sidebar),
                 'blocks' => $this->parseBlocks($this->blocks),
+                'displaySocialShare' => $this->displaySocialShare,
                 // @TODO: we want to eventually remove the need for hideFromNavigation field
                 // in favor of always linking to pages referenced in the `pages` field.
                 'hideFromNavigation' => $this->hideFromNavigation,

--- a/contentful/migrations/2018_09_28_001_add_display_social_share_toggle_field_to_page.js
+++ b/contentful/migrations/2018_09_28_001_add_display_social_share_toggle_field_to_page.js
@@ -1,0 +1,12 @@
+module.exports = function(migration) {
+  const page = migration.editContentType('page');
+
+  page
+    .createField('displaySocialShare')
+    .name('Display Social Share')
+    .type('Boolean')
+    .required(false)
+    .localized(false);
+
+  page.moveField('displaySocialShare').afterField('blocks');
+};

--- a/resources/assets/components/pages/GeneralPage/GeneralPage.js
+++ b/resources/assets/components/pages/GeneralPage/GeneralPage.js
@@ -22,7 +22,15 @@ import './general-page.scss';
  * @returns {XML}
  */
 const GeneralPage = props => {
-  const { authors, title, subTitle, content, sidebar, blocks } = props;
+  const {
+    authors,
+    title,
+    subTitle,
+    content,
+    sidebar,
+    blocks,
+    displaySocialShare,
+  } = props;
 
   return (
     <div>
@@ -82,11 +90,13 @@ const GeneralPage = props => {
             </div>
           ))}
 
-          <SocialShareTray
-            shareLink={window.location.href}
-            platforms={['facebook', 'twitter']}
-            title="found this useful?"
-          />
+          {displaySocialShare ? (
+            <SocialShareTray
+              shareLink={window.location.href}
+              platforms={['facebook', 'twitter']}
+              title="found this useful?"
+            />
+          ) : null}
 
           {authors.length ? (
             <ul className="general-page__author-bios">
@@ -119,6 +129,7 @@ GeneralPage.propTypes = {
   content: PropTypes.string,
   sidebar: PropTypes.arrayOf(PropTypes.object),
   blocks: PropTypes.arrayOf(PropTypes.object).isRequired,
+  displaySocialShare: PropTypes.bool,
 };
 
 GeneralPage.defaultProps = {
@@ -126,6 +137,7 @@ GeneralPage.defaultProps = {
   content: null,
   sidebar: [],
   subTitle: null,
+  displaySocialShare: false,
 };
 
 export default GeneralPage;


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR adds a `displaySocialShare` field to pages and toggles the share tray in General Page based on setting.

- `displaySocialShare` field Contentful migration script for Page
- `displaySocialShare` field in the Page Entity
- toggle displaying the tray in the `GeneralPage` component based on the field setting. 

We're defaulting to not displaying the share tray unless manually set to `true`. 


### What are the relevant tickets/cards?

Refs [Pivotal ID #159745577](https://www.pivotaltracker.com/story/show/159745577)

### Checklist

* [ ] Documentation added for new features/changed endpoints. *I'll add the docs in a separate PR as they've been updated since this branch was created*

![image](https://user-images.githubusercontent.com/12417657/46263312-7aaf7080-c4db-11e8-8f11-a8bea56eb367.png)
