### PR TITLE
Page caching and Admin Dashboard

### DIFF
--- a/app/Repositories/PageRepository.php
+++ b/app/Repositories/PageRepository.php
@@ -20,7 +20,7 @@ class PageRepository
         if (! config('services.contentful.cache')) {
             $page = $this->getEntryFromSlugAsJson('page', $slug);
         } else {
-            $page = remember($slug, 15, function () use ($slug) {
+            $page = remember('page_'.$slug, 15, function () use ($slug) {
                 return $this->getEntryFromSlugAsJson('page', $slug);
             });
         }

--- a/resources/assets/components/AdminDashboard/PageDashboard/PageDashboard.js
+++ b/resources/assets/components/AdminDashboard/PageDashboard/PageDashboard.js
@@ -1,0 +1,21 @@
+/* global window */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const PageDashboard = ({ slug }) => (
+  <div>
+    <a
+      className="button -secondary margin-md"
+      href={`/next/cache/page_${slug}?redirect=${window.location.pathname}`}
+    >
+      Clear Cache
+    </a>
+  </div>
+);
+
+PageDashboard.propTypes = {
+  slug: PropTypes.string.isRequired,
+};
+
+export default PageDashboard;

--- a/resources/assets/components/AdminDashboard/PageDashboard/PageDashboardContainer.js
+++ b/resources/assets/components/AdminDashboard/PageDashboard/PageDashboardContainer.js
@@ -1,0 +1,10 @@
+import { get } from 'lodash';
+import { connect } from 'react-redux';
+
+import PageDashboard from './PageDashboard';
+
+const mapStateToProps = state => ({
+  slug: get(state, 'page.fields.slug'),
+});
+
+export default connect(mapStateToProps)(PageDashboard);

--- a/resources/assets/components/pages/GeneralPage/GeneralPage.js
+++ b/resources/assets/components/pages/GeneralPage/GeneralPage.js
@@ -11,6 +11,8 @@ import AuthorBio from '../../utilities/Author/AuthorBio';
 import Markdown from '../../utilities/Markdown/Markdown';
 import { contentfulImageUrl, withoutNulls } from '../../../helpers';
 import SocialShareTray from '../../utilities/SocialShareTray/SocialShareTray';
+import AdminDashboardContainer from '../../AdminDashboard/AdminDashboardContainer';
+import PageDashboardContainer from '../../AdminDashboard/PageDashboard/PageDashboardContainer';
 
 import './general-page.scss';
 
@@ -24,6 +26,10 @@ const GeneralPage = props => {
 
   return (
     <div>
+      <AdminDashboardContainer>
+        <PageDashboardContainer />
+      </AdminDashboardContainer>
+
       <div className="main clearfix general-page">
         <Enclosure className="default-container margin-vertical">
           <div className="general-page__heading text-centered">


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR adds a Page Admin Dashboard to general content pages to enable staff to clear the page from the cache.

- New `PageDashboard` component with a link to the backend cache clearing route
- Added a `page_` prefix to the cache key for pages

### Any background context you want to provide?
I was working on the toggle for the Social Share tray in general pages, and realized that there wasn't ye a way to clear the Page cache so address this card we had in the icebox real quick.
@weerd had mentioned us potentially rethinking the Admin Dashboard in general, but figured this could work for now.


### What are the relevant tickets/cards?

Refs [Pivotal ID #160696564](https://www.pivotaltracker.com/story/show/160696564)