### PR TITLE
TSA user gallery fix

### DIFF
--- a/resources/assets/components/actions/TextSubmissionAction/TextSubmissionAction.js
+++ b/resources/assets/components/actions/TextSubmissionAction/TextSubmissionAction.js
@@ -100,53 +100,52 @@ class TextSubmissionAction extends React.Component {
 
     return (
       <React.Fragment>
-        <Card
-          id={this.props.id}
-          className={classnames(
-            'bordered rounded text-submission-action',
-            this.props.className,
-          )}
-          title={this.props.title}
-        >
-          {formResponse ? <FormValidation response={formResponse} /> : null}
+        <div className="text-submission-action">
+          <Card
+            id={this.props.id}
+            className={classnames('bordered rounded', this.props.className)}
+            title={this.props.title}
+          >
+            {formResponse ? <FormValidation response={formResponse} /> : null}
 
-          <form onSubmit={this.handleSubmit}>
-            <div className="padded">
-              <div className="form-item">
-                <label
-                  className={classnames('field-label', {
-                    'has-error': has(errors, 'text'),
-                  })}
-                  htmlFor="text"
-                >
-                  {this.props.textFieldLabel}
-                </label>
-                <input
-                  className={classnames('text-field', {
-                    'has-error shake': has(errors, 'text'),
-                  })}
-                  type="text"
-                  id="text"
-                  name="text"
-                  placeholder={this.props.textFieldPlaceholder}
-                  value={this.state.textValue}
-                  onChange={this.handleChange}
-                />
+            <form onSubmit={this.handleSubmit}>
+              <div className="padded">
+                <div className="form-item">
+                  <label
+                    className={classnames('field-label', {
+                      'has-error': has(errors, 'text'),
+                    })}
+                    htmlFor="text"
+                  >
+                    {this.props.textFieldLabel}
+                  </label>
+                  <input
+                    className={classnames('text-field', {
+                      'has-error shake': has(errors, 'text'),
+                    })}
+                    type="text"
+                    id="text"
+                    name="text"
+                    placeholder={this.props.textFieldPlaceholder}
+                    value={this.state.textValue}
+                    onChange={this.handleChange}
+                  />
+                </div>
+                <p className="footnote">
+                  Your submission will be reviewed by a DoSomething.org staffer
+                  and added to our public gallery.
+                </p>
               </div>
-              <p className="footnote">
-                Your submission will be reviewed by a DoSomething.org staffer
-                and added to our public gallery.
-              </p>
-            </div>
-            <Button
-              type="submit"
-              loading={submissionItem ? submissionItem.isPending : true}
-              attached
-            >
-              {this.props.buttonText}
-            </Button>
-          </form>
-        </Card>
+              <Button
+                type="submit"
+                loading={submissionItem ? submissionItem.isPending : true}
+                attached
+              >
+                {this.props.buttonText}
+              </Button>
+            </form>
+          </Card>
+        </div>
 
         {this.state.showModal ? (
           <Modal onClose={() => this.setState({ showModal: false })}>

--- a/resources/assets/components/actions/TextSubmissionAction/text-submission-action.scss
+++ b/resources/assets/components/actions/TextSubmissionAction/text-submission-action.scss
@@ -1,4 +1,11 @@
+@import '../../../scss/next-toolbox.scss';
+
 .text-submission-action {
+  @include media($large) {
+    padding-right: $half-spacing;
+    width: 66.6666666666666%;
+  }
+
   .field-label {
     height: auto;
   }

--- a/resources/assets/components/pages/CampaignPage/CampaignPageContent.js
+++ b/resources/assets/components/pages/CampaignPage/CampaignPageContent.js
@@ -30,6 +30,7 @@ const CampaignPageContent = props => {
   const renderBlock = json => {
     const type = parseContentfulType(json);
 
+    // @TODO (2018-10-11) Would like to rethink this approach with fullWidth.
     let fullWidth = false;
     if (
       [

--- a/resources/assets/components/pages/CampaignPage/CampaignPageContent.js
+++ b/resources/assets/components/pages/CampaignPage/CampaignPageContent.js
@@ -34,6 +34,7 @@ const CampaignPageContent = props => {
     if (
       [
         'photoSubmissionAction',
+        'textSubmissionAction',
         'gallery',
         'imagesBlock',
         'socialDriveAction',


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR fixes an issue with how the TSA user gallery was displaying. Since the parent container was not expanding the full width the gallery was ending up compact. Did a couple fixes to resolve this while still keeping the TSA from being full width on large screen size, and also unifying the markup between it and the PSA.

### Any background context you want to provide?

**Before**:
<img width="1082" alt="screen shot 2018-10-11 at 12 54 00 pm" src="https://user-images.githubusercontent.com/105849/46820905-4cd8f000-cd55-11e8-9d42-97dbabea838d.png">

**After**:
<img width="1103" alt="screen shot 2018-10-11 at 12 50 48 pm" src="https://user-images.githubusercontent.com/105849/46820931-5cf0cf80-cd55-11e8-9209-f01c974742f7.png">


### What are the relevant tickets/cards?

🌵 

### Checklist

* [ ] Added screenshot to PR description of related front-end updates on **small** screens.
* [ ] Added screenshot to PR description of related front-end updates on **medium** screens.
* [x] Added screenshot to PR description of related front-end updates on **large** screens.
