### PR TITLE
Bug fix - Purge null props from shareAction JSON with helper

### DIFF
--- a/resources/assets/components/ContentfulEntry/renderers.js
+++ b/resources/assets/components/ContentfulEntry/renderers.js
@@ -46,7 +46,7 @@ export function renderShareAction(step) {
   return (
     <div key={`share-action-${contentfulId}`} className="margin-horizontal-md">
       <PuckWaypoint name="share_action-top" waypointData={{ contentfulId }} />
-      <ShareActionContainer id={step.id} {...step.fields} />
+      <ShareActionContainer id={step.id} {...withoutNulls(step.fields)} />
       <PuckWaypoint
         name="share_action-bottom"
         waypointData={{ contentfulId }}


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR uses the `withoutNulls` helper to ensure we don't pass `null` props to the `ShareAction` from the `renderShareAction` method.

### Any background context you want to provide?
If no Affirmation block nor text is set for a Share Action, we mean to render a default value using `defaultProps`. However, we were passing through the JSON data including the `affirmation` field which would cause the default props to be by-passed. Causing an error e.g. in this affirmation Share Action in the `support-survivors` campaign:

![image](https://user-images.githubusercontent.com/12417657/46830941-f927d000-cd6f-11e8-834d-675583fa7598.png)

