### PR TITLE
Gallery Block rendering - first pass

### DIFF
--- a/app/Entities/Entity.php
+++ b/app/Entities/Entity.php
@@ -76,6 +76,8 @@ class Entity implements ArrayAccess, JsonSerializable
                 }
 
                 return new CustomBlock($block->entry);
+            case 'galleryBlock':
+                return new GalleryBlock($block->entry);
             case 'imagesBlock':
                 return new ImagesBlock($block->entry);
             case 'landingPage':

--- a/app/Entities/Entity.php
+++ b/app/Entities/Entity.php
@@ -62,6 +62,8 @@ class Entity implements ArrayAccess, JsonSerializable
                 return new Affirmation($block->entry);
             case 'callToAction':
                 return new CallToAction($block->entry);
+            case 'campaign':
+                return new TruncatedCampaign($block->entry);
             case 'campaignUpdate':
                 return new CampaignUpdate($block->entry);
             case 'contentBlock':

--- a/app/Entities/GalleryBlock.php
+++ b/app/Entities/GalleryBlock.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Entities;
+
+use JsonSerializable;
+
+class GalleryBlock extends Entity implements JsonSerializable
+{
+    /**
+     * Convert the object into something JSON serializable.
+     *
+     * @return array
+     */
+    public function jsonSerialize()
+    {
+        return [
+            'id' => $this->entry->getId(),
+            'type' => $this->getContentType(),
+            'fields' => [
+                'title' => $this->title,
+                'blocks' => $this->parseBlocks($this->blocks),
+            ],
+        ];
+    }
+}

--- a/resources/assets/components/ContentfulEntry/ContentfulEntry.js
+++ b/resources/assets/components/ContentfulEntry/ContentfulEntry.js
@@ -10,6 +10,7 @@ import { ContentfulEntryJson } from '../../types';
 import PollLocator from '../PollLocator/PollLocator';
 import { CampaignUpdateContainer } from '../CampaignUpdate';
 import ImagesBlock from '../blocks/ImagesBlock/ImagesBlock';
+import GalleryBlock from '../blocks/GalleryBlock/GalleryBlock';
 import { parseContentfulType, report, withoutNulls } from '../../helpers';
 import CallToActionContainer from '../CallToAction/CallToActionContainer';
 import LandingPageContainer from '../pages/LandingPage/LandingPageContainer';
@@ -93,6 +94,9 @@ class ContentfulEntry extends React.Component<Props, State> {
             <CampaignGalleryBlockContainer />
           </div>
         );
+
+      case 'galleryBlock':
+        return <GalleryBlock {...json.fields} />;
 
       case 'imagesBlock':
         return <ImagesBlock images={json.fields.images} />;

--- a/resources/assets/components/blocks/GalleryBlock/GalleryBlock.js
+++ b/resources/assets/components/blocks/GalleryBlock/GalleryBlock.js
@@ -37,7 +37,7 @@ const renderBlock = block => {
 
 const GalleryBlock = ({ title, blocks }) => (
   <div className="gallery-block">
-    <h1 className="text-centered">{title}</h1>
+    {title ? <h1 className="text-centered">{title}</h1> : null}
 
     <Gallery type="triad">{blocks.map(renderBlock)}</Gallery>
   </div>

--- a/resources/assets/components/blocks/GalleryBlock/GalleryBlock.js
+++ b/resources/assets/components/blocks/GalleryBlock/GalleryBlock.js
@@ -1,0 +1,56 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import { Figure } from '../../Figure';
+import Gallery from '../../utilities/Gallery/Gallery';
+import { contentfulImageUrl } from '../../../helpers';
+
+const renderBlock = block => {
+  let imageUrl;
+  let text;
+
+  switch (block.type) {
+    case 'person':
+      imageUrl = block.fields.photo;
+      text = block.fields.name;
+      break;
+
+    case 'campaign':
+      imageUrl = block.coverImage.url;
+      text = block.title;
+      break;
+
+    default:
+      return null;
+  }
+
+  return (
+    <Figure
+      key={block.id}
+      alignment="vertical"
+      alt={`${block.type}-${text}`}
+      image={contentfulImageUrl(imageUrl, '400', '400', 'fill')}
+    >
+      <p className="league-gothic">{text}</p>
+    </Figure>
+  );
+};
+
+const GalleryBlock = ({ title, blocks }) => (
+  <div className="gallery-block">
+    <h1 className="text-centered">{title}</h1>
+
+    <Gallery type="triad">{blocks.map(renderBlock)}</Gallery>
+  </div>
+);
+
+GalleryBlock.propTypes = {
+  title: PropTypes.string,
+  blocks: PropTypes.arrayOf(PropTypes.object).isRequired,
+};
+
+GalleryBlock.defaultProps = {
+  title: null,
+};
+
+export default GalleryBlock;

--- a/resources/assets/components/blocks/GalleryBlock/GalleryBlock.js
+++ b/resources/assets/components/blocks/GalleryBlock/GalleryBlock.js
@@ -27,7 +27,6 @@ const renderBlock = block => {
   return (
     <Figure
       key={block.id}
-      alignment="vertical"
       alt={`${block.type}-${text}`}
       image={contentfulImageUrl(imageUrl, '400', '400', 'fill')}
     >


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR adds support and rendering for the new Gallery Block in Phoenix.


- adds new `GalleryBlock` Entity
- adds new case for `galleryBlock` type to `Entity#parseBlock`
- adds new case for `campaign` type to `Entity#parseBlock` (we now have Campaigns as reference blocks for the first time 🎊) using the `TruncatedCampaign` since we only need some top level fields.
- adds new `GalleryBlock` React component,and a case for rendering in the `ContentfulEntry`.

### Any background context you want to provide?
As per our Pivotal discussion, this is kind of a rough first pass at just getting this component up and running. 

I tested this with support for `Person` and `Campaign` references. I couldn't think of any other Content Types we wanted/needed to do this with as of yet.

Using `Figure` to help with Image/text layout was an absolute lifesaver.

I think the hairiest part of this is the `renderBlock` method in the `galleryBlock` component. Which addresses -I think- what is/going-to-be the most complex about setting this all up properly.

I went with -again, per the discussion- using a `switch` to set up specified `imageUrl` and `text` fields, pulling from the correct Entry fields based on the Content-Type. (for now, support for just Campaigns and Persons).

Question (beyond whether I did any of this right):
I had a thought while setting up the Entity, that that might be an interesting place to take care of formalizing the fields for the GalleryBlock nodes?

Would it be cool if the Entity had it's own `parseBlocks` method that based on the Content-Type, returned the `imageUrl` and `text` from the correct fields instead of the component taking care of that?

### What are the relevant tickets/cards?

Refs [Pivotal ID #160603556](https://www.pivotaltracker.com/story/show/160603556)

### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.
* [x] Added screenshot to PR description of related front-end updates on **small** screens.
* [x] Added screenshot to PR description of related front-end updates on **medium** screens.
* [x] Added screenshot to PR description of related front-end updates on **large** screens.

**CAMPAIGNS no title** 
![image](https://user-images.githubusercontent.com/12417657/46880612-2a0f1000-ce17-11e8-8301-30a3a1cb0039.png)

![image](https://user-images.githubusercontent.com/12417657/46880989-3cd61480-ce18-11e8-9d60-9d1e5853ec61.png)


![image](https://user-images.githubusercontent.com/12417657/46880692-5e82cc00-ce17-11e8-9961-872d4c4c1d67.png)

**Persons with title**
![image](https://user-images.githubusercontent.com/12417657/46880925-0a2c1c00-ce18-11e8-9b82-59112c9c3f48.png)

**On a campaign page**
![image](https://user-images.githubusercontent.com/12417657/46881146-93dbe980-ce18-11e8-819d-60c54d7b3b5c.png)

