### PR TITLE
Page cache clearing fix

### DIFF
--- a/app/Repositories/PageRepository.php
+++ b/app/Repositories/PageRepository.php
@@ -20,7 +20,7 @@ class PageRepository
         if (! config('services.contentful.cache')) {
             $page = $this->getEntryFromSlugAsJson('page', $slug);
         } else {
-            $page = remember('page_'.$slug, 15, function () use ($slug) {
+            $page = remember('page_'.str_replace('/', '_', $slug), 15, function () use ($slug) {
                 return $this->getEntryFromSlugAsJson('page', $slug);
             });
         }

--- a/resources/assets/components/AdminDashboard/PageDashboard/PageDashboard.js
+++ b/resources/assets/components/AdminDashboard/PageDashboard/PageDashboard.js
@@ -7,7 +7,9 @@ const PageDashboard = ({ slug }) => (
   <div>
     <a
       className="button -secondary margin-md"
-      href={`/next/cache/page_${slug}?redirect=${window.location.pathname}`}
+      href={`/next/cache/page_${slug.replace(/\//g, '_')}?redirect=${
+        window.location.pathname
+      }`}
     >
       Clear Cache
     </a>


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR updates our page cache keys for a URL safe solution to enable clearing cached Page slugs with forward slashes via the cache endpoint

### Any background context you want to provide?
We ran into an issue where pages with a forward slash in the slug (`articles/cool-page`), would cause the Cache clearing button (#1119) to malfunction since the redirect would be to a nested route due to the `/` (`next/cache/articles/cool-page` 🔕).

Replacing them with underscores (both when storing the key and redirecting to the endpoint) neatly solved the issue (`next/cache/articles_cool-page`).


### What are the relevant tickets/cards?

Refs [Pivotal ID #160696564](https://www.pivotaltracker.com/story/show/160696564)