### PR TITLE
Poll Locator Updates - remove electionId default

### DIFF
--- a/resources/assets/components/PollLocator/PollLocator.js
+++ b/resources/assets/components/PollLocator/PollLocator.js
@@ -78,7 +78,7 @@ class PollLocator extends React.Component {
       return;
     }
 
-    window.vit.load({
+    let vitConfig = {
       modal: true,
       officialOnly: false,
       title: 'Find Where to Vote',
@@ -90,8 +90,18 @@ class PollLocator extends React.Component {
         landscapeBackgroundHeader: '#228a9d',
       },
       language: 'en',
-      electionId: get(this.props.additionalContent, 'electionId'),
-    });
+    };
+
+    const electionId = get(this.props.additionalContent, 'electionId');
+
+    if (electionId) {
+      vitConfig = {
+        ...vitConfig,
+        electionId,
+      };
+    }
+
+    window.vit.load(vitConfig);
   };
 
   render() {
@@ -115,8 +125,7 @@ PollLocator.propTypes = {
 
 PollLocator.defaultProps = {
   additionalContent: {
-    // Election ID defaults to 2000 -- the standard VIP test Election ID.
-    electionId: 2000,
+    electionId: null,
   },
 };
 


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR removes the `electionId` default prop from the `PollLocator` component.

### Any background context you want to provide?
Previously, if the editor did not set an `additionalContent.electionId` field, we'd default to using the `2000` test ID. (Not ideal -- test data!).

Now, the editor can choose to set the field if they want the Poll Locator to be limited to a specific election, or opt to leave it out, and the Poll Locator will attempt to pull data from any live election.

### What are the relevant tickets/cards?

Refs [Pivotal ID #160290866](https://www.pivotaltracker.com/story/show/160290866)
