### PR TITLE
Updates to add support for page metadata.

### DIFF
--- a/app/Entities/Campaign.php
+++ b/app/Entities/Campaign.php
@@ -114,6 +114,7 @@ class Campaign extends Entity implements JsonSerializable
             'template' => $this->template->first() ?: 'mosaic',
             'title' => $this->title,
             'slug' => $this->slug,
+            'metadata' => new Metadata(),
             'status' => null, // @TODO: calculate status based on the endDate!
             'endDate' => $this->endDate,
             'callToAction' => $this->callToAction, //@TODO: deprecate in favor of tagline.

--- a/app/Entities/Metadata.php
+++ b/app/Entities/Metadata.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Entities;
+
+use JsonSerializable;
+
+class Metadata implements JsonSerializable
+{
+  /**
+   * Convert the object into something JSON serializable.
+   *
+   * @return array
+   */
+  public function jsonSerialize()
+  {
+    // @TODO: using placeholers for now. Upcoming PR will flesh these out!
+    return [
+      'id' => str_random(24),
+      'type' => 'metadata',
+      'fields' => [
+        'internalTitle' => null,
+        'title' => null,
+        'description' => null,
+        'image' => null,
+      ],
+    ];
+  }
+}

--- a/app/Entities/Metadata.php
+++ b/app/Entities/Metadata.php
@@ -7,10 +7,10 @@ use JsonSerializable;
 class Metadata implements JsonSerializable
 {
     /**
-    * Convert the object into something JSON serializable.
-    *
-    * @return array
-    */
+     * Convert the object into something JSON serializable.
+     *
+     * @return array
+     */
     public function jsonSerialize()
     {
         // @TODO: using placeholers for now. Upcoming PR will flesh these out!

--- a/app/Entities/Metadata.php
+++ b/app/Entities/Metadata.php
@@ -6,23 +6,23 @@ use JsonSerializable;
 
 class Metadata implements JsonSerializable
 {
-  /**
-   * Convert the object into something JSON serializable.
-   *
-   * @return array
-   */
-  public function jsonSerialize()
-  {
-    // @TODO: using placeholers for now. Upcoming PR will flesh these out!
-    return [
-      'id' => str_random(24),
-      'type' => 'metadata',
-      'fields' => [
-        'internalTitle' => null,
-        'title' => null,
-        'description' => null,
-        'image' => null,
-      ],
-    ];
-  }
+    /**
+    * Convert the object into something JSON serializable.
+    *
+    * @return array
+    */
+    public function jsonSerialize()
+    {
+        // @TODO: using placeholers for now. Upcoming PR will flesh these out!
+        return [
+            'id' => str_random(24),
+            'type' => 'metadata',
+            'fields' => [
+                'internalTitle' => null,
+                'title' => null,
+                'description' => null,
+                'image' => null,
+            ],
+        ];
+    }
 }

--- a/app/Entities/Page.php
+++ b/app/Entities/Page.php
@@ -38,6 +38,7 @@ class Page extends Entity implements JsonSerializable
                 'title' => $this->title,
                 'subTitle' => $this->subTitle,
                 'slug' => $this->slug,
+                'metadata' => new Metadata(),
                 'authors' => $this->parseBlocks($this->authors),
                 'content' => $this->content,
                 'sidebar' => $this->parseBlocks($this->sidebar),

--- a/app/Http/Controllers/CampaignController.php
+++ b/app/Http/Controllers/CampaignController.php
@@ -51,6 +51,7 @@ class CampaignController extends Controller
             // This is used to build campaign-specific login links in the
             // server-rendered top navigation bar.
             'campaign' => $campaign,
+            'metadata' => get_metadata($campaign),
             // We render social metatags server-side because Facebook & Twitter
             // do not render JavaScript when crawling pages like Google does.
             'socialFields' => get_campaign_social_fields($campaign, $request->url()),

--- a/app/Http/Controllers/CategorizedPageController.php
+++ b/app/Http/Controllers/CategorizedPageController.php
@@ -36,6 +36,7 @@ class CategorizedPageController extends Controller
         $page = $this->pageRepository->findBySlug($category.'/'.$slug);
 
         return view('app', [
+            'metadata' => get_metadata($page),
             'socialFields' => get_social_fields($page),
             'pageTitle' => $page->fields->title,
         ])->with('state', [

--- a/app/Http/Controllers/PageController.php
+++ b/app/Http/Controllers/PageController.php
@@ -35,6 +35,7 @@ class PageController extends Controller
         $page = $this->pageRepository->findBySlug($slug);
 
         return view('app', [
+            'metadata' => get_metadata($page),
             'socialFields' => get_social_fields($page),
             'pageTitle' => $page->fields->title,
         ])->with('state', [

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -271,7 +271,7 @@ function get_metadata($entry)
 
     $image = $entry->metadata->fields->image;
 
-    if (!$image && data_get($entry, 'coverImage')) {
+    if (! $image && data_get($entry, 'coverImage')) {
         $image = $entry->coverImage->url.'?w=1200&h=1200&fm=jpg&fit=fill';
     }
 

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -224,6 +224,7 @@ function useOverrideIfSet($field, $base, $override)
  *
  * @param  \Contentful\Delivery\Resource\Entry|stdClass $entry
  * @return array|null
+ * @deprecated Will be removed; use get_metadata() instead.
  */
 function get_social_fields($entry)
 {
@@ -254,6 +255,36 @@ function get_social_fields($entry)
         'facebookAppId' => config('services.analytics.facebook_id'),
         'quote' => $socialOverride->quote,
     ];
+}
+
+/**
+ * Get metadata associated with a page or campaign.
+ *
+ * @param  \Contentful\Delivery\Resource\Entry|stdClass $entry
+ * @return array
+ */
+function get_metadata($entry)
+{
+    if ($entry->type !== 'campaign') {
+        $entry = $entry->fields;
+    }
+
+    $image = $entry->metadata->fields->image;
+
+    if (!$image && data_get($entry, 'coverImage')) {
+        $image = $entry->coverImage->url.'?w=1200&h=1200&fm=jpg&fit=fill';
+    }
+
+    $data = [
+        'title' => $entry->metadata->fields->title ?: $entry->title,
+        'type' => 'article',
+        'description' => $entry->metadata->fields->description ?: null,
+        'url' => config('services.phoenix.url').'/us/'.$entry->slug,
+        'facebook_app_id' => config('services.analytics.facebook_id'),
+        'image' => $image ?: 'https://forge.dosomething.org/resources/ds-logo-highres.png',
+    ];
+
+    return $data;
 }
 
 /**

--- a/resources/views/layouts/master.blade.php
+++ b/resources/views/layouts/master.blade.php
@@ -8,6 +8,10 @@
     <meta name="csrf-token" content="{{ csrf_token() }}">
     <title>{{ $pageTitle or 'Let\'s Do this!' }} | DoSomething.org</title>
 
+    @if(isset($metadata))
+        @include('partials.metadata')
+    @endif
+
     <link rel="preload" href="{{ elixir('vendors~app.js', 'next/assets') }}" as="script" />
     <link rel="preload" href="{{ elixir('app.js', 'next/assets') }}" as="script" />
 

--- a/resources/views/partials/metadata.blade.php
+++ b/resources/views/partials/metadata.blade.php
@@ -1,0 +1,24 @@
+@if ($metadata['description'])
+    <meta name="description" content="{{ $metadata['description'] }}">
+@endif
+
+{{-- Twitter Card data --}}
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="{{ $metadata['title'] }}">
+@if ($metadata['description'])
+    <meta name="twitter:description" content="{{ $metadata['description'] }}">
+@endif
+<meta name="twitter:site" content="@dosomething">
+<meta name="twitter:creator" content="@dosomething">
+<meta name="twitter:image" content="{{ $metadata['image'] }}">
+
+{{-- Open Graph data --}}
+<meta property="og:title" content="{{ $metadata['title'] }}" />
+<meta property="og:type" content="article" />
+@if ($metadata['description'])
+    <meta property="og:description" content="{{ $metadata['description'] }}" />
+@endif
+<meta property="og:url" content="{{ $metadata['url'] }}" />
+<meta property="og:site_name" content="DoSomething.org" />
+<meta property="og:image" content="{{ $metadata['image'] }}" />
+<meta property="fb:admins" content="{{ $metadata['facebook_app_id'] }}" />


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR adds support on the Phoenix side for campaign and page `metadata`, which will help with SEO and also help simplify how we add social overrides to aforementioned content. Our current `socialOverrides` approach is a bit convoluted and not used much and/or not used well.

This new `metadata` support will ensure that a basic level of SEO is added to campaigns and pages, but will also allow for overriding certain items when necessary via an upcoming new `metadata` content type that can be referenced on a campaign or page.

### Any background context you want to provide?

This only adds support on the Phoenix side... I have an upcoming PR which will provide a migration to add the `metadata` content type to Contentful, as well as updating the `Metadata` entity to pull from Contentful. The items in the entity are currently just placeholder but end up providing suitable defaults for the meta tags on a page. That being said, lets hold off to merge this util the content type migration is also available to run 💃 

### What are the relevant tickets/cards?

Refs [Pivotal ID #159468120](https://www.pivotaltracker.com/story/show/159468120)

### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.
