### PR TITLE
Remove voter reg from account query

### DIFF
--- a/resources/assets/components/pages/AccountPage/AccountQuery.js
+++ b/resources/assets/components/pages/AccountPage/AccountQuery.js
@@ -14,7 +14,6 @@ const ACCOUNT_QUERY = gql`
       mobile
       birthdate
       email
-      voterRegistrationStatus
     }
   }
 `;


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR removes the request for the `voterRegistrationStatus` from the graphql `AccountQuery` for the user account page.

### Any background context you want to provide?
The schema on this field needs updating which was causing some errors, and the voter registration status feature is not live yet anyways.

Error: `Expected a value of type "VoterRegistrationStatus" but received: UNREGISTERED
`


### What are the relevant tickets/cards?

[Slack conversation](https://dosomething.slack.com/archives/C2BPA7M8F/p1539801422000100)