### PR TITLE
Update to add unique key for iterator and remove console warning.

### DIFF
--- a/resources/assets/components/pages/GeneralPage/GeneralPage.js
+++ b/resources/assets/components/pages/GeneralPage/GeneralPage.js
@@ -101,9 +101,8 @@ const GeneralPage = props => {
           {authors.length ? (
             <ul className="general-page__author-bios">
               {authors.map(author => (
-                <li className="padding-vertical-md">
+                <li className="padding-vertical-md" key={author.id}>
                   <AuthorBio
-                    key={author.id}
                     {...withoutNulls(author.fields)}
                     photo={contentfulImageUrl(
                       author.fields.photo,


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR moves the `key` property to the list item so React stops warning about the iterator not having a unique key (I had placed it on the wrong element 🤦‍♂️ )

### What are the relevant tickets/cards?

🌵 

### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.