### PR TITLE
Gallery Block - Items Per Row

### DIFF
--- a/app/Entities/GalleryBlock.php
+++ b/app/Entities/GalleryBlock.php
@@ -19,6 +19,7 @@ class GalleryBlock extends Entity implements JsonSerializable
             'fields' => [
                 'title' => $this->title,
                 'blocks' => $this->parseBlocks($this->blocks),
+                'itemsPerRow' => $this->itemsPerRow,
             ],
         ];
     }

--- a/contentful/content-types/galleryBlock.js
+++ b/contentful/content-types/galleryBlock.js
@@ -1,6 +1,6 @@
 module.exports = function(migration) {
   const galleryBlock = migration
-    .createContentType('galleryBlock')
+    .editContentType('galleryBlock')
     .name('Gallery Block')
     .description('Displays a gallery of referenced entries')
     .displayField('internalTitle');

--- a/contentful/content-types/galleryBlock.js
+++ b/contentful/content-types/galleryBlock.js
@@ -41,4 +41,21 @@ module.exports = function(migration) {
     })
     .required(true)
     .localized(false);
+
+  galleryBlock
+    .createField('itemsPerRow')
+    .name('Items Per Row')
+    .type('Integer')
+    .validations([
+      {
+        in: [2, 3, 4],
+      },
+    ])
+    .required(true)
+    .localized(false);
+
+  galleryBlock.changeEditorInterface('galleryBlock', 'radio', {
+    helpText:
+      'The maximum number of items in a single row when viewing the gallery in a large display. (small screens are limited to one per row).',
+  });
 };

--- a/contentful/content-types/galleryBlock.js
+++ b/contentful/content-types/galleryBlock.js
@@ -56,6 +56,6 @@ module.exports = function(migration) {
 
   galleryBlock.changeEditorInterface('itemsPerRow', 'radio', {
     helpText:
-      'The maximum number of items in a single row when viewing the gallery in a large display. (small screens are limited to one per row).',
+      'The maximum number of items in a single row when viewing the gallery in a large display.',
   });
 };

--- a/contentful/content-types/galleryBlock.js
+++ b/contentful/content-types/galleryBlock.js
@@ -1,6 +1,6 @@
 module.exports = function(migration) {
   const galleryBlock = migration
-    .editContentType('galleryBlock')
+    .createContentType('galleryBlock')
     .name('Gallery Block')
     .description('Displays a gallery of referenced entries')
     .displayField('internalTitle');

--- a/contentful/content-types/galleryBlock.js
+++ b/contentful/content-types/galleryBlock.js
@@ -54,7 +54,7 @@ module.exports = function(migration) {
     .required(true)
     .localized(false);
 
-  galleryBlock.changeEditorInterface('galleryBlock', 'radio', {
+  galleryBlock.changeEditorInterface('itemsPerRow', 'radio', {
     helpText:
       'The maximum number of items in a single row when viewing the gallery in a large display. (small screens are limited to one per row).',
   });

--- a/resources/assets/components/blocks/GalleryBlock/GalleryBlock.js
+++ b/resources/assets/components/blocks/GalleryBlock/GalleryBlock.js
@@ -20,6 +20,7 @@ const renderBlock = block => {
 const galleryTypes = ['duo', 'triad', 'quartet'];
 
 const GalleryBlock = ({ title, blocks, itemsPerRow }) => {
+  // Subtract 2 from itemsPerRow to map properly to the galleryTypes indices (see propTypes).
   const galleryType = galleryTypes[itemsPerRow - 2];
 
   return (

--- a/resources/assets/components/blocks/GalleryBlock/GalleryBlock.js
+++ b/resources/assets/components/blocks/GalleryBlock/GalleryBlock.js
@@ -34,7 +34,7 @@ const GalleryBlock = ({ title, blocks, itemsPerRow }) => {
 GalleryBlock.propTypes = {
   title: PropTypes.string,
   blocks: PropTypes.arrayOf(PropTypes.object).isRequired,
-  itemsPerRow: PropTypes.number.isRequired,
+  itemsPerRow: PropTypes.oneOf([2, 3, 4]).isRequired,
 };
 
 GalleryBlock.defaultProps = {

--- a/resources/assets/components/blocks/GalleryBlock/GalleryBlock.js
+++ b/resources/assets/components/blocks/GalleryBlock/GalleryBlock.js
@@ -17,17 +17,24 @@ const renderBlock = block => {
   }
 };
 
-const GalleryBlock = ({ title, blocks }) => (
-  <div className="gallery-block">
-    {title ? <h1>{title}</h1> : null}
+const galleryTypes = ['duo', 'triad', 'quartet'];
 
-    <Gallery type="triad">{blocks.map(renderBlock)}</Gallery>
-  </div>
-);
+const GalleryBlock = ({ title, blocks, itemsPerRow }) => {
+  const galleryType = galleryTypes[itemsPerRow - 2];
+
+  return (
+    <div className="gallery-block">
+      {title ? <h1 className="padding-horizontal-md">{title}</h1> : null}
+
+      <Gallery type={galleryType}>{blocks.map(renderBlock)}</Gallery>
+    </div>
+  );
+};
 
 GalleryBlock.propTypes = {
   title: PropTypes.string,
   blocks: PropTypes.arrayOf(PropTypes.object).isRequired,
+  itemsPerRow: PropTypes.number.isRequired,
 };
 
 GalleryBlock.defaultProps = {

--- a/resources/assets/components/blocks/GalleryBlock/GalleryBlock.js
+++ b/resources/assets/components/blocks/GalleryBlock/GalleryBlock.js
@@ -17,11 +17,10 @@ const renderBlock = block => {
   }
 };
 
-const galleryTypes = ['duo', 'triad', 'quartet'];
+const galleryTypes = { '2': 'duo', '3': 'triad', '4': 'quartet' };
 
 const GalleryBlock = ({ title, blocks, itemsPerRow }) => {
-  // Subtract 2 from itemsPerRow to map properly to the galleryTypes indices (see propTypes).
-  const galleryType = galleryTypes[itemsPerRow - 2];
+  const galleryType = galleryTypes[itemsPerRow];
 
   return (
     <div className="gallery-block">

--- a/resources/assets/components/utilities/Gallery/Gallery.js
+++ b/resources/assets/components/utilities/Gallery/Gallery.js
@@ -18,7 +18,7 @@ const Gallery = ({ type, children, className = null }) =>
 Gallery.propTypes = {
   children: PropTypes.arrayOf(PropTypes.element),
   className: PropTypes.string,
-  type: PropTypes.oneOf(['triad', 'quartet']),
+  type: PropTypes.oneOf(['duo', 'triad', 'quartet']),
 };
 
 Gallery.defaultProps = {


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR adds support for setting the number of items per row for Gallery Blocks.

- Moves gallery block migration script to `contentful/content-types` in a new `gallery-block.js` file (you're welcome @weerd 😁)
- Adds `itemsPerRow` field and validations 
- Adds the field to the `GalleryBlock` Entity
- Adjusts the `GalleryBlock` component to use this prop to map to the `type` for the `Gallery` (`2 => 'duo', 3 => 'triad', 4 => 'quartet'`)
- Adds 'duo' as a supported `type` prop to `Gallery`. (The functionality is already supported via [Forge](https://github.com/DoSomething/forge/blob/dev/scss/_modules/_gallery.scss#L172)


### Any background context you want to provide?
~One interesting thing - while adding the new GalleryBlock `itemsPerRow` field to the migration script, I tried running the migration to ensure it had the correct syntax and got the following error:
`Error: "max" validation expected to be "number", but got "null"`
(This seems to have to do with it being of type `Integer` since `"max"` is one of the potential validations)~
~I confirmed that the syntax is indeed correct by adding and configuring the `itemsPerRow` field manually on Contentful and running a migration generation with the `contentful-cli` but no dice -- same error.~
~So this seems to be a Contentful issue and I did indeed find a similar issue referenced [here](https://github.com/contentful/contentful-migration/issues/106) from a while back, although that's closed out now. So while this field is valid, and works (I tested across the whole flow and everything is 👌) as of now at least - this is not a runnable migration. I can throw a question on the community forum to see what's up if you think this is worth investigating.~
I 👏 just 👏 needed 👏 to 👏 update 👏 my 👏 `contentful-cli` 👏 
The migration works wonders. That issue was closed bc it *was* indeed fixed.

Another separate thing --  I wasn't completely sure about how to gracefully map the numeric values set for `itemsPerRow` to the proper Gallery `types`. So I hope my approach is up to par! (Storing the types in an array and subtracting from the values and mapping them as indices)


### What are the relevant tickets/cards?

Refs [Pivotal ID #160603556](https://www.pivotaltracker.com/story/show/160603556)