### PR TITLE
Gallery Block - Advisory board template

### DIFF
--- a/resources/assets/components/Person/Person.js
+++ b/resources/assets/components/Person/Person.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 
 import StaffTemplate from './templates/StaffTemplate/StaffTemplate';
 import BoardMemberTemplate from './templates/BoardMemberTemplate/BoardMemberTemplate';
+import AdvisoryBoardMemberTemplate from './templates/AdvisoryBoardMemberTemplate/AdvisoryBoardMemberTemplate';
 
 const Person = props => {
   switch (props.type) {
@@ -11,6 +12,9 @@ const Person = props => {
 
     case 'board member':
       return <BoardMemberTemplate {...props} />;
+
+    case 'advisory board member':
+      return <AdvisoryBoardMemberTemplate {...props} />;
 
     default:
       return null;

--- a/resources/assets/components/Person/templates/AdvisoryBoardMemberTemplate/AdvisoryBoardMemberTemplate.js
+++ b/resources/assets/components/Person/templates/AdvisoryBoardMemberTemplate/AdvisoryBoardMemberTemplate.js
@@ -1,0 +1,30 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import { Figure } from '../../../Figure';
+import { contentfulImageUrl } from '../../../../helpers';
+import Markdown from '../../../utilities/Markdown/Markdown';
+
+const AdvisoryBoardMemberTemplate = props => {
+  const { name, photo, description } = props;
+
+  return (
+    <Figure
+      alt={`${name}-photo`}
+      image={contentfulImageUrl(photo, '100', '100', 'fill')}
+      alignment="left"
+    >
+      <h3>{name}</h3>
+
+      {description ? <Markdown>{description}</Markdown> : null}
+    </Figure>
+  );
+};
+
+AdvisoryBoardMemberTemplate.propTypes = {
+  name: PropTypes.string.isRequired,
+  photo: PropTypes.string.isRequired,
+  description: PropTypes.string.isRequired,
+};
+
+export default AdvisoryBoardMemberTemplate;


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR adds an Advisory Board Template for the `Person` component so we can replicate the [Ashes advisory board gallery](https://www.dosomething.org/us/about/advisory-board).

### Any background context you want to provide?
Still using the pretty static naming as we work through the various gallery variations.
@lkpttn hates this formatting.

### What are the relevant tickets/cards?

Refs [Pivotal ID #160603556](https://www.pivotaltracker.com/story/show/160603556)

### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.
* [x] Added screenshot to PR description of related front-end updates on **small** screens.
* [x] Added screenshot to PR description of related front-end updates on **medium** screens.
* [x] Added screenshot to PR description of related front-end updates on **large** screens.

![image](https://user-images.githubusercontent.com/12417657/47238520-8098c300-d3b0-11e8-8d04-db482d6347cf.png)

![image](https://user-images.githubusercontent.com/12417657/47238608-bb9af680-d3b0-11e8-917f-a007d6f17f8b.png)


![image](https://user-images.githubusercontent.com/12417657/47238554-97d7b080-d3b0-11e8-9151-4cdbc8462a09.png)

