### PR TITLE
Page Cover Image Field Contentful Migration

### DIFF
--- a/contentful/migrations/2018_10_22_001_add_cover_image_field_to_page.js
+++ b/contentful/migrations/2018_10_22_001_add_cover_image_field_to_page.js
@@ -13,6 +13,6 @@ module.exports = function(migration) {
   page.moveField('coverImage').beforeField('content');
 
   page.changeEditorInterface('coverImage', 'assetLinkEditor', {
-    helpText: 'The cover Image will display on the page before the content',
+    helpText: 'The cover image will display on the page before the content.',
   });
 };

--- a/contentful/migrations/2018_10_22_001_add_cover_image_field_to_page.js
+++ b/contentful/migrations/2018_10_22_001_add_cover_image_field_to_page.js
@@ -1,0 +1,18 @@
+module.exports = function(migration) {
+  const page = migration.editContentType('page');
+
+  page
+    .createField('coverImage')
+    .name('Cover Image')
+    .type('Link')
+    .linkType('Asset')
+    .validations([{ linkMimetypeGroup: ['image'] }])
+    .required(false)
+    .localized(false);
+
+  page.moveField('coverImage').beforeField('content');
+
+  page.changeEditorInterface('coverImage', 'assetLinkEditor', {
+    helpText: 'The cover Image will display on the page before the content',
+  });
+};


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR adds a Contentful Migration script which adds a `coverImage` field to the Page Content Type.

### What are the relevant tickets/cards?

Refs [Pivotal ID #161386896](https://www.pivotaltracker.com/story/show/161386896)

![image](https://user-images.githubusercontent.com/12417657/47302064-8a0f6e80-d5ee-11e8-836a-77e465d57c23.png)
