### PR TITLE
Add support for Page Cover Image field

### DIFF
--- a/app/Entities/Page.php
+++ b/app/Entities/Page.php
@@ -40,6 +40,10 @@ class Page extends Entity implements JsonSerializable
                 'slug' => $this->slug,
                 'metadata' => $this->metadata ? new Metadata($this->metadata->entry) : null,
                 'authors' => $this->parseBlocks($this->authors),
+                'coverImage' => [
+                    'description' => $this->coverImage ? $this->coverImage->getDescription() : '',
+                    'url' => get_image_url($this->coverImage),
+                ],
                 'content' => $this->content,
                 'sidebar' => $this->parseBlocks($this->sidebar),
                 'blocks' => $this->parseBlocks($this->blocks),


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR adds the new Page `coverImage` field to the Page Entity JSON serializer.

### Any background context you want to provide?
The format is copied from the Campaign [`coverImage` field](https://github.com/DoSomething/phoenix-next/blob/03a3b0200d1c26c1b005dad87cd225d7ea32fcb0/app/Entities/Campaign.php#L123) aside from the `landscapeUrl` which I figured we wouldn't need.

### What are the relevant tickets/cards?

Refs [Pivotal ID #161386896](https://www.pivotaltracker.com/story/show/161386896)
#1150 