### PR TITLE
Add cover image

### DIFF
--- a/resources/assets/components/pages/GeneralPage/GeneralPage.js
+++ b/resources/assets/components/pages/GeneralPage/GeneralPage.js
@@ -5,6 +5,7 @@ import PropTypes from 'prop-types';
 import classnames from 'classnames';
 
 import Enclosure from '../../Enclosure';
+import LazyImage from '../../utilities/LazyImage';
 import Byline from '../../utilities/Byline/Byline';
 import ContentfulEntry from '../../ContentfulEntry';
 import AuthorBio from '../../utilities/Author/AuthorBio';
@@ -26,6 +27,7 @@ const GeneralPage = props => {
     authors,
     title,
     subTitle,
+    coverImage,
     content,
     sidebar,
     blocks,
@@ -65,6 +67,14 @@ const GeneralPage = props => {
               </div>
             ) : null}
           </div>
+
+          {coverImage.url ? (
+            <LazyImage
+              className="padding-vertical-md margin-horizontal-auto"
+              alt={coverImage.description || 'Page Cover Image'}
+              src={contentfulImageUrl(coverImage.url, 1440, 620)}
+            />
+          ) : null}
 
           {content ? (
             <div className={classnames({ row: sidebar.length })}>
@@ -125,6 +135,10 @@ GeneralPage.propTypes = {
   authors: PropTypes.arrayOf(PropTypes.object),
   title: PropTypes.string.isRequired,
   subTitle: PropTypes.string,
+  coverImage: PropTypes.shape({
+    url: PropTypes.string,
+    description: PropTypes.string,
+  }),
   content: PropTypes.string,
   sidebar: PropTypes.arrayOf(PropTypes.object),
   blocks: PropTypes.arrayOf(PropTypes.object).isRequired,
@@ -133,6 +147,7 @@ GeneralPage.propTypes = {
 
 GeneralPage.defaultProps = {
   authors: [],
+  coverImage: {},
   content: null,
   sidebar: [],
   subTitle: null,


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR adds the optional Cover Image prop to content pages `GeneralPage` and outputs the Cover Image in landscape format.

### Any background context you want to provide?
A couple of things I did which are hopefully correct:
- I omitted to pass a format option to the `contentful_image_url` helper, allowing editors the discretion of choosing images that work well, without any cropping on our part.
- used a `LazyImage` here for a more graceful image load
- set the `alt` attribute to the assets `description`, defaulting to `'Page Cover Image'`
- placed the Cover Image *under* the horizontal rule. (should it be on top instead? As more of a heading to the article?)



### What are the relevant tickets/cards?

Refs [Pivotal ID #161386896](https://www.pivotaltracker.com/story/show/161386896)

### Checklist

* [ ] Documentation added for new features/changed endpoints. (*will add post merge*)
* [ ] Added appropriate feature/unit tests.
* [x] Added screenshot to PR description of related front-end updates on **small** screens.
* [x] Added screenshot to PR description of related front-end updates on **medium** screens.
* [x] Added screenshot to PR description of related front-end updates on **large** screens.


![image](https://user-images.githubusercontent.com/12417657/47316534-5eec4580-d615-11e8-9fad-17e0a4da0d32.png)

![image](https://user-images.githubusercontent.com/12417657/47316743-d0c48f00-d615-11e8-934c-ec79a2fa44fb.png)


![image](https://user-images.githubusercontent.com/12417657/47316590-83482200-d615-11e8-841c-cf5efcf022ce.png)


(Here's how it could look on top of the rule:)
![image](https://user-images.githubusercontent.com/12417657/47316820-02d5f100-d616-11e8-9415-89a416133090.png)
