### PR TITLE
Content Block Gallery Template

### DIFF
--- a/app/Entities/ContentBlock.php
+++ b/app/Entities/ContentBlock.php
@@ -25,7 +25,7 @@ class ContentBlock extends Entity implements JsonSerializable
                     'url' => get_image_url($this->image),
                     'description' => $this->image ? $this->image->getDescription() : null,
                 ],
-                'imageAlignment' => $this->imageAlignment ? strtolower($this->imageAlignment) : null,
+                'imageAlignment' => $this->imageAlignment ? strtolower($this->imageAlignment) : 'right',
                 'additionalContent' => $this->additionalContent,
             ],
         ];

--- a/app/Entities/ContentBlock.php
+++ b/app/Entities/ContentBlock.php
@@ -21,7 +21,10 @@ class ContentBlock extends Entity implements JsonSerializable
                 'title' => $this->title,
                 'subTitle' => $this->subTitle,
                 'content' => $this->content,
-                'image' => get_image_url($this->image),
+                'image' => [
+                    'url' => get_image_url($this->image),
+                    'description' => $this->image ? $this->image->getDescription() : null,
+                ],
                 'imageAlignment' => $this->imageAlignment ? strtolower($this->imageAlignment) : null,
                 'additionalContent' => $this->additionalContent,
             ],

--- a/contentful/content-types/galleryBlock.js
+++ b/contentful/content-types/galleryBlock.js
@@ -34,7 +34,7 @@ module.exports = function(migration) {
       type: 'Link',
       validations: [
         {
-          linkContentType: ['person', 'campaign', 'page'],
+          linkContentType: ['person', 'campaign', 'page', 'contentBlock'],
         },
       ],
       linkType: 'Entry',

--- a/resources/assets/components/blocks/ContentBlock/ContentBlock.js
+++ b/resources/assets/components/blocks/ContentBlock/ContentBlock.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import requiredIf from 'react-required-if';
 
 import { Figure } from '../../Figure';
 import SectionHeader from '../../SectionHeader';
@@ -45,13 +46,13 @@ ContentBlock.propTypes = {
     url: PropTypes.string,
     description: PropTypes.string,
   }).isRequired,
-  imageAlignment: PropTypes.string,
+  imageAlignment: requiredIf(PropTypes.string, props => props.image.url),
   superTitle: PropTypes.string,
   title: PropTypes.string,
 };
 
 ContentBlock.defaultProps = {
-  imageAlignment: 'right',
+  imageAlignment: null,
   superTitle: null,
   title: null,
 };

--- a/resources/assets/components/blocks/ContentBlock/ContentBlock.js
+++ b/resources/assets/components/blocks/ContentBlock/ContentBlock.js
@@ -22,7 +22,7 @@ const ContentBlock = props => {
       ) : null}
 
       <div className="margin-horizontal-md">
-        {image ? (
+        {image.url ? (
           <Figure
             image={contentfulImageUrl(image.url, '600', '600', 'fill')}
             alt={image.description || 'content-block'}

--- a/resources/assets/components/blocks/ContentBlock/ContentBlock.js
+++ b/resources/assets/components/blocks/ContentBlock/ContentBlock.js
@@ -24,8 +24,8 @@ const ContentBlock = props => {
       <div className="margin-horizontal-md">
         {image ? (
           <Figure
-            image={contentfulImageUrl(image, '600', '600', 'fill')}
-            alt="content-block"
+            image={contentfulImageUrl(image.url, '600', '600', 'fill')}
+            alt={image.description || 'content-block'}
             alignment={`${imageAlignment}-collapse`}
             size="one-third"
           >
@@ -41,14 +41,16 @@ const ContentBlock = props => {
 
 ContentBlock.propTypes = {
   content: PropTypes.string.isRequired,
-  image: PropTypes.string,
+  image: PropTypes.shape({
+    url: PropTypes.string,
+    description: PropTypes.string,
+  }).isRequired,
   imageAlignment: PropTypes.string,
   superTitle: PropTypes.string,
   title: PropTypes.string,
 };
 
 ContentBlock.defaultProps = {
-  image: null,
   imageAlignment: 'right',
   superTitle: null,
   title: null,

--- a/resources/assets/components/blocks/ContentBlock/ContentBlock.test.js
+++ b/resources/assets/components/blocks/ContentBlock/ContentBlock.test.js
@@ -4,17 +4,19 @@ import { shallowToJson } from 'enzyme-to-json';
 
 import ContentBlock from './ContentBlock';
 
+const emptyImage = { url: null, description: null };
+const image = { url: 'image.com', description: 'cool image of image.com' };
+
 const props = {
   superTitle: 'Test Super Title',
   title: 'Test Title',
   content: 'Test Content',
+  image: emptyImage,
 };
-
-const image = { image: 'image.com' };
 
 describe('ContentBlock component', () => {
   test('is rendered with the proper child components when image is set', () => {
-    const wrapper = shallow(<ContentBlock {...props} {...image} />);
+    const wrapper = shallow(<ContentBlock {...props} image={image} />);
 
     expect(wrapper.find('SectionHeader').length).toEqual(1);
     expect(wrapper.find('Figure').length).toEqual(1);
@@ -25,7 +27,7 @@ describe('ContentBlock component', () => {
 
   test("does not include SectionHeader when there's no title", () => {
     const wrapper = shallow(
-      <ContentBlock {...props} {...image} title={undefined} />,
+      <ContentBlock {...props} image={image} title={undefined} />,
     );
 
     expect(wrapper.find('SectionHeader').length).toEqual(0);
@@ -43,23 +45,25 @@ describe('ContentBlock component', () => {
 
   test('it renders the correct alignment class for "left" and "right" image props', () => {
     let wrapper = shallow(
-      <ContentBlock {...props} {...image} imageAlignment="left" />,
+      <ContentBlock {...props} image={image} imageAlignment="left" />,
     );
     expect(wrapper.find('Figure').props().alignment).toEqual('left-collapse');
 
     wrapper = shallow(
-      <ContentBlock {...props} {...image} imageAlignment="right" />,
+      <ContentBlock {...props} image={image} imageAlignment="right" />,
     );
     expect(wrapper.find('Figure').props().alignment).toEqual('right-collapse');
   });
 
   test('it defaults to "right" image alignment', () => {
-    const wrapper = shallow(<ContentBlock {...props} {...image} />);
+    const wrapper = shallow(<ContentBlock {...props} image={image} />);
     expect(wrapper.find('Figure').props().alignment).toEqual('right-collapse');
   });
 
-  test('it works beautifully with a mere content prop', () => {
-    const wrapper = shallow(<ContentBlock content="hi there" />);
+  test('it works beautifully with a content and empty image prop', () => {
+    const wrapper = shallow(
+      <ContentBlock content="hi there" image={emptyImage} />,
+    );
 
     expect(shallowToJson(wrapper)).toMatchSnapshot();
   });

--- a/resources/assets/components/blocks/ContentBlock/ContentBlock.test.js
+++ b/resources/assets/components/blocks/ContentBlock/ContentBlock.test.js
@@ -14,6 +14,7 @@ const props = {
     url: 'image.com',
     description: 'cool image of image.com',
   },
+  imageAlignment: 'right',
 };
 
 describe('ContentBlock component', () => {
@@ -47,16 +48,11 @@ describe('ContentBlock component', () => {
     let wrapper = shallow(<ContentBlock {...props} imageAlignment="left" />);
     expect(wrapper.find('Figure').props().alignment).toEqual('left-collapse');
 
-    wrapper = shallow(<ContentBlock {...props} imageAlignment="right" />);
+    wrapper = shallow(<ContentBlock {...props} />);
     expect(wrapper.find('Figure').props().alignment).toEqual('right-collapse');
   });
 
-  test('it defaults to "right" image alignment', () => {
-    const wrapper = shallow(<ContentBlock {...props} />);
-    expect(wrapper.find('Figure').props().alignment).toEqual('right-collapse');
-  });
-
-  test('it works beautifully with a content and empty image prop', () => {
+  test('it works beautifully with content and an empty image prop', () => {
     const wrapper = shallow(
       <ContentBlock content="hi there" image={emptyImage} />,
     );

--- a/resources/assets/components/blocks/ContentBlock/ContentBlock.test.js
+++ b/resources/assets/components/blocks/ContentBlock/ContentBlock.test.js
@@ -5,18 +5,20 @@ import { shallowToJson } from 'enzyme-to-json';
 import ContentBlock from './ContentBlock';
 
 const emptyImage = { url: null, description: null };
-const image = { url: 'image.com', description: 'cool image of image.com' };
 
 const props = {
   superTitle: 'Test Super Title',
   title: 'Test Title',
   content: 'Test Content',
-  image: emptyImage,
+  image: {
+    url: 'image.com',
+    description: 'cool image of image.com',
+  },
 };
 
 describe('ContentBlock component', () => {
   test('is rendered with the proper child components when image is set', () => {
-    const wrapper = shallow(<ContentBlock {...props} image={image} />);
+    const wrapper = shallow(<ContentBlock {...props} />);
 
     expect(wrapper.find('SectionHeader').length).toEqual(1);
     expect(wrapper.find('Figure').length).toEqual(1);
@@ -26,9 +28,7 @@ describe('ContentBlock component', () => {
   });
 
   test("does not include SectionHeader when there's no title", () => {
-    const wrapper = shallow(
-      <ContentBlock {...props} image={image} title={undefined} />,
-    );
+    const wrapper = shallow(<ContentBlock {...props} title={undefined} />);
 
     expect(wrapper.find('SectionHeader').length).toEqual(0);
 
@@ -36,7 +36,7 @@ describe('ContentBlock component', () => {
   });
 
   test('is rendered with the proper child components when image is not set', () => {
-    const wrapper = shallow(<ContentBlock {...props} />);
+    const wrapper = shallow(<ContentBlock {...props} image={emptyImage} />);
 
     expect(wrapper.find('SectionHeader').length).toEqual(1);
     expect(wrapper.find('Figure').length).toEqual(0);
@@ -44,19 +44,15 @@ describe('ContentBlock component', () => {
   });
 
   test('it renders the correct alignment class for "left" and "right" image props', () => {
-    let wrapper = shallow(
-      <ContentBlock {...props} image={image} imageAlignment="left" />,
-    );
+    let wrapper = shallow(<ContentBlock {...props} imageAlignment="left" />);
     expect(wrapper.find('Figure').props().alignment).toEqual('left-collapse');
 
-    wrapper = shallow(
-      <ContentBlock {...props} image={image} imageAlignment="right" />,
-    );
+    wrapper = shallow(<ContentBlock {...props} imageAlignment="right" />);
     expect(wrapper.find('Figure').props().alignment).toEqual('right-collapse');
   });
 
   test('it defaults to "right" image alignment', () => {
-    const wrapper = shallow(<ContentBlock {...props} image={image} />);
+    const wrapper = shallow(<ContentBlock {...props} />);
     expect(wrapper.find('Figure').props().alignment).toEqual('right-collapse');
   });
 

--- a/resources/assets/components/blocks/ContentBlock/__snapshots__/ContentBlock.test.js.snap
+++ b/resources/assets/components/blocks/ContentBlock/__snapshots__/ContentBlock.test.js.snap
@@ -9,7 +9,7 @@ exports[`ContentBlock component does not include SectionHeader when there's no t
   >
     <Figure
       alignment="right-collapse"
-      alt="content-block"
+      alt="cool image of image.com"
       image="image.com?w=600&h=600&fit=fill"
       imageClassName={null}
       size="one-third"
@@ -41,7 +41,7 @@ exports[`ContentBlock component is rendered with the proper child components whe
   >
     <Figure
       alignment="right-collapse"
-      alt="content-block"
+      alt="cool image of image.com"
       image="image.com?w=600&h=600&fit=fill"
       imageClassName={null}
       size="one-third"
@@ -56,7 +56,7 @@ exports[`ContentBlock component is rendered with the proper child components whe
 </div>
 `;
 
-exports[`ContentBlock component it works beautifully with a mere content prop 1`] = `
+exports[`ContentBlock component it works beautifully with a content and empty image prop 1`] = `
 <div
   className="content-block"
 >

--- a/resources/assets/components/blocks/ContentBlock/__snapshots__/ContentBlock.test.js.snap
+++ b/resources/assets/components/blocks/ContentBlock/__snapshots__/ContentBlock.test.js.snap
@@ -56,7 +56,7 @@ exports[`ContentBlock component is rendered with the proper child components whe
 </div>
 `;
 
-exports[`ContentBlock component it works beautifully with a content and empty image prop 1`] = `
+exports[`ContentBlock component it works beautifully with content and an empty image prop 1`] = `
 <div
   className="content-block"
 >

--- a/resources/assets/components/blocks/GalleryBlock/GalleryBlock.js
+++ b/resources/assets/components/blocks/GalleryBlock/GalleryBlock.js
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 import Person from '../../Person/Person';
 import Gallery from '../../utilities/Gallery/Gallery';
 import PageGalleryItem from '../../utilities/Gallery/templates/PageGalleryItem/PageGalleryItem';
+import ContentBlockGalleryItem from '../../utilities/Gallery/templates/ContentBlockGalleryItem';
 
 const renderBlock = block => {
   switch (block.type) {
@@ -15,6 +16,9 @@ const renderBlock = block => {
 
     case 'page':
       return <PageGalleryItem key={block.id} {...block.fields} />;
+
+    case 'contentBlock':
+      return <ContentBlockGalleryItem key={block.id} {...block.fields} />;
 
     default:
       return null;

--- a/resources/assets/components/blocks/GalleryBlock/GalleryBlock.js
+++ b/resources/assets/components/blocks/GalleryBlock/GalleryBlock.js
@@ -6,7 +6,7 @@ import Gallery from '../../utilities/Gallery/Gallery';
 import PageGalleryItem from '../../utilities/Gallery/templates/PageGalleryItem/PageGalleryItem';
 import ContentBlockGalleryItem from '../../utilities/Gallery/templates/ContentBlockGalleryItem';
 
-const renderBlock = block => {
+const renderBlock = (block, imageAlignment) => {
   switch (block.type) {
     case 'person':
       return <Person key={block.id} {...block.fields} />;
@@ -18,7 +18,13 @@ const renderBlock = block => {
       return <PageGalleryItem key={block.id} {...block.fields} />;
 
     case 'contentBlock':
-      return <ContentBlockGalleryItem key={block.id} {...block.fields} />;
+      return (
+        <ContentBlockGalleryItem
+          key={block.id}
+          {...block.fields}
+          imageAlignment={imageAlignment}
+        />
+      );
 
     default:
       return null;
@@ -27,14 +33,16 @@ const renderBlock = block => {
 
 const galleryTypes = { '2': 'duo', '3': 'triad', '4': 'quartet' };
 
-const GalleryBlock = ({ title, blocks, itemsPerRow }) => {
+const GalleryBlock = ({ title, blocks, imageAlignment, itemsPerRow }) => {
   const galleryType = galleryTypes[itemsPerRow];
 
   return (
     <div className="gallery-block">
       {title ? <h1 className="padding-horizontal-md">{title}</h1> : null}
 
-      <Gallery type={galleryType}>{blocks.map(renderBlock)}</Gallery>
+      <Gallery type={galleryType}>
+        {blocks.map(block => renderBlock(block, imageAlignment))}
+      </Gallery>
     </div>
   );
 };
@@ -42,6 +50,7 @@ const GalleryBlock = ({ title, blocks, itemsPerRow }) => {
 GalleryBlock.propTypes = {
   title: PropTypes.string,
   blocks: PropTypes.arrayOf(PropTypes.object).isRequired,
+  imageAlignment: PropTypes.oneOf(['top', 'left']).isRequired,
   itemsPerRow: PropTypes.oneOf([2, 3, 4]).isRequired,
 };
 

--- a/resources/assets/components/utilities/Gallery/templates/ContentBlockGalleryItem.js
+++ b/resources/assets/components/utilities/Gallery/templates/ContentBlockGalleryItem.js
@@ -2,20 +2,38 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import { Figure } from '../../../Figure';
+import { contentfulImageUrl } from '../../../../helpers';
 import Markdown from '../../../utilities/Markdown/Markdown';
 
-const ContentBlockGalleryItem = ({ title, image, content }) => (
-  <Figure alt={`${title}-photo`} image={image}>
-    <h3>{title}</h3>
+const ContentBlockGalleryItem = ({ title, image, content, imageAlignment }) => {
+  // Image formatting needs to be smaller if they are left-aligned.
+  const imageFormatting = imageAlignment === 'left' ? '100' : '400';
+  // Ensure we don't pass the unsupported 'top' as the alignment prop to Figure.
+  const alignment = imageAlignment === 'top' ? null : imageAlignment;
 
-    {content ? <Markdown>{content}</Markdown> : null}
-  </Figure>
-);
+  return (
+    <Figure
+      alt={`${title}-photo`}
+      image={contentfulImageUrl(
+        image,
+        imageFormatting,
+        imageFormatting,
+        'fill',
+      )}
+      alignment={alignment}
+    >
+      <h3>{title}</h3>
+
+      {content ? <Markdown>{content}</Markdown> : null}
+    </Figure>
+  );
+};
 
 ContentBlockGalleryItem.propTypes = {
   title: PropTypes.string.isRequired,
   image: PropTypes.string,
   content: PropTypes.string.isRequired,
+  imageAlignment: PropTypes.oneOf(['top', 'left']).isRequired,
 };
 
 ContentBlockGalleryItem.defaultProps = {

--- a/resources/assets/components/utilities/Gallery/templates/ContentBlockGalleryItem.js
+++ b/resources/assets/components/utilities/Gallery/templates/ContentBlockGalleryItem.js
@@ -9,6 +9,7 @@ const ContentBlockGalleryItem = ({ title, image, content, imageAlignment }) => {
   // Image formatting needs to be smaller if they are left-aligned.
   const imageFormatting = imageAlignment === 'left' ? '100' : '400';
   // Ensure we don't pass the unsupported 'top' as the alignment prop to Figure.
+  // @TODO (11/01/2018) Update this logic once we refactor the Figure component!
   const alignment = imageAlignment === 'top' ? null : imageAlignment;
 
   return (

--- a/resources/assets/components/utilities/Gallery/templates/ContentBlockGalleryItem.js
+++ b/resources/assets/components/utilities/Gallery/templates/ContentBlockGalleryItem.js
@@ -13,9 +13,9 @@ const ContentBlockGalleryItem = ({ title, image, content, imageAlignment }) => {
 
   return (
     <Figure
-      alt={`${title}-photo`}
+      alt={image.description || `${title}-photo`}
       image={contentfulImageUrl(
-        image,
+        image.url,
         imageFormatting,
         imageFormatting,
         'fill',
@@ -31,13 +31,12 @@ const ContentBlockGalleryItem = ({ title, image, content, imageAlignment }) => {
 
 ContentBlockGalleryItem.propTypes = {
   title: PropTypes.string.isRequired,
-  image: PropTypes.string,
+  image: PropTypes.shape({
+    url: PropTypes.string,
+    description: PropTypes.string,
+  }).isRequired,
   content: PropTypes.string.isRequired,
   imageAlignment: PropTypes.oneOf(['top', 'left']).isRequired,
-};
-
-ContentBlockGalleryItem.defaultProps = {
-  image: null,
 };
 
 export default ContentBlockGalleryItem;

--- a/resources/assets/components/utilities/Gallery/templates/ContentBlockGalleryItem.js
+++ b/resources/assets/components/utilities/Gallery/templates/ContentBlockGalleryItem.js
@@ -1,0 +1,25 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import { Figure } from '../../../Figure';
+import Markdown from '../../../utilities/Markdown/Markdown';
+
+const ContentBlockGalleryItem = ({ title, image, content }) => (
+  <Figure alt={`${title}-photo`} image={image}>
+    <h3>{title}</h3>
+
+    {content ? <Markdown>{content}</Markdown> : null}
+  </Figure>
+);
+
+ContentBlockGalleryItem.propTypes = {
+  title: PropTypes.string.isRequired,
+  image: PropTypes.string,
+  content: PropTypes.string.isRequired,
+};
+
+ContentBlockGalleryItem.defaultProps = {
+  image: null,
+};
+
+export default ContentBlockGalleryItem;


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR adds a new `ContentBlockGalleryItem` component as a (surprise!) Gallery item template for Content Blocks.

It also implements the `imageAlignment` field in the `GalleryBlock` and passes it along to the `ContentBlockGalleryItem` which uses it to determine the images formatting as well as passing the alignment along to `Figure`.

Also adds `contentBlock` as a valid reference item for the Gallery Block `blocks` field.

Additionally, we've updated the `ContentBlock->image` field to be an array of `url` and `description` fields, and updated the `ContentBlock` components/tests to reflect. We've also set a default `imageAlignment` value to the Entity, and updated the component/tests to reflect.

### Any background context you want to provide?
This will serve as the 'general' gallery item for galleries consisting of specific content as opposed to derivatives off of an existing entry/content type.

e.g. on Ashes the galleries on this page:
https://www.dosomething.org/us/about/who-we-are
![image](https://user-images.githubusercontent.com/12417657/47436806-3d09d480-d775-11e8-8a6b-2cb7e06ae901.png)

![image](https://user-images.githubusercontent.com/12417657/47800695-31815500-dd03-11e8-9d61-1781825f031a.png)



I noticed two things about the `ContentBlock->image` field:
- ~we're still formatting the image on the backend (https://github.com/DoSomething/phoenix-next/blob/master/app/Entities/ContentBlock.php#L24), is that something we want to change for the `ContentBlock`?~ We'd need to in order to support general galleries with image alignment! #1165 
- we're returning an image URL directly as opposed to an array of `url` and `description`. We do this for other images as well, so I guess I'm asking if we'd like to start refactoring these `image` fields to all return the array (which adventageously, gives us the `description` field which can be handy for `alt` attributes), *or* if we only care for this image array in specific entities like `Campaign` or `Page`? **Update**: YES.


### What are the relevant tickets/cards?

Refs [Pivotal ID #160603556](https://www.pivotaltracker.com/story/show/160603556)

### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.
* [x] Added screenshot to PR description of related front-end updates on **small** screens.
* [x] Added screenshot to PR description of related front-end updates on **medium** screens.
* [x] Added screenshot to PR description of related front-end updates on **large** screens.


### Screenshots
#### Top aligned image gallery
- [**Desktop**](https://user-images.githubusercontent.com/12417657/47393890-dd68e600-d6ee-11e8-8d31-7530128d735b.png)

- [**Tablet**](https://user-images.githubusercontent.com/12417657/47393925-fb364b00-d6ee-11e8-970e-580ffda3676c.png)

- [**Mobile**](https://user-images.githubusercontent.com/12417657/47393978-2de04380-d6ef-11e8-85a1-ee06ab6cc0c9.png)



#### Left aligned image gallery
- [**Desktop**](https://user-images.githubusercontent.com/12417657/47800854-61305d00-dd03-11e8-8628-6ee9b7a181a9.png)

- [**Tablet**](https://user-images.githubusercontent.com/12417657/47800884-74432d00-dd03-11e8-92aa-a66fe11b89b4.png)

- [**Mobile**](https://user-images.githubusercontent.com/12417657/47800951-92a92880-dd03-11e8-804e-a08be3922a6f.png)