### PR TITLE
Campaign Gallery Item Template

### DIFF
--- a/resources/assets/components/blocks/GalleryBlock/GalleryBlock.js
+++ b/resources/assets/components/blocks/GalleryBlock/GalleryBlock.js
@@ -5,6 +5,7 @@ import Person from '../../Person/Person';
 import Gallery from '../../utilities/Gallery/Gallery';
 import PageGalleryItem from '../../utilities/Gallery/templates/PageGalleryItem/PageGalleryItem';
 import ContentBlockGalleryItem from '../../utilities/Gallery/templates/ContentBlockGalleryItem';
+import CampaignGalleryItem from '../../utilities/Gallery/templates/CampaignGalleryItem/CampaignGalleryItem';
 
 const renderBlock = (block, imageAlignment) => {
   switch (block.type) {
@@ -12,7 +13,7 @@ const renderBlock = (block, imageAlignment) => {
       return <Person key={block.id} {...block.fields} />;
 
     case 'campaign':
-      return null;
+      return <CampaignGalleryItem key={block.id} {...block} />;
 
     case 'page':
       return <PageGalleryItem key={block.id} {...block.fields} />;

--- a/resources/assets/components/utilities/Gallery/templates/CampaignGalleryItem/CampaignGalleryItem.js
+++ b/resources/assets/components/utilities/Gallery/templates/CampaignGalleryItem/CampaignGalleryItem.js
@@ -7,7 +7,10 @@ import { contentfulImageUrl } from '../../../../../helpers';
 import './campaign-gallery-item.scss';
 
 const CampaignGalleryItem = ({ title, tagline, coverImage, slug }) => (
-  <a className="page-gallery-item display-block" href={`/us/campaigns/${slug}`}>
+  <a
+    className="campaign-gallery-item display-block"
+    href={`/us/campaigns/${slug}`}
+  >
     <Figure
       alt={`${coverImage.description || title}-photo`}
       image={contentfulImageUrl(coverImage.url, '400', '400', 'fill')}

--- a/resources/assets/components/utilities/Gallery/templates/CampaignGalleryItem/CampaignGalleryItem.js
+++ b/resources/assets/components/utilities/Gallery/templates/CampaignGalleryItem/CampaignGalleryItem.js
@@ -1,0 +1,32 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import { Figure } from '../../../../Figure';
+import { contentfulImageUrl } from '../../../../../helpers';
+
+import './campaign-gallery-item.scss';
+
+const CampaignGalleryItem = ({ title, tagline, coverImage, slug }) => (
+  <a className="page-gallery-item display-block" href={`/us/campaigns/${slug}`}>
+    <Figure
+      alt={`${coverImage.description || title}-photo`}
+      image={contentfulImageUrl(coverImage.url, '400', '400', 'fill')}
+    >
+      <h3>{title}</h3>
+
+      {tagline ? <p className="description">{tagline}</p> : null}
+    </Figure>
+  </a>
+);
+
+CampaignGalleryItem.propTypes = {
+  title: PropTypes.string.isRequired,
+  tagline: PropTypes.string.isRequired,
+  coverImage: PropTypes.shape({
+    url: PropTypes.string,
+    description: PropTypes.string,
+  }).isRequired,
+  slug: PropTypes.string.isRequired,
+};
+
+export default CampaignGalleryItem;

--- a/resources/assets/components/utilities/Gallery/templates/CampaignGalleryItem/campaign-gallery-item.scss
+++ b/resources/assets/components/utilities/Gallery/templates/CampaignGalleryItem/campaign-gallery-item.scss
@@ -1,0 +1,7 @@
+@import '../../../../../scss/next-toolbox.scss';
+
+.page-gallery-item {
+  .description {
+    font-weight: $weight-normal;
+  }
+}

--- a/resources/assets/components/utilities/Gallery/templates/CampaignGalleryItem/campaign-gallery-item.scss
+++ b/resources/assets/components/utilities/Gallery/templates/CampaignGalleryItem/campaign-gallery-item.scss
@@ -1,6 +1,6 @@
 @import '../../../../../scss/next-toolbox.scss';
 
-.page-gallery-item {
+.campaign-gallery-item {
   .description {
     font-weight: $weight-normal;
   }


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR adds a `CampaignGalleryItem` component as a template for Gallery Items of type `campaign`.

### Any background context you want to provide?
This component is virtually identical to the [`PageGalleryItem` component](https://github.com/DoSomething/phoenix-next/blob/master/resources/assets/components/utilities/Gallery/templates/PageGalleryItem/PageGalleryItem.js) template, (aside from the link (it has the `/campaigns` prefix)). I do know @weerd had in mind to eventually consolidate these into a more abstract one.
Worth doing now? Or should we merge this and tackle that later?

### What are the relevant tickets/cards?

Refs [Pivotal ID #160603556](https://www.pivotaltracker.com/story/show/160603556)

### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.
* [x] Added screenshot to PR description of related front-end updates on **small** screens.
* [x] Added screenshot to PR description of related front-end updates on **medium** screens.
* [x] Added screenshot to PR description of related front-end updates on **large** screens.

### Screenshots
- [**Desktop**](https://user-images.githubusercontent.com/12417657/47503636-96870780-d838-11e8-925a-c8060756f7ec.png)

- [**Tablet**](https://user-images.githubusercontent.com/12417657/47503780-ec5baf80-d838-11e8-9a8f-e41c4016f042.png)

- [**Mobile**](https://user-images.githubusercontent.com/12417657/47503891-21680200-d839-11e8-9fa0-5d6708015964.png)

