### PR TITLE
Dynamic Source Token for Link Action

### DIFF
--- a/resources/assets/components/actions/LinkAction/LinkActionContainer.js
+++ b/resources/assets/components/actions/LinkAction/LinkActionContainer.js
@@ -1,17 +1,19 @@
 import { connect } from 'react-redux';
 
 import LinkAction from './LinkAction';
+import { withoutNulls } from '../../../helpers';
 import { getUserId } from '../../../selectors/user';
 
 /**
  * Provide state from the Redux store as props for this component.
  */
-const mapStateToProps = state => ({
-  userId: getUserId(state),
-  campaignId: state.campaign.legacyCampaignId,
-  campaignRunId: state.campaign.legacyCampaignRunId,
-  source: state.user.source || undefined,
-});
+const mapStateToProps = state =>
+  withoutNulls({
+    userId: getUserId(state),
+    campaignId: state.campaign.legacyCampaignId,
+    campaignRunId: state.campaign.legacyCampaignRunId,
+    source: state.user.source,
+  });
 
 // Export the container component.
 export default connect(mapStateToProps)(LinkAction);

--- a/resources/assets/components/actions/LinkAction/LinkActionContainer.js
+++ b/resources/assets/components/actions/LinkAction/LinkActionContainer.js
@@ -10,6 +10,7 @@ const mapStateToProps = state => ({
   userId: getUserId(state),
   campaignId: state.campaign.legacyCampaignId,
   campaignRunId: state.campaign.legacyCampaignRunId,
+  source: state.user.source || undefined,
 });
 
 // Export the container component.

--- a/resources/assets/components/actions/LinkAction/templates/CtaTemplate.js
+++ b/resources/assets/components/actions/LinkAction/templates/CtaTemplate.js
@@ -4,10 +4,10 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import Card from '../../../utilities/Card/Card';
-import { isExternal } from '../../../../helpers';
 import Button from '../../../utilities/Button/Button';
 import Markdown from '../../../utilities/Markdown/Markdown';
 import { trackPuckEvent } from '../../../../helpers/analytics';
+import { isExternal, dynamicString } from '../../../../helpers';
 
 import './cta-template.scss';
 
@@ -16,30 +16,35 @@ const onLinkClick = link => {
   trackPuckEvent('clicked link action', { link });
 };
 
-const CtaTemplate = props => (
-  <Card className="cta-template rounded padded text-centered bg-black dark caps-lock">
-    <h3 className="cta-template__title margin-top-lg">{props.title}</h3>
+const CtaTemplate = ({ title, content, link, buttonText, source }) => {
+  const href = dynamicString(link, {
+    source,
+  });
 
-    <Markdown className="cta-template__content">{props.content}</Markdown>
+  return (
+    <Card className="cta-template rounded padded text-centered bg-black dark caps-lock">
+      <h3 className="cta-template__title margin-top-lg">{title}</h3>
 
-    <Button
-      className="margin-vertical-md"
-      onClick={() => onLinkClick(props.link)}
-    >
-      {props.buttonText}
-    </Button>
-  </Card>
-);
+      <Markdown className="cta-template__content">{content}</Markdown>
+
+      <Button className="margin-vertical-md" onClick={() => onLinkClick(href)}>
+        {buttonText}
+      </Button>
+    </Card>
+  );
+};
 
 CtaTemplate.propTypes = {
   title: PropTypes.string.isRequired,
   content: PropTypes.string.isRequired,
   link: PropTypes.string.isRequired,
   buttonText: PropTypes.string,
+  source: PropTypes.string,
 };
 
 CtaTemplate.defaultProps = {
   buttonText: "Let's do this!",
+  source: 'web',
 };
 
 export default CtaTemplate;

--- a/resources/assets/components/actions/LinkAction/templates/DefaultTemplate.js
+++ b/resources/assets/components/actions/LinkAction/templates/DefaultTemplate.js
@@ -26,6 +26,7 @@ const DefaultTemplate = props => {
     campaignRunId,
     buttonText,
     affiliateLogo,
+    source,
   } = props;
 
   // The affiliate logo specific text is hard-coded for OZY. Though we can set this title
@@ -38,7 +39,7 @@ const DefaultTemplate = props => {
     northstarId: userId, // @TODO: Remove!
     campaignId,
     campaignRunId,
-    source: 'web',
+    source,
   });
 
   // If no content is provided, show as an embed.
@@ -93,6 +94,7 @@ DefaultTemplate.defaultProps = {
   campaignId: null,
   campaignRunId: null,
   userId: null,
+  source: 'web',
 };
 
 DefaultTemplate.propTypes = {
@@ -104,6 +106,7 @@ DefaultTemplate.propTypes = {
   campaignId: PropTypes.string,
   campaignRunId: PropTypes.string,
   userId: PropTypes.string,
+  source: PropTypes.string,
 };
 
 export default DefaultTemplate;


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR pulls the `state.user.source` field as a new `source` prop for the `LinkAction` and uses it as a valid dynamic token for `link`.

The `source` prop in the container defaults to `undefined` if `null`, allowing the default prop to be set as `'web'`, since that was the hardcoded value previously configured.

###  background context you want to provide?
The `user.source` field is set initially in the [`AppServiceProvider`](https://github.com/DoSomething/phoenix-next/blob/master/app/Providers/AppServiceProvider.php#L49), pulled from the `utm_source` query parameter.

This allows us to dynamically source link actions, instead of manually creating separate links, and thus content pages for SMS and WEB. (more deets in the Pivotal ticket.)

To test this, go to https://dosomething-phoenix-de-pr-1162.herokuapp.com/us/testing-dynamic-source and append any `utm_source=` param. The link on the page should have the correct source set based on your input.

Here's the entry https://app.contentful.com/spaces/81iqaqpfd8fy/environments/dev/entries/S5tdCOzMwSa6KI4eegUCG?previousEntries=1RAcQWG72cCCOQiweO0Qg2

### What are the relevant tickets/cards?

Refs [Pivotal ID #161090964](https://www.pivotaltracker.com/story/show/161090964)