### PR TITLE
Gallery Block Image Alignment field

### DIFF
--- a/app/Entities/GalleryBlock.php
+++ b/app/Entities/GalleryBlock.php
@@ -19,6 +19,7 @@ class GalleryBlock extends Entity implements JsonSerializable
             'fields' => [
                 'title' => $this->title,
                 'blocks' => $this->parseBlocks($this->blocks),
+                'imageAlignment' => $this->imageAlignment,
                 'itemsPerRow' => $this->itemsPerRow,
             ],
         ];

--- a/contentful/content-types/galleryBlock.js
+++ b/contentful/content-types/galleryBlock.js
@@ -1,6 +1,6 @@
 module.exports = function(migration) {
   const galleryBlock = migration
-    .createContentType('galleryBlock')
+    .createContentType('galleryBlock2')
     .name('Gallery Block')
     .description('Displays a gallery of referenced entries')
     .displayField('internalTitle');
@@ -43,6 +43,14 @@ module.exports = function(migration) {
     .localized(false);
 
   galleryBlock
+    .createField('imageAlignment')
+    .name('Image Alignment')
+    .type('Symbol')
+    .validations([{ in: ['top', 'left'] }])
+    .required(true)
+    .localized(false);
+
+  galleryBlock
     .createField('itemsPerRow')
     .name('Items Per Row')
     .type('Integer')
@@ -53,6 +61,11 @@ module.exports = function(migration) {
     ])
     .required(true)
     .localized(false);
+
+  galleryBlock.changeEditorInterface('imageAlignment', 'radio', {
+    helpText:
+      "Determines where the gallery item's images are aligned relative to their text.",
+  });
 
   galleryBlock.changeEditorInterface('itemsPerRow', 'radio', {
     helpText:

--- a/contentful/content-types/galleryBlock.js
+++ b/contentful/content-types/galleryBlock.js
@@ -1,6 +1,6 @@
 module.exports = function(migration) {
   const galleryBlock = migration
-    .createContentType('galleryBlock2')
+    .createContentType('galleryBlock')
     .name('Gallery Block')
     .description('Displays a gallery of referenced entries')
     .displayField('internalTitle');


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR updates the Gallery Block content type with a new field called `imageAlignment` 
- adds new field to the content type Contentful migration script
- adds new field to the Gallery Block Entity

### Any background context you want to provide?
This allows the editor to toggle between the two currently existing gallery types - with the image on top of the text or right aligned.

### What are the relevant tickets/cards?

Refs [Pivotal ID #160603556](https://www.pivotaltracker.com/story/show/160603556)
https://www.pivotaltracker.com/story/show/160603556/comments/195829585