### PR TITLE
Content Block Image Formatting

### DIFF
--- a/app/Entities/ContentBlock.php
+++ b/app/Entities/ContentBlock.php
@@ -21,7 +21,7 @@ class ContentBlock extends Entity implements JsonSerializable
                 'title' => $this->title,
                 'subTitle' => $this->subTitle,
                 'content' => $this->content,
-                'image' => get_image_url($this->image, 'square'),
+                'image' => get_image_url($this->image),
                 'imageAlignment' => $this->imageAlignment ? strtolower($this->imageAlignment) : null,
                 'additionalContent' => $this->additionalContent,
             ],

--- a/resources/assets/components/blocks/ContentBlock/ContentBlock.js
+++ b/resources/assets/components/blocks/ContentBlock/ContentBlock.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 
 import { Figure } from '../../Figure';
 import SectionHeader from '../../SectionHeader';
+import { contentfulImageUrl } from '../../../helpers';
 import Markdown from '../../utilities/Markdown/Markdown';
 
 import './content-block.scss';
@@ -23,7 +24,7 @@ const ContentBlock = props => {
       <div className="margin-horizontal-md">
         {image ? (
           <Figure
-            image={image}
+            image={contentfulImageUrl(image, '600', '600', 'fill')}
             alt="content-block"
             alignment={`${imageAlignment}-collapse`}
             size="one-third"

--- a/resources/assets/components/blocks/ContentBlock/__snapshots__/ContentBlock.test.js.snap
+++ b/resources/assets/components/blocks/ContentBlock/__snapshots__/ContentBlock.test.js.snap
@@ -10,7 +10,7 @@ exports[`ContentBlock component does not include SectionHeader when there's no t
     <Figure
       alignment="right-collapse"
       alt="content-block"
-      image="image.com"
+      image="image.com?w=600&h=600&fit=fill"
       imageClassName={null}
       size="one-third"
     >
@@ -42,7 +42,7 @@ exports[`ContentBlock component is rendered with the proper child components whe
     <Figure
       alignment="right-collapse"
       alt="content-block"
-      image="image.com"
+      image="image.com?w=600&h=600&fit=fill"
       imageClassName={null}
       size="one-third"
     >


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR moves the formatting of the `image` field for `ContentBlocks` from the Entity to the component on the front end.

### Any background context you want to provide?
We've started refraining from formatting image URLs on the backend, in favor of leaving it up to the individual components discretion.

This is necessary here so that we can allow General Gallery Blocks which use Content Blocks to be image aligned properly based on the `imageAlignment` setting, since now, the gallery template can format the image small (100/100) or larger (400/400), depending on that image alignment setting for the gallery.

### What are the relevant tickets/cards?

Refs [Pivotal ID #160603556](https://www.pivotaltracker.com/story/show/160603556)
#1157 