### PR TITLE
Affiliate Option Component - Visual Bug

### DIFF
--- a/resources/assets/components/AffiliateOption/AffiliateOption.js
+++ b/resources/assets/components/AffiliateOption/AffiliateOption.js
@@ -21,7 +21,7 @@ class AffiliateOption extends React.Component {
 
   render() {
     return (
-      <div className="form-wrapper affiliate-option">
+      <div className="form-wrapper affiliate-option clear-both">
         <label className="option -checkbox" htmlFor="affiliate_opt_in">
           <input
             type="checkbox"


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR adds a quick fix to a visual bug on the `AffiliateOption` component

### Any background context you want to provide?
On the `MosaicTemplate`, large screens, the affiliate option checkbox appears within the signup button:
<img width="1552" alt="screen shot 2018-10-30 at 4 27 00 pm" src="https://user-images.githubusercontent.com/12417657/47748283-d4cd5e00-dc60-11e8-8593-36c23b22db9c.png">
😕 

After adding a `clear-both` class to `AffiliateOption`:
![image](https://user-images.githubusercontent.com/12417657/47748328-ea428800-dc60-11e8-8271-475a282d7c08.png)
😌 



### What are the relevant tickets/cards?
I'm in the process of switching over all remaining `legacy` template campaigns, and this is one of 'em. (The bug didn't exist on LegacyTemplates)