### PR TITLE
Gallery Styling Updates

### DIFF
--- a/resources/assets/components/Figure/figure.scss
+++ b/resources/assets/components/Figure/figure.scss
@@ -69,5 +69,14 @@
 }
 
 .gallery-block .figure {
-  text-align: left;
+  .figure__body {
+    text-align: left;
+  }
+
+  @include media($small) {
+    // Counteract the margin 0 auto set by Forge since we want the image left-aligned.
+    .figure__media img {
+      margin-left: 0;
+    }
+  }
 }

--- a/resources/assets/components/Figure/figure.scss
+++ b/resources/assets/components/Figure/figure.scss
@@ -67,3 +67,7 @@
     }
   }
 }
+
+.gallery-block .figure {
+  text-align: left;
+}

--- a/resources/assets/components/Figure/figure.scss
+++ b/resources/assets/components/Figure/figure.scss
@@ -71,6 +71,10 @@
 .gallery-block .figure {
   .figure__body {
     text-align: left;
+
+    h4 {
+      font-family: $primary-font-family;
+    }
   }
 
   @include media($small) {

--- a/resources/assets/components/Person/templates/AdvisoryBoardMemberTemplate/AdvisoryBoardMemberTemplate.js
+++ b/resources/assets/components/Person/templates/AdvisoryBoardMemberTemplate/AdvisoryBoardMemberTemplate.js
@@ -14,7 +14,7 @@ const AdvisoryBoardMemberTemplate = props => {
       image={contentfulImageUrl(photo, '100', '100', 'fill')}
       alignment="left"
     >
-      <p className="font-bold">{name}</p>
+      <h4>{name}</h4>
 
       {description ? <Markdown>{description}</Markdown> : null}
     </Figure>

--- a/resources/assets/components/Person/templates/AdvisoryBoardMemberTemplate/AdvisoryBoardMemberTemplate.js
+++ b/resources/assets/components/Person/templates/AdvisoryBoardMemberTemplate/AdvisoryBoardMemberTemplate.js
@@ -14,7 +14,7 @@ const AdvisoryBoardMemberTemplate = props => {
       image={contentfulImageUrl(photo, '100', '100', 'fill')}
       alignment="left"
     >
-      <h3>{name}</h3>
+      <p className="font-bold">{name}</p>
 
       {description ? <Markdown>{description}</Markdown> : null}
     </Figure>

--- a/resources/assets/components/Person/templates/BoardMemberTemplate/BoardMemberTemplate.js
+++ b/resources/assets/components/Person/templates/BoardMemberTemplate/BoardMemberTemplate.js
@@ -13,7 +13,7 @@ const BoardMemberTemplate = props => {
       alt={`${name}-photo`}
       image={contentfulImageUrl(alternatePhoto, '400', '400', 'fill')}
     >
-      <h3>{name}</h3>
+      <p className="font-bold">{name}</p>
 
       {description ? <Markdown>{description}</Markdown> : null}
     </Figure>

--- a/resources/assets/components/Person/templates/BoardMemberTemplate/BoardMemberTemplate.js
+++ b/resources/assets/components/Person/templates/BoardMemberTemplate/BoardMemberTemplate.js
@@ -13,7 +13,7 @@ const BoardMemberTemplate = props => {
       alt={`${name}-photo`}
       image={contentfulImageUrl(alternatePhoto, '400', '400', 'fill')}
     >
-      <p className="font-bold">{name}</p>
+      <h4>{name}</h4>
 
       {description ? <Markdown>{description}</Markdown> : null}
     </Figure>

--- a/resources/assets/components/Person/templates/StaffTemplate/StaffTemplate.js
+++ b/resources/assets/components/Person/templates/StaffTemplate/StaffTemplate.js
@@ -12,23 +12,20 @@ const StaffTemplate = props => {
       alt={`${name}-photo`}
       image={contentfulImageUrl(alternatePhoto, '400', '400', 'fill')}
     >
-      <p>
-        <span className="font-bold">
-          {twitterId ? (
-            <a
-              href={`https://twitter.com/${twitterId}`}
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              {name}
-            </a>
-          ) : (
-            name
-          )}
-        </span>
-        <br />
-        {jobTitle}
-      </p>
+      <h4>
+        {twitterId ? (
+          <a
+            href={`https://twitter.com/${twitterId}`}
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            {name}
+          </a>
+        ) : (
+          name
+        )}
+      </h4>
+      <p>{jobTitle}</p>
     </Figure>
   );
 };

--- a/resources/assets/components/Person/templates/StaffTemplate/StaffTemplate.js
+++ b/resources/assets/components/Person/templates/StaffTemplate/StaffTemplate.js
@@ -12,19 +12,23 @@ const StaffTemplate = props => {
       alt={`${name}-photo`}
       image={contentfulImageUrl(alternatePhoto, '400', '400', 'fill')}
     >
-      <h3>{name}</h3>
       <p>
-        <em>{jobTitle}</em>
+        <span className="font-bold">
+          {twitterId ? (
+            <a
+              href={`https://twitter.com/${twitterId}`}
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              {name}
+            </a>
+          ) : (
+            name
+          )}
+        </span>
+        <br />
+        {jobTitle}
       </p>
-      {twitterId ? (
-        <a
-          href={`https://twitter.com/${twitterId}`}
-          rel="noopener noreferrer"
-          target="_blank"
-        >
-          @{twitterId}
-        </a>
-      ) : null}
     </Figure>
   );
 };

--- a/resources/assets/components/utilities/Gallery/templates/CampaignGalleryItem/CampaignGalleryItem.js
+++ b/resources/assets/components/utilities/Gallery/templates/CampaignGalleryItem/CampaignGalleryItem.js
@@ -13,8 +13,7 @@ const CampaignGalleryItem = ({ title, tagline, coverImage, slug }) => (
       alt={`${coverImage.description || title}-photo`}
       image={contentfulImageUrl(coverImage.url, '400', '400', 'fill')}
     >
-      <span className="font-bold">{title}</span>
-      <br />
+      <h4 className="color-blue">{title}</h4>
       {tagline ? <p className="font-normal">{tagline}</p> : null}
     </Figure>
   </a>

--- a/resources/assets/components/utilities/Gallery/templates/CampaignGalleryItem/CampaignGalleryItem.js
+++ b/resources/assets/components/utilities/Gallery/templates/CampaignGalleryItem/CampaignGalleryItem.js
@@ -13,7 +13,7 @@ const CampaignGalleryItem = ({ title, tagline, coverImage, slug }) => (
       alt={`${coverImage.description || title}-photo`}
       image={contentfulImageUrl(coverImage.url, '400', '400', 'fill')}
     >
-      <h4 className="color-blue">{title}</h4>
+      <h4>{title}</h4>
       {tagline ? <p className="font-normal">{tagline}</p> : null}
     </Figure>
   </a>

--- a/resources/assets/components/utilities/Gallery/templates/CampaignGalleryItem/CampaignGalleryItem.js
+++ b/resources/assets/components/utilities/Gallery/templates/CampaignGalleryItem/CampaignGalleryItem.js
@@ -4,8 +4,6 @@ import PropTypes from 'prop-types';
 import { Figure } from '../../../../Figure';
 import { contentfulImageUrl } from '../../../../../helpers';
 
-import './campaign-gallery-item.scss';
-
 const CampaignGalleryItem = ({ title, tagline, coverImage, slug }) => (
   <a
     className="campaign-gallery-item display-block"
@@ -15,9 +13,9 @@ const CampaignGalleryItem = ({ title, tagline, coverImage, slug }) => (
       alt={`${coverImage.description || title}-photo`}
       image={contentfulImageUrl(coverImage.url, '400', '400', 'fill')}
     >
-      <h3>{title}</h3>
-
-      {tagline ? <p className="description">{tagline}</p> : null}
+      <span className="font-bold">{title}</span>
+      <br />
+      {tagline ? <p className="font-normal">{tagline}</p> : null}
     </Figure>
   </a>
 );

--- a/resources/assets/components/utilities/Gallery/templates/CampaignGalleryItem/campaign-gallery-item.scss
+++ b/resources/assets/components/utilities/Gallery/templates/CampaignGalleryItem/campaign-gallery-item.scss
@@ -1,7 +1,0 @@
-@import '../../../../../scss/next-toolbox.scss';
-
-.campaign-gallery-item {
-  .description {
-    font-weight: $weight-normal;
-  }
-}

--- a/resources/assets/components/utilities/Gallery/templates/ContentBlockGalleryItem.js
+++ b/resources/assets/components/utilities/Gallery/templates/ContentBlockGalleryItem.js
@@ -23,7 +23,7 @@ const ContentBlockGalleryItem = ({ title, image, content, imageAlignment }) => {
       )}
       alignment={alignment}
     >
-      <h3>{title}</h3>
+      <p className="font-bold">{title}</p>
 
       {content ? <Markdown>{content}</Markdown> : null}
     </Figure>

--- a/resources/assets/components/utilities/Gallery/templates/ContentBlockGalleryItem.js
+++ b/resources/assets/components/utilities/Gallery/templates/ContentBlockGalleryItem.js
@@ -23,7 +23,7 @@ const ContentBlockGalleryItem = ({ title, image, content, imageAlignment }) => {
       )}
       alignment={alignment}
     >
-      <p className="font-bold">{title}</p>
+      <h4>{title}</h4>
 
       {content ? <Markdown>{content}</Markdown> : null}
     </Figure>

--- a/resources/assets/components/utilities/Gallery/templates/PageGalleryItem/PageGalleryItem.js
+++ b/resources/assets/components/utilities/Gallery/templates/PageGalleryItem/PageGalleryItem.js
@@ -4,17 +4,15 @@ import PropTypes from 'prop-types';
 import { Figure } from '../../../../Figure';
 import { contentfulImageUrl } from '../../../../../helpers';
 
-import './page-gallery-item.scss';
-
 const PageGalleryItem = ({ title, subTitle, coverImage, slug }) => (
   <a className="page-gallery-item display-block" href={`/us/${slug}`}>
     <Figure
       alt={`${coverImage.description || title}-photo`}
       image={contentfulImageUrl(coverImage.url, '400', '400', 'fill')}
     >
-      <h3>{title}</h3>
-
-      {subTitle ? <p className="description">{subTitle}</p> : null}
+      <span className="font-bold">{title}</span>
+      <br />
+      {subTitle ? <p className="font-normal">{subTitle}</p> : null}
     </Figure>
   </a>
 );

--- a/resources/assets/components/utilities/Gallery/templates/PageGalleryItem/PageGalleryItem.js
+++ b/resources/assets/components/utilities/Gallery/templates/PageGalleryItem/PageGalleryItem.js
@@ -10,7 +10,7 @@ const PageGalleryItem = ({ title, subTitle, coverImage, slug }) => (
       alt={`${coverImage.description || title}-photo`}
       image={contentfulImageUrl(coverImage.url, '400', '400', 'fill')}
     >
-      <h4 className="color-blue">{title}</h4>
+      <h4>{title}</h4>
       {subTitle ? <p className="font-normal">{subTitle}</p> : null}
     </Figure>
   </a>

--- a/resources/assets/components/utilities/Gallery/templates/PageGalleryItem/PageGalleryItem.js
+++ b/resources/assets/components/utilities/Gallery/templates/PageGalleryItem/PageGalleryItem.js
@@ -10,8 +10,7 @@ const PageGalleryItem = ({ title, subTitle, coverImage, slug }) => (
       alt={`${coverImage.description || title}-photo`}
       image={contentfulImageUrl(coverImage.url, '400', '400', 'fill')}
     >
-      <span className="font-bold">{title}</span>
-      <br />
+      <h4 className="color-blue">{title}</h4>
       {subTitle ? <p className="font-normal">{subTitle}</p> : null}
     </Figure>
   </a>

--- a/resources/assets/components/utilities/Gallery/templates/PageGalleryItem/page-gallery-item.scss
+++ b/resources/assets/components/utilities/Gallery/templates/PageGalleryItem/page-gallery-item.scss
@@ -1,7 +1,0 @@
-@import '../../../../../scss/next-toolbox.scss';
-
-.page-gallery-item {
-  .description {
-    font-weight: $weight-normal;
-  }
-}

--- a/resources/assets/scss/base.scss
+++ b/resources/assets/scss/base.scss
@@ -76,6 +76,10 @@ p {
   color: $primary-color !important;
 }
 
+.color-blue {
+  color: $blue !important;
+}
+
 .bg-black {
   background-color: $black !important;
 }

--- a/resources/assets/scss/base.scss
+++ b/resources/assets/scss/base.scss
@@ -76,10 +76,6 @@ p {
   color: $primary-color !important;
 }
 
-.color-blue {
-  color: $blue !important;
-}
-
 .bg-black {
   background-color: $black !important;
 }

--- a/resources/assets/scss/base.scss
+++ b/resources/assets/scss/base.scss
@@ -187,6 +187,10 @@ p {
   font-weight: $weight-bold;
 }
 
+.font-normal {
+  font-weight: normal;
+}
+
 .font-size-lg {
   font-size: $font-large;
 


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR updates the styling/layout of the Gallery templates to align with the [mocks](https://share.goabstract.com/9fbef065-ce9a-49b1-bf1d-a682ff3b9c38)

You can catch the various galleries [on the PR review app](https://dosomething-phoenix-de-pr-1170.herokuapp.com/us/about/our-people)

### Any background context you want to provide?
Essentially, we just add a simple rule to `figure.scss` to ensure `.gallery-block` items have their text `left-align`ed (and that images on small screens are not centered which is quite awkward on top of left aligned content). As well as updating the captions to all be ~bold `<p>`s~ `<h4>`s, and removing some unneeded `scss` files.

One notable change is to the `StaffTemplate` - we're moving the twitter link to be part of the caption as opposed to an explicit link under the description.

Also, added a `font-normal` utility class to accompany the `font-bold`.

### What are the relevant tickets/cards?

Refs [Pivotal ID #160603556](https://www.pivotaltracker.com/story/show/160603556)

### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.
* [x] Added screenshot to PR description of related front-end updates on **small** screens.
* [x] Added screenshot to PR description of related front-end updates on **medium** screens.
* [x] Added screenshot to PR description of related front-end updates on **large** screens.


### Screenshots
- [Small](https://user-images.githubusercontent.com/12417657/47884067-bc4a7880-de05-11e8-8673-47d2dd52fd88.png)

- [Medium](https://user-images.githubusercontent.com/12417657/48008688-26a23800-e0e8-11e8-865c-216ac2ebcf92.png)

- [Large](https://user-images.githubusercontent.com/12417657/48008736-3d488f00-e0e8-11e8-9617-40e70d258c7c.png)

