### PR TITLE
Gallery Block Image Crop Field

### DIFF
--- a/app/Entities/GalleryBlock.php
+++ b/app/Entities/GalleryBlock.php
@@ -19,8 +19,8 @@ class GalleryBlock extends Entity implements JsonSerializable
             'fields' => [
                 'title' => $this->title,
                 'blocks' => $this->parseBlocks($this->blocks),
-                'imageAlignment' => $this->imageAlignment,
                 'itemsPerRow' => $this->itemsPerRow,
+                'imageAlignment' => $this->imageAlignment,
                 'imageCrop' => $this->imageCrop ?: 'fill',
             ],
         ];

--- a/app/Entities/GalleryBlock.php
+++ b/app/Entities/GalleryBlock.php
@@ -21,6 +21,7 @@ class GalleryBlock extends Entity implements JsonSerializable
                 'blocks' => $this->parseBlocks($this->blocks),
                 'imageAlignment' => $this->imageAlignment,
                 'itemsPerRow' => $this->itemsPerRow,
+                'imageCrop' => $this->imageCrop ?: 'fill',
             ],
         ];
     }

--- a/app/Entities/GalleryBlock.php
+++ b/app/Entities/GalleryBlock.php
@@ -21,7 +21,7 @@ class GalleryBlock extends Entity implements JsonSerializable
                 'blocks' => $this->parseBlocks($this->blocks),
                 'itemsPerRow' => $this->itemsPerRow,
                 'imageAlignment' => $this->imageAlignment,
-                'imageCrop' => $this->imageCrop ?: 'fill',
+                'imageFit' => $this->imageFit ?: 'fill',
             ],
         ];
     }

--- a/contentful/content-types/galleryBlock.js
+++ b/contentful/content-types/galleryBlock.js
@@ -81,8 +81,8 @@ module.exports = function(migration) {
   });
 
   galleryBlock.changeEditorInterface('imageFit', 'radio', {
-    helpText: `Controls the cropping method for the gallery images. "Fill" will resize the images to ensure they
-      fit neatly into a square, cropping the image if needed. "Pad" will do the same but will add padding
+    helpText: `Controls the cropping method for the gallery images. 'Fill' will resize the images to ensure they
+      fit neatly into a square, cropping the image if needed. 'Pad' will do the same but will add padding
       to the image instead of cropping it.`,
   });
 };

--- a/contentful/content-types/galleryBlock.js
+++ b/contentful/content-types/galleryBlock.js
@@ -63,8 +63,8 @@ module.exports = function(migration) {
     .localized(false);
 
   galleryBlock
-    .createField('imageCrop')
-    .name('Image Crop')
+    .createField('imageFit')
+    .name('Image Fit')
     .type('Symbol')
     .validations([{ in: ['fill', 'pad'] }])
     .required(false)
@@ -80,7 +80,7 @@ module.exports = function(migration) {
       "Determines where the gallery item's images are aligned relative to their text.",
   });
 
-  galleryBlock.changeEditorInterface('imageCrop', 'radio', {
+  galleryBlock.changeEditorInterface('imageFit', 'radio', {
     helpText: `Controls the cropping method for the gallery images. "Fill" will resize the images to ensure they
       fit neatly into a square, cropping the image if needed. "Pad" will do the same but will add padding
       to the image instead of cropping it.`,

--- a/contentful/content-types/galleryBlock.js
+++ b/contentful/content-types/galleryBlock.js
@@ -43,14 +43,6 @@ module.exports = function(migration) {
     .localized(false);
 
   galleryBlock
-    .createField('imageAlignment')
-    .name('Image Alignment')
-    .type('Symbol')
-    .validations([{ in: ['top', 'left'] }])
-    .required(true)
-    .localized(false);
-
-  galleryBlock
     .createField('itemsPerRow')
     .name('Items Per Row')
     .type('Integer')
@@ -63,6 +55,14 @@ module.exports = function(migration) {
     .localized(false);
 
   galleryBlock
+    .createField('imageAlignment')
+    .name('Image Alignment')
+    .type('Symbol')
+    .validations([{ in: ['top', 'left'] }])
+    .required(true)
+    .localized(false);
+
+  galleryBlock
     .createField('imageCrop')
     .name('Image Crop')
     .type('Symbol')
@@ -70,14 +70,14 @@ module.exports = function(migration) {
     .required(false)
     .localized(false);
 
-  galleryBlock.changeEditorInterface('imageAlignment', 'radio', {
-    helpText:
-      "Determines where the gallery item's images are aligned relative to their text.",
-  });
-
   galleryBlock.changeEditorInterface('itemsPerRow', 'radio', {
     helpText:
       'The maximum number of items in a single row when viewing the gallery in a large display.',
+  });
+
+  galleryBlock.changeEditorInterface('imageAlignment', 'radio', {
+    helpText:
+      "Determines where the gallery item's images are aligned relative to their text.",
   });
 
   galleryBlock.changeEditorInterface('imageCrop', 'radio', {

--- a/contentful/content-types/galleryBlock.js
+++ b/contentful/content-types/galleryBlock.js
@@ -62,6 +62,14 @@ module.exports = function(migration) {
     .required(true)
     .localized(false);
 
+  galleryBlock
+    .createField('imageCrop')
+    .name('Image Crop')
+    .type('Symbol')
+    .validations([{ in: ['fill', 'pad'] }])
+    .required(false)
+    .localized(false);
+
   galleryBlock.changeEditorInterface('imageAlignment', 'radio', {
     helpText:
       "Determines where the gallery item's images are aligned relative to their text.",
@@ -70,5 +78,11 @@ module.exports = function(migration) {
   galleryBlock.changeEditorInterface('itemsPerRow', 'radio', {
     helpText:
       'The maximum number of items in a single row when viewing the gallery in a large display.',
+  });
+
+  galleryBlock.changeEditorInterface('imageCrop', 'radio', {
+    helpText: `Controls the cropping method for the gallery images. "Fill" will resize the images to ensure they
+      fit neatly into a square, cropping the image if needed. "Pad" will do that same but will add padding
+      to the image instead of cropping it.`,
   });
 };

--- a/contentful/content-types/galleryBlock.js
+++ b/contentful/content-types/galleryBlock.js
@@ -82,7 +82,7 @@ module.exports = function(migration) {
 
   galleryBlock.changeEditorInterface('imageCrop', 'radio', {
     helpText: `Controls the cropping method for the gallery images. "Fill" will resize the images to ensure they
-      fit neatly into a square, cropping the image if needed. "Pad" will do that same but will add padding
+      fit neatly into a square, cropping the image if needed. "Pad" will do the same but will add padding
       to the image instead of cropping it.`,
   });
 };


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR adds an `imageCrop` field to the Gallery Block Content Type to control the image cropping/fitting for the gallery items.

### Any background context you want to provide?
This field allows toggling between the [`fill` and `pad` settings](https://www.contentful.com/developers/docs/references/images-api/#/reference/resizing-&-cropping/change-the-resizing-behavior) which we'll use to set the Contentful image URL `fit` query param.

How's the naming? Another idea I had was `imageFit`?

Documentation! There's some help text for now, but hopefully, once we get the documentation for this finalized, we can link to the appropriate section to help clarify this field for editors.

### What are the relevant tickets/cards?

Refs [Pivotal ID #160603556](https://www.pivotaltracker.com/story/show/160603556)
Specifically [this comment](https://www.pivotaltracker.com/story/show/160603556/comments/196054628)
