### PR TITLE
Gallery Block component - Image Fit Field

### DIFF
--- a/resources/assets/components/blocks/GalleryBlock/GalleryBlock.js
+++ b/resources/assets/components/blocks/GalleryBlock/GalleryBlock.js
@@ -35,13 +35,9 @@ const renderBlock = (block, imageAlignment, imageFit) => {
 
 const galleryTypes = { '2': 'duo', '3': 'triad', '4': 'quartet' };
 
-const GalleryBlock = ({
-  title,
-  blocks,
-  imageAlignment,
-  itemsPerRow,
-  imageFit,
-}) => {
+const GalleryBlock = props => {
+  const { title, blocks, itemsPerRow, imageAlignment, imageFit } = props;
+
   const galleryType = galleryTypes[itemsPerRow];
 
   return (
@@ -58,8 +54,8 @@ const GalleryBlock = ({
 GalleryBlock.propTypes = {
   title: PropTypes.string,
   blocks: PropTypes.arrayOf(PropTypes.object).isRequired,
-  imageAlignment: PropTypes.oneOf(['top', 'left']).isRequired,
   itemsPerRow: PropTypes.oneOf([2, 3, 4]).isRequired,
+  imageAlignment: PropTypes.oneOf(['top', 'left']).isRequired,
   imageFit: PropTypes.oneOf(['fill', 'pad']).isRequired,
 };
 

--- a/resources/assets/components/blocks/GalleryBlock/GalleryBlock.js
+++ b/resources/assets/components/blocks/GalleryBlock/GalleryBlock.js
@@ -7,7 +7,7 @@ import PageGalleryItem from '../../utilities/Gallery/templates/PageGalleryItem/P
 import ContentBlockGalleryItem from '../../utilities/Gallery/templates/ContentBlockGalleryItem';
 import CampaignGalleryItem from '../../utilities/Gallery/templates/CampaignGalleryItem/CampaignGalleryItem';
 
-const renderBlock = (block, imageAlignment) => {
+const renderBlock = (block, imageAlignment, imageFit) => {
   switch (block.type) {
     case 'person':
       return <Person key={block.id} {...block.fields} />;
@@ -24,6 +24,7 @@ const renderBlock = (block, imageAlignment) => {
           key={block.id}
           {...block.fields}
           imageAlignment={imageAlignment}
+          imageFit={imageFit}
         />
       );
 
@@ -34,7 +35,13 @@ const renderBlock = (block, imageAlignment) => {
 
 const galleryTypes = { '2': 'duo', '3': 'triad', '4': 'quartet' };
 
-const GalleryBlock = ({ title, blocks, imageAlignment, itemsPerRow }) => {
+const GalleryBlock = ({
+  title,
+  blocks,
+  imageAlignment,
+  itemsPerRow,
+  imageFit,
+}) => {
   const galleryType = galleryTypes[itemsPerRow];
 
   return (
@@ -42,7 +49,7 @@ const GalleryBlock = ({ title, blocks, imageAlignment, itemsPerRow }) => {
       {title ? <h1 className="padding-horizontal-md">{title}</h1> : null}
 
       <Gallery type={galleryType}>
-        {blocks.map(block => renderBlock(block, imageAlignment))}
+        {blocks.map(block => renderBlock(block, imageAlignment, imageFit))}
       </Gallery>
     </div>
   );
@@ -53,6 +60,7 @@ GalleryBlock.propTypes = {
   blocks: PropTypes.arrayOf(PropTypes.object).isRequired,
   imageAlignment: PropTypes.oneOf(['top', 'left']).isRequired,
   itemsPerRow: PropTypes.oneOf([2, 3, 4]).isRequired,
+  imageFit: PropTypes.oneOf(['fill', 'pad']).isRequired,
 };
 
 GalleryBlock.defaultProps = {

--- a/resources/assets/components/utilities/Gallery/templates/ContentBlockGalleryItem.js
+++ b/resources/assets/components/utilities/Gallery/templates/ContentBlockGalleryItem.js
@@ -5,7 +5,13 @@ import { Figure } from '../../../Figure';
 import { contentfulImageUrl } from '../../../../helpers';
 import Markdown from '../../../utilities/Markdown/Markdown';
 
-const ContentBlockGalleryItem = ({ title, image, content, imageAlignment }) => {
+const ContentBlockGalleryItem = ({
+  title,
+  image,
+  content,
+  imageAlignment,
+  imageFit,
+}) => {
   // Image formatting needs to be smaller if they are left-aligned.
   const imageFormatting = imageAlignment === 'left' ? '100' : '400';
   // Ensure we don't pass the unsupported 'top' as the alignment prop to Figure.
@@ -19,7 +25,7 @@ const ContentBlockGalleryItem = ({ title, image, content, imageAlignment }) => {
         image.url,
         imageFormatting,
         imageFormatting,
-        'fill',
+        imageFit,
       )}
       alignment={alignment}
     >
@@ -38,6 +44,7 @@ ContentBlockGalleryItem.propTypes = {
   }).isRequired,
   content: PropTypes.string.isRequired,
   imageAlignment: PropTypes.oneOf(['top', 'left']).isRequired,
+  imageFit: PropTypes.oneOf(['fill', 'pad']).isRequired,
 };
 
 export default ContentBlockGalleryItem;


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR adds the `imageFit` prop to the `GalleryBlock` component and adds its functionality to the `ContentBlockGalleryItem` component.

### Any background context you want to provide?
It's only being passed along to the `ContentBlockGalleryItem` at the moment and not any of the other gallery templates. (Same BTW with the `imageAlignment` field).

I did this since in the efforts towards the Ashes migration, these are the only templates that need them, though this does mean that the fields in Contentful are essentially useless for any other gallery types.

I felt like this would be OK until we consolidate these gallery templates, as long as we document that this is the case. 

Does anyone think these are must-haves for the other galleries as well atm?

### What are the relevant tickets/cards?

Refs [Pivotal ID #160603556](https://www.pivotaltracker.com/story/show/160603556)
#1173 
[More Context in this Pivotal thread](https://www.pivotaltracker.com/story/show/160603556/comments/196054628)

### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.
* [ ] Added screenshot to PR description of related front-end updates on **small** screens.
* [ ] Added screenshot to PR description of related front-end updates on **medium** screens.
* [ ] Added screenshot to PR description of related front-end updates on **large** screens.

*Rectangular images with `fill`*
![image](https://user-images.githubusercontent.com/12417657/48143355-96492c00-e27c-11e8-9a2d-1f6d0353ffe0.png)

*With `pad`*:
![image](https://user-images.githubusercontent.com/12417657/48143432-c7c1f780-e27c-11e8-9e25-28e5d15208e1.png)

(See 'The Buzz' on [this page](https://www.dosomething.org/us/campaigns/game-winning-drive) for reference)

