### PR TITLE
Fixing up how the OAuth redirect data hand-off works.

### DIFF
--- a/app/Http/Controllers/AuthController.php
+++ b/app/Http/Controllers/AuthController.php
@@ -75,8 +75,6 @@ class AuthController extends Controller
             $url .= str_contains($url, '?') ? '&'.$actionIdParam : '?'.$actionIdParam;
         }
 
-        \Illuminate\Support\Facades\Log::info('AuthController@getLogin', [$url]);
-
         return gateway('northstar')->authorize($request, $response, $url, $destination, $options);
     }
 

--- a/app/Http/Controllers/AuthController.php
+++ b/app/Http/Controllers/AuthController.php
@@ -70,8 +70,12 @@ class AuthController extends Controller
 
         // If there is an actionId in the session, set it as a query param on to the intended URL.
         if (session('actionId')) {
-            $url .= '?actionId=' . urlencode(session('actionId'));
+            $actionIdParam = 'actionId='.urlencode(session('actionId'));
+
+            $url .= str_contains($url, '?') ? '&'.$actionIdParam : '?'.$actionIdParam;
         }
+
+        \Illuminate\Support\Facades\Log::info('AuthController@getLogin', [$url]);
 
         return gateway('northstar')->authorize($request, $response, $url, $destination, $options);
     }

--- a/resources/assets/helpers/index.js
+++ b/resources/assets/helpers/index.js
@@ -18,12 +18,15 @@ export const EMPTY_IMAGE =
 /**
  * Build login redirect URL with optional context data.
  *
- * @param  {Null|Object} jsonOptions
+ * @param  {Null|Object} options
  * @param  {Null|String} actionId
  * @return {String}
  */
-export function buildLoginRedirectUrl(jsonOptions = null, actionId = null) {
-  const params = queryString.stringify({ actionId, jsonOptions });
+export function buildLoginRedirectUrl(options = null, actionId = null) {
+  const params = queryString.stringify({
+    actionId,
+    options: JSON.stringify(options),
+  });
 
   return `${window.location.origin}/next/login?${params}`;
 }

--- a/resources/assets/middleware/requiresAuthentication.js
+++ b/resources/assets/middleware/requiresAuthentication.js
@@ -23,6 +23,8 @@ const requiresAuthenticationMiddleware = ({ getState }) => next => action => {
         actionId,
       );
     });
+
+    return null;
   }
 
   return next(action);

--- a/resources/assets/selectors/campaign.js
+++ b/resources/assets/selectors/campaign.js
@@ -22,11 +22,14 @@ export function getCampaignDataForNorthstar(state) {
   const data = {};
 
   if (state.campaign) {
-    data.callToAction = encodeURIComponent(state.campaign.callToAction);
-    data.coverImage = encodeURIComponent(
-      contentfulImageUrl(state.campaign.coverImage.url, '800', '600', 'fill'),
+    data.callToAction = state.campaign.callToAction;
+    data.coverImage = contentfulImageUrl(
+      state.campaign.coverImage.url,
+      '800',
+      '600',
+      'fill',
     );
-    data.title = encodeURIComponent(state.campaign.title);
+    data.title = state.campaign.title;
   }
 
   return data;


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR does a bit of tweaking and some fixes for the OAuth login flow and with how metadata is passed around between Phoenix and Northstar.

It updates a couple things that weren't working correctly and causing Northstar to not receive any of the metadata options to customize the Northstar login for a user to provide context with info from the origin campaign and I also slightly cleans up the `AuthController@getLogin()` method.

### Any background context you want to provide?
There was a [question in the prior pull-request](https://github.com/DoSomething/phoenix-next/pull/1174#discussion_r233610852) regarding the need to flash the `actionId` in the session.

I did some further investigating and just needed to re-familiarize myself with how the Auth flow works. Here are the steps for an anonymous user on a campaign that clicks the campaign signup button:
1. User clicks button on the TFJ campaign.
2. The `requiresAuthenticationMiddleware` notices that the user is not logged in, so it does some prep work, then creates an `actionId`, stores it locally in the browser and also appends this `actionId` as a query parameter of the login URL, and then redirects them to this URL.
3. The login route activates the `AuthController@getLogin()` method, and user has no Auth `code`, so this method does some prep work, flashes the `actionId` into the session and uses `gateway` to redirect the user over to Northstar.
4. The user logs in via Northstar (Identity), and then is redirected back to the login route with their shiny, new Auth `code` and `state`.
5. Thus, we're now back to Phoenix at the login route, which again activates the `AuthController@getLogin()` method, but this time equipped with an Auth `code`. However, there's no `actionId` in the URL from Northstar, so we check the session, find an `actionId`, grab it and append it to the intended URL which is the URL for the TFJ campaign.
6. After we're redirected to the TFJ campaign, when initializing the App, we check to see if the URL has an `actionId`, and if so, use it's value as the key to find the item that was previously stored locally in the browser, which happens to be a `storeCampaignSignup` action, and then dispatch it!
7. User is signed up for the campaign and on the action page!

We also `flash()` the `actionId` since it doesn't really need to stick around in the session past the returning request to Phoenix from Northstar.

### What are the relevant tickets/cards?

Refs [Pivotal ID #160602918](https://www.pivotaltracker.com/story/show/160602918)
Refs [Pivotal ID #152003980](https://www.pivotaltracker.com/story/show/152003980)
