### PR TITLE
Updated HomePage component

### DIFF
--- a/app/Http/Controllers/HomePageController.php
+++ b/app/Http/Controllers/HomePageController.php
@@ -39,6 +39,7 @@ class HomePageController extends Controller
 
         return view('app', [
             'pageTitle' => $homePage->fields->title,
+            'legacyNavigation' => true,
         ])->with('homePage', $homePage);
     }
 }

--- a/resources/assets/components/pages/HomePage/HomePage.js
+++ b/resources/assets/components/pages/HomePage/HomePage.js
@@ -26,7 +26,7 @@ class HomePage extends React.Component {
       <article className="tile" key={id}>
         <a
           className="wrapper"
-          href={`/us/${isCampaign ? '/campaigns/' : ''}${slug}`}
+          href={`/us/${isCampaign ? 'campaigns/' : ''}${slug}`}
         >
           {staffPick ? (
             <div className="tile__flag -staff-pick">STAFF PICK</div>

--- a/resources/assets/components/pages/HomePage/HomePage.js
+++ b/resources/assets/components/pages/HomePage/HomePage.js
@@ -76,7 +76,7 @@ class HomePage extends React.Component {
                 {sponsorList.map(sponsor => (
                   <li key={sponsor.name}>
                     <img
-                      src={sponsor.image}
+                      src={contentfulImageUrl(sponsor.image, '125', '40')}
                       title={sponsor.name}
                       alt={sponsor.name}
                     />

--- a/resources/assets/components/pages/HomePage/HomePage.js
+++ b/resources/assets/components/pages/HomePage/HomePage.js
@@ -3,14 +3,91 @@
 import React from 'react';
 import { get } from 'lodash';
 
+import sponsorList from './sponsor-list';
+import { contentfulImageUrl } from '../../../helpers';
+
+import './home-page.scss';
+
 class HomePage extends React.Component {
   constructor() {
     super();
     this.state = get(window.HOMEPAGE, 'fields', {});
   }
 
+  renderGalleryBlock = block => {
+    const { id, type, staffPick } = block;
+
+    const isCampaign = type === 'campaign';
+
+    const fields = isCampaign ? block : block.fields;
+    const { slug, title, coverImage } = fields;
+
+    return (
+      <article className="tile" key={id}>
+        <a
+          className="wrapper"
+          href={`/us/${isCampaign ? '/campaigns/' : ''}${slug}`}
+        >
+          {staffPick ? (
+            <div className="tile__flag -staff-pick">STAFF PICK</div>
+          ) : null}
+
+          <div className="tile__meta">
+            <h1 className="tile__title">{title}</h1>
+            <p className="tile__tagline">{fields.tagline || fields.subTitle}</p>
+          </div>
+
+          <img
+            src={contentfulImageUrl(coverImage.url, '400', '400', 'fill')}
+            alt={coverImage.description || `${title} cover image`}
+          />
+        </a>
+      </article>
+    );
+  };
+
   render() {
-    return this.state.title ? <h1>{this.state.title}</h1> : null;
+    const { blocks, title, subTitle } = this.state;
+
+    if (!blocks) {
+      return null;
+    }
+
+    return (
+      <div className="home-page">
+        <header role="banner" className="header header--home">
+          <div className="wrapper">
+            <h1 className="header__title">{title}</h1>
+            <h2 className="header__subtitle">{subTitle}</h2>
+          </div>
+        </header>
+
+        <section className="home-page__gallery">
+          {blocks.map(this.renderGalleryBlock)}
+        </section>
+
+        <section className="container container--sponsors">
+          <div className="wrapper">
+            <div className="container__block">
+              {/* Workaround for this jsx-a11y bug https://git.io/fN814 */}
+              {/* eslint-disable-next-line jsx-a11y/heading-has-content */}
+              <h4>Sponsors</h4>
+              <ul>
+                {sponsorList.map(sponsor => (
+                  <li key={sponsor.name}>
+                    <img
+                      src={sponsor.image}
+                      title={sponsor.name}
+                      alt={sponsor.name}
+                    />
+                  </li>
+                ))}
+              </ul>
+            </div>
+          </div>
+        </section>
+      </div>
+    );
   }
 }
 

--- a/resources/assets/components/pages/HomePage/home-page.scss
+++ b/resources/assets/components/pages/HomePage/home-page.scss
@@ -49,15 +49,12 @@
     }
 
     img {
-      max-width: 90px;
-      max-height: 30px;
       vertical-align: middle;
       opacity: 0.2;
 
-      @include media($tablet) {
-        // retina sizing, see Image Style preset
-        max-width: 125px;
-        max-height: 40px;
+      @include media($mobile) {
+        max-width: 90px;
+        max-height: 30px;
       }
     }
   }

--- a/resources/assets/components/pages/HomePage/home-page.scss
+++ b/resources/assets/components/pages/HomePage/home-page.scss
@@ -15,7 +15,6 @@
   }
 
   .header {
-    padding-top: 50px;
     padding-bottom: 50px;
   }
 

--- a/resources/assets/components/pages/HomePage/home-page.scss
+++ b/resources/assets/components/pages/HomePage/home-page.scss
@@ -1,0 +1,64 @@
+@import '../../../scss/next-toolbox';
+
+.home-page {
+  .home-page__gallery {
+    display: grid;
+
+    @include media($medium) {
+      grid-template-columns: repeat(4, 1fr);
+
+      .tile:first-of-type {
+        grid-column: span 2;
+        grid-row: span 2;
+      }
+    }
+  }
+
+  .header {
+    padding-top: 50px;
+    padding-bottom: 50px;
+  }
+
+  .header--home {
+    .header__title {
+      text-align: center;
+    }
+
+    .header__subtitle {
+      font-size: $font-medium;
+      font-weight: $weight-normal;
+      text-align: center;
+    }
+  }
+
+  .container--sponsors {
+    text-align: center;
+
+    h4 {
+      color: $light-gray;
+    }
+
+    ul {
+      list-style: none;
+      padding: 0;
+    }
+
+    li {
+      display: inline-block;
+      margin: gutter() $base-spacing;
+    }
+
+    img {
+      max-width: 90px;
+      max-height: 30px;
+      vertical-align: middle;
+      opacity: 0.2;
+
+      @include media($tablet) {
+        // retina sizing, see Image Style preset
+        max-width: 125px;
+        max-height: 40px;
+      }
+    }
+  }
+}

--- a/resources/assets/components/pages/HomePage/sponsor-list.js
+++ b/resources/assets/components/pages/HomePage/sponsor-list.js
@@ -1,0 +1,119 @@
+const sponsorList = [
+  {
+    name: 'Channel One News',
+    image:
+      'https://images.ctfassets.net/81iqaqpfd8fy/6SpDVyHrkAAEI0qSqyygIs/ae921b0fa77ea051d69102ca8de81f19/Channel_One_News_logo__28introduced_2013_29_0.png',
+  },
+  {
+    name: 'Fastweb',
+    image:
+      'https://images.ctfassets.net/81iqaqpfd8fy/3YgDpELTfay2ko4cw2Qw86/af4a645f852898dc5cf048a7ced40859/fastweb-Logo_0.png',
+  },
+  {
+    name: 'General Motors',
+    image:
+      'https://images.ctfassets.net/81iqaqpfd8fy/1HbTwmA2zSOCqQAK2uAS8u/d5ec2d4f30ce540fb8a351cb182d37e4/General-Motors-Signature.jpg',
+  },
+  {
+    name: 'Jet Blue',
+    image:
+      'https://images.ctfassets.net/81iqaqpfd8fy/51oT5WIvO0KuseKe8KUUwG/1672e778430cc396a41cbc512f8a288c/JetBlue_grayscale.png',
+  },
+  {
+    name: 'H&M',
+    image:
+      'https://images.ctfassets.net/81iqaqpfd8fy/3kuKElQGXKAcaY4c4Wiyym/4e3c89ead5f080387009ebbbd71103aa/HM-1_0.png',
+  },
+  {
+    name: 'Google',
+    image:
+      'https://images.ctfassets.net/81iqaqpfd8fy/6r6VAzdzdCQkcmGCMOyas4/2cafbfcbaf31d1c648fbaf82724bb591/Logo_Google_2013_Official.svg__0.png',
+  },
+  {
+    name: '3M',
+    image:
+      'https://images.ctfassets.net/81iqaqpfd8fy/5HS3laXKkoo2QgwOkwuaew/dfdc90ac7fa937777e775f2b441c231f/3M_20logo_20_281_29.png',
+  },
+  {
+    name: 'Omidyar Network',
+    image:
+      'https://images.ctfassets.net/81iqaqpfd8fy/6CTHozYQzSwEQ0qaY8IQSe/db4d0d9f61610a4b56d64e1d01142f15/omidyar-logo_0.jpg',
+  },
+  {
+    name: 'Ford Foundation',
+    image:
+      'https://images.ctfassets.net/81iqaqpfd8fy/Q4v63LdpsIkoAkgkUAEOe/213a574b5cf8cce7131537c5677935b6/Ford-Foundation_logo.jpg',
+  },
+  {
+    name: 'Coke',
+    image:
+      'https://images.ctfassets.net/81iqaqpfd8fy/2VJuWzmYyIEyqgOcYEYSQC/ed5ab329fb68a359e36c2159385f6213/800px-Coca-Cola_logo.svg_202_0.png',
+  },
+  {
+    name: 'Takis',
+    image:
+      'https://images.ctfassets.net/81iqaqpfd8fy/4GFSZpoDtme4AqAMOeAc8a/1f255a7c5a0197ace5ff49ce8ffd2cdc/takis-3.png',
+  },
+  {
+    name: 'ESPN',
+    image:
+      'https://images.ctfassets.net/81iqaqpfd8fy/2CftMNWZQ4we6K0Qe6o8wK/1b7a4bd1a339ebd0031fd06716cd9350/espn-logo_0.png',
+  },
+  {
+    name: 'ABC be inspired',
+    image:
+      'https://images.ctfassets.net/81iqaqpfd8fy/hwPGwTIDU446MEAqqU2SQ/959776b19114a07d2085fb0f6fd42fee/abc-be-inspired.png',
+  },
+  {
+    name: 'Truth',
+    image:
+      'https://images.ctfassets.net/81iqaqpfd8fy/1azvfECZPWKqAA0CEeaece/895603a1acce99a7460c6ac20cc3648d/truth_20logo_20orange-no_20bg_0.png',
+  },
+  {
+    name: 'CVS Health Foundation',
+    image:
+      'https://images.ctfassets.net/81iqaqpfd8fy/4tqLqBgVQQ0EuosqoCOC2q/e9e1f1d6f44cc586b08de4e812ddbacf/CVSHealthFoundation.png',
+  },
+  {
+    name: 'J&J',
+    image:
+      'https://images.ctfassets.net/81iqaqpfd8fy/EsUqcK9aOyayGcsGQqmWS/d6f101af2953971d6375dd4719b6ca92/jj-logo_0.png',
+  },
+  {
+    name: 'General Mills',
+    image:
+      'https://images.ctfassets.net/81iqaqpfd8fy/69juzVYMvuGI4KSae2AyGK/7acca4734fac1e75e2629292d49cafdd/GMI-Corporate-Logo-V_FC.png',
+  },
+  {
+    name: 'Garnier',
+    image:
+      'https://images.ctfassets.net/81iqaqpfd8fy/20CRMNAHvmCq4ysw4Cw4IO/a47b86aa3d4dfb55f41607409ab161a8/Garnier_Logo-01.png',
+  },
+  {
+    name: 'Chevrolet',
+    image:
+      'https://images.ctfassets.net/81iqaqpfd8fy/2HQ3xouauciK8oUwgEqyaE/e5c554e7eff7a98e7051ccfe59a050fd/chevy_0.png',
+  },
+  {
+    name: 'Ozy',
+    image:
+      'https://images.ctfassets.net/81iqaqpfd8fy/44ChBO6fAsU8KGQKYGgOYE/4e1958f320b8a68dc64cd5e41f194c24/ozy_logo.png',
+  },
+  {
+    name: 'Power Rangers',
+    image:
+      'https://images.ctfassets.net/81iqaqpfd8fy/2KZZyZm2TegaqMWyEq228o/6500335c9676f2ea3d5c036c692c3951/power-rangers-logo-01.png',
+  },
+  {
+    name: 'Taco Bell Foundation',
+    image:
+      'https://images.ctfassets.net/81iqaqpfd8fy/1tx8p40l2ogSwMysomY2Ao/f393029ef44c96f895ab072384b01d40/7376214-logo.png',
+  },
+  {
+    name: 'Cooper Tires',
+    image:
+      'https://images.ctfassets.net/81iqaqpfd8fy/6z3TizyUDYCymWQEgCUWGA/6eb48fb4a607f7c7db1845422efe8d1c/CooperTireLogo_stacked.png',
+  },
+];
+
+export default sponsorList;

--- a/resources/assets/scss/navigation.scss
+++ b/resources/assets/scss/navigation.scss
@@ -3,7 +3,6 @@
 // Temporary override of the page navigation.
 // Fixed pixel height helps with vh units in banner.
 .navigation {
-  background-color: $white;
   height: 84px;
   position: relative;
   z-index: 100;

--- a/resources/views/partials/navigation.blade.php
+++ b/resources/views/partials/navigation.blade.php
@@ -1,4 +1,4 @@
-<div class="navigation">
+<div class="navigation {{isset($legacyNavigation) ? '-white -floating' : 'bg-white'}}">
     <a class="navigation__logo" href="{{ url('/') }}"><span>DoSomething.org</span></a>
     <a  id="js-navigation-toggle" class="navigation__toggle"><span>Show Menu</span></a>
     <div class="navigation__menu">


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR adds a mostly fleshed out HomePage component based on the current Ashes homepage

[Preview Deploy](https://dosomething-phoenix-de-pr-1187.herokuapp.com/us)

### Any background context you want to provide?
- ~This should completely replicate the ashes homepage besides for the navigation bar which is still white. In order to make this purple, we'd need to adjust some things with the blade files themselves (and arrange for some logic to determine some class names based on if it's a homepage or otherwise), so I figured I'd save this for the next PR.~ Turned out to be a small update - added to this PR.

- This accounts for Campaign and Page blocks. As of yet, no support for an external link block. Hoping to discuss this IRL in sprint planning tomorrow.

- Pages do not require the `coverImage` and `subTitle` fields which are necessary for the homepage gallery to look proper, though it shouldn't error out in their absence. Is this something we need to account for, or can we rely on editor discretion?

### What are the relevant tickets/cards?

Refs [Pivotal ID #161254955](https://www.pivotaltracker.com/story/show/161254955)

### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.
* [x] Added screenshot to PR description of related front-end updates on **small** screens.
* [x] Added screenshot to PR description of related front-end updates on **medium** screens.
* [x] Added screenshot to PR description of related front-end updates on **large** screens.


- [DESKTOP](https://user-images.githubusercontent.com/12417657/49264416-244ba900-f41c-11e8-80cd-1a45cdf3b694.png)
- [Tablet](https://user-images.githubusercontent.com/12417657/49264358-ecdcfc80-f41b-11e8-8948-60e402fb9726.png)
- [Mobile](https://user-images.githubusercontent.com/12417657/49264445-404f4a80-f41c-11e8-882a-427fd3078efd.png)

