### PR TITLE
Affirmation Legacy Author Photo Update

### DIFF
--- a/app/Entities/Affirmation.php
+++ b/app/Entities/Affirmation.php
@@ -26,7 +26,7 @@ class Affirmation extends Entity implements JsonSerializable
                     'active' => true,
                     'jobTitle' => 'Campaign Lead',
                     'email' => 'help@dosomething.org',
-                    'photo' => null,
+                    'photo' => get_image_url($this->photo, 'square'),
                     'alternatePhoto' => null,
                     'description' => null,
                 ],
@@ -40,7 +40,6 @@ class Affirmation extends Entity implements JsonSerializable
             'type' => $this->getContentType(),
             'fields' => [
                 'header' => $this->header,
-                'photo' => get_image_url($this->photo, 'square'),
                 'quote' => $this->quote,
                 'author' => $author,
                 'callToActionHeader' => $this->callToActionHeader,

--- a/app/Entities/Affirmation.php
+++ b/app/Entities/Affirmation.php
@@ -26,7 +26,7 @@ class Affirmation extends Entity implements JsonSerializable
                     'active' => true,
                     'jobTitle' => 'Campaign Lead',
                     'email' => 'help@dosomething.org',
-                    'photo' => get_image_url($this->photo, 'square'),
+                    'photo' => null,
                     'alternatePhoto' => null,
                     'description' => null,
                 ],
@@ -40,6 +40,7 @@ class Affirmation extends Entity implements JsonSerializable
             'type' => $this->getContentType(),
             'fields' => [
                 'header' => $this->header,
+                'photo' => get_image_url($this->photo, 'square'),
                 'quote' => $this->quote,
                 'author' => $author,
                 'callToActionHeader' => $this->callToActionHeader,

--- a/resources/assets/components/Affirmation/Affirmation.js
+++ b/resources/assets/components/Affirmation/Affirmation.js
@@ -32,7 +32,6 @@ const Affirmation = ({ content }) => (
 Affirmation.propTypes = {
   content: PropTypes.shape({
     header: PropTypes.string,
-    photo: PropTypes.string,
     author: PropTypes.object,
     quote: PropTypes.string,
     callToActionHeader: PropTypes.string,

--- a/resources/assets/components/Affirmation/Affirmation.js
+++ b/resources/assets/components/Affirmation/Affirmation.js
@@ -32,6 +32,7 @@ const Affirmation = ({ content }) => (
 Affirmation.propTypes = {
   content: PropTypes.shape({
     header: PropTypes.string,
+    photo: PropTypes.string,
     author: PropTypes.object,
     quote: PropTypes.string,
     callToActionHeader: PropTypes.string,

--- a/resources/assets/components/Affirmation/Affirmation.js
+++ b/resources/assets/components/Affirmation/Affirmation.js
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 import { Flex, FlexCell } from '../Flex';
 import Card from '../utilities/Card/Card';
 import Share from '../utilities/Share/Share';
+import { withoutNulls } from '../../helpers';
 import Byline from '../utilities/Byline/Byline';
 import Markdown from '../utilities/Markdown/Markdown';
 
@@ -23,7 +24,7 @@ const Affirmation = ({ content }) => (
     </Flex>
     <Byline
       author={content.author.fields.name}
-      {...content.author.fields}
+      {...withoutNulls(content.author.fields)}
       className="padded"
     />
   </Card>


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR ensures old Affirmations author photo fields show up in the Campaign Affirmation

**UPDATE**: SEE https://github.com/DoSomething/phoenix-next/pull/1188#issuecomment-442924467

### Any background context you want to provide?
I'm not completely sure of the complete origin story (we've had several iterations on the Affirmation content type and Entity, so it's hard to pin down when this happened) - but we stopped sending over an `author->fields->photo` for affirmations which were not using a `Staff` (or now - `Person`) linked entry as the Affirmation author. Or rather we sent over the field hardcoded to `null` which means the author photo is not showing up in legacy affirmations:
![image](https://user-images.githubusercontent.com/12417657/49236364-ef166b00-f3c9-11e8-9eb5-e44f8d03ff70.png)

This PR will just use the top level `photo` field as the `author->fields->photo` for these legacy affirmations.

### What are the relevant tickets/cards?
Bumped into this issue today as an editor attempted to create an affirmation. We're also [making some changes on the Contentful side](https://dosomething.slack.com/archives/C2BPA7M8F/p1543502240156800) to ensure more coherency and consistency going forward.