### PR TITLE
Update to main nav and signups reducer.

### DIFF
--- a/resources/assets/reducers/signups.js
+++ b/resources/assets/reducers/signups.js
@@ -48,7 +48,10 @@ const signupReducer = (state = {}, action) => {
       };
 
     case STORE_CAMPAIGN_SIGNUPS_FAILED:
-      return state;
+      return {
+        ...state,
+        isPending: true,
+      };
 
     case STORE_CAMPAIGN_SIGNUPS_PENDING:
       return {

--- a/resources/assets/reducers/signups.js
+++ b/resources/assets/reducers/signups.js
@@ -50,7 +50,7 @@ const signupReducer = (state = {}, action) => {
     case STORE_CAMPAIGN_SIGNUPS_FAILED:
       return {
         ...state,
-        isPending: true,
+        isPending: false,
       };
 
     case STORE_CAMPAIGN_SIGNUPS_PENDING:

--- a/resources/views/partials/navigation.blade.php
+++ b/resources/views/partials/navigation.blade.php
@@ -4,7 +4,7 @@
     <div class="navigation__menu">
         <ul class="navigation__primary">
             <li>
-                <a href="{{ phoenixLink('us/campaigns') }}">
+                <a href="{{ config('app.url') }}/us/campaigns">
                     <strong class="navigation__title">Explore Campaigns</strong>
                     <span class="navigation__subtitle">Find ways to take action both online and off.</span>
                 </a>


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR makes a quick update to the nav so we don't keep linking to Thor DS when clicking on the Explore Campaigns link and instead go to the `/us/campaigns` of the current env that the user is on. It also makes an update to fix the state changes on the signup reducer based on @mendelB's [comment](https://github.com/DoSomething/phoenix-next/pull/1186#pullrequestreview-180852582).

### What are the relevant tickets/cards?

🌵 
