### PR TITLE
Defaulting campaignRunId to 0 so it does not break things.

### DIFF
--- a/resources/assets/components/actions/LinkAction/templates/DefaultTemplate.js
+++ b/resources/assets/components/actions/LinkAction/templates/DefaultTemplate.js
@@ -37,6 +37,7 @@ const DefaultTemplate = props => {
     userId,
     northstarId: userId, // @TODO: Remove!
     campaignId,
+    campaignRunId: 0,
     source,
   });
 

--- a/resources/assets/components/actions/ReferralSubmissionAction/ReferralSubmissionActionContainer.js
+++ b/resources/assets/components/actions/ReferralSubmissionAction/ReferralSubmissionActionContainer.js
@@ -11,7 +11,7 @@ import {
  * Provide state from the Redux store as props for this component.
  */
 const mapStateToProps = state => ({
-  campaignId: state.campaign.id,
+  campaignId: state.campaign.campaignId,
   submissions: state.postSubmissions,
 });
 
@@ -28,6 +28,7 @@ const actionCreators = {
 /**
  * Export the container component.
  */
-export default connect(mapStateToProps, actionCreators)(
-  ReferralSubmissionAction,
-);
+export default connect(
+  mapStateToProps,
+  actionCreators,
+)(ReferralSubmissionAction);

--- a/resources/assets/components/actions/ShareAction/ShareAction.js
+++ b/resources/assets/components/actions/ShareAction/ShareAction.js
@@ -106,6 +106,7 @@ class ShareAction extends React.Component {
       userId,
       northstarId: userId, // @TODO: Remove!
       campaignId,
+      campaignRunId: 0,
       source: 'web',
     });
 

--- a/resources/assets/components/actions/VoterRegistrationAction/VoterRegistrationAction.js
+++ b/resources/assets/components/actions/VoterRegistrationAction/VoterRegistrationAction.js
@@ -23,6 +23,7 @@ const VoterRegistrationAction = props => {
     userId,
     northstarId: userId, // @TODO: Remove!
     campaignId,
+    campaignRunId: 0,
     source: 'web',
   };
 


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR updates the `ReferralSubmissionAction` `campaignId` property to use the actual campaign ID and also defaults all instances of `campaignRunId` passed to the `dynamicLink()` helper method to be `0` just to make sure it has a value because it could break other services if missing.

### What are the relevant tickets/cards?

Refs [Pivotal ID #162396969](https://www.pivotaltracker.com/story/show/162396969)
