### PR TITLE
Adding method to check if signup recently occurred and should show modal.

### DIFF
--- a/app/Http/Controllers/Api/CampaignSignupsController.php
+++ b/app/Http/Controllers/Api/CampaignSignupsController.php
@@ -72,6 +72,6 @@ class CampaignSignupsController extends Controller
 
         Log::debug('[Phoenix] CampaignSignupsController@store response data:', $data);
 
-        return response()->json($data, 201);
+        return $data;
     }
 }

--- a/resources/assets/components/Campaign/CampaignRoute/CampaignRoute.js
+++ b/resources/assets/components/Campaign/CampaignRoute/CampaignRoute.js
@@ -19,13 +19,13 @@ const CampaignRoute = props => {
     hasCommunityPage,
     isCampaignClosed,
     match,
-    shouldShowSignupAffirmation,
+    shouldShowAffirmation,
   } = props;
 
   return (
     <div>
       <div>
-        {shouldShowSignupAffirmation ? (
+        {shouldShowAffirmation ? (
           <Modal onClose={clickedHideAffirmation}>
             <PostSignupModalContainer />
           </Modal>
@@ -79,7 +79,7 @@ CampaignRoute.propTypes = {
   hasCommunityPage: PropTypes.bool.isRequired,
   isCampaignClosed: PropTypes.bool.isRequired,
   match: ReactRouterPropTypes.match.isRequired,
-  shouldShowSignupAffirmation: PropTypes.bool.isRequired,
+  shouldShowAffirmation: PropTypes.bool.isRequired,
 };
 
 CampaignRoute.defaultProps = {

--- a/resources/assets/components/Campaign/CampaignRoute/CampaignRouteContainer.js
+++ b/resources/assets/components/Campaign/CampaignRoute/CampaignRouteContainer.js
@@ -19,7 +19,7 @@ const mapStateToProps = state => ({
   ),
   isCampaignClosed: isCampaignClosed(state.campaign.endDate),
   legacyCampaignId: state.campaign.legacyCampaignId,
-  shouldShowSignupAffirmation: state.signups.shouldShowAffirmation,
+  shouldShowAffirmation: state.signups.shouldShowAffirmation,
 });
 
 /**

--- a/resources/assets/helpers/index.js
+++ b/resources/assets/helpers/index.js
@@ -409,7 +409,7 @@ export function isCampaignClosed(endDate) {
  * @param  {Number}  minutes
  * @return {Boolean}
  */
-export function isWithinMinutes(date, minutes = 5) {
+export function isWithinMinutes(date, minutes = 2) {
   if (!date) {
     return false;
   }

--- a/resources/assets/helpers/index.js
+++ b/resources/assets/helpers/index.js
@@ -1,10 +1,10 @@
 /* global window, document, Blob, URL */
 
-import { isBefore } from 'date-fns';
 import MarkdownIt from 'markdown-it';
 import queryString from 'query-string';
 import iterator from 'markdown-it-for-inline';
 import markdownItFootnote from 'markdown-it-footnote';
+import { getTime, isBefore, isWithinInterval } from 'date-fns';
 import { get, find, isNull, isUndefined, omitBy } from 'lodash';
 
 import Sixpack from '../services/Sixpack';
@@ -400,6 +400,24 @@ export function isCampaignClosed(endDate) {
   }
 
   return isBefore(endDate, new Date());
+}
+
+/**
+ * Check if specified date occurred within the last specified minutes.
+ *
+ * @param  {Date|String|Number}  date
+ * @param  {Number}  minutes
+ * @return {Boolean}
+ */
+export function isWithinMinutes(date, minutes = 5) {
+  if (!date) {
+    return false;
+  }
+
+  return isWithinInterval(getTime(date), {
+    start: Date.now() - minutes * 60 * 1000,
+    end: Date.now(),
+  });
 }
 
 /**

--- a/resources/assets/middleware/api.js
+++ b/resources/assets/middleware/api.js
@@ -75,7 +75,7 @@ const postRequest = (payload, dispatch, getState) => {
       // @TODO: Not ideal. We would prefer to know the status code from response to know
       // if data was created or not, but Gateway doesn't currently pass this to us. So for
       // now we're resolving to check against the data's created_at value to decide time elapsed.
-      const dataCreatedAt = get(response, 'data.created_at', Date.now());
+      const dataCreatedAt = get(response, 'data.created_at', null);
 
       response.status = {
         success: {

--- a/resources/assets/middleware/api.js
+++ b/resources/assets/middleware/api.js
@@ -70,15 +70,16 @@ const postRequest = (payload, dispatch, getState) => {
   return client
     .post(payload.url, body)
     .then(response => {
-      console.log('👾 POST request response: ', response);
-
       tabularLog(get(response, 'data', null));
 
+      // @TODO: Not ideal. We would prefer to know the status code from response to know
+      // if data was created or not, but Gateway doesn't currently pass this to us. So for
+      // now we're resolving to check against the data's created_at value to decide time elapsed.
       const dataCreatedAt = get(response, 'data.created_at', Date.now());
 
       response.status = {
         success: {
-          code: isWithinMinutes(dataCreatedAt, 10) ? 201 : 200,
+          code: isWithinMinutes(dataCreatedAt, 5) ? 201 : 200,
           message: get(payload, 'meta.messaging.success', 'Thanks!'),
         },
       };

--- a/resources/assets/reducers/signups.js
+++ b/resources/assets/reducers/signups.js
@@ -22,6 +22,7 @@ import {
  */
 const signupReducer = (state = {}, action) => {
   const data = get(action, 'response.data');
+  const status = get(action, 'response.status');
   let signups = [];
 
   switch (action.type) {
@@ -60,8 +61,6 @@ const signupReducer = (state = {}, action) => {
       };
 
     case STORE_CAMPAIGN_SIGNUPS_SUCCESSFUL:
-      const status = get(action, 'response.status.success.code');
-
       if (data) {
         signups = [...state.data, data.campaign_id];
       }
@@ -70,7 +69,7 @@ const signupReducer = (state = {}, action) => {
         ...state,
         data: signups,
         isPending: false,
-        shouldShowAffirmation: status === 201,
+        shouldShowAffirmation: get(status, 'success.code') === 201,
         thisCampaign: true, // @TODO: remove from state; use a selector instead
       };
 

--- a/resources/assets/reducers/signups.js
+++ b/resources/assets/reducers/signups.js
@@ -60,7 +60,8 @@ const signupReducer = (state = {}, action) => {
       };
 
     case STORE_CAMPAIGN_SIGNUPS_SUCCESSFUL:
-      console.log('👻 STORE_CAMPAIGN_SIGNUPS_SUCCESSFUL', action);
+      const status = get(action, 'response.status.success.code');
+
       if (data) {
         signups = [...state.data, data.campaign_id];
       }
@@ -69,6 +70,7 @@ const signupReducer = (state = {}, action) => {
         ...state,
         data: signups,
         isPending: false,
+        shouldShowAffirmation: status === 201,
         thisCampaign: true, // @TODO: remove from state; use a selector instead
       };
 

--- a/resources/assets/reducers/signups.js
+++ b/resources/assets/reducers/signups.js
@@ -60,6 +60,7 @@ const signupReducer = (state = {}, action) => {
       };
 
     case STORE_CAMPAIGN_SIGNUPS_SUCCESSFUL:
+      console.log('👻 STORE_CAMPAIGN_SIGNUPS_SUCCESSFUL', action);
       if (data) {
         signups = [...state.data, data.campaign_id];
       }


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR adds a way to check against a signup's `created_at` date to see if the signup occurred recently or has existed for some time. If the signup _is within minutes_ of being created, then we change the status code in the response object passed to the store from the API Middleware to be `201` to indicate record was created. In the reducer we check against this status code and show the signup affirmation modal if it is `201`.

Also rename props in the `CampaignRouteContainer` and `CampaignRoute` to match the naming convention used elsewhere (making finding in code easier later!).

### Any background context you want to provide?

Ideally we _don't_ want to rely on a slightly hacky method of comparing `created_at` date for a response from Rogue, however our Gateway package currently only passes along the data in the response from Rogue instead of also including the additional status info. Initially we probably did this to help simplify things, but in the long run, seems like it's something we want to keep. So this approach is intended to be a hacky solution, with the intent that it will be easy to update the API Middleware to pass the actual response status, instead of relying on the `isWithinMinutes()` method. Once Gateway is updated it's a simple fix!

### What are the relevant tickets/cards?

Refs [Pivotal ID #162418535](https://www.pivotaltracker.com/story/show/162418535)

### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.