### PR TITLE
Remove PuckConnecter event tracking

### DIFF
--- a/resources/assets/actions/quiz.js
+++ b/resources/assets/actions/quiz.js
@@ -3,7 +3,7 @@
 import { find, get } from 'lodash';
 
 import {
-  clickedSignUpAction,
+  clickedSignupAction,
   PICK_QUIZ_ANSWER,
   COMPARE_QUIZ_ANSWER,
   VIEW_QUIZ_RESULT,
@@ -33,7 +33,7 @@ export function quizConvert(quizId, resultActionId) {
     const campaignId = getState().campaign.legacyCampaignId;
 
     dispatch(
-      clickedSignUpAction(campaignId, {
+      clickedSignupAction(campaignId, {
         body: { details: { source: 'quiz' } },
       }),
     );

--- a/resources/assets/components/CallToAction/__snapshots__/CallToAction.test.js.snap
+++ b/resources/assets/components/CallToAction/__snapshots__/CallToAction.test.js.snap
@@ -12,7 +12,7 @@ exports[`CallToAction snapshot test 1`] = `
   >
     Aenean eu leo quam. Pellentesque ornare sem vestibulum.
   </div>
-  <Connect(PuckWrapper)
+  <Connect(SignupButton)
     source="call to action"
   />
 </Card>

--- a/resources/assets/components/LegacyQuiz/LegacyQuiz.js
+++ b/resources/assets/components/LegacyQuiz/LegacyQuiz.js
@@ -7,6 +7,7 @@ import Conclusion from './Conclusion';
 import Share from '../utilities/Share/Share';
 import ContentfulEntry from '../ContentfulEntry';
 import Markdown from '../utilities/Markdown/Markdown';
+import { trackPuckEvent } from '../../helpers/analytics';
 
 import './legacy-quiz.scss';
 
@@ -17,7 +18,6 @@ const LegacyQuiz = props => {
     data,
     completeQuiz,
     pickQuizAnswer,
-    trackEvent,
     submitButtonText,
   } = props;
   const { error, shouldSeeResult, selectedResult } = data;
@@ -64,7 +64,7 @@ const LegacyQuiz = props => {
   };
 
   if (shouldSeeResult) {
-    trackEvent('converted on quiz', {
+    trackPuckEvent('converted on quiz', {
       responses: data.questions,
     });
   }
@@ -112,7 +112,6 @@ LegacyQuiz.propTypes = {
   completeQuiz: PropTypes.func.isRequired,
   pickQuizAnswer: PropTypes.func.isRequired,
   submitButtonText: PropTypes.string,
-  trackEvent: PropTypes.func.isRequired,
 };
 
 LegacyQuiz.defaultProps = {

--- a/resources/assets/components/LegacyQuiz/LegacyQuiz.test.js
+++ b/resources/assets/components/LegacyQuiz/LegacyQuiz.test.js
@@ -20,7 +20,6 @@ test('it should display a placeholder quiz', () => {
       completeQuiz={() => {}}
       viewQuizResult={() => {}}
       startQuiz={() => {}}
-      trackEvent={() => {}}
       pickQuizAnswer={() => {}}
       showLedeBanner={false}
     />,

--- a/resources/assets/components/LegacyQuiz/LegacyQuizContainer.js
+++ b/resources/assets/components/LegacyQuiz/LegacyQuizContainer.js
@@ -1,5 +1,4 @@
 import { connect } from 'react-redux';
-import { PuckConnector } from '@dosomething/puck-client';
 import { get } from 'lodash';
 
 import LegacyQuiz from './LegacyQuiz';
@@ -47,4 +46,7 @@ const actions = {
 };
 
 // Export the container component.
-export default connect(mapStateToProps, actions)(PuckConnector(LegacyQuiz));
+export default connect(
+  mapStateToProps,
+  actions,
+)(LegacyQuiz);

--- a/resources/assets/components/Quiz/Quiz.js
+++ b/resources/assets/components/Quiz/Quiz.js
@@ -13,6 +13,7 @@ import Share from '../utilities/Share/Share';
 import QuizConclusion from './QuizConclusion';
 import ContentfulEntry from '../ContentfulEntry';
 import ScrollConcierge from '../ScrollConcierge';
+import { trackPuckEvent } from '../../helpers/analytics';
 import { calculateResult, resultParams, appendResultParams } from './helpers';
 
 import './quiz.scss';
@@ -75,7 +76,6 @@ class Quiz extends React.Component {
     }
 
     const {
-      trackEvent,
       questions,
       resultBlocks,
       autoSubmit,
@@ -91,7 +91,7 @@ class Quiz extends React.Component {
       resultBlocks,
     );
 
-    trackEvent('converted on quiz', {
+    trackPuckEvent('converted on quiz', {
       responses: this.state.choices,
     });
 
@@ -258,7 +258,6 @@ Quiz.propTypes = {
   slug: PropTypes.string.isRequired,
   hideQuestionNumber: PropTypes.bool,
   title: PropTypes.string,
-  trackEvent: PropTypes.func.isRequired,
 };
 
 Quiz.defaultProps = {

--- a/resources/assets/components/Quiz/Quiz.test.js
+++ b/resources/assets/components/Quiz/Quiz.test.js
@@ -1,7 +1,7 @@
 /* global location, jsdom */
 
 import React from 'react';
-import { render, shallow } from 'enzyme';
+import { shallow } from 'enzyme';
 import { createMemoryHistory } from 'history';
 
 import Quiz from './Quiz';
@@ -94,35 +94,26 @@ const props = {
   campaignId: '1',
 };
 
-test('it should display a placeholder quiz', () => {
-  const wrapper = shallow(<Quiz {...props} />);
+let wrapper = shallow(<Quiz {...props} />);
 
+test('it should display a placeholder quiz', () => {
   expect(wrapper.find('.quiz')).toHaveLength(1);
 });
 
 test('the button is disabled when quiz is incomplete', () => {
-  const wrapper = render(<Quiz {...props} />);
-
   expect(wrapper.find('button').prop('disabled')).toBe(true);
 });
 
 test('the questions are displayed', () => {
-  const wrapper = shallow(<Quiz {...props} />);
-
   expect(wrapper.find('QuizQuestion')).toHaveLength(2);
 });
 
 test('the button is not disabled when quiz is complete', () => {
-  const wrapper = shallow(<Quiz {...props} />);
   wrapper.setState({ choices: { 0: '0', 1: '0' } });
   expect(wrapper.find('button').prop('disabled')).toBe(false);
 });
 
 test('clicking the button hides the quiz, shows the conclusion, and tracks the conversion', () => {
-  const wrapper = shallow(<Quiz {...props} />);
-
-  wrapper.setState({ choices: { 0: '0', 1: '0' } });
-
   wrapper.find('button').simulate('click');
 
   expect(trackEventMock).toHaveBeenCalled();
@@ -132,7 +123,7 @@ test('clicking the button hides the quiz, shows the conclusion, and tracks the c
 });
 
 test('a winning quiz resultBlock causes a redirect to the new quiz', () => {
-  const wrapper = shallow(<Quiz {...props} />);
+  wrapper = shallow(<Quiz {...props} />);
 
   wrapper.setState({ choices: { 0: '1', 1: '1' } });
 

--- a/resources/assets/components/Quiz/Quiz.test.js
+++ b/resources/assets/components/Quiz/Quiz.test.js
@@ -6,6 +6,9 @@ import { createMemoryHistory } from 'history';
 
 import Quiz from './Quiz';
 import QuizQuestion from './QuizQuestion';
+import { trackPuckEvent as trackEventMock } from '../../helpers/analytics';
+
+jest.mock('../../helpers/analytics');
 
 const history = createMemoryHistory();
 
@@ -92,48 +95,44 @@ const props = {
 };
 
 test('it should display a placeholder quiz', () => {
-  const wrapper = shallow(<Quiz trackEvent={() => {}} {...props} />);
+  const wrapper = shallow(<Quiz {...props} />);
 
   expect(wrapper.find('.quiz')).toHaveLength(1);
 });
 
 test('the button is disabled when quiz is incomplete', () => {
-  const wrapper = render(<Quiz trackEvent={() => {}} {...props} />);
+  const wrapper = render(<Quiz {...props} />);
 
   expect(wrapper.find('button').prop('disabled')).toBe(true);
 });
 
 test('the questions are displayed', () => {
-  const wrapper = shallow(<Quiz trackEvent={() => {}} {...props} />);
+  const wrapper = shallow(<Quiz {...props} />);
 
   expect(wrapper.find('QuizQuestion')).toHaveLength(2);
 });
 
 test('the button is not disabled when quiz is complete', () => {
-  const wrapper = shallow(<Quiz trackEvent={() => {}} {...props} />);
+  const wrapper = shallow(<Quiz {...props} />);
   wrapper.setState({ choices: { 0: '0', 1: '0' } });
   expect(wrapper.find('button').prop('disabled')).toBe(false);
 });
 
 test('clicking the button hides the quiz, shows the conclusion, and tracks the conversion', () => {
-  const tracker = jest.fn();
-
-  const wrapper = shallow(<Quiz trackEvent={tracker} {...props} />);
+  const wrapper = shallow(<Quiz {...props} />);
 
   wrapper.setState({ choices: { 0: '0', 1: '0' } });
 
   wrapper.find('button').simulate('click');
 
-  expect(tracker).toHaveBeenCalled();
+  expect(trackEventMock).toHaveBeenCalled();
   expect(history.push).toHaveBeenCalledTimes(0);
   expect(wrapper.find(QuizQuestion)).toHaveLength(0);
   expect(wrapper.find('ContentfulEntry')).toHaveLength(1);
 });
 
 test('a winning quiz resultBlock causes a redirect to the new quiz', () => {
-  const tracker = jest.fn();
-
-  const wrapper = shallow(<Quiz trackEvent={tracker} {...props} />);
+  const wrapper = shallow(<Quiz {...props} />);
 
   wrapper.setState({ choices: { 0: '1', 1: '1' } });
 

--- a/resources/assets/components/Quiz/QuizContainer.js
+++ b/resources/assets/components/Quiz/QuizContainer.js
@@ -1,6 +1,5 @@
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router';
-import { PuckConnector } from '@dosomething/puck-client';
 
 import Quiz from './Quiz';
 import { clickedSignupAction } from '../../actions/signup';
@@ -27,5 +26,5 @@ export default withRouter(
   connect(
     mapStateToProps,
     actionCreators,
-  )(PuckConnector(Quiz)),
+  )(Quiz),
 );

--- a/resources/assets/components/SignupButton/SignupButton.js
+++ b/resources/assets/components/SignupButton/SignupButton.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { get } from 'lodash';
 
 import Button from '../utilities/Button/Button';
+import { trackPuckEvent } from '../../helpers/analytics';
 
 const SignupButton = props => {
   const {
@@ -14,7 +15,6 @@ const SignupButton = props => {
     sourceActionText,
     template,
     text,
-    trackEvent,
     trafficSource,
     campaignId,
     campaignContentfulId,
@@ -26,7 +26,7 @@ const SignupButton = props => {
       body: { details: { campaignContentfulId } },
     });
 
-    trackEvent('signup', {
+    trackPuckEvent('signup', {
       template,
       legacyCampaignId: campaignId, // @TODO: confirm it's ok to send as campaignID and not legacyCampaignId
       source,
@@ -61,7 +61,6 @@ SignupButton.propTypes = {
   sourceActionText: PropTypes.objectOf(PropTypes.string),
   template: PropTypes.string,
   text: PropTypes.string,
-  trackEvent: PropTypes.func.isRequired,
   trafficSource: PropTypes.string,
 };
 

--- a/resources/assets/components/SignupButton/SignupButtonContainer.js
+++ b/resources/assets/components/SignupButton/SignupButtonContainer.js
@@ -1,5 +1,4 @@
 import { connect } from 'react-redux';
-import { PuckConnector } from '@dosomething/puck-client';
 import { get } from 'lodash';
 
 import SignupButton from './SignupButton';
@@ -30,4 +29,4 @@ const actionCreators = {
 export default connect(
   mapStateToProps,
   actionCreators,
-)(PuckConnector(SignupButton));
+)(SignupButton);

--- a/resources/assets/components/actions/VoterRegistrationAction/VoterRegistrationAction.js
+++ b/resources/assets/components/actions/VoterRegistrationAction/VoterRegistrationAction.js
@@ -5,19 +5,12 @@ import Card from '../../utilities/Card/Card';
 import { set } from '../../../helpers/storage';
 import { dynamicString } from '../../../helpers';
 import Markdown from '../../utilities/Markdown/Markdown';
+import { trackPuckEvent } from '../../../helpers/analytics';
 
 import './voter-registration-action.scss';
 
 const VoterRegistrationAction = props => {
-  const {
-    campaignId,
-    content,
-    contentfulId,
-    link,
-    modalType,
-    trackEvent,
-    userId,
-  } = props;
+  const { campaignId, content, contentfulId, link, modalType, userId } = props;
 
   const tokens = {
     userId,
@@ -31,7 +24,7 @@ const VoterRegistrationAction = props => {
 
   const handleClick = () => {
     const trackingData = { contentfulId, url: parsedLink, modal: modalType };
-    trackEvent('clicked voter registration action', trackingData);
+    trackPuckEvent('clicked voter registration action', trackingData);
     set(`${props.userId}_hide_voter_reg_modal`, 'boolean', true);
   };
 
@@ -65,7 +58,6 @@ VoterRegistrationAction.propTypes = {
   contentfulId: PropTypes.string.isRequired,
   link: PropTypes.string.isRequired,
   modalType: PropTypes.string,
-  trackEvent: PropTypes.func.isRequired,
   userId: PropTypes.string.isRequired,
 };
 

--- a/resources/assets/components/actions/VoterRegistrationAction/VoterRegistrationAction.test.js
+++ b/resources/assets/components/actions/VoterRegistrationAction/VoterRegistrationAction.test.js
@@ -4,8 +4,9 @@ import { shallow } from 'enzyme';
 import { get } from '../../../helpers/storage';
 import VoterRegistrationAction from './VoterRegistrationAction';
 import LocalStorageMock from '../../../__mocks__/localStorageMock';
+import { trackPuckEvent as trackEventMock } from '../../../helpers/analytics';
 
-const trackEventMock = jest.fn();
+jest.mock('../../../helpers/analytics');
 
 global.localStorage = new LocalStorageMock();
 
@@ -19,7 +20,6 @@ const renderVoterRegistration = () =>
       link="http://example.com?campaign={campaignId}&campaingRun={campaignRunId}&user={northstarId}&source={source}"
       title="Register to vote!"
       userId="551234567890abcdefghijkl"
-      trackEvent={trackEventMock}
     />,
   );
 

--- a/resources/assets/components/actions/VoterRegistrationAction/VoterRegistrationActionContainer.js
+++ b/resources/assets/components/actions/VoterRegistrationAction/VoterRegistrationActionContainer.js
@@ -1,5 +1,4 @@
 import { connect } from 'react-redux';
-import { PuckConnector } from '@dosomething/puck-client';
 
 import { getUserId } from '../../../selectors/user';
 import VoterRegistrationAction from './VoterRegistrationAction';
@@ -15,4 +14,4 @@ const mapStateToProps = state => ({
 /**
  * Export the container component.
  */
-export default connect(mapStateToProps)(PuckConnector(VoterRegistrationAction));
+export default connect(mapStateToProps)(VoterRegistrationAction);


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

🏒 This PR removes all vestiges of the `PuckConnecter`s which were wrapping components to enable implicitly passing a `trackEvent` prop, and instead uses the `trackPuckEvent` analytics helper method.

### Any background context you want to provide?
We favor the more simple and digestible approach of using a plain ole helper function for explicit event tracking. This is also in preparation for some work we're going to be doing to the event tracking in general. Stay tuned!

### What are the relevant tickets/cards?

Refs [Pivotal ID #162068080](https://www.pivotaltracker.com/story/show/162068080)