### PR TITLE
Initial fix for allowing default affirmations.

### DIFF
--- a/app/Entities/Campaign.php
+++ b/app/Entities/Campaign.php
@@ -131,7 +131,7 @@ class Campaign extends Entity implements JsonSerializable
             'affiliatePartners' => $this->parseAffiliates($this->affiliatePartners),
             'quizzes' => $this->parseQuizzes($this->quizzes),
             'dashboard' => $this->dashboard,
-            'affirmation' => $this->parseBlock($this->affirmation),
+            'affirmation' => $this->affirmation ? $this->parseBlock($this->affirmation) : null,
             'pages' => $this->parseBlocks($this->pages),
             'landingPage' => $this->parseLandingPage($this->landingPage),
             'socialOverride' => $this->socialOverride ? new SocialOverride($this->socialOverride->entry) : null,

--- a/resources/assets/components/Affirmation/Affirmation.js
+++ b/resources/assets/components/Affirmation/Affirmation.js
@@ -4,41 +4,69 @@ import PropTypes from 'prop-types';
 import { Flex, FlexCell } from '../Flex';
 import Card from '../utilities/Card/Card';
 import Share from '../utilities/Share/Share';
-import { withoutNulls } from '../../helpers';
+import { contentfulImageUrl, withoutNulls } from '../../helpers';
 import Byline from '../utilities/Byline/Byline';
 import Markdown from '../utilities/Markdown/Markdown';
 
 import './affirmation.scss';
 
-const Affirmation = ({ content }) => (
-  <Card className="affirmation rounded" title="Thanks for joining us!">
-    <Markdown className="padded">{content.quote}</Markdown>
+// @TODO: Refactor/redesign.
+// We seem to have removed the content "photo" from being used in the actual output.
+// Also it would be nice to be able to default to the Campaign Lead attached to the
+// campaign if no author is provided!
+const Affirmation = ({
+  author,
+  callToActionDescription,
+  callToActionHeader,
+  header,
+  photo,
+  quote,
+}) => (
+  <Card className="affirmation rounded" title={header}>
+    {quote ? (
+      <Markdown className="padding-top-md padding-horizontal-md">
+        {quote}
+      </Markdown>
+    ) : null}
+
     <Flex className="flex-align-center">
-      <FlexCell className="affirmation__cta padded" width="half">
-        <h3>{content.callToActionHeader}</h3>
-        <p>{content.callToActionDescription}</p>
+      <FlexCell className="affirmation__cta  padded" width="half">
+        <h3>{callToActionHeader}</h3>
+        <p>{callToActionDescription}</p>
       </FlexCell>
       <FlexCell className="padded" width="half">
         <Share variant="blue" parentSource="affirmation" />
       </FlexCell>
     </Flex>
-    <Byline
-      author={content.author.fields.name}
-      {...withoutNulls(content.author.fields)}
-      className="padded"
-    />
+
+    {author ? (
+      <Byline
+        author={author.fields.name}
+        {...withoutNulls(author.fields)}
+        photo={contentfulImageUrl(author.fields.photo, 175, 175, 'fill')}
+        className="padding-bottom-md padding-horizontal-md"
+      />
+    ) : null}
   </Card>
 );
 
 Affirmation.propTypes = {
-  content: PropTypes.shape({
-    header: PropTypes.string,
-    photo: PropTypes.string,
-    author: PropTypes.object,
-    quote: PropTypes.string,
-    callToActionHeader: PropTypes.string,
-    callToActionDescription: PropTypes.string,
-  }).isRequired,
+  author: PropTypes.object,
+  callToActionDescription: PropTypes.string,
+  callToActionHeader: PropTypes.string,
+  header: PropTypes.string,
+  photo: PropTypes.string,
+  quote: PropTypes.string,
+};
+
+Affirmation.defaultProps = {
+  author: null,
+  callToActionDescription:
+    "By joining this campaign, you've teamed up with millions of other members who are making an impact on the causes affecting your world. As a DoSomething.org member, you're part of something bigger. You're part of a global movement for good.",
+  callToActionHeader: "Woohoo! You're signed up.",
+  header: 'Thanks for joining us!',
+  photo: null,
+  quote: null,
 };
 
 export default Affirmation;

--- a/resources/assets/components/Affirmation/Affirmation.js
+++ b/resources/assets/components/Affirmation/Affirmation.js
@@ -19,7 +19,6 @@ const Affirmation = ({
   callToActionDescription,
   callToActionHeader,
   header,
-  photo,
   quote,
 }) => (
   <Card className="affirmation rounded" title={header}>
@@ -51,11 +50,10 @@ const Affirmation = ({
 );
 
 Affirmation.propTypes = {
-  author: PropTypes.object,
+  author: PropTypes.object, // eslint-disable-line react/forbid-prop-types
   callToActionDescription: PropTypes.string,
   callToActionHeader: PropTypes.string,
   header: PropTypes.string,
-  photo: PropTypes.string,
   quote: PropTypes.string,
 };
 
@@ -65,7 +63,6 @@ Affirmation.defaultProps = {
     "By joining this campaign, you've teamed up with millions of other members who are making an impact on the causes affecting your world. As a DoSomething.org member, you're part of something bigger. You're part of a global movement for good.",
   callToActionHeader: "Woohoo! You're signed up.",
   header: 'Thanks for joining us!',
-  photo: null,
   quote: null,
 };
 

--- a/resources/assets/components/Affirmation/Affirmation.js
+++ b/resources/assets/components/Affirmation/Affirmation.js
@@ -30,7 +30,7 @@ const Affirmation = ({
     ) : null}
 
     <Flex className="flex-align-center">
-      <FlexCell className="affirmation__cta  padded" width="half">
+      <FlexCell className="affirmation__cta padded" width="half">
         <h3>{callToActionHeader}</h3>
         <p>{callToActionDescription}</p>
       </FlexCell>

--- a/resources/assets/components/Campaign/CampaignRoute/CampaignRoute.js
+++ b/resources/assets/components/Campaign/CampaignRoute/CampaignRoute.js
@@ -6,14 +6,15 @@ import { Switch, Route, Redirect } from 'react-router-dom';
 
 import Modal from '../../utilities/Modal/Modal';
 import CampaignFooter from '../../CampaignFooter';
+import PostSignupModal from '../../pages/PostSignupModal/PostSignupModal';
 import BlockPageContainer from '../../pages/BlockPage/BlockPageContainer';
 import CampaignPageContainer from '../../pages/CampaignPage/CampaignPageContainer';
-import PostSignupModalContainer from '../../pages/PostSignupModal/PostSignupModalContainer';
 
 const CampaignRoute = props => {
   const {
     affiliatePartners,
     affiliateSponsors,
+    affirmation,
     campaignLead,
     clickedHideAffirmation,
     hasCommunityPage,
@@ -27,7 +28,7 @@ const CampaignRoute = props => {
       <div>
         {shouldShowAffirmation ? (
           <Modal onClose={clickedHideAffirmation}>
-            <PostSignupModalContainer />
+            <PostSignupModal affirmation={affirmation || undefined} />
           </Modal>
         ) : null}
 

--- a/resources/assets/components/Campaign/CampaignRoute/CampaignRoute.js
+++ b/resources/assets/components/Campaign/CampaignRoute/CampaignRoute.js
@@ -72,6 +72,7 @@ const CampaignRoute = props => {
 CampaignRoute.propTypes = {
   affiliatePartners: PropTypes.array.isRequired, // eslint-disable-line react/forbid-prop-types
   affiliateSponsors: PropTypes.array.isRequired, // eslint-disable-line react/forbid-prop-types
+  affirmation: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
   campaignLead: PropTypes.shape({
     name: PropTypes.string,
     email: PropTypes.string,

--- a/resources/assets/components/Campaign/CampaignRoute/CampaignRouteContainer.js
+++ b/resources/assets/components/Campaign/CampaignRoute/CampaignRouteContainer.js
@@ -11,6 +11,7 @@ import { clickedHideAffirmation } from '../../../actions';
 const mapStateToProps = state => ({
   affiliateSponsors: state.campaign.affiliateSponsors,
   affiliatePartners: state.campaign.affiliatePartners,
+  affirmation: state.campaign.affirmation,
   campaignLead: get(state, 'campaign.campaignLead.fields', null),
   hasCommunityPage: Boolean(
     state.campaign.pages.find(

--- a/resources/assets/components/ContentfulEntry/renderers.js
+++ b/resources/assets/components/ContentfulEntry/renderers.js
@@ -100,6 +100,12 @@ export function renderTextSubmissionAction(data) {
   );
 }
 
+/**
+ * Render a photo submission action.
+ *
+ * @param  {Object} data
+ * @return {Component}
+ */
 export function renderPhotoSubmissionAction(data) {
   const contentfulId = data.id;
   const fields = withoutNulls(data.fields);
@@ -120,6 +126,12 @@ export function renderPhotoSubmissionAction(data) {
   );
 }
 
+/**
+ * Render a referral submission action.
+ *
+ * @param  {Object} data
+ * @return {Component}
+ */
 export function renderReferralSubmissionAction(data) {
   const fields = withoutNulls(data.fields);
 
@@ -131,12 +143,15 @@ export function renderReferralSubmissionAction(data) {
 }
 
 /**
- * Render the affirmation step.
+ * Render an affirmation.
  *
+ * @param  {Object} data
  * @return {Component}
  */
-export function renderAffirmation(step) {
-  return <Affirmation content={step.fields} />;
+export function renderAffirmation(data) {
+  const fields = withoutNulls(data.fields);
+
+  return <Affirmation {...fields} />;
 }
 
 /**

--- a/resources/assets/components/pages/PostSignupModal/PostSignupModal.js
+++ b/resources/assets/components/pages/PostSignupModal/PostSignupModal.js
@@ -13,7 +13,13 @@ const PostSignupModal = ({ affirmation }) => (
 );
 
 PostSignupModal.propTypes = {
-  affirmation: PropTypes.object.isRequired, // eslint-disable-line
+  affirmation: PropTypes.object, // eslint-disable-line
+};
+
+PostSignupModal.defaultProps = {
+  affirmation: {
+    type: 'affirmation',
+  },
 };
 
 export default PostSignupModal;


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR eliminates requiring editors to populate the `affirmation` field on a campaign. If no content type is attached, the system will now just provide some default content. This was a quick fix to allow for this functionality to unblock the Ashes migration. I would definitely like to take another pass at this, clean it up some more, remove the use of a pretty much defunct `PostSignupModal` component that currently passes the affirmation data through it and also make some better defaults (like using the Campaign Lead for the affirmation).

### Any background context you want to provide?

Basic work to get this up to snuff; will definitely be getting another update in the near future! 

If an affirmation content type is added to the `affirmation` field, it renders it as before (cleaned up a little):
![image](https://user-images.githubusercontent.com/105849/49675480-eb2abe80-fa43-11e8-8186-8eb0d2c5199c.png)

Otherwise it uses defaults to populate the affirmation:
![image](https://user-images.githubusercontent.com/105849/49675523-0f869b00-fa44-11e8-95d9-f5c80145c6ad.png)

We can definitely update the language I borrowed from from the old, Ashes onboarding flow.

### What are the relevant tickets/cards?

Refs [Pivotal ID #162418794](https://www.pivotaltracker.com/story/show/162418794)

### Checklist

* [ ] Documentation added for new features/changed endpoints.
