### PR TITLE
Updated Analytics Tracking Method

### DIFF
--- a/resources/assets/helpers/analytics.js
+++ b/resources/assets/helpers/analytics.js
@@ -141,7 +141,7 @@ export function trackAnalyticsEvent(name, data, service) {
  * Track an analytics event with a specified service. (Defaults to tracking with all services.)
  *
  * @param  {Object}      nameParams
- * @param  {Object}      data
+ * @param  {Object|Null} data
  * @param  {String|Null} service
  * @return {Object}
  */

--- a/resources/assets/helpers/analytics.js
+++ b/resources/assets/helpers/analytics.js
@@ -15,6 +15,22 @@ import { get as getHistory } from '../history';
 const APP_NAME = 'phoenix';
 
 /**
+ * Parse analytics event name parameters into a snake cased string.
+ *
+ * @param  {String} verb
+ * @param  {String} noun
+ * @param  {String|Null} adjective
+ * @return {void}
+ */
+const parseEventName = (verb, noun, adjective) => {
+  let eventName = `${APP_NAME}_${verb}_${noun}`;
+  // Append adjective if defined.
+  eventName += adjective ? `_${adjective}` : '';
+
+  return eventName;
+};
+
+/**
  * Send event to analyze with Google Analytics.
  *
  * @param  {String} category

--- a/resources/assets/helpers/analytics.js
+++ b/resources/assets/helpers/analytics.js
@@ -31,31 +31,6 @@ const parseEventName = (verb, noun, adjective) => {
 };
 
 /**
- * Dispatch analytics event to specified service, or all services by default.
- *
- * @param  {String}      category
- * @param  {String}      name
- * @param  {Object}      data
- * @param  {Object|Null} service
- * @return {void}
- */
-const dispatchToServices = (category, name, data, service) => {
-  switch (service) {
-    case 'ga':
-      analyzeWithGoogleAnalytics(category, name);
-      break;
-
-    case 'puck':
-      analyzeWithPuck(name, data);
-      break;
-
-    default:
-      analyzeWithGoogleAnalytics(category, name);
-      analyzeWithPuck(name, data);
-  }
-};
-
-/**
  * Send event to analyze with Google Analytics.
  *
  * @param  {String} category
@@ -94,6 +69,31 @@ export function analyzeWithPuck(name, data) {
 
   Puck.trackEvent(name, data);
 }
+
+/**
+ * Dispatch analytics event to specified service, or all services by default.
+ *
+ * @param  {String}      category
+ * @param  {String}      name
+ * @param  {Object}      data
+ * @param  {Object|Null} service
+ * @return {void}
+ */
+const dispatchToServices = (category, name, data, service) => {
+  switch (service) {
+    case 'ga':
+      analyzeWithGoogleAnalytics(category, name);
+      break;
+
+    case 'puck':
+      analyzeWithPuck(name, data);
+      break;
+
+    default:
+      analyzeWithGoogleAnalytics(category, name);
+      analyzeWithPuck(name, data);
+  }
+};
 
 /**
  * Watch the given parameters for changes in their state

--- a/resources/assets/helpers/analytics.js
+++ b/resources/assets/helpers/analytics.js
@@ -113,6 +113,44 @@ export function trackAnalyticsEvent(name, data, service) {
 }
 
 /**
+ * Track an analytics event with a specified service. (Defaults to tracking with all services.)
+ *
+ * @param  {Object}      verb, noun, adjective
+ * @param  {Object}      data
+ * @param  {String|Null} service
+ * @return {Object}
+ */
+export function trackAnalyticsEventBeta(
+  { verb, noun, adjective },
+  data,
+  service,
+) {
+  if (!verb || !noun) {
+    console.error('The Verb or Noun is missing!');
+    return;
+  }
+
+  const eventName = parseEventName(verb, noun, adjective);
+
+  // Define category parameter for Google Analytics.
+  const category = `${APP_NAME}_${noun}`;
+
+  switch (service) {
+    case 'ga':
+      analyzeWithGoogleAnalytics(category, eventName);
+      break;
+
+    case 'puck':
+      analyzeWithPuck(eventName, data);
+      break;
+
+    default:
+      analyzeWithGoogleAnalytics(category, eventName);
+      analyzeWithPuck(eventName, data);
+  }
+}
+
+/**
  * Track an analytics event with Google Analytics.
  *
  * @param  {String} name

--- a/resources/assets/helpers/analytics.js
+++ b/resources/assets/helpers/analytics.js
@@ -146,7 +146,7 @@ export function trackAnalyticsEvent(name, data, service) {
  * @return {Object}
  */
 export function trackAnalyticsEventBeta(nameParams, data, service) {
-  const { verb, noun, adjective } = nameParams;
+  const { verb, noun, adjective } = nameParams || {};
 
   if (!verb || !noun) {
     console.error('The Verb or Noun is missing!');

--- a/resources/assets/helpers/analytics.js
+++ b/resources/assets/helpers/analytics.js
@@ -17,8 +17,8 @@ const APP_NAME = 'phoenix';
 /**
  * Parse analytics event name parameters into a snake cased string.
  *
- * @param  {String} verb
- * @param  {String} noun
+ * @param  {String}      verb
+ * @param  {String}      noun
  * @param  {String|Null} adjective
  * @return {void}
  */

--- a/resources/assets/helpers/analytics.js
+++ b/resources/assets/helpers/analytics.js
@@ -79,7 +79,7 @@ export function analyzeWithPuck(name, data) {
  * @param  {String|Null} service
  * @return {void}
  */
-const dispatchToServices = (category, name, data, service) => {
+const sendToServices = (category, name, data, service) => {
   switch (service) {
     case 'ga':
       analyzeWithGoogleAnalytics(category, name);
@@ -161,7 +161,7 @@ export function trackAnalyticsEventBeta(options = {}) {
   // Define category parameter for Google Analytics.
   const category = `${APP_PREFIX}_${noun}`;
 
-  dispatchToServices(category, eventName, data, service);
+  sendToServices(category, eventName, data, service);
 }
 
 /**

--- a/resources/assets/helpers/analytics.js
+++ b/resources/assets/helpers/analytics.js
@@ -12,7 +12,7 @@ import { PUCK_URL } from '../constants';
 import { get as getHistory } from '../history';
 
 // App name prefix used for event naming.
-const APP_NAME = 'phoenix';
+const APP_PREFIX = 'phoenix';
 
 /**
  * Parse analytics event name parameters into a snake cased string.

--- a/resources/assets/helpers/analytics.js
+++ b/resources/assets/helpers/analytics.js
@@ -140,13 +140,16 @@ export function trackAnalyticsEvent(name, data, service) {
 /**
  * Track an analytics event with a specified service. (Defaults to tracking with all services.)
  *
- * @param  {Object}      nameParams
- * @param  {Object|Null} data
- * @param  {String|Null} service
- * @return {Object}
+ * @param  {Object} options
+ * @param  {String} options.verb
+ * @param  {String} options.noun
+ * @param  {String} [options.adjective]
+ * @param  {Object} [options.data]
+ * @param  {String} [options.service]
+ * @return {void}
  */
-export function trackAnalyticsEventBeta(nameParams, data, service) {
-  const { verb, noun, adjective } = nameParams || {};
+export function trackAnalyticsEventBeta(options = {}) {
+  const { verb, noun, adjective, data, service } = options;
 
   if (!verb || !noun) {
     console.error('The Verb or Noun is missing!');

--- a/resources/assets/helpers/analytics.js
+++ b/resources/assets/helpers/analytics.js
@@ -31,6 +31,31 @@ const parseEventName = (verb, noun, adjective) => {
 };
 
 /**
+ * Dispatch analytics event to specified service, or all services by default.
+ *
+ * @param  {String}      category
+ * @param  {String}      name
+ * @param  {Object}      data
+ * @param  {Object|Null} service
+ * @return {void}
+ */
+const dispatchToServices = (category, name, data, service) => {
+  switch (service) {
+    case 'ga':
+      analyzeWithGoogleAnalytics(category, name);
+      break;
+
+    case 'puck':
+      analyzeWithPuck(name, data);
+      break;
+
+    default:
+      analyzeWithGoogleAnalytics(category, name);
+      analyzeWithPuck(name, data);
+  }
+};
+
+/**
  * Send event to analyze with Google Analytics.
  *
  * @param  {String} category

--- a/resources/assets/helpers/analytics.js
+++ b/resources/assets/helpers/analytics.js
@@ -1,5 +1,6 @@
 /* global window */
 
+import { snakeCase } from 'lodash';
 import { Engine as PuckClient } from '@dosomething/puck-client';
 import {
   dimensionByCookie,
@@ -23,9 +24,9 @@ const APP_PREFIX = 'phoenix';
  * @return {void}
  */
 const formatEventName = (verb, noun, adjective = null) => {
-  let eventName = `${APP_PREFIX}_${verb}_${noun}`;
+  let eventName = `${APP_PREFIX}_${snakeCase(verb)}_${snakeCase(noun)}`;
   // Append adjective if defined.
-  eventName += adjective ? `_${adjective}` : '';
+  eventName += adjective ? `_${snakeCase(adjective)}` : '';
 
   return eventName;
 };
@@ -163,7 +164,7 @@ export function trackAnalyticsEventBeta({
   const eventName = formatEventName(verb, noun, adjective);
 
   // Define category parameter for Google Analytics.
-  const category = `${APP_PREFIX}_${noun}`;
+  const category = `${APP_PREFIX}_${snakeCase(noun)}`;
 
   sendToServices(category, eventName, data, service);
 }

--- a/resources/assets/helpers/analytics.js
+++ b/resources/assets/helpers/analytics.js
@@ -160,19 +160,7 @@ export function trackAnalyticsEventBeta(
   // Define category parameter for Google Analytics.
   const category = `${APP_NAME}_${noun}`;
 
-  switch (service) {
-    case 'ga':
-      analyzeWithGoogleAnalytics(category, eventName);
-      break;
-
-    case 'puck':
-      analyzeWithPuck(eventName, data);
-      break;
-
-    default:
-      analyzeWithGoogleAnalytics(category, eventName);
-      analyzeWithPuck(eventName, data);
-  }
+  dispatchToServices(category, eventName, data, service);
 }
 
 /**

--- a/resources/assets/helpers/analytics.js
+++ b/resources/assets/helpers/analytics.js
@@ -11,6 +11,9 @@ import {
 import { PUCK_URL } from '../constants';
 import { get as getHistory } from '../history';
 
+// App name prefix used for event naming.
+const APP_NAME = 'phoenix';
+
 /**
  * Send event to analyze with Google Analytics.
  *

--- a/resources/assets/helpers/analytics.js
+++ b/resources/assets/helpers/analytics.js
@@ -23,7 +23,7 @@ const APP_PREFIX = 'phoenix';
  * @return {void}
  */
 const parseEventName = (verb, noun, adjective = null) => {
-  let eventName = `${APP_NAME}_${verb}_${noun}`;
+  let eventName = `${APP_PREFIX}_${verb}_${noun}`;
   // Append adjective if defined.
   eventName += adjective ? `_${adjective}` : '';
 
@@ -156,7 +156,7 @@ export function trackAnalyticsEventBeta(nameParams, data, service) {
   const eventName = parseEventName(verb, noun, adjective);
 
   // Define category parameter for Google Analytics.
-  const category = `${APP_NAME}_${noun}`;
+  const category = `${APP_PREFIX}_${noun}`;
 
   dispatchToServices(category, eventName, data, service);
 }

--- a/resources/assets/helpers/analytics.js
+++ b/resources/assets/helpers/analytics.js
@@ -20,7 +20,7 @@ const APP_PREFIX = 'phoenix';
  *
  * @param  {String}      verb
  * @param  {String}      noun
- * @param  {String|Null} adjective
+ * @param  {String|Null} [adjective=null]
  * @return {void}
  */
 const formatEventName = (verb, noun, adjective = null) => {
@@ -76,8 +76,8 @@ export function analyzeWithPuck(name, data) {
  *
  * @param  {String}      category
  * @param  {String}      name
- * @param  {Object}      data
- * @param  {String|Null} service
+ * @param  {Object|Null} [data]
+ * @param  {String|Null} [service]
  * @return {void}
  */
 const sendToServices = (category, name, data, service) => {

--- a/resources/assets/helpers/analytics.js
+++ b/resources/assets/helpers/analytics.js
@@ -22,7 +22,7 @@ const APP_PREFIX = 'phoenix';
  * @param  {String|Null} adjective
  * @return {void}
  */
-const parseEventName = (verb, noun, adjective) => {
+const parseEventName = (verb, noun, adjective = null) => {
   let eventName = `${APP_NAME}_${verb}_${noun}`;
   // Append adjective if defined.
   eventName += adjective ? `_${adjective}` : '';

--- a/resources/assets/helpers/analytics.js
+++ b/resources/assets/helpers/analytics.js
@@ -22,7 +22,7 @@ const APP_PREFIX = 'phoenix';
  * @param  {String|Null} adjective
  * @return {void}
  */
-const parseEventName = (verb, noun, adjective = null) => {
+const formatEventName = (verb, noun, adjective = null) => {
   let eventName = `${APP_PREFIX}_${verb}_${noun}`;
   // Append adjective if defined.
   eventName += adjective ? `_${adjective}` : '';
@@ -156,7 +156,7 @@ export function trackAnalyticsEventBeta(options = {}) {
     return;
   }
 
-  const eventName = parseEventName(verb, noun, adjective);
+  const eventName = formatEventName(verb, noun, adjective);
 
   // Define category parameter for Google Analytics.
   const category = `${APP_PREFIX}_${noun}`;

--- a/resources/assets/helpers/analytics.js
+++ b/resources/assets/helpers/analytics.js
@@ -148,9 +148,13 @@ export function trackAnalyticsEvent(name, data, service) {
  * @param  {String} [options.service]
  * @return {void}
  */
-export function trackAnalyticsEventBeta(options = {}) {
-  const { verb, noun, adjective, data, service } = options;
-
+export function trackAnalyticsEventBeta({
+  verb,
+  noun,
+  adjective,
+  data,
+  service,
+}) {
   if (!verb || !noun) {
     console.error('The Verb or Noun is missing!');
     return;

--- a/resources/assets/helpers/analytics.js
+++ b/resources/assets/helpers/analytics.js
@@ -141,12 +141,12 @@ export function trackAnalyticsEvent(name, data, service) {
 /**
  * Track an analytics event with a specified service. (Defaults to tracking with all services.)
  *
- * @param  {Object} options
- * @param  {String} options.verb
- * @param  {String} options.noun
- * @param  {String} [options.adjective]
- * @param  {Object} [options.data]
- * @param  {String} [options.service]
+ * @param  {Object}      options
+ * @param  {String}      options.verb
+ * @param  {String}      options.noun
+ * @param  {String}      [options.adjective]
+ * @param  {Object|Null} [options.data]
+ * @param  {String|Null} [options.service]
  * @return {void}
  */
 export function trackAnalyticsEventBeta({

--- a/resources/assets/helpers/analytics.js
+++ b/resources/assets/helpers/analytics.js
@@ -140,16 +140,14 @@ export function trackAnalyticsEvent(name, data, service) {
 /**
  * Track an analytics event with a specified service. (Defaults to tracking with all services.)
  *
- * @param  {Object}      verb, noun, adjective
+ * @param  {Object}      nameParams
  * @param  {Object}      data
  * @param  {String|Null} service
  * @return {Object}
  */
-export function trackAnalyticsEventBeta(
-  { verb, noun, adjective },
-  data,
-  service,
-) {
+export function trackAnalyticsEventBeta(nameParams, data, service) {
+  const { verb, noun, adjective } = nameParams;
+
   if (!verb || !noun) {
     console.error('The Verb or Noun is missing!');
     return;

--- a/resources/assets/helpers/analytics.js
+++ b/resources/assets/helpers/analytics.js
@@ -76,7 +76,7 @@ export function analyzeWithPuck(name, data) {
  * @param  {String}      category
  * @param  {String}      name
  * @param  {Object}      data
- * @param  {Object|Null} service
+ * @param  {String|Null} service
  * @return {void}
  */
 const dispatchToServices = (category, name, data, service) => {


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_


### What does this PR do?

This PR adds an updated analytics tracking method (`trackAnalyticsEventBeta`) which provides a new event naming structure - an object consisting of `verb`, `noun` and the options `adjective` fields. As well as a new service dispatching methodology - it will dispatch the event to all services by default, and only to specific service if specified.

### Any background context you want to provide?
The method quickly grew to be pretty large, so I moved some of the logic into two helpers:
- `formatEventName` to generate a full snake cased event name from the `verb`, `noun`, and `adjective`
- `sendToServices` which dispatches the event to all services or the specified one

I also set up an `APP_PREFIX` constant to store the app prefix we use for event names.

### What are the relevant tickets/cards?

Refs [Pivotal ID #162068080](https://www.pivotaltracker.com/story/show/162068080)

### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.
* [ ] Added screenshot to PR description of related front-end updates on **small** screens.
* [ ] Added screenshot to PR description of related front-end updates on **medium** screens.
* [ ] Added screenshot to PR description of related front-end updates on **large** screens.
