### PR TITLE
Update All Analytics Events to Our New Format!

### DIFF
--- a/resources/assets/actions/post.js
+++ b/resources/assets/actions/post.js
@@ -80,8 +80,8 @@ export function storeCampaignPost(campaignId, data) {
   const { action, body, id, type } = data;
 
   const analytics = {
-    name: `${type}-submission-action`,
-    service: 'puck',
+    verb: 'submitted',
+    noun: `${type}_submission_action`,
     payload: {
       action,
       campaignId,

--- a/resources/assets/actions/signup.js
+++ b/resources/assets/actions/signup.js
@@ -119,8 +119,8 @@ export function getCampaignSignups(id = null, query = {}) {
 export function storeCampaignSignup(campaignId, data) {
   const path = join('api/v2/campaigns', campaignId, 'signups');
   const analytics = {
-    name: 'phoenix_clicked_signup',
-    service: 'puck',
+    verb: 'clicked',
+    noun: 'signup',
     payload: {
       campaignId,
     },

--- a/resources/assets/actions/signup.js
+++ b/resources/assets/actions/signup.js
@@ -123,6 +123,7 @@ export function storeCampaignSignup(campaignId, data) {
     noun: 'signup',
     payload: {
       campaignId,
+      ...data.analytics,
     },
   };
 

--- a/resources/assets/components/LegacyQuiz/LegacyQuiz.js
+++ b/resources/assets/components/LegacyQuiz/LegacyQuiz.js
@@ -7,7 +7,7 @@ import Conclusion from './Conclusion';
 import Share from '../utilities/Share/Share';
 import ContentfulEntry from '../ContentfulEntry';
 import Markdown from '../utilities/Markdown/Markdown';
-import { trackAnalyticsEventBeta } from '../../helpers/analytics';
+import { trackAnalyticsEvent } from '../../helpers/analytics';
 
 import './legacy-quiz.scss';
 
@@ -64,7 +64,7 @@ const LegacyQuiz = props => {
   };
 
   if (shouldSeeResult) {
-    trackAnalyticsEventBeta({
+    trackAnalyticsEvent({
       verb: 'submitted',
       noun: 'quiz',
       data: {

--- a/resources/assets/components/LegacyQuiz/LegacyQuiz.js
+++ b/resources/assets/components/LegacyQuiz/LegacyQuiz.js
@@ -7,7 +7,7 @@ import Conclusion from './Conclusion';
 import Share from '../utilities/Share/Share';
 import ContentfulEntry from '../ContentfulEntry';
 import Markdown from '../utilities/Markdown/Markdown';
-import { trackPuckEvent } from '../../helpers/analytics';
+import { trackAnalyticsEventBeta } from '../../helpers/analytics';
 
 import './legacy-quiz.scss';
 
@@ -64,8 +64,12 @@ const LegacyQuiz = props => {
   };
 
   if (shouldSeeResult) {
-    trackPuckEvent('converted on quiz', {
-      responses: data.questions,
+    trackAnalyticsEventBeta({
+      verb: 'submitted',
+      noun: 'quiz',
+      data: {
+        responses: data.questions,
+      },
     });
   }
 

--- a/resources/assets/components/PollLocator/PollLocator.js
+++ b/resources/assets/components/PollLocator/PollLocator.js
@@ -3,7 +3,7 @@ import React from 'react';
 import { get } from 'lodash';
 import PropTypes from 'prop-types';
 
-import { trackAnalyticsEventBeta } from '../../helpers/analytics';
+import { trackAnalyticsEvent } from '../../helpers/analytics';
 
 class PollLocator extends React.Component {
   componentDidMount() {
@@ -17,7 +17,7 @@ class PollLocator extends React.Component {
   }
 
   handleSearchButtonClick = () => {
-    trackAnalyticsEventBeta({
+    trackAnalyticsEvent({
       verb: 'clicked',
       noun: 'poll_locator',
     });
@@ -36,7 +36,7 @@ class PollLocator extends React.Component {
         .getElementById('_vit')
         .querySelector('#address-not-found');
       if (get(addressNotFoundModal, 'style.display') === 'block') {
-        trackAnalyticsEventBeta({
+        trackAnalyticsEvent({
           verb: 'opened',
           noun: 'modal',
           adjective: 'poll_locator_not_found',
@@ -58,7 +58,7 @@ class PollLocator extends React.Component {
     this.vitModalObserver = new MutationObserver(() => {
       const modal = document.querySelector('html > #_vitModal');
       if (modal) {
-        trackAnalyticsEventBeta({
+        trackAnalyticsEvent({
           verb: 'opened',
           noun: 'modal',
           adjective: 'poll_locator',

--- a/resources/assets/components/PollLocator/PollLocator.js
+++ b/resources/assets/components/PollLocator/PollLocator.js
@@ -3,7 +3,7 @@ import React from 'react';
 import { get } from 'lodash';
 import PropTypes from 'prop-types';
 
-import { trackPuckEvent } from '../../helpers/analytics';
+import { trackAnalyticsEventBeta } from '../../helpers/analytics';
 
 class PollLocator extends React.Component {
   componentDidMount() {
@@ -17,7 +17,10 @@ class PollLocator extends React.Component {
   }
 
   handleSearchButtonClick = () => {
-    trackPuckEvent('phoenix_clicked_poll_locator');
+    trackAnalyticsEventBeta({
+      verb: 'clicked',
+      noun: 'poll_locator',
+    });
   };
 
   /**
@@ -33,7 +36,11 @@ class PollLocator extends React.Component {
         .getElementById('_vit')
         .querySelector('#address-not-found');
       if (get(addressNotFoundModal, 'style.display') === 'block') {
-        trackPuckEvent('phoenix_opened_poll_locator_not_found_modal');
+        trackAnalyticsEventBeta({
+          verb: 'opened',
+          noun: 'modal',
+          adjective: 'poll_locator_not_found',
+        });
       }
 
       const searchButton = document.getElementById('submit-address-button');
@@ -51,7 +58,11 @@ class PollLocator extends React.Component {
     this.vitModalObserver = new MutationObserver(() => {
       const modal = document.querySelector('html > #_vitModal');
       if (modal) {
-        trackPuckEvent('phoenix_opened_poll_locator_modal');
+        trackAnalyticsEventBeta({
+          verb: 'opened',
+          noun: 'modal',
+          adjective: 'poll_locator',
+        });
       }
     });
 

--- a/resources/assets/components/Quiz/Quiz.js
+++ b/resources/assets/components/Quiz/Quiz.js
@@ -13,7 +13,7 @@ import Share from '../utilities/Share/Share';
 import QuizConclusion from './QuizConclusion';
 import ContentfulEntry from '../ContentfulEntry';
 import ScrollConcierge from '../ScrollConcierge';
-import { trackPuckEvent } from '../../helpers/analytics';
+import { trackAnalyticsEventBeta } from '../../helpers/analytics';
 import { calculateResult, resultParams, appendResultParams } from './helpers';
 
 import './quiz.scss';
@@ -91,8 +91,12 @@ class Quiz extends React.Component {
       resultBlocks,
     );
 
-    trackPuckEvent('converted on quiz', {
-      responses: this.state.choices,
+    trackAnalyticsEventBeta({
+      verb: 'submitted',
+      noun: 'quiz',
+      data: {
+        responses: this.state.choices,
+      },
     });
 
     // Run a quiz conversion (campaign signup) if this quiz is not set to auto submit

--- a/resources/assets/components/Quiz/Quiz.js
+++ b/resources/assets/components/Quiz/Quiz.js
@@ -13,7 +13,7 @@ import Share from '../utilities/Share/Share';
 import QuizConclusion from './QuizConclusion';
 import ContentfulEntry from '../ContentfulEntry';
 import ScrollConcierge from '../ScrollConcierge';
-import { trackAnalyticsEventBeta } from '../../helpers/analytics';
+import { trackAnalyticsEvent } from '../../helpers/analytics';
 import { calculateResult, resultParams, appendResultParams } from './helpers';
 
 import './quiz.scss';
@@ -91,7 +91,7 @@ class Quiz extends React.Component {
       resultBlocks,
     );
 
-    trackAnalyticsEventBeta({
+    trackAnalyticsEvent({
       verb: 'submitted',
       noun: 'quiz',
       data: {

--- a/resources/assets/components/Quiz/Quiz.test.js
+++ b/resources/assets/components/Quiz/Quiz.test.js
@@ -6,7 +6,7 @@ import { createMemoryHistory } from 'history';
 
 import Quiz from './Quiz';
 import QuizQuestion from './QuizQuestion';
-import { trackPuckEvent as trackEventMock } from '../../helpers/analytics';
+import { trackAnalyticsEventBeta as trackEventMock } from '../../helpers/analytics';
 
 jest.mock('../../helpers/analytics');
 

--- a/resources/assets/components/Quiz/Quiz.test.js
+++ b/resources/assets/components/Quiz/Quiz.test.js
@@ -6,7 +6,7 @@ import { createMemoryHistory } from 'history';
 
 import Quiz from './Quiz';
 import QuizQuestion from './QuizQuestion';
-import { trackAnalyticsEventBeta as trackEventMock } from '../../helpers/analytics';
+import { trackAnalyticsEvent as trackEventMock } from '../../helpers/analytics';
 
 jest.mock('../../helpers/analytics');
 

--- a/resources/assets/components/SignupButton/SignupButton.js
+++ b/resources/assets/components/SignupButton/SignupButton.js
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import { get } from 'lodash';
 
 import Button from '../utilities/Button/Button';
-import { trackAnalyticsEvent } from '../../helpers/analytics';
 
 const SignupButton = props => {
   const {
@@ -24,14 +23,8 @@ const SignupButton = props => {
   const onSignup = buttonText => {
     clickedSignupAction(campaignId, {
       body: { details: { campaignContentfulId } },
-    });
-
-    trackAnalyticsEvent({
-      verb: 'clicked',
-      noun: 'signup',
-      data: {
+      analytics: {
         template,
-        legacyCampaignId: campaignId, // @TODO: confirm it's ok to send as campaignID and not legacyCampaignId
         source,
         sourceData: { text: buttonText },
       },

--- a/resources/assets/components/SignupButton/SignupButton.js
+++ b/resources/assets/components/SignupButton/SignupButton.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { get } from 'lodash';
 
 import Button from '../utilities/Button/Button';
-import { trackPuckEvent } from '../../helpers/analytics';
+import { trackAnalyticsEventBeta } from '../../helpers/analytics';
 
 const SignupButton = props => {
   const {
@@ -26,11 +26,15 @@ const SignupButton = props => {
       body: { details: { campaignContentfulId } },
     });
 
-    trackPuckEvent('signup', {
-      template,
-      legacyCampaignId: campaignId, // @TODO: confirm it's ok to send as campaignID and not legacyCampaignId
-      source,
-      sourceData: { text: buttonText },
+    trackAnalyticsEventBeta({
+      verb: 'clicked',
+      noun: 'signup',
+      data: {
+        template,
+        legacyCampaignId: campaignId, // @TODO: confirm it's ok to send as campaignID and not legacyCampaignId
+        source,
+        sourceData: { text: buttonText },
+      },
     });
   };
 

--- a/resources/assets/components/SignupButton/SignupButton.js
+++ b/resources/assets/components/SignupButton/SignupButton.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { get } from 'lodash';
 
 import Button from '../utilities/Button/Button';
-import { trackAnalyticsEventBeta } from '../../helpers/analytics';
+import { trackAnalyticsEvent } from '../../helpers/analytics';
 
 const SignupButton = props => {
   const {
@@ -26,7 +26,7 @@ const SignupButton = props => {
       body: { details: { campaignContentfulId } },
     });
 
-    trackAnalyticsEventBeta({
+    trackAnalyticsEvent({
       verb: 'clicked',
       noun: 'signup',
       data: {

--- a/resources/assets/components/actions/LinkAction/templates/CtaTemplate.js
+++ b/resources/assets/components/actions/LinkAction/templates/CtaTemplate.js
@@ -6,14 +6,14 @@ import PropTypes from 'prop-types';
 import Card from '../../../utilities/Card/Card';
 import Button from '../../../utilities/Button/Button';
 import Markdown from '../../../utilities/Markdown/Markdown';
-import { trackAnalyticsEventBeta } from '../../../../helpers/analytics';
+import { trackAnalyticsEvent } from '../../../../helpers/analytics';
 import { isExternal, dynamicString } from '../../../../helpers';
 
 import './cta-template.scss';
 
 const onLinkClick = link => {
   window.open(link, isExternal(link) ? '_blank' : '_self');
-  trackAnalyticsEventBeta({
+  trackAnalyticsEvent({
     verb: 'clicked',
     noun: 'link_action',
     data: { link },

--- a/resources/assets/components/actions/LinkAction/templates/CtaTemplate.js
+++ b/resources/assets/components/actions/LinkAction/templates/CtaTemplate.js
@@ -6,14 +6,18 @@ import PropTypes from 'prop-types';
 import Card from '../../../utilities/Card/Card';
 import Button from '../../../utilities/Button/Button';
 import Markdown from '../../../utilities/Markdown/Markdown';
-import { trackPuckEvent } from '../../../../helpers/analytics';
+import { trackAnalyticsEventBeta } from '../../../../helpers/analytics';
 import { isExternal, dynamicString } from '../../../../helpers';
 
 import './cta-template.scss';
 
 const onLinkClick = link => {
   window.open(link, isExternal(link) ? '_blank' : '_self');
-  trackPuckEvent('clicked link action', { link });
+  trackAnalyticsEventBeta({
+    verb: 'clicked',
+    noun: 'link_action',
+    data: { link },
+  });
 };
 
 const CtaTemplate = ({ title, content, link, buttonText, source }) => {

--- a/resources/assets/components/actions/LinkAction/templates/DefaultTemplate.js
+++ b/resources/assets/components/actions/LinkAction/templates/DefaultTemplate.js
@@ -9,12 +9,12 @@ import Embed from '../../../utilities/Embed/Embed';
 import Button from '../../../utilities/Button/Button';
 import SponsorPromotion from '../../../SponsorPromotion';
 import Markdown from '../../../utilities/Markdown/Markdown';
-import { trackAnalyticsEventBeta } from '../../../../helpers/analytics';
+import { trackAnalyticsEvent } from '../../../../helpers/analytics';
 import { isExternal, dynamicString } from '../../../../helpers';
 
 const onLinkClick = link => {
   window.open(link, isExternal(link) ? '_blank' : '_self');
-  trackAnalyticsEventBeta({
+  trackAnalyticsEvent({
     verb: 'clicked',
     noun: 'link_action',
     data: { link },

--- a/resources/assets/components/actions/LinkAction/templates/DefaultTemplate.js
+++ b/resources/assets/components/actions/LinkAction/templates/DefaultTemplate.js
@@ -9,12 +9,16 @@ import Embed from '../../../utilities/Embed/Embed';
 import Button from '../../../utilities/Button/Button';
 import SponsorPromotion from '../../../SponsorPromotion';
 import Markdown from '../../../utilities/Markdown/Markdown';
-import { trackPuckEvent } from '../../../../helpers/analytics';
+import { trackAnalyticsEventBeta } from '../../../../helpers/analytics';
 import { isExternal, dynamicString } from '../../../../helpers';
 
 const onLinkClick = link => {
   window.open(link, isExternal(link) ? '_blank' : '_self');
-  trackPuckEvent('clicked link action', { link });
+  trackAnalyticsEventBeta({
+    verb: 'clicked',
+    noun: 'link_action',
+    data: { link },
+  });
 };
 
 const DefaultTemplate = props => {

--- a/resources/assets/components/actions/LinkAction/templates/DefaultTemplate.test.js
+++ b/resources/assets/components/actions/LinkAction/templates/DefaultTemplate.test.js
@@ -4,7 +4,7 @@ import React from 'react';
 import { shallow } from 'enzyme';
 
 import DefaultTemplate from './DefaultTemplate';
-import { trackAnalyticsEventBeta as trackEventMock } from '../../../../helpers/analytics';
+import { trackAnalyticsEvent as trackEventMock } from '../../../../helpers/analytics';
 
 jest.mock('../../../../helpers/analytics');
 

--- a/resources/assets/components/actions/LinkAction/templates/DefaultTemplate.test.js
+++ b/resources/assets/components/actions/LinkAction/templates/DefaultTemplate.test.js
@@ -4,7 +4,7 @@ import React from 'react';
 import { shallow } from 'enzyme';
 
 import DefaultTemplate from './DefaultTemplate';
-import { trackPuckEvent as trackEventMock } from '../../../../helpers/analytics';
+import { trackAnalyticsEventBeta as trackEventMock } from '../../../../helpers/analytics';
 
 jest.mock('../../../../helpers/analytics');
 

--- a/resources/assets/components/actions/ShareAction/ShareAction.js
+++ b/resources/assets/components/actions/ShareAction/ShareAction.js
@@ -9,7 +9,7 @@ import Button from '../../utilities/Button/Button';
 import ContentfulEntry from '../../ContentfulEntry';
 import { setFormData } from '../../../helpers/forms';
 import Markdown from '../../utilities/Markdown/Markdown';
-import { trackPuckEvent } from '../../../helpers/analytics';
+import { trackAnalyticsEventBeta } from '../../../helpers/analytics';
 import {
   dynamicString,
   loadFacebookSDK,
@@ -28,7 +28,7 @@ class ShareAction extends React.Component {
   }
 
   storeSharePost = puckId => {
-    const type = 'share-social';
+    const type = 'share_social';
 
     const action = get(this.props.additionalContent, 'action', 'default');
 
@@ -58,29 +58,51 @@ class ShareAction extends React.Component {
   handleFacebookClick = url => {
     const { link, userId } = this.props;
 
-    let trackingData = { url: link };
+    const trackingData = { url: link };
+    let trackingOptions = {
+      noun: 'share_action',
+      adjective: 'facebook',
+      data: trackingData,
+    };
 
-    trackPuckEvent('clicked facebook share action', trackingData);
+    trackAnalyticsEventBeta({
+      verb: 'clicked',
+      ...trackingOptions,
+    });
 
     showFacebookShareDialog(url)
       .then(() => {
         // Send share post to Rogue for authenticated users
         if (this.props.isAuthenticated && this.props.campaignId) {
           const puckId = `phoenix_${userId}_${Date.now()}`;
-          trackingData = { ...trackingData, puck_id: puckId };
+          trackingOptions = {
+            ...trackingOptions,
+            data: { ...trackingData, puck_id: puckId },
+          };
           this.storeSharePost(puckId);
         }
 
-        trackPuckEvent('share action completed', trackingData);
+        trackAnalyticsEventBeta({
+          verb: 'completed',
+          ...trackingOptions,
+        });
         this.setState({ showModal: true });
       })
       .catch(() => {
-        trackPuckEvent('share action cancelled', trackingData);
+        trackAnalyticsEventBeta({
+          verb: 'cancelled',
+          ...trackingOptions,
+        });
       });
   };
 
   handleTwitterClick = url => {
-    trackPuckEvent('clicked twitter share action', { url: this.props.link });
+    trackAnalyticsEventBeta({
+      verb: 'clicked',
+      noun: 'share_action',
+      adjective: 'twitter',
+      data: { url: this.props.link },
+    });
     showTwitterSharePrompt(url, '', () => this.setState({ showModal: true }));
   };
 

--- a/resources/assets/components/actions/ShareAction/ShareAction.js
+++ b/resources/assets/components/actions/ShareAction/ShareAction.js
@@ -9,7 +9,7 @@ import Button from '../../utilities/Button/Button';
 import ContentfulEntry from '../../ContentfulEntry';
 import { setFormData } from '../../../helpers/forms';
 import Markdown from '../../utilities/Markdown/Markdown';
-import { trackAnalyticsEventBeta } from '../../../helpers/analytics';
+import { trackAnalyticsEvent } from '../../../helpers/analytics';
 import {
   dynamicString,
   loadFacebookSDK,
@@ -65,7 +65,7 @@ class ShareAction extends React.Component {
       data: trackingData,
     };
 
-    trackAnalyticsEventBeta({
+    trackAnalyticsEvent({
       verb: 'clicked',
       ...trackingOptions,
     });
@@ -82,14 +82,14 @@ class ShareAction extends React.Component {
           this.storeSharePost(puckId);
         }
 
-        trackAnalyticsEventBeta({
+        trackAnalyticsEvent({
           verb: 'completed',
           ...trackingOptions,
         });
         this.setState({ showModal: true });
       })
       .catch(() => {
-        trackAnalyticsEventBeta({
+        trackAnalyticsEvent({
           verb: 'cancelled',
           ...trackingOptions,
         });
@@ -97,7 +97,7 @@ class ShareAction extends React.Component {
   };
 
   handleTwitterClick = url => {
-    trackAnalyticsEventBeta({
+    trackAnalyticsEvent({
       verb: 'clicked',
       noun: 'share_action',
       adjective: 'twitter',

--- a/resources/assets/components/actions/ShareAction/ShareAction.test.js
+++ b/resources/assets/components/actions/ShareAction/ShareAction.test.js
@@ -3,7 +3,7 @@ import { shallow } from 'enzyme';
 
 import ShareAction from './ShareAction';
 import setFBshare from '../../../__mocks__/facebookShareMock';
-import { trackAnalyticsEventBeta as trackEventMock } from '../../../helpers/analytics';
+import { trackAnalyticsEvent as trackEventMock } from '../../../helpers/analytics';
 
 jest.mock('./ShareActionContainer', () => 'ShareActionContainer');
 

--- a/resources/assets/components/actions/ShareAction/ShareAction.test.js
+++ b/resources/assets/components/actions/ShareAction/ShareAction.test.js
@@ -3,7 +3,7 @@ import { shallow } from 'enzyme';
 
 import ShareAction from './ShareAction';
 import setFBshare from '../../../__mocks__/facebookShareMock';
-import { trackPuckEvent as trackEventMock } from '../../../helpers/analytics';
+import { trackAnalyticsEventBeta as trackEventMock } from '../../../helpers/analytics';
 
 jest.mock('./ShareActionContainer', () => 'ShareActionContainer');
 
@@ -77,8 +77,12 @@ describe('ShareAction component', () => {
       expect(trackEventMock.mock.calls.length).toBeGreaterThan(0);
 
       expect(trackEventMock.mock.calls[0]).toEqual([
-        'clicked facebook share action',
-        trackingData,
+        {
+          verb: 'clicked',
+          noun: 'share_action',
+          adjective: 'facebook',
+          data: trackingData,
+        },
       ]);
     });
 
@@ -118,8 +122,12 @@ describe('ShareAction component', () => {
       expect(trackEventMock.mock.calls.length).toBeGreaterThan(0);
 
       expect(trackEventMock.mock.calls[0]).toEqual([
-        'clicked twitter share action',
-        trackingData,
+        {
+          verb: 'clicked',
+          noun: 'share_action',
+          adjective: 'twitter',
+          data: trackingData,
+        },
       ]);
     });
 

--- a/resources/assets/components/actions/SocialDriveAction/SocialDriveAction.js
+++ b/resources/assets/components/actions/SocialDriveAction/SocialDriveAction.js
@@ -7,7 +7,7 @@ import linkIcon from './linkIcon.svg';
 import Card from '../../utilities/Card/Card';
 import Embed from '../../utilities/Embed/Embed';
 import { postRequest } from '../../../helpers/api';
-import { trackPuckEvent } from '../../../helpers/analytics';
+import { trackAnalyticsEventBeta } from '../../../helpers/analytics';
 import { dynamicString, withoutTokens } from '../../../helpers';
 import SocialShareTray from '../../utilities/SocialShareTray/SocialShareTray';
 
@@ -37,8 +37,12 @@ class SocialDriveAction extends React.Component {
   handleCopyLinkClick = () => {
     this.linkInput.current.select();
     document.execCommand('copy');
-    trackPuckEvent('phoenix_clicked_copy_to_clipboard', {
-      url: this.props.link,
+    trackAnalyticsEventBeta({
+      verb: 'clicked',
+      noun: 'copy_to_clipboard',
+      data: {
+        url: this.props.link,
+      },
     });
   };
 

--- a/resources/assets/components/actions/SocialDriveAction/SocialDriveAction.js
+++ b/resources/assets/components/actions/SocialDriveAction/SocialDriveAction.js
@@ -7,7 +7,7 @@ import linkIcon from './linkIcon.svg';
 import Card from '../../utilities/Card/Card';
 import Embed from '../../utilities/Embed/Embed';
 import { postRequest } from '../../../helpers/api';
-import { trackAnalyticsEventBeta } from '../../../helpers/analytics';
+import { trackAnalyticsEvent } from '../../../helpers/analytics';
 import { dynamicString, withoutTokens } from '../../../helpers';
 import SocialShareTray from '../../utilities/SocialShareTray/SocialShareTray';
 
@@ -37,7 +37,7 @@ class SocialDriveAction extends React.Component {
   handleCopyLinkClick = () => {
     this.linkInput.current.select();
     document.execCommand('copy');
-    trackAnalyticsEventBeta({
+    trackAnalyticsEvent({
       verb: 'clicked',
       noun: 'copy_to_clipboard',
       data: {

--- a/resources/assets/components/actions/VoterRegistrationAction/VoterRegistrationAction.js
+++ b/resources/assets/components/actions/VoterRegistrationAction/VoterRegistrationAction.js
@@ -5,7 +5,7 @@ import Card from '../../utilities/Card/Card';
 import { set } from '../../../helpers/storage';
 import { dynamicString } from '../../../helpers';
 import Markdown from '../../utilities/Markdown/Markdown';
-import { trackPuckEvent } from '../../../helpers/analytics';
+import { trackAnalyticsEventBeta } from '../../../helpers/analytics';
 
 import './voter-registration-action.scss';
 
@@ -24,7 +24,11 @@ const VoterRegistrationAction = props => {
 
   const handleClick = () => {
     const trackingData = { contentfulId, url: parsedLink, modal: modalType };
-    trackPuckEvent('clicked voter registration action', trackingData);
+    trackAnalyticsEventBeta({
+      verb: 'clicked',
+      noun: 'voter_registration_action',
+      data: trackingData,
+    });
     set(`${props.userId}_hide_voter_reg_modal`, 'boolean', true);
   };
 

--- a/resources/assets/components/actions/VoterRegistrationAction/VoterRegistrationAction.js
+++ b/resources/assets/components/actions/VoterRegistrationAction/VoterRegistrationAction.js
@@ -5,7 +5,7 @@ import Card from '../../utilities/Card/Card';
 import { set } from '../../../helpers/storage';
 import { dynamicString } from '../../../helpers';
 import Markdown from '../../utilities/Markdown/Markdown';
-import { trackAnalyticsEventBeta } from '../../../helpers/analytics';
+import { trackAnalyticsEvent } from '../../../helpers/analytics';
 
 import './voter-registration-action.scss';
 
@@ -24,7 +24,7 @@ const VoterRegistrationAction = props => {
 
   const handleClick = () => {
     const trackingData = { contentfulId, url: parsedLink, modal: modalType };
-    trackAnalyticsEventBeta({
+    trackAnalyticsEvent({
       verb: 'clicked',
       noun: 'voter_registration_action',
       data: trackingData,

--- a/resources/assets/components/actions/VoterRegistrationAction/VoterRegistrationAction.test.js
+++ b/resources/assets/components/actions/VoterRegistrationAction/VoterRegistrationAction.test.js
@@ -4,7 +4,7 @@ import { shallow } from 'enzyme';
 import { get } from '../../../helpers/storage';
 import VoterRegistrationAction from './VoterRegistrationAction';
 import LocalStorageMock from '../../../__mocks__/localStorageMock';
-import { trackPuckEvent as trackEventMock } from '../../../helpers/analytics';
+import { trackAnalyticsEventBeta as trackEventMock } from '../../../helpers/analytics';
 
 jest.mock('../../../helpers/analytics');
 

--- a/resources/assets/components/actions/VoterRegistrationAction/VoterRegistrationAction.test.js
+++ b/resources/assets/components/actions/VoterRegistrationAction/VoterRegistrationAction.test.js
@@ -4,7 +4,7 @@ import { shallow } from 'enzyme';
 import { get } from '../../../helpers/storage';
 import VoterRegistrationAction from './VoterRegistrationAction';
 import LocalStorageMock from '../../../__mocks__/localStorageMock';
-import { trackAnalyticsEventBeta as trackEventMock } from '../../../helpers/analytics';
+import { trackAnalyticsEvent as trackEventMock } from '../../../helpers/analytics';
 
 jest.mock('../../../helpers/analytics');
 

--- a/resources/assets/components/utilities/Modal/Modal.js
+++ b/resources/assets/components/utilities/Modal/Modal.js
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 import ReactDom from 'react-dom';
 
 import ModalContent from './ModalContent';
-import { trackAnalyticsEventBeta } from '../../../helpers/analytics';
+import { trackAnalyticsEvent } from '../../../helpers/analytics';
 
 import './modal.scss';
 
@@ -32,7 +32,7 @@ class Modal extends React.Component {
 
     // Track in analytics that the modal opened:
     if (this.props.trackingId) {
-      trackAnalyticsEventBeta({
+      trackAnalyticsEvent({
         verb: 'opened',
         noun: 'modal',
         data: {
@@ -51,7 +51,7 @@ class Modal extends React.Component {
 
     // Track in analytics that the modal closed:
     if (this.props.trackingId) {
-      trackAnalyticsEventBeta({
+      trackAnalyticsEvent({
         verb: 'closed',
         noun: 'modal',
         data: {

--- a/resources/assets/components/utilities/Modal/Modal.js
+++ b/resources/assets/components/utilities/Modal/Modal.js
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 import ReactDom from 'react-dom';
 
 import ModalContent from './ModalContent';
-import { trackPuckEvent } from '../../../helpers/analytics';
+import { trackAnalyticsEventBeta } from '../../../helpers/analytics';
 
 import './modal.scss';
 
@@ -32,7 +32,13 @@ class Modal extends React.Component {
 
     // Track in analytics that the modal opened:
     if (this.props.trackingId) {
-      trackPuckEvent('open modal', { modalType: this.props.trackingId });
+      trackAnalyticsEventBeta({
+        verb: 'opened',
+        noun: 'modal',
+        data: {
+          modalType: this.props.trackingId,
+        },
+      });
     }
   }
 

--- a/resources/assets/components/utilities/Modal/Modal.js
+++ b/resources/assets/components/utilities/Modal/Modal.js
@@ -48,6 +48,17 @@ class Modal extends React.Component {
     window.scroll(0, this.scrollOffset);
     this.modalPortal.classList.remove('is-active');
     this.modalPortal.removeChild(this.el);
+
+    // Track in analytics that the modal closed:
+    if (this.props.trackingId) {
+      trackAnalyticsEventBeta({
+        verb: 'closed',
+        noun: 'modal',
+        data: {
+          modalType: this.props.trackingId,
+        },
+      });
+    }
   }
 
   render() {

--- a/resources/assets/components/utilities/SocialShareTray/SocialShareTray.js
+++ b/resources/assets/components/utilities/SocialShareTray/SocialShareTray.js
@@ -8,10 +8,7 @@ import emailIcon from './emailIcon.svg';
 import twitterIcon from './twitterIcon.svg';
 import facebookIcon from './facebookIcon.svg';
 import messengerIcon from './messengerIcon.svg';
-import {
-  trackPuckEvent,
-  trackAnalyticsEventBeta,
-} from '../../../helpers/analytics';
+import { trackAnalyticsEventBeta } from '../../../helpers/analytics';
 import {
   loadFacebookSDK,
   handleTwitterShareClick,
@@ -65,7 +62,6 @@ class SocialShareTray extends React.Component {
       data: trackingData,
     };
 
-    trackPuckEvent('phoenix_clicked_share_facebook_messenger', trackingData);
     trackAnalyticsEventBeta({
       verb: 'clicked',
       ...trackingOptions,

--- a/resources/assets/components/utilities/SocialShareTray/SocialShareTray.js
+++ b/resources/assets/components/utilities/SocialShareTray/SocialShareTray.js
@@ -8,7 +8,10 @@ import emailIcon from './emailIcon.svg';
 import twitterIcon from './twitterIcon.svg';
 import facebookIcon from './facebookIcon.svg';
 import messengerIcon from './messengerIcon.svg';
-import { trackPuckEvent } from '../../../helpers/analytics';
+import {
+  trackPuckEvent,
+  trackAnalyticsEventBeta,
+} from '../../../helpers/analytics';
 import {
   loadFacebookSDK,
   handleTwitterShareClick,
@@ -26,59 +29,93 @@ class SocialShareTray extends React.Component {
   }
 
   handleFacebookShareClick = (shareLink, trackLink) => {
-    const trackingData = { url: trackLink };
+    const trackingOptions = {
+      noun: 'share',
+      adjective: 'facebook',
+      data: {
+        url: trackLink,
+      },
+    };
 
-    trackPuckEvent('clicked facebook share action', trackingData);
+    trackAnalyticsEventBeta({
+      verb: 'clicked',
+      ...trackingOptions,
+    });
 
     showFacebookShareDialog(shareLink)
       .then(() => {
-        trackPuckEvent('share action completed', trackingData);
+        trackAnalyticsEventBeta({
+          verb: 'completed',
+          ...trackingOptions,
+        });
       })
       .catch(() => {
-        trackPuckEvent('share action cancelled', trackingData);
+        trackAnalyticsEventBeta({
+          verb: 'cancelled',
+          ...trackingOptions,
+        });
       });
   };
 
   handleFacebookMessengerClick = (shareLink, trackLink) => {
     const trackingData = { url: trackLink };
+    let trackingOptions = {
+      noun: 'share',
+      adjective: 'facebook_messenger',
+      data: trackingData,
+    };
 
     trackPuckEvent('phoenix_clicked_share_facebook_messenger', trackingData);
+    trackAnalyticsEventBeta({
+      verb: 'clicked',
+      ...trackingOptions,
+    });
 
     if (getFormattedScreenSize() === 'large') {
       // Show Send Dialog for Desktop clients.
       showFacebookSendDialog(shareLink)
         .then(() => {
-          trackPuckEvent(
-            'phoenix_completed_share_facebook_messenger',
-            trackingData,
-          );
+          trackAnalyticsEventBeta({
+            verb: 'completed',
+            ...trackingOptions,
+          });
         })
         .catch(() => {
-          trackPuckEvent(
-            'phoenix_cancelled_share_facebook_messenger',
-            trackingData,
-          );
+          trackAnalyticsEventBeta({
+            verb: 'cancelled',
+            ...trackingOptions,
+          });
         });
     } else {
+      trackingOptions = {
+        noun: 'redirect',
+        adjective: 'facebook_messenger_app',
+        data: trackingData,
+      };
       // Redirect mobile / tablet clients to the Messenger app.
       facebookMessengerShare(shareLink)
         .then(() => {
-          trackPuckEvent(
-            'phoenix_successful_redirect_facebook_messenger_app',
-            trackingData,
-          );
+          trackAnalyticsEventBeta({
+            verb: 'successful',
+            ...trackingOptions,
+          });
         })
         .catch(() => {
-          trackPuckEvent(
-            'phoenix_failed_redirect_facebook_messenger_app',
-            trackingData,
-          );
+          trackAnalyticsEventBeta({
+            verb: 'failed',
+            ...trackingOptions,
+          });
         });
     }
   };
 
   handleEmailShareClick = (shareLink, trackLink) => {
-    trackPuckEvent('phoenix_clicked_share_email', { url: trackLink });
+    trackAnalyticsEventBeta({
+      verb: 'clicked',
+      noun: 'share',
+      adjective: 'email',
+      data: { url: trackLink },
+    });
     window.location = `mailto:?body=${encodeURIComponent(shareLink)}`;
   };
 

--- a/resources/assets/components/utilities/SocialShareTray/SocialShareTray.js
+++ b/resources/assets/components/utilities/SocialShareTray/SocialShareTray.js
@@ -8,7 +8,7 @@ import emailIcon from './emailIcon.svg';
 import twitterIcon from './twitterIcon.svg';
 import facebookIcon from './facebookIcon.svg';
 import messengerIcon from './messengerIcon.svg';
-import { trackAnalyticsEventBeta } from '../../../helpers/analytics';
+import { trackAnalyticsEvent } from '../../../helpers/analytics';
 import {
   loadFacebookSDK,
   handleTwitterShareClick,
@@ -34,20 +34,20 @@ class SocialShareTray extends React.Component {
       },
     };
 
-    trackAnalyticsEventBeta({
+    trackAnalyticsEvent({
       verb: 'clicked',
       ...trackingOptions,
     });
 
     showFacebookShareDialog(shareLink)
       .then(() => {
-        trackAnalyticsEventBeta({
+        trackAnalyticsEvent({
           verb: 'completed',
           ...trackingOptions,
         });
       })
       .catch(() => {
-        trackAnalyticsEventBeta({
+        trackAnalyticsEvent({
           verb: 'cancelled',
           ...trackingOptions,
         });
@@ -62,7 +62,7 @@ class SocialShareTray extends React.Component {
       data: trackingData,
     };
 
-    trackAnalyticsEventBeta({
+    trackAnalyticsEvent({
       verb: 'clicked',
       ...trackingOptions,
     });
@@ -71,13 +71,13 @@ class SocialShareTray extends React.Component {
       // Show Send Dialog for Desktop clients.
       showFacebookSendDialog(shareLink)
         .then(() => {
-          trackAnalyticsEventBeta({
+          trackAnalyticsEvent({
             verb: 'completed',
             ...trackingOptions,
           });
         })
         .catch(() => {
-          trackAnalyticsEventBeta({
+          trackAnalyticsEvent({
             verb: 'cancelled',
             ...trackingOptions,
           });
@@ -91,13 +91,13 @@ class SocialShareTray extends React.Component {
       // Redirect mobile / tablet clients to the Messenger app.
       facebookMessengerShare(shareLink)
         .then(() => {
-          trackAnalyticsEventBeta({
+          trackAnalyticsEvent({
             verb: 'successful',
             ...trackingOptions,
           });
         })
         .catch(() => {
-          trackAnalyticsEventBeta({
+          trackAnalyticsEvent({
             verb: 'failed',
             ...trackingOptions,
           });
@@ -106,7 +106,7 @@ class SocialShareTray extends React.Component {
   };
 
   handleEmailShareClick = (shareLink, trackLink) => {
-    trackAnalyticsEventBeta({
+    trackAnalyticsEvent({
       verb: 'clicked',
       noun: 'share',
       adjective: 'email',

--- a/resources/assets/helpers/analytics.js
+++ b/resources/assets/helpers/analytics.js
@@ -114,31 +114,6 @@ export function googleAnalyticsInit(history) {
 }
 
 /**
- * Track an analytics event with a specified service.
- *
- * @param  {String} name
- * @param  {Object} data
- * @param  {String} service
- * @return {Object}
- */
-export function trackAnalyticsEvent(name, data, service) {
-  switch (service) {
-    case 'ga':
-      analyzeWithGoogleAnalytics(name, data);
-      break;
-
-    case 'puck':
-      analyzeWithPuck(name, data);
-      break;
-
-    default:
-      console.error(
-        `The "${service}" service is missing, not supported or incorrect!`,
-      );
-  }
-}
-
-/**
  * Track an analytics event with a specified service. (Defaults to tracking with all services.)
  *
  * @param  {Object}      options
@@ -149,13 +124,7 @@ export function trackAnalyticsEvent(name, data, service) {
  * @param  {String|Null} [options.service]
  * @return {void}
  */
-export function trackAnalyticsEventBeta({
-  verb,
-  noun,
-  adjective,
-  data,
-  service,
-}) {
+export function trackAnalyticsEvent({ verb, noun, adjective, data, service }) {
   if (!verb || !noun) {
     console.error('The Verb or Noun is missing!');
     return;

--- a/resources/assets/helpers/analytics.js
+++ b/resources/assets/helpers/analytics.js
@@ -137,25 +137,3 @@ export function trackAnalyticsEvent({ verb, noun, adjective, data, service }) {
 
   sendToServices(category, eventName, data, service);
 }
-
-/**
- * Track an analytics event with Google Analytics.
- *
- * @param  {String} name
- * @param  {Object} data
- * @return {Function}
- */
-export function trackGoogleAnalyticsEvent(name, data) {
-  trackAnalyticsEvent(name, data, 'ga');
-}
-
-/**
- * Track an analytics event with Puck.
- *
- * @param  {String} name
- * @param  {Object} data
- * @return {Function}
- */
-export function trackPuckEvent(name, data) {
-  trackAnalyticsEvent(name, data, 'puck');
-}

--- a/resources/assets/helpers/index.js
+++ b/resources/assets/helpers/index.js
@@ -8,7 +8,7 @@ import { getTime, isBefore, isWithinInterval } from 'date-fns';
 import { get, find, isNull, isUndefined, omitBy } from 'lodash';
 
 import Sixpack from '../services/Sixpack';
-import { trackPuckEvent } from './analytics';
+import { trackAnalyticsEventBeta } from './analytics';
 import { isSignedUp } from '../selectors/signup';
 
 // Helper Constants
@@ -672,7 +672,14 @@ export function showTwitterSharePrompt(href, quote = '', callback) {
  * @param {Object} trackingData
  */
 export function handleFacebookShareClick(href, trackingData) {
-  trackPuckEvent('clicked facebook share', trackingData);
+  trackAnalyticsEventBeta({
+    verb: 'clicked',
+    noun: 'share',
+    adjective: 'facebook',
+    data: trackingData,
+  });
+  // @todo 12/13/2018: Use the showFacebookShareDialog to track
+  // 'completed' and 'cancelled' events as well.
   showFacebookSharePrompt(href);
 }
 
@@ -684,7 +691,12 @@ export function handleFacebookShareClick(href, trackingData) {
  * @param {String} quote
  */
 export function handleTwitterShareClick(href, trackingData, quote = '') {
-  trackPuckEvent('clicked twitter share', trackingData);
+  trackAnalyticsEventBeta({
+    verb: 'clicked',
+    noun: 'share',
+    adjective: 'twitter',
+    data: trackingData,
+  });
   showTwitterSharePrompt(href, quote);
 }
 

--- a/resources/assets/helpers/index.js
+++ b/resources/assets/helpers/index.js
@@ -8,7 +8,7 @@ import { getTime, isBefore, isWithinInterval } from 'date-fns';
 import { get, find, isNull, isUndefined, omitBy } from 'lodash';
 
 import Sixpack from '../services/Sixpack';
-import { trackAnalyticsEventBeta } from './analytics';
+import { trackAnalyticsEvent } from './analytics';
 import { isSignedUp } from '../selectors/signup';
 
 // Helper Constants
@@ -672,7 +672,7 @@ export function showTwitterSharePrompt(href, quote = '', callback) {
  * @param {Object} trackingData
  */
 export function handleFacebookShareClick(href, trackingData) {
-  trackAnalyticsEventBeta({
+  trackAnalyticsEvent({
     verb: 'clicked',
     noun: 'share',
     adjective: 'facebook',
@@ -691,7 +691,7 @@ export function handleFacebookShareClick(href, trackingData) {
  * @param {String} quote
  */
 export function handleTwitterShareClick(href, trackingData, quote = '') {
-  trackAnalyticsEventBeta({
+  trackAnalyticsEvent({
     verb: 'clicked',
     noun: 'share',
     adjective: 'twitter',

--- a/resources/assets/middleware/analytics.js
+++ b/resources/assets/middleware/analytics.js
@@ -1,6 +1,6 @@
 import { has, get } from 'lodash';
 
-import { trackAnalyticsEvent } from '../helpers/analytics';
+import { trackAnalyticsEventBeta } from '../helpers/analytics';
 
 /**
  * Append additional information to the data to decorate it.
@@ -31,9 +31,9 @@ const analyticsMiddleware = ({ getState }) => next => action => {
   const event = action.payload.meta.analytics;
 
   // Decorate the data with some additional information if available.
-  const data = appendAdditionalData(event.payload, getState());
+  event.data = appendAdditionalData(event.payload, getState());
 
-  trackAnalyticsEvent(event.name, data, event.service);
+  trackAnalyticsEventBeta(event);
 
   return next(action);
 };

--- a/resources/assets/middleware/analytics.js
+++ b/resources/assets/middleware/analytics.js
@@ -1,6 +1,6 @@
 import { has, get } from 'lodash';
 
-import { trackAnalyticsEventBeta } from '../helpers/analytics';
+import { trackAnalyticsEvent } from '../helpers/analytics';
 
 /**
  * Append additional information to the data to decorate it.
@@ -33,7 +33,7 @@ const analyticsMiddleware = ({ getState }) => next => action => {
   // Decorate the data with some additional information if available.
   event.data = appendAdditionalData(event.payload, getState());
 
-  trackAnalyticsEventBeta(event);
+  trackAnalyticsEvent(event);
 
   return next(action);
 };

--- a/resources/assets/middleware/api.js
+++ b/resources/assets/middleware/api.js
@@ -8,7 +8,7 @@ import { PHOENIX_URL } from '../constants';
 import { setFormData } from '../helpers/forms';
 import { API } from '../constants/action-types';
 import { getUserToken } from '../selectors/user';
-import { trackAnalyticsEventBeta } from '../helpers/analytics';
+import { trackAnalyticsEvent } from '../helpers/analytics';
 import { getRequest, setRequestHeaders, tabularLog } from '../helpers/api';
 
 /**
@@ -93,7 +93,7 @@ const postRequest = (payload, dispatch, getState) => {
     .catch(error => {
       report(error);
 
-      trackAnalyticsEventBeta({
+      trackAnalyticsEvent({
         verb: 'failed',
         noun: 'post_request',
         data: {

--- a/resources/assets/middleware/api.js
+++ b/resources/assets/middleware/api.js
@@ -8,7 +8,7 @@ import { PHOENIX_URL } from '../constants';
 import { setFormData } from '../helpers/forms';
 import { API } from '../constants/action-types';
 import { getUserToken } from '../selectors/user';
-import { trackPuckEvent } from '../helpers/analytics';
+import { trackAnalyticsEventBeta } from '../helpers/analytics';
 import { getRequest, setRequestHeaders, tabularLog } from '../helpers/api';
 
 /**
@@ -93,9 +93,14 @@ const postRequest = (payload, dispatch, getState) => {
     .catch(error => {
       report(error);
 
-      trackPuckEvent('phoenix_failed_post_request', {
-        url: payload.url,
-        error,
+      trackAnalyticsEventBeta({
+        verb: 'failed',
+        noun: 'post_request',
+        data: {
+          url: payload.url,
+          error,
+        },
+        service: 'puck',
       });
 
       if (window.ENV.APP_ENV !== 'production') {


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR replaces the `trackAnalyticsEvent` method with the current Beta version and updates all of our puck tracking events to use the `trackAnalyticsEvent` method, with updated event naming based on our [established naming conventions](https://github.com/orgs/DoSomething/teams/tech-leads/discussions/3). 🥂 

We also remove some legacy analytics helpers specific to Puck and GA based on the older format.

### Any background context you want to provide?
This is a ton - but mostly very straightforward! 
I'll highlight anything I did which was beyond a simple event tracking update in the comments.

All events will be tracked to all services by default besides for the failed POST request event tracked in the [API middleware](https://github.com/DoSomething/phoenix-next/pull/1206/files#diff-252fe66a09d3de77eb4b779ca827a98dR103) since that seemed like it shouldn't be going to GA.

### What are the relevant tickets/cards?

Refs [Pivotal ID #162068080](https://www.pivotaltracker.com/story/show/162068080)