### PR TITLE
Explore campaigns pagination

### DIFF
--- a/app/Http/Controllers/CampaignController.php
+++ b/app/Http/Controllers/CampaignController.php
@@ -30,11 +30,23 @@ class CampaignController extends Controller
      *
      * @return \Illuminate\Http\Response
      */
-    public function index()
+    public function index(Request $request)
     {
-        $campaigns = $this->campaignRepository->getAllCampaignsSorted();
+        $count = 24;
+        $page = intval($request->query('page', 1));
 
-        return view('campaigns.index', ['campaigns' => $campaigns]);
+        $campaigns = $this->campaignRepository->getAllCampaignsPaginated($count, $page);
+
+        if (!$campaigns->count()) {
+            return redirect('/us/campaigns');
+        }
+
+        return view('campaigns.index', [
+            'campaigns' => $campaigns,
+            'count' => $count,
+            'nextPage' => $page + 1,
+            'previousPage' => $page - 1,
+        ]);
     }
 
     /**

--- a/app/Http/Controllers/CampaignController.php
+++ b/app/Http/Controllers/CampaignController.php
@@ -37,7 +37,7 @@ class CampaignController extends Controller
 
         $campaigns = $this->campaignRepository->getAllCampaignsPaginated($count, $page);
 
-        if (!$campaigns->count()) {
+        if (! $campaigns->count()) {
             return redirect('/us/campaigns');
         }
 

--- a/app/Http/Controllers/CampaignController.php
+++ b/app/Http/Controllers/CampaignController.php
@@ -32,7 +32,7 @@ class CampaignController extends Controller
      */
     public function index(Request $request)
     {
-        $count = 36;
+        $count = 12;
         $page = intval($request->query('page', 1));
 
         $campaigns = $this->campaignRepository->getAllCampaignsPaginated($count, $page);

--- a/app/Http/Controllers/CampaignController.php
+++ b/app/Http/Controllers/CampaignController.php
@@ -32,7 +32,7 @@ class CampaignController extends Controller
      */
     public function index(Request $request)
     {
-        $count = 24;
+        $count = 36;
         $page = intval($request->query('page', 1));
 
         $campaigns = $this->campaignRepository->getAllCampaignsPaginated($count, $page);

--- a/app/Repositories/CampaignRepository.php
+++ b/app/Repositories/CampaignRepository.php
@@ -43,13 +43,37 @@ class CampaignRepository
      *
      * @return array
      */
-    public function getAll()
+    public function getAll($limit = null, $step = null)
     {
-        $campaigns = remember('campaigns', 15, function () {
-            return $this->getEntriesAsJson('campaign');
-        });
+        return json_decode($this->getEntriesAsJson('campaign', $limit, $step));
 
-        return json_decode($campaigns);
+        // $campaigns = remember('campaigns', 15, function () {
+        //     return $this->getEntriesAsJson('campaign');
+        // });
+
+        // return json_decode($campaigns);
+    }
+
+    /**
+     * Get all campaigns using pagination.
+     *
+     * @param  integer $count
+     * @param  integer $page
+     * @return \Illuminate\Support\Collection
+     */
+    public function getAllCampaignsPaginated($count = 24, $page = 1)
+    {
+        if (intval($page) <= 0) {
+            return collect();
+        }
+
+        $page = intval($page) - 1;
+
+        $skip = $page >= 1 ? $count * $page : null;
+
+        $campaigns = $this->getAll($count, $skip);
+
+        return collect($campaigns);
     }
 
     /**

--- a/app/Repositories/CampaignRepository.php
+++ b/app/Repositories/CampaignRepository.php
@@ -72,10 +72,10 @@ class CampaignRepository
             return collect();
         }
 
-        // Calculate number to multiply count by, to get number to skip in collection query.
+        // Calculate number to multiply count by, to get number of items to skip in collection query.
         $multiplier = intval($page) - 1;
 
-        $skip = $multiplier >= 1 ? $count * $multiplier : null;
+        $skip = $count * $multiplier;
 
         $campaigns = $this->getAll($count, $skip);
 

--- a/app/Repositories/CampaignRepository.php
+++ b/app/Repositories/CampaignRepository.php
@@ -41,12 +41,16 @@ class CampaignRepository
     /**
      * Get all campaigns.
      *
+     * @param  int|null $limit
+     * @param  int|null $skip
      * @return array
      */
     public function getAll($limit = null, $skip = null)
     {
         $cacheKey = 'campaigns';
-        $cacheKey = $limit ? $cacheKey.':limit='.$limit : $cacheKey;
+
+        // Append limit and skip values to cache key if skip is defined.
+        $cacheKey = $limit && $skip ? $cacheKey.':limit='.$limit : $cacheKey;
         $cacheKey = $skip ? $cacheKey.':skip='.$skip : $cacheKey;
 
         $campaigns = remember($cacheKey, 15, function () use ($limit, $skip) {
@@ -65,13 +69,15 @@ class CampaignRepository
      */
     public function getAllCampaignsPaginated($count = 24, $page = 1)
     {
+        // Return an empty collection if page is 0 or negative.
         if (intval($page) <= 0) {
             return collect();
         }
 
-        $page = intval($page) - 1;
+        // Calculate number to multiply count by, to get number to skip in collection query.
+        $multiplier = intval($page) - 1;
 
-        $skip = $page >= 1 ? $count * $page : null;
+        $skip = $multiplier >= 1 ? $count * $multiplier : null;
 
         $campaigns = $this->getAll($count, $skip);
 

--- a/app/Repositories/CampaignRepository.php
+++ b/app/Repositories/CampaignRepository.php
@@ -43,15 +43,17 @@ class CampaignRepository
      *
      * @return array
      */
-    public function getAll($limit = null, $step = null)
+    public function getAll($limit = null, $skip = null)
     {
-        return json_decode($this->getEntriesAsJson('campaign', $limit, $step));
+        $cacheKey = 'campaigns';
+        $cacheKey = $limit ? $cacheKey.':limit='.$limit : $cacheKey;
+        $cacheKey = $skip ? $cacheKey.':skip='.$skip : $cacheKey;
 
-        // $campaigns = remember('campaigns', 15, function () {
-        //     return $this->getEntriesAsJson('campaign');
-        // });
+        $campaigns = remember($cacheKey, 15, function () use ($limit, $skip) {
+            return $this->getEntriesAsJson('campaign', $limit, $skip);
+        });
 
-        // return json_decode($campaigns);
+        return json_decode($campaigns);
     }
 
     /**

--- a/app/Repositories/CampaignRepository.php
+++ b/app/Repositories/CampaignRepository.php
@@ -57,8 +57,8 @@ class CampaignRepository
     /**
      * Get all campaigns using pagination.
      *
-     * @param  integer $count
-     * @param  integer $page
+     * @param  int $count
+     * @param  int $page
      * @return \Illuminate\Support\Collection
      */
     public function getAllCampaignsPaginated($count = 24, $page = 1)

--- a/app/Repositories/CampaignRepository.php
+++ b/app/Repositories/CampaignRepository.php
@@ -48,9 +48,7 @@ class CampaignRepository
     public function getAll($limit = null, $skip = null)
     {
         $cacheKey = 'campaigns';
-
-        // Append limit and skip values to cache key if skip is defined.
-        $cacheKey = $limit && $skip ? $cacheKey.':limit='.$limit : $cacheKey;
+        $cacheKey = $limit ? $cacheKey.':limit='.$limit : $cacheKey;
         $cacheKey = $skip ? $cacheKey.':skip='.$skip : $cacheKey;
 
         $campaigns = remember($cacheKey, 15, function () use ($limit, $skip) {

--- a/app/Repositories/QueriesContentful.php
+++ b/app/Repositories/QueriesContentful.php
@@ -15,15 +15,17 @@ trait QueriesContentful
      *
      * @param  string $type
      * @param  int $limit
+     * @param  int $skip
      * @return string
      */
-    protected function getEntriesAsJson($type, $limit = null)
+    protected function getEntriesAsJson($type, $limit = null, $skip = null)
     {
         $query = (new Query)
                 ->setContentType($type)
                 ->setInclude(0)
                 ->orderBy('sys.updatedAt', true)
-                ->setLimit($limit);
+                ->setLimit($limit)
+                ->setSkip($skip);
 
         $entries = app('contentful.delivery')->getEntries($query)->getItems();
 

--- a/resources/views/campaigns/index.blade.php
+++ b/resources/views/campaigns/index.blade.php
@@ -1,3 +1,5 @@
+{{-- {{ dump([$nextPage, $previousPage]) }} --}}
+
 @extends('layouts.master')
 
 @section('content')
@@ -24,6 +26,16 @@
                     </li>
                 @endforeach
             </ul>
+
+            <div class="pagination clearfix">
+                @if($previousPage > 0)
+                    <a class="button -tertiary float-left clear-none" href="?page={{$previousPage}}">Previous</a>
+                @endif
+
+                @if($campaigns->count() >= $count)
+                    <a class="button -tertiary float-right clear-none" href="?page={{$nextPage}}">Next</a>
+                @endif
+            </div>
         </div>
     </div>
 @stop

--- a/resources/views/campaigns/index.blade.php
+++ b/resources/views/campaigns/index.blade.php
@@ -1,5 +1,3 @@
-{{-- {{ dump([$nextPage, $previousPage]) }} --}}
-
 @extends('layouts.master')
 
 @section('content')


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR implements _very basic_ pagination for the Explore Campaigns page at `/us/campaigns`. 

To implement pagination properly, I had to circumvent the original method `getCampaignsSorted()`, which would gather ALL campaigns and sort them to remove closed campaigns, as well as sort the open campaigns by `staffPick` up top. As we continue adding more and more campaigns from Ashes into Phoenix, the complete list of campaigns will grow significantly and it will no longer be performant to gather ALL campaigns in one shot.

![explore campaigns pagination](https://user-images.githubusercontent.com/105849/50016792-312dd800-ff98-11e8-894a-5e50ec1a860f.gif)

### Any background context you want to provide?

To allow for pagination and collecting campaigns by `36` at a time, we had to make a few concessions that we can address a bit better in follow up PRs. This solution is just v1!

- Both open and closed campaigns are displayed (will be addressed in follow up PR)
- List of campaigns is not preferentially sorted to display "Staff Pick" campaigns at the top (may have a potential solution for this in follow up PR).
- Will be increasing cache duration after adding a cache clearing option in upcoming PR.

### What are the relevant tickets/cards?

Refs [Pivotal ID #162651211](https://www.pivotaltracker.com/story/show/162651211)

### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.