### PR TITLE
Forgot to update the count 🤦‍♂️.

### DIFF
--- a/app/Http/Controllers/CampaignController.php
+++ b/app/Http/Controllers/CampaignController.php
@@ -32,7 +32,7 @@ class CampaignController extends Controller
      */
     public function index(Request $request)
     {
-        $count = 12;
+        $count = 36;
         $page = intval($request->query('page', 1));
 
         $campaigns = $this->campaignRepository->getAllCampaignsPaginated($count, $page);


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR updates the count to `36` campaigns per page on the Explore Campaigns page. I had reduced it in #1208 for testing purposes with Dev data, but then forgot to restore it to `36` 🤦‍♂️ 

### What are the relevant tickets/cards?

🌵 