### PR TITLE
Push Analytics Events to Google Tag Manager

### DIFF
--- a/resources/assets/helpers/analytics.js
+++ b/resources/assets/helpers/analytics.js
@@ -32,19 +32,6 @@ const formatEventName = (verb, noun, adjective = null) => {
 };
 
 /**
- * Analyze event with Google Tag Manager.
- * (pushes event into the window's Data Layer array.)
- *
- * @param  {String} event
- * @return {void}
- */
-export function analyzeWithGoogleTagManager(event) {
-  window.dataLayer = window.dataLayer || [];
-
-  window.dataLayer.push({ event });
-}
-
-/**
  * Send event to analyze with Google Analytics.
  *
  * @param  {String} category
@@ -63,7 +50,10 @@ export function analyzeWithGoogleAnalytics(category, action) {
   const identifier = `${category}:${action}:${label}`;
 
   analyze(identifier);
-  analyzeWithGoogleTagManager(action);
+
+  // Push event action to Google Tag Manager's data layer.
+  window.dataLayer = window.dataLayer || [];
+  window.dataLayer.push({ event: action });
 }
 
 /**

--- a/resources/assets/helpers/analytics.js
+++ b/resources/assets/helpers/analytics.js
@@ -32,6 +32,19 @@ const formatEventName = (verb, noun, adjective = null) => {
 };
 
 /**
+ * Analyze event with Google Tag Manager.
+ * (pushes event into the window's Data Layer array.)
+ *
+ * @param  {String} event
+ * @return {void}
+ */
+export function analyzeWithGoogleTagManager(event) {
+  window.dataLayer = window.dataLayer || [];
+
+  window.dataLayer.push({ event });
+}
+
+/**
  * Send event to analyze with Google Analytics.
  *
  * @param  {String} category
@@ -50,6 +63,7 @@ export function analyzeWithGoogleAnalytics(category, action) {
   const identifier = `${category}:${action}:${label}`;
 
   analyze(identifier);
+  analyzeWithGoogleTagManager(action);
 }
 
 /**


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR updates our analytics system to push Google Analytics events to the Google Tag Manager using it's `dataLayer`.

### Any background context you want to provide?
https://developers.google.com/tag-manager/devguide

This will -for any event tracked to Google Analytics- also push the event (using the 'action' as the event name) into the `dataLayer` array exposed by Google Tag Manager.

### What are the relevant tickets/cards?

Refs [Pivotal ID #162068080](https://www.pivotaltracker.com/story/show/162068080)