### PR TITLE
Social Share Action Type Field Fix

### DIFF
--- a/resources/assets/actions/post.js
+++ b/resources/assets/actions/post.js
@@ -79,9 +79,11 @@ export function storeCampaignPost(campaignId, data) {
 
   const { action, body, id, type } = data;
 
+  // Ensure snake casing on the type field for usage as analytics noun.
+  const analyticsNoun = (type || '').replace(/-/g, '_');
   const analytics = {
     verb: 'submitted',
-    noun: `${type}_submission_action`,
+    noun: `${analyticsNoun}_submission_action`,
     payload: {
       action,
       campaignId,

--- a/resources/assets/components/actions/ShareAction/ShareAction.js
+++ b/resources/assets/components/actions/ShareAction/ShareAction.js
@@ -10,6 +10,7 @@ import ContentfulEntry from '../../ContentfulEntry';
 import { setFormData } from '../../../helpers/forms';
 import Markdown from '../../utilities/Markdown/Markdown';
 import { trackAnalyticsEvent } from '../../../helpers/analytics';
+import { SOCIAL_SHARE_TYPE } from '../../../constants/post-types';
 import {
   dynamicString,
   loadFacebookSDK,
@@ -28,15 +29,13 @@ class ShareAction extends React.Component {
   }
 
   storeSharePost = puckId => {
-    const type = 'share_social';
-
     const action = get(this.props.additionalContent, 'action', 'default');
 
     const { id, campaignId, link } = this.props;
 
     const formData = setFormData({
       action,
-      type,
+      type: SOCIAL_SHARE_TYPE,
       id,
       details: {
         url: link,
@@ -51,7 +50,7 @@ class ShareAction extends React.Component {
       action,
       body: formData,
       id,
-      type,
+      type: SOCIAL_SHARE_TYPE,
     });
   };
 

--- a/resources/assets/constants/post-types.js
+++ b/resources/assets/constants/post-types.js
@@ -1,0 +1,1 @@
+export const SOCIAL_SHARE_TYPE = 'share-social'; // eslint-disable-line import/prefer-default-export


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR updates the `type` field used in the Social Share Action to the correct format.

- uses an imported constant from the new `post-types` file, with the updated (fixed) naming
- formats the analytics noun derived from the `type` field in the post action to use snake casing

### Any background context you want to provide?
This addresses an error introduced in #1206 where we mistakenly renamed the `type` field for the sake of the analytics formatting.

The constants file will introduce formality to the naming, and hopefully be less error-prone!

### What are the relevant tickets/cards?
#1214 