### PR TITLE
Removing unsed env var related to Rogue v2 API.

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,9 +26,9 @@ CONTENTFUL_ENVIRONMENT_ID=
 CONTENTFUL_USE_PREVIEW_API=false
 CONTENTFUL_SPACE_ID=
 
-GRAPHQL_URL=https://graphql-qa.dosomething.org/graphql
+GRAPHQL_URL=https://graphql-dev.dosomething.org/graphql
 
-NORTHSTAR_URL=https://identity-qa.dosomething.org
+NORTHSTAR_URL=https://identity-dev.dosomething.org
 NORTHSTAR_AUTHORIZATION_ID=dev-oauth
 NORTHSTAR_AUTHORIZATION_SECRET=
 
@@ -39,8 +39,7 @@ PHOENIX_LEGACY_PASSWORD=
 BERTLY_URL=
 BERTLY_API_KEY=
 
-ROGUE_URL=https://activity-qa.dosomething.org
-ROGUE_API_KEY=
+ROGUE_URL=https://activity-dev.dosomething.org
 
 REDIS_URL=redis://127.0.0.1:6379
 REDIS_HOST=127.0.0.1

--- a/app.json
+++ b/app.json
@@ -59,9 +59,6 @@
     "PUCK_URL": {
       "required": true
     },
-    "ROGUE_API_KEY": {
-      "required": true
-    },
     "ROGUE_URL": {
       "required": true
     },

--- a/config/services.php
+++ b/config/services.php
@@ -28,7 +28,6 @@ return [
 
     'rogue' => [
         'url' => env('ROGUE_URL', 'https://rogue-qa.dosomething.org'),
-        'key' => env('ROGUE_API_KEY'),
     ],
 
     'northstar' => [


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR removes an old env var we no longer use since we no longer connect to the Rogue v2 API. We're on the new and shiny Rogue v3 API!

### Any background context you want to provide?

![tumbleweed](https://user-images.githubusercontent.com/105849/50708173-5e1e5980-1031-11e9-8902-2297215c9efa.gif)
