### PR TITLE
Logging for Gateway Validation Exceptions

### DIFF
--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -30,6 +30,7 @@ class Handler extends ExceptionHandler
         \Illuminate\Database\Eloquent\ModelNotFoundException::class,
         \Illuminate\Session\TokenMismatchException::class,
         ValidationException::class,
+        GatewayValidationException::class,
     ];
 
     /**

--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -53,6 +53,8 @@ class Handler extends ExceptionHandler
         if ($exception instanceof GatewayAccessDeniedException) {
             // Log the contents of 'Authorization' header for any malformed JWTs.
             Log::warning('malformed_jwt', ['hint' => $exception->hint, 'jwt' => request()->header('Authorization')]);
+        } elseif ($exception instanceof GatewayValidationException) {
+            Log::debug($exception->getMessage(), $exception->getErrors());
         }
 
         parent::report($exception);


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR updates the reporting for Gateway validation errors.
- adds `Gateway ValidationException`s to the `$dontReport` list
- adds a debug level log for those exceptions instead

### Any background context you want to provide?
This was raised regarding an influx of these errors seeming to inflate our reported error count from Papertrail. 

One other difference in the logging I'd point out is that whereas the error log before had the id/email of the affected user, but obscured the actual message behind an object - e.g.
```
2019-01-07 15:13:40] local.ERROR: Exception from "POST v3/posts": [422] Validation errors returned. 
{"userId":"59b83901a0bfad2fd539736f","email":"mblesofsky@dosomething.org",
"exception":"[object] (DoSomething\\Gateway\\Exceptions\\ValidationException(code: 422): Exception from \"POST v3/posts\": [422] Validation errors returned. at /home/vagrant/Code/phoenix-next/app/Services/RogueClient.php:43)
```

This will now *not* show the id/email but show the error message - e.g.
```
[2019-01-07 15:13:40] local.DEBUG: Exception from "POST v3/posts": [422] Validation errors returned. {"file":["The file has invalid image dimensions."]} 
```

I wasn't sure how to add those details in there and whether we needed that info, or if we did - could tie the error to the [log of the users request](https://github.com/DoSomething/phoenix-next/blob/validation-logging/app/Http/Controllers/Api/CampaignPostsController.php#L64) via timestamp.

### What are the relevant tickets/cards?
https://dosomething.slack.com/archives/C3ASB4204/p1546401674002400