### PR TITLE
Updating middleware order of operations.

### DIFF
--- a/resources/assets/store/middlewares.js
+++ b/resources/assets/store/middlewares.js
@@ -4,9 +4,14 @@ import sixpackExperimentsMiddleware from '../middleware/sixpackExperiments';
 import requiresAuthenticationMiddleware from '../middleware/requiresAuthentication';
 
 const middlewares = [
+  // Event data collection for analysis needs to execute first.
   analyticsMiddleware,
   sixpackExperimentsMiddleware,
+
+  // Authentication executes after event data collection, since it could redirect user out of app.
   requiresAuthenticationMiddleware,
+
+  // User requests and activity execute last.
   apiMiddleware,
 ];
 

--- a/resources/assets/store/middlewares.js
+++ b/resources/assets/store/middlewares.js
@@ -4,10 +4,10 @@ import sixpackExperimentsMiddleware from '../middleware/sixpackExperiments';
 import requiresAuthenticationMiddleware from '../middleware/requiresAuthentication';
 
 const middlewares = [
-  requiresAuthenticationMiddleware,
   analyticsMiddleware,
-  apiMiddleware,
   sixpackExperimentsMiddleware,
+  requiresAuthenticationMiddleware,
+  apiMiddleware,
 ];
 
 export default middlewares;


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR updates and improves the middleware order of execution so that event data related middleware fire prior to authentication and other user related requests/executions.

### Any background context you want to provide?

Prior to this fix, we were intending to fire analytics events for when the signup button was clicked, but if the user was not logged in, the middleware to authenticate them would fire before the middleware to track the event, sending the user off to Northstar and never getting a chance to fire the click event!

### What are the relevant tickets/cards?

Refs [Pivotal ID #162797146](https://www.pivotaltracker.com/story/show/162797146)

### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.