### PR TITLE
Update getEntriesAsJson Contentful Query

### DIFF
--- a/app/Repositories/CampaignRepository.php
+++ b/app/Repositories/CampaignRepository.php
@@ -41,8 +41,10 @@ class CampaignRepository
         $cacheKey = $limit ? $cacheKey.':limit='.$limit : $cacheKey;
         $cacheKey = $skip ? $cacheKey.':skip='.$skip : $cacheKey;
 
-        $campaigns = remember($cacheKey, 15, function () use ($limit, $skip) {
-            return $this->getEntriesAsJson('campaign', $limit, $skip);
+        $options = ['includeDepth' => 1, 'limit' => $limit, 'skip' => $skip];
+
+        $campaigns = remember($cacheKey, 15, function () use ($options) {
+            return $this->getEntriesAsJson('campaign', $options);
         });
 
         return json_decode($campaigns);

--- a/app/Repositories/HomePageRepository.php
+++ b/app/Repositories/HomePageRepository.php
@@ -13,11 +13,13 @@ class HomePageRepository
      */
     public function getFirst()
     {
+        $options = ['includeDepth' => 2, 'limit' => 1];
+
         if (! config('services.contentful.cache')) {
-            $homePages = $this->getEntriesAsJson('homePage', 1);
+            $homePages = $this->getEntriesAsJson('homePage', $options);
         } else {
-            $homePages = remember('home_pages', 15, function () {
-                return $this->getEntriesAsJson('homePage', 1);
+            $homePages = remember('home_pages', 15, function () use ($options) {
+                return $this->getEntriesAsJson('homePage', $options);
             });
         }
 

--- a/app/Repositories/QueriesContentful.php
+++ b/app/Repositories/QueriesContentful.php
@@ -14,18 +14,20 @@ trait QueriesContentful
      * Get entries from a Contentful Query and return data as JSON.
      *
      * @param  string $type
-     * @param  int $limit
-     * @param  int $skip
+     * @param  array  $options
+     * @param  int    $options['includeDepth']
+     * @param  string $options['limit']
+     * @param  string $options['skip']
      * @return string
      */
-    protected function getEntriesAsJson($type, $limit = null, $skip = null)
+    protected function getEntriesAsJson($type, $options = [])
     {
         $query = (new Query)
                 ->setContentType($type)
-                ->setInclude(0)
+                ->setInclude(array_get($options, 'includeDepth', 0))
                 ->orderBy('sys.updatedAt', true)
-                ->setLimit($limit)
-                ->setSkip($skip);
+                ->setLimit(array_get($options, 'limit'))
+                ->setSkip(array_get($options, 'skip'));
 
         $entries = app('contentful.delivery')->getEntries($query)->getItems();
 


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR updates the `QueriesContentful#getEntriesAsJson` Contentful Query to be more efficient.

- utilize an `$options` array for all -optional- setting params
- include a `includeDepth` param to allow us to control the `setInclude` setting to heavilly optimize our querying, improving speed
- update the calls to this query from the `CampaignRepository#getAll`, and the `HomepageRepository#getFirst`

### Any background context you want to provide?
In our effort to solve the immense amount of time our campaigns index Contentful query was taking, and to preemptively understand if it was worth our while to pursue a basic site search feature - we ended up being able to easily optimize via the `setInclude` setting which will resolve Linked Entries up to the specified depth, and thus eager load the nested fields we were using in `TruncatedCampaign`, (as well as a bonus speed boost to our usage of `Homepage`)

**Q:** How do y'all feel about the docblock format for the `$options` array?


### What are the relevant tickets/cards?

Refs 
[Pivotal ID #162718264](https://www.pivotaltracker.com/story/show/162718264) (Varnish cache issue)
[Pivotal ID #162972495](https://www.pivotaltracker.com/story/show/162972495) (Site search)
fixes #1222 
