### PR TITLE
Updates to differentiate signups found versus new completed signups.

### DIFF
--- a/resources/assets/actions/signup.js
+++ b/resources/assets/actions/signup.js
@@ -118,14 +118,6 @@ export function getCampaignSignups(id = null, query = {}) {
  */
 export function storeCampaignSignup(campaignId, data) {
   const path = join('api/v2/campaigns', campaignId, 'signups');
-  const analytics = {
-    verb: 'clicked',
-    noun: 'signup',
-    payload: {
-      campaignId,
-      ...data.analytics,
-    },
-  };
 
   return dispatch => {
     dispatch(
@@ -134,7 +126,6 @@ export function storeCampaignSignup(campaignId, data) {
         failure: STORE_CAMPAIGN_SIGNUPS_FAILED,
         meta: {
           id: campaignId,
-          analytics,
           sixpackExperiments: { conversion: 'signup' },
           messaging: {
             success: 'Thanks for signing up!',

--- a/resources/assets/components/SignupButton/SignupButton.js
+++ b/resources/assets/components/SignupButton/SignupButton.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { get } from 'lodash';
 
 import Button from '../utilities/Button/Button';
+import { trackAnalyticsEvent } from '../../helpers/analytics';
 
 const SignupButton = props => {
   const {
@@ -21,13 +22,20 @@ const SignupButton = props => {
 
   // Decorate click handler for A/B tests & analytics.
   const onSignup = buttonText => {
-    clickedSignupAction(campaignId, {
-      body: { details: { campaignContentfulId } },
-      analytics: {
-        template,
+    trackAnalyticsEvent({
+      verb: 'clicked',
+      noun: 'signup',
+      data: {
+        campaignId,
+        campaignContentfulId,
         source,
         sourceData: { text: buttonText },
+        template,
       },
+    });
+
+    clickedSignupAction(campaignId, {
+      body: { details: { campaignContentfulId } },
     });
   };
 

--- a/resources/assets/middleware/api.js
+++ b/resources/assets/middleware/api.js
@@ -88,7 +88,9 @@ const postRequest = (payload, dispatch, getState) => {
       trackAnalyticsEvent({
         verb: statusCode === 200 ? 'found' : 'completed',
         noun: get(payload, 'meta.analytics.noun', 'post_request'),
-        data: get(payload, 'meta.analytics.data', null),
+        data: {
+          campaignId: payload.meta.id,
+        },
       });
 
       dispatch({

--- a/resources/assets/middleware/api.js
+++ b/resources/assets/middleware/api.js
@@ -76,13 +76,21 @@ const postRequest = (payload, dispatch, getState) => {
       // if data was created or not, but Gateway doesn't currently pass this to us. So for
       // now we're resolving to check against the data's created_at value to decide time elapsed.
       const dataCreatedAt = get(response, 'data.created_at', null);
+      const statusCode = isWithinMinutes(dataCreatedAt, 5) ? 201 : 200;
 
       response.status = {
         success: {
-          code: isWithinMinutes(dataCreatedAt, 5) ? 201 : 200,
+          code: statusCode,
           message: get(payload, 'meta.messaging.success', 'Thanks!'),
         },
       };
+
+      trackAnalyticsEvent({
+        verb: statusCode === 200 ? 'found' : 'completed',
+        noun: get(payload, 'meta.analytics.noun', 'post_request'),
+        data: {},
+        service: 'puck',
+      });
 
       dispatch({
         meta: payload.meta,
@@ -122,6 +130,8 @@ const apiMiddleware = ({ dispatch, getState }) => next => action => {
   if (action.type !== API) {
     return next(action);
   }
+
+  console.log('🖕🏽 apiMiddleware firing!');
 
   const { payload } = action;
 

--- a/resources/assets/middleware/api.js
+++ b/resources/assets/middleware/api.js
@@ -131,8 +131,6 @@ const apiMiddleware = ({ dispatch, getState }) => next => action => {
     return next(action);
   }
 
-  console.log('🖕🏽 apiMiddleware firing!');
-
   const { payload } = action;
 
   switch (action.method) {

--- a/resources/assets/middleware/api.js
+++ b/resources/assets/middleware/api.js
@@ -88,8 +88,7 @@ const postRequest = (payload, dispatch, getState) => {
       trackAnalyticsEvent({
         verb: statusCode === 200 ? 'found' : 'completed',
         noun: get(payload, 'meta.analytics.noun', 'post_request'),
-        data: {},
-        service: 'puck',
+        data: get(payload, 'meta.analytics.data'),
       });
 
       dispatch({

--- a/resources/assets/middleware/api.js
+++ b/resources/assets/middleware/api.js
@@ -88,7 +88,7 @@ const postRequest = (payload, dispatch, getState) => {
       trackAnalyticsEvent({
         verb: statusCode === 200 ? 'found' : 'completed',
         noun: get(payload, 'meta.analytics.noun', 'post_request'),
-        data: get(payload, 'meta.analytics.data'),
+        data: get(payload, 'meta.analytics.data', null),
       });
 
       dispatch({

--- a/resources/assets/store/store.js
+++ b/resources/assets/store/store.js
@@ -1,5 +1,5 @@
 import localforage from 'localforage';
-import { isNull, merge, set } from 'lodash';
+import { isNull, merge } from 'lodash';
 import { createStore, combineReducers, applyMiddleware, compose } from 'redux';
 
 import initialState from './initialState';
@@ -75,10 +75,6 @@ export function initializeStore(store) {
       if (isNull(action)) {
         return;
       }
-
-      // Specify that the clicked_signup action about to be dispatched was triggered
-      // after returning from authentication redirect.
-      set(action, 'payload.meta.analytics.adjective', 'triggered_post_auth');
 
       store.dispatch(action);
 

--- a/resources/assets/store/store.js
+++ b/resources/assets/store/store.js
@@ -1,5 +1,5 @@
 import localforage from 'localforage';
-import { isNull, merge } from 'lodash';
+import { isNull, merge, set } from 'lodash';
 import { createStore, combineReducers, applyMiddleware, compose } from 'redux';
 
 import initialState from './initialState';
@@ -75,6 +75,10 @@ export function initializeStore(store) {
       if (isNull(action)) {
         return;
       }
+
+      // Specify that the clicked_signup action about to be dispatched was triggered
+      // after returning from authentication redirect.
+      set(action, 'payload.meta.analytics.adjective', 'triggered_post_auth');
 
       store.dispatch(action);
 


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR wraps up adding new analytics events that follow `phoenix_clicked_signup` so that we can differentiate if the user was signing in to a previously signed up campaign, or signing up for the campaign for the very first time.

It also adds an adjective to the clicked signup event IF the event was triggered AFTER a redirect to authenticate on identity.dosomething.org (Northstar). Even though the `phoenix_clicked_signup` event _will_ fire to log the event _before_ the redirection to Northstar, it fires again when returning from Northstar and dispatching the signup action again that it previously stored in localstorage. I found it might be helpful to differentiate between the duplicate events by specifying that the second was actually triggered post authentication to finalize the signup process on the selected campaign. That event is now named `phoenix_clicked_signup_triggered_post_auth`. Hopefully this is useful!

Additionally, we now have events after successful signup response from Rogue:
- `phoenix_completed_signup` for a `201` status response to a successfully created signup record
- `phoenix_found_signup` for a `200` status response to a found signup record

The above also apply for other successful post requests, and the API middleware uses the `payload.meta.analytics.noun` to determine what the post request type is and use that as the `noun`, defaulting to generic `post_request` if no noun is otherwise found. Examples:
- `phoenix_completed_photo_submission_action`
- `phoenix_completed_text_submission_action`

### Any background context you want to provide?

The middleware order sorting in #1223 helped pave the way for this PR 😄 I testing events on both authenticated and unauthenticated users and all seems to look good!

### What are the relevant tickets/cards?

Refs [Pivotal ID #162797146](https://www.pivotaltracker.com/story/show/162797146)

### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.