### PR TITLE
Update getEntriesAsJson Contentful Query With Query Option

### DIFF
--- a/app/Repositories/QueriesContentful.php
+++ b/app/Repositories/QueriesContentful.php
@@ -18,6 +18,7 @@ trait QueriesContentful
      * @param  int    $options['includeDepth']
      * @param  string $options['limit']
      * @param  string $options['skip']
+     * @param  string $options['query']
      * @return string
      */
     protected function getEntriesAsJson($type, $options = [])
@@ -27,7 +28,8 @@ trait QueriesContentful
                 ->setInclude(array_get($options, 'includeDepth', 0))
                 ->orderBy('sys.updatedAt', true)
                 ->setLimit(array_get($options, 'limit'))
-                ->setSkip(array_get($options, 'skip'));
+                ->setSkip(array_get($options, 'skip'))
+                ->where('query', array_get($options, 'query'));
 
         $entries = app('contentful.delivery')->getEntries($query)->getItems();
 


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR adds a new `query` option to the `QueriesContentful` trait's `getEntriesAsJson`, to enable optional [full-text search](https://www.contentful.com/developers/docs/references/content-delivery-api/#/reference/search-parameters/full-text-search)

### Any background context you want to provide?
This is preemptive for the upcoming basic site search feature, where [we've opted](https://www.pivotaltracker.com/story/show/162972495/comments/198398792) for a full-text search across all fields. Beautifully, this should be most of what we need to add to enable basic Contentful search queries.

(@weerd see now I'm grateful for [your 🔮](https://github.com/DoSomething/phoenix-next/issues/1222#issuecomment-453600128) re the `$options` param)



### What are the relevant tickets/cards?

Refs [Pivotal ID #](https://www.pivotaltracker.com/story/show/162972495)
