### PR TITLE
List dynamic link tokens docs in summary/overview

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -71,6 +71,7 @@
 - [HomePage](content-publishing/home-page.md)
 - [Quiz](content-publishing/quiz.md)
 - [Sixpack Experiments](content-publishing/sixpack-experiments.md)
+- [Dynamic Link Tokens](content-publishing/dynamic-link-tokens.md)
 
 ## Contributing Instructions
 

--- a/docs/content-publishing/overview.md
+++ b/docs/content-publishing/overview.md
@@ -19,3 +19,4 @@ description: >-
 - [Pages](pages/)
 - [HomePage](home-page.md)
 - [Quiz](quiz.md)
+- [Dynamic Link Tokens](dynamic-link-tokens)


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR lists the dynamic link token doc page in the Summary and Content Publishing overview.

### Any background context you want to provide?
For some reason, this wasn't listed. (I probably just forgot to take care of that in #1164 )

### What are the relevant tickets/cards?
#1164 