### PR TITLE
Analytics events bug fix

### DIFF
--- a/resources/assets/components/SignupButton/SignupButton.js
+++ b/resources/assets/components/SignupButton/SignupButton.js
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import { get } from 'lodash';
 
 import Button from '../utilities/Button/Button';
-import { trackAnalyticsEvent } from '../../helpers/analytics';
 
 const SignupButton = props => {
   const {
@@ -22,20 +21,14 @@ const SignupButton = props => {
 
   // Decorate click handler for A/B tests & analytics.
   const onSignup = buttonText => {
-    trackAnalyticsEvent({
-      verb: 'clicked',
-      noun: 'signup',
-      data: {
-        campaignId,
+    clickedSignupAction(campaignId, {
+      body: { details: { campaignContentfulId } },
+      analytics: {
         campaignContentfulId,
         source,
         sourceData: { text: buttonText },
         template,
       },
-    });
-
-    clickedSignupAction(campaignId, {
-      body: { details: { campaignContentfulId } },
     });
   };
 

--- a/resources/assets/helpers/analytics.js
+++ b/resources/assets/helpers/analytics.js
@@ -101,6 +101,35 @@ const sendToServices = (category, name, data, service) => {
 };
 
 /**
+ * Format analytics event noun string.
+ *
+ * @param  {String} string
+ * @return {String}
+ */
+export function formatEventNoun(string) {
+  if (!string) {
+    console.error('Event Noun text string was not provided!');
+    return null;
+  }
+
+  const submissionActions = [
+    'photo',
+    'referral',
+    'share-social',
+    'text',
+    'voter-reg',
+  ];
+
+  let noun = string;
+
+  if (submissionActions.indexOf(noun) >= 0) {
+    noun = `${noun}_submission_action`;
+  }
+
+  return noun.replace(/-/g, '_');
+}
+
+/**
  * Watch the given parameters for changes in their state
  * and record it to Google Analytics.
  */

--- a/resources/assets/middleware/api.js
+++ b/resources/assets/middleware/api.js
@@ -8,8 +8,8 @@ import { PHOENIX_URL } from '../constants';
 import { setFormData } from '../helpers/forms';
 import { API } from '../constants/action-types';
 import { getUserToken } from '../selectors/user';
-import { trackAnalyticsEvent } from '../helpers/analytics';
 import { getRequest, setRequestHeaders, tabularLog } from '../helpers/api';
+import { formatEventNoun, trackAnalyticsEvent } from '../helpers/analytics';
 
 /**
  * Send a GET request and dispatch actions.
@@ -61,9 +61,12 @@ const postRequest = (payload, dispatch, getState) => {
 
   const body =
     payload.body instanceof FormData ? payload.body : setFormData(payload.body);
+  const campaignContentfulId = get(payload, 'meta.id', 'post_request');
+  const campaignId = get(payload, 'meta.campaignId');
+  const postType = get(payload, 'meta.type', 'post_request');
 
   dispatch({
-    id: payload.meta.id,
+    id: payload.meta.id, // @TODO: rename to campaignContentfulId or campaignId
     type: payload.pending,
   });
 
@@ -76,7 +79,7 @@ const postRequest = (payload, dispatch, getState) => {
       // if data was created or not, but Gateway doesn't currently pass this to us. So for
       // now we're resolving to check against the data's created_at value to decide time elapsed.
       const dataCreatedAt = get(response, 'data.created_at', null);
-      const statusCode = isWithinMinutes(dataCreatedAt, 5) ? 201 : 200;
+      const statusCode = isWithinMinutes(dataCreatedAt, 2) ? 201 : 200;
 
       response.status = {
         success: {
@@ -86,10 +89,13 @@ const postRequest = (payload, dispatch, getState) => {
       };
 
       trackAnalyticsEvent({
-        verb: statusCode === 200 ? 'found' : 'completed',
-        noun: get(payload, 'meta.analytics.noun', 'post_request'),
+        verb:
+          statusCode === 200 && postType === 'signup' ? 'found' : 'completed',
+        noun: formatEventNoun(postType),
         data: {
-          campaignId: payload.meta.id,
+          activityId: response.data.id,
+          campaignContentfulId,
+          campaignId,
         },
       });
 
@@ -104,12 +110,13 @@ const postRequest = (payload, dispatch, getState) => {
 
       trackAnalyticsEvent({
         verb: 'failed',
-        noun: 'post_request',
+        noun: formatEventNoun(postType),
         data: {
-          url: payload.url,
+          body,
+          campaignContentfulId,
+          campaignId,
           error,
         },
-        service: 'puck',
       });
 
       if (window.ENV.APP_ENV !== 'production') {

--- a/resources/assets/middleware/api.js
+++ b/resources/assets/middleware/api.js
@@ -61,7 +61,7 @@ const postRequest = (payload, dispatch, getState) => {
 
   const body =
     payload.body instanceof FormData ? payload.body : setFormData(payload.body);
-  const campaignContentfulId = get(payload, 'meta.id', 'post_request');
+  const campaignContentfulId = get(payload, 'meta.id', null);
   const campaignId = get(payload, 'meta.campaignId');
   const postType = get(payload, 'meta.type', 'post_request');
 

--- a/resources/assets/middleware/api.js
+++ b/resources/assets/middleware/api.js
@@ -112,7 +112,6 @@ const postRequest = (payload, dispatch, getState) => {
         verb: 'failed',
         noun: formatEventNoun(postType),
         data: {
-          body,
           campaignContentfulId,
           campaignId,
           error,


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR does a few updates to fix an issue with how `clicked_signup` events were being reported, along with `found_signup` and `completed_signup` and improves the analytics triggering for both the `signup` and `post` actions.

### Any background context you want to provide?

#1225 removed the `analytics` object from the action dispatched in `storeCampaignSignup()` for an alternate approach. However, this caused a bug because in the API middleware `postRequest()` the `noun` for the event that would be triggered in this method was looking for it in `meta.analyitcs.noun` which no longer existed, and thus defaulting to a generic `noun` of `post_request`. This was confusing in the GA results.

Screenshot of the correct, expected events in Google Analytics (local dev account):
![image](https://user-images.githubusercontent.com/105849/51409955-3e0e9000-1b31-11e9-89b2-fc117624ab66.png)

### What are the relevant tickets/cards?
 
Refs [Pivotal ID #162797146](https://www.pivotaltracker.com/story/show/162797146)

### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.
