### PR TITLE
Update Share Action id prop

### DIFF
--- a/resources/assets/components/actions/ShareAction/ShareAction.js
+++ b/resources/assets/components/actions/ShareAction/ShareAction.js
@@ -31,12 +31,12 @@ class ShareAction extends React.Component {
   storeSharePost = puckId => {
     const action = get(this.props.additionalContent, 'action', 'default');
 
-    const { id, campaignId, link } = this.props;
+    const { campaignContentfulId, campaignId, link } = this.props;
 
     const formData = setFormData({
       action,
       type: SOCIAL_SHARE_TYPE,
-      id,
+      id: campaignContentfulId,
       details: {
         url: link,
         platform: 'facebook',
@@ -49,7 +49,7 @@ class ShareAction extends React.Component {
     this.props.storeCampaignPost(campaignId, {
       action,
       body: formData,
-      id,
+      id: campaignContentfulId,
       type: SOCIAL_SHARE_TYPE,
     });
   };
@@ -172,9 +172,9 @@ ShareAction.propTypes = {
   affirmation: PropTypes.string,
   affirmationBlock: PropTypes.object, // eslint-disable-line
   campaignId: PropTypes.string.isRequired,
+  campaignContentfulId: PropTypes.string.isRequired,
   content: PropTypes.string,
   hideEmbed: PropTypes.bool,
-  id: PropTypes.string.isRequired,
   isAuthenticated: PropTypes.bool.isRequired,
   link: PropTypes.string.isRequired,
   socialPlatform: PropTypes.oneOf(['twitter', 'facebook']).isRequired,

--- a/resources/assets/components/actions/ShareAction/ShareActionContainer.js
+++ b/resources/assets/components/actions/ShareAction/ShareActionContainer.js
@@ -11,6 +11,7 @@ const mapStateToProps = state => ({
   userId: getUserId(state),
   campaignId: state.campaign.campaignId,
   isAuthenticated: isAuthenticated(state),
+  campaignContentfulId: state.campaign.id,
 });
 
 /**


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR updates the `id` prop passed from the `ShareAction` to the `storeCampaignPost` function with the new `campaignContentfulId` prop.

### Any background context you want to provide?
The `id` prop was the Share Action Contentful ID as opposed to the intended Campaign Contentful ID

### What are the relevant tickets/cards?

https://dosomething.slack.com/archives/C3ASB4204/p1548261761165300