### PR TITLE
Adding health status check endpoint

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,7 +4,7 @@ APP_KEY=
 APP_DEBUG=true
 APP_LOG=single
 APP_LOG_LEVEL=debug
-APP_URL=http://localhost
+APP_URL=http://phoenix.test
 
 DB_CONNECTION=mysql
 DB_HOST=127.0.0.1
@@ -31,10 +31,6 @@ GRAPHQL_URL=https://graphql-dev.dosomething.org/graphql
 NORTHSTAR_URL=https://identity-dev.dosomething.org
 NORTHSTAR_AUTHORIZATION_ID=dev-oauth
 NORTHSTAR_AUTHORIZATION_SECRET=
-
-PHOENIX_LEGACY_URL=
-PHOENIX_LEGACY_USERNAME=
-PHOENIX_LEGACY_PASSWORD=
 
 BERTLY_URL=
 BERTLY_API_KEY=

--- a/routes/api.php
+++ b/routes/api.php
@@ -34,3 +34,8 @@ $router->group(['prefix' => 'v2'], function () {
     // Signups
     $this->get('/signups', 'Api\SignupsController@index');
 });
+
+// Simple health check endpoint
+$router->get('/status', function () {
+    return ['status' => 'good'];
+});


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR adds a health status check endpoint, similar to that of Northstar for use in our uptime Ghost Inspector tests. It also updates our .env.example file, and removes the old Ashes related env vars.

### What are the relevant tickets/cards?

🌵 
