### PR TITLE
Fix for status health endpoint

### DIFF
--- a/routes/api.php
+++ b/routes/api.php
@@ -13,6 +13,11 @@
 
 // v2 Routes
 $router->group(['prefix' => 'v2'], function () {
+    // Status health check
+    $this->get('/status', function () {
+        return ['status' => 'good'];
+    });
+
     // Campaigns
     $this->get('/campaigns', 'Api\CampaignsController@index');
     $this->get('/campaigns/{id}', 'Api\CampaignsController@show');
@@ -33,9 +38,4 @@ $router->group(['prefix' => 'v2'], function () {
 
     // Signups
     $this->get('/signups', 'Api\SignupsController@index');
-});
-
-// Simple health check endpoint
-$router->get('/status', function () {
-    return ['status' => 'good'];
 });


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR updates the `/status` endpoint to be located at `/api/v2/status` since any request that goes to `/something` in Phoenix gets rerouted to `/us/something` and thus 404ing 😢 

### Any background context you want to provide?

I jumped the gun and should have tested this better 🤦‍♂️ 
