### PR TITLE
Fix for bug in graphql query to show campaigns posts on profile page.

### DIFF
--- a/resources/assets/components/pages/AccountPage/UserPostsQuery.js
+++ b/resources/assets/components/pages/AccountPage/UserPostsQuery.js
@@ -21,6 +21,8 @@ const USER_POSTS_QUERY = gql`
       user {
         firstName
       }
+      ...PostCard
+      ...ReactionButton
     }
   }
 

--- a/resources/assets/components/pages/AccountPage/UserPostsQuery.js
+++ b/resources/assets/components/pages/AccountPage/UserPostsQuery.js
@@ -18,9 +18,6 @@ const USER_POSTS_QUERY = gql`
       text
       tags
       quantity
-      user {
-        firstName
-      }
       ...PostCard
       ...ReactionButton
     }


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR fixes a bug in the `UserPostsQuery` component that is meant to show a user's posts in the Profile > Campaigns page. It was missing references to the components to use in the query

### Any background context you want to provide?

🐞  Before:
![screen shot 2019-01-29 at 5 23 09 pm](https://user-images.githubusercontent.com/105849/51945255-2f0ac600-23ec-11e9-8040-23f1bb9d0c8a.png)

🥾  After:
![screen shot 2019-01-29 at 5 23 27 pm](https://user-images.githubusercontent.com/105849/51945266-33cf7a00-23ec-11e9-903f-73d319b0107c.png)


### What are the relevant tickets/cards?

Refs [Pivotal ID #163561914](https://www.pivotaltracker.com/story/show/163561914)

