### PR TITLE
Adding Signup Affirmation Toggle Option

### DIFF
--- a/resources/assets/actions/signup.js
+++ b/resources/assets/actions/signup.js
@@ -147,6 +147,7 @@ export function storeCampaignSignup(campaignId, data) {
             success: 'Thanks for signing up!',
             failure: 'Whoops! Something went wrong!',
           },
+          shouldShowAffirmation: get(data, 'shouldShowAffirmation', true),
         },
         pending: STORE_CAMPAIGN_SIGNUPS_PENDING,
         requiresAuthentication: true,

--- a/resources/assets/components/Quiz/Quiz.js
+++ b/resources/assets/components/Quiz/Quiz.js
@@ -111,7 +111,7 @@ class Quiz extends React.Component {
         return;
       }
 
-      clickedSignupAction(campaignId);
+      clickedSignupAction(campaignId, { shouldShowAffirmation: false });
     }
 
     this.quizResultBlockHandler(results.resultBlock);

--- a/resources/assets/reducers/signups.js
+++ b/resources/assets/reducers/signups.js
@@ -69,7 +69,9 @@ const signupReducer = (state = {}, action) => {
         ...state,
         data: signups,
         isPending: false,
-        shouldShowAffirmation: get(status, 'success.code') === 201,
+        shouldShowAffirmation:
+          get(data, 'shouldShowAffirmation', true) &&
+          get(status, 'success.code') === 201,
         thisCampaign: true, // @TODO: remove from state; use a selector instead
       };
 


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR adds logic to allow optionally toggling the Signup Affirmation Modal to be hidden upon successful signup. Quiz signup conversions will now toggle this to false.

### Any background context you want to provide?
For successful signups, by default, we'd set the redux state `shouldShowAffirmation` to `true`, this works fine except for Quiz conversions, where we don't want to show the affirmation modal (to allow results to be surfaced immediately and to prevent a Quiz re-render which would restart the quiz and hide the results).

This PR adds another `data` parameter field called `shouldShowAffirmation` (modeled after the existing field), which defaults to `true`, since that's our presumed case, but manually toggles this `false` for Quiz signups.

### What are the relevant tickets/cards?

Refs [Pivotal ID #163655159](https://www.pivotaltracker.com/story/show/163655159)