### PR TITLE
Signup Affirmation Toggle Fix

### DIFF
--- a/resources/assets/actions/signup.js
+++ b/resources/assets/actions/signup.js
@@ -122,6 +122,7 @@ export function storeCampaignSignup(campaignId, data) {
   const analytics = get(data, 'analytics', {});
   const path = join('api/v2/campaigns', campaignId, 'signups');
   const type = 'signup';
+  const shouldShowAffirmation = get(data, 'shouldShowAffirmation', true);
 
   // Track signup click submission event.
   trackAnalyticsEvent({
@@ -147,7 +148,7 @@ export function storeCampaignSignup(campaignId, data) {
             success: 'Thanks for signing up!',
             failure: 'Whoops! Something went wrong!',
           },
-          shouldShowAffirmation: get(data, 'shouldShowAffirmation', true),
+          shouldShowAffirmation,
         },
         pending: STORE_CAMPAIGN_SIGNUPS_PENDING,
         requiresAuthentication: true,

--- a/resources/assets/reducers/signups.js
+++ b/resources/assets/reducers/signups.js
@@ -70,7 +70,7 @@ const signupReducer = (state = {}, action) => {
         data: signups,
         isPending: false,
         shouldShowAffirmation:
-          get(data, 'shouldShowAffirmation', true) &&
+          get(action, 'meta.shouldShowAffirmation', true) &&
           get(status, 'success.code') === 201,
         thisCampaign: true, // @TODO: remove from state; use a selector instead
       };


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR fixes a really clumsy mistake I made in #1243 grabbing the `shouldShowAffirmation` field in the signup reducer from the wrong `action` field. 

Also moving the evaluation of `shouldShowAffirmation` atop the signup action for clarity.

### What are the relevant tickets/cards?

Refs [Pivotal ID #163655159](https://www.pivotaltracker.com/story/show/163655159)
#1243 