### PR TITLE
Another Quiz Signup Affirmation Patch (So Help Me God)

### DIFF
--- a/resources/assets/components/Quiz/Quiz.js
+++ b/resources/assets/components/Quiz/Quiz.js
@@ -99,19 +99,21 @@ class Quiz extends React.Component {
       },
     });
 
+    const clickedSignupActionData = { shouldShowAffirmation: false };
+
     // Run a quiz conversion (campaign signup) if this quiz is not set to auto submit
     if (!autoSubmit) {
       if (!isAuthenticated) {
         // Append result and resultBlock IDs to URL, so that upon redirect from login flow, we can show their results
         appendResultParams(results);
 
-        clickedSignupAction(campaignId);
+        clickedSignupAction(campaignId, clickedSignupActionData);
 
         // Hard return so the results won't display before the login redirect
         return;
       }
 
-      clickedSignupAction(campaignId, { shouldShowAffirmation: false });
+      clickedSignupAction(campaignId, clickedSignupActionData);
     }
 
     this.quizResultBlockHandler(results.resultBlock);


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_


### What does this PR do?

This PR ensures we *always* pass the correct data to the `clickedSignupAction` in the quiz to toggle signup affirmation to `false`

Me:
<img src="http://pa1.narvii.com/5794/49a8bdbe8827ba063c97a2e4da51f015f73714a8_00.gif"/>

#1244 #1243 