### PR TITLE
Company pages setup continued

### DIFF
--- a/app/Entities/Entity.php
+++ b/app/Entities/Entity.php
@@ -66,6 +66,8 @@ class Entity implements ArrayAccess, JsonSerializable
                 return new TruncatedCampaign($block->entry);
             case 'campaignUpdate':
                 return new CampaignUpdate($block->entry);
+            case 'companyPage':
+                return new CompanyPage($block->entry);
             case 'contentBlock':
                 return new ContentBlock($block->entry);
             case 'customBlock':

--- a/app/Http/Controllers/CategorizedPageController.php
+++ b/app/Http/Controllers/CategorizedPageController.php
@@ -33,7 +33,7 @@ class CategorizedPageController extends Controller
      */
     public function show($category, $slug)
     {
-        $page = $this->pageRepository->findBySlug($category.'/'.$slug);
+        $page = $this->pageRepository->findBySlug($category.'/'.$slug, get_content_type_by_category($category));
 
         return view('app', [
             'headTitle' => $page->fields->title,

--- a/app/Repositories/PageRepository.php
+++ b/app/Repositories/PageRepository.php
@@ -15,13 +15,13 @@ class PageRepository
      * @return \Contentful\Delivery\Resource\Entry
      * @throws \Illuminate\Database\Eloquent\ModelNotFoundException
      */
-    public function findBySlug($slug)
+    public function findBySlug($slug, $type)
     {
         if (! config('services.contentful.cache')) {
-            $page = $this->getEntryFromSlugAsJson('page', $slug);
+            $page = $this->getEntryFromSlugAsJson($type, $slug);
         } else {
             $page = remember('page_'.str_replace('/', '_', $slug), 15, function () use ($slug) {
-                return $this->getEntryFromSlugAsJson('page', $slug);
+                return $this->getEntryFromSlugAsJson($type, $slug);
             });
         }
 

--- a/app/Repositories/QueriesContentful.php
+++ b/app/Repositories/QueriesContentful.php
@@ -2,8 +2,6 @@
 
 namespace App\Repositories;
 
-use App\Entities\Page;
-use App\Entities\Campaign;
 use App\Entities\HomePage;
 use Contentful\Delivery\Query;
 use App\Entities\TruncatedCampaign;
@@ -68,12 +66,11 @@ trait QueriesContentful
             return 'not_found';
         }
 
-        switch ($type) {
-            case 'campaign':
-                return json_encode(new Campaign($entry[0]));
+        // Eg: campaign -> Campaign
+        // Eg: companyPage -> CompanyPage
+        // Eg: page -> Page
+        $entityClass = '\\App\\Entities\\'.ucwords($type);
 
-            case 'page':
-                return json_encode(new Page($entry[0]));
-        }
+        return json_encode(new $entityClass($entry[0]));
     }
 }

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -5,6 +5,17 @@ use Illuminate\Support\HtmlString;
 use Contentful\Core\File\ImageOptions;
 use Contentful\Delivery\Resource\Asset;
 
+function get_content_type_by_category($category)
+{
+    $types = [
+        'about' => 'companyPage',
+        'articles' => 'page',
+        'facts' => 'page',
+    ];
+
+    return data_get($types, $category, 'page');
+}
+
 /**
  * Get Heroku database configuration variables from supplied
  * database url.

--- a/contentful/content-types/companyPage.js
+++ b/contentful/content-types/companyPage.js
@@ -51,7 +51,7 @@ module.exports = function(migration) {
       },
       {
         regexp: {
-          pattern: '^(?!/)[a-zA-z0-9-/]+$',
+          pattern: '^(?!/)[a-zA-Z0-9-/]+$',
         },
 
         message:

--- a/contentful/content-types/companyPage.js
+++ b/contentful/content-types/companyPage.js
@@ -51,11 +51,11 @@ module.exports = function(migration) {
       },
       {
         regexp: {
-          pattern: '^[a-zA-Z0-9-/]+$',
+          pattern: '^(?!/)[a-zA-z0-9-/]+$',
         },
 
         message:
-          'Only alphanumeric, forward-slash, and hyphen characters are allowed in slugs!',
+          'Only alphanumeric, forward-slash, and hyphen characters are allowed in slugs! Entry cannot start with a forward-slash.',
       },
     ])
     .disabled(false)


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR does a few updates to support being able to properly query for `companyPage`s as a content type in Contentful. Since we cannot query Contentful with multiple content types in a query, I needed to find a reasonable way to determine what type of page the slug is referring to. The easiest spot seemed related to the `$category` for the slug. It all seems to work rather well 💃 

### Any background context you want to provide?

🌵 

### What are the relevant tickets/cards?

Refs [Pivotal ID #162972504](https://www.pivotaltracker.com/story/show/162972504)

### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.