### PR TITLE
Adding page type dispatcher

### DIFF
--- a/app/Entities/CompanyPage.php
+++ b/app/Entities/CompanyPage.php
@@ -17,6 +17,7 @@ class CompanyPage extends Entity implements JsonSerializable
                 'subTitle' => $this->subTitle,
                 'slug' => $this->slug,
                 'metadata' => $this->metadata ? new Metadata($this->metadata->entry) : null,
+                // 'content' => data_get($this->content, 'nodeType', null) === 'document' ? new RichText($this->content) : $this->content,
                 'content' => $this->content,
                 'blocks' => $this->parseBlocks($this->blocks),
             ],

--- a/app/Entities/CompanyPage.php
+++ b/app/Entities/CompanyPage.php
@@ -17,7 +17,6 @@ class CompanyPage extends Entity implements JsonSerializable
                 'subTitle' => $this->subTitle,
                 'slug' => $this->slug,
                 'metadata' => $this->metadata ? new Metadata($this->metadata->entry) : null,
-                // 'content' => data_get($this->content, 'nodeType', null) === 'document' ? new RichText($this->content) : $this->content,
                 'content' => $this->content,
                 'blocks' => $this->parseBlocks($this->blocks),
             ],

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -8,7 +8,7 @@ use Contentful\Delivery\Resource\Asset;
 function get_content_type_by_category($category)
 {
     $types = [
-        'about' => 'companyPage',
+        'about' => 'page',
         'articles' => 'page',
         'facts' => 'page',
     ];

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -5,6 +5,12 @@ use Illuminate\Support\HtmlString;
 use Contentful\Core\File\ImageOptions;
 use Contentful\Delivery\Resource\Asset;
 
+/**
+ * Get the appropriate page content type by page category.
+ *
+ * @param  string $category
+ * @return string
+ */
 function get_content_type_by_category($category)
 {
     $types = [

--- a/resources/assets/components/App.js
+++ b/resources/assets/components/App.js
@@ -14,7 +14,7 @@ import { puckErrorReport } from '../helpers/analytics';
 import CampaignContainer from './Campaign/CampaignContainer';
 import { getUserId, isAuthenticated } from '../selectors/user';
 import AccountContainer from './pages/AccountPage/AccountContainer';
-import GeneralPageContainer from './pages/GeneralPage/GeneralPageContainer';
+import PageDispatcherContainer from './PageDispatcher/PageDispatcherContainer';
 
 const App = ({ store, history }) => {
   initializeStore(store);
@@ -37,7 +37,7 @@ const App = ({ store, history }) => {
               <Route exact path="/us" component={HomePage} />
               <Route path="/us/account" component={AccountContainer} />
               <Route path="/us/campaigns/:slug" component={CampaignContainer} />
-              <Route path="/us/:slug" component={GeneralPageContainer} />
+              <Route path="/us/:slug" component={PageDispatcherContainer} />
             </Switch>
           </ConnectedRouter>
         </ApolloProvider>

--- a/resources/assets/components/PageDispatcher/PageDispatcher.js
+++ b/resources/assets/components/PageDispatcher/PageDispatcher.js
@@ -1,0 +1,21 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import CompanyPageContainer from '../pages/CompanyPage/CompanyPageContainer';
+import GeneralPageContainer from '../pages/GeneralPage/GeneralPageContainer';
+
+const PageDispatcher = ({ type }) => {
+  switch (type) {
+    case 'companyPage':
+      return <CompanyPageContainer />;
+
+    default:
+      return <GeneralPageContainer />;
+  }
+};
+
+PageDispatcher.propTypes = {
+  type: PropTypes.string.isRequired,
+};
+
+export default PageDispatcher;

--- a/resources/assets/components/PageDispatcher/PageDispatcherContainer.js
+++ b/resources/assets/components/PageDispatcher/PageDispatcherContainer.js
@@ -1,0 +1,13 @@
+import { connect } from 'react-redux';
+
+import PageDispatcher from './PageDispatcher';
+
+/**
+ * Provide state from the Redux store as props for this component.
+ */
+const mapStateToProps = state => ({
+  type: state.page.type,
+});
+
+// Export the container component.
+export default connect(mapStateToProps)(PageDispatcher);

--- a/resources/assets/components/pages/CompanyPage/CompanyPage.js
+++ b/resources/assets/components/pages/CompanyPage/CompanyPage.js
@@ -1,0 +1,14 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const CompanyPage = props => {
+  const { title } = props;
+
+  return <div>{title}</div>;
+};
+
+CompanyPage.propTypes = {
+  title: PropTypes.string.isRequired,
+};
+
+export default CompanyPage;

--- a/resources/assets/components/pages/CompanyPage/CompanyPageContainer.js
+++ b/resources/assets/components/pages/CompanyPage/CompanyPageContainer.js
@@ -1,0 +1,11 @@
+import { connect } from 'react-redux';
+
+import CompanyPage from './CompanyPage';
+
+/**
+ * Provide state from the Redux store as props for this component.
+ */
+const mapStateToProps = state => state.page.fields;
+
+// Export the container component.
+export default connect(mapStateToProps)(CompanyPage);


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR updates to add a new `PageDispatcher` component that will help to render pages using the proper component, such as a `GeneralPage` or the new `CompanyPage`. It also updates the array in the `get_content_type_by_category()` helper method to continue to use `page` as the content type for `/about` pages for the time being until we're ready for a switcheroo.

### Any background context you want to provide?

🌵 

### What are the relevant tickets/cards?

Refs [Pivotal ID #162972504](https://www.pivotaltracker.com/story/show/162972504)

### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.