### PR TITLE
Refactoring markdown component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -421,13 +421,12 @@
         "is-buffer": "^1.1.5"
       }
     },
-    "@contentful/rich-text-html-renderer": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/@contentful/rich-text-html-renderer/-/rich-text-html-renderer-13.0.0.tgz",
-      "integrity": "sha512-gUhEjNyU/QR36+RsJ7/N+IaqJbQ9GiTezNRpF2NztOILdyjxplIbTt3HN5Yo99DT9K+qs8GbFV43EsIxbWgVjA==",
+    "@contentful/rich-text-react-renderer": {
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/@contentful/rich-text-react-renderer/-/rich-text-react-renderer-13.0.1.tgz",
+      "integrity": "sha512-oF4DQPQ5FAwq/na5a317rkRhDkESjYpqQ0BLZw4ewlfZ51C+vSJA/ZvJizJDenkt65VZszqaAiDg7DBTqScheg==",
       "requires": {
-        "@contentful/rich-text-types": "^13.0.0",
-        "escape-html": "^1.0.3"
+        "@contentful/rich-text-types": "^13.0.0"
       }
     },
     "@contentful/rich-text-types": {
@@ -4523,7 +4522,8 @@
     "escape-html": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
-      "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
+      "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=",
+      "dev": true
     },
     "escape-string-regexp": {
       "version": "1.0.5",
@@ -10537,9 +10537,9 @@
       "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks="
     },
     "prettier": {
-      "version": "1.15.3",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.15.3.tgz",
-      "integrity": "sha512-gAU9AGAPMaKb3NNSUUuhhFAS7SCO4ALTN4nRIn6PJ075Qd28Yn2Ig2ahEJWdJwJmlEBTUfC7mMUSFy8MwsOCfg=="
+      "version": "1.16.4",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.16.4.tgz",
+      "integrity": "sha512-ZzWuos7TI5CKUeQAtFd6Zhm2s6EpAD/ZLApIhsF9pRvRtM1RFo61dM/4MSRUA0SuLugA/zgrZD8m0BaY46Og7g=="
     },
     "pretty-format": {
       "version": "22.4.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "@babel/types": {
           "version": "7.0.0-beta.44",
           "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.44.tgz",
-          "integrity": "sha1-axsWRZH3fewKA0KsqZXy0Eazp1c=",
+          "integrity": "sha512-5eTV4WRmqbaFM3v9gHAIljEQJU4Ssc6fxL61JN+Oe2ga/BwyjzjamwkCVVAQjHGuAX8i0BWo42dshL8eO5KfLQ==",
           "dev": true,
           "requires": {
             "esutils": "^2.0.2",
@@ -62,7 +62,7 @@
         "@babel/types": {
           "version": "7.0.0-beta.44",
           "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.44.tgz",
-          "integrity": "sha1-axsWRZH3fewKA0KsqZXy0Eazp1c=",
+          "integrity": "sha512-5eTV4WRmqbaFM3v9gHAIljEQJU4Ssc6fxL61JN+Oe2ga/BwyjzjamwkCVVAQjHGuAX8i0BWo42dshL8eO5KfLQ==",
           "dev": true,
           "requires": {
             "esutils": "^2.0.2",
@@ -90,7 +90,7 @@
         "@babel/types": {
           "version": "7.0.0-beta.44",
           "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.44.tgz",
-          "integrity": "sha1-axsWRZH3fewKA0KsqZXy0Eazp1c=",
+          "integrity": "sha512-5eTV4WRmqbaFM3v9gHAIljEQJU4Ssc6fxL61JN+Oe2ga/BwyjzjamwkCVVAQjHGuAX8i0BWo42dshL8eO5KfLQ==",
           "dev": true,
           "requires": {
             "esutils": "^2.0.2",
@@ -127,7 +127,7 @@
         "@babel/types": {
           "version": "7.0.0-beta.44",
           "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.44.tgz",
-          "integrity": "sha1-axsWRZH3fewKA0KsqZXy0Eazp1c=",
+          "integrity": "sha512-5eTV4WRmqbaFM3v9gHAIljEQJU4Ssc6fxL61JN+Oe2ga/BwyjzjamwkCVVAQjHGuAX8i0BWo42dshL8eO5KfLQ==",
           "dev": true,
           "requires": {
             "esutils": "^2.0.2",
@@ -211,7 +211,7 @@
         "@babel/code-frame": {
           "version": "7.0.0-beta.44",
           "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.44.tgz",
-          "integrity": "sha1-KgJkM2jegJFhYr5whlyXd08629k=",
+          "integrity": "sha512-cuAuTTIQ9RqcFRJ/Y8PvTh+paepNcaGxwQwjIDRWPXmzzyAeCO4KqS9ikMvq0MCbRk6GlYKwfzStrcP3/jSL8g==",
           "dev": true,
           "requires": {
             "@babel/highlight": "7.0.0-beta.44"
@@ -220,7 +220,7 @@
         "@babel/highlight": {
           "version": "7.0.0-beta.44",
           "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.44.tgz",
-          "integrity": "sha1-GMlM5UORaoBVPtzc9oGJCyAHR9U=",
+          "integrity": "sha512-Il19yJvy7vMFm8AVAh6OZzaFoAd0hbkeMZiX3P5HGD+z7dyI7RzndHB0dg6Urh/VAFfHtpOIzDUSxmY6coyZWQ==",
           "dev": true,
           "requires": {
             "chalk": "^2.0.0",
@@ -231,7 +231,7 @@
         "@babel/types": {
           "version": "7.0.0-beta.44",
           "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.44.tgz",
-          "integrity": "sha1-axsWRZH3fewKA0KsqZXy0Eazp1c=",
+          "integrity": "sha512-5eTV4WRmqbaFM3v9gHAIljEQJU4Ssc6fxL61JN+Oe2ga/BwyjzjamwkCVVAQjHGuAX8i0BWo42dshL8eO5KfLQ==",
           "dev": true,
           "requires": {
             "esutils": "^2.0.2",
@@ -309,7 +309,7 @@
         "@babel/code-frame": {
           "version": "7.0.0-beta.44",
           "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.44.tgz",
-          "integrity": "sha1-KgJkM2jegJFhYr5whlyXd08629k=",
+          "integrity": "sha512-cuAuTTIQ9RqcFRJ/Y8PvTh+paepNcaGxwQwjIDRWPXmzzyAeCO4KqS9ikMvq0MCbRk6GlYKwfzStrcP3/jSL8g==",
           "dev": true,
           "requires": {
             "@babel/highlight": "7.0.0-beta.44"
@@ -318,7 +318,7 @@
         "@babel/highlight": {
           "version": "7.0.0-beta.44",
           "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.44.tgz",
-          "integrity": "sha1-GMlM5UORaoBVPtzc9oGJCyAHR9U=",
+          "integrity": "sha512-Il19yJvy7vMFm8AVAh6OZzaFoAd0hbkeMZiX3P5HGD+z7dyI7RzndHB0dg6Urh/VAFfHtpOIzDUSxmY6coyZWQ==",
           "dev": true,
           "requires": {
             "chalk": "^2.0.0",
@@ -329,7 +329,7 @@
         "@babel/types": {
           "version": "7.0.0-beta.44",
           "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.44.tgz",
-          "integrity": "sha1-axsWRZH3fewKA0KsqZXy0Eazp1c=",
+          "integrity": "sha512-5eTV4WRmqbaFM3v9gHAIljEQJU4Ssc6fxL61JN+Oe2ga/BwyjzjamwkCVVAQjHGuAX8i0BWo42dshL8eO5KfLQ==",
           "dev": true,
           "requires": {
             "esutils": "^2.0.2",
@@ -420,6 +420,20 @@
         "follow-redirects": "^1.2.5",
         "is-buffer": "^1.1.5"
       }
+    },
+    "@contentful/rich-text-html-renderer": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/@contentful/rich-text-html-renderer/-/rich-text-html-renderer-13.0.0.tgz",
+      "integrity": "sha512-gUhEjNyU/QR36+RsJ7/N+IaqJbQ9GiTezNRpF2NztOILdyjxplIbTt3HN5Yo99DT9K+qs8GbFV43EsIxbWgVjA==",
+      "requires": {
+        "@contentful/rich-text-types": "^13.0.0",
+        "escape-html": "^1.0.3"
+      }
+    },
+    "@contentful/rich-text-types": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/@contentful/rich-text-types/-/rich-text-types-13.0.0.tgz",
+      "integrity": "sha512-1+a/WAFVBZl1tJb4J7nHZxbqde1CqwLYE+xtpqO8Pqr5zOgVV4MJHzA2t7SDYc/ypJIoNL0W8yEUNgf43iFL/Q=="
     },
     "@dosomething/analytics": {
       "version": "2.1.2",
@@ -1488,7 +1502,7 @@
     },
     "async": {
       "version": "1.0.0",
-      "resolved": "http://registry.npmjs.org/async/-/async-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/async/-/async-1.0.0.tgz",
       "integrity": "sha1-+PwEyjoTeErenhZBr5hXjPvWR6k="
     },
     "async-each": {
@@ -1646,7 +1660,7 @@
         "@babel/code-frame": {
           "version": "7.0.0-beta.44",
           "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.44.tgz",
-          "integrity": "sha1-KgJkM2jegJFhYr5whlyXd08629k=",
+          "integrity": "sha512-cuAuTTIQ9RqcFRJ/Y8PvTh+paepNcaGxwQwjIDRWPXmzzyAeCO4KqS9ikMvq0MCbRk6GlYKwfzStrcP3/jSL8g==",
           "dev": true,
           "requires": {
             "@babel/highlight": "7.0.0-beta.44"
@@ -1655,7 +1669,7 @@
         "@babel/highlight": {
           "version": "7.0.0-beta.44",
           "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.44.tgz",
-          "integrity": "sha1-GMlM5UORaoBVPtzc9oGJCyAHR9U=",
+          "integrity": "sha512-Il19yJvy7vMFm8AVAh6OZzaFoAd0hbkeMZiX3P5HGD+z7dyI7RzndHB0dg6Urh/VAFfHtpOIzDUSxmY6coyZWQ==",
           "dev": true,
           "requires": {
             "chalk": "^2.0.0",
@@ -1666,7 +1680,7 @@
         "@babel/types": {
           "version": "7.0.0-beta.44",
           "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.44.tgz",
-          "integrity": "sha1-axsWRZH3fewKA0KsqZXy0Eazp1c=",
+          "integrity": "sha512-5eTV4WRmqbaFM3v9gHAIljEQJU4Ssc6fxL61JN+Oe2ga/BwyjzjamwkCVVAQjHGuAX8i0BWo42dshL8eO5KfLQ==",
           "dev": true,
           "requires": {
             "esutils": "^2.0.2",
@@ -3017,7 +3031,7 @@
         "y18n": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
-          "integrity": "sha1-le+U+F7MgdAHwmThkKEg8KPIVms=",
+          "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
           "dev": true
         }
       }
@@ -4509,8 +4523,7 @@
     "escape-html": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
-      "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=",
-      "dev": true
+      "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
     },
     "escape-string-regexp": {
       "version": "1.0.5",
@@ -5536,27 +5549,27 @@
       "dependencies": {
         "abbrev": {
           "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+          "resolved": false,
           "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
           "dev": true,
           "optional": true
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "resolved": false,
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
           "dev": true
         },
         "aproba": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
+          "resolved": false,
           "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
           "dev": true,
           "optional": true
         },
         "are-we-there-yet": {
           "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
+          "resolved": false,
           "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
           "dev": true,
           "optional": true,
@@ -5567,13 +5580,13 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+          "resolved": false,
           "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
           "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+          "resolved": false,
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "dev": true,
           "requires": {
@@ -5583,39 +5596,39 @@
         },
         "chownr": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.0.1.tgz",
+          "resolved": false,
           "integrity": "sha1-4qdQQqlVGQi+vSW4Uj1fl2nXkYE=",
           "dev": true,
           "optional": true
         },
         "code-point-at": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+          "resolved": false,
           "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
           "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+          "resolved": false,
           "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
           "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+          "resolved": false,
           "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
           "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+          "resolved": false,
           "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
           "dev": true,
           "optional": true
         },
         "debug": {
           "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "resolved": false,
           "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
           "dev": true,
           "optional": true,
@@ -5625,28 +5638,28 @@
         },
         "deep-extend": {
           "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.5.1.tgz",
+          "resolved": false,
           "integrity": "sha512-N8vBdOa+DF7zkRrDCsaOXoCs/E2fJfx9B9MrKnnSiHNh4ws7eSys6YQE4KvT1cecKmOASYQBhbKjeuDD9lT81w==",
           "dev": true,
           "optional": true
         },
         "delegates": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+          "resolved": false,
           "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
           "dev": true,
           "optional": true
         },
         "detect-libc": {
           "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
+          "resolved": false,
           "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
           "dev": true,
           "optional": true
         },
         "fs-minipass": {
           "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.5.tgz",
+          "resolved": false,
           "integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
           "dev": true,
           "optional": true,
@@ -5656,14 +5669,14 @@
         },
         "fs.realpath": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+          "resolved": false,
           "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
           "dev": true,
           "optional": true
         },
         "gauge": {
           "version": "2.7.4",
-          "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
+          "resolved": false,
           "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
           "dev": true,
           "optional": true,
@@ -5680,7 +5693,7 @@
         },
         "glob": {
           "version": "7.1.2",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "resolved": false,
           "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "dev": true,
           "optional": true,
@@ -5695,14 +5708,14 @@
         },
         "has-unicode": {
           "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+          "resolved": false,
           "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
           "dev": true,
           "optional": true
         },
         "iconv-lite": {
           "version": "0.4.21",
-          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.21.tgz",
+          "resolved": false,
           "integrity": "sha512-En5V9za5mBt2oUA03WGD3TwDv0MKAruqsuxstbMUZaj9W9k/m1CV/9py3l0L5kw9Bln8fdHQmzHSYtvpvTLpKw==",
           "dev": true,
           "optional": true,
@@ -5712,7 +5725,7 @@
         },
         "ignore-walk": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.1.tgz",
+          "resolved": false,
           "integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
           "dev": true,
           "optional": true,
@@ -5722,7 +5735,7 @@
         },
         "inflight": {
           "version": "1.0.6",
-          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+          "resolved": false,
           "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
           "dev": true,
           "optional": true,
@@ -5733,20 +5746,20 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+          "resolved": false,
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
           "dev": true
         },
         "ini": {
           "version": "1.3.5",
-          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+          "resolved": false,
           "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
           "dev": true,
           "optional": true
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "resolved": false,
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
           "requires": {
@@ -5755,14 +5768,14 @@
         },
         "isarray": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "resolved": false,
           "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
           "dev": true,
           "optional": true
         },
         "minimatch": {
           "version": "3.0.4",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "resolved": false,
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "requires": {
@@ -5771,13 +5784,13 @@
         },
         "minimist": {
           "version": "0.0.8",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "resolved": false,
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
           "dev": true
         },
         "minipass": {
           "version": "2.2.4",
-          "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.2.4.tgz",
+          "resolved": false,
           "integrity": "sha512-hzXIWWet/BzWhYs2b+u7dRHlruXhwdgvlTMDKC6Cb1U7ps6Ac6yQlR39xsbjWJE377YTCtKwIXIpJ5oP+j5y8g==",
           "dev": true,
           "requires": {
@@ -5787,7 +5800,7 @@
         },
         "minizlib": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.1.0.tgz",
+          "resolved": false,
           "integrity": "sha512-4T6Ur/GctZ27nHfpt9THOdRZNgyJ9FZchYO1ceg5S8Q3DNLCKYy44nCZzgCJgcvx2UM8czmqak5BCxJMrq37lA==",
           "dev": true,
           "optional": true,
@@ -5797,7 +5810,7 @@
         },
         "mkdirp": {
           "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "resolved": false,
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
           "requires": {
@@ -5806,14 +5819,14 @@
         },
         "ms": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "resolved": false,
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true,
           "optional": true
         },
         "needle": {
           "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/needle/-/needle-2.2.0.tgz",
+          "resolved": false,
           "integrity": "sha512-eFagy6c+TYayorXw/qtAdSvaUpEbBsDwDyxYFgLZ0lTojfH7K+OdBqAF7TAFwDokJaGpubpSGG0wO3iC0XPi8w==",
           "dev": true,
           "optional": true,
@@ -5825,7 +5838,7 @@
         },
         "node-pre-gyp": {
           "version": "0.10.0",
-          "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.10.0.tgz",
+          "resolved": false,
           "integrity": "sha512-G7kEonQLRbcA/mOoFoxvlMrw6Q6dPf92+t/l0DFSMuSlDoWaI9JWIyPwK0jyE1bph//CUEL65/Fz1m2vJbmjQQ==",
           "dev": true,
           "optional": true,
@@ -5844,7 +5857,7 @@
         },
         "nopt": {
           "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
+          "resolved": false,
           "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
           "dev": true,
           "optional": true,
@@ -5855,14 +5868,14 @@
         },
         "npm-bundled": {
           "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.0.3.tgz",
+          "resolved": false,
           "integrity": "sha512-ByQ3oJ/5ETLyglU2+8dBObvhfWXX8dtPZDMePCahptliFX2iIuhyEszyFk401PZUNQH20vvdW5MLjJxkwU80Ow==",
           "dev": true,
           "optional": true
         },
         "npm-packlist": {
           "version": "1.1.10",
-          "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.1.10.tgz",
+          "resolved": false,
           "integrity": "sha512-AQC0Dyhzn4EiYEfIUjCdMl0JJ61I2ER9ukf/sLxJUcZHfo+VyEfz2rMJgLZSS1v30OxPQe1cN0LZA1xbcaVfWA==",
           "dev": true,
           "optional": true,
@@ -5873,7 +5886,7 @@
         },
         "npmlog": {
           "version": "4.1.2",
-          "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
+          "resolved": false,
           "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
           "dev": true,
           "optional": true,
@@ -5886,20 +5899,20 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+          "resolved": false,
           "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
           "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+          "resolved": false,
           "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
           "dev": true,
           "optional": true
         },
         "once": {
           "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+          "resolved": false,
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
           "requires": {
@@ -5908,21 +5921,21 @@
         },
         "os-homedir": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+          "resolved": false,
           "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
           "dev": true,
           "optional": true
         },
         "os-tmpdir": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+          "resolved": false,
           "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
           "dev": true,
           "optional": true
         },
         "osenv": {
           "version": "0.1.5",
-          "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
+          "resolved": false,
           "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
           "dev": true,
           "optional": true,
@@ -5933,21 +5946,21 @@
         },
         "path-is-absolute": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+          "resolved": false,
           "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
           "dev": true,
           "optional": true
         },
         "process-nextick-args": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+          "resolved": false,
           "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
           "dev": true,
           "optional": true
         },
         "rc": {
           "version": "1.2.7",
-          "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.7.tgz",
+          "resolved": false,
           "integrity": "sha512-LdLD8xD4zzLsAT5xyushXDNscEjB7+2ulnl8+r1pnESlYtlJtVSoCMBGr30eDRJ3+2Gq89jK9P9e4tCEH1+ywA==",
           "dev": true,
           "optional": true,
@@ -5960,7 +5973,7 @@
           "dependencies": {
             "minimist": {
               "version": "1.2.0",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+              "resolved": false,
               "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
               "dev": true,
               "optional": true
@@ -5969,7 +5982,7 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "resolved": false,
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
           "optional": true,
@@ -5985,7 +5998,7 @@
         },
         "rimraf": {
           "version": "2.6.2",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
+          "resolved": false,
           "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
           "dev": true,
           "optional": true,
@@ -5995,48 +6008,48 @@
         },
         "safe-buffer": {
           "version": "5.1.1",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+          "resolved": false,
           "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
           "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+          "resolved": false,
           "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
           "dev": true,
           "optional": true
         },
         "sax": {
           "version": "1.2.4",
-          "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+          "resolved": false,
           "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
           "dev": true,
           "optional": true
         },
         "semver": {
           "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
+          "resolved": false,
           "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
           "dev": true,
           "optional": true
         },
         "set-blocking": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+          "resolved": false,
           "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
           "dev": true,
           "optional": true
         },
         "signal-exit": {
           "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+          "resolved": false,
           "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
           "dev": true,
           "optional": true
         },
         "string-width": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "resolved": false,
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
           "requires": {
@@ -6047,7 +6060,7 @@
         },
         "string_decoder": {
           "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "resolved": false,
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "dev": true,
           "optional": true,
@@ -6057,7 +6070,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "resolved": false,
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
@@ -6066,14 +6079,14 @@
         },
         "strip-json-comments": {
           "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+          "resolved": false,
           "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
           "dev": true,
           "optional": true
         },
         "tar": {
           "version": "4.4.1",
-          "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.1.tgz",
+          "resolved": false,
           "integrity": "sha512-O+v1r9yN4tOsvl90p5HAP4AEqbYhx4036AGMm075fH9F8Qwi3oJ+v4u50FkT/KkvywNGtwkk0zRI+8eYm1X/xg==",
           "dev": true,
           "optional": true,
@@ -6089,14 +6102,14 @@
         },
         "util-deprecate": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+          "resolved": false,
           "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
           "dev": true,
           "optional": true
         },
         "wide-align": {
           "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
+          "resolved": false,
           "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
           "dev": true,
           "optional": true,
@@ -6106,13 +6119,13 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+          "resolved": false,
           "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
           "dev": true
         },
         "yallist": {
           "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.2.tgz",
+          "resolved": false,
           "integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k=",
           "dev": true
         }
@@ -14033,7 +14046,7 @@
         "braces": {
           "version": "2.3.2",
           "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
-          "integrity": "sha1-WXn9PxTNUxVl5fot8av/8d+u5yk=",
+          "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
           "dev": true,
           "requires": {
             "arr-flatten": "^1.1.0",
@@ -14062,7 +14075,7 @@
         "debug": {
           "version": "2.6.9",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
           "dev": true,
           "requires": {
             "ms": "2.0.0"
@@ -14071,7 +14084,7 @@
         "eslint-scope": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.0.tgz",
-          "integrity": "sha1-UL8wcekzi83EMzF5Sgy1M/ATYXI=",
+          "integrity": "sha512-1G6UTDi7Jc1ELFwnR58HV4fK9OQK4S6N985f166xqXxpjU6plxFISJa2Ba9KCQuFa8RCnj/lSFJbHo7UFDBnUA==",
           "dev": true,
           "requires": {
             "esrecurse": "^4.1.0",
@@ -14165,7 +14178,7 @@
             "kind-of": {
               "version": "5.1.0",
               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-              "integrity": "sha1-cpyR4thXt6QZofmqZWhcTDP1hF0=",
+              "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
               "dev": true
             }
           }
@@ -14173,7 +14186,7 @@
         "extglob": {
           "version": "2.0.4",
           "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
-          "integrity": "sha1-rQD+TcYSqSMuhxhxHcXLWrAoVUM=",
+          "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
           "dev": true,
           "requires": {
             "array-unique": "^0.3.2",
@@ -14238,7 +14251,7 @@
         "is-accessor-descriptor": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
-          "integrity": "sha1-FpwvbT3x+ZJhgHI2XJsOofaHhlY=",
+          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "dev": true,
           "requires": {
             "kind-of": "^6.0.0"
@@ -14247,7 +14260,7 @@
         "is-data-descriptor": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
-          "integrity": "sha1-2Eh2Mh0Oet0DmQQGq7u9NrqSaMc=",
+          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "dev": true,
           "requires": {
             "kind-of": "^6.0.0"
@@ -14256,7 +14269,7 @@
         "is-descriptor": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
-          "integrity": "sha1-OxWXRqZmBLBPjIFSS6NlxfFNhuw=",
+          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "dev": true,
           "requires": {
             "is-accessor-descriptor": "^1.0.0",
@@ -14293,19 +14306,19 @@
         "json-schema-traverse": {
           "version": "0.4.1",
           "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-          "integrity": "sha1-afaofZUTq4u4/mO9sJecRI5oRmA=",
+          "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
           "dev": true
         },
         "kind-of": {
           "version": "6.0.2",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-          "integrity": "sha1-ARRrNqYhjmTljzqNZt5df8b20FE=",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
           "dev": true
         },
         "micromatch": {
           "version": "3.1.10",
           "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
-          "integrity": "sha1-cIWbyVyYQJUvNZoGij/En57PrCM=",
+          "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
           "dev": true,
           "requires": {
             "arr-diff": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "testURL": "http://localhost"
   },
   "dependencies": {
-    "@contentful/rich-text-html-renderer": "^13.0.0",
+    "@contentful/rich-text-react-renderer": "^13.0.1",
     "@dosomething/analytics": "^2.1.2",
     "@dosomething/forge": "^6.8.0",
     "@dosomething/gateway": "^1.4.0",
@@ -88,7 +88,7 @@
     "markdown-it": "^8.4.0",
     "markdown-it-footnote": "^3.0.1",
     "markdown-it-for-inline": "^0.1.1",
-    "prettier": "^1.15.3",
+    "prettier": "^1.16.4",
     "prop-types": "^15.6.2",
     "query-string": "^5.1.1",
     "react": "^16.6.3",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "testURL": "http://localhost"
   },
   "dependencies": {
+    "@contentful/rich-text-html-renderer": "^13.0.0",
     "@dosomething/analytics": "^2.1.2",
     "@dosomething/forge": "^6.8.0",
     "@dosomething/gateway": "^1.4.0",

--- a/resources/assets/components/pages/CompanyPage/CompanyPage.js
+++ b/resources/assets/components/pages/CompanyPage/CompanyPage.js
@@ -1,14 +1,24 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
+import Markdown from '../../utilities/Markdown/Markdown';
+
 const CompanyPage = props => {
   const { title } = props;
 
-  return <div>{title}</div>;
+  return (
+    <div>
+      <h1>{title}</h1>
+      <Markdown>{props.content}</Markdown>
+    </div>
+  );
 };
 
 CompanyPage.propTypes = {
   title: PropTypes.string.isRequired,
+  content: PropTypes.oneOfType([PropTypes.object]).isRequired,
 };
 
 export default CompanyPage;
+
+// <div dangerouslySetInnerHTML={{__html: documentToHtmlString(props.content)}} />

--- a/resources/assets/components/pages/CompanyPage/CompanyPage.js
+++ b/resources/assets/components/pages/CompanyPage/CompanyPage.js
@@ -20,5 +20,3 @@ CompanyPage.propTypes = {
 };
 
 export default CompanyPage;
-
-// <div dangerouslySetInnerHTML={{__html: documentToHtmlString(props.content)}} />

--- a/resources/assets/components/utilities/Markdown/Markdown.js
+++ b/resources/assets/components/utilities/Markdown/Markdown.js
@@ -1,27 +1,31 @@
-/* eslint-disable react/no-danger */
-
 import React from 'react';
+import { has } from 'lodash';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 
-import { createMarkup } from '../../../helpers/markdown';
+import RichTextDocument from './RichTextDocument';
+import StandardMarkdown from './StandardMarkdown';
 
 import './markdown.scss';
 
 /**
  * Render Markdown as Markup prepared for a React Component
- * @see  https://reactjs.org/docs/dom-elements.html#dangerouslysetinnerhtml
  *
- * @param  {String} props.className
- * @param  {String|Array|Object} props.children
+ * @TODO: rename component to <TextContent>
+ * @param  {String} options.className
+ * @param  {String|Array|Object} options.children
  * @return {Object}
  */
-const Markdown = ({ className = null, children }) => (
-  <div
-    className={classnames('markdown', 'with-lists', className)}
-    dangerouslySetInnerHTML={{ __html: createMarkup(children) }}
-  />
-);
+const Markdown = ({ className = null, children }) =>
+  has(children, 'nodeType') ? (
+    <RichTextDocument className={classnames(className)}>
+      {children}
+    </RichTextDocument>
+  ) : (
+    <StandardMarkdown className={classnames(className)}>
+      {children}
+    </StandardMarkdown>
+  );
 
 Markdown.propTypes = {
   children: PropTypes.oneOfType([

--- a/resources/assets/components/utilities/Markdown/Markdown.js
+++ b/resources/assets/components/utilities/Markdown/Markdown.js
@@ -4,33 +4,30 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 
-import { markdown, contentfulImageUrl } from '../../../helpers';
+import { createMarkup } from '../../../helpers/markdown';
 
 import './markdown.scss';
 
-const pattern = /\/\/images\.(ctfassets\.net|contentful\.com).+\.(jpg|png)/g;
-const contentfulImageFormat = url => contentfulImageUrl(url, '1000');
-const formatImageUrls = string =>
-  string.replace(pattern, contentfulImageFormat);
-
-const Markdown = ({ className = null, children }) => {
-  // When directly writing content into this component, React may pass it as an
-  // array of strings. If so, combine them to get the Markdown source!
-  const sourceMarkdown = Array.isArray(children) ? children.join('') : children;
-  const html = markdown(formatImageUrls(sourceMarkdown));
-
-  return (
-    <div
-      className={classnames('markdown', 'with-lists', className)}
-      dangerouslySetInnerHTML={html}
-    />
-  );
-};
+/**
+ * Render Markdown as Markup prepared for a React Component
+ * @see  https://reactjs.org/docs/dom-elements.html#dangerouslysetinnerhtml
+ *
+ * @param  {String} props.className
+ * @param  {String|Array|Object} props.children
+ * @return {Object}
+ */
+const Markdown = ({ className = null, children }) => (
+  <div
+    className={classnames('markdown', 'with-lists', className)}
+    dangerouslySetInnerHTML={{ __html: createMarkup(children) }}
+  />
+);
 
 Markdown.propTypes = {
   children: PropTypes.oneOfType([
     PropTypes.string,
     PropTypes.arrayOf(PropTypes.string),
+    PropTypes.object,
   ]).isRequired,
   className: PropTypes.string,
 };

--- a/resources/assets/components/utilities/Markdown/RichTextDocument.js
+++ b/resources/assets/components/utilities/Markdown/RichTextDocument.js
@@ -1,0 +1,30 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import classnames from 'classnames';
+
+import { parseRichTextDocument } from '../../../helpers/text';
+
+/**
+ * Return React Components for provided RichText.
+ * @see  https://github.com/contentful/rich-text/tree/master/packages/rich-text-react-renderer
+ *
+ * @param  {String} options.className
+ * @param  {Object} options.children
+ * @return {Object}
+ */
+const RichTextDocument = ({ className = null, children }) => (
+  <div className={classnames('markdown rich-text', 'with-lists', className)}>
+    {parseRichTextDocument(children)}
+  </div>
+);
+
+RichTextDocument.propTypes = {
+  children: PropTypes.oneOfType([PropTypes.object]).isRequired,
+  className: PropTypes.string,
+};
+
+RichTextDocument.defaultProps = {
+  className: null,
+};
+
+export default RichTextDocument;

--- a/resources/assets/components/utilities/Markdown/StandardMarkdown.js
+++ b/resources/assets/components/utilities/Markdown/StandardMarkdown.js
@@ -1,0 +1,36 @@
+/* eslint-disable react/no-danger */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import classnames from 'classnames';
+
+import { parseStandardMarkdown } from '../../../helpers/text';
+
+/**
+ * Return Markup for provided Markdown.
+ * @see  https://reactjs.org/docs/dom-elements.html#dangerouslysetinnerhtml
+ *
+ * @param  {String} options.className
+ * @param  {String|Array} options.children
+ * @return {Object}
+ */
+const StandardMarkdown = ({ className = null, children }) => (
+  <div
+    className={classnames('markdown', 'with-lists', className)}
+    dangerouslySetInnerHTML={{ __html: parseStandardMarkdown(children) }}
+  />
+);
+
+StandardMarkdown.propTypes = {
+  children: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.arrayOf(PropTypes.string),
+  ]).isRequired,
+  className: PropTypes.string,
+};
+
+StandardMarkdown.defaultProps = {
+  className: null,
+};
+
+export default StandardMarkdown;

--- a/resources/assets/components/utilities/Markdown/StandardMarkdown.js
+++ b/resources/assets/components/utilities/Markdown/StandardMarkdown.js
@@ -14,12 +14,13 @@ import { parseStandardMarkdown } from '../../../helpers/text';
  * @param  {String|Array} options.children
  * @return {Object}
  */
-const StandardMarkdown = ({ className = null, children }) => (
-  <div
-    className={classnames('markdown', 'with-lists', className)}
-    dangerouslySetInnerHTML={{ __html: parseStandardMarkdown(children) }}
-  />
-);
+const StandardMarkdown = ({ className = null, children }) =>
+  children ? (
+    <div
+      className={classnames('markdown', 'with-lists', className)}
+      dangerouslySetInnerHTML={{ __html: parseStandardMarkdown(children) }}
+    />
+  ) : null;
 
 StandardMarkdown.propTypes = {
   children: PropTypes.oneOfType([

--- a/resources/assets/helpers/index.js
+++ b/resources/assets/helpers/index.js
@@ -1,9 +1,6 @@
 /* global window, document, Blob, URL */
 
-import MarkdownIt from 'markdown-it';
 import queryString from 'query-string';
-import iterator from 'markdown-it-for-inline';
-import markdownItFootnote from 'markdown-it-footnote';
 import { getTime, isBefore, isWithinInterval } from 'date-fns';
 import { get, find, isNull, isUndefined, omitBy } from 'lodash';
 
@@ -132,31 +129,6 @@ export function ready(fn) {
   } else {
     document.addEventListener('DOMContentLoaded', fn);
   }
-}
-
-/**
- * Render Markdown for a React component.
- *
- * @param {String} source - Markdown source
- * @returns {{__html}} - Prepared object for React's dangerouslySetInnerHtml
- */
-export function markdown(source = '') {
-  const markdownIt = new MarkdownIt();
-  markdownIt.use(markdownItFootnote);
-
-  markdownIt.use(iterator, 'url_new_win', 'link_open', (tokens, index) => {
-    const token = tokens[index];
-    const hrefIndex = token.attrIndex('href');
-    const url = token.attrs[hrefIndex][1];
-
-    if (isExternal(url)) {
-      token.attrPush(['target', '_blank']);
-    }
-  });
-
-  return {
-    __html: markdownIt.render(source),
-  };
 }
 
 /**

--- a/resources/assets/helpers/markdown.js
+++ b/resources/assets/helpers/markdown.js
@@ -63,7 +63,7 @@ function getMarkdownItInstance() {
  * @param  {Object} markdown
  * @return {String}
  */
-function parseRichTextMarkdown(markdown) {
+export function parseRichTextMarkdown(markdown) {
   // @TODO: more to come here. Stay tuned!
 
   return documentToHtmlString(markdown);
@@ -75,7 +75,7 @@ function parseRichTextMarkdown(markdown) {
  * @param  {String|Array} markdown
  * @return {String}
  */
-function parseStandardMarkdown(markdown = '') {
+export function parseStandardMarkdown(markdown = '') {
   const markdownIt = getMarkdownItInstance();
 
   return markdownIt.render(formatStandardMarkdown(markdown));

--- a/resources/assets/helpers/markdown.js
+++ b/resources/assets/helpers/markdown.js
@@ -1,0 +1,94 @@
+import { has } from 'lodash';
+import MarkdownIt from 'markdown-it';
+import iterator from 'markdown-it-for-inline';
+import markdownItFootnote from 'markdown-it-footnote';
+import { documentToHtmlString } from '@contentful/rich-text-html-renderer';
+
+import { contentfulImageUrl, isExternal } from '../helpers';
+
+/**
+ * Format any Contentful image URLs in Markdown string to resize them.
+ *
+ * @param  {String} string
+ * @return {String}
+ */
+function formatImageUrls(string) {
+  const pattern = /\/\/images\.(ctfassets\.net|contentful\.com).+\.(jpg|png)/g;
+  const contentfulImageFormat = url => contentfulImageUrl(url, '1000');
+
+  return string.replace(pattern, contentfulImageFormat);
+}
+
+/**
+ * Format Standard Markdown to a standard markdown string.
+ *
+ * @param  {String|Array} markdown
+ * @return {String}
+ */
+function formatStandardMarkdown(markdown) {
+  // When directly writing content into a Markdown component, React may pass it as an
+  // array of strings; if so, combine them to get the Markdown source!
+  const formattedMarkdown = Array.isArray(markdown)
+    ? markdown.join('')
+    : markdown;
+
+  return formatImageUrls(formattedMarkdown);
+}
+
+/**
+ * Get a customized instance of MarkdownIt.
+ *
+ * @return {Object}
+ */
+function getMarkdownItInstance() {
+  const markdownIt = new MarkdownIt();
+
+  markdownIt.use(markdownItFootnote);
+  markdownIt.use(iterator, 'url_new_win', 'link_open', (tokens, index) => {
+    const token = tokens[index];
+    const hrefIndex = token.attrIndex('href');
+    const url = token.attrs[hrefIndex][1];
+
+    if (isExternal(url)) {
+      token.attrPush(['target', '_blank']);
+    }
+  });
+
+  return markdownIt;
+}
+
+/**
+ * Parse RichText Markdown to Markup.
+ *
+ * @param  {Object} markdown
+ * @return {String}
+ */
+function parseRichTextMarkdown(markdown) {
+  // @TODO: more to come here. Stay tuned!
+
+  return documentToHtmlString(markdown);
+}
+
+/**
+ * Parse Standard Markdown to Markup.
+ *
+ * @param  {String|Array} markdown
+ * @return {String}
+ */
+function parseStandardMarkdown(markdown = '') {
+  const markdownIt = getMarkdownItInstance();
+
+  return markdownIt.render(formatStandardMarkdown(markdown));
+}
+
+/**
+ * Create Markup from provided Markdown.
+ *
+ * @param  {String|Array|Object} markdown
+ * @return {String}
+ */
+export function createMarkup(markdown) {
+  return has(markdown, 'nodeType')
+    ? parseRichTextMarkdown(markdown)
+    : parseStandardMarkdown(markdown);
+}

--- a/resources/assets/helpers/text.js
+++ b/resources/assets/helpers/text.js
@@ -1,8 +1,7 @@
-import { has } from 'lodash';
 import MarkdownIt from 'markdown-it';
 import iterator from 'markdown-it-for-inline';
 import markdownItFootnote from 'markdown-it-footnote';
-import { documentToHtmlString } from '@contentful/rich-text-html-renderer';
+import { documentToReactComponents } from '@contentful/rich-text-react-renderer';
 
 import { contentfulImageUrl, isExternal } from '../helpers';
 
@@ -58,15 +57,15 @@ function getMarkdownItInstance() {
 }
 
 /**
- * Parse RichText Markdown to Markup.
+ * Parse RichText Document to React components.
  *
- * @param  {Object} markdown
+ * @param  {Object} document
  * @return {String}
  */
-export function parseRichTextMarkdown(markdown) {
+export function parseRichTextDocument(document) {
   // @TODO: more to come here. Stay tuned!
 
-  return documentToHtmlString(markdown);
+  return documentToReactComponents(document);
 }
 
 /**
@@ -79,16 +78,4 @@ export function parseStandardMarkdown(markdown = '') {
   const markdownIt = getMarkdownItInstance();
 
   return markdownIt.render(formatStandardMarkdown(markdown));
-}
-
-/**
- * Create Markup from provided Markdown.
- *
- * @param  {String|Array|Object} markdown
- * @return {String}
- */
-export function createMarkup(markdown) {
-  return has(markdown, 'nodeType')
-    ? parseRichTextMarkdown(markdown)
-    : parseStandardMarkdown(markdown);
 }

--- a/resources/assets/helpers/text.js
+++ b/resources/assets/helpers/text.js
@@ -19,19 +19,19 @@ function formatImageUrls(string) {
 }
 
 /**
- * Format Standard Markdown to a standard markdown string.
+ * Cleanup the provided markdown.
  *
  * @param  {String|Array} markdown
  * @return {String}
  */
-function formatStandardMarkdown(markdown) {
+function cleanupStandardMarkdown(markdown) {
   // When directly writing content into a Markdown component, React may pass it as an
   // array of strings; if so, combine them to get the Markdown source!
-  const formattedMarkdown = Array.isArray(markdown)
+  const flattenedMarkdown = Array.isArray(markdown)
     ? markdown.join('')
     : markdown;
 
-  return formatImageUrls(formattedMarkdown);
+  return formatImageUrls(flattenedMarkdown);
 }
 
 /**
@@ -77,5 +77,5 @@ export function parseRichTextDocument(document) {
 export function parseStandardMarkdown(markdown = '') {
   const markdownIt = getMarkdownItInstance();
 
-  return markdownIt.render(formatStandardMarkdown(markdown));
+  return markdownIt.render(cleanupStandardMarkdown(markdown));
 }


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR refactors the `Markdown` component to start supporting both standard markdown and Contentful's new richtext-style markdown. It creates a new ` helpers/markdown.js` file to contain all the helper methods for rendering either standard or richtext markdown moving forward.

There's still a bit more to come with the richtext rendering and passing it an customized object to help with rendering embedded entities, etc, but this begins adding some basic support, without breaking prior standard markdown support!

### Any background context you want to provide?

🌵 

### What are the relevant tickets/cards?

Refs [Pivotal ID #162972504](https://www.pivotaltracker.com/story/show/162972504)

### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.