### PR TITLE
Unsubmitted Quiz Event

### DIFF
--- a/docs/development/analytics.md
+++ b/docs/development/analytics.md
@@ -56,6 +56,7 @@ The following are all events currently tracked across the Phoenix application:
 | `phoenix_clicked_poll_locator`                       | clicked the search button on a Poll Locator                                                                                          | Puck, GA  |
 | `phoenix_opened_modal`                               | opened a Modal (The specific modal ID is tracked within the Puck payload)                                                            | Puck, GA  |
 | `phoenix_submitted_quiz`                             | submitted a quiz (The quiz results are tracked within the Puck payload)                                                              | Puck, GA  |
+| `phoenix_left_quiz`                                  | left a quiz before completion                                                                                                        | Puck, GA  |
 | `phoenix_opened_modal_poll_locator`                  | opened a modal on a Poll Locater (the modal could contain poll location results or be empty)                                         | Puck, GA  |
 | `phoenix_opened_modal_poll_locator_not_found`        | opened the 'Not Found' modal from a Poll Locator                                                                                     | Puck, GA  |
 | `phoenix_clicked_copy_to_clipboard`                  | clicked the clipboard copy button in a Social Drive Action                                                                           | Puck, GA  |

--- a/docs/development/analytics.md
+++ b/docs/development/analytics.md
@@ -56,7 +56,7 @@ The following are all events currently tracked across the Phoenix application:
 | `phoenix_clicked_poll_locator`                       | clicked the search button on a Poll Locator                                                                                          | Puck, GA  |
 | `phoenix_opened_modal`                               | opened a Modal (The specific modal ID is tracked within the Puck payload)                                                            | Puck, GA  |
 | `phoenix_submitted_quiz`                             | submitted a quiz (The quiz results are tracked within the Puck payload)                                                              | Puck, GA  |
-| `phoenix_left_quiz`                                  | left a quiz before completion                                                                                                        | Puck, GA  |
+| `phoenix_abandoned_quiz`                             | abandoned a quiz before completion                                                                                                   | Puck, GA  |
 | `phoenix_opened_modal_poll_locator`                  | opened a modal on a Poll Locater (the modal could contain poll location results or be empty)                                         | Puck, GA  |
 | `phoenix_opened_modal_poll_locator_not_found`        | opened the 'Not Found' modal from a Poll Locator                                                                                     | Puck, GA  |
 | `phoenix_clicked_copy_to_clipboard`                  | clicked the clipboard copy button in a Social Drive Action                                                                           | Puck, GA  |

--- a/resources/assets/components/Quiz/Quiz.js
+++ b/resources/assets/components/Quiz/Quiz.js
@@ -55,7 +55,7 @@ class Quiz extends React.Component {
   }
 
   componentDidMount() {
-    window.addEventListener('beforeunload', this.trackUnfinishedQuiz);
+    window.addEventListener('beforeunload', this.trackAbandonedQuiz);
   }
 
   componentDidUpdate() {
@@ -69,16 +69,16 @@ class Quiz extends React.Component {
   }
 
   componentWillUnmount() {
-    window.removeEventListener('beforeunload', this.trackUnfinishedQuiz);
-    this.trackUnfinishedQuiz();
     /*
       Users would primarily be abandoning a quiz by exiting the page completely.
       This addresses the edge case, where the quiz is abandoned while remaining within the page
       (thus triggering the componentWillUnmount.)
     */
+    window.removeEventListener('beforeunload', this.trackAbandonedQuiz);
+    this.trackAbandonedQuiz();
   }
 
-  trackUnfinishedQuiz = () => {
+  trackAbandonedQuiz = () => {
     if (this.state.completedQuiz) {
       return;
     }

--- a/resources/assets/components/Quiz/Quiz.js
+++ b/resources/assets/components/Quiz/Quiz.js
@@ -54,6 +54,10 @@ class Quiz extends React.Component {
     setTimeout(() => this.setState({ renderScrollConcierge: false }), 500);
   }
 
+  componentDidMount() {
+    window.addEventListener('beforeunload', this.trackUnfinishedQuiz);
+  }
+
   componentDidUpdate() {
     if (!this.props.autoSubmit) {
       return;
@@ -63,6 +67,25 @@ class Quiz extends React.Component {
       setTimeout(this.completeQuiz, 300);
     }
   }
+
+  componentWillUnmount() {
+    window.removeEventListener('beforeunload', this.trackUnfinishedQuiz);
+    this.trackUnfinishedQuiz();
+  }
+
+  trackUnfinishedQuiz = () => {
+    if (this.state.completedQuiz) {
+      return;
+    }
+
+    trackAnalyticsEvent({
+      verb: 'left',
+      noun: 'quiz',
+      data: {
+        responses: this.state.choices,
+      },
+    });
+  };
 
   evaluateQuiz = () => {
     const questions = this.props.questions;

--- a/resources/assets/components/Quiz/Quiz.js
+++ b/resources/assets/components/Quiz/Quiz.js
@@ -47,6 +47,7 @@ class Quiz extends React.Component {
       showResults,
       // Show the scroll concierge for nested quizzes
       renderScrollConcierge: get(props.additionalContent, 'isNestedQuiz'),
+      completedQuiz: false,
     };
 
     // Quickly hide scroll concierge so that we can re-render it when showing the quiz results
@@ -58,7 +59,7 @@ class Quiz extends React.Component {
       return;
     }
 
-    if (!this.state.showResults && this.evaluateQuiz()) {
+    if (!this.state.completedQuiz && this.evaluateQuiz()) {
       setTimeout(this.completeQuiz, 300);
     }
   }
@@ -74,6 +75,9 @@ class Quiz extends React.Component {
     if (!this.evaluateQuiz()) {
       return;
     }
+
+    // This signifier is necessary to cover various post-completion states (auto submit quizzes, gated quizzes, etc.)
+    this.setState({ completedQuiz: true });
 
     const {
       questions,

--- a/resources/assets/components/Quiz/Quiz.js
+++ b/resources/assets/components/Quiz/Quiz.js
@@ -71,6 +71,11 @@ class Quiz extends React.Component {
   componentWillUnmount() {
     window.removeEventListener('beforeunload', this.trackUnfinishedQuiz);
     this.trackUnfinishedQuiz();
+    /*
+      Users would primarily be abandoning a quiz by exiting the page completely.
+      This addresses the edge case, where the quiz is abandoned while remaining within the page
+      (thus triggering the componentWillUnmount.)
+    */
   }
 
   trackUnfinishedQuiz = () => {

--- a/resources/assets/components/Quiz/Quiz.js
+++ b/resources/assets/components/Quiz/Quiz.js
@@ -79,7 +79,7 @@ class Quiz extends React.Component {
     }
 
     trackAnalyticsEvent({
-      verb: 'left',
+      verb: 'abandoned',
       noun: 'quiz',
       data: {
         responses: this.state.choices,


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR adds Puck tracking for an incomplete or unsubmitted quiz.

It's called `phoenix_left_quiz` but I am not completely confident that that's the best name for this. (`abandoned`? `incomplete`?, `left_incomplete`, `hates_quizzes`?)

### Any background context you want to provide?
- https://github.com/DoSomething/phoenix-next/commit/6a404333d1815f25e1df6258a9cd4f96d34c8948 adds a new state property called `completedQuiz`. This allows us to determine completion or 'submission' status irrespective of the quiz being an autocomplete, gated, or what have you quiz.

- The `beforeunload` event was necessary since a user would primarilly be abandoning a quiz by exiting the page somehow, which would fail to trigger a `componentWillUnmount`. (In fact, I'm not currently sure if there's a regular user case of leaving a quiz with a `componentWillUnmount` being triggered, but I did add that secenario to be sure.)

### What are the relevant tickets/cards?

Refs [Pivotal ID #163570667](https://www.pivotaltracker.com/story/show/163570667)

### Checklist

* [x] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.
