### PR TITLE
Action ID Field in RB Posts

### DIFF
--- a/resources/assets/components/actions/PhotoSubmissionAction/PhotoSubmissionAction.js
+++ b/resources/assets/components/actions/PhotoSubmissionAction/PhotoSubmissionAction.js
@@ -399,6 +399,7 @@ class PhotoSubmissionAction extends React.Component {
 }
 
 PhotoSubmissionAction.propTypes = {
+  actionId: PropTypes.number,
   affirmationContent: PropTypes.string,
   additionalContent: PropTypes.shape({
     action: PropTypes.string,
@@ -428,6 +429,7 @@ PhotoSubmissionAction.propTypes = {
 };
 
 PhotoSubmissionAction.defaultProps = {
+  actionId: null,
   additionalContent: null,
   affirmationContent:
     "Thanks for joining the movement, and submitting your photo! After we review your submission, we'll add it to the public gallery alongside submissions from all the other members taking action in this campaign.",

--- a/resources/assets/components/actions/PhotoSubmissionAction/PhotoSubmissionAction.js
+++ b/resources/assets/components/actions/PhotoSubmissionAction/PhotoSubmissionAction.js
@@ -172,7 +172,7 @@ class PhotoSubmissionAction extends React.Component {
       );
     }
 
-    const formData = setFormData({
+    let formFields = {
       action,
       type,
       id: this.props.id,
@@ -180,12 +180,20 @@ class PhotoSubmissionAction extends React.Component {
       ...values,
       file: this.state.mediaValue.file || '',
       show_quantity: this.props.showQuantityField ? 1 : 0,
-    });
+    };
+
+    // @TODO: Once Rogue/Contentful requires this field, we can do away with this conditional logic.
+    if (this.props.actionId) {
+      formFields = {
+        ...formFields,
+        action_id: this.props.actionId,
+      };
+    }
 
     // Send request to store the campaign photo submission post.
     this.props.storeCampaignPost(this.props.campaignId, {
       action,
-      body: formData,
+      body: setFormData(formFields),
       id: this.props.id,
       type,
     });

--- a/resources/assets/components/actions/ShareAction/ShareAction.js
+++ b/resources/assets/components/actions/ShareAction/ShareAction.js
@@ -31,9 +31,9 @@ class ShareAction extends React.Component {
   storeSharePost = puckId => {
     const action = get(this.props.additionalContent, 'action', 'default');
 
-    const { campaignContentfulId, campaignId, link } = this.props;
+    const { actionId, campaignContentfulId, campaignId, link } = this.props;
 
-    const formData = setFormData({
+    let formFields = {
       action,
       type: SOCIAL_SHARE_TYPE,
       id: campaignContentfulId,
@@ -43,12 +43,20 @@ class ShareAction extends React.Component {
         campaign_id: campaignId,
         puck_id: puckId,
       },
-    });
+    };
+
+    // @TODO: Once Rogue/Contentful requires this field, we can do away with this conditional logic.
+    if (actionId) {
+      formFields = {
+        ...formFields,
+        action_id: actionId,
+      };
+    }
 
     // Send request to store the social share post.
     this.props.storeCampaignPost(campaignId, {
       action,
-      body: formData,
+      body: setFormData(formFields),
       id: campaignContentfulId,
       type: SOCIAL_SHARE_TYPE,
     });

--- a/resources/assets/components/actions/ShareAction/ShareAction.js
+++ b/resources/assets/components/actions/ShareAction/ShareAction.js
@@ -168,6 +168,7 @@ class ShareAction extends React.Component {
 }
 
 ShareAction.propTypes = {
+  actionId: PropTypes.number,
   additionalContent: PropTypes.shape({
     action: PropTypes.string,
   }),
@@ -186,6 +187,7 @@ ShareAction.propTypes = {
 };
 
 ShareAction.defaultProps = {
+  actionId: null,
   additionalContent: null,
   affirmation: 'Thanks for rallying your friends on Facebook!',
   content: null,

--- a/resources/assets/components/actions/TextSubmissionAction/TextSubmissionAction.js
+++ b/resources/assets/components/actions/TextSubmissionAction/TextSubmissionAction.js
@@ -156,6 +156,7 @@ class TextSubmissionAction extends React.Component {
 }
 
 TextSubmissionAction.propTypes = {
+  actionId: PropTypes.number,
   affirmationContent: PropTypes.string,
   additionalContent: PropTypes.shape({
     action: PropTypes.string,
@@ -177,6 +178,7 @@ TextSubmissionAction.propTypes = {
 };
 
 TextSubmissionAction.defaultProps = {
+  actionId: null,
   additionalContent: null,
   affirmationContent:
     "Thanks for joining the movement, and submitting your message! After we review your submission, we'll add it to the public gallery alongside submissions from all the other members taking action in this campaign.",

--- a/resources/assets/components/actions/TextSubmissionAction/TextSubmissionAction.js
+++ b/resources/assets/components/actions/TextSubmissionAction/TextSubmissionAction.js
@@ -60,18 +60,26 @@ class TextSubmissionAction extends React.Component {
 
     const action = get(this.props.additionalContent, 'action', 'default');
 
-    const formData = setFormData({
+    let formFields = {
       action,
       type,
       id: this.props.id,
       // Associate state values to fields.
       ...mapValues(this.fields, value => this.state[`${value}Value`]),
-    });
+    };
+
+    // @TODO: Once Rogue/Contentful requires this field, we can do away with this conditional logic.
+    if (this.props.actionId) {
+      formFields = {
+        ...formFields,
+        action_id: this.props.actionId,
+      };
+    }
 
     // Send request to store the campaign text submission post.
     this.props.storeCampaignPost(this.props.campaignId, {
       action,
-      body: formData,
+      body: setFormData(formFields),
       id: this.props.id,
       type,
     });


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR adds the `action_id` field to our various RB action post's form data.

### Any background context you want to provide?
- I did not remove the `action` field, since it's presently still [required in Rogue](https://github.com/DoSomething/rogue/blob/master/app/Http/Requests/PostRequest.php#L33) and used to [auto assign Actions to Posts](https://github.com/DoSomething/rogue/blob/master/app/Repositories/PostRepository.php#L87)
- we needed some logic to only append the `action_id` field *if* it is not falsey, since, if it's sent over as a `null` value it'll [fail validation](https://github.com/DoSomething/rogue/blob/master/app/Http/Requests/PostRequest.php#L34)

**Question**:
Should I add a validation rule to our [`PostRequest#rules`](https://github.com/DoSomething/phoenix-next/blob/master/app/Http/Requests/PostRequest.php#L54) for `action_id`? 
It'd need to be for all post types, so it might require shifting the logic around a bit, or just repeating the rule for all three action types `case`s

### What are the relevant tickets/cards?

Refs [Pivotal ID #163728937](https://www.pivotaltracker.com/story/show/163728937)

### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.