### PR TITLE
Remove Puck -> NR error reporting

### DIFF
--- a/resources/assets/components/App.js
+++ b/resources/assets/components/App.js
@@ -10,7 +10,6 @@ import { env } from '../helpers';
 import graphqlClient from '../graphql';
 import { initializeStore } from '../store/store';
 import HomePage from './pages/HomePage/HomePage';
-import { puckErrorReport } from '../helpers/analytics';
 import CampaignContainer from './Campaign/CampaignContainer';
 import { getUserId, isAuthenticated } from '../selectors/user';
 import AccountContainer from './pages/AccountPage/AccountContainer';
@@ -29,7 +28,6 @@ const App = ({ store, history }) => {
         isAuthenticated={() => isAuthenticated(state)}
         history={history}
         puckUrl={env('PUCK_URL')}
-        onError={puckErrorReport}
       >
         <ApolloProvider client={graphqlClient(env('GRAPHQL_URL'))}>
           <ConnectedRouter history={history}>

--- a/resources/assets/helpers/analytics.js
+++ b/resources/assets/helpers/analytics.js
@@ -11,34 +11,11 @@ import {
 
 import { PUCK_URL } from '../constants';
 import { get as getHistory } from '../history';
-import { report } from '../helpers';
 
 // App name prefix used for event naming.
 const APP_PREFIX = 'phoenix';
 // Variable that stores the instance of PuckClient.
 let puckClient = null;
-
-/**
- * Report Puck error to New Relic with identifying custom attributes.
- *
- * @param  {String} errorName
- * @param  {Error}  error
- * @return {void}
- */
-export function puckErrorReport(errorName, error) {
-  if (!puckClient) {
-    return;
-  }
-
-  const deviceId = puckClient.deviceId;
-
-  report(error, {
-    errorName: `Puck Error: ${errorName}`,
-    deviceId,
-    // Puck doesn't expose the actual session ID, but this is how it's generated.
-    sessionId: `${deviceId}${puckClient.landingTimestamp}`,
-  });
-}
 
 /**
  * Parse analytics event name parameters into a snake cased string.
@@ -96,7 +73,6 @@ export function analyzeWithPuck(name, data) {
       isAuthenticated: () => window.AUTH.isAuthenticated,
       puckUrl: PUCK_URL,
       history: getHistory(),
-      onError: puckErrorReport,
     });
   }
 


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR removes the error reporting we had set up for Puck errors.

### Any background context you want to provide?
For now, we've determined the NR error reporting initiated via the Puck error handling callback to be unhelpful and causing much clutter in our Browser JS error analytics.

Hopefully, soon, more to come re https://github.com/DoSomething/puck/issues/17 when we have more breathing room. (and I guess pending decision making re Puck's future etc.)

### What are the relevant tickets/cards?
#1236 
https://dosomething.slack.com/archives/C3ASB4204/p1549916235007400
Refs [Pivotal ID #163064958](https://www.pivotaltracker.com/story/show/163064958)