### PR TITLE
Fixing bug previously introduced when refacorting pages.

### DIFF
--- a/app/Http/Controllers/CategorizedPageController.php
+++ b/app/Http/Controllers/CategorizedPageController.php
@@ -33,7 +33,7 @@ class CategorizedPageController extends Controller
      */
     public function show($category, $slug)
     {
-        $page = $this->pageRepository->findBySlug($category.'/'.$slug, get_content_type_by_category($category));
+        $page = $this->pageRepository->findBySlug(get_content_type_by_category($category), $category.'/'.$slug);
 
         return view('app', [
             'headTitle' => $page->fields->title,

--- a/app/Http/Controllers/PageController.php
+++ b/app/Http/Controllers/PageController.php
@@ -32,7 +32,7 @@ class PageController extends Controller
      */
     public function show($slug)
     {
-        $page = $this->pageRepository->findBySlug($slug);
+        $page = $this->pageRepository->findBySlug('page', $slug);
 
         return view('app', [
             'headTitle' => $page->fields->title,

--- a/app/Repositories/PageRepository.php
+++ b/app/Repositories/PageRepository.php
@@ -11,16 +11,17 @@ class PageRepository
     /**
      * Find a page by its slug.
      *
+     * @param  string $type
      * @param  string $slug
      * @return \Contentful\Delivery\Resource\Entry
      * @throws \Illuminate\Database\Eloquent\ModelNotFoundException
      */
-    public function findBySlug($slug, $type)
+    public function findBySlug($type, $slug)
     {
         if (! config('services.contentful.cache')) {
             $page = $this->getEntryFromSlugAsJson($type, $slug);
         } else {
-            $page = remember('page_'.str_replace('/', '_', $slug), 15, function () use ($slug) {
+            $page = remember('page_'.str_replace('/', '_', $slug), 15, function () use ($type, $slug) {
                 return $this->getEntryFromSlugAsJson($type, $slug);
             });
         }


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR fixes a bug with the `PageRepository` that was leading to 500 errors on categorized pages. The bug wasn't immediately evident when testing since it only really applied when pages where being cached. The issue was a missing `$type` variable not being passed via `use` for the function's scope.

### Any background context you want to provide?

This issue also brought to mind whether we may want to set `CONTENTFUL_CACHE` to TRUE on QA instead of FALSE to fully represent how production works and so that this bug would have been found on QA instead of on Production.

### What are the relevant tickets/cards?

🐞 

### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.