### PR TITLE
Updating to use plural category prefix.

### DIFF
--- a/app/helpers.php
+++ b/app/helpers.php
@@ -17,7 +17,7 @@ function get_content_type_by_category($category)
         'about' => 'page',
         'articles' => 'page',
         'facts' => 'page',
-        'story' => 'storyPage',
+        'stories' => 'storyPage',
     ];
 
     return data_get($types, $category, 'page');

--- a/contentful/content-types/storyPage.js
+++ b/contentful/content-types/storyPage.js
@@ -52,12 +52,12 @@ module.exports = function(migration) {
       },
       {
         regexp: {
-          pattern: '^(?!/)story/[a-zA-Z0-9-/]+$',
+          pattern: '^(?!/)stories/[a-zA-Z0-9-/]+$',
           flags: '',
         },
 
         message:
-          'Only alphanumeric, forward-slash, and hyphen characters are allowed in slugs! Entry must begin with "story/".',
+          'Only alphanumeric, forward-slash, and hyphen characters are allowed in slugs! Entry must begin with "stories/".',
       },
     ])
     .disabled(false)
@@ -122,7 +122,7 @@ module.exports = function(migration) {
 
   storyPage.changeEditorInterface('slug', 'slugEditor', {
     helpText:
-      'For story pages, please add the required "story/" category prefix for the slug, e.g. "story/page-name-here".',
+      'Must begin with the "stories/" category prefix for the slug, e.g. "stories/page-name-here".',
   });
 
   storyPage.changeEditorInterface('metadata', 'entryLinkEditor', {});

--- a/routes/web.php
+++ b/routes/web.php
@@ -44,7 +44,7 @@ $router->get('search', function () {
 });
 
 // Categorized Pages (articles, facts)
-$categories = 'articles|facts|about|story';
+$categories = 'articles|facts|about|stories';
 
 $router->get('us/{category}/{slug}', 'CategorizedPageController@show')->where('category', $categories);
 $router->get('{category}/{slug}', function ($category, $slug) {


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR updates the category prefix for `storyPage` content types to be plural "stories/" instead of the singular "story/" to follow our established standard! Thanks for the reminder @mendelB 💡 

### Any background context you want to provide?

🌵 

### What are the relevant tickets/cards?

Refs [Pivotal ID #163913064](https://www.pivotaltracker.com/story/show/163913064)
