### PR TITLE
Add Action ID to Docs

### DIFF
--- a/docs/content-publishing/actions/README.md
+++ b/docs/content-publishing/actions/README.md
@@ -4,6 +4,10 @@ We want to provide DoSomething.org members with multiple actions they can decide
 
 Actions are typically found on the **Action Page**. Please refer to the [instructions](../pages/page-creation.md) on how to create an Action Page for a campaign to add actions to it.
 
+{% hint style="warning" %}
+For new Photo, Share, and Text Submission Actions, make sure that you create a new Action on your campaign in Rogue so that you have a valid Action ID for your new action!
+{% endhint %}
+
 ## Available Reportback Actions
 
 - [Link Action](link-action.md)

--- a/docs/content-publishing/actions/photo-submission-action.md
+++ b/docs/content-publishing/actions/photo-submission-action.md
@@ -15,6 +15,7 @@ The Photo Submission Action consists of the following fields:
 _For all the fields below designated as "\(optional\)", a default value will be used if no value is entered._
 
 - **internalTitle** _\(required\)_: the title used internally to find this component in Contentful; please follow helper text displyed under the field for suggested naming convention.
+- **actionId** _\(required\)_: the ID for this action in Rogue.
 - **title** _\(optional\)_: the title that will show up in the yellow bar atop the Photo Submission Action.
 - **captionFieldLabel** _\(optional\)_: the text label for the caption field.
 - **captionFieldPlaceholder** _\(optional\)_: the text placeholder in the caption field to provide an example.

--- a/docs/content-publishing/actions/share-action.md
+++ b/docs/content-publishing/actions/share-action.md
@@ -9,6 +9,7 @@ The `ShareAction` component renders a visual component which features an embedde
 The Share Action consists of three fields:
 
 - **title \(required\)**: The title that will show up in the yellow bar atop the Link Action.
+- **actionId \(required\)**: the ID for this action in Rogue.
 - **socialPlatform \(required\)**: The social platform that the Share Action will share to. \(Limited to Facebook or Twitter\).
 - **content \(optional\)**: content in Markdown format that will appear within the card atop the link.
 - **link \(required\)**: a valid URL which will be embedded within the card, and used as the URL for the social share button.

--- a/docs/content-publishing/actions/text-submission-action.md
+++ b/docs/content-publishing/actions/text-submission-action.md
@@ -15,6 +15,7 @@ The Text Submission Action consists of the following fields:
 _For all the fields below designated as "\(optional\)", a default value will be used if no value is entered._
 
 - **internalTitle** _\(required\)_: the title used internally to find this component in Contentful; please follow helper text displyed under the field for suggested naming convention.
+- **actionId** _\(required\)_: the ID for this action in Rogue.
 - **title** _\(optional\)_: the title that will show up in the yellow bar atop the Text Submission Action.
 - **textFieldLabel** _\(optional\)_: the text label for the text field.
 - **textFieldPlaceholder** _\(optional\)_: the text placeholder in the text field to provide an example.


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR adds some info regarding the Action ID field to our RB action documentation.

### Any background context you want to provide?
I marked these fields as required, even though they're still temporarily optional.

### What are the relevant tickets/cards?

Refs [Pivotal ID #163728937](https://www.pivotaltracker.com/story/show/163728937)
