### PR TITLE
Add Lazy Authentication mode to Text RB Submission Action

### DIFF
--- a/resources/assets/actions/post.js
+++ b/resources/assets/actions/post.js
@@ -1,5 +1,3 @@
-/* global FormData */
-
 import { join } from 'path';
 
 import apiRequest from './api';

--- a/resources/assets/actions/post.js
+++ b/resources/assets/actions/post.js
@@ -105,6 +105,7 @@ export function storeCampaignPost(campaignId, data) {
           sixpackExperiments,
           type,
         },
+        requiresAuthentication: type === 'text',
         pending: POST_SUBMISSION_PENDING,
         success: POST_SUBMISSION_SUCCESSFUL,
         url,

--- a/resources/assets/actions/post.js
+++ b/resources/assets/actions/post.js
@@ -1,3 +1,5 @@
+/* global FormData */
+
 import { join } from 'path';
 
 import apiRequest from './api';

--- a/resources/assets/actions/post.js
+++ b/resources/assets/actions/post.js
@@ -70,14 +70,6 @@ export function resetPostSubmissionItem(id) {
  * @return {function}
  */
 export function storeCampaignPost(campaignId, data) {
-  if (!(data.body instanceof FormData)) {
-    throw Error(
-      `The supplied data.body must be an instance of FormData, instead it is an instance of ${
-        data.body.constructor.name
-      }.`,
-    );
-  }
-
   const { action, body, id, type } = data;
 
   const sixpackExperiments = {

--- a/resources/assets/components/actions/TextSubmissionAction/TextSubmissionAction.js
+++ b/resources/assets/components/actions/TextSubmissionAction/TextSubmissionAction.js
@@ -7,9 +7,9 @@ import Card from '../../utilities/Card/Card';
 import Modal from '../../utilities/Modal/Modal';
 import Button from '../../utilities/Button/Button';
 import { withoutUndefined } from '../../../helpers';
+import { getFieldErrors } from '../../../helpers/forms';
 import FormValidation from '../../utilities/Form/FormValidation';
 import TextContent from '../../utilities/TextContent/TextContent';
-import { getFieldErrors, setFormData } from '../../../helpers/forms';
 
 import './text-submission-action.scss';
 

--- a/resources/assets/components/actions/TextSubmissionAction/TextSubmissionAction.js
+++ b/resources/assets/components/actions/TextSubmissionAction/TextSubmissionAction.js
@@ -79,7 +79,7 @@ class TextSubmissionAction extends React.Component {
     // Send request to store the campaign text submission post.
     this.props.storeCampaignPost(this.props.campaignId, {
       action,
-      body: setFormData(formFields),
+      body: formFields,
       id: this.props.id,
       type,
     });


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR allows unauthenticated users to submit a Text RB, using the "Lazy Auth" approach.

**UPDATE**
Our reformatting of the way we format our API posts in #1269 addressed the issues discussed throughout this PR.
Now, all we need to do to allow 'lazy auth' Text posts is literally just adding the conditional `requiredAuthentication` to the payload! Pretty damn sweet!

### Any background context you want to provide?
💡We utilize our [`requiresAuthentication`](https://github.com/DoSomething/phoenix-next/blob/lazy-auth-text-posts/resources/assets/middleware/requiresAuthentication.js) middleware by setting `requiresAuthentication` to `true` within text post's payload, thus redirecting the user to the Northstar auth flow before dispatching the post submission to Rogue.

💡We needed to pass through the un `FormData`'d form fields, since `localForage` wouldn't allow storing the `FormData` object. The good news is, API post requests will [convert it to `FormData`](https://github.com/DoSomething/phoenix-next/blob/master/resources/assets/middleware/api.js#L62-L63) for free

❗️*Side Effect*: the `phoenix_submitted_text_submission_action` event [we're tracking](https://github.com/DoSomething/phoenix-next/blob/lazy-auth-text-posts/resources/assets/actions/post.js#L86) will now fire off before the user is authenticated, thus
- we won't have the Northstar ID attached to the event
- technically, this won't necessarilly mean that the RB was posted to Rogue, since the user might drop off during Northstar conversion

So this would change the meaning of this event a tad from "They've submitted the RB to Rogue", to "They definitely submitted the RB to us, probably also to Rogue too if they've converted on authentication"

❓*Question*: I opted to only set the [`requiresAuthentication`](https://github.com/DoSomething/phoenix-next/blob/lazy-auth-text-posts/resources/assets/actions/post.js#L106) for `text` posts, though we could get away with setting it for all RBs since they shouldn't be accessed in a non autheticated environment anyway. Issue being that the error message that'd pop up -in whatever edge case has an unauthed user using this form- would be obscure as opposed to the current `Unauthenticated` error message. Does that make sense?


### What are the relevant tickets/cards?

Refs [Pivotal ID #163867272](https://www.pivotaltracker.com/story/show/163867272)

[lil video demo of this in action](https://dosomething.slack.com/files/U720V2G1J/FGD9KM40P/lazy_auth_text_rb.mov)