### PR TITLE
Append location to post submissions.

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -40,11 +40,16 @@ class AppServiceProvider extends ServiceProvider
         });
 
         View::composer('*', function ($view) {
+            // Read Fastly's geolocation headers for location-based features.
+            $country = request()->header('X-Fastly-Country-Code');
+            $region = request()->header('X-Fastly-Region-Code');
+
             $view->with('auth', [
                 'isAuthenticated' => auth()->check(),
                 'id' => auth()->id() ?: request()->query('user_id'),
                 'token' => auth()->user() ? auth()->user()->access_token : null,
                 'role' => auth()->user() ? auth()->user()->role : 'user',
+                'location' => $country && $region ? $country . '-' . $region : null,
                 'source' => request()->query('utm_source'),
             ]);
         });

--- a/resources/assets/actions/post.js
+++ b/resources/assets/actions/post.js
@@ -1,4 +1,4 @@
-/* global FormData */
+/* global FormData, window */
 
 import { join } from 'path';
 
@@ -79,6 +79,11 @@ export function storeCampaignPost(campaignId, data) {
   }
 
   const { action, body, id, type } = data;
+
+  // Attach location information, provided by Fastly.
+  if (window.AUTH.location) {
+    body.append('location', window.AUTH.location);
+  }
 
   const sixpackExperiments = {
     conversion: 'reportbackPost',


### PR DESCRIPTION
### What does this PR do?
This pull request reads the `X-Fastly-Country-Code` and `X-Fastly-Region-Code` headers, if present, and uses them to set the `location` field on any posts that a user submits.

### Any background context you want to provide?
I had thought we could read the headers directly from the front-end but [it turns out we can't](https://stackoverflow.com/a/4881836/811624)!

### What are the relevant tickets/cards?

Refs [Pivotal ID #163728657](https://www.pivotaltracker.com/story/show/163728657).

### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.
* [ ] Added screenshot to PR description of related front-end updates on **small** screens.
* [ ] Added screenshot to PR description of related front-end updates on **medium** screens.
* [ ] Added screenshot to PR description of related front-end updates on **large** screens.