### PR TITLE
Update our API Post Requests FormData Formatting

### DIFF
--- a/resources/assets/actions/post.js
+++ b/resources/assets/actions/post.js
@@ -70,7 +70,8 @@ export function resetPostSubmissionItem(id) {
  * @return {function}
  */
 export function storeCampaignPost(campaignId, data) {
-  const { action, body, id, type } = data;
+  const { action, id, type } = data;
+  let { body } = data;
 
   if (type === 'photo' && !(body instanceof FormData)) {
     throw Error(
@@ -82,7 +83,11 @@ export function storeCampaignPost(campaignId, data) {
 
   // Attach location information, provided by Fastly.
   if (window.AUTH.location) {
-    body.append('location', window.AUTH.location);
+    if (body instanceof FormData) {
+      body.append('location', window.AUTH.location);
+    } else {
+      body = { ...body, location: window.AUTH.location };
+    }
   }
 
   const sixpackExperiments = {

--- a/resources/assets/actions/post.js
+++ b/resources/assets/actions/post.js
@@ -1,4 +1,4 @@
-/* global window */
+/* global FormData, window */
 
 import { join } from 'path';
 
@@ -71,6 +71,14 @@ export function resetPostSubmissionItem(id) {
  */
 export function storeCampaignPost(campaignId, data) {
   const { action, body, id, type } = data;
+
+  if (type === 'photo' && !(body instanceof FormData)) {
+    throw Error(
+      `The supplied data.body must be an instance of FormData, instead it is an instance of ${
+        body.constructor.name
+      }.`,
+    );
+  }
 
   // Attach location information, provided by Fastly.
   if (window.AUTH.location) {

--- a/resources/assets/actions/post.js
+++ b/resources/assets/actions/post.js
@@ -1,4 +1,4 @@
-/* global FormData, window */
+/* global window */
 
 import { join } from 'path';
 
@@ -70,14 +70,6 @@ export function resetPostSubmissionItem(id) {
  * @return {function}
  */
 export function storeCampaignPost(campaignId, data) {
-  if (!(data.body instanceof FormData)) {
-    throw Error(
-      `The supplied data.body must be an instance of FormData, instead it is an instance of ${
-        data.body.constructor.name
-      }.`,
-    );
-  }
-
   const { action, body, id, type } = data;
 
   // Attach location information, provided by Fastly.

--- a/resources/assets/actions/post.js
+++ b/resources/assets/actions/post.js
@@ -1,4 +1,4 @@
-/* global FormData, window */
+/* global FormData */
 
 import { join } from 'path';
 
@@ -70,8 +70,7 @@ export function resetPostSubmissionItem(id) {
  * @return {function}
  */
 export function storeCampaignPost(campaignId, data) {
-  const { action, id, type } = data;
-  let { body } = data;
+  const { action, body, id, type } = data;
 
   if (type === 'photo' && !(body instanceof FormData)) {
     throw Error(
@@ -79,15 +78,6 @@ export function storeCampaignPost(campaignId, data) {
         body.constructor.name
       }.`,
     );
-  }
-
-  // Attach location information, provided by Fastly.
-  if (window.AUTH.location) {
-    if (body instanceof FormData) {
-      body.append('location', window.AUTH.location);
-    } else {
-      body = { ...body, location: window.AUTH.location };
-    }
   }
 
   const sixpackExperiments = {

--- a/resources/assets/components/SignupButton/SignupButton.js
+++ b/resources/assets/components/SignupButton/SignupButton.js
@@ -22,7 +22,7 @@ const SignupButton = props => {
   // Decorate click handler for A/B tests & analytics.
   const onSignup = buttonText => {
     clickedSignupAction(campaignId, {
-      body: { details: { campaignContentfulId } },
+      body: { details: JSON.stringify({ campaignContentfulId }) },
       analytics: {
         campaignContentfulId,
         source,

--- a/resources/assets/components/actions/PhotoSubmissionAction/PhotoSubmissionAction.js
+++ b/resources/assets/components/actions/PhotoSubmissionAction/PhotoSubmissionAction.js
@@ -16,7 +16,7 @@ import TextContent from '../../utilities/TextContent/TextContent';
 import {
   calculateDifference,
   getFieldErrors,
-  setFormData,
+  formatFormFields,
 } from '../../../helpers/forms';
 
 import './photo-submission-action.scss';
@@ -193,7 +193,7 @@ class PhotoSubmissionAction extends React.Component {
     // Send request to store the campaign photo submission post.
     this.props.storeCampaignPost(this.props.campaignId, {
       action,
-      body: setFormData(formFields),
+      body: formatFormFields(formFields),
       id: this.props.id,
       type,
     });

--- a/resources/assets/components/actions/ReferralSubmissionAction/ReferralSubmissionAction.js
+++ b/resources/assets/components/actions/ReferralSubmissionAction/ReferralSubmissionAction.js
@@ -9,7 +9,7 @@ import Button from '../../utilities/Button/Button';
 import { withoutUndefined } from '../../../helpers';
 import FormValidation from '../../utilities/Form/FormValidation';
 import TextContent from '../../utilities/TextContent/TextContent';
-import { getFieldErrors, setFormData } from '../../../helpers/forms';
+import { getFieldErrors, formatFormFields } from '../../../helpers/forms';
 
 class ReferralSubmissionAction extends React.Component {
   constructor(props) {
@@ -62,7 +62,7 @@ class ReferralSubmissionAction extends React.Component {
 
     const action = get(this.props.additionalContent, 'action', 'default');
 
-    const formData = setFormData({
+    const formData = formatFormFields({
       action,
       type,
       id: this.props.id,

--- a/resources/assets/components/actions/ShareAction/ShareAction.js
+++ b/resources/assets/components/actions/ShareAction/ShareAction.js
@@ -7,6 +7,7 @@ import Embed from '../../utilities/Embed/Embed';
 import Modal from '../../utilities/Modal/Modal';
 import Button from '../../utilities/Button/Button';
 import ContentfulEntry from '../../ContentfulEntry';
+import { formatFormFields } from '../../../helpers/forms';
 import { trackAnalyticsEvent } from '../../../helpers/analytics';
 import { SOCIAL_SHARE_TYPE } from '../../../constants/post-types';
 import TextContent from '../../utilities/TextContent/TextContent';
@@ -36,12 +37,12 @@ class ShareAction extends React.Component {
       action,
       type: SOCIAL_SHARE_TYPE,
       id: campaignContentfulId,
-      details: JSON.stringify({
+      details: {
         url: link,
         platform: 'facebook',
         campaign_id: campaignId,
         puck_id: puckId,
-      }),
+      },
     };
 
     // @TODO: Once Rogue/Contentful requires this field, we can do away with this conditional logic.
@@ -55,7 +56,7 @@ class ShareAction extends React.Component {
     // Send request to store the social share post.
     this.props.storeCampaignPost(campaignId, {
       action,
-      body: formFields,
+      body: formatFormFields(formFields),
       id: campaignContentfulId,
       type: SOCIAL_SHARE_TYPE,
     });

--- a/resources/assets/components/actions/ShareAction/ShareAction.js
+++ b/resources/assets/components/actions/ShareAction/ShareAction.js
@@ -7,7 +7,6 @@ import Embed from '../../utilities/Embed/Embed';
 import Modal from '../../utilities/Modal/Modal';
 import Button from '../../utilities/Button/Button';
 import ContentfulEntry from '../../ContentfulEntry';
-import { setFormData } from '../../../helpers/forms';
 import { trackAnalyticsEvent } from '../../../helpers/analytics';
 import { SOCIAL_SHARE_TYPE } from '../../../constants/post-types';
 import TextContent from '../../utilities/TextContent/TextContent';
@@ -37,12 +36,12 @@ class ShareAction extends React.Component {
       action,
       type: SOCIAL_SHARE_TYPE,
       id: campaignContentfulId,
-      details: {
+      details: JSON.stringify({
         url: link,
         platform: 'facebook',
         campaign_id: campaignId,
         puck_id: puckId,
-      },
+      }),
     };
 
     // @TODO: Once Rogue/Contentful requires this field, we can do away with this conditional logic.
@@ -56,7 +55,7 @@ class ShareAction extends React.Component {
     // Send request to store the social share post.
     this.props.storeCampaignPost(campaignId, {
       action,
-      body: setFormData(formFields),
+      body: formFields,
       id: campaignContentfulId,
       type: SOCIAL_SHARE_TYPE,
     });

--- a/resources/assets/components/actions/TextSubmissionAction/TextSubmissionAction.js
+++ b/resources/assets/components/actions/TextSubmissionAction/TextSubmissionAction.js
@@ -7,9 +7,9 @@ import Card from '../../utilities/Card/Card';
 import Modal from '../../utilities/Modal/Modal';
 import Button from '../../utilities/Button/Button';
 import { withoutUndefined } from '../../../helpers';
-import { getFieldErrors } from '../../../helpers/forms';
 import FormValidation from '../../utilities/Form/FormValidation';
 import TextContent from '../../utilities/TextContent/TextContent';
+import { getFieldErrors, formatFormFields } from '../../../helpers/forms';
 
 import './text-submission-action.scss';
 
@@ -79,7 +79,7 @@ class TextSubmissionAction extends React.Component {
     // Send request to store the campaign text submission post.
     this.props.storeCampaignPost(this.props.campaignId, {
       action,
-      body: formFields,
+      body: formatFormFields(formFields),
       id: this.props.id,
       type,
     });

--- a/resources/assets/components/actions/TextSubmissionAction/TextSubmissionAction.js
+++ b/resources/assets/components/actions/TextSubmissionAction/TextSubmissionAction.js
@@ -7,9 +7,9 @@ import Card from '../../utilities/Card/Card';
 import Modal from '../../utilities/Modal/Modal';
 import Button from '../../utilities/Button/Button';
 import { withoutUndefined } from '../../../helpers';
+import { getFieldErrors } from '../../../helpers/forms';
 import FormValidation from '../../utilities/Form/FormValidation';
 import TextContent from '../../utilities/TextContent/TextContent';
-import { getFieldErrors, setFormData } from '../../../helpers/forms';
 
 import './text-submission-action.scss';
 
@@ -79,7 +79,7 @@ class TextSubmissionAction extends React.Component {
     // Send request to store the campaign text submission post.
     this.props.storeCampaignPost(this.props.campaignId, {
       action,
-      body: setFormData(formFields),
+      body: formFields,
       id: this.props.id,
       type,
     });

--- a/resources/assets/helpers/forms.js
+++ b/resources/assets/helpers/forms.js
@@ -72,7 +72,7 @@ export function getFieldErrorMessages(response) {
  * @param {Object} data
  * @return FormData
  */
-export function setFormData(data = {}) {
+export function createFormData(data = {}) {
   const formData = new FormData();
 
   forEach(data, (value, key) => formData.append(key, value));
@@ -125,7 +125,7 @@ export function formatFormFields(data = {}) {
 
   // Photo RBs contain file uploads and thus need to be converted to a FormData object.
   if (data.type === 'photo') {
-    formattedData = setFormData(formattedData);
+    formattedData = createFormData(formattedData);
   }
 
   return formattedData;

--- a/resources/assets/helpers/forms.js
+++ b/resources/assets/helpers/forms.js
@@ -1,4 +1,4 @@
-/* global FormData */
+/* global FormData, window */
 
 import { forEach, get, isInteger } from 'lodash';
 
@@ -70,19 +70,10 @@ export function getFieldErrorMessages(response) {
  * Set form data for the provided data values.
  *
  * @param {Object} data
- * @param {Undefined|Object} data.details
  * @return FormData
  */
 export function setFormData(data = {}) {
   const formData = new FormData();
-
-  const details = get(data, 'details', null);
-
-  if (details) {
-    delete data.details; // eslint-disable-line no-param-reassign
-
-    formData.append('details', JSON.stringify(details));
-  }
 
   forEach(data, (value, key) => formData.append(key, value));
 
@@ -109,4 +100,33 @@ export function getFormData(formData) {
   }
 
   return formDataObject;
+}
+
+/**
+ * Format and furnish RB post data.
+ *
+ * @param {Object} data
+ * @param {Undefined|Object} data.details
+ * @param {Undefined|String} data.type
+ * @return FormData|Object
+ */
+export function formatFormFields(data = {}) {
+  let formattedData = data;
+
+  // JSON serialize details field which gets validated as JSON.
+  if (data.details) {
+    formattedData.details = JSON.stringify(data.details);
+  }
+
+  // Attach location information, provided by Fastly.
+  if (window.AUTH.location) {
+    formattedData = { ...formattedData, location: window.AUTH.location };
+  }
+
+  // Photo RBs contain file uploads and thus need to be converted to a FormData object.
+  if (data.type === 'photo') {
+    formattedData = setFormData(formattedData);
+  }
+
+  return formattedData;
 }

--- a/resources/assets/middleware/api.js
+++ b/resources/assets/middleware/api.js
@@ -5,7 +5,6 @@ import { RestApiClient } from '@dosomething/gateway';
 
 import { report, isWithinMinutes } from '../helpers';
 import { PHOENIX_URL } from '../constants';
-import { setFormData } from '../helpers/forms';
 import { API } from '../constants/action-types';
 import { getUserToken } from '../selectors/user';
 import { getRequest, setRequestHeaders, tabularLog } from '../helpers/api';
@@ -55,12 +54,15 @@ const getRequestAction = (payload, dispatch) => {
 const postRequest = (payload, dispatch, getState) => {
   const token = getUserToken(getState()) || window.AUTH.token;
 
+  const contentType =
+    payload.body instanceof FormData
+      ? 'multipart/form-data'
+      : 'application/json';
+
   const client = new RestApiClient(PHOENIX_URL, {
-    headers: setRequestHeaders({ token, contentType: 'multipart/form-data' }),
+    headers: setRequestHeaders({ token, contentType }),
   });
 
-  const body =
-    payload.body instanceof FormData ? payload.body : setFormData(payload.body);
   const campaignContentfulId = get(payload, 'meta.id', null);
   const campaignId = get(payload, 'meta.campaignId');
   const postType = get(payload, 'meta.type', 'post_request');
@@ -71,7 +73,7 @@ const postRequest = (payload, dispatch, getState) => {
   });
 
   return client
-    .post(payload.url, body)
+    .post(payload.url, payload.body)
     .then(response => {
       tabularLog(get(response, 'data', null));
 

--- a/resources/assets/middleware/api.js
+++ b/resources/assets/middleware/api.js
@@ -49,7 +49,6 @@ const getRequestAction = (payload, dispatch) => {
  * @param  {Function} dispatch
  * @return {Object}
  * @todo   rename to postRequestAction and refactor to use helpers/api@postRequest().
- * @todo   Only use multipart/from-data if sending FormData.
  */
 const postRequest = (payload, dispatch, getState) => {
   const token = getUserToken(getState()) || window.AUTH.token;


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR updates our `middleware/api#postRequest` to format the request's content-type header based on the `data.body`'s type.

This enabled removing the `FormData`-fication of all post requests within that same method and allows removing that validation and formatting from `ShareAction` and `TextSubmissionAction` since those don't attach any files to the request's body.

### Any background context you want to provide?
❗️One catch here was that the helper method which took care of converting the form's body to `FormData`, [also took care](https://github.com/DoSomething/phoenix-next/blob/e3725ed887c1efd9e3d2cd75f5209848c1d69a73/resources/assets/helpers/forms.js#L79-L85) of properly serializing any `body.details` fields which get [validated as a string](https://github.com/DoSomething/phoenix-next/blob/e3725ed887c1efd9e3d2cd75f5209848c1d69a73/app/Http/Controllers/Api/CampaignSignupsController.php#L66).

I had initially wanted to add a new helper somewhere to abstract that logic from the existing form helper. But couldn't really think of an elegant way to do so, and felt like it even made more sense for the various components themselves to take care of this. Anyone have contrasting thoughts?

### What are the relevant tickets/cards?

Refs [Pivotal ID #162349035](https://www.pivotaltracker.com/story/show/162349035)
#1265 
