### PR TITLE
Adding API route and related functionality for blocks.

### DIFF
--- a/app/Http/Controllers/Api/BlocksController.php
+++ b/app/Http/Controllers/Api/BlocksController.php
@@ -2,8 +2,6 @@
 
 namespace App\Http\Controllers\Api;
 
-use App\Entities\Entity;
-use Illuminate\Http\Request;
 use App\Http\Controllers\Controller;
 use App\Repositories\QueriesContentful;
 

--- a/app/Http/Controllers/Api/BlocksController.php
+++ b/app/Http/Controllers/Api/BlocksController.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Entities\Entity;
+use Illuminate\Http\Request;
+use App\Http\Controllers\Controller;
+use App\Repositories\QueriesContentful;
+
+class BlocksController extends Controller
+{
+    use QueriesContentful;
+
+    /**
+     * Display the specified resource.
+     *
+     * @param  string $id
+     * @return \Illuminate\Http\JsonResponse
+     */
+    public function show($id)
+    {
+        $block = $this->getEntryFromIdAsJson($id);
+
+        return response()->json($block);
+    }
+}

--- a/app/Repositories/QueriesContentful.php
+++ b/app/Repositories/QueriesContentful.php
@@ -2,6 +2,7 @@
 
 namespace App\Repositories;
 
+use App\Entities\Entity;
 use App\Entities\HomePage;
 use Contentful\Delivery\Query;
 use App\Entities\TruncatedCampaign;
@@ -43,6 +44,23 @@ trait QueriesContentful
 
                 return $results->toJson();
         }
+    }
+
+    /**
+     * Get a single entry from Contentful by ID.
+     *
+     * @param  string $id
+     * @return mixed
+     */
+    protected function getEntryFromIdAsJson($id)
+    {
+        $entry = app('contentful.delivery')->getEntry($id);
+
+        $entity = new Entity($entry);
+
+        $block = $entity->parseBlock($entity);
+
+        return $block;
     }
 
     /**

--- a/routes/api.php
+++ b/routes/api.php
@@ -18,6 +18,9 @@ $router->group(['prefix' => 'v2'], function () {
         return ['status' => 'good'];
     });
 
+    // Blocks
+    $this->get('/blocks/{id}', 'Api\BlocksController@show');
+
     // Campaigns
     $this->get('/campaigns', 'Api\CampaignsController@index');
     $this->get('/campaigns/{id}', 'Api\CampaignsController@show');
@@ -30,11 +33,11 @@ $router->group(['prefix' => 'v2'], function () {
     $this->get('/campaigns/{id}/signups', 'Api\CampaignSignupsController@index');
     $this->post('/campaigns/{id}/signups', 'Api\CampaignSignupsController@store');
 
-    // Posts
-    $this->get('/posts', 'Api\PostsController@index');
-
     // Shortlinks
     $this->post('/links', 'Api\LinkController@store');
+
+    // Posts
+    $this->get('/posts', 'Api\PostsController@index');
 
     // Signups
     $this->get('/signups', 'Api\SignupsController@index');


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR adds a new API `/blocks/{id}` route, which for only has a show method for now in the `Api\BlocksController`. I didn't add a `BlockRepository` because it seemed like overkill for now, but did add a new method to the `QueriesContentful` trait, called `getEntryFromIdAsJson()` which will grab a Contentful entry via a supplied entry ID.

### Any background context you want to provide?

This endpoint is needed so that we can render out entries added via RichText.

### What are the relevant tickets/cards?

Refs [Pivotal ID #164092381](https://www.pivotaltracker.com/story/show/164092381)

### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.
* [ ] Added screenshot to PR description of related front-end updates on **small** screens.
* [ ] Added screenshot to PR description of related front-end updates on **medium** screens.
* [ ] Added screenshot to PR description of related front-end updates on **large** screens.
