### PR TITLE
Petition submission action migration

### DIFF
--- a/app/Entities/Entity.php
+++ b/app/Entities/Entity.php
@@ -92,6 +92,8 @@ class Entity implements ArrayAccess, JsonSerializable
                 return new Page($block->entry);
             case 'person':
                 return new Person($block->entry);
+            case 'petitionSubmissionAction':
+                return new PetitionSubmissionAction($block->entry);
             case 'photoSubmissionAction':
                 return new PhotoSubmissionAction($block->entry);
             case 'quiz':

--- a/app/Entities/PetitionSubmissionAction.php
+++ b/app/Entities/PetitionSubmissionAction.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Entities;
+
+use JsonSerializable;
+
+class PetitionSubmissionAction extends Entity implements JsonSerializable
+{
+    public function jsonSerialize()
+    {
+        return [
+            'id' => $this->entry->getId(),
+            'type' => $this->getContentType(),
+            'fields' => [
+                'actionId' => $this->actionId,
+                'title' => $this->title,
+                'content' => $this->content,
+                'textFieldPlaceholder' => $this->textFieldPlaceholder,
+                'buttonText' => $this->buttonText,
+                'informationTitle' => $this->informationTitle,
+                'informationContent' => $this->informationContent,
+                'affirmationContent' => $this->affirmationContent,
+                'additionalContent' => $this->additionalContent,
+            ],
+        ];
+    }
+}

--- a/contentful/content-types/petitionSubmissionAction.js
+++ b/contentful/content-types/petitionSubmissionAction.js
@@ -1,0 +1,189 @@
+module.exports = function(migration) {
+  const petitionSubmissionAction = migration
+    .createContentType('petitionSubmissionAction')
+    .name('Petition Submission Action')
+    .description('Action block for submitting petition reportback posts.')
+    .displayField('internalTitle');
+
+  petitionSubmissionAction
+    .createField('internalTitle')
+    .name('Internal Title')
+    .type('Symbol')
+    .localized(false)
+    .required(true)
+    .validations([])
+    .disabled(false)
+    .omitted(false);
+
+  petitionSubmissionAction
+    .createField('actionId')
+    .name('Action ID')
+    .type('Integer')
+    .localized(false)
+    .required(true)
+    .validations([
+      {
+        unique: true,
+      },
+    ])
+    .disabled(false)
+    .omitted(false);
+
+  petitionSubmissionAction
+    .createField('title')
+    .name('Title')
+    .type('Symbol')
+    .localized(true)
+    .required(false)
+    .validations([
+      {
+        size: {
+          max: 65,
+        },
+      },
+    ])
+    .disabled(false)
+    .omitted(false);
+
+  petitionSubmissionAction
+    .createField('content')
+    .name('Content')
+    .type('Text')
+    .localized(true)
+    .required(true)
+    .validations([])
+    .disabled(false)
+    .omitted(false);
+
+  petitionSubmissionAction
+    .createField('textFieldPlaceholder')
+    .name('Text Field Placeholder Message')
+    .type('Symbol')
+    .localized(true)
+    .required(false)
+    .validations([])
+    .disabled(false)
+    .omitted(false);
+
+  petitionSubmissionAction
+    .createField('buttonText')
+    .name('Button Text')
+    .type('Symbol')
+    .localized(true)
+    .required(false)
+    .validations([
+      {
+        size: {
+          max: 25,
+        },
+      },
+    ])
+    .disabled(false)
+    .omitted(false);
+
+  petitionSubmissionAction
+    .createField('informationTitle')
+    .name('Information Title')
+    .type('Symbol')
+    .localized(true)
+    .required(false)
+    .validations([])
+    .disabled(false)
+    .omitted(false);
+
+  petitionSubmissionAction
+    .createField('informationContent')
+    .name('Information Content')
+    .type('Text')
+    .localized(true)
+    .required(false)
+    .validations([])
+    .disabled(false)
+    .omitted(false);
+
+  petitionSubmissionAction
+    .createField('affirmationContent')
+    .name('Affirmation Content')
+    .type('Text')
+    .localized(true)
+    .required(false)
+    .validations([])
+    .disabled(false)
+    .omitted(false);
+
+  petitionSubmissionAction
+    .createField('additionalContent')
+    .name('Additional Content')
+    .type('Object')
+    .localized(false)
+    .required(false)
+    .validations([])
+    .disabled(false)
+    .omitted(false);
+
+  petitionSubmissionAction.changeEditorInterface(
+    'internalTitle',
+    'singleLine',
+    {},
+  );
+
+  petitionSubmissionAction.changeEditorInterface('actionId', 'numberEditor', {
+    helpText: 'The Action ID associated with this action in Rogue.',
+  });
+
+  petitionSubmissionAction.changeEditorInterface('title', 'singleLine', {
+    helpText:
+      'The title of the petition block (defaults to "Sign The Petition").',
+  });
+
+  petitionSubmissionAction.changeEditorInterface('content', 'markdown', {
+    helpText: "The petition's content.",
+  });
+
+  petitionSubmissionAction.changeEditorInterface(
+    'textFieldPlaceholder',
+    'singleLine',
+    {
+      helpText:
+        'The placeholder for the "custom message" text field (defaults to "Add your custom message...").',
+    },
+  );
+
+  petitionSubmissionAction.changeEditorInterface('buttonText', 'singleLine', {
+    helpText:
+      'Text to display on the submission button (defaults to "Add your name").',
+  });
+
+  petitionSubmissionAction.changeEditorInterface(
+    'informationTitle',
+    'singleLine',
+    {
+      helpText:
+        'Title to display for the information block (defaults to "More Info").',
+    },
+  );
+
+  petitionSubmissionAction.changeEditorInterface(
+    'informationContent',
+    'markdown',
+    {
+      helpText:
+        'Content to display for the information block (defaults to basic information regarding what happens with user\'s signature").',
+    },
+  );
+
+  petitionSubmissionAction.changeEditorInterface(
+    'affirmationContent',
+    'markdown',
+    {
+      helpText:
+        'Content to display once the user successfully submits their petition reportback (defaults to a generic thank you message).',
+    },
+  );
+
+  petitionSubmissionAction.changeEditorInterface(
+    'additionalContent',
+    'objectEditor',
+    {},
+  );
+};

--- a/contentful/content-types/petitionSubmissionAction.js
+++ b/contentful/content-types/petitionSubmissionAction.js
@@ -124,7 +124,9 @@ module.exports = function(migration) {
   petitionSubmissionAction.changeEditorInterface(
     'internalTitle',
     'singleLine',
-    {},
+    {
+      helpText: 'This title is used internally to help find this content.',
+    },
   );
 
   petitionSubmissionAction.changeEditorInterface('actionId', 'numberEditor', {


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR adds a Contentful content type migration script for the brand new `PetitionSubmissionAction`!

Also adds the Entity and the block parser case.

### Any background context you want to provide?
I was able to extrapolate most of this from the `PhotoSubmissionAction` and the `TextSubmissionAction` which had the fields we needed for this.

For reference, here's the Petition in the mock:
![image](https://user-images.githubusercontent.com/12417657/53361835-b291d700-3906-11e9-929b-c6c954566afc.png)



### What are the relevant tickets/cards?

Refs [Pivotal ID #163867938](https://www.pivotaltracker.com/story/show/163867938)

### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.