### PR TITLE
Refresh the page if token is expired.

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -48,9 +48,11 @@ class AppServiceProvider extends ServiceProvider
                 'isAuthenticated' => auth()->check(),
                 'id' => auth()->id() ?: request()->query('user_id'),
                 'token' => auth()->user() ? auth()->user()->access_token : null,
+                'expiresAt' => auth()->user() ? auth()->user()->access_token_expiration : null,
                 'role' => auth()->user() ? auth()->user()->role : 'user',
                 'location' => $country && $region ? $country . '-' . $region : null,
                 'source' => request()->query('utm_source'),
+                'now' => now()->timestamp,
             ]);
         });
     }

--- a/resources/assets/helpers/auth.js
+++ b/resources/assets/helpers/auth.js
@@ -1,0 +1,42 @@
+/* global window */
+
+/**
+ * Get the current UNIX timestamp (in seconds), optionally
+ * adjusted by the given clock skew.
+ *
+ * @param {Number} skew
+ * @return {Number}
+ */
+const now = (skew = 0) => Math.floor(+new Date() / 1000) + skew;
+
+/**
+ * Bind an event listener which will refresh the page
+ * if the current access token is expired.
+ */
+export function bindTokenRefreshEvent() {
+  const { token, expiresAt } = window.AUTH;
+
+  // Take into account clock skew between server & user's browser:
+  const skew = window.AUTH.now - now();
+
+  // Refresh the page if our authentication token is expired:
+  const authCheck = setInterval(() => {
+    if (token) {
+      // Read the current time, and adjust by our originally recorded
+      // clock "skew" – so we make sure we're not refreshing until the
+      // server expects this token to be expired.
+      const expiresIn = expiresAt - now(skew);
+
+      console.debug(`Token expires in ${Math.floor(expiresIn)} seconds.`);
+
+      if (expiresIn < 0) {
+        console.log('Token has expired! Refreshing...');
+
+        clearInterval(authCheck);
+        window.location.reload(true);
+      }
+    }
+  }, 5000);
+}
+
+export default null;

--- a/resources/assets/helpers/auth.js
+++ b/resources/assets/helpers/auth.js
@@ -1,5 +1,7 @@
 /* global window */
 
+import { trackAnalyticsEvent } from './analytics';
+
 /**
  * Get the current UNIX timestamp (in seconds), optionally
  * adjusted by the given clock skew.
@@ -31,6 +33,11 @@ export function bindTokenRefreshEvent() {
 
       if (expiresIn < 0) {
         console.log('Token has expired! Refreshing...');
+        trackAnalyticsEvent({
+          verb: 'refreshed',
+          noun: 'token',
+          data: { skew },
+        });
 
         clearInterval(authCheck);
         window.location.reload(true);

--- a/resources/assets/init.js
+++ b/resources/assets/init.js
@@ -38,6 +38,7 @@ import App from './components/App';
 // DOM Helpers
 import { ready } from './helpers';
 import { init as historyInit } from './history';
+import { bindTokenRefreshEvent } from './helpers/auth';
 import { googleAnalyticsInit } from './helpers/analytics';
 import { bindNavigationEvents } from './helpers/navigation';
 
@@ -54,6 +55,9 @@ ready(() => {
     middleware,
     { ...preloadedState, user: window.AUTH },
   );
+
+  // Add periodic check that our token hasn't expired.
+  bindTokenRefreshEvent();
 
   // Add event listeners for top-level navigation.
   bindNavigationEvents();


### PR DESCRIPTION
### What does this PR do?

This pull request adds an event which periodically checks whether or not the user's access token has expired. If it has, it refreshes the page so that the [RefreshTokenMiddleware](https://github.com/DoSomething/phoenix-next/blob/b9e40dc567997ff16b8865878396a5a8bbe1bdc2/app/Http/Kernel.php#L39) will kick in and fetch a new token for the user.

### Any background context you want to provide?
This should hopefully clear up most of the remaining "token expired" errors we see when users leave a tab open for more than an hour. 🤞 I've also been working on an experiment for a more graceful solution to this problem, which I'm hoping to wrap up and share this week.

### What are the relevant tickets/cards?

Refs [Pivotal ID #157665698](https://www.pivotaltracker.com/story/show/157665698).

### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.
* [ ] Added screenshot to PR description of related front-end updates on **small** screens.
* [ ] Added screenshot to PR description of related front-end updates on **medium** screens.
* [ ] Added screenshot to PR description of related front-end updates on **large** screens.