### PR TITLE
Story page initial styling

### DIFF
--- a/app/Entities/StoryPage.php
+++ b/app/Entities/StoryPage.php
@@ -17,6 +17,10 @@ class StoryPage extends Entity implements JsonSerializable
                 'subTitle' => $this->subTitle,
                 'slug' => $this->slug,
                 'metadata' => $this->metadata ? new Metadata($this->metadata->entry) : null,
+                'coverImage' => [
+                    'description' => $this->coverImage ? $this->coverImage->getDescription() : '',
+                    'url' => get_image_url($this->coverImage),
+                ],
                 'blocks' => $this->parseBlocks($this->blocks),
             ],
         ];

--- a/contentful/content-types/storyPage.js
+++ b/contentful/content-types/storyPage.js
@@ -79,6 +79,37 @@ module.exports = function(migration) {
     .linkType('Entry');
 
   storyPage
+    .createField('coverImage')
+    .name('Cover Image')
+    .type('Link')
+    .localized(false)
+    .required(false)
+    .validations([
+      {
+        linkMimetypeGroup: ['image'],
+      },
+      {
+        assetImageDimensions: {
+          width: {
+            min: 1440,
+            max: null,
+          },
+
+          height: {
+            min: 610,
+            max: null,
+          },
+        },
+
+        message:
+          'The provided image needs to be at least 1440px wide by 610px tall.',
+      },
+    ])
+    .disabled(false)
+    .omitted(false)
+    .linkType('Asset');
+
+  storyPage
     .createField('blocks')
     .name('Blocks')
     .type('Array')
@@ -113,6 +144,11 @@ module.exports = function(migration) {
   });
 
   storyPage.changeEditorInterface('metadata', 'entryLinkEditor', {});
+
+  storyPage.changeEditorInterface('coverImage', 'assetLinkEditor', {
+    helpText:
+      'This cover image is used in the banner at the top of the Story Page, as well as for the tile on home page and explore campaigns.',
+  });
 
   storyPage.changeEditorInterface('blocks', 'entryLinksEditor', {
     bulkEditing: false,

--- a/resources/assets/components/CallToAction/CallToAction.js
+++ b/resources/assets/components/CallToAction/CallToAction.js
@@ -52,7 +52,7 @@ const CallToAction = ({
   return (
     <Card
       className={classnames(
-        'call-to-action rounded padded text-centered',
+        'call-to-action rounded padded text-center',
         className,
         {
           '-sticky': sticky,

--- a/resources/assets/components/CallToAction/__snapshots__/CallToAction.test.js.snap
+++ b/resources/assets/components/CallToAction/__snapshots__/CallToAction.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`CallToAction snapshot test 1`] = `
 <Card
-  className="call-to-action rounded padded text-centered bg-white bordered light"
+  className="call-to-action rounded padded text-center bg-white bordered light"
   link={null}
   onClose={null}
   title={null}

--- a/resources/assets/components/actions/LinkAction/templates/CtaTemplate.js
+++ b/resources/assets/components/actions/LinkAction/templates/CtaTemplate.js
@@ -26,7 +26,7 @@ const CtaTemplate = ({ title, content, link, buttonText, source }) => {
   });
 
   return (
-    <Card className="cta-template rounded padded text-centered bg-black dark caps-lock">
+    <Card className="cta-template rounded padded text-center bg-black dark caps-lock">
       <h3 className="cta-template__title margin-top-lg">{title}</h3>
 
       <TextContent className="cta-template__content">{content}</TextContent>

--- a/resources/assets/components/pages/GeneralPage/GeneralPage.js
+++ b/resources/assets/components/pages/GeneralPage/GeneralPage.js
@@ -42,7 +42,7 @@ const GeneralPage = props => {
 
       <div className="main clearfix general-page">
         <Enclosure className="default-container margin-vertical">
-          <div className="general-page__heading text-centered">
+          <div className="general-page__heading text-center">
             <h1 className="general-page__title caps-lock">{title}</h1>
             {subTitle ? (
               <p className="general-page__subtitle">{subTitle}</p>

--- a/resources/assets/components/pages/StoryPage/StoryPage.js
+++ b/resources/assets/components/pages/StoryPage/StoryPage.js
@@ -45,7 +45,7 @@ StoryPage.propTypes = {
   blocks: PropTypes.arrayOf(PropTypes.object),
   coverImage: PropTypes.shape({
     url: PropTypes.string,
-    descsription: PropTypes.string,
+    description: PropTypes.string,
   }),
   subTitle: PropTypes.string,
   title: PropTypes.string.isRequired,

--- a/resources/assets/components/pages/StoryPage/StoryPage.js
+++ b/resources/assets/components/pages/StoryPage/StoryPage.js
@@ -2,30 +2,58 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import ContentfulEntry from '../../ContentfulEntry';
+import { contentfulImageUrl, withoutNulls } from '../../../helpers';
+
+import './story-page.scss';
 
 const StoryPage = props => {
-  const { blocks, subTitle, title } = props;
+  const { blocks, coverImage, subTitle, title } = props;
+
+  const backgroundImage = coverImage
+    ? `url(${contentfulImageUrl(coverImage.url, '1440', '610', 'fill')})`
+    : null;
+
+  const styles = {
+    backgroundImage,
+  };
+
+  console.log(styles);
 
   return (
-    <div>
-      <h1>{title}</h1>
-      {subTitle ? <h2>{subTitle}</h2> : null}
+    <article className="story-page">
+      <header
+        role="banner"
+        className="lede-banner"
+        style={withoutNulls(styles)}
+      >
+        <wrapper className="text-center">
+          <h1 className="lede-banner__headline-title color-white caps-lock">
+            {title}
+          </h1>
+          {subTitle ? <h2 className="color-yellow">{subTitle}</h2> : null}
+        </wrapper>
+      </header>
 
       {blocks.map(block => (
         <ContentfulEntry key={block.id} json={block} />
       ))}
-    </div>
+    </article>
   );
 };
 
 StoryPage.propTypes = {
   blocks: PropTypes.arrayOf(PropTypes.object),
+  coverImage: PropTypes.shape({
+    url: PropTypes.string,
+    descsription: PropTypes.string,
+  }),
   subTitle: PropTypes.string,
   title: PropTypes.string.isRequired,
 };
 
 StoryPage.defaultProps = {
   blocks: [],
+  coverImage: null,
   subTitle: null,
 };
 

--- a/resources/assets/components/pages/StoryPage/story-page.scss
+++ b/resources/assets/components/pages/StoryPage/story-page.scss
@@ -1,0 +1,18 @@
+@import '../../../scss/next-toolbox';
+
+.story-page {
+  .lede-banner {
+    min-height: 500px;
+
+    @include media($medium) {
+      min-height: 610px;
+    }
+
+    .lede-banner__headline-title {
+      // @todo Mock's use League Gothic Regular
+      font-family: $secondary-font-family;
+      font-size: 97px;
+      font-weight: normal;
+    }
+  }
+}

--- a/resources/assets/components/utilities/PostGallery/PostGallery.js
+++ b/resources/assets/components/utilities/PostGallery/PostGallery.js
@@ -22,7 +22,7 @@ const PostGallery = props => {
       </Gallery>
       <LoadMore
         buttonClassName="-tertiary"
-        className="padding-lg text-centered"
+        className="padding-lg text-center"
         text="view more"
         onClick={loadMorePosts}
         isLoading={loading}

--- a/resources/assets/components/utilities/SocialShareTray/SocialShareTray.js
+++ b/resources/assets/components/utilities/SocialShareTray/SocialShareTray.js
@@ -120,7 +120,7 @@ class SocialShareTray extends React.Component {
     const trackLink = this.props.trackLink || this.props.shareLink;
 
     return (
-      <div className="social-share-tray padded text-centered">
+      <div className="social-share-tray padded text-center">
         <p className="title caps-lock font-bold">{title}</p>
 
         <div className="share-buttons">

--- a/resources/assets/scss/base.scss
+++ b/resources/assets/scss/base.scss
@@ -364,7 +364,7 @@ p {
   opacity: 0.5;
 }
 
-.text-centered {
+.text-center {
   text-align: center;
 }
 


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR adds support for a `coverImage` on the StoryPage, which mostly happened in [this commit](https://github.com/DoSomething/phoenix-next/commit/180bd4f95ce4c0bb114e8910975d1d10b1a26130). 

I'm also starting to rename our custom utility classes by the name that Tailwind uses instead, so when we eventually transition over to using Tailwind, it'll be more seamless and we can just delete our utility classes without any side effects.

### Any background context you want to provide?

I decided not to use a templated `LedeBanner` component on the `StoryPage` for now. It seemed like overkill since the lede banner on these pages is more simplified than in other uses on campaigns, etc. This could change in the future, but going the simpler route for now, seemed prudent.

**Example StoryPage with cover image:**
![image](https://user-images.githubusercontent.com/105849/53580706-3556a400-3b4a-11e9-8123-757bfcb1b079.png)


### What are the relevant tickets/cards?

Refs [Pivotal ID #164092392](https://www.pivotaltracker.com/story/show/164092392)

### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.