### PR TITLE
Add new text gallery styling.

### DIFF
--- a/apollo.config.js
+++ b/apollo.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  client: {
+    service: 'dosomething-graphql-dev-lambda',
+    includes: ['./resources/assets/**/*.js'],
+  },
+};

--- a/resources/assets/components/utilities/PostCard/PostCard.js
+++ b/resources/assets/components/utilities/PostCard/PostCard.js
@@ -20,6 +20,8 @@ export const postCardFragment = gql`
     text
     tags
     quantity
+    location(format: HUMAN_FORMAT)
+
     user {
       firstName
     }
@@ -27,7 +29,11 @@ export const postCardFragment = gql`
 `;
 
 const PostCard = ({ post, noun }) => {
-  const firstName = post.user ? post.user.firstName : 'A Doer';
+  // If this post isn't anonymous, show first name. Otherwise, state or fallback to "A Doer".
+  const displayName = post.user
+    ? post.user.firstName
+    : post.location || 'A Doer';
+
   const reactionElement = isAuthenticated() ? (
     <ReactionButton post={post} />
   ) : null;
@@ -37,13 +43,13 @@ const PostCard = ({ post, noun }) => {
   switch (post.type) {
     case 'text':
       media = (
-        <div className="chat-bubble -post-bubble flex-center-y margin-bottom-none rounded-top">
-          <p className="color-white">{post.text}</p>
+        <div className="chat-bubble -post-bubble margin-bottom-none rounded-top">
+          <p className="font-italic">{post.text}</p>
         </div>
       );
       break;
     case 'photo':
-      media = <LazyImage alt={`${firstName}'s photo`} src={post.url} />;
+      media = <LazyImage alt={`${displayName}'s photo`} src={post.url} />;
       break;
 
     default:
@@ -51,14 +57,14 @@ const PostCard = ({ post, noun }) => {
   }
 
   return (
-    <BaseFigure className="post" media={media}>
+    <BaseFigure className={`post post-${post.type}`} media={media}>
       <BaseFigure
         media={reactionElement}
         alignment="right"
         className="padded margin-bottom-none"
       >
         <h4>
-          {firstName}
+          {displayName}
           <PostBadge status={post.status} tags={post.tags} />
         </h4>
         {post.quantity ? (

--- a/resources/assets/components/utilities/PostCard/post.scss
+++ b/resources/assets/components/utilities/PostCard/post.scss
@@ -16,7 +16,7 @@
   }
 
   > .figure__media {
-    background-color: $med-gray;
+    background-color: $white;
 
     & > img {
       width: 480px; // HACK: Expand smaller images to fit in card.
@@ -32,32 +32,22 @@
   }
 }
 
+.post-text {
+  border-left: $half-spacing solid #7069d8;
+}
+
 .chat-bubble.-post-bubble {
-  font-family: $font-league-gothic;
-  min-height: 340px; // HACK: short text posts should be same height as photos.
-  background-color: $purple;
-
-  &:before {
-    // Offset the 'tail' from bottom with a 1px overlap to avoid
-    // sub-pixel rendering issue w/ slight gap between elements.
-    top: auto;
-    bottom: -19px;
-
-    border-color: $purple transparent transparent $purple;
-    left: 25%;
-  }
-
-  h4 {
-    @include media($only-medium) {
-      font-size: $font-small;
-    }
-  }
+  min-height: 332px; // HACK: short text posts should be same height as photos.
+  color: $black;
+  background-color: $white;
+  padding: $base-spacing $half-spacing;
 
   p {
-    font-size: 42px;
+    color: $black;
+    font-size: $font-medium;
 
     @include media($only-medium) {
-      font-size: $font-medium;
+      font-size: $font-regular;
     }
   }
 }

--- a/resources/assets/components/utilities/PostGallery/post-gallery.scss
+++ b/resources/assets/components/utilities/PostGallery/post-gallery.scss
@@ -1,13 +1,3 @@
 @import '../../../scss/next-toolbox';
 
-.post-gallery {
-  // Alternate adjacent 'chat-bubble' colors within a gallery.
-  li:nth-of-type(2n) .chat-bubble {
-    $bright-purple: #563795;
-    background-color: $bright-purple;
-
-    &:before {
-      border-color: $bright-purple transparent transparent $bright-purple;
-    }
-  }
-}
+// ...

--- a/resources/assets/scss/base.scss
+++ b/resources/assets/scss/base.scss
@@ -183,6 +183,10 @@ p {
   float: right;
 }
 
+.font-italic {
+  font-style: italic;
+}
+
 .font-bold {
   font-weight: $weight-bold;
 }


### PR DESCRIPTION
### What does this PR do?

This pull request adds the new text gallery styling, designed for the upcoming "Prom For All" campaign. This will replace the [old appearance](https://user-images.githubusercontent.com/583202/53599983-6d73dc00-3b76-11e9-9ba2-e61da66e9a58.png) for all galleries with text posts ([discussion](https://dosomething.slack.com/archives/C3ASB4204/p1551302391159200)).

![screen shot 2019-02-28 at 4 34 04 pm](https://user-images.githubusercontent.com/583202/53600092-add35a00-3b76-11e9-8258-eddc5dfb1432.png)

### Any background context you want to provide?

Some open questions:
- At the moment, we'll only show the state where a post was submitted from if the user is `null` (which for anonymous actions, they would be). It might make sense to set this on the gallery (or expose as a property on the post response) so we don't create confusion for staffers...
- Right now, we hardcode a min-height for these. It might be nice to see if we can update the gallery to support dynamic heights (but consistent within rows). That's a CSS Grid thing, yah? 🎨
- Is there a reason we omitted reactions here? We could add a toggle to the gallery content type, perhaps, but it'd be nice to keep this consistent everywhere if possible...
- Finally, I snagged `#7069d8` from @lkpttn's mocks. Do we have a name for that?

### What are the relevant tickets/cards?

Refs [Pivotal ID #164214415](https://www.pivotaltracker.com/story/show/164214415).

### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.
* [ ] Added screenshot to PR description of related front-end updates on **small** screens.
* [ ] Added screenshot to PR description of related front-end updates on **medium** screens.
* [ ] Added screenshot to PR description of related front-end updates on **large** screens.