### PR TITLE
Visual touch-ups for the new text gallery.

### DIFF
--- a/resources/assets/components/utilities/Gallery/Gallery.js
+++ b/resources/assets/components/utilities/Gallery/Gallery.js
@@ -2,15 +2,15 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 
-import { modifiers } from '../../../helpers';
-
 const renderGalleryItem = (child, index) => (
   <li key={`submission-${index}`}>{child}</li>
 );
 
 const Gallery = ({ type, children, className = null }) =>
   children.length ? (
-    <ul className={classnames('gallery', className, modifiers(type))}>
+    <ul
+      className={classnames('gallery-grid', `gallery-grid-${type}`, className)}
+    >
       {children.map(renderGalleryItem)}
     </ul>
   ) : null;

--- a/resources/assets/components/utilities/PostCard/PostCard.js
+++ b/resources/assets/components/utilities/PostCard/PostCard.js
@@ -57,7 +57,8 @@ const PostCard = ({ post, noun }) => {
   }
 
   return (
-    <BaseFigure className={`post post-${post.type}`} media={media}>
+    <div className={`post post-${post.type}`}>
+      <div className="flex-grow">{media}</div>
       <BaseFigure
         media={reactionElement}
         alignment="right"
@@ -75,7 +76,7 @@ const PostCard = ({ post, noun }) => {
         ) : null}
         {post.type !== 'text' && post.text ? <p>{post.text}</p> : null}
       </BaseFigure>
-    </BaseFigure>
+    </div>
   );
 };
 

--- a/resources/assets/components/utilities/PostCard/post.scss
+++ b/resources/assets/components/utilities/PostCard/post.scss
@@ -4,6 +4,9 @@
   position: relative;
   font-family: $primary-font-family;
   margin-bottom: 0;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
 
   h4 {
     display: inline;
@@ -37,7 +40,6 @@
 }
 
 .chat-bubble.-post-bubble {
-  min-height: 332px; // HACK: short text posts should be same height as photos.
   color: $black;
   background-color: $white;
   padding: $base-spacing $half-spacing;

--- a/resources/assets/components/utilities/PostGallery/PostGallery.js
+++ b/resources/assets/components/utilities/PostGallery/PostGallery.js
@@ -15,7 +15,7 @@ const PostGallery = props => {
     <div>
       <Gallery type="triad" className="post-gallery expand-horizontal-md">
         {posts.map(post => (
-          <Card className="rounded height-100" key={post.id}>
+          <Card className="rounded h-full" key={post.id}>
             <PostCard post={post} />
           </Card>
         ))}

--- a/resources/assets/components/utilities/PostGallery/PostGallery.js
+++ b/resources/assets/components/utilities/PostGallery/PostGallery.js
@@ -15,7 +15,7 @@ const PostGallery = props => {
     <div>
       <Gallery type="triad" className="post-gallery expand-horizontal-md">
         {posts.map(post => (
-          <Card className="rounded" key={post.id}>
+          <Card className="rounded height-100" key={post.id}>
             <PostCard post={post} />
           </Card>
         ))}

--- a/resources/assets/components/utilities/ReactionButton/reaction.scss
+++ b/resources/assets/components/utilities/ReactionButton/reaction.scss
@@ -12,9 +12,10 @@
   .reaction__button {
     display: inline-block;
     width: 24px;
-    height: 24px;
+    height: 18px; // Prevent this from "expanding" below the count text.
     background: url('./heart-empty.svg') no-repeat;
     background-size: contain;
+    background-position: center;
 
     &.-reacted {
       background-image: url('./heart-filled.svg');

--- a/resources/assets/scss/base.scss
+++ b/resources/assets/scss/base.scss
@@ -179,7 +179,7 @@ p {
   flex-grow: 1;
 }
 
-.height-100 {
+.h-full {
   height: 100%;
 }
 

--- a/resources/assets/scss/base.scss
+++ b/resources/assets/scss/base.scss
@@ -175,6 +175,10 @@ p {
   align-items: center;
 }
 
+.height-100 {
+  height: 100%;
+}
+
 .float-left {
   float: left;
 }

--- a/resources/assets/scss/base.scss
+++ b/resources/assets/scss/base.scss
@@ -175,6 +175,10 @@ p {
   align-items: center;
 }
 
+.flex-grow {
+  flex-grow: 1;
+}
+
 .height-100 {
   height: 100%;
 }

--- a/resources/assets/scss/gallery-grid.scss
+++ b/resources/assets/scss/gallery-grid.scss
@@ -1,7 +1,8 @@
 @import 'next-toolbox';
 
 // @TODO: Rename to something better?
-.gallery-grid-quartet {
+.gallery-grid-quartet,
+.gallery-grid-triad {
   display: grid;
   grid-template-columns: 1fr;
   grid-row-gap: $half-spacing;
@@ -13,7 +14,9 @@
     grid-column-gap: $half-spacing;
     grid-row-gap: $half-spacing;
   }
+}
 
+.gallery-grid-quartet {
   @include media($medium) {
     grid-template-columns: repeat(2, 1fr);
   }
@@ -24,6 +27,22 @@
 
   @include media($larger) {
     grid-template-columns: repeat(4, 1fr);
+    grid-column-gap: $base-spacing;
+    grid-row-gap: $base-spacing;
+  }
+}
+
+.gallery-grid-triad {
+  @include media($medium) {
+    grid-template-columns: repeat(1, 1fr);
+  }
+
+  @include media($large) {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  @include media($larger) {
+    grid-template-columns: repeat(3, 1fr);
     grid-column-gap: $base-spacing;
     grid-row-gap: $base-spacing;
   }

--- a/resources/assets/scss/gallery-grid.scss
+++ b/resources/assets/scss/gallery-grid.scss
@@ -1,6 +1,5 @@
 @import 'next-toolbox';
 
-// @TODO: Rename to something better?
 .gallery-grid-quartet,
 .gallery-grid-triad {
   display: grid;


### PR DESCRIPTION
### What does this PR do?

This pull request includes some visual touch-ups to the post gallery, to make the new "text" post style look a little bit more at-home. In particular, it uses CSS Grid & Flexbox to make the post cards flexible – they'll now expand and shrink to fit the content in each row:

<img width="966" alt="screen shot 2019-03-01 at 12 07 56 pm" src="https://user-images.githubusercontent.com/583202/53654124-f17f9f80-3c1a-11e9-9fc2-2f7f1805a02d.png">

I also fixed a little "overflow" bug where the reaction button would cause the post's meta-information to overflow and add an [unexpectedly large bottom margin](https://user-images.githubusercontent.com/583202/53654232-33a8e100-3c1b-11e9-92d5-fd4355f2963d.png).

### Any background context you want to provide?
This is necessary to get the consistent row heights from [the mocks](https://user-images.githubusercontent.com/583202/53654313-72d73200-3c1b-11e9-88fe-7e3c002864dc.png) without relying on the `min-height` hack we'd previously used here.

### What are the relevant tickets/cards?

Refs [Pivotal ID #164214415](https://www.pivotaltracker.com/story/show/164214415).

### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.
* [ ] Added screenshot to PR description of related front-end updates on **small** screens.
* [ ] Added screenshot to PR description of related front-end updates on **medium** screens.
* [ ] Added screenshot to PR description of related front-end updates on **large** screens.