### PR TITLE
Action Post Data Alterations

### DIFF
--- a/resources/assets/actions/post.js
+++ b/resources/assets/actions/post.js
@@ -70,7 +70,7 @@ export function resetPostSubmissionItem(id) {
  * @return {function}
  */
 export function storeCampaignPost(campaignId, data) {
-  const { action, body, campaignContentfulId, id, type } = data;
+  const { action, actionId, body, campaignContentfulId, id, type } = data;
 
   if (type === 'photo' && !(body instanceof FormData)) {
     throw Error(
@@ -96,6 +96,7 @@ export function storeCampaignPost(campaignId, data) {
     noun: formatEventNoun(type),
     data: {
       action,
+      actionId,
       campaignId,
       campaignContentfulId,
     },
@@ -108,6 +109,7 @@ export function storeCampaignPost(campaignId, data) {
         failure: POST_SUBMISSION_FAILED,
         meta: {
           action,
+          actionId,
           campaignId,
           campaignContentfulId,
           id,

--- a/resources/assets/actions/post.js
+++ b/resources/assets/actions/post.js
@@ -70,7 +70,7 @@ export function resetPostSubmissionItem(id) {
  * @return {function}
  */
 export function storeCampaignPost(campaignId, data) {
-  const { action, body, id, type } = data;
+  const { action, body, campaignContentfulId, id, type } = data;
 
   if (type === 'photo' && !(body instanceof FormData)) {
     throw Error(
@@ -97,7 +97,7 @@ export function storeCampaignPost(campaignId, data) {
     data: {
       action,
       campaignId,
-      campaignContentfulId: id,
+      campaignContentfulId,
     },
   });
 
@@ -109,6 +109,7 @@ export function storeCampaignPost(campaignId, data) {
         meta: {
           action,
           campaignId,
+          campaignContentfulId,
           id,
           sixpackExperiments,
           type,

--- a/resources/assets/components/actions/PhotoSubmissionAction/PhotoSubmissionAction.js
+++ b/resources/assets/components/actions/PhotoSubmissionAction/PhotoSubmissionAction.js
@@ -186,6 +186,7 @@ class PhotoSubmissionAction extends React.Component {
     // Send request to store the campaign photo submission post.
     this.props.storeCampaignPost(this.props.campaignId, {
       action,
+      actionId: this.props.actionId,
       body: formatFormFields(formFields),
       id: this.props.id,
       campaignContentfulId: this.props.campaignContentfulId,

--- a/resources/assets/components/actions/PhotoSubmissionAction/PhotoSubmissionAction.js
+++ b/resources/assets/components/actions/PhotoSubmissionAction/PhotoSubmissionAction.js
@@ -188,6 +188,7 @@ class PhotoSubmissionAction extends React.Component {
       action,
       body: formatFormFields(formFields),
       id: this.props.id,
+      campaignContentfulId: this.props.campaignContentfulId,
       type,
     });
   };
@@ -407,6 +408,7 @@ PhotoSubmissionAction.propTypes = {
   }),
   buttonText: PropTypes.string,
   campaignId: PropTypes.string.isRequired,
+  campaignContentfulId: PropTypes.string.isRequired,
   captionFieldLabel: PropTypes.string,
   captionFieldPlaceholder: PropTypes.string,
   className: PropTypes.string,

--- a/resources/assets/components/actions/PhotoSubmissionAction/PhotoSubmissionAction.js
+++ b/resources/assets/components/actions/PhotoSubmissionAction/PhotoSubmissionAction.js
@@ -8,7 +8,7 @@ import { get, has, invert, mapValues } from 'lodash';
 import Card from '../../utilities/Card/Card';
 import Modal from '../../utilities/Modal/Modal';
 import Button from '../../utilities/Button/Button';
-import { withoutUndefined } from '../../../helpers';
+import { withoutUndefined, withoutNulls } from '../../../helpers';
 import MediaUploader from '../../utilities/MediaUploader';
 import { getUserCampaignSignups } from '../../../helpers/api';
 import FormValidation from '../../utilities/Form/FormValidation';
@@ -172,23 +172,16 @@ class PhotoSubmissionAction extends React.Component {
       );
     }
 
-    let formFields = {
+    const formFields = withoutNulls({
       action,
       type,
       id: this.props.id,
+      action_id: this.props.actionId,
       // Associate state values to fields.
       ...values,
       file: this.state.mediaValue.file || '',
       show_quantity: this.props.showQuantityField ? 1 : 0,
-    };
-
-    // @TODO: Once Rogue/Contentful requires this field, we can do away with this conditional logic.
-    if (this.props.actionId) {
-      formFields = {
-        ...formFields,
-        action_id: this.props.actionId,
-      };
-    }
+    });
 
     // Send request to store the campaign photo submission post.
     this.props.storeCampaignPost(this.props.campaignId, {

--- a/resources/assets/components/actions/PhotoSubmissionAction/PhotoSubmissionActionContainer.js
+++ b/resources/assets/components/actions/PhotoSubmissionAction/PhotoSubmissionActionContainer.js
@@ -10,6 +10,7 @@ import {
 
 const mapStateToProps = state => ({
   campaignId: state.campaign.campaignId,
+  campaignContentfulId: state.campaign.id,
   submissions: state.postSubmissions,
   userId: getUserId(state),
 });

--- a/resources/assets/components/actions/ShareAction/ShareAction.js
+++ b/resources/assets/components/actions/ShareAction/ShareAction.js
@@ -51,8 +51,9 @@ class ShareAction extends React.Component {
     this.props.storeCampaignPost(campaignId, {
       action,
       actionId,
+      campaignContentfulId,
       body: formatFormFields(formFields),
-      id: campaignContentfulId,
+      id: this.props.id,
       type: SOCIAL_SHARE_TYPE,
     });
   };
@@ -181,6 +182,7 @@ ShareAction.propTypes = {
   campaignContentfulId: PropTypes.string.isRequired,
   content: PropTypes.string,
   hideEmbed: PropTypes.bool,
+  id: PropTypes.string.isRequired,
   isAuthenticated: PropTypes.bool.isRequired,
   link: PropTypes.string.isRequired,
   socialPlatform: PropTypes.oneOf(['twitter', 'facebook']).isRequired,

--- a/resources/assets/components/actions/ShareAction/ShareAction.js
+++ b/resources/assets/components/actions/ShareAction/ShareAction.js
@@ -50,6 +50,7 @@ class ShareAction extends React.Component {
     // Send request to store the social share post.
     this.props.storeCampaignPost(campaignId, {
       action,
+      actionId,
       body: formatFormFields(formFields),
       id: campaignContentfulId,
       type: SOCIAL_SHARE_TYPE,

--- a/resources/assets/components/actions/ShareAction/ShareAction.js
+++ b/resources/assets/components/actions/ShareAction/ShareAction.js
@@ -16,6 +16,7 @@ import {
   loadFacebookSDK,
   showFacebookShareDialog,
   showTwitterSharePrompt,
+  withoutNulls,
 } from '../../../helpers';
 
 class ShareAction extends React.Component {
@@ -33,25 +34,18 @@ class ShareAction extends React.Component {
 
     const { actionId, campaignContentfulId, campaignId, link } = this.props;
 
-    let formFields = {
+    const formFields = withoutNulls({
       action,
       type: SOCIAL_SHARE_TYPE,
       id: campaignContentfulId,
+      action_id: actionId,
       details: {
         url: link,
         platform: 'facebook',
         campaign_id: campaignId,
         puck_id: puckId,
       },
-    };
-
-    // @TODO: Once Rogue/Contentful requires this field, we can do away with this conditional logic.
-    if (actionId) {
-      formFields = {
-        ...formFields,
-        action_id: actionId,
-      };
-    }
+    });
 
     // Send request to store the social share post.
     this.props.storeCampaignPost(campaignId, {

--- a/resources/assets/components/actions/TextSubmissionAction/TextSubmissionAction.js
+++ b/resources/assets/components/actions/TextSubmissionAction/TextSubmissionAction.js
@@ -6,7 +6,7 @@ import { get, has, invert, mapValues } from 'lodash';
 import Card from '../../utilities/Card/Card';
 import Modal from '../../utilities/Modal/Modal';
 import Button from '../../utilities/Button/Button';
-import { withoutUndefined } from '../../../helpers';
+import { withoutUndefined, withoutNulls } from '../../../helpers';
 import FormValidation from '../../utilities/Form/FormValidation';
 import TextContent from '../../utilities/TextContent/TextContent';
 import { getFieldErrors, formatFormFields } from '../../../helpers/forms';
@@ -60,21 +60,14 @@ class TextSubmissionAction extends React.Component {
 
     const action = get(this.props.additionalContent, 'action', 'default');
 
-    let formFields = {
+    const formFields = withoutNulls({
       action,
       type,
       id: this.props.id,
+      action_id: this.props.actionId,
       // Associate state values to fields.
       ...mapValues(this.fields, value => this.state[`${value}Value`]),
-    };
-
-    // @TODO: Once Rogue/Contentful requires this field, we can do away with this conditional logic.
-    if (this.props.actionId) {
-      formFields = {
-        ...formFields,
-        action_id: this.props.actionId,
-      };
-    }
+    });
 
     // Send request to store the campaign text submission post.
     this.props.storeCampaignPost(this.props.campaignId, {

--- a/resources/assets/components/actions/TextSubmissionAction/TextSubmissionAction.js
+++ b/resources/assets/components/actions/TextSubmissionAction/TextSubmissionAction.js
@@ -72,6 +72,7 @@ class TextSubmissionAction extends React.Component {
     // Send request to store the campaign text submission post.
     this.props.storeCampaignPost(this.props.campaignId, {
       action,
+      actionId: this.props.actionId,
       body: formatFormFields(formFields),
       id: this.props.id,
       campaignContentfulId: this.props.campaignContentfulId,

--- a/resources/assets/components/actions/TextSubmissionAction/TextSubmissionAction.js
+++ b/resources/assets/components/actions/TextSubmissionAction/TextSubmissionAction.js
@@ -74,6 +74,7 @@ class TextSubmissionAction extends React.Component {
       action,
       body: formatFormFields(formFields),
       id: this.props.id,
+      campaignContentfulId: this.props.campaignContentfulId,
       type,
     });
   };
@@ -164,6 +165,7 @@ TextSubmissionAction.propTypes = {
   }),
   buttonText: PropTypes.string,
   campaignId: PropTypes.string.isRequired,
+  campaignContentfulId: PropTypes.string.isRequired,
   className: PropTypes.string,
   id: PropTypes.string.isRequired,
   initPostSubmissionItem: PropTypes.func.isRequired,

--- a/resources/assets/components/actions/TextSubmissionAction/TextSubmissionActionContainer.js
+++ b/resources/assets/components/actions/TextSubmissionAction/TextSubmissionActionContainer.js
@@ -12,6 +12,7 @@ import {
  */
 const mapStateToProps = state => ({
   campaignId: state.campaign.campaignId,
+  campaignContentfulId: state.campaign.id,
   submissions: state.postSubmissions,
 });
 

--- a/resources/assets/middleware/api.js
+++ b/resources/assets/middleware/api.js
@@ -62,12 +62,12 @@ const postRequest = (payload, dispatch, getState) => {
     headers: setRequestHeaders({ token, contentType }),
   });
 
-  const campaignContentfulId = get(payload, 'meta.id', null);
+  const campaignContentfulId = get(payload, 'meta.campaignContentfulId', null);
   const campaignId = get(payload, 'meta.campaignId');
   const postType = get(payload, 'meta.type', 'post_request');
 
   dispatch({
-    id: payload.meta.id, // @TODO: rename to campaignContentfulId or campaignId
+    id: payload.meta.id,
     type: payload.pending,
   });
 

--- a/resources/assets/middleware/api.js
+++ b/resources/assets/middleware/api.js
@@ -62,6 +62,7 @@ const postRequest = (payload, dispatch, getState) => {
     headers: setRequestHeaders({ token, contentType }),
   });
 
+  const actionId = get(payload, 'meta.actionId', null);
   const campaignContentfulId = get(payload, 'meta.campaignContentfulId', null);
   const campaignId = get(payload, 'meta.campaignId');
   const postType = get(payload, 'meta.type', 'post_request');
@@ -95,6 +96,7 @@ const postRequest = (payload, dispatch, getState) => {
         noun: formatEventNoun(postType),
         data: {
           activityId: response.data.id,
+          actionId,
           campaignContentfulId,
           campaignId,
         },
@@ -113,6 +115,7 @@ const postRequest = (payload, dispatch, getState) => {
         verb: 'failed',
         noun: formatEventNoun(postType),
         data: {
+          actionId,
           campaignContentfulId,
           campaignId,
           error,


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_



### What does this PR do?

This PR introduces a few updates to our action POSTs.

*I think a commit by commit review would be easiest for this PR*:

- https://github.com/DoSomething/phoenix-next/commit/d324374728a7c5f80db574061641df8590cb8b03 refactors the way we append the `action_id` field which will still be `null` for most actions. (https://github.com/DoSomething/phoenix-next/pull/1272#discussion_r260892155)

- https://github.com/DoSomething/phoenix-next/commit/d95cd02e74583ae1d7a2f7478c646ddc51cb7649 is a quick fix to the `campaignContentfulId` field we use for analytics tracking. We've been accidentally tracking the respective Action entry's ID instead of the overall campaign's.

- https://github.com/DoSomething/phoenix-next/commit/31a409fcf32ab11ad7c955dc2e5e3bffe963da21 appends the `actionId` field to action posts so we can track those in our analytics events as well. This feel like a good way for us to have the specificty of the respective Contentful entry / Rogue action ID within the request's analytics event lifecycle.

- https://github.com/DoSomething/phoenix-next/commit/e373021bda3f8dd82c6c56d10160a381c9f7f34e quick patch to the `ShareAction` so that we're passing the `campaignContentfulId` and specific entry ID properly. (In Photo and Text RB's we use the entry's ID as the `postSubmission`'s unique identifier, so I added that here too just for consistency)
 
### Any background context you want to provide?
This is a precurser to some upcoming work for Campaign ID independant posts along with `PetitionSubmissionAction` posts. (while digging into changes for those, these quick fixes fell into place).

### What are the relevant tickets/cards?

Refs [Pivotal ID #163728507](https://www.pivotaltracker.com/story/show/163728507)

### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.
