### PR TITLE
Petition Submission Action Posts!

### DIFF
--- a/app/Http/Controllers/Api/PostsController.php
+++ b/app/Http/Controllers/Api/PostsController.php
@@ -3,6 +3,8 @@
 namespace App\Http\Controllers\Api;
 
 use Illuminate\Http\Request;
+use App\Http\Requests\PostRequest;
+use Illuminate\Support\Facades\Log;
 use App\Http\Controllers\Controller;
 use App\Repositories\PostRepository;
 
@@ -36,5 +38,22 @@ class PostsController extends Controller
         $data = $this->postRepository->getPosts($request->all());
 
         return response()->json($data);
+    }
+
+    /**
+     * Store a newly created resource.
+     *
+     * @param  PostRequest $request
+     * @return \Illuminate\Http\JsonResponse
+     */
+    public function store(PostRequest $request)
+    {
+        Log::debug('[Phoenix] PostsController@store '.$request->input('type').' submission request data:', $request->all());
+
+        $data = $this->postRepository->storePost($request->all());
+
+        Log::debug('[Phoenix] PostsController@store  '.$request->input('type').' submission response data:', array_except($data, 'data.signup'));
+
+        return response()->json($data, 201);
     }
 }

--- a/app/Http/Requests/PostRequest.php
+++ b/app/Http/Requests/PostRequest.php
@@ -66,7 +66,7 @@ class PostRequest extends FormRequest
 
             case 'text':
                 return [
-                    'text' => 'max:256',
+                    'text' => 'max:500',
                 ];
 
             default:

--- a/app/Http/Requests/PostRequest.php
+++ b/app/Http/Requests/PostRequest.php
@@ -66,7 +66,7 @@ class PostRequest extends FormRequest
 
             case 'text':
                 return [
-                    'text' => 'required|max:256',
+                    'text' => 'max:256',
                 ];
 
             default:

--- a/resources/assets/actions/post.js
+++ b/resources/assets/actions/post.js
@@ -124,3 +124,49 @@ export function storeCampaignPost(campaignId, data) {
     );
   };
 }
+
+/**
+ * Store action posts.
+ *
+ * @param  {Object} data
+ * @param  {Number} data.actionId
+ * @param  {Object} data.body
+ * @param  {String} data.id
+ * @param  {String} data.type
+ * @return {function}
+ */
+export function storePost(data) {
+  const { actionId, body, id, type } = data;
+
+  const sixpackExperiments = {
+    conversion: 'reportbackPost',
+  };
+
+  // Track post submission event.
+  trackAnalyticsEvent({
+    verb: 'submitted',
+    noun: formatEventNoun(type),
+    data: {
+      actionId,
+    },
+  });
+
+  return dispatch => {
+    dispatch(
+      apiRequest('POST', {
+        body,
+        failure: POST_SUBMISSION_FAILED,
+        meta: {
+          sixpackExperiments,
+          actionId,
+          type,
+          id,
+        },
+        requiresAuthentication: type === 'text',
+        pending: POST_SUBMISSION_PENDING,
+        success: POST_SUBMISSION_SUCCESSFUL,
+        url: '/api/v2/posts',
+      }),
+    );
+  };
+}

--- a/resources/assets/components/ContentfulEntry/renderers.js
+++ b/resources/assets/components/ContentfulEntry/renderers.js
@@ -6,12 +6,12 @@ import ContentBlock from '../blocks/ContentBlock/ContentBlock';
 import { withoutNulls } from '../../helpers';
 import LinkActionContainer from '../actions/LinkAction/LinkActionContainer';
 import ShareActionContainer from '../actions/ShareAction/ShareActionContainer';
-import PetitionSubmissionAction from '../actions/PetitionSubmissioncAction/PetitionSubmissionAction';
 import TextSubmissionActionContainer from '../actions/TextSubmissionAction/TextSubmissionActionContainer';
 import PhotoSubmissionActionContainer from '../actions/PhotoSubmissionAction/PhotoSubmissionActionContainer';
 import SubmissionGalleryBlockContainer from '../blocks/SubmissionGalleryBlock/SubmissionGalleryBlockContainer';
 import VoterRegistrationActionContainer from '../actions/VoterRegistrationAction/VoterRegistrationActionContainer';
 import ReferralSubmissionActionContainer from '../actions/ReferralSubmissionAction/ReferralSubmissionActionContainer';
+import PetitionSubmissionActionContainer from '../actions/PetitionSubmissioncAction/PetitionSubmissionActionContainer';
 
 /**
  * Render the voter registration action container.
@@ -143,7 +143,7 @@ export function renderPetitionSubmissionAction(data) {
         name="petition_submission_action-top"
         waypointData={{ contentfulId }}
       />
-      <PetitionSubmissionAction id={contentfulId} {...fields} />
+      <PetitionSubmissionActionContainer id={contentfulId} {...fields} />
       <PuckWaypoint
         name="petition_submission_action-bottom"
         waypointData={{ contentfulId }}

--- a/resources/assets/components/actions/PetitionSubmissioncAction/PetitionSubmissionAction.js
+++ b/resources/assets/components/actions/PetitionSubmissioncAction/PetitionSubmissionAction.js
@@ -17,6 +17,7 @@ class PetitionSubmissionAction extends React.Component {
 
     this.state = {
       showAffirmation: false,
+      textValue: '',
     };
 
     this.props.initPostSubmissionItem(this.props.id);
@@ -38,6 +39,8 @@ class PetitionSubmissionAction extends React.Component {
 
     return null;
   }
+
+  handleChange = event => this.setState({ textValue: event.target.value });
 
   handleSubmit = event => {
     event.preventDefault();
@@ -100,6 +103,8 @@ class PetitionSubmissionAction extends React.Component {
                     'has-error shake': has(formErrors, 'text'),
                   })}
                   placeholder={textFieldPlaceholder}
+                  value={this.state.textValue}
+                  onChange={this.handleChange}
                 />
                 <p className="footnote">500 character limit</p>
               </div>

--- a/resources/assets/components/actions/PetitionSubmissioncAction/PetitionSubmissionAction.js
+++ b/resources/assets/components/actions/PetitionSubmissioncAction/PetitionSubmissionAction.js
@@ -1,61 +1,152 @@
 import React from 'react';
+import { has } from 'lodash';
 import PropTypes from 'prop-types';
 
 import Card from '../../utilities/Card/Card';
 import Button from '../../utilities/Button/Button';
+import { formatFormFields } from '../../../helpers/forms';
+import FormValidation from '../../utilities/Form/FormValidation';
 import TextContent from '../../utilities/TextContent/TextContent';
 
 import './petition-submission-action.scss';
 
-const PetitionSubmissionAction = props => (
-  <React.Fragment>
-    <div className="petition-submission-action margin-bottom-lg" id={props.id}>
-      <Card className="bordered rounded" title={props.title}>
-        <TextContent className="padding-md">{props.content}</TextContent>
+class PetitionSubmissionAction extends React.Component {
+  constructor(props) {
+    super(props);
 
-        <form>
-          <div className="padded">
-            <textarea
-              className="text-field petition-textarea"
-              placeholder={props.textFieldPlaceholder}
-            />
-            <p className="footnote">500 character limit</p>
-          </div>
+    this.state = {
+      showAffirmation: false,
+    };
 
-          <Button type="submit" attached>
-            {props.buttonText}
-          </Button>
-        </form>
-      </Card>
-    </div>
+    this.props.initPostSubmissionItem(this.props.id);
+  }
 
-    <div className="petition-submission-information">
-      <Card className="bordered rounded" title={props.informationTitle}>
-        <TextContent className="padding-md">
-          {props.informationContent}
-        </TextContent>
-      </Card>
-    </div>
-  </React.Fragment>
-);
+  static getDerivedStateFromProps(nextProps) {
+    const response = nextProps.submissions.items[nextProps.id] || null;
+
+    if (has(response, 'status.success')) {
+      // Resetting the submission item so that this won't be triggered continually for further renders.
+      nextProps.resetPostSubmissionItem(nextProps.id);
+
+      return {
+        // @TODO: change this to showModal, and display an affirmation modal in place of the success message.
+        showAffirmation: true,
+        textValue: '',
+      };
+    }
+
+    return null;
+  }
+
+  handleSubmit = event => {
+    event.preventDefault();
+
+    const { id, actionId, storePost } = this.props;
+
+    // Reset any straggling post submission data for this action.
+    this.props.resetPostSubmissionItem(id);
+
+    const type = 'text';
+
+    // Send request to store the petition submission post.
+    storePost({
+      body: formatFormFields({
+        action_id: actionId,
+        text: this.state.textValue,
+        type,
+      }),
+      type,
+      actionId,
+      id,
+    });
+  };
+
+  render() {
+    const {
+      buttonText,
+      content,
+      id,
+      informationContent,
+      informationTitle,
+      submissions,
+      title,
+      textFieldPlaceholder,
+    } = this.props;
+
+    const submissionItem = submissions.items[id];
+
+    const formResponse = has(submissionItem, 'status') ? submissionItem : null;
+
+    return (
+      <React.Fragment>
+        <div className="petition-submission-action margin-bottom-lg" id={id}>
+          <Card className="bordered rounded" title={title}>
+            {this.state.showAffirmation ? (
+              <p className="padded affirmation-message">
+                Thanks for signing the petition!
+              </p>
+            ) : null}
+
+            {formResponse ? <FormValidation response={formResponse} /> : null}
+            <TextContent className="padding-md">{content}</TextContent>
+
+            <form onSubmit={this.handleSubmit}>
+              <div className="padded">
+                <textarea
+                  className="text-field petition-textarea"
+                  placeholder={textFieldPlaceholder}
+                />
+                <p className="footnote">500 character limit</p>
+              </div>
+
+              <Button
+                type="submit"
+                attached
+                loading={submissionItem ? submissionItem.isPending : true}
+                disabled={this.state.showAffirmation}
+              >
+                {buttonText}
+              </Button>
+            </form>
+          </Card>
+        </div>
+
+        <div className="petition-submission-information">
+          <Card className="bordered rounded" title={informationTitle}>
+            <TextContent className="padding-md">
+              {informationContent}
+            </TextContent>
+          </Card>
+        </div>
+      </React.Fragment>
+    );
+  }
+}
 
 PetitionSubmissionAction.propTypes = {
-  id: PropTypes.string.isRequired,
-  title: PropTypes.string,
-  content: PropTypes.string.isRequired,
-  textFieldPlaceholder: PropTypes.string,
+  actionId: PropTypes.number.isRequired,
   buttonText: PropTypes.string,
-  informationTitle: PropTypes.string,
+  content: PropTypes.string.isRequired,
+  id: PropTypes.string.isRequired,
   informationContent: PropTypes.string,
+  informationTitle: PropTypes.string,
+  initPostSubmissionItem: PropTypes.func.isRequired,
+  resetPostSubmissionItem: PropTypes.func.isRequired,
+  storePost: PropTypes.func.isRequired,
+  submissions: PropTypes.shape({
+    items: PropTypes.object,
+  }).isRequired,
+  textFieldPlaceholder: PropTypes.string,
+  title: PropTypes.string,
 };
 
 PetitionSubmissionAction.defaultProps = {
-  title: 'Sign The Petition',
-  textFieldPlaceholder: 'Add your custom message...',
   buttonText: 'Add your name',
-  informationTitle: 'More Info',
+  textFieldPlaceholder: 'Add your custom message...',
+  title: 'Sign The Petition',
   informationContent:
     'Your first name and email will be added to our petition. We do not collect any additional information.',
+  informationTitle: 'More Info',
 };
 
 export default PetitionSubmissionAction;

--- a/resources/assets/components/actions/PetitionSubmissioncAction/PetitionSubmissionAction.js
+++ b/resources/assets/components/actions/PetitionSubmissioncAction/PetitionSubmissionAction.js
@@ -1,12 +1,13 @@
 import React from 'react';
 import { has } from 'lodash';
 import PropTypes from 'prop-types';
+import classnames from 'classnames';
 
 import Card from '../../utilities/Card/Card';
 import Button from '../../utilities/Button/Button';
-import { formatFormFields } from '../../../helpers/forms';
 import FormValidation from '../../utilities/Form/FormValidation';
 import TextContent from '../../utilities/TextContent/TextContent';
+import { formatFormFields, getFieldErrors } from '../../../helpers/forms';
 
 import './petition-submission-action.scss';
 
@@ -77,6 +78,8 @@ class PetitionSubmissionAction extends React.Component {
 
     const formResponse = has(submissionItem, 'status') ? submissionItem : null;
 
+    const formErrors = getFieldErrors(formResponse);
+
     return (
       <React.Fragment>
         <div className="petition-submission-action margin-bottom-lg" id={id}>
@@ -93,7 +96,9 @@ class PetitionSubmissionAction extends React.Component {
             <form onSubmit={this.handleSubmit}>
               <div className="padded">
                 <textarea
-                  className="text-field petition-textarea"
+                  className={classnames('text-field petition-textarea', {
+                    'has-error shake': has(formErrors, 'text'),
+                  })}
                   placeholder={textFieldPlaceholder}
                 />
                 <p className="footnote">500 character limit</p>

--- a/resources/assets/components/actions/PetitionSubmissioncAction/PetitionSubmissionActionContainer.js
+++ b/resources/assets/components/actions/PetitionSubmissioncAction/PetitionSubmissionActionContainer.js
@@ -1,0 +1,30 @@
+import { connect } from 'react-redux';
+
+import {
+  initPostSubmissionItem,
+  resetPostSubmissionItem,
+  storePost,
+} from '../../../actions/post';
+import PetitionSubmissionAction from './PetitionSubmissionAction';
+
+/**
+ * Provide state from the Redux store as props for this component.
+ */
+const mapStateToProps = state => ({
+  submissions: state.postSubmissions,
+});
+
+/**
+ * Provide pre-bound functions that allow the component to dispatch
+ * actions to the Redux store as props for this component.
+ */
+const actionCreators = {
+  initPostSubmissionItem,
+  resetPostSubmissionItem,
+  storePost,
+};
+
+export default connect(
+  mapStateToProps,
+  actionCreators,
+)(PetitionSubmissionAction);

--- a/resources/assets/components/actions/PetitionSubmissioncAction/petition-submission-action.scss
+++ b/resources/assets/components/actions/PetitionSubmissioncAction/petition-submission-action.scss
@@ -1,5 +1,12 @@
+@import '../../../scss/next-toolbox.scss';
+
 .petition-submission-action {
   .petition-textarea {
     height: 122px;
+  }
+
+  .affirmation-message {
+    color: $success-color;
+    font-size: $font-medium;
   }
 }

--- a/resources/assets/components/actions/TextSubmissionAction/TextSubmissionAction.js
+++ b/resources/assets/components/actions/TextSubmissionAction/TextSubmissionAction.js
@@ -135,6 +135,7 @@ class TextSubmissionAction extends React.Component {
               <Button
                 type="submit"
                 loading={submissionItem ? submissionItem.isPending : true}
+                disabled={!this.state.textValue}
                 attached
               >
                 {this.props.buttonText}

--- a/routes/api.php
+++ b/routes/api.php
@@ -38,6 +38,7 @@ $router->group(['prefix' => 'v2'], function () {
 
     // Posts
     $this->get('/posts', 'Api\PostsController@index');
+    $this->post('/posts', 'Api\PostsController@store');
 
     // Signups
     $this->get('/signups', 'Api\SignupsController@index');


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR adds support for Campaign ID-less posts and fleshes out the `PetitionSubmissionAction` component

*This can be a nice fun commit by commit journey (grab some Svedka):*

- https://github.com/DoSomething/phoenix-next/commit/e1b13dfb45d10dbbd75cf01ac205c418c3188a89 Adds new `/posts` POST route, and a `store` action for the `PostsController`
- https://github.com/DoSomething/phoenix-next/commit/3f7e950e7829fc660b16ecb2448aa170d649019d https://github.com/DoSomething/phoenix-next/commit/0b6e531dedf16e97979eeb0c1041d7568233349f updated the `type: text` validation rules to allow empty posts, and bump the character limit to `500`. (This will complement the -pending- [updated validation in Rogue](https://github.com/DoSomething/rogue/pull/840))
- https://github.com/DoSomething/phoenix-next/commit/0f387f977c0ac3a4e327f7ed1113a718d981b288 Disables the button for `TextSubmissionAction`s until there's some value in the input. (This is admittedly a super lite validation, but feels like a nice token way to replace the backend `required` validation, since we do kinda expect content for these posts. (we could of course make this beefier if we prefer, e.g. trimming the `textValue` first, and/or expecting min characters)) 
- https://github.com/DoSomething/phoenix-next/commit/a020a9fdf6de594b66414c81881869f37fa9e77e adds a new `storePost` action to allow storing posts without a `campaignId`. This also expects an `actionId` since that's what's [required from Rogue](https://github.com/DoSomething/rogue/blob/b6bfcdea357ebb2ee0a0e17cb76524be0d69b2e8/app/Http/Requests/PostRequest.php#L29) in absence of a `campaign_id`.
- https://github.com/DoSomething/phoenix-next/commit/41cc89e477a1d999890ce345ec1af9d767be9dbb https://github.com/DoSomething/phoenix-next/commit/d3eff78254f657a7171d841f2c262decb89a9c90 adds a fully fleshed out `PetitionSubmissionAction`, which [for now](https://dosomething.slack.com/archives/C3ASB4204/p1551368259006800), displays a cute little affirmation message in place of the Modal.
- (Update: https://github.com/DoSomething/phoenix-next/pull/1284/commits/ed724c27715fa3166c03f6b4a10c8ded5ea74460 and https://github.com/DoSomething/phoenix-next/pull/1284/commits/ca7b44c94d5f2490bf7af7d0bb5124a02aed015f two little updates to provide full form functionality for the `PetitionSubmissionAction`)

*Post submission state for the Petition Action (how bad is it 😭)*
![image](https://user-images.githubusercontent.com/12417657/53667224-61535180-3c3e-11e9-996b-042c03700d75.png)


### What are the relevant tickets/cards?

Refs [Pivotal ID #163728507](https://www.pivotaltracker.com/story/show/163728507)
[Pivotal ID #163867938](https://www.pivotaltracker.com/story/show/163867938)

### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.
* [ ] Added screenshot to PR description of related front-end updates on **small** screens.
* [ ] Added screenshot to PR description of related front-end updates on **medium** screens.
* [ ] Added screenshot to PR description of related front-end updates on **large** screens.
