### PR TITLE
Differentiate anonymous posts & source nouns from Rogue.

### DIFF
--- a/resources/assets/components/utilities/PostCard/PostCard.js
+++ b/resources/assets/components/utilities/PostCard/PostCard.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { get } from 'lodash';
 import gql from 'graphql-tag';
 import { propType } from 'graphql-anywhere';
 
@@ -36,8 +37,8 @@ export const postCardFragment = gql`
 const PostCard = ({ post }) => {
   // For anonymous posts, label with state if available. Otherwise, the user's first name.
   const authorLabel = post.actionDetails.anonymous
-    ? post.location || 'Anonymous'
-    : post.user.firstName || 'A Doer';
+    ? get(post, 'location', 'Anonymous')
+    : get(post, 'user.firstName', 'A Doer');
 
   const reactionElement = isAuthenticated() ? (
     <ReactionButton post={post} />

--- a/resources/assets/components/utilities/PostCard/PostCard.js
+++ b/resources/assets/components/utilities/PostCard/PostCard.js
@@ -38,7 +38,7 @@ const PostCard = ({ post }) => {
   // If this post is for an anonymous action, label it with the state (if available).
   // For non-anonymous posts (default), label with the user's first name.
   const authorLabel = post.actionDetails.anonymous
-    ? get(post, 'location', 'Anonymous')
+    ? post.location || 'Anonymous'
     : get(post, 'user.firstName', 'A Doer');
 
   const reactionElement = isAuthenticated() ? (

--- a/resources/assets/components/utilities/PostCard/PostCard.js
+++ b/resources/assets/components/utilities/PostCard/PostCard.js
@@ -21,6 +21,11 @@ export const postCardFragment = gql`
     tags
     quantity
     location(format: HUMAN_FORMAT)
+    signupId
+
+    actionDetails {
+      anonymous
+    }
 
     user {
       firstName
@@ -28,11 +33,11 @@ export const postCardFragment = gql`
   }
 `;
 
-const PostCard = ({ post, noun }) => {
-  // If this post isn't anonymous, show first name. Otherwise, state or fallback to "A Doer".
-  const displayName = post.user
-    ? post.user.firstName
-    : post.location || 'A Doer';
+const PostCard = ({ post }) => {
+  // For anonymous posts, label with state if available. Otherwise, the user's first name.
+  const authorLabel = post.actionDetails.anonymous
+    ? post.location || 'Anonymous'
+    : post.user.firstName || 'A Doer';
 
   const reactionElement = isAuthenticated() ? (
     <ReactionButton post={post} />
@@ -49,7 +54,7 @@ const PostCard = ({ post, noun }) => {
       );
       break;
     case 'photo':
-      media = <LazyImage alt={`${displayName}'s photo`} src={post.url} />;
+      media = <LazyImage alt={`${authorLabel}'s photo`} src={post.url} />;
       break;
 
     default:
@@ -65,7 +70,7 @@ const PostCard = ({ post, noun }) => {
         className="padded margin-bottom-none"
       >
         <h4>
-          {displayName}
+          {authorLabel}
           <PostBadge status={post.status} tags={post.tags} />
         </h4>
         {post.quantity ? (

--- a/resources/assets/components/utilities/PostCard/PostCard.js
+++ b/resources/assets/components/utilities/PostCard/PostCard.js
@@ -1,13 +1,12 @@
 import React from 'react';
 import gql from 'graphql-tag';
-import PropTypes from 'prop-types';
 import { propType } from 'graphql-anywhere';
 
 import PostBadge from './PostBadge';
 import { BaseFigure } from '../../Figure';
 import LazyImage from '../../utilities/LazyImage';
 import ReactionButton from '../ReactionButton/ReactionButton';
-import { isAuthenticated, pluralize } from '../../../helpers';
+import { isAuthenticated } from '../../../helpers';
 
 import './post.scss';
 
@@ -25,6 +24,7 @@ export const postCardFragment = gql`
 
     actionDetails {
       anonymous
+      noun
     }
 
     user {
@@ -75,8 +75,7 @@ const PostCard = ({ post }) => {
         </h4>
         {post.quantity ? (
           <p className="footnote">
-            {post.quantity}{' '}
-            {pluralize(post.quantity, noun.singular, noun.plural)}
+            {post.quantity} {post.actionDetails.noun}
           </p>
         ) : null}
         {post.type !== 'text' && post.text ? <p>{post.text}</p> : null}
@@ -87,17 +86,6 @@ const PostCard = ({ post }) => {
 
 PostCard.propTypes = {
   post: propType(postCardFragment).isRequired,
-  noun: PropTypes.shape({
-    singular: PropTypes.string,
-    plural: PropTypes.string,
-  }),
-};
-
-PostCard.defaultProps = {
-  noun: {
-    singular: 'item',
-    plural: 'items',
-  },
 };
 
 export default PostCard;

--- a/resources/assets/components/utilities/PostCard/PostCard.js
+++ b/resources/assets/components/utilities/PostCard/PostCard.js
@@ -35,7 +35,8 @@ export const postCardFragment = gql`
 `;
 
 const PostCard = ({ post }) => {
-  // For anonymous posts, label with state if available. Otherwise, the user's first name.
+  // If this post is for an anonymous action, label it with the state (if available).
+  // For non-anonymous posts (default), label with the user's first name.
   const authorLabel = post.actionDetails.anonymous
     ? get(post, 'location', 'Anonymous')
     : get(post, 'user.firstName', 'A Doer');

--- a/resources/assets/components/utilities/PostCard/PostCard.js
+++ b/resources/assets/components/utilities/PostCard/PostCard.js
@@ -44,9 +44,9 @@ const PostCard = ({ post }) => {
   const reactionElement = isAuthenticated() ? (
     <ReactionButton post={post} />
   ) : null;
-  let media = null;
 
   // Render the appropriate media for this post:
+  let media = null;
   switch (post.type) {
     case 'text':
       media = (


### PR DESCRIPTION
### What does this PR do?
This pull request makes it easier to tell when a post is for an "anonymous" action (since previously, post owners would still see their name & staffers would see for all posts). It also sources `noun` from Rogue actions, since that's the source of truth!

For review, here are some posts I've made. From left to right – anonymous without a location (uploaded my local, so no Fastly magic), anonymous with location & a photo post with quantity:

<img width="956" alt="screen shot 2019-03-01 at 4 45 42 pm" src="https://user-images.githubusercontent.com/583202/53668291-7a113680-3c41-11e9-9e5c-1c4e3d75646c.png">


### Any background context you want to provide?
We don't yet expose a convenient way to pluralize the noun, so it's possible to end up with `1 things`. We can make a card to revisit this (and return a properly pluralized version of this on the `Post`).

### What are the relevant tickets/cards?

Refs [Pivotal ID #164214415](https://www.pivotaltracker.com/story/show/164214415)

### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.
* [ ] Added screenshot to PR description of related front-end updates on **small** screens.
* [ ] Added screenshot to PR description of related front-end updates on **medium** screens.
* [ ] Added screenshot to PR description of related front-end updates on **large** screens.