### PR TITLE
Require Action ID Field in Contentful for Actions

### DIFF
--- a/contentful/content-types/photoSubmissionAction.js
+++ b/contentful/content-types/photoSubmissionAction.js
@@ -19,7 +19,7 @@ module.exports = function(migration) {
     .createField('actionId')
     .name('Action ID')
     .type('Integer')
-    .required(false)
+    .required(true)
     .localized(false)
     .validations([
       {

--- a/contentful/content-types/shareAction.js
+++ b/contentful/content-types/shareAction.js
@@ -21,7 +21,7 @@ module.exports = function(migration) {
     .createField('actionId')
     .name('Action ID')
     .type('Integer')
-    .required(false)
+    .required(true)
     .localized(false)
     .validations([
       {

--- a/contentful/content-types/textSubmissionAction.js
+++ b/contentful/content-types/textSubmissionAction.js
@@ -19,7 +19,7 @@ module.exports = function(migration) {
     .createField('actionId')
     .name('Action ID')
     .type('Integer')
-    .required(false)
+    .required(true)
     .localized(false)
     .validations([
       {


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR requires the `actionId` field in the Contentful migration scripts for our Action content types.

### Any background context you want to provide?
The action ID is now live on our Contentful `master` environment. Time to make this field required!

This will mean that older entries which are currently valid without their Action ID, will need to have it added to republish if ever edited, but I think we're fine with this since editors have been trained to - and can find the respective Action IDs in Rogue!

### What are the relevant tickets/cards?

Refs [Pivotal ID #163728937](https://www.pivotaltracker.com/story/show/163728937)