### PR TITLE
Text Submission Action Updates

### DIFF
--- a/app/Entities/TextSubmissionAction.php
+++ b/app/Entities/TextSubmissionAction.php
@@ -22,6 +22,8 @@ class TextSubmissionAction extends Entity implements JsonSerializable
                 'textFieldLabel' => $this->textFieldLabel,
                 'textFieldPlaceholder' => $this->textFieldPlaceholder,
                 'buttonText' => $this->buttonText,
+                'informationTitle' => $this->informationTitle,
+                'informationContent' => $this->informationContent,
                 'affirmationContent' => $this->affirmationContent ?: null,
                 'additionalContent' => $this->additionalContent,
             ],

--- a/contentful/content-types/textSubmissionAction.js
+++ b/contentful/content-types/textSubmissionAction.js
@@ -80,6 +80,26 @@ module.exports = function(migration) {
     .omitted(false);
 
   textSubmissionAction
+    .createField('informationTitle')
+    .name('Information Title')
+    .type('Symbol')
+    .localized(true)
+    .required(false)
+    .validations([])
+    .disabled(false)
+    .omitted(false);
+
+  textSubmissionAction
+    .createField('informationContent')
+    .name('Information Content')
+    .type('Text')
+    .localized(true)
+    .required(false)
+    .validations([])
+    .disabled(false)
+    .omitted(false);
+
+  textSubmissionAction
     .createField('affirmationContent')
     .name('Affirmation Content')
     .type('Text')
@@ -120,6 +140,16 @@ module.exports = function(migration) {
         'The placeholder for the "text" field, providing an example of what a text submission should look like.',
     },
   );
+
+  textSubmissionAction.changeEditorInterface('informationTitle', 'singleLine', {
+    helpText:
+      'Title to display for the information block (defaults to "More Info").',
+  });
+
+  textSubmissionAction.changeEditorInterface('informationContent', 'markdown', {
+    helpText:
+      'Content to display for the information block (this block will be hidden by default unless content is provided).',
+  });
 
   textSubmissionAction.changeEditorInterface('buttonText', 'singleLine', {});
 

--- a/resources/assets/components/ContentfulEntry/renderers.js
+++ b/resources/assets/components/ContentfulEntry/renderers.js
@@ -81,6 +81,7 @@ export function renderLinkAction(step) {
  */
 export function renderTextSubmissionAction(data) {
   const contentfulId = data.id;
+  const fields = withoutNulls(data.fields);
 
   return (
     <div
@@ -91,7 +92,7 @@ export function renderTextSubmissionAction(data) {
         name="text_submission_action-top"
         waypointData={{ contentfulId }}
       />
-      <TextSubmissionActionContainer id={contentfulId} {...data.fields} />
+      <TextSubmissionActionContainer id={contentfulId} {...fields} />
       <SubmissionGalleryBlockContainer type="text" />
       <PuckWaypoint
         name="text_submission_action-bottom"

--- a/resources/assets/components/actions/TextSubmissionAction/TextSubmissionAction.js
+++ b/resources/assets/components/actions/TextSubmissionAction/TextSubmissionAction.js
@@ -106,31 +106,25 @@ class TextSubmissionAction extends React.Component {
 
             <form onSubmit={this.handleSubmit}>
               <div className="padded">
-                <div className="form-item">
-                  <label
-                    className={classnames('field-label', {
-                      'has-error': has(errors, 'text'),
-                    })}
-                    htmlFor="text"
-                  >
-                    {this.props.textFieldLabel}
-                  </label>
-                  <input
-                    className={classnames('text-field', {
-                      'has-error shake': has(errors, 'text'),
-                    })}
-                    type="text"
-                    id="text"
-                    name="text"
-                    placeholder={this.props.textFieldPlaceholder}
-                    value={this.state.textValue}
-                    onChange={this.handleChange}
-                  />
-                </div>
-                <p className="footnote">
-                  Your submission will be reviewed by a DoSomething.org staffer
-                  and added to our public gallery.
-                </p>
+                <label
+                  className={classnames('field-label', {
+                    'has-error': has(errors, 'text'),
+                  })}
+                  htmlFor="text"
+                >
+                  {this.props.textFieldLabel}
+                </label>
+                <textarea
+                  className={classnames('text-field text-submission-texarea', {
+                    'has-error shake': has(errors, 'text'),
+                  })}
+                  id="text"
+                  name="text"
+                  placeholder={this.props.textFieldPlaceholder}
+                  value={this.state.textValue}
+                  onChange={this.handleChange}
+                />
+                <p className="footnote">500 character limit</p>
               </div>
               <Button
                 type="submit"
@@ -139,6 +133,10 @@ class TextSubmissionAction extends React.Component {
               >
                 {this.props.buttonText}
               </Button>
+              <p className="footnote padding-horizontal-md padding-bottom-md">
+                Your submission will be reviewed by a DoSomething.org staffer
+                and added to our public gallery.
+              </p>
             </form>
           </Card>
         </div>

--- a/resources/assets/components/actions/TextSubmissionAction/TextSubmissionAction.js
+++ b/resources/assets/components/actions/TextSubmissionAction/TextSubmissionAction.js
@@ -143,6 +143,19 @@ class TextSubmissionAction extends React.Component {
           </Card>
         </div>
 
+        {this.props.informationContent ? (
+          <div className="text-submission-information margin-top-lg">
+            <Card
+              className="bordered rounded"
+              title={this.props.informationTitle}
+            >
+              <TextContent className="padding-md">
+                {this.props.informationContent}
+              </TextContent>
+            </Card>
+          </div>
+        ) : null}
+
         {this.state.showModal ? (
           <Modal onClose={() => this.setState({ showModal: false })}>
             <Card className="bordered rounded" title="We got your message!">
@@ -169,6 +182,8 @@ TextSubmissionAction.propTypes = {
   campaignContentfulId: PropTypes.string.isRequired,
   className: PropTypes.string,
   id: PropTypes.string.isRequired,
+  informationTitle: PropTypes.string,
+  informationContent: PropTypes.string,
   initPostSubmissionItem: PropTypes.func.isRequired,
   resetPostSubmissionItem: PropTypes.func.isRequired,
   storeCampaignPost: PropTypes.func.isRequired,
@@ -188,6 +203,8 @@ TextSubmissionAction.defaultProps = {
     "Thanks for joining the movement, and submitting your message! After we review your submission, we'll add it to the public gallery alongside submissions from all the other members taking action in this campaign.",
   buttonText: 'Submit',
   className: null,
+  informationContent: null,
+  informationTitle: 'More Info',
   textFieldLabel: 'I did something by...',
   textFieldPlaceholder: 'Indicate what you did to make a difference.',
   title: 'Submit your text',

--- a/resources/assets/components/actions/TextSubmissionAction/text-submission-action.scss
+++ b/resources/assets/components/actions/TextSubmissionAction/text-submission-action.scss
@@ -4,4 +4,8 @@
   .field-label {
     height: auto;
   }
+
+  .text-submission-texarea {
+    height: 138px;
+  }
 }

--- a/resources/assets/components/actions/TextSubmissionAction/text-submission-action.scss
+++ b/resources/assets/components/actions/TextSubmissionAction/text-submission-action.scss
@@ -1,11 +1,6 @@
 @import '../../../scss/next-toolbox.scss';
 
 .text-submission-action {
-  @include media($large) {
-    padding-right: $half-spacing;
-    width: 66.6666666666666%;
-  }
-
   .field-label {
     height: auto;
   }

--- a/resources/assets/components/pages/CampaignPage/CampaignPageContent.js
+++ b/resources/assets/components/pages/CampaignPage/CampaignPageContent.js
@@ -31,7 +31,6 @@ const CampaignPageContent = props => {
     if (
       [
         'photoSubmissionAction',
-        'textSubmissionAction',
         'gallery',
         'imagesBlock',
         'socialDriveAction',


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR updates the `TextSubmissionAction` in a couple of ways:
- new `informationTitle` and `informationContent` fields for displaying an optional 'Information block'
- updated footnotes. replacing current footnote with `500 character limit` messaging, and moving the 'disclaimer' footnote to the bottom of the action.

### Any background context you want to provide?
This is in the spirit of the new design for Text actions, specifically towards supporting the new 'Story' mocks, and generally to support the increased character limit, and parity with the Photo and Petition Action's information blocks.

I did not add the styling to have the information block appear to the side of the action on larger screens in the spirit of the Petition block as well, pending the Story Page.

❓ I did want to confirm the approach here to follow up on our [Slack discussion](https://dosomething.slack.com/archives/C2BPA7M8F/p1551715898025000?thread_ts=1551711619.018700&cid=C2BPA7M8F):
Actions have a disclaimer footnote within the action block, which will hopefully soon be dynamic based on the Action details. They'll additionally have the optional editor-editable Information Block for added context. 
Am I understanding this correctly? And do we want to implement this approach for Photo and Petition actions?

**Before**
![image](https://user-images.githubusercontent.com/12417657/53765872-3d427b00-3e9f-11e9-8693-2881037c2b44.png)


**After**
![image](https://user-images.githubusercontent.com/12417657/53765791-02d8de00-3e9f-11e9-8e89-6fdb8029c155.png)

**With Information Content**
![image](https://user-images.githubusercontent.com/12417657/53766325-86df9580-3ea0-11e9-817e-01b8b83419fb.png)




### What are the relevant tickets/cards?

Refs [Pivotal ID #164287413](https://www.pivotaltracker.com/story/show/164287413)
[Mocks](https://share.goabstract.com/e49949de-48f3-4772-8523-91c3fce110f1)
### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.
* [ ] Added screenshot to PR description of related front-end updates on **small** screens.
* [ ] Added screenshot to PR description of related front-end updates on **medium** screens.
* [x] Added screenshot to PR description of related front-end updates on **large** screens.
