### PR TITLE
Add "Post Gallery" content type & block.

### DIFF
--- a/app/Entities/Entity.php
+++ b/app/Entities/Entity.php
@@ -66,6 +66,8 @@ class Entity implements ArrayAccess, JsonSerializable
                 return new TruncatedCampaign($block->entry);
             case 'campaignUpdate':
                 return new CampaignUpdate($block->entry);
+            case 'postGallery':
+                return new PostGallery($block->entry);
             case 'companyPage':
                 return new CompanyPage($block->entry);
             case 'contentBlock':

--- a/app/Entities/PostGallery.php
+++ b/app/Entities/PostGallery.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Entities;
+
+use JsonSerializable;
+
+class PostGallery extends Entity implements JsonSerializable
+{
+    /**
+     * Convert the object into something JSON serializable.
+     *
+     * @return array
+     */
+    public function jsonSerialize()
+    {
+        return [
+            'id' => $this->entry->getId(),
+            'type' => $this->getContentType(),
+            'fields' => [
+                'internalTitle' => $this->internalTitle,
+                'actionIds' => $this->actionIds,
+            ],
+        ];
+    }
+}

--- a/contentful/content-types/postGallery.js
+++ b/contentful/content-types/postGallery.js
@@ -1,0 +1,40 @@
+module.exports = function(migration) {
+  const postGallery = migration
+    .createContentType('postGallery')
+    .name('Post Gallery')
+    .description('A gallery of user-submitted posts.')
+    .displayField('internalTitle');
+
+  postGallery
+    .createField('internalTitle')
+    .name('Internal Title')
+    .type('Symbol')
+    .localized(false)
+    .required(true);
+
+  postGallery
+    .createField('actionIds')
+    .name('Action IDs')
+    .type('Array')
+    .items({
+      type: 'Symbol',
+      validations: [
+        {
+          regexp: {
+            pattern: '[0-9]+',
+            flags: null,
+          },
+          message: 'This must be a numeric Action ID.',
+        },
+      ],
+    })
+    .localized(false)
+    .required(true);
+
+  postGallery.changeEditorInterface('internalTitle', 'singleLine', {});
+
+  postGallery.changeEditorInterface('actionIds', 'listInput', {
+    helpText: `A comma-separated list of one or more Action IDs to display in this gallery. Action IDs
+    can be found in Rogue: https://dosome.click/nyshrf`,
+  });
+};

--- a/resources/assets/components/ContentfulEntry/ContentfulEntry.js
+++ b/resources/assets/components/ContentfulEntry/ContentfulEntry.js
@@ -15,6 +15,7 @@ import SectionBlock from '../blocks/SectionBlock/SectionBlock';
 import { parseContentfulType, report, withoutNulls } from '../../helpers';
 import CallToActionContainer from '../CallToAction/CallToActionContainer';
 import LandingPageContainer from '../pages/LandingPage/LandingPageContainer';
+import PostGalleryBlockQuery from '../blocks/PostGalleryBlock/PostGalleryBlockQuery';
 import SocialDriveActionContainer from '../actions/SocialDriveAction/SocialDriveActionContainer';
 import SixpackExperimentContainer from '../utilities/SixpackExperiment/SixpackExperimentContainer';
 import CampaignGalleryBlockContainer from '../blocks/CampaignGalleryBlock/CampaignGalleryBlockContainer';
@@ -94,6 +95,13 @@ class ContentfulEntry extends React.Component<Props, State> {
         return (
           <div className="margin-horizontal-md">
             <CampaignGalleryBlockContainer />
+          </div>
+        );
+
+      case 'postGallery':
+        return (
+          <div className="margin-horizontal-md">
+            <PostGalleryBlockQuery {...json.fields} />
           </div>
         );
 

--- a/resources/assets/components/blocks/PostGalleryBlock/PostGalleryBlockQuery.js
+++ b/resources/assets/components/blocks/PostGalleryBlock/PostGalleryBlockQuery.js
@@ -10,7 +10,7 @@ import { reactionButtonFragment } from '../../utilities/ReactionButton/ReactionB
 /**
  * The GraphQL query to load data for this component.
  */
-const CAMPAIGN_GALLERY_QUERY = gql`
+const POST_GALLERY_QUERY = gql`
   query PostGalleryQuery($actionIds: [String], $count: Int, $page: Int) {
     posts(actionIds: $actionIds, count: $count, page: $page) {
       ...PostCard
@@ -27,7 +27,7 @@ const CAMPAIGN_GALLERY_QUERY = gql`
  */
 const PostGalleryBlockQuery = ({ actionIds }) => (
   <PaginatedQuery
-    query={CAMPAIGN_GALLERY_QUERY}
+    query={POST_GALLERY_QUERY}
     queryName="posts"
     variables={{ actionIds }}
     count={9}

--- a/resources/assets/components/blocks/PostGalleryBlock/PostGalleryBlockQuery.js
+++ b/resources/assets/components/blocks/PostGalleryBlock/PostGalleryBlockQuery.js
@@ -1,0 +1,54 @@
+import React from 'react';
+import gql from 'graphql-tag';
+import PropTypes from 'prop-types';
+
+import PaginatedQuery from '../../PaginatedQuery';
+import PostGallery from '../../utilities/PostGallery/PostGallery';
+import { postCardFragment } from '../../utilities/PostCard/PostCard';
+import { reactionButtonFragment } from '../../utilities/ReactionButton/ReactionButton';
+
+/**
+ * The GraphQL query to load data for this component.
+ */
+const CAMPAIGN_GALLERY_QUERY = gql`
+  query PostGalleryQuery($actionIds: [String], $count: Int, $page: Int) {
+    posts(actionIds: $actionIds, count: $count, page: $page) {
+      ...PostCard
+      ...ReactionButton
+    }
+  }
+
+  ${postCardFragment}
+  ${reactionButtonFragment}
+`;
+
+/**
+ * Fetch results via GraphQL using a query component.
+ */
+const PostGalleryBlockQuery = ({ actionIds }) => (
+  <PaginatedQuery
+    query={CAMPAIGN_GALLERY_QUERY}
+    queryName="posts"
+    variables={{ actionIds }}
+    count={9}
+  >
+    {({ result, fetching, fetchMore }) => (
+      <PostGallery
+        posts={result}
+        loading={fetching}
+        loadMorePosts={fetchMore}
+      />
+    )}
+  </PaginatedQuery>
+);
+
+PostGalleryBlockQuery.propTypes = {
+  actionIds: PropTypes.arrayOf(PropTypes.string),
+};
+
+PostGalleryBlockQuery.defaultProps = {
+  actionIds: [],
+};
+
+// Export the GraphQL query component.
+export default PostGalleryBlockQuery;

--- a/resources/assets/components/utilities/PostCard/PostCard.js
+++ b/resources/assets/components/utilities/PostCard/PostCard.js
@@ -51,7 +51,7 @@ const PostCard = ({ post }) => {
     case 'text':
       media = (
         <div className="chat-bubble -post-bubble margin-bottom-none rounded-top">
-          <p className="font-italic">{post.text}</p>
+          <p className="font-italic word-break">{post.text}</p>
         </div>
       );
       break;

--- a/resources/assets/scss/base.scss
+++ b/resources/assets/scss/base.scss
@@ -215,6 +215,10 @@ p {
   text-transform: uppercase;
 }
 
+.word-break {
+  word-break: break-word;
+}
+
 // TODO: Remove this.
 .padded {
   padding: $half-spacing;


### PR DESCRIPTION
### What does this PR do?

This pull request adds a **Post Gallery** content type that allows editors to create a gallery for one or more actions. Notably, this will be able to be used _anywhere_, not just on a campaign page!

📄 Adds dead-simple "Post Gallery" content type, with "Internal Title" and "Action IDs" fields. 4bfdd09

🖼 Adds support to `ContentfulEntry` to render this new "post gallery" content type. 4d9610d

🔡 Fixes an issue I'd seen where [text could overflow and break the gallery](https://user-images.githubusercontent.com/583202/53821284-72041000-3f3b-11e9-8321-a02e0aa75946.png). eb8421c

<img width="1334" alt="screen shot 2019-03-05 at 11 44 04 am" src="https://user-images.githubusercontent.com/583202/53821546-ff476480-3f3b-11e9-9fd2-0b68b08b5d06.png">

### Any background context you want to provide?

I haven't yet added this to the list of "allowed blocks" anywhere, but it's _ready_!

### What are the relevant tickets/cards?

Refs [Pivotal ID #164214415](https://www.pivotaltracker.com/story/show/164214415).

### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.
* [ ] Added screenshot to PR description of related front-end updates on **small** screens.
* [ ] Added screenshot to PR description of related front-end updates on **medium** screens.
* [ ] Added screenshot to PR description of related front-end updates on **large** screens.