### PR TITLE
Campaign Independent Text Submission Action Posts

### DIFF
--- a/resources/assets/components/actions/TextSubmissionAction/TextSubmissionAction.js
+++ b/resources/assets/components/actions/TextSubmissionAction/TextSubmissionAction.js
@@ -80,9 +80,11 @@ class TextSubmissionAction extends React.Component {
 
     // Send request to store the text submission post.
     // (Use campaign ID independant post method if actionId is provided).
-    this.props.actionId
-      ? this.props.storePost(data)
-      : this.props.storeCampaignPost(this.props.campaignId, data);
+    if (this.props.actionId) {
+      this.props.storePost(data);
+    } else {
+      this.props.storeCampaignPost(this.props.campaignId, data);
+    }
   };
 
   render() {

--- a/resources/assets/components/actions/TextSubmissionAction/TextSubmissionAction.js
+++ b/resources/assets/components/actions/TextSubmissionAction/TextSubmissionAction.js
@@ -69,15 +69,20 @@ class TextSubmissionAction extends React.Component {
       ...mapValues(this.fields, value => this.state[`${value}Value`]),
     });
 
-    // Send request to store the campaign text submission post.
-    this.props.storeCampaignPost(this.props.campaignId, {
+    const data = {
       action,
       actionId: this.props.actionId,
       body: formatFormFields(formFields),
       id: this.props.id,
       campaignContentfulId: this.props.campaignContentfulId,
       type,
-    });
+    };
+
+    // Send request to store the text submission post.
+    // (Use campaign ID independant post method if actionId is provided).
+    this.props.actionId
+      ? this.props.storePost(data)
+      : this.props.storeCampaignPost(this.props.campaignId, data);
   };
 
   render() {
@@ -166,13 +171,14 @@ TextSubmissionAction.propTypes = {
     action: PropTypes.string,
   }),
   buttonText: PropTypes.string,
-  campaignId: PropTypes.string.isRequired,
-  campaignContentfulId: PropTypes.string.isRequired,
+  campaignId: PropTypes.string,
+  campaignContentfulId: PropTypes.string,
   className: PropTypes.string,
   id: PropTypes.string.isRequired,
   initPostSubmissionItem: PropTypes.func.isRequired,
   resetPostSubmissionItem: PropTypes.func.isRequired,
   storeCampaignPost: PropTypes.func.isRequired,
+  storePost: PropTypes.func.isRequired,
   submissions: PropTypes.shape({
     isPending: PropTypes.bool,
     items: PropTypes.object,
@@ -188,6 +194,8 @@ TextSubmissionAction.defaultProps = {
   affirmationContent:
     "Thanks for joining the movement, and submitting your message! After we review your submission, we'll add it to the public gallery alongside submissions from all the other members taking action in this campaign.",
   buttonText: 'Submit',
+  campaignId: null,
+  campaignContentfulId: null,
   className: null,
   textFieldLabel: 'I did something by...',
   textFieldPlaceholder: 'Indicate what you did to make a difference.',

--- a/resources/assets/components/actions/TextSubmissionAction/TextSubmissionActionContainer.js
+++ b/resources/assets/components/actions/TextSubmissionAction/TextSubmissionActionContainer.js
@@ -5,6 +5,7 @@ import {
   initPostSubmissionItem,
   resetPostSubmissionItem,
   storeCampaignPost,
+  storePost,
 } from '../../../actions/post';
 
 /**
@@ -24,6 +25,7 @@ const actionCreators = {
   initPostSubmissionItem,
   resetPostSubmissionItem,
   storeCampaignPost,
+  storePost,
 };
 
 /**

--- a/resources/assets/selectors/campaign.js
+++ b/resources/assets/selectors/campaign.js
@@ -21,7 +21,7 @@ export function getCampaignAdditionalContent(state) {
 export function getCampaignDataForNorthstar(state) {
   const data = {};
 
-  if (state.campaign) {
+  if (get(state, 'campaign.type', null) === 'campaign') {
     data.callToAction = state.campaign.callToAction;
     data.coverImage = contentfulImageUrl(
       state.campaign.coverImage.url,


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR sets the `TextSubmissionAction` component free of its Campaign parental clutches, allowing it to be embedded anywhere, attempting to use its Action ID with our Campaign independent posting method to soar toward its glorious Rogue destiny 👼 

(https://github.com/DoSomething/phoenix-next/pull/1292/commits/80624636ac681ab957faa99ddc689bffe2ed75c0 snuck a little update in to ensure our Lazy Auth™ will work on actions outside of a campaign. The [`getCampaignDataForNorthstar`](https://github.com/DoSomething/phoenix-next/blob/80624636ac681ab957faa99ddc689bffe2ed75c0/resources/assets/selectors/campaign.js#L21) was always assuming a `campaign` was within `state` since we [`default`](https://github.com/DoSomething/phoenix-next/blob/80624636ac681ab957faa99ddc689bffe2ed75c0/resources/assets/store/initialState.js#L12)that property to an empty object. I copied over the logic used in the [`analytics` middleware](https://github.com/DoSomething/phoenix-next/blob/80624636ac681ab957faa99ddc689bffe2ed75c0/resources/assets/middleware/analytics.js#L15) and it now works 👌).

### Any background context you want to provide?
Testing this with the #1289 Block Route was a dream! This should work across the board, and will fall back to the Campaign ID for legacy actions which don't have that field filled out.


### What are the relevant tickets/cards?

Refs [Pivotal ID #163728507](https://www.pivotaltracker.com/story/show/163728507)


### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.
