### PR TITLE
Add 'duo' modifier to grid gallery.

### DIFF
--- a/resources/assets/scss/gallery-grid.scss
+++ b/resources/assets/scss/gallery-grid.scss
@@ -1,7 +1,8 @@
 @import 'next-toolbox';
 
 .gallery-grid-quartet,
-.gallery-grid-triad {
+.gallery-grid-triad,
+.gallery-grid-duo {
   display: grid;
   grid-template-columns: 1fr;
   grid-row-gap: $half-spacing;
@@ -42,6 +43,18 @@
 
   @include media($larger) {
     grid-template-columns: repeat(3, 1fr);
+    grid-column-gap: $base-spacing;
+    grid-row-gap: $base-spacing;
+  }
+}
+
+.gallery-grid-duo {
+  @include media($large) {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  @include media($larger) {
+    grid-template-columns: repeat(2, 1fr);
     grid-column-gap: $base-spacing;
     grid-row-gap: $base-spacing;
   }


### PR DESCRIPTION
### What does this PR do?

This pull request implements the `gallery-grid-duo` modifier so image galleries work as expected.

Here's how things look now on [small phones](https://user-images.githubusercontent.com/583202/53982690-8be05700-40e3-11e9-9d33-212c96826184.png), [big phones](https://user-images.githubusercontent.com/583202/53982687-88e56680-40e3-11e9-943c-9d0188ecdf70.png), [tablets](https://user-images.githubusercontent.com/583202/53982680-8256ef00-40e3-11e9-94d0-3d1183e86436.png), and **desktop**:

![screen shot 2019-03-07 at 2 17 56 pm](https://user-images.githubusercontent.com/583202/53982802-d06bf280-40e3-11e9-8b22-8e2b9d575618.png)

### Any background context you want to provide?

I hadn't realized this same `Gallery` component is used here as well. Should've tested more thoroughly!

### What are the relevant tickets/cards?

Refs [Pivotal ID #164472105](https://www.pivotaltracker.com/story/show/164472105).

### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.
* [x] Added screenshot to PR description of related front-end updates on **small** screens.
* [x] Added screenshot to PR description of related front-end updates on **medium** screens.
* [x] Added screenshot to PR description of related front-end updates on **large** screens.