### PR TITLE
Petition auth signature

### DIFF
--- a/resources/assets/components/actions/PetitionSubmissioncAction/PetitionSubmissionAction.js
+++ b/resources/assets/components/actions/PetitionSubmissioncAction/PetitionSubmissionAction.js
@@ -89,8 +89,8 @@ class PetitionSubmissionAction extends React.Component {
 
     const formErrors = getFieldErrors(formResponse);
 
-    const FIRST_NAME_QUERY = gql`
-      query AccountQuery($userId: String!) {
+    const SIGNATURE_QUERY = gql`
+      query SignatureQuery($userId: String!) {
         user(id: $userId) {
           firstName
         }
@@ -126,7 +126,7 @@ class PetitionSubmissionAction extends React.Component {
 
               {userId ? (
                 <Query
-                  query={FIRST_NAME_QUERY}
+                  query={SIGNATURE_QUERY}
                   queryName="user"
                   variables={{ userId }}
                 >

--- a/resources/assets/components/actions/PetitionSubmissioncAction/PetitionSubmissionAction.js
+++ b/resources/assets/components/actions/PetitionSubmissioncAction/PetitionSubmissionAction.js
@@ -116,6 +116,7 @@ class PetitionSubmissionAction extends React.Component {
                   placeholder={textFieldPlaceholder}
                   value={this.state.textValue}
                   onChange={this.handleChange}
+                  disabled={this.state.showAffirmation}
                 />
                 <p className="footnote">500 character limit</p>
               </div>

--- a/resources/assets/components/actions/PetitionSubmissioncAction/PetitionSubmissionAction.js
+++ b/resources/assets/components/actions/PetitionSubmissioncAction/PetitionSubmissionAction.js
@@ -1,6 +1,6 @@
 import React from 'react';
-import { get, has } from 'lodash';
 import gql from 'graphql-tag';
+import { get, has } from 'lodash';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import { Query } from 'react-apollo';

--- a/resources/assets/components/actions/PetitionSubmissioncAction/PetitionSubmissionAction.js
+++ b/resources/assets/components/actions/PetitionSubmissioncAction/PetitionSubmissionAction.js
@@ -1,7 +1,9 @@
 import React from 'react';
-import { has } from 'lodash';
+import { get, has } from 'lodash';
+import gql from 'graphql-tag';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
+import { Query } from 'react-apollo';
 
 import Card from '../../utilities/Card/Card';
 import Button from '../../utilities/Button/Button';
@@ -75,6 +77,7 @@ class PetitionSubmissionAction extends React.Component {
       submissions,
       title,
       textFieldPlaceholder,
+      userId,
     } = this.props;
 
     const submissionItem = submissions.items[id];
@@ -82,6 +85,14 @@ class PetitionSubmissionAction extends React.Component {
     const formResponse = has(submissionItem, 'status') ? submissionItem : null;
 
     const formErrors = getFieldErrors(formResponse);
+
+    const FIRST_NAME_QUERY = gql`
+      query AccountQuery($userId: String!) {
+        user(id: $userId) {
+          firstName
+        }
+      }
+    `;
 
     return (
       <React.Fragment>
@@ -108,6 +119,36 @@ class PetitionSubmissionAction extends React.Component {
                 />
                 <p className="footnote">500 character limit</p>
               </div>
+
+              {userId ? (
+                <Query
+                  query={FIRST_NAME_QUERY}
+                  queryName="user"
+                  variables={{ userId }}
+                >
+                  {({ loading, data }) => {
+                    let signature = get(data, 'user.firstName', 'A Doer');
+
+                    if (loading) {
+                      signature = 'Loading name...';
+                    }
+
+                    return (
+                      <div className="padded">
+                        <p className="petition-signature-label padding-bottom-sm">
+                          Signed,
+                        </p>
+                        <input
+                          className="text-field petition-signature"
+                          type="text"
+                          disabled
+                          value={signature}
+                        />
+                      </div>
+                    );
+                  }}
+                </Query>
+              ) : null}
 
               <Button
                 type="submit"
@@ -148,6 +189,7 @@ PetitionSubmissionAction.propTypes = {
   }).isRequired,
   textFieldPlaceholder: PropTypes.string,
   title: PropTypes.string,
+  userId: PropTypes.string,
 };
 
 PetitionSubmissionAction.defaultProps = {
@@ -157,6 +199,7 @@ PetitionSubmissionAction.defaultProps = {
   informationContent:
     'Your first name and email will be added to our petition. We do not collect any additional information.',
   informationTitle: 'More Info',
+  userId: null,
 };
 
 export default PetitionSubmissionAction;

--- a/resources/assets/components/actions/PetitionSubmissioncAction/PetitionSubmissionAction.js
+++ b/resources/assets/components/actions/PetitionSubmissioncAction/PetitionSubmissionAction.js
@@ -22,7 +22,10 @@ class PetitionSubmissionAction extends React.Component {
       textValue: '',
     };
 
-    this.props.initPostSubmissionItem(this.props.id);
+    // Initialize post submission item in store if it doesn't yet exist.
+    if (!props.submissions.items[props.id]) {
+      this.props.initPostSubmissionItem(this.props.id);
+    }
   }
 
   static getDerivedStateFromProps(nextProps) {

--- a/resources/assets/components/actions/PetitionSubmissioncAction/PetitionSubmissionActionContainer.js
+++ b/resources/assets/components/actions/PetitionSubmissioncAction/PetitionSubmissionActionContainer.js
@@ -1,17 +1,19 @@
 import { connect } from 'react-redux';
 
+import { getUserId } from '../../../selectors/user';
+import PetitionSubmissionAction from './PetitionSubmissionAction';
 import {
   initPostSubmissionItem,
   resetPostSubmissionItem,
   storePost,
 } from '../../../actions/post';
-import PetitionSubmissionAction from './PetitionSubmissionAction';
 
 /**
  * Provide state from the Redux store as props for this component.
  */
 const mapStateToProps = state => ({
   submissions: state.postSubmissions,
+  userId: getUserId(state),
 });
 
 /**

--- a/resources/assets/components/actions/PetitionSubmissioncAction/petition-submission-action.scss
+++ b/resources/assets/components/actions/PetitionSubmissioncAction/petition-submission-action.scss
@@ -9,4 +9,9 @@
     color: $success-color;
     font-size: $font-medium;
   }
+
+  .petition-signature-label,
+  .petition-signature {
+    font-size: 21px;
+  }
 }

--- a/resources/assets/components/actions/TextSubmissionAction/TextSubmissionAction.js
+++ b/resources/assets/components/actions/TextSubmissionAction/TextSubmissionAction.js
@@ -22,7 +22,10 @@ class TextSubmissionAction extends React.Component {
       textValue: '',
     };
 
-    this.props.initPostSubmissionItem(this.props.id);
+    // Initialize post submission item in store if it doesn't yet exist.
+    if (!props.submissions.items[props.id]) {
+      this.props.initPostSubmissionItem(this.props.id);
+    }
   }
 
   static getDerivedStateFromProps(nextProps) {

--- a/resources/assets/scss/base.scss
+++ b/resources/assets/scss/base.scss
@@ -252,6 +252,10 @@ p {
   padding-right: $base-spacing;
 }
 
+.padding-bottom-sm {
+  padding-bottom: $half-spacing / 2;
+}
+
 .padding-bottom-md {
   padding-bottom: $half-spacing;
 }


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR adds the authenticated state to the `PetitionSubmissionAction`, displaying the user's signature (first name). https://github.com/DoSomething/phoenix-next/commit/bb58ec95f6f92574d1b37005f6144b4ebb11e935

Also snuck in https://github.com/DoSomething/phoenix-next/commit/4ccd4cd3636b72a2da67e6f4f6326d3c45cd9db1 to disable the `textarea` field on successful submissions as part of the lite post-submission state.

https://github.com/DoSomething/phoenix-next/commit/39081c37c7be51b370cf4f75009817d0970c5187 was interesting. I was seeing that for Lazy Auth'd posts (regular text or petition), once the user autheticates and is redirected, the `pending` state of the submission which is initiated by the queued post action would be overriden with the call to [`initPostSubmissionItem`](https://github.com/DoSomething/phoenix-next/blob/e42812dd73aabfa1a27d20dc3c0a20c343afae48/resources/assets/components/actions/PetitionSubmissioncAction/PetitionSubmissionAction.js#L23) in the component's constructors.
This isn't a very big deal at all, but it did mean that the button wouldn't be in a loading state, which for a slower connection could lead the viewer to attempt to resubmit the post etc.
I added the [conditional](https://github.com/DoSomething/phoenix-next/compare/petition-auth-signature?expand=1#diff-f9ba48856d8e39c6eba8fd1a4ce29d77R26) to ensure  this doesn't happen, but:
❓I actually figure that we can get rid of this call completely, since initiating the post in the store can just happen when the post request is made and the ['pending' reducer functionality](https://github.com/DoSomething/phoenix-next/blob/e42812dd73aabfa1a27d20dc3c0a20c343afae48/resources/assets/reducers/postSubmissions.js#L56-L65) is triggered, and we don't need the post to be in the store until then?

### What are the relevant tickets/cards?

Refs [Pivotal ID #163867938](https://www.pivotaltracker.com/story/show/163867938)

![image](https://user-images.githubusercontent.com/12417657/53918492-15851b80-4035-11e9-8953-1043b8c18054.png)

![image](https://user-images.githubusercontent.com/12417657/53918505-1d44c000-4035-11e9-99da-35e9b6eb15c1.png)


### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.
* [x] Added screenshot to PR description of related front-end updates on **large** screens.
