### PR TITLE
Remove Call to the initPostSubmission Action

### DIFF
--- a/resources/assets/components/actions/PetitionSubmissioncAction/PetitionSubmissionAction.js
+++ b/resources/assets/components/actions/PetitionSubmissioncAction/PetitionSubmissionAction.js
@@ -21,11 +21,6 @@ class PetitionSubmissionAction extends React.Component {
       showAffirmation: false,
       textValue: '',
     };
-
-    // Initialize post submission item in store if it doesn't yet exist.
-    if (!props.submissions.items[props.id]) {
-      this.props.initPostSubmissionItem(this.props.id);
-    }
   }
 
   static getDerivedStateFromProps(nextProps) {
@@ -157,7 +152,7 @@ class PetitionSubmissionAction extends React.Component {
               <Button
                 type="submit"
                 attached
-                loading={submissionItem ? submissionItem.isPending : true}
+                loading={submissionItem && submissionItem.isPending}
                 disabled={this.state.showAffirmation}
               >
                 {buttonText}
@@ -185,7 +180,6 @@ PetitionSubmissionAction.propTypes = {
   id: PropTypes.string.isRequired,
   informationContent: PropTypes.string,
   informationTitle: PropTypes.string,
-  initPostSubmissionItem: PropTypes.func.isRequired,
   resetPostSubmissionItem: PropTypes.func.isRequired,
   storePost: PropTypes.func.isRequired,
   submissions: PropTypes.shape({

--- a/resources/assets/components/actions/PetitionSubmissioncAction/PetitionSubmissionActionContainer.js
+++ b/resources/assets/components/actions/PetitionSubmissioncAction/PetitionSubmissionActionContainer.js
@@ -2,11 +2,7 @@ import { connect } from 'react-redux';
 
 import { getUserId } from '../../../selectors/user';
 import PetitionSubmissionAction from './PetitionSubmissionAction';
-import {
-  initPostSubmissionItem,
-  resetPostSubmissionItem,
-  storePost,
-} from '../../../actions/post';
+import { resetPostSubmissionItem, storePost } from '../../../actions/post';
 
 /**
  * Provide state from the Redux store as props for this component.
@@ -21,7 +17,6 @@ const mapStateToProps = state => ({
  * actions to the Redux store as props for this component.
  */
 const actionCreators = {
-  initPostSubmissionItem,
   resetPostSubmissionItem,
   storePost,
 };

--- a/resources/assets/components/actions/PhotoSubmissionAction/PhotoSubmissionAction.js
+++ b/resources/assets/components/actions/PhotoSubmissionAction/PhotoSubmissionAction.js
@@ -68,8 +68,6 @@ class PhotoSubmissionAction extends React.Component {
       showModal: false,
       whyParticipatedValue: '',
     };
-
-    this.props.initPostSubmissionItem(this.props.id);
   }
 
   /**
@@ -363,7 +361,7 @@ class PhotoSubmissionAction extends React.Component {
 
                 <Button
                   type="submit"
-                  loading={submissionItem ? submissionItem.isPending : true}
+                  loading={submissionItem && submissionItem.isPending}
                   attached
                 >
                   {this.props.buttonText}
@@ -416,7 +414,6 @@ PhotoSubmissionAction.propTypes = {
   id: PropTypes.string.isRequired,
   informationContent: PropTypes.string,
   informationTitle: PropTypes.string,
-  initPostSubmissionItem: PropTypes.func.isRequired,
   quantityFieldLabel: PropTypes.string,
   quantityFieldPlaceholder: PropTypes.string,
   resetPostSubmissionItem: PropTypes.func.isRequired,

--- a/resources/assets/components/actions/PhotoSubmissionAction/PhotoSubmissionAction.test.js
+++ b/resources/assets/components/actions/PhotoSubmissionAction/PhotoSubmissionAction.test.js
@@ -12,7 +12,6 @@ describe('PhotoSubmissionAction component', () => {
     <PhotoSubmissionAction
       campaignId="1234"
       id={id}
-      initPostSubmissionItem={jest.fn()}
       resetPostSubmissionItem={jest.fn()}
       storeCampaignPost={jest.fn()}
       submissions={{

--- a/resources/assets/components/actions/PhotoSubmissionAction/PhotoSubmissionActionContainer.js
+++ b/resources/assets/components/actions/PhotoSubmissionAction/PhotoSubmissionActionContainer.js
@@ -3,7 +3,6 @@ import { connect } from 'react-redux';
 import { getUserId } from '../../../selectors/user';
 import PhotoSubmissionAction from './PhotoSubmissionAction';
 import {
-  initPostSubmissionItem,
   resetPostSubmissionItem,
   storeCampaignPost,
 } from '../../../actions/post';
@@ -16,7 +15,6 @@ const mapStateToProps = state => ({
 });
 
 const actionCreators = {
-  initPostSubmissionItem,
   resetPostSubmissionItem,
   storeCampaignPost,
 };

--- a/resources/assets/components/actions/ReferralSubmissionAction/ReferralSubmissionAction.js
+++ b/resources/assets/components/actions/ReferralSubmissionAction/ReferralSubmissionAction.js
@@ -21,8 +21,6 @@ class ReferralSubmissionAction extends React.Component {
       // @todo allow for multiple sorts of referral fields in addition to email. (e.g. phone number.)
       emailValue: '',
     };
-
-    this.props.initPostSubmissionItem(this.props.id);
   }
 
   static getDerivedStateFromProps(nextProps) {
@@ -155,7 +153,7 @@ class ReferralSubmissionAction extends React.Component {
             </div>
             <Button
               type="submit"
-              loading={submissionItem ? submissionItem.isPending : true}
+              loading={submissionItem && submissionItem.isPending}
               attached
             >
               {this.props.buttonText ||
@@ -188,7 +186,6 @@ ReferralSubmissionAction.propTypes = {
   campaignId: PropTypes.string.isRequired,
   className: PropTypes.string,
   id: PropTypes.string.isRequired,
-  initPostSubmissionItem: PropTypes.func.isRequired,
   resetPostSubmissionItem: PropTypes.func.isRequired,
   storeCampaignPost: PropTypes.func.isRequired,
   submissions: PropTypes.shape({

--- a/resources/assets/components/actions/ReferralSubmissionAction/ReferralSubmissionAction.test.js
+++ b/resources/assets/components/actions/ReferralSubmissionAction/ReferralSubmissionAction.test.js
@@ -10,7 +10,6 @@ describe('PhotoSubmissionAction component', () => {
     <ReferralSubmissionAction
       campaignId="1234"
       campaignRunId="6789"
-      initPostSubmissionItem={jest.fn()}
       resetPostSubmissionItem={jest.fn()}
       id={id}
       storeCampaignPost={jest.fn()}

--- a/resources/assets/components/actions/ReferralSubmissionAction/ReferralSubmissionActionContainer.js
+++ b/resources/assets/components/actions/ReferralSubmissionAction/ReferralSubmissionActionContainer.js
@@ -2,7 +2,6 @@ import { connect } from 'react-redux';
 
 import ReferralSubmissionAction from './ReferralSubmissionAction';
 import {
-  initPostSubmissionItem,
   resetPostSubmissionItem,
   storeCampaignPost,
 } from '../../../actions/post';
@@ -20,7 +19,6 @@ const mapStateToProps = state => ({
  * actions to the Redux store as props for this component.
  */
 const actionCreators = {
-  initPostSubmissionItem,
   resetPostSubmissionItem,
   storeCampaignPost,
 };

--- a/resources/assets/components/actions/TextSubmissionAction/TextSubmissionAction.js
+++ b/resources/assets/components/actions/TextSubmissionAction/TextSubmissionAction.js
@@ -21,11 +21,6 @@ class TextSubmissionAction extends React.Component {
       showModal: false,
       textValue: '',
     };
-
-    // Initialize post submission item in store if it doesn't yet exist.
-    if (!props.submissions.items[props.id]) {
-      this.props.initPostSubmissionItem(this.props.id);
-    }
   }
 
   static getDerivedStateFromProps(nextProps) {
@@ -138,7 +133,7 @@ class TextSubmissionAction extends React.Component {
               </div>
               <Button
                 type="submit"
-                loading={submissionItem ? submissionItem.isPending : true}
+                loading={submissionItem && submissionItem.isPending}
                 disabled={!this.state.textValue}
                 attached
               >
@@ -193,7 +188,6 @@ TextSubmissionAction.propTypes = {
   id: PropTypes.string.isRequired,
   informationTitle: PropTypes.string,
   informationContent: PropTypes.string,
-  initPostSubmissionItem: PropTypes.func.isRequired,
   resetPostSubmissionItem: PropTypes.func.isRequired,
   storeCampaignPost: PropTypes.func.isRequired,
   storePost: PropTypes.func.isRequired,

--- a/resources/assets/components/actions/TextSubmissionAction/TextSubmissionAction.test.js
+++ b/resources/assets/components/actions/TextSubmissionAction/TextSubmissionAction.test.js
@@ -10,7 +10,6 @@ describe('TextSubmissionAction component', () => {
     <TextSubmissionAction
       campaignId="1234"
       id={id}
-      initPostSubmissionItem={jest.fn()}
       resetPostSubmissionItem={jest.fn()}
       storeCampaignPost={jest.fn()}
       submissions={{

--- a/resources/assets/components/actions/TextSubmissionAction/TextSubmissionActionContainer.js
+++ b/resources/assets/components/actions/TextSubmissionAction/TextSubmissionActionContainer.js
@@ -2,7 +2,6 @@ import { connect } from 'react-redux';
 
 import TextSubmissionAction from './TextSubmissionAction';
 import {
-  initPostSubmissionItem,
   resetPostSubmissionItem,
   storeCampaignPost,
   storePost,
@@ -22,7 +21,6 @@ const mapStateToProps = state => ({
  * actions to the Redux store as props for this component.
  */
 const actionCreators = {
-  initPostSubmissionItem,
   resetPostSubmissionItem,
   storeCampaignPost,
   storePost,


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR removes the call to the `initPostSubmission` action in our various post submission action components.

### Any background context you want to provide?
This is a quick follow up to #1295 where we [deemed it unnecessary](https://github.com/DoSomething/phoenix-next/pull/1295#issuecomment-470667594) to be making this call for now.

### What are the relevant tickets/cards?

Refs [Pivotal ID #163867938](https://www.pivotaltracker.com/story/show/163867938)