### PR TITLE
Adds appropriate margin around submission galleries.

### DIFF
--- a/resources/assets/components/ContentfulEntry/renderers.js
+++ b/resources/assets/components/ContentfulEntry/renderers.js
@@ -93,7 +93,9 @@ export function renderTextSubmissionAction(data) {
         waypointData={{ contentfulId }}
       />
       <TextSubmissionActionContainer id={contentfulId} {...fields} />
-      <SubmissionGalleryBlockContainer type="text" />
+      <div className="margin-vertical-md">
+        <SubmissionGalleryBlockContainer type="text" />
+      </div>
       <PuckWaypoint
         name="text_submission_action-bottom"
         waypointData={{ contentfulId }}
@@ -119,7 +121,9 @@ export function renderPhotoSubmissionAction(data) {
         waypointData={{ contentfulId }}
       />
       <PhotoSubmissionActionContainer id={contentfulId} {...fields} />
-      <SubmissionGalleryBlockContainer type="photo" />
+      <div className="margin-vertical-md">
+        <SubmissionGalleryBlockContainer type="photo" />
+      </div>
       <PuckWaypoint
         name="photo_submission_action-bottom"
         waypointData={{ contentfulId }}


### PR DESCRIPTION
### What does this PR do?

This pull request adds a "medium" margin around the submission gallery. This bug was introduced in #1281, because the `.gallery-grid` class doesn't include the same "built-in" outer margins (because of how [we'd implemented](https://github.com/DoSomething/forge/blob/5da31df332198c9bfa8bfcb9cdffa93a506a2f44/scss/_modules/_gallery.scss#L21) gutters in the pre-Grid world.)

And here's a nice [before](https://user-images.githubusercontent.com/583202/54057364-c79d1e80-41c0-11e9-8919-2fa6efaa4ad0.png) and **after**:

![Screen Shot 2019-03-08 at 4 36 08 PM](https://user-images.githubusercontent.com/583202/54057373-ca980f00-41c0-11e9-810d-e73cac112bfc.png)

Thanks @mendelB for helping me figure out where this was actually happening!! 🙃

### Any background context you want to provide?

I decided to add the margin to this particular combination of submission block + gallery, rather than baking it into galleries everywhere (since we've previously regretted the decision to bake "layout" information like that into elements themselves). I chose a "medium" margin since this is just visual spacing between two related components, but obviously no strong feels there!

### What are the relevant tickets/cards?

Refs [Pivotal ID #164381891](https://www.pivotaltracker.com/story/show/164381891).

### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.
* [ ] Added screenshot to PR description of related front-end updates on **small** screens.
* [ ] Added screenshot to PR description of related front-end updates on **medium** screens.
* [ ] Added screenshot to PR description of related front-end updates on **large** screens.