### PR TITLE
Subscription Center

### DIFF
--- a/resources/assets/components/pages/AccountPage/AccountNavigation.js
+++ b/resources/assets/components/pages/AccountPage/AccountNavigation.js
@@ -18,6 +18,13 @@ const AccountNavigation = () => (
       >
         Profile
       </NavLink>
+      <NavLink
+        className="nav-link"
+        activeClassName="is-active"
+        to="/us/account/profile/subscriptions"
+      >
+        Subscriptions
+      </NavLink>
     </div>
   </div>
 );

--- a/resources/assets/components/pages/AccountPage/AccountNavigation.js
+++ b/resources/assets/components/pages/AccountPage/AccountNavigation.js
@@ -14,6 +14,7 @@ const AccountNavigation = () => (
       <NavLink
         className="nav-link"
         activeClassName="is-active"
+        exact
         to="/us/account/profile"
       >
         Profile

--- a/resources/assets/components/pages/AccountPage/AccountQuery.js
+++ b/resources/assets/components/pages/AccountPage/AccountQuery.js
@@ -9,11 +9,13 @@ import Account from './Account';
 const ACCOUNT_QUERY = gql`
   query AccountQuery($userId: String!) {
     user(id: $userId) {
+      id
       firstName
       lastName
       mobile
       birthdate
       email
+      emailSubscriptionTopics
     }
   }
 `;

--- a/resources/assets/components/pages/AccountPage/AccountRoute.js
+++ b/resources/assets/components/pages/AccountPage/AccountRoute.js
@@ -3,10 +3,15 @@ import { Switch, Route } from 'react-router-dom';
 import PropTypes from 'prop-types';
 
 import Profile from './Profile';
+import Subscriptions from './Subscriptions';
 import UserPostsQuery from './UserPostsQuery';
 
 const AccountRoute = props => (
   <Switch>
+    <Route
+      path="/us/account/profile/subscriptions"
+      render={() => <Subscriptions {...props} />}
+    />
     <Route path="/us/account/profile" render={() => <Profile {...props} />} />
     <Route
       path="/us/account/campaigns"

--- a/resources/assets/components/pages/AccountPage/EmailSubscriptionCheckbox.js
+++ b/resources/assets/components/pages/AccountPage/EmailSubscriptionCheckbox.js
@@ -1,0 +1,33 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const EmailSubscriptionCheckbox = props => (
+  <div className="padded">
+    <label className="option -checkbox" htmlFor="email_topics">
+      <input
+        type="checkbox"
+        name={props.identifier}
+        defaultChecked={
+          props.userTopics ? props.userTopics.includes(props.identifier) : false
+        }
+        className="form-checkbox"
+        onChange={props.onChange}
+      />
+      <span className="option__indicator" />
+      {/* Workaround for this jsx-a11y bug https://git.io/fN814 */}
+      {/* eslint-disable-next-line jsx-a11y/heading-has-content */}
+      <h4>{props.title}</h4>
+      <p>{props.description}</p>
+    </label>
+  </div>
+);
+
+EmailSubscriptionCheckbox.propTypes = {
+  identifier: PropTypes.string.isRequired,
+  title: PropTypes.string.isRequired,
+  description: PropTypes.string.isRequired,
+  userTopics: PropTypes.arrayOf(PropTypes.string).isRequired,
+  onChange: PropTypes.func.isRequired,
+};
+
+export default EmailSubscriptionCheckbox;

--- a/resources/assets/components/pages/AccountPage/EmailSubscriptionCheckbox.js
+++ b/resources/assets/components/pages/AccountPage/EmailSubscriptionCheckbox.js
@@ -14,8 +14,6 @@ const EmailSubscriptionCheckbox = props => (
         onChange={props.onChange}
       />
       <span className="option__indicator" />
-      {/* Workaround for this jsx-a11y bug https://git.io/fN814 */}
-      {/* eslint-disable-next-line jsx-a11y/heading-has-content */}
       <h4>{props.title}</h4>
       <p>{props.description}</p>
     </label>

--- a/resources/assets/components/pages/AccountPage/EmailSubscriptions.js
+++ b/resources/assets/components/pages/AccountPage/EmailSubscriptions.js
@@ -3,9 +3,7 @@ import PropTypes from 'prop-types';
 import gql from 'graphql-tag';
 import { Mutation } from 'react-apollo';
 
-// import FormItem from './FormItem';
 import Button from '../../utilities/Button/Button';
-// import VoterRegStatusBlock from './VoterRegStatusBlock';
 
 class EmailSubscriptions extends React.Component {
   constructor(props) {
@@ -14,6 +12,7 @@ class EmailSubscriptions extends React.Component {
       emailSubscriptionTopics: this.props.user.emailSubscriptionTopics
         ? this.props.user.emailSubscriptionTopics
         : [],
+      showAffirmation: false,
     };
 
     this.handleTopicChange = this.handleTopicChange.bind(this);
@@ -35,6 +34,7 @@ class EmailSubscriptions extends React.Component {
 
     this.setState({
       emailSubscriptionTopics: newTopics,
+      showAffirmation: false,
     });
   }
 
@@ -60,15 +60,22 @@ class EmailSubscriptions extends React.Component {
             <form
               onSubmit={event => {
                 event.preventDefault();
-                // determine if there should be topics here
                 emailSubscriptionsMutation({
                   variables: {
                     userId: this.props.user.id,
                     emailSubscriptionTopics: this.state.emailSubscriptionTopics,
                   },
                 });
+                this.setState({
+                  showAffirmation: true,
+                });
               }}
             >
+              {this.state.showAffirmation ? (
+                <p className="padded affirmation-message">
+                  Your subscriptions have been updated!
+                </p>
+              ) : null}
               <div className="padded">
                 <div className="form-wrapper clear-both">
                   <label className="option -checkbox" htmlFor="email_topics">

--- a/resources/assets/components/pages/AccountPage/EmailSubscriptions.js
+++ b/resources/assets/components/pages/AccountPage/EmailSubscriptions.js
@@ -1,0 +1,72 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import gql from 'graphql-tag';
+import { Mutation } from 'react-apollo';
+
+// import FormItem from './FormItem';
+import Button from '../../utilities/Button/Button';
+// import VoterRegStatusBlock from './VoterRegStatusBlock';
+
+const EMAIL_SUBSCRIPTIONS_MUTATION = gql`
+  mutation EmailSubscriptionsMutation(
+    $userId: String!
+    $emailSubscriptionTopics: [EmailSubscriptionTopic]
+  ) {
+    user(id: $userId, emailSubscriptionTopics: $emailSubscriptionTopics) {
+      emailSubscriptionTopics
+    }
+  }
+`;
+
+const EmailSubscriptions = props => (
+  <Mutation mutation={EMAIL_SUBSCRIPTIONS_MUTATION}>
+    {emailSubscriptionsMutation => {
+      const shutUp = 'face';
+      return (
+        <form
+          onSubmit={event => {
+            event.preventDefault();
+            emailSubscriptionsMutation({
+              variables: {
+                userId: props.user.userId,
+                emailSubscriptionTopics: null,
+              },
+            });
+          }}
+        >
+          <div className="padded">
+            <div className="form-wrapper affiliate-option clear-both">
+              <label className="option -checkbox" htmlFor="email_topics">
+                <input
+                  type="checkbox"
+                  id="opt_in"
+                  name="email_topics"
+                  value="news"
+                  defaultChecked={props.user.emailSubscriptionTopics.includes(
+                    'NEWS',
+                  )}
+                  className="form-checkbox"
+                />
+                <span className="option__indicator" />
+                NEWS
+              </label>
+            </div>
+          </div>
+
+          <Button type="submit" attached>
+            Save subscriptions {shutUp}
+          </Button>
+        </form>
+      );
+    }}
+  </Mutation>
+);
+
+EmailSubscriptions.propTypes = {
+  user: PropTypes.shape({
+    emailSubscriptionTopics: PropTypes.array,
+    userId: PropTypes.string,
+  }).isRequired,
+};
+
+export default EmailSubscriptions;

--- a/resources/assets/components/pages/AccountPage/EmailSubscriptions.js
+++ b/resources/assets/components/pages/AccountPage/EmailSubscriptions.js
@@ -55,132 +55,136 @@ class EmailSubscriptions extends React.Component {
 
     return (
       <Mutation mutation={EMAIL_SUBSCRIPTIONS_MUTATION}>
-        {emailSubscriptionsMutation => {
-          return (
-            <form
-              onSubmit={event => {
-                event.preventDefault();
-                emailSubscriptionsMutation({
-                  variables: {
-                    userId: this.props.user.id,
-                    emailSubscriptionTopics: this.state.emailSubscriptionTopics,
-                  },
-                });
-                this.setState({
-                  showAffirmation: true,
-                });
-              }}
-            >
-              {this.state.showAffirmation ? (
-                <p className="padded affirmation-message">
-                  Your subscriptions have been updated!
-                </p>
-              ) : null}
-              <div className="padded">
-                <div className="form-wrapper clear-both">
-                  <label className="option -checkbox" htmlFor="email_topics">
-                    <input
-                      type="checkbox"
-                      id="opt_in"
-                      name="ACTIONS"
-                      defaultChecked={
-                        this.props.user.emailSubscriptionTopics
-                          ? this.props.user.emailSubscriptionTopics.includes(
-                              'ACTIONS',
-                            )
-                          : false
-                      }
-                      className="form-checkbox"
-                      onChange={this.handleTopicChange}
-                    />
-                    <span className="option__indicator" />
-                    <h4>Community</h4>
-                    <p>
-                      A roundup of writing, photos, and impact from the
-                      DoSomething community, along with updates on DoSomething
-                      staff, events, and office culture.
-                    </p>
-                  </label>
-                  <label className="option -checkbox" htmlFor="email_topics">
-                    <input
-                      type="checkbox"
-                      id="opt_in"
-                      name="NEWS"
-                      defaultChecked={
-                        this.props.user.emailSubscriptionTopics
-                          ? this.props.user.emailSubscriptionTopics.includes(
-                              'NEWS',
-                            )
-                          : false
-                      }
-                      className="form-checkbox"
-                      onChange={this.handleTopicChange}
-                    />
-                    <span className="option__indicator" />
-                    <h4>News</h4>
-                    <p>
-                      Read the news, change the news. A roundup of current
-                      events, along with ways to take action and impact the
-                      headlines.
-                    </p>
-                  </label>
-                  <label className="option -checkbox" htmlFor="email_topics">
-                    <input
-                      type="checkbox"
-                      id="opt_in"
-                      name="LIFESTYLE"
-                      defaultChecked={
-                        this.props.user.emailSubscriptionTopics
-                          ? this.props.user.emailSubscriptionTopics.includes(
-                              'LIFESTYLE',
-                            )
-                          : false
-                      }
-                      className="form-checkbox"
-                      onChange={this.handleTopicChange}
-                    />
-                    <span className="option__indicator" />
-                    <h4>Lifestyle</h4>
-                    <p>
-                      Advice, action guides, social change horoscopes,
-                      inspirational playlists, recommendations, and other
-                      content to live your best life and help others do the
-                      same.
-                    </p>
-                  </label>
+        {emailSubscriptionsMutation => (
+          <form
+            onSubmit={event => {
+              event.preventDefault();
+              emailSubscriptionsMutation({
+                variables: {
+                  userId: this.props.user.id,
+                  emailSubscriptionTopics: this.state.emailSubscriptionTopics,
+                },
+              });
+              this.setState({
+                showAffirmation: true,
+              });
+            }}
+          >
+            {this.state.showAffirmation ? (
+              <p className="padded affirmation-message">
+                Your subscriptions have been updated!
+              </p>
+            ) : null}
+            <div className="padded">
+              <div className="form-wrapper clear-both">
+                <label className="option -checkbox" htmlFor="email_topics">
+                  <input
+                    type="checkbox"
+                    id="opt_in"
+                    name="ACTIONS"
+                    defaultChecked={
+                      this.props.user.emailSubscriptionTopics
+                        ? this.props.user.emailSubscriptionTopics.includes(
+                            'ACTIONS',
+                          )
+                        : false
+                    }
+                    className="form-checkbox"
+                    onChange={this.handleTopicChange}
+                  />
+                  <span className="option__indicator" />
+                  {/* Workaround for this jsx-a11y bug https://git.io/fN814 */}
+                  {/* eslint-disable-next-line jsx-a11y/heading-has-content */}
+                  <h4>Community</h4>
+                  <p>
+                    A roundup of writing, photos, and impact from the
+                    DoSomething community, along with updates on DoSomething
+                    staff, events, and office culture.
+                  </p>
+                </label>
+                <label className="option -checkbox" htmlFor="email_topics">
+                  <input
+                    type="checkbox"
+                    id="opt_in"
+                    name="NEWS"
+                    defaultChecked={
+                      this.props.user.emailSubscriptionTopics
+                        ? this.props.user.emailSubscriptionTopics.includes(
+                            'NEWS',
+                          )
+                        : false
+                    }
+                    className="form-checkbox"
+                    onChange={this.handleTopicChange}
+                  />
+                  <span className="option__indicator" />
+                  {/* Workaround for this jsx-a11y bug https://git.io/fN814 */}
+                  {/* eslint-disable-next-line jsx-a11y/heading-has-content */}
+                  <h4>News</h4>
+                  <p>
+                    Read the news, change the news. A roundup of current events,
+                    along with ways to take action and impact the headlines.
+                  </p>
+                </label>
+                <label className="option -checkbox" htmlFor="email_topics">
+                  <input
+                    type="checkbox"
+                    id="opt_in"
+                    name="LIFESTYLE"
+                    defaultChecked={
+                      this.props.user.emailSubscriptionTopics
+                        ? this.props.user.emailSubscriptionTopics.includes(
+                            'LIFESTYLE',
+                          )
+                        : false
+                    }
+                    className="form-checkbox"
+                    onChange={this.handleTopicChange}
+                  />
+                  <span className="option__indicator" />
+                  {/* Workaround for this jsx-a11y bug https://git.io/fN814 */}
+                  {/* eslint-disable-next-line jsx-a11y/heading-has-content */}
+                  <h4>Lifestyle</h4>
+                  <p>
+                    Advice, action guides, social change horoscopes,
+                    inspirational playlists, recommendations, and other content
+                    to live your best life and help others do the same.
+                  </p>
+                </label>
 
-                  <label className="option -checkbox" htmlFor="email_topics">
-                    <input
-                      type="checkbox"
-                      id="opt_in"
-                      name="SCHOLARSHIPS"
-                      title="Scholarships"
-                      defaultChecked={
-                        this.props.user.emailSubscriptionTopics
-                          ? this.props.user.emailSubscriptionTopics.includes(
-                              'SCHOLARSHIPS',
-                            )
-                          : false
-                      }
-                      className="form-checkbox"
-                      onChange={this.handleTopicChange}
-                    />
-                    <span className="option__indicator" />
-                    <h4>Scholarships</h4>
-                    <p>
-                      Alerts on new ways to earn scholarships by doing social
-                      good, plus announcements of scholarship winners.
-                    </p>
-                  </label>
-                </div>
+                <label className="option -checkbox" htmlFor="email_topics">
+                  <input
+                    type="checkbox"
+                    id="opt_in"
+                    name="SCHOLARSHIPS"
+                    title="Scholarships"
+                    defaultChecked={
+                      this.props.user.emailSubscriptionTopics
+                        ? this.props.user.emailSubscriptionTopics.includes(
+                            'SCHOLARSHIPS',
+                          )
+                        : false
+                    }
+                    className="form-checkbox"
+                    onChange={this.handleTopicChange}
+                  />
+                  <span className="option__indicator" />
+                  {/* Workaround for this jsx-a11y bug https://git.io/fN814 */}
+                  {/* eslint-disable-next-line jsx-a11y/heading-has-content */}
+                  <h4>Scholarships</h4>
+                  <p>
+                    Alerts on new ways to earn scholarships by doing social
+                    good, plus announcements of scholarship winners.
+                  </p>
+                </label>
               </div>
+            </div>
 
-              <Button type="submit" attached>
-                Save subscriptions
-              </Button>
-            </form>
-          );
-        }}
+            <Button type="submit" attached>
+              Save subscriptions
+            </Button>
+          </form>
+        )}
       </Mutation>
     );
   }

--- a/resources/assets/components/pages/AccountPage/EmailSubscriptions.js
+++ b/resources/assets/components/pages/AccountPage/EmailSubscriptions.js
@@ -20,13 +20,11 @@ class EmailSubscriptions extends React.Component {
 
   handleTopicChange(event) {
     const target = event.target;
-    const value = target.checked;
-
     const name = target.name;
 
     const newTopics = this.state.emailSubscriptionTopics;
 
-    if (value) {
+    if (target.checked) {
       newTopics.push(name);
     } else {
       newTopics.pop(name);
@@ -77,106 +75,115 @@ class EmailSubscriptions extends React.Component {
             ) : null}
             <div className="padded">
               <div className="form-wrapper clear-both">
-                <label className="option -checkbox" htmlFor="email_topics">
-                  <input
-                    type="checkbox"
-                    id="opt_in"
-                    name="ACTIONS"
-                    defaultChecked={
-                      this.props.user.emailSubscriptionTopics
-                        ? this.props.user.emailSubscriptionTopics.includes(
-                            'ACTIONS',
-                          )
-                        : false
-                    }
-                    className="form-checkbox"
-                    onChange={this.handleTopicChange}
-                  />
-                  <span className="option__indicator" />
-                  {/* Workaround for this jsx-a11y bug https://git.io/fN814 */}
-                  {/* eslint-disable-next-line jsx-a11y/heading-has-content */}
-                  <h4>Community</h4>
-                  <p>
-                    A roundup of writing, photos, and impact from the
-                    DoSomething community, along with updates on DoSomething
-                    staff, events, and office culture.
-                  </p>
-                </label>
-                <label className="option -checkbox" htmlFor="email_topics">
-                  <input
-                    type="checkbox"
-                    id="opt_in"
-                    name="NEWS"
-                    defaultChecked={
-                      this.props.user.emailSubscriptionTopics
-                        ? this.props.user.emailSubscriptionTopics.includes(
-                            'NEWS',
-                          )
-                        : false
-                    }
-                    className="form-checkbox"
-                    onChange={this.handleTopicChange}
-                  />
-                  <span className="option__indicator" />
-                  {/* Workaround for this jsx-a11y bug https://git.io/fN814 */}
-                  {/* eslint-disable-next-line jsx-a11y/heading-has-content */}
-                  <h4>News</h4>
-                  <p>
-                    Read the news, change the news. A roundup of current events,
-                    along with ways to take action and impact the headlines.
-                  </p>
-                </label>
-                <label className="option -checkbox" htmlFor="email_topics">
-                  <input
-                    type="checkbox"
-                    id="opt_in"
-                    name="LIFESTYLE"
-                    defaultChecked={
-                      this.props.user.emailSubscriptionTopics
-                        ? this.props.user.emailSubscriptionTopics.includes(
-                            'LIFESTYLE',
-                          )
-                        : false
-                    }
-                    className="form-checkbox"
-                    onChange={this.handleTopicChange}
-                  />
-                  <span className="option__indicator" />
-                  {/* Workaround for this jsx-a11y bug https://git.io/fN814 */}
-                  {/* eslint-disable-next-line jsx-a11y/heading-has-content */}
-                  <h4>Lifestyle</h4>
-                  <p>
-                    Advice, action guides, social change horoscopes,
-                    inspirational playlists, recommendations, and other content
-                    to live your best life and help others do the same.
-                  </p>
-                </label>
-
-                <label className="option -checkbox" htmlFor="email_topics">
-                  <input
-                    type="checkbox"
-                    id="opt_in"
-                    name="SCHOLARSHIPS"
-                    title="Scholarships"
-                    defaultChecked={
-                      this.props.user.emailSubscriptionTopics
-                        ? this.props.user.emailSubscriptionTopics.includes(
-                            'SCHOLARSHIPS',
-                          )
-                        : false
-                    }
-                    className="form-checkbox"
-                    onChange={this.handleTopicChange}
-                  />
-                  <span className="option__indicator" />
-                  {/* Workaround for this jsx-a11y bug https://git.io/fN814 */}
-                  {/* eslint-disable-next-line jsx-a11y/heading-has-content */}
-                  <h4>Scholarships</h4>
-                  <p>
-                    Alerts on new ways to earn scholarships by doing social
-                    good, plus announcements of scholarship winners.
-                  </p>
-                </label>
+                <div className="padded">
+                  <label className="option -checkbox" htmlFor="email_topics">
+                    <input
+                      type="checkbox"
+                      id="opt_in"
+                      name="ACTIONS"
+                      defaultChecked={
+                        this.props.user.emailSubscriptionTopics
+                          ? this.props.user.emailSubscriptionTopics.includes(
+                              'ACTIONS',
+                            )
+                          : false
+                      }
+                      className="form-checkbox"
+                      onChange={this.handleTopicChange}
+                    />
+                    <span className="option__indicator" />
+                    {/* Workaround for this jsx-a11y bug https://git.io/fN814 */}
+                    {/* eslint-disable-next-line jsx-a11y/heading-has-content */}
+                    <h4>Community</h4>
+                    <p>
+                      A roundup of writing, photos, and impact from the
+                      DoSomething community, along with updates on DoSomething
+                      staff, events, and office culture.
+                    </p>
+                  </label>
+                </div>
+                <div className="padded">
+                  <label className="option -checkbox" htmlFor="email_topics">
+                    <input
+                      type="checkbox"
+                      id="opt_in"
+                      name="NEWS"
+                      defaultChecked={
+                        this.props.user.emailSubscriptionTopics
+                          ? this.props.user.emailSubscriptionTopics.includes(
+                              'NEWS',
+                            )
+                          : false
+                      }
+                      className="form-checkbox"
+                      onChange={this.handleTopicChange}
+                    />
+                    <span className="option__indicator" />
+                    {/* Workaround for this jsx-a11y bug https://git.io/fN814 */}
+                    {/* eslint-disable-next-line jsx-a11y/heading-has-content */}
+                    <h4>News</h4>
+                    <p>
+                      Read the news, change the news. A roundup of current
+                      events, along with ways to take action and impact the
+                      headlines.
+                    </p>
+                  </label>
+                </div>
+                <div className="padded">
+                  <label className="option -checkbox" htmlFor="email_topics">
+                    <input
+                      type="checkbox"
+                      id="opt_in"
+                      name="LIFESTYLE"
+                      defaultChecked={
+                        this.props.user.emailSubscriptionTopics
+                          ? this.props.user.emailSubscriptionTopics.includes(
+                              'LIFESTYLE',
+                            )
+                          : false
+                      }
+                      className="form-checkbox"
+                      onChange={this.handleTopicChange}
+                    />
+                    <span className="option__indicator" />
+                    {/* Workaround for this jsx-a11y bug https://git.io/fN814 */}
+                    {/* eslint-disable-next-line jsx-a11y/heading-has-content */}
+                    <h4>Lifestyle</h4>
+                    <p>
+                      Advice, action guides, social change horoscopes,
+                      inspirational playlists, recommendations, and other
+                      content to live your best life and help others do the
+                      same.
+                    </p>
+                  </label>
+                </div>
+                <div className="padded">
+                  <label className="option -checkbox" htmlFor="email_topics">
+                    <input
+                      type="checkbox"
+                      id="opt_in"
+                      name="SCHOLARSHIPS"
+                      title="Scholarships"
+                      defaultChecked={
+                        this.props.user.emailSubscriptionTopics
+                          ? this.props.user.emailSubscriptionTopics.includes(
+                              'SCHOLARSHIPS',
+                            )
+                          : false
+                      }
+                      className="form-checkbox"
+                      onChange={this.handleTopicChange}
+                    />
+                    <span className="option__indicator" />
+                    {/* Workaround for this jsx-a11y bug https://git.io/fN814 */}
+                    {/* eslint-disable-next-line jsx-a11y/heading-has-content */}
+                    <h4>Scholarships</h4>
+                    <p>
+                      Alerts on new ways to earn scholarships by doing social
+                      good, plus announcements of scholarship winners.
+                    </p>
+                  </label>
+                </div>
               </div>
             </div>
 

--- a/resources/assets/components/pages/AccountPage/EmailSubscriptions.js
+++ b/resources/assets/components/pages/AccountPage/EmailSubscriptions.js
@@ -4,6 +4,21 @@ import gql from 'graphql-tag';
 import { Mutation } from 'react-apollo';
 
 import Button from '../../utilities/Button/Button';
+import EmailSubscriptionCheckbox from './EmailSubscriptionCheckbox';
+
+const EMAIL_SUBSCRIPTIONS_MUTATION = gql`
+  mutation EmailSubscriptionsMutation(
+    $userId: String!
+    $emailSubscriptionTopics: [EmailSubscriptionTopic]!
+  ) {
+    updateEmailSubscriptionTopics(
+      id: $userId
+      emailSubscriptionTopics: $emailSubscriptionTopics
+    ) {
+      emailSubscriptionTopics
+    }
+  }
+`;
 
 class EmailSubscriptions extends React.Component {
   constructor(props) {
@@ -27,7 +42,7 @@ class EmailSubscriptions extends React.Component {
     if (target.checked) {
       newTopics.push(name);
     } else {
-      newTopics.pop(name);
+      newTopics.splice(newTopics.indexOf(name), 1);
     }
 
     this.setState({
@@ -37,20 +52,6 @@ class EmailSubscriptions extends React.Component {
   }
 
   render() {
-    const EMAIL_SUBSCRIPTIONS_MUTATION = gql`
-      mutation EmailSubscriptionsMutation(
-        $userId: String!
-        $emailSubscriptionTopics: [EmailSubscriptionTopic]!
-      ) {
-        updateEmailSubscriptionTopics(
-          id: $userId
-          emailSubscriptionTopics: $emailSubscriptionTopics
-        ) {
-          emailSubscriptionTopics
-        }
-      }
-    `;
-
     return (
       <Mutation mutation={EMAIL_SUBSCRIPTIONS_MUTATION}>
         {emailSubscriptionsMutation => (
@@ -75,115 +76,41 @@ class EmailSubscriptions extends React.Component {
             ) : null}
             <div className="padded">
               <div className="form-wrapper clear-both">
-                <div className="padded">
-                  <label className="option -checkbox" htmlFor="email_topics">
-                    <input
-                      type="checkbox"
-                      id="opt_in"
-                      name="ACTIONS"
-                      defaultChecked={
-                        this.props.user.emailSubscriptionTopics
-                          ? this.props.user.emailSubscriptionTopics.includes(
-                              'ACTIONS',
-                            )
-                          : false
-                      }
-                      className="form-checkbox"
-                      onChange={this.handleTopicChange}
-                    />
-                    <span className="option__indicator" />
-                    {/* Workaround for this jsx-a11y bug https://git.io/fN814 */}
-                    {/* eslint-disable-next-line jsx-a11y/heading-has-content */}
-                    <h4>Community</h4>
-                    <p>
-                      A roundup of writing, photos, and impact from the
-                      DoSomething community, along with updates on DoSomething
-                      staff, events, and office culture.
-                    </p>
-                  </label>
-                </div>
-                <div className="padded">
-                  <label className="option -checkbox" htmlFor="email_topics">
-                    <input
-                      type="checkbox"
-                      id="opt_in"
-                      name="NEWS"
-                      defaultChecked={
-                        this.props.user.emailSubscriptionTopics
-                          ? this.props.user.emailSubscriptionTopics.includes(
-                              'NEWS',
-                            )
-                          : false
-                      }
-                      className="form-checkbox"
-                      onChange={this.handleTopicChange}
-                    />
-                    <span className="option__indicator" />
-                    {/* Workaround for this jsx-a11y bug https://git.io/fN814 */}
-                    {/* eslint-disable-next-line jsx-a11y/heading-has-content */}
-                    <h4>News</h4>
-                    <p>
-                      Read the news, change the news. A roundup of current
+                <EmailSubscriptionCheckbox
+                  identifier="ACTIONS"
+                  title="Community"
+                  description="A roundup of writing, photos, and impact from the DoSomething community,
+        along with updates on DoSomething staff, events, and office culture."
+                  userTopics={this.state.emailSubscriptionTopics}
+                  onChange={this.handleTopicChange}
+                />
+                <EmailSubscriptionCheckbox
+                  identifier="NEWS"
+                  title="News"
+                  description="Read the news, change the news. A roundup of current
                       events, along with ways to take action and impact the
-                      headlines.
-                    </p>
-                  </label>
-                </div>
-                <div className="padded">
-                  <label className="option -checkbox" htmlFor="email_topics">
-                    <input
-                      type="checkbox"
-                      id="opt_in"
-                      name="LIFESTYLE"
-                      defaultChecked={
-                        this.props.user.emailSubscriptionTopics
-                          ? this.props.user.emailSubscriptionTopics.includes(
-                              'LIFESTYLE',
-                            )
-                          : false
-                      }
-                      className="form-checkbox"
-                      onChange={this.handleTopicChange}
-                    />
-                    <span className="option__indicator" />
-                    {/* Workaround for this jsx-a11y bug https://git.io/fN814 */}
-                    {/* eslint-disable-next-line jsx-a11y/heading-has-content */}
-                    <h4>Lifestyle</h4>
-                    <p>
-                      Advice, action guides, social change horoscopes,
+                      headlines."
+                  userTopics={this.state.emailSubscriptionTopics}
+                  onChange={this.handleTopicChange}
+                />
+                <EmailSubscriptionCheckbox
+                  identifier="LIFESTYLE"
+                  title="Lifestyle"
+                  description="Advice, action guides, social change horoscopes,
                       inspirational playlists, recommendations, and other
                       content to live your best life and help others do the
-                      same.
-                    </p>
-                  </label>
-                </div>
-                <div className="padded">
-                  <label className="option -checkbox" htmlFor="email_topics">
-                    <input
-                      type="checkbox"
-                      id="opt_in"
-                      name="SCHOLARSHIPS"
-                      title="Scholarships"
-                      defaultChecked={
-                        this.props.user.emailSubscriptionTopics
-                          ? this.props.user.emailSubscriptionTopics.includes(
-                              'SCHOLARSHIPS',
-                            )
-                          : false
-                      }
-                      className="form-checkbox"
-                      onChange={this.handleTopicChange}
-                    />
-                    <span className="option__indicator" />
-                    {/* Workaround for this jsx-a11y bug https://git.io/fN814 */}
-                    {/* eslint-disable-next-line jsx-a11y/heading-has-content */}
-                    <h4>Scholarships</h4>
-                    <p>
-                      Alerts on new ways to earn scholarships by doing social
-                      good, plus announcements of scholarship winners.
-                    </p>
-                  </label>
-                </div>
+                      same."
+                  userTopics={this.state.emailSubscriptionTopics}
+                  onChange={this.handleTopicChange}
+                />
+                <EmailSubscriptionCheckbox
+                  identifier="SCHOLARSHIPS"
+                  title="Scholarships"
+                  description="Alerts on new ways to earn scholarships by doing social
+                      good, plus announcements of scholarship winners."
+                  userTopics={this.state.emailSubscriptionTopics}
+                  onChange={this.handleTopicChange}
+                />
               </div>
             </div>
 

--- a/resources/assets/components/pages/AccountPage/EmailSubscriptions.js
+++ b/resources/assets/components/pages/AccountPage/EmailSubscriptions.js
@@ -10,7 +10,32 @@ import Button from '../../utilities/Button/Button';
 class EmailSubscriptions extends React.Component {
   constructor(props) {
     super(props);
-    this.state = {};
+    this.state = {
+      emailSubscriptionTopics: this.props.user.emailSubscriptionTopics
+        ? this.props.user.emailSubscriptionTopics
+        : [],
+    };
+
+    this.handleTopicChange = this.handleTopicChange.bind(this);
+  }
+
+  handleTopicChange(event) {
+    const target = event.target;
+    const value = target.checked;
+
+    const name = target.name;
+
+    const newTopics = this.state.emailSubscriptionTopics;
+
+    if (value) {
+      newTopics.push(name);
+    } else {
+      newTopics.pop(name);
+    }
+
+    this.setState({
+      emailSubscriptionTopics: newTopics,
+    });
   }
 
   render() {
@@ -28,65 +53,110 @@ class EmailSubscriptions extends React.Component {
       }
     `;
 
-    <Mutation mutation={EMAIL_SUBSCRIPTIONS_MUTATION}>
-      {emailSubscriptionsMutation => {
-        const shutUp = 'face';
+    return (
+      <Mutation mutation={EMAIL_SUBSCRIPTIONS_MUTATION}>
+        {emailSubscriptionsMutation => {
+          return (
+            <form
+              onSubmit={event => {
+                event.preventDefault();
+                // determine if there should be topics here
+                emailSubscriptionsMutation({
+                  variables: {
+                    userId: this.props.user.id,
+                    emailSubscriptionTopics: this.state.emailSubscriptionTopics,
+                  },
+                });
+              }}
+            >
+              <div className="padded">
+                <div className="form-wrapper clear-both">
+                  <label className="option -checkbox" htmlFor="email_topics">
+                    <input
+                      type="checkbox"
+                      id="opt_in"
+                      name="NEWS"
+                      defaultChecked={
+                        this.props.user.emailSubscriptionTopics
+                          ? this.props.user.emailSubscriptionTopics.includes(
+                              'NEWS',
+                            )
+                          : false
+                      }
+                      className="form-checkbox"
+                      onChange={this.handleTopicChange}
+                    />
+                    <span className="option__indicator" />
+                    NEWS
+                  </label>
 
-        function handleTopicChange(event) {
-          const target = event.target;
-          const value = target.checked;
+                  <label className="option -checkbox" htmlFor="email_topics">
+                    <input
+                      type="checkbox"
+                      id="opt_in"
+                      name="SCHOLARSHIPS"
+                      defaultChecked={
+                        this.props.user.emailSubscriptionTopics
+                          ? this.props.user.emailSubscriptionTopics.includes(
+                              'SCHOLARSHIPS',
+                            )
+                          : false
+                      }
+                      className="form-checkbox"
+                      onChange={this.handleTopicChange}
+                    />
+                    <span className="option__indicator" />
+                    SCHOLARSHIPS
+                  </label>
 
-          const name = target.name;
+                  <label className="option -checkbox" htmlFor="email_topics">
+                    <input
+                      type="checkbox"
+                      id="opt_in"
+                      name="ACTIONS"
+                      defaultChecked={
+                        this.props.user.emailSubscriptionTopics
+                          ? this.props.user.emailSubscriptionTopics.includes(
+                              'ACTIONS',
+                            )
+                          : false
+                      }
+                      className="form-checkbox"
+                      onChange={this.handleTopicChange}
+                    />
+                    <span className="option__indicator" />
+                    ACTIONS
+                  </label>
 
-          this.setState({
-            [name]: value,
-          });
-        }
-
-        return (
-          <form
-            onSubmit={event => {
-              event.preventDefault();
-              const topics = [];
-              // determine if there should be topics here
-              emailSubscriptionsMutation({
-                variables: {
-                  userId: this.props.user.id,
-                  emailSubscriptionTopics: topics,
-                },
-              });
-            }}
-          >
-            <div className="padded">
-              <div className="form-wrapper affiliate-option clear-both">
-                <label className="option -checkbox" htmlFor="email_topics">
-                  <input
-                    type="checkbox"
-                    id="opt_in"
-                    name="news"
-                    defaultChecked={
-                      this.props.user.emailSubscriptionTopics
-                        ? this.props.user.emailSubscriptionTopics.includes(
-                            'NEWS',
-                          )
-                        : false
-                    }
-                    className="form-checkbox"
-                    onChange={handleTopicChange}
-                  />
-                  <span className="option__indicator" />
-                  NEWS
-                </label>
+                  <label className="option -checkbox" htmlFor="email_topics">
+                    <input
+                      type="checkbox"
+                      id="opt_in"
+                      name="LIFESTYLE"
+                      defaultChecked={
+                        this.props.user.emailSubscriptionTopics
+                          ? this.props.user.emailSubscriptionTopics.includes(
+                              'LIFESTYLE',
+                            )
+                          : false
+                      }
+                      className="form-checkbox"
+                      onChange={this.handleTopicChange}
+                    />
+                    <span className="option__indicator" />
+                    LIFESTYLE
+                  </label>
+                </div>
               </div>
-            </div>
 
-            <Button type="submit" attached>
-              Save subscriptions {shutUp}
-            </Button>
-          </form>
-        );
-      }}
-    </Mutation>;
+              <Button type="submit" attached>
+                Save subscriptions
+              </Button>
+            </form>
+          );
+        }}
+      </Mutation>
+    );
   }
 }
 

--- a/resources/assets/components/pages/AccountPage/EmailSubscriptions.js
+++ b/resources/assets/components/pages/AccountPage/EmailSubscriptions.js
@@ -7,66 +7,88 @@ import { Mutation } from 'react-apollo';
 import Button from '../../utilities/Button/Button';
 // import VoterRegStatusBlock from './VoterRegStatusBlock';
 
-const EMAIL_SUBSCRIPTIONS_MUTATION = gql`
-  mutation EmailSubscriptionsMutation(
-    $userId: String!
-    $emailSubscriptionTopics: [EmailSubscriptionTopic]!
-  ) {
-    updateEmailSubscriptionTopics(
-      id: $userId
-      emailSubscriptionTopics: $emailSubscriptionTopics
-    ) {
-      emailSubscriptionTopics
-    }
+class EmailSubscriptions extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {};
   }
-`;
 
-const EmailSubscriptions = props => (
-  <Mutation mutation={EMAIL_SUBSCRIPTIONS_MUTATION}>
-    {emailSubscriptionsMutation => {
-      const shutUp = 'face';
-      return (
-        <form
-          onSubmit={event => {
-            event.preventDefault();
-            const topics = [];
-            // determine if there should be topics here
-            emailSubscriptionsMutation({
-              variables: {
-                userId: props.user.id,
-                emailSubscriptionTopics: topics,
-              },
-            });
-          }}
-        >
-          <div className="padded">
-            <div className="form-wrapper affiliate-option clear-both">
-              <label className="option -checkbox" htmlFor="email_topics">
-                <input
-                  type="checkbox"
-                  id="opt_in"
-                  name="email_topics"
-                  defaultChecked={
-                    props.user.emailSubscriptionTopics
-                      ? props.user.emailSubscriptionTopics.includes('NEWS')
-                      : false
-                  }
-                  className="form-checkbox"
-                />
-                <span className="option__indicator" />
-                NEWS
-              </label>
+  render() {
+    const EMAIL_SUBSCRIPTIONS_MUTATION = gql`
+      mutation EmailSubscriptionsMutation(
+        $userId: String!
+        $emailSubscriptionTopics: [EmailSubscriptionTopic]!
+      ) {
+        updateEmailSubscriptionTopics(
+          id: $userId
+          emailSubscriptionTopics: $emailSubscriptionTopics
+        ) {
+          emailSubscriptionTopics
+        }
+      }
+    `;
+
+    <Mutation mutation={EMAIL_SUBSCRIPTIONS_MUTATION}>
+      {emailSubscriptionsMutation => {
+        const shutUp = 'face';
+
+        function handleTopicChange(event) {
+          const target = event.target;
+          const value = target.checked;
+
+          const name = target.name;
+
+          this.setState({
+            [name]: value,
+          });
+        }
+
+        return (
+          <form
+            onSubmit={event => {
+              event.preventDefault();
+              const topics = [];
+              // determine if there should be topics here
+              emailSubscriptionsMutation({
+                variables: {
+                  userId: this.props.user.id,
+                  emailSubscriptionTopics: topics,
+                },
+              });
+            }}
+          >
+            <div className="padded">
+              <div className="form-wrapper affiliate-option clear-both">
+                <label className="option -checkbox" htmlFor="email_topics">
+                  <input
+                    type="checkbox"
+                    id="opt_in"
+                    name="news"
+                    defaultChecked={
+                      this.props.user.emailSubscriptionTopics
+                        ? this.props.user.emailSubscriptionTopics.includes(
+                            'NEWS',
+                          )
+                        : false
+                    }
+                    className="form-checkbox"
+                    onChange={handleTopicChange}
+                  />
+                  <span className="option__indicator" />
+                  NEWS
+                </label>
+              </div>
             </div>
-          </div>
 
-          <Button type="submit" attached>
-            Save subscriptions {shutUp}
-          </Button>
-        </form>
-      );
-    }}
-  </Mutation>
-);
+            <Button type="submit" attached>
+              Save subscriptions {shutUp}
+            </Button>
+          </form>
+        );
+      }}
+    </Mutation>;
+  }
+}
 
 EmailSubscriptions.propTypes = {
   user: PropTypes.shape({

--- a/resources/assets/components/pages/AccountPage/EmailSubscriptions.js
+++ b/resources/assets/components/pages/AccountPage/EmailSubscriptions.js
@@ -77,7 +77,7 @@ class EmailSubscriptions extends React.Component {
             <div className="padded">
               <div className="form-wrapper clear-both">
                 <EmailSubscriptionCheckbox
-                  identifier="ACTIONS"
+                  identifier="COMMUNITY"
                   title="Community"
                   description="A roundup of writing, photos, and impact from the DoSomething community,
         along with updates on DoSomething staff, events, and office culture."

--- a/resources/assets/components/pages/AccountPage/EmailSubscriptions.js
+++ b/resources/assets/components/pages/AccountPage/EmailSubscriptions.js
@@ -10,9 +10,12 @@ import Button from '../../utilities/Button/Button';
 const EMAIL_SUBSCRIPTIONS_MUTATION = gql`
   mutation EmailSubscriptionsMutation(
     $userId: String!
-    $emailSubscriptionTopics: [EmailSubscriptionTopic]
+    $emailSubscriptionTopics: [EmailSubscriptionTopic]!
   ) {
-    user(id: $userId, emailSubscriptionTopics: $emailSubscriptionTopics) {
+    updateEmailSubscriptionTopics(
+      id: $userId
+      emailSubscriptionTopics: $emailSubscriptionTopics
+    ) {
       emailSubscriptionTopics
     }
   }
@@ -26,10 +29,12 @@ const EmailSubscriptions = props => (
         <form
           onSubmit={event => {
             event.preventDefault();
+            const topics = [];
+            // determine if there should be topics here
             emailSubscriptionsMutation({
               variables: {
-                userId: props.user.userId,
-                emailSubscriptionTopics: null,
+                userId: props.user.id,
+                emailSubscriptionTopics: topics,
               },
             });
           }}
@@ -41,10 +46,11 @@ const EmailSubscriptions = props => (
                   type="checkbox"
                   id="opt_in"
                   name="email_topics"
-                  value="news"
-                  defaultChecked={props.user.emailSubscriptionTopics.includes(
-                    'NEWS',
-                  )}
+                  defaultChecked={
+                    props.user.emailSubscriptionTopics
+                      ? props.user.emailSubscriptionTopics.includes('NEWS')
+                      : false
+                  }
                   className="form-checkbox"
                 />
                 <span className="option__indicator" />
@@ -65,7 +71,7 @@ const EmailSubscriptions = props => (
 EmailSubscriptions.propTypes = {
   user: PropTypes.shape({
     emailSubscriptionTopics: PropTypes.array,
-    userId: PropTypes.string,
+    id: PropTypes.string,
   }).isRequired,
 };
 

--- a/resources/assets/components/pages/AccountPage/EmailSubscriptions.js
+++ b/resources/assets/components/pages/AccountPage/EmailSubscriptions.js
@@ -79,27 +79,21 @@ class EmailSubscriptions extends React.Component {
                 <EmailSubscriptionCheckbox
                   identifier="COMMUNITY"
                   title="Community"
-                  description="A roundup of writing, photos, and impact from the DoSomething community,
-        along with updates on DoSomething staff, events, and office culture."
+                  description="A roundup of photos, writing, and stories of impact from the DoSomething community and members like you."
                   userTopics={this.state.emailSubscriptionTopics}
                   onChange={this.handleTopicChange}
                 />
                 <EmailSubscriptionCheckbox
                   identifier="NEWS"
                   title="News"
-                  description="Read the news, change the news. A roundup of current
-                      events, along with ways to take action and impact the
-                      headlines."
+                  description="Don’t just read the news…*change* the news. Our current events newsletter has headlines, along with immediate ways to impact them."
                   userTopics={this.state.emailSubscriptionTopics}
                   onChange={this.handleTopicChange}
                 />
                 <EmailSubscriptionCheckbox
                   identifier="LIFESTYLE"
                   title="Lifestyle"
-                  description="Advice, action guides, social change horoscopes,
-                      inspirational playlists, recommendations, and other
-                      content to live your best life and help others do the
-                      same."
+                  description="Stories of incredible young people, actionable how-tos, inspirational playlists, and other content to live your best life and help others do the same."
                   userTopics={this.state.emailSubscriptionTopics}
                   onChange={this.handleTopicChange}
                 />

--- a/resources/assets/components/pages/AccountPage/EmailSubscriptions.js
+++ b/resources/assets/components/pages/AccountPage/EmailSubscriptions.js
@@ -82,44 +82,6 @@ class EmailSubscriptions extends React.Component {
                     <input
                       type="checkbox"
                       id="opt_in"
-                      name="NEWS"
-                      defaultChecked={
-                        this.props.user.emailSubscriptionTopics
-                          ? this.props.user.emailSubscriptionTopics.includes(
-                              'NEWS',
-                            )
-                          : false
-                      }
-                      className="form-checkbox"
-                      onChange={this.handleTopicChange}
-                    />
-                    <span className="option__indicator" />
-                    NEWS
-                  </label>
-
-                  <label className="option -checkbox" htmlFor="email_topics">
-                    <input
-                      type="checkbox"
-                      id="opt_in"
-                      name="SCHOLARSHIPS"
-                      defaultChecked={
-                        this.props.user.emailSubscriptionTopics
-                          ? this.props.user.emailSubscriptionTopics.includes(
-                              'SCHOLARSHIPS',
-                            )
-                          : false
-                      }
-                      className="form-checkbox"
-                      onChange={this.handleTopicChange}
-                    />
-                    <span className="option__indicator" />
-                    SCHOLARSHIPS
-                  </label>
-
-                  <label className="option -checkbox" htmlFor="email_topics">
-                    <input
-                      type="checkbox"
-                      id="opt_in"
                       name="ACTIONS"
                       defaultChecked={
                         this.props.user.emailSubscriptionTopics
@@ -132,9 +94,36 @@ class EmailSubscriptions extends React.Component {
                       onChange={this.handleTopicChange}
                     />
                     <span className="option__indicator" />
-                    ACTIONS
+                    <h4>Community</h4>
+                    <p>
+                      A roundup of writing, photos, and impact from the
+                      DoSomething community, along with updates on DoSomething
+                      staff, events, and office culture.
+                    </p>
                   </label>
-
+                  <label className="option -checkbox" htmlFor="email_topics">
+                    <input
+                      type="checkbox"
+                      id="opt_in"
+                      name="NEWS"
+                      defaultChecked={
+                        this.props.user.emailSubscriptionTopics
+                          ? this.props.user.emailSubscriptionTopics.includes(
+                              'NEWS',
+                            )
+                          : false
+                      }
+                      className="form-checkbox"
+                      onChange={this.handleTopicChange}
+                    />
+                    <span className="option__indicator" />
+                    <h4>News</h4>
+                    <p>
+                      Read the news, change the news. A roundup of current
+                      events, along with ways to take action and impact the
+                      headlines.
+                    </p>
+                  </label>
                   <label className="option -checkbox" htmlFor="email_topics">
                     <input
                       type="checkbox"
@@ -151,7 +140,37 @@ class EmailSubscriptions extends React.Component {
                       onChange={this.handleTopicChange}
                     />
                     <span className="option__indicator" />
-                    LIFESTYLE
+                    <h4>Lifestyle</h4>
+                    <p>
+                      Advice, action guides, social change horoscopes,
+                      inspirational playlists, recommendations, and other
+                      content to live your best life and help others do the
+                      same.
+                    </p>
+                  </label>
+
+                  <label className="option -checkbox" htmlFor="email_topics">
+                    <input
+                      type="checkbox"
+                      id="opt_in"
+                      name="SCHOLARSHIPS"
+                      title="Scholarships"
+                      defaultChecked={
+                        this.props.user.emailSubscriptionTopics
+                          ? this.props.user.emailSubscriptionTopics.includes(
+                              'SCHOLARSHIPS',
+                            )
+                          : false
+                      }
+                      className="form-checkbox"
+                      onChange={this.handleTopicChange}
+                    />
+                    <span className="option__indicator" />
+                    <h4>Scholarships</h4>
+                    <p>
+                      Alerts on new ways to earn scholarships by doing social
+                      good, plus announcements of scholarship winners.
+                    </p>
                   </label>
                 </div>
               </div>

--- a/resources/assets/components/pages/AccountPage/Subscriptions.js
+++ b/resources/assets/components/pages/AccountPage/Subscriptions.js
@@ -1,0 +1,30 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+// import FormItem from './FormItem';
+// import VoterRegStatusBlock from './VoterRegStatusBlock';
+import EmailSubscriptions from './EmailSubscriptions';
+
+const Subscriptions = props => (
+  <div className="bg-gray padding-bottom-lg wrapper">
+    <h2 className="caps-lock league-gothic -sm">Your Email Subscriptions</h2>
+    <div className="margin-top-lg float-left">
+      <div className="margin-top-lg">
+        <EmailSubscriptions {...props} />
+      </div>
+    </div>
+  </div>
+);
+
+// Subscriptions.propTypes = {
+//   emailSubscriptionTopics: PropTypes.shape({}).isRequired,
+// };
+
+Subscriptions.propTypes = {
+  user: PropTypes.shape({
+    emailSubscriptionTopics: PropTypes.array,
+    userId: PropTypes.string,
+  }).isRequired,
+};
+
+export default Subscriptions;

--- a/resources/assets/components/pages/AccountPage/Subscriptions.js
+++ b/resources/assets/components/pages/AccountPage/Subscriptions.js
@@ -1,8 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-// import FormItem from './FormItem';
-// import VoterRegStatusBlock from './VoterRegStatusBlock';
 import EmailSubscriptions from './EmailSubscriptions';
 
 const Subscriptions = props => (
@@ -15,10 +13,6 @@ const Subscriptions = props => (
     </div>
   </div>
 );
-
-// Subscriptions.propTypes = {
-//   emailSubscriptionTopics: PropTypes.shape({}).isRequired,
-// };
 
 Subscriptions.propTypes = {
   user: PropTypes.shape({

--- a/routes/web.php
+++ b/routes/web.php
@@ -18,9 +18,9 @@ $router->redirect('auth/login', 'next/login'); // Fix for hard-coded redirect in
 
 // Profile
 $router->redirect('/northstar/{id}', '/us/account/profile');
-$router->get('/us/account/{slug}', function () {
-    return auth()->user() ? view('app') : redirect('/next/login');
-})->where('slug', 'campaigns|profile|profile/subscriptions');
+$router->view('/us/account/{clientRoute?}', 'app')
+    ->where('clientRoute', '.*')
+    ->middleware('auth');
 
 // Campaigns index
 $router->get('us/campaigns', 'CampaignController@index');

--- a/routes/web.php
+++ b/routes/web.php
@@ -20,7 +20,7 @@ $router->redirect('auth/login', 'next/login'); // Fix for hard-coded redirect in
 $router->redirect('/northstar/{id}', '/us/account/profile');
 $router->get('/us/account/{slug}', function () {
     return auth()->user() ? view('app') : redirect('/next/login');
-})->where('slug', 'campaigns|profile');
+})->where('slug', 'campaigns|profile|profile/subscriptions');
 
 // Campaigns index
 $router->get('us/campaigns', 'CampaignController@index');


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

Adds a subscription center to the user profile! 
- Adds "Subscriptions" to the navigation bar
- Grabs `emailSubscriptionTopics` from GraphQL
- Adds 2 new components: 
    - Subscriptions
    - EmailSubscriptions (should this one be broken up more or we think okay for MVP?)
        - This is where the magic mutation happens!

Here is what it looks like:
![sub_demo](https://user-images.githubusercontent.com/4240292/54240025-28d33380-44da-11e9-9056-0c6549a1e937.gif)

Updated screenshot:
![image](https://user-images.githubusercontent.com/4240292/54307071-013aa480-4588-11e9-8910-f1a48d81ceaa.png)

Updated copy:
![image](https://user-images.githubusercontent.com/4240292/55348930-35a9ce00-546d-11e9-93ed-2eee805534e6.png)



### Any background context you want to provide?

[Product brief](https://docs.google.com/document/d/1z58kFTdIrD38GICfWNBZDkVUbp8K6MG-oSJrzyeFydU/edit?disco=AAAACk_ZbbM&usp_dm=false&ts=5c6c8206)

I believe we are in the process of swapping "actions" with "community" so that is why that heading doesn't match what is happening behind the scenes.

### What are the relevant tickets/cards?

Refs [Pivotal ID #164080359](https://www.pivotaltracker.com/story/show/164080359)

### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.
* [ ] Added screenshot to PR description of related front-end updates on **small** screens.
* [ ] Added screenshot to PR description of related front-end updates on **medium** screens.
* [ ] Added screenshot to PR description of related front-end updates on **large** screens.

