### PR TITLE
Embed Content Type

### DIFF
--- a/app/Entities/Embed.php
+++ b/app/Entities/Embed.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Entities;
+
+use JsonSerializable;
+
+class Embed extends Entity implements JsonSerializable
+{
+    /**
+     * Convert the object into something JSON serializable.
+     *
+     * @return array
+     */
+    public function jsonSerialize()
+    {
+        return [
+            'id' => $this->entry->getId(),
+            'type' => $this->getContentType(),
+            'fields' => [
+                'url' => $this->url,
+            ],
+        ];
+    }
+}

--- a/contentful/content-types/embed.js
+++ b/contentful/content-types/embed.js
@@ -1,0 +1,48 @@
+module.exports = function(migration) {
+  const embed = migration
+    .createContentType('embed')
+    .name('Embed')
+    .description('Embed content from a URL onto a page.')
+    .displayField('internalTitle');
+
+  embed
+    .createField('internalTitle')
+    .name('Internal Title')
+    .type('Symbol')
+    .localized(false)
+    .required(true)
+    .validations([])
+    .disabled(false)
+    .omitted(false);
+
+  embed
+    .createField('url')
+    .name('URL')
+    .type('Symbol')
+    .localized(false)
+    .required(true)
+    .validations([
+      {
+        regexp: {
+          pattern:
+            'https:\\/\\/dosomething\\.carto\\.com\\/builder\\/[a-z0-9-]+\\/embed',
+          flags: null,
+        },
+
+        message:
+          'Must be a valid Carto embeddable map URL from the DoSomething space. (https://dosomething.carto.com/dashboard).',
+      },
+    ])
+    .disabled(false)
+    .omitted(false);
+
+  embed.changeEditorInterface('internalTitle', 'singleLine', {
+    helpText:
+      'This title is used internally to help find this content. It will not be displayed anywhere on the rendered web page.',
+  });
+
+  embed.changeEditorInterface('url', 'singleLine', {
+    helpText:
+      'The URL for the embed. (Currently only supporting Carto map embed URLs. (https://dosomething.carto.com/dashboard)).',
+  });
+};


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR adds a very basic `Embed` Content type (migration script, Entity).

### Any background context you want to provide?
This is extremely bare bones for now, with only a `url` field to be embedded in an <iframe>.

This is also strictly validated as a DoSomething Carto map embed URL for now.

### What are the relevant tickets/cards?

Refs [Pivotal ID #164541569](https://www.pivotaltracker.com/story/show/164541569)

### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.
