### PR TITLE
Show submission date on text posts.

### DIFF
--- a/resources/assets/components/utilities/PostCard/PostCard.js
+++ b/resources/assets/components/utilities/PostCard/PostCard.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { get } from 'lodash';
 import gql from 'graphql-tag';
 import { propType } from 'graphql-anywhere';
+import { format } from 'date-fns';
 
 import PostBadge from './PostBadge';
 import { BaseFigure } from '../../Figure';
@@ -22,6 +23,7 @@ export const postCardFragment = gql`
     quantity
     location(format: HUMAN_FORMAT)
     signupId
+    createdAt
 
     actionDetails {
       anonymous
@@ -35,9 +37,11 @@ export const postCardFragment = gql`
 `;
 
 const PostCard = ({ post }) => {
+  const isAnonymous = post.actionDetails.anonymous;
+
   // If this post is for an anonymous action, label it with the state (if available).
   // For non-anonymous posts (default), label with the user's first name.
-  const authorLabel = post.actionDetails.anonymous
+  const authorLabel = isAnonymous
     ? post.location || 'Anonymous'
     : get(post, 'user.firstName', 'A Doer');
 
@@ -79,6 +83,9 @@ const PostCard = ({ post }) => {
           <p className="footnote">
             {post.quantity} {post.actionDetails.noun}
           </p>
+        ) : null}
+        {isAnonymous ? (
+          <p className="footnote">{format(post.createdAt, 'PPP')}</p>
         ) : null}
         {post.type !== 'text' && post.text ? <p>{post.text}</p> : null}
       </BaseFigure>

--- a/resources/assets/components/utilities/PostCard/PostCard.js
+++ b/resources/assets/components/utilities/PostCard/PostCard.js
@@ -1,8 +1,8 @@
 import React from 'react';
 import { get } from 'lodash';
 import gql from 'graphql-tag';
-import { propType } from 'graphql-anywhere';
 import { format } from 'date-fns';
+import { propType } from 'graphql-anywhere';
 
 import PostBadge from './PostBadge';
 import { BaseFigure } from '../../Figure';


### PR DESCRIPTION
### What does this PR do?

This PR adds the submission date to text posts, a requested feature for the "Prom For All" gallery:

![Screen Shot 2019-03-11 at 1 49 09 PM](https://user-images.githubusercontent.com/583202/54145570-a4fb4780-4404-11e9-9cae-7e696b2bd403.png)

For now, we're not showing submission dates on other post types.

### Any background context you want to provide?

🖼

### What are the relevant tickets/cards?

Refs [Pivotal ID #164546893](https://www.pivotaltracker.com/story/show/164546893).

### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.
* [ ] Added screenshot to PR description of related front-end updates on **small** screens.
* [ ] Added screenshot to PR description of related front-end updates on **medium** screens.
* [ ] Added screenshot to PR description of related front-end updates on **large** screens.