### PR TITLE
Allow editors to customize number of columns in Post Galleries.

### DIFF
--- a/app/Entities/PostGallery.php
+++ b/app/Entities/PostGallery.php
@@ -19,6 +19,7 @@ class PostGallery extends Entity implements JsonSerializable
             'fields' => [
                 'internalTitle' => $this->internalTitle,
                 'actionIds' => $this->actionIds,
+                'itemsPerRow' => $this->itemsPerRow,
             ],
         ];
     }

--- a/contentful/content-types/postGallery.js
+++ b/contentful/content-types/postGallery.js
@@ -31,10 +31,27 @@ module.exports = function(migration) {
     .localized(false)
     .required(true);
 
+  postGallery
+    .createField('itemsPerRow')
+    .name('Items Per Row')
+    .type('Integer')
+    .validations([
+      {
+        in: [2, 3],
+      },
+    ])
+    .required(true)
+    .localized(false);
+
   postGallery.changeEditorInterface('internalTitle', 'singleLine', {});
 
   postGallery.changeEditorInterface('actionIds', 'listInput', {
     helpText: `A comma-separated list of one or more Action IDs to display in this gallery. Action IDs
     can be found in Rogue: https://dosome.click/nyshrf`,
+  });
+
+  postGallery.changeEditorInterface('itemsPerRow', 'radio', {
+    helpText:
+      'The maximum number of items in a single row when viewing the gallery in a large display.',
   });
 };

--- a/resources/assets/components/ContentfulEntry/ContentfulEntry.js
+++ b/resources/assets/components/ContentfulEntry/ContentfulEntry.js
@@ -101,7 +101,7 @@ class ContentfulEntry extends React.Component<Props, State> {
       case 'postGallery':
         return (
           <div className="margin-horizontal-md">
-            <PostGalleryBlockQuery {...json.fields} />
+            <PostGalleryBlockQuery {...withoutNulls(json.fields)} />
           </div>
         );
 

--- a/resources/assets/components/blocks/PostGalleryBlock/PostGalleryBlockQuery.js
+++ b/resources/assets/components/blocks/PostGalleryBlock/PostGalleryBlockQuery.js
@@ -30,7 +30,7 @@ const PostGalleryBlockQuery = ({ actionIds, itemsPerRow }) => (
     query={POST_GALLERY_QUERY}
     queryName="posts"
     variables={{ actionIds }}
-    count={9}
+    count={itemsPerRow * 3}
   >
     {({ result, fetching, fetchMore }) => (
       <PostGallery

--- a/resources/assets/components/blocks/PostGalleryBlock/PostGalleryBlockQuery.js
+++ b/resources/assets/components/blocks/PostGalleryBlock/PostGalleryBlockQuery.js
@@ -25,7 +25,7 @@ const POST_GALLERY_QUERY = gql`
 /**
  * Fetch results via GraphQL using a query component.
  */
-const PostGalleryBlockQuery = ({ actionIds }) => (
+const PostGalleryBlockQuery = ({ actionIds, itemsPerRow }) => (
   <PaginatedQuery
     query={POST_GALLERY_QUERY}
     queryName="posts"
@@ -36,6 +36,7 @@ const PostGalleryBlockQuery = ({ actionIds }) => (
       <PostGallery
         posts={result}
         loading={fetching}
+        itemsPerRow={itemsPerRow}
         loadMorePosts={fetchMore}
       />
     )}
@@ -43,11 +44,13 @@ const PostGalleryBlockQuery = ({ actionIds }) => (
 );
 
 PostGalleryBlockQuery.propTypes = {
-  actionIds: PropTypes.arrayOf(PropTypes.string),
+  actionIds: PropTypes.arrayOf(PropTypes.number),
+  itemsPerRow: PropTypes.number,
 };
 
 PostGalleryBlockQuery.defaultProps = {
   actionIds: [],
+  itemsPerRow: 3,
 };
 
 // Export the GraphQL query component.

--- a/resources/assets/components/utilities/PostGallery/PostGallery.js
+++ b/resources/assets/components/utilities/PostGallery/PostGallery.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { get } from 'lodash';
 import PropTypes from 'prop-types';
 
 import Card from '../Card/Card';
@@ -9,11 +10,20 @@ import PostCard from '../PostCard/PostCard';
 import './post-gallery.scss';
 
 const PostGallery = props => {
-  const { loading, posts, loadMorePosts } = props;
+  const { loading, posts, itemsPerRow, loadMorePosts } = props;
+
+  // Map the desired 'items per row' to a gallery type.
+  const galleryTypes = {
+    2: 'duo',
+    3: 'triad',
+  };
 
   return posts.length ? (
     <div>
-      <Gallery type="triad" className="post-gallery expand-horizontal-md">
+      <Gallery
+        type={get(galleryTypes, itemsPerRow)}
+        className="post-gallery expand-horizontal-md"
+      >
         {posts.map(post => (
           <Card className="rounded h-full" key={post.id}>
             <PostCard post={post} />
@@ -33,6 +43,7 @@ const PostGallery = props => {
 
 PostGallery.propTypes = {
   posts: PropTypes.array, // eslint-disable-line react/forbid-prop-types
+  itemsPerRow: PropTypes.number.isRequired,
   loading: PropTypes.bool.isRequired,
   loadMorePosts: PropTypes.func.isRequired,
 };


### PR DESCRIPTION
### What does this PR do?

This pull request adds an `itemsPerRow` field, modeled off of our ["editorial" gallery block](https://github.com/DoSomething/phoenix-next/blob/master/contentful/content-types/galleryBlock.js). This will allow us to use the "duo" gallery in our "Prom For All" story page, like in the [mocks](https://share.goabstract.com/315547ed-2962-4cdc-8db5-7e3fa2c3393a).

Here's the very cramped, extremely stress-inducing gallery **before**:

![](https://user-images.githubusercontent.com/583202/54149867-8ea5b980-440d-11e9-85e6-9f6ead43d328.png)

…and the infinitely more chill & relaxed gallery, **after**:

![](https://user-images.githubusercontent.com/583202/54149872-936a6d80-440d-11e9-8a12-65cf9ddc1ff2.png)

### Any background context you want to provide?

🔡 🔡 
🔡 🔡 
🔡 🔡 

### What are the relevant tickets/cards?

N/A, based on discussion with @lkpttn.

### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.
* [ ] Added screenshot to PR description of related front-end updates on **small** screens.
* [ ] Added screenshot to PR description of related front-end updates on **medium** screens.
* [ ] Added screenshot to PR description of related front-end updates on **large** screens.