### PR TITLE
Some fixes to Post Gallery layout.

### DIFF
--- a/resources/assets/components/utilities/PostCard/PostCard.js
+++ b/resources/assets/components/utilities/PostCard/PostCard.js
@@ -60,7 +60,13 @@ const PostCard = ({ post }) => {
       );
       break;
     case 'photo':
-      media = <LazyImage alt={`${authorLabel}'s photo`} src={post.url} />;
+      media = (
+        <LazyImage
+          className="post-photo"
+          alt={`${authorLabel}'s photo`}
+          src={post.url}
+        />
+      );
       break;
 
     default:

--- a/resources/assets/components/utilities/PostCard/post.scss
+++ b/resources/assets/components/utilities/PostCard/post.scss
@@ -18,18 +18,6 @@
     color: $med-gray;
   }
 
-  > .figure__media {
-    background-color: $white;
-
-    & > img {
-      width: 480px; // HACK: Expand smaller images to fit in card.
-    }
-  }
-
-  > .figure__body p {
-    word-break: break-word;
-  }
-
   .figure.-right > .figure__body {
     overflow: unset;
   }

--- a/resources/assets/components/utilities/PostCard/post.scss
+++ b/resources/assets/components/utilities/PostCard/post.scss
@@ -23,6 +23,10 @@
   }
 }
 
+.post-photo {
+  width: 100%;
+}
+
 .post-text {
   border-left: $half-spacing solid #7069d8;
 }

--- a/resources/assets/components/utilities/PostGallery/PostGallery.js
+++ b/resources/assets/components/utilities/PostGallery/PostGallery.js
@@ -9,14 +9,14 @@ import PostCard from '../PostCard/PostCard';
 
 import './post-gallery.scss';
 
+// Mapping of 'items per row' to gallery style.
+const galleryTypes = {
+  2: 'duo',
+  3: 'triad',
+};
+
 const PostGallery = props => {
   const { loading, posts, itemsPerRow, loadMorePosts } = props;
-
-  // Map the desired 'items per row' to a gallery type.
-  const galleryTypes = {
-    2: 'duo',
-    3: 'triad',
-  };
 
   return posts.length ? (
     <div>
@@ -43,13 +43,14 @@ const PostGallery = props => {
 
 PostGallery.propTypes = {
   posts: PropTypes.array, // eslint-disable-line react/forbid-prop-types
-  itemsPerRow: PropTypes.number.isRequired,
+  itemsPerRow: PropTypes.oneOf(Object.keys(galleryTypes).map(Number)),
   loading: PropTypes.bool.isRequired,
   loadMorePosts: PropTypes.func.isRequired,
 };
 
 PostGallery.defaultProps = {
   posts: [],
+  itemsPerRow: 3,
 };
 
 export default PostGallery;


### PR DESCRIPTION
### What does this PR do?

This pull request includes some fixes to the Post Gallery layout:

🗑 Removes unused CSS from before this was updated to use Flexbox in #1282. de4be72

↔️ Fixes issue with photos on wider post cards. ([Before](https://user-images.githubusercontent.com/583202/54158094-244a4480-4420-11e9-992f-1e7ca1eb8993.png), [After](https://user-images.githubusercontent.com/583202/54158103-290ef880-4420-11e9-803a-5562e030b94f.png)) e382fe6

🔢 Adds a fallback if `itemsPerRow` isn't specified, and better prop-type checking. 59a7bbf

### Any background context you want to provide?
🛰 

### What are the relevant tickets/cards?

N/A, flagged by @mendelB in this [Slack message](https://dosomething.slack.com/archives/C2BPA7M8F/p1552335869134500).

### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.
* [ ] Added screenshot to PR description of related front-end updates on **small** screens.
* [ ] Added screenshot to PR description of related front-end updates on **medium** screens.
* [ ] Added screenshot to PR description of related front-end updates on **large** screens.