### PR TITLE
Bonus: Make text post ornament transparent.

### DIFF
--- a/resources/assets/components/utilities/PostCard/PostCard.js
+++ b/resources/assets/components/utilities/PostCard/PostCard.js
@@ -4,6 +4,7 @@ import gql from 'graphql-tag';
 import { format } from 'date-fns';
 import { propType } from 'graphql-anywhere';
 
+import Card from '../Card/Card';
 import PostBadge from './PostBadge';
 import { BaseFigure } from '../../Figure';
 import LazyImage from '../../utilities/LazyImage';
@@ -74,28 +75,30 @@ const PostCard = ({ post }) => {
   }
 
   return (
-    <div className={`post post-${post.type}`}>
-      <div className="flex-grow">{media}</div>
-      <BaseFigure
-        media={reactionElement}
-        alignment="right"
-        className="padded margin-bottom-none"
-      >
-        <h4>
-          {authorLabel}
-          <PostBadge status={post.status} tags={post.tags} />
-        </h4>
-        {post.quantity ? (
-          <p className="footnote">
-            {post.quantity} {post.actionDetails.noun}
-          </p>
-        ) : null}
-        {isAnonymous ? (
-          <p className="footnote">{format(post.createdAt, 'PPP')}</p>
-        ) : null}
-        {post.type !== 'text' && post.text ? <p>{post.text}</p> : null}
-      </BaseFigure>
-    </div>
+    <Card className={`rounded h-full post-ornament-${post.type}`} key={post.id}>
+      <div className="post">
+        <div className="flex-grow">{media}</div>
+        <BaseFigure
+          media={reactionElement}
+          alignment="right"
+          className="padded margin-bottom-none"
+        >
+          <h4>
+            {authorLabel}
+            <PostBadge status={post.status} tags={post.tags} />
+          </h4>
+          {post.quantity ? (
+            <p className="footnote">
+              {post.quantity} {post.actionDetails.noun}
+            </p>
+          ) : null}
+          {isAnonymous ? (
+            <p className="footnote">{format(post.createdAt, 'PPP')}</p>
+          ) : null}
+          {post.type !== 'text' && post.text ? <p>{post.text}</p> : null}
+        </BaseFigure>
+      </div>
+    </Card>
   );
 };
 

--- a/resources/assets/components/utilities/PostCard/post.scss
+++ b/resources/assets/components/utilities/PostCard/post.scss
@@ -2,6 +2,7 @@
 
 .post {
   position: relative;
+  background: #fff;
   font-family: $primary-font-family;
   margin-bottom: 0;
   height: 100%;
@@ -27,8 +28,9 @@
   width: 100%;
 }
 
-.post-text {
-  border-left: $half-spacing solid #7069d8;
+.post-ornament-text {
+  border-left: $half-spacing solid rgba(#fff, 0.3);
+  background-clip: padding-box; // Allow border to "see through" background.
 }
 
 .chat-bubble.-post-bubble {

--- a/resources/assets/components/utilities/PostCard/post.scss
+++ b/resources/assets/components/utilities/PostCard/post.scss
@@ -33,6 +33,11 @@
   background-clip: padding-box; // Allow border to "see through" background.
 }
 
+// HACK: Ensure text post cards look okay on "classic" campaign pages.
+.campaign-page .post-ornament-text {
+  border-left-color: $light-gray;
+}
+
 .chat-bubble.-post-bubble {
   color: $black;
   background-color: $white;

--- a/resources/assets/components/utilities/PostGallery/PostGallery.js
+++ b/resources/assets/components/utilities/PostGallery/PostGallery.js
@@ -2,7 +2,6 @@ import React from 'react';
 import { get } from 'lodash';
 import PropTypes from 'prop-types';
 
-import Card from '../Card/Card';
 import Gallery from '../Gallery/Gallery';
 import LoadMore from '../LoadMore/LoadMore';
 import PostCard from '../PostCard/PostCard';
@@ -25,9 +24,7 @@ const PostGallery = props => {
         className="post-gallery expand-horizontal-md"
       >
         {posts.map(post => (
-          <Card className="rounded h-full" key={post.id}>
-            <PostCard post={post} />
-          </Card>
+          <PostCard post={post} />
         ))}
       </Gallery>
       <LoadMore


### PR DESCRIPTION
### What does this PR do?

I was _just about_ to sneak this into #1302 but @mendelB beat me to it and reviewed the PR! Anyways, this pull request makes the "ornament" on the side of text posts transparent, as @lkpttn once only dreamt. Gaze upon it's technicolor beauty:

![Screen Recording 2019-03-11 at 05 36 PM](https://user-images.githubusercontent.com/583202/54159952-a3da1280-4424-11e9-918e-5dab923f656b.gif)

One downside – now you can barely see it on normal campaign galleries:

![Screen Shot 2019-03-11 at 5 40 45 PM](https://user-images.githubusercontent.com/583202/54160019-da179200-4424-11e9-9b05-4061c6fb79df.png)

Well, you can't have it all. 🤷‍♂️ 

### Any background context you want to provide?

I guess we could apply a separate "static" color modifier on campaign pages? I dunno.

### What are the relevant tickets/cards?

N/A

### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.
* [ ] Added screenshot to PR description of related front-end updates on **small** screens.
* [ ] Added screenshot to PR description of related front-end updates on **medium** screens.
* [ ] Added screenshot to PR description of related front-end updates on **large** screens.