### PR TITLE
Embed iframe rendering

### DIFF
--- a/app/Entities/Entity.php
+++ b/app/Entities/Entity.php
@@ -82,6 +82,8 @@ class Entity implements ArrayAccess, JsonSerializable
                 }
 
                 return new CustomBlock($block->entry);
+            case 'embed':
+                return new Embed($block->entry);
             case 'galleryBlock':
                 return new GalleryBlock($block->entry);
             case 'imagesBlock':

--- a/resources/assets/components/ContentfulEntry/ContentfulEntry.js
+++ b/resources/assets/components/ContentfulEntry/ContentfulEntry.js
@@ -20,6 +20,7 @@ import SocialDriveActionContainer from '../actions/SocialDriveAction/SocialDrive
 import SixpackExperimentContainer from '../utilities/SixpackExperiment/SixpackExperimentContainer';
 import CampaignGalleryBlockContainer from '../blocks/CampaignGalleryBlock/CampaignGalleryBlockContainer';
 import {
+  renderEmbed,
   renderLinkAction,
   renderAffirmation,
   renderShareAction,
@@ -90,6 +91,9 @@ class ContentfulEntry extends React.Component<Props, State> {
 
       case 'contentBlock':
         return renderContentBlock(json);
+
+      case 'embed':
+        return renderEmbed(json);
 
       case 'gallery':
         return (

--- a/resources/assets/components/ContentfulEntry/renderers.js
+++ b/resources/assets/components/ContentfulEntry/renderers.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { PuckWaypoint } from '@dosomething/puck-client';
 
 import Affirmation from '../Affirmation';
+import Iframe from '../utilities/Iframe';
 import ContentBlock from '../blocks/ContentBlock/ContentBlock';
 import { withoutNulls } from '../../helpers';
 import LinkActionContainer from '../actions/LinkAction/LinkActionContainer';
@@ -196,5 +197,24 @@ export function renderContentBlock(data) {
 
   return (
     <ContentBlock key={`content-block-${data.id}`} id={data.id} {...fields} />
+  );
+}
+
+/**
+ * Render an embed.
+ *
+ * @param {Object} data Embed
+ * @return {Component}
+ */
+export function renderEmbed(data) {
+  const contentfulId = data.id;
+  const fields = withoutNulls(data.fields);
+
+  return (
+    <React.Fragment>
+      <PuckWaypoint name="embed-top" waypointData={{ contentfulId }} />
+      <Iframe id={contentfulId} {...fields} />
+      <PuckWaypoint name="embed-bottom" waypointData={{ contentfulId }} />
+    </React.Fragment>
   );
 }

--- a/resources/assets/components/utilities/Iframe.js
+++ b/resources/assets/components/utilities/Iframe.js
@@ -1,0 +1,24 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import ErrorBlock from '../ErrorBlock/ErrorBlock';
+
+const permittedHostnames = ['dosomething.carto.com'];
+
+const Iframe = ({ id, url }) => {
+  const hostname = url && new URL(url).hostname;
+
+  if (!permittedHostnames.includes(hostname)) {
+    console.warn(`Invalid URL ${url} supplied to Iframe component`);
+    return <ErrorBlock />;
+  }
+
+  return <iframe title={`embed ${id}`} src={url} width="100%" height="520" />;
+};
+
+Iframe.propTypes = {
+  id: PropTypes.string.isRequired,
+  url: PropTypes.string.isRequired,
+};
+
+export default Iframe;


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR adds a very basic `Iframe` component for rendering `Embed` entries.

### Any background context you want to provide?
It felt like a good idea to strictly enforce some hostname sanitizing on this `Iframe` even though we do already have the [validation rules](https://github.com/DoSomething/phoenix-next/blob/e42812dd73aabfa1a27d20dc3c0a20c343afae48/contentful/content-types/embed.js#L24-L34) in place on the Content-Type. 

### What are the relevant tickets/cards?

Refs [Pivotal ID #164541569](https://www.pivotaltracker.com/story/show/164541569)

![image](https://user-images.githubusercontent.com/12417657/54161534-d71ea080-4428-11e9-915e-53de63ddc4f3.png)

([Medium Screens](https://user-images.githubusercontent.com/12417657/54161587-fcabaa00-4428-11e9-90f2-e2f7d98984d4.png))


### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.
* [x] Added screenshot to PR description of related front-end updates on **medium** screens.
* [x] Added screenshot to PR description of related front-end updates on **large** screens.
