### PR TITLE
A quick fix for the 'view more' button on galleries.

### DIFF
--- a/resources/assets/components/utilities/Button/button.scss
+++ b/resources/assets/components/utilities/Button/button.scss
@@ -30,3 +30,7 @@
 .button__attached-container {
   padding: $half-spacing;
 }
+
+.button.-tertiary {
+  background: #fff;
+}


### PR DESCRIPTION
### What does this PR do?

Following [up on this comment in #1301](https://github.com/DoSomething/phoenix-next/pull/1301#issuecomment-471679734), this pull request adds a white background to "tertiary" buttons so they work in more places. This is a quick fix to get the gallery block working on both the art-directed story pages & traditional campaign pages:

On the story page, [before](https://user-images.githubusercontent.com/583202/54150824-d1689100-440f-11e9-9a7f-be0de825568e.png) and **after**:

<img width="615" alt="Screen Shot 2019-03-12 at 12 20 10 PM" src="https://user-images.githubusercontent.com/583202/54217152-768f7200-44c1-11e9-910c-aba5a70baa8c.png">


And on the campaign page, [before](https://user-images.githubusercontent.com/583202/54217202-8c9d3280-44c1-11e9-99a6-f3bdc766f0b2.png) and **after**:

<img width="965" alt="Screen Shot 2019-03-12 at 12 20 30 PM" src="https://user-images.githubusercontent.com/583202/54217147-73948180-44c1-11e9-9b9b-7874de413bb5.png">


### Any background context you want to provide?

I know this doesn't perfectly fit the mocks, but I think it's a good compromise since we're so close to the launch deadline for this experience. Up for other suggestions as well!

### What are the relevant tickets/cards?

N/A

### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.
* [ ] Added screenshot to PR description of related front-end updates on **small** screens.
* [ ] Added screenshot to PR description of related front-end updates on **medium** screens.
* [ ] Added screenshot to PR description of related front-end updates on **large** screens.