### PR TITLE
Update to add new text-content class and styles.

### DIFF
--- a/resources/assets/components/blocks/SectionBlock/SectionBlock.js
+++ b/resources/assets/components/blocks/SectionBlock/SectionBlock.js
@@ -21,7 +21,9 @@ const SectionBlock = props => {
       style={withoutNulls(styles)}
     >
       <div className="wrapper">
-        <TextContent styles={styles}>{content}</TextContent>
+        <TextContent className="section-block__content" styles={styles}>
+          {content}
+        </TextContent>
       </div>
     </section>
   );

--- a/resources/assets/components/blocks/SectionBlock/section-block.scss
+++ b/resources/assets/components/blocks/SectionBlock/section-block.scss
@@ -16,10 +16,10 @@
       grid-column: 5 / -5;
     }
   }
+}
 
-  h1 {
-    font-size: 42px;
-    line-height: 1;
+.section-block__content {
+  > h1 {
     margin-bottom: $base-spacing;
 
     @include media($medium) {
@@ -27,18 +27,5 @@
       display: inline-block;
       font-size: 60px;
     }
-  }
-
-  h2 {
-    font-size: $font-larger;
-  }
-
-  h3 {
-    font-size: $font-large;
-  }
-
-  ul,
-  ol {
-    text-align: left;
   }
 }

--- a/resources/assets/components/utilities/TextContent/RichTextDocument.js
+++ b/resources/assets/components/utilities/TextContent/RichTextDocument.js
@@ -14,7 +14,7 @@ import { parseRichTextDocument } from '../../../helpers/text';
  * @return {Object}
  */
 const RichTextDocument = ({ className = null, children, styles }) => (
-  <div className={classnames('markdown rich-text', className)}>
+  <div className={classnames('richtext', className)}>
     {parseRichTextDocument(children, styles)}
   </div>
 );

--- a/resources/assets/components/utilities/TextContent/TextContent.js
+++ b/resources/assets/components/utilities/TextContent/TextContent.js
@@ -6,29 +6,32 @@ import classnames from 'classnames';
 import RichTextDocument from './RichTextDocument';
 import StandardMarkdown from './StandardMarkdown';
 
-import './markdown.scss';
+import './text-content.scss';
+import './markdown.scss'; // @deprecate
 
 /**
- * Render Markdown as Markup prepared for a React Component
+ * Render TextContent as Markup prepared for a React Component.
  *
- * @TODO: rename component to <TextContent>
  * @param  {String} options.className
  * @param  {String|Array|Object} options.children
  * @param  {Object} options.styles
  * @return {Object}
  */
-const Markdown = ({ className = null, children, styles }) =>
+const TextContent = ({ className = null, children, styles }) =>
   has(children, 'nodeType') ? (
-    <RichTextDocument className={classnames(className)} styles={styles}>
+    <RichTextDocument
+      className={classnames('text-content', className)}
+      styles={styles}
+    >
       {children}
     </RichTextDocument>
   ) : (
-    <StandardMarkdown className={classnames(className)}>
+    <StandardMarkdown className={classnames('text-content', className)}>
       {children}
     </StandardMarkdown>
   );
 
-Markdown.propTypes = {
+TextContent.propTypes = {
   children: PropTypes.oneOfType([
     PropTypes.string,
     PropTypes.arrayOf(PropTypes.string),
@@ -38,9 +41,9 @@ Markdown.propTypes = {
   styles: PropTypes.object, // eslint-disable-line react/forbid-prop-types
 };
 
-Markdown.defaultProps = {
+TextContent.defaultProps = {
   className: null,
   styles: {},
 };
 
-export default Markdown;
+export default TextContent;

--- a/resources/assets/components/utilities/TextContent/markdown.scss
+++ b/resources/assets/components/utilities/TextContent/markdown.scss
@@ -72,7 +72,7 @@
 
   h1 {
     font-family: $secondary-font-family;
-    font-size: 41px;
+    font-size: 42px;
     font-weight: $weight-normal;
     text-transform: uppercase;
     color: $black;
@@ -87,7 +87,7 @@
   }
 
   h2 {
-    font-size: 41px;
+    font-size: 42px;
   }
 
   h3 {

--- a/resources/assets/components/utilities/TextContent/text-content.scss
+++ b/resources/assets/components/utilities/TextContent/text-content.scss
@@ -1,0 +1,90 @@
+@import '../../../scss/next-toolbox.scss';
+
+.text-content {
+  p {
+    color: inherit;
+  }
+
+  strong,
+  b {
+    font-weight: 700;
+  }
+
+  em,
+  i {
+    font-style: italic;
+  }
+
+  > h1 + p,
+  > h2 + p,
+  > h3 + p,
+  > h4 + p,
+  > h5 + p,
+  > h6 + p,
+  > p + p,
+  > p + ul,
+  > p + ol,
+  > ul + p,
+  > ul + ul,
+  > ul + ol,
+  > ol + p,
+  > ol + ol,
+  > ol + ul {
+    margin-top: $half-spacing;
+  }
+
+  > h1 {
+    color: $black;
+    font-family: $secondary-font-family;
+    font-size: 42px;
+    font-weight: $weight-normal;
+    line-height: 1;
+    text-transform: uppercase;
+  }
+
+  > h2,
+  > h3,
+  > h4 {
+    color: $black;
+    font-family: $primary-font-family;
+    font-weight: $weight-bold;
+  }
+
+  > h2 {
+    font-size: $font-larger;
+  }
+
+  > h3 {
+    font-size: $font-large;
+  }
+
+  > h4 {
+    font-size: 18px;
+  }
+
+  > ul,
+  > ol {
+    text-align: left;
+  }
+
+  > blockquote {
+    position: relative;
+    text-align: left;
+    margin: $base-spacing 0;
+
+    &:before {
+      content: '';
+      height: 102%;
+      left: 0;
+      top: -1%;
+      width: 4px;
+      background: $primary-color;
+      position: absolute;
+    }
+
+    p {
+      font-size: $font-medium;
+      margin-left: $base-spacing;
+    }
+  }
+}


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR adds a new stylesheet for the `TextContent` component. The intention is to begin deprecating the `.markdown` class in favor of the `.text-content` class which applies to both `RichText` and `StandardMarkdown` content. The `.markdown` and `.richtext` classes will exist, but they will only be used to override any `.text-content` styles that the `StandardMarkdown` and `RichText` components respectively, need to adjust.

### Any background context you want to provide?

Since we can now utilize entries inside of RichText fields, I found we could harness the power of the [*child combinator*](https://developer.mozilla.org/en-US/docs/Web/CSS/Child_combinator) selector to ensure that only specific tags that are immediate children of the tag containing the text content get styles applied, but the styles do not leak into embedded entries.

![image](https://user-images.githubusercontent.com/105849/54232918-2ffe3f80-44e2-11e9-8b63-1a87d2d77395.png)


### What are the relevant tickets/cards?

Refs [Pivotal ID #164584567](https://www.pivotaltracker.com/story/show/164584567)

### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.