### PR TITLE
Updating to relocate PuckWaypoints on some components.

### DIFF
--- a/resources/assets/components/ContentfulEntry/ContentfulEntry.js
+++ b/resources/assets/components/ContentfulEntry/ContentfulEntry.js
@@ -1,6 +1,6 @@
 /* @flow */
 
-import React from 'react';
+import * as React from 'react';
 
 import NotFound from '../NotFound';
 import Iframe from '../utilities/Iframe';

--- a/resources/assets/components/ContentfulEntry/ContentfulEntry.js
+++ b/resources/assets/components/ContentfulEntry/ContentfulEntry.js
@@ -1,6 +1,6 @@
 /* @flow */
 
-import { React, Fragment } from 'react';
+import React from 'react';
 
 import NotFound from '../NotFound';
 import Iframe from '../utilities/Iframe';
@@ -208,7 +208,7 @@ class ContentfulEntry extends React.Component<Props, State> {
 
       case 'textSubmissionAction':
         return (
-          <Fragment>
+          <React.Fragment>
             <TextSubmissionActionContainer
               className={className}
               id={json.id}
@@ -218,7 +218,7 @@ class ContentfulEntry extends React.Component<Props, State> {
               className={className}
               type="text"
             />
-          </Fragment>
+          </React.Fragment>
         );
 
       case 'voterRegistrationAction':

--- a/resources/assets/components/ContentfulEntry/ContentfulEntry.js
+++ b/resources/assets/components/ContentfulEntry/ContentfulEntry.js
@@ -3,6 +3,7 @@
 import React from 'react';
 
 import NotFound from '../NotFound';
+import Iframe from '../utilities/Iframe';
 import Loader from '../utilities/Loader';
 import StaticBlock from '../StaticBlock';
 import ErrorBlock from '../ErrorBlock/ErrorBlock';
@@ -19,16 +20,16 @@ import PostGalleryBlockQuery from '../blocks/PostGalleryBlock/PostGalleryBlockQu
 import SocialDriveActionContainer from '../actions/SocialDriveAction/SocialDriveActionContainer';
 import SixpackExperimentContainer from '../utilities/SixpackExperiment/SixpackExperimentContainer';
 import CampaignGalleryBlockContainer from '../blocks/CampaignGalleryBlock/CampaignGalleryBlockContainer';
+import TextSubmissionActionContainer from '../actions/TextSubmissionAction/TextSubmissionActionContainer';
+import SubmissionGalleryBlockContainer from '../blocks/SubmissionGalleryBlock/SubmissionGalleryBlockContainer';
+import PetitionSubmissionActionContainer from '../actions/PetitionSubmissioncAction/PetitionSubmissionActionContainer';
 import {
-  renderEmbed,
   renderLinkAction,
   renderAffirmation,
   renderShareAction,
   renderContentBlock,
   renderPhotoSubmissionAction,
-  renderTextSubmissionAction,
   renderVoterRegistrationAction,
-  renderPetitionSubmissionAction,
   renderReferralSubmissionAction,
 } from './renderers';
 
@@ -94,7 +95,14 @@ class ContentfulEntry extends React.Component<Props, State> {
         return renderContentBlock(json, className);
 
       case 'embed':
-        return renderEmbed(json, className);
+        return (
+          <Iframe
+            className={className}
+            id={json.id}
+            {...withoutNulls(json.fields)}
+          />
+        );
+      // return renderEmbed(json, className);
 
       case 'gallery':
         return (
@@ -135,7 +143,13 @@ class ContentfulEntry extends React.Component<Props, State> {
         );
 
       case 'petitionSubmissionAction':
-        return renderPetitionSubmissionAction(json, className);
+        return (
+          <PetitionSubmissionActionContainer
+            className={className}
+            id={json.id}
+            {...withoutNulls(json.fields)}
+          />
+        );
 
       case 'photoSubmissionAction':
         return renderPhotoSubmissionAction(json);
@@ -194,7 +208,19 @@ class ContentfulEntry extends React.Component<Props, State> {
         );
 
       case 'textSubmissionAction':
-        return renderTextSubmissionAction(json, className);
+        return (
+          <React.Fragment>
+            <TextSubmissionActionContainer
+              className={className}
+              id={json.id}
+              {...withoutNulls(json.fields)}
+            />
+            <SubmissionGalleryBlockContainer
+              className={className}
+              type="text"
+            />
+          </React.Fragment>
+        );
 
       case 'voterRegistrationAction':
         return renderVoterRegistrationAction(json);

--- a/resources/assets/components/ContentfulEntry/ContentfulEntry.js
+++ b/resources/assets/components/ContentfulEntry/ContentfulEntry.js
@@ -102,7 +102,6 @@ class ContentfulEntry extends React.Component<Props, State> {
             {...withoutNulls(json.fields)}
           />
         );
-      // return renderEmbed(json, className);
 
       case 'gallery':
         return (

--- a/resources/assets/components/ContentfulEntry/ContentfulEntry.js
+++ b/resources/assets/components/ContentfulEntry/ContentfulEntry.js
@@ -1,6 +1,6 @@
 /* @flow */
 
-import React from 'react';
+import { React, Fragment } from 'react';
 
 import NotFound from '../NotFound';
 import Iframe from '../utilities/Iframe';
@@ -208,7 +208,7 @@ class ContentfulEntry extends React.Component<Props, State> {
 
       case 'textSubmissionAction':
         return (
-          <React.Fragment>
+          <Fragment>
             <TextSubmissionActionContainer
               className={className}
               id={json.id}
@@ -218,7 +218,7 @@ class ContentfulEntry extends React.Component<Props, State> {
               className={className}
               type="text"
             />
-          </React.Fragment>
+          </Fragment>
         );
 
       case 'voterRegistrationAction':

--- a/resources/assets/components/ContentfulEntry/renderers.js
+++ b/resources/assets/components/ContentfulEntry/renderers.js
@@ -2,17 +2,14 @@ import React from 'react';
 import { PuckWaypoint } from '@dosomething/puck-client';
 
 import Affirmation from '../Affirmation';
-import Iframe from '../utilities/Iframe';
 import { withoutNulls } from '../../helpers';
 import ContentBlock from '../blocks/ContentBlock/ContentBlock';
 import LinkActionContainer from '../actions/LinkAction/LinkActionContainer';
 import ShareActionContainer from '../actions/ShareAction/ShareActionContainer';
-import TextSubmissionActionContainer from '../actions/TextSubmissionAction/TextSubmissionActionContainer';
 import PhotoSubmissionActionContainer from '../actions/PhotoSubmissionAction/PhotoSubmissionActionContainer';
 import SubmissionGalleryBlockContainer from '../blocks/SubmissionGalleryBlock/SubmissionGalleryBlockContainer';
 import VoterRegistrationActionContainer from '../actions/VoterRegistrationAction/VoterRegistrationActionContainer';
 import ReferralSubmissionActionContainer from '../actions/ReferralSubmissionAction/ReferralSubmissionActionContainer';
-import PetitionSubmissionActionContainer from '../actions/PetitionSubmissioncAction/PetitionSubmissionActionContainer';
 
 /**
  * Render the voter registration action container.
@@ -75,36 +72,6 @@ export function renderLinkAction(step) {
 }
 
 /**
- * Render a text submission action.
- *
- * @param {Object} data
- * @return {Component}
- */
-export function renderTextSubmissionAction(data, className = null) {
-  const contentfulId = data.id;
-  const fields = withoutNulls(data.fields);
-
-  return (
-    <React.Fragment>
-      <PuckWaypoint
-        name="text_submission_action-top"
-        waypointData={{ contentfulId }}
-      />
-      <TextSubmissionActionContainer
-        className={className}
-        id={contentfulId}
-        {...fields}
-      />
-      <SubmissionGalleryBlockContainer className={className} type="text" />
-      <PuckWaypoint
-        name="text_submission_action-bottom"
-        waypointData={{ contentfulId }}
-      />
-    </React.Fragment>
-  );
-}
-
-/**
  * Render a photo submission action.
  *
  * @param  {Object} data
@@ -129,35 +96,6 @@ export function renderPhotoSubmissionAction(data) {
         waypointData={{ contentfulId }}
       />
     </div>
-  );
-}
-
-/**
- * Render a petition submission action.
- *
- * @param  {Object} data
- * @return {Component}
- */
-export function renderPetitionSubmissionAction(data, className = null) {
-  const contentfulId = data.id;
-  const fields = withoutNulls(data.fields);
-
-  return (
-    <React.Fragment>
-      <PuckWaypoint
-        name="petition_submission_action-top"
-        waypointData={{ contentfulId }}
-      />
-      <PetitionSubmissionActionContainer
-        className={className}
-        id={contentfulId}
-        {...fields}
-      />
-      <PuckWaypoint
-        name="petition_submission_action-bottom"
-        waypointData={{ contentfulId }}
-      />
-    </React.Fragment>
   );
 }
 
@@ -199,23 +137,4 @@ export function renderContentBlock(data, className = null) {
   const fields = withoutNulls(data.fields);
 
   return <ContentBlock className={className} id={data.id} {...fields} />;
-}
-
-/**
- * Render an embed.
- *
- * @param {Object} data Embed
- * @return {Component}
- */
-export function renderEmbed(data, className = null) {
-  const contentfulId = data.id;
-  const fields = withoutNulls(data.fields);
-
-  return (
-    <React.Fragment>
-      <PuckWaypoint name="embed-top" waypointData={{ contentfulId }} />
-      <Iframe className={className} id={contentfulId} {...fields} />
-      <PuckWaypoint name="embed-bottom" waypointData={{ contentfulId }} />
-    </React.Fragment>
-  );
 }

--- a/resources/assets/components/actions/PetitionSubmissioncAction/PetitionSubmissionAction.js
+++ b/resources/assets/components/actions/PetitionSubmissioncAction/PetitionSubmissionAction.js
@@ -4,6 +4,7 @@ import { get, has } from 'lodash';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import { Query } from 'react-apollo';
+import { PuckWaypoint } from '@dosomething/puck-client';
 
 import Card from '../../utilities/Card/Card';
 import Button from '../../utilities/Button/Button';
@@ -97,12 +98,15 @@ class PetitionSubmissionAction extends React.Component {
       <React.Fragment>
         <div
           className={classnames(
-            'petition-submission-action',
-            'margin-bottom-lg',
+            'petition-submission-action margin-bottom-lg',
             this.props.className,
           )}
           id={id}
         >
+          <PuckWaypoint
+            name="petition_submission_action-top"
+            waypointData={{ contentfulId: id }}
+          />
           <Card className="bordered rounded" title={title}>
             {this.state.showAffirmation ? (
               <p className="padded affirmation-message">
@@ -167,13 +171,16 @@ class PetitionSubmissionAction extends React.Component {
               </Button>
             </form>
           </Card>
+          <PuckWaypoint
+            name="petition_submission_action-bottom"
+            waypointData={{ contentfulId: id }}
+          />
         </div>
 
         {this.props.informationContent ? (
           <div
             className={classnames(
-              'petition-submission-information',
-              'margin-bottom-md',
+              'petition-submission-information margin-bottom-lg',
               this.props.className,
             )}
           >

--- a/resources/assets/components/actions/TextSubmissionAction/TextSubmissionAction.js
+++ b/resources/assets/components/actions/TextSubmissionAction/TextSubmissionAction.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import { get, has, invert, mapValues } from 'lodash';
+import { PuckWaypoint } from '@dosomething/puck-client';
 
 import Card from '../../utilities/Card/Card';
 import Modal from '../../utilities/Modal/Modal';
@@ -103,9 +104,16 @@ class TextSubmissionAction extends React.Component {
     return (
       <React.Fragment>
         <div
-          className={classnames('text-submission-action', this.props.className)}
+          className={classnames(
+            'text-submission-action margin-bottom-lg',
+            this.props.className,
+          )}
           id={this.props.id}
         >
+          <PuckWaypoint
+            name="text_submission_action-top"
+            waypointData={{ contentfulId: this.props.id }}
+          />
           <Card className="bordered rounded" title={this.props.title}>
             {formResponse ? <FormValidation response={formResponse} /> : null}
 
@@ -145,14 +153,16 @@ class TextSubmissionAction extends React.Component {
               </p>
             </form>
           </Card>
+          <PuckWaypoint
+            name="text_submission_action-bottom"
+            waypointData={{ contentfulId: this.props.id }}
+          />
         </div>
 
         {this.props.informationContent ? (
           <div
             className={classnames(
-              'text-submission-information',
-              'margin-top-lg',
-              'margin-bottom-lg',
+              'text-submission-information margin-bottom-lg',
               this.props.className,
             )}
           >

--- a/resources/assets/components/utilities/Iframe.js
+++ b/resources/assets/components/utilities/Iframe.js
@@ -2,6 +2,7 @@ import React from 'react';
 import Media from 'react-media';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
+import { PuckWaypoint } from '@dosomething/puck-client';
 
 import LazyImage from './LazyImage';
 import { getRequest } from '../../helpers/api';
@@ -54,7 +55,8 @@ const Iframe = ({ className, id, url }) => {
   }
 
   return (
-    <div id={id} className={classnames('embed', className)}>
+    <div id={id} className={classnames('embed margin-bottom-lg', className)}>
+      <PuckWaypoint name="embed-top" waypointData={{ contentfulId: id }} />
       <Media query="(max-width: 759px)">
         {matches =>
           matches ? (
@@ -64,6 +66,7 @@ const Iframe = ({ className, id, url }) => {
           )
         }
       </Media>
+      <PuckWaypoint name="embed-bottom" waypointData={{ contentfulId: id }} />
     </div>
   );
 };

--- a/resources/assets/components/utilities/TextContent/text-content.scss
+++ b/resources/assets/components/utilities/TextContent/text-content.scss
@@ -27,8 +27,7 @@
   > ol + ol,
   > ol + ul,
   > div + h1, // @TODO: should be able to remove the "div +" items after we nest PuckWaypoints inside components.
-  > p + .component-entry,
-  > div + .component-entry {
+  > p + .component-entry {
     margin-top: $half-spacing;
   }
 

--- a/resources/assets/helpers/text.js
+++ b/resources/assets/helpers/text.js
@@ -108,11 +108,12 @@ export function parseRichTextDocument(document, styles) {
           {children}
         </h6>
       ),
-      [BLOCKS.PARAGRAPH]: (node, children) => (
-        <p className="grid-main" style={textColor}>
-          {children}
-        </p>
-      ),
+      [BLOCKS.PARAGRAPH]: (node, children) =>
+        children[0] ? (
+          <p className="grid-main" style={textColor}>
+            {children}
+          </p>
+        ) : null,
       [BLOCKS.UL_LIST]: (node, children) => (
         <ul className="grid-main text-left list" style={textColor}>
           {children}


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_


### What does this PR do?

This PR does some margin cleanup but primarily moves some `PuckWaypoints` components _inside_ of some of the submission actions and the embed. I think in general it makes more sense to keep them in the component and helps actually remove some code cruft in the `renderers.js` (if we do this to all items we probably don't even need this file).

The `PuckWaypoints` also output empty divs in the markup, and while this is usually fine, it's not so great if those empty divs become child elements of the grid and can actually affect the layout of other items:

![Screen Shot 2019-03-14 at 7 20 30 PM](https://user-images.githubusercontent.com/105849/54399815-80b69980-4696-11e9-8dbc-21ec89f2a34f.png)

By moving them inside the component it helps make sure they don't impact the grid layout and the markup just looks generally cleaner ✨ 

### Any background context you want to provide?

...

### What are the relevant tickets/cards?

🌵 

### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.