### PR TITLE
Some More #Quick Design QA Updates

### DIFF
--- a/resources/assets/scss/base.scss
+++ b/resources/assets/scss/base.scss
@@ -57,6 +57,11 @@ p {
   }
 }
 
+// Override Forge rule for .text-field font-family (https://git.io/fjeFh).
+.text-field {
+  font-family: $primary-font-family;
+}
+
 // Utility classes.
 // @TODO: Move over to Forge 7 soon!
 .background-image-centered {

--- a/resources/assets/scss/gallery-grid.scss
+++ b/resources/assets/scss/gallery-grid.scss
@@ -9,7 +9,7 @@
   padding: 0 $half-spacing;
   overflow: hidden;
 
-  @include media('(min-width: 376px)') {
+  @include media('(min-width: 425px)') {
     grid-template-columns: 1fr 1fr;
     grid-column-gap: $half-spacing;
     grid-row-gap: $half-spacing;
@@ -80,7 +80,7 @@
   font-weight: $weight-bold;
   margin-bottom: $increment-spacing;
 
-  @include media('(min-width: 376px)') {
+  @include media('(min-width: 425px)') {
     font-size: $font-small;
   }
 
@@ -102,7 +102,7 @@
   font-weight: $weight-normal;
   line-height: 1.3;
 
-  @include media('(min-width: 376px)') {
+  @include media('(min-width: 425px)') {
     font-size: $font-small;
   }
 


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR adds a couple of quick styling updates:
- Override the Forge font rule for `.text-field`s so we use `Source Sans Pro` (https://goo.gl/yuqiri)
- Bump the minimum width for the two column styling to kick in for the gallery grid system

### Any background context you want to provide?
Re the gallery grid width - totally open to debate of course, but while testing Prom on my (android 😲) phone, it felt a bit claustrophobic to have the two column grid on the gallery:
![Exhibit A](https://user-images.githubusercontent.com/12417657/54441871-f876d980-4713-11e9-89c7-a0fb40d54da0.png)

As opposed to one:
![Exhibit B](https://user-images.githubusercontent.com/12417657/54441965-25c38780-4714-11e9-9204-5e7c7166ecc0.png)

The only other place this would currently affect would be the Explore Campaigns gallery:
![Exhibit C](https://user-images.githubusercontent.com/12417657/54442237-aaaea100-4714-11e9-9011-56c0d7161840.png)


Which addmittedly does not seem as claustrophobic currently:
![Exhibit D](https://user-images.githubusercontent.com/12417657/54442176-8ce13c00-4714-11e9-8134-61327a2bba88.png)

LMK whatcha think! CC @lkpttn 


### What are the relevant tickets/cards?

Refs [Pivotal ID #164637008](https://www.pivotaltracker.com/story/show/164637008)