### PR TITLE
Add stricter location validation & fixes for particular country codes.

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -52,6 +52,12 @@ class AppServiceProvider extends ServiceProvider
                 $region = null;
             }
 
+            // Fix improper ISO-3601-2 format for American territories:
+            if (in_array($country, ['AS', 'GU', 'MP', 'PR'])) {
+                $region = $country;
+                $country = 'US';
+            }
+
             $view->with('auth', [
                 'isAuthenticated' => auth()->check(),
                 'id' => auth()->id() ?: request()->query('user_id'),

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -40,9 +40,17 @@ class AppServiceProvider extends ServiceProvider
         });
 
         View::composer('*', function ($view) {
-            // Read Fastly's geolocation headers for location-based features.
+            // Read Fastly's geolocation headers for location-based features,
+            // and check that they look like valid ISO-3601-2 codes.
             $country = request()->header('X-Fastly-Country-Code');
+            if (strlen($country) !== 2) {
+                $country = null;
+            }
+
             $region = request()->header('X-Fastly-Region-Code');
+            if (! in_array(strlen($region), [2, 3])) {
+                $region = null;
+            }
 
             $view->with('auth', [
                 'isAuthenticated' => auth()->check(),

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -42,12 +42,12 @@ class AppServiceProvider extends ServiceProvider
         View::composer('*', function ($view) {
             // Read Fastly's geolocation headers for location-based features,
             // and check that they look like valid ISO-3601-2 codes.
-            $country = 'CA';
+            $country = request()->header('X-Fastly-Country-Code');
             if (strlen($country) !== 2) {
                 $country = null;
             }
 
-            $region = 'ON';
+            $region = request()->header('X-Fastly-Region-Code');
             if (! in_array(strlen($region), [2, 3])) {
                 $region = null;
             }

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -42,18 +42,18 @@ class AppServiceProvider extends ServiceProvider
         View::composer('*', function ($view) {
             // Read Fastly's geolocation headers for location-based features,
             // and check that they look like valid ISO-3601-2 codes.
-            $country = request()->header('X-Fastly-Country-Code');
+            $country = 'CA';
             if (strlen($country) !== 2) {
                 $country = null;
             }
 
-            $region = request()->header('X-Fastly-Region-Code');
+            $region = 'ON';
             if (! in_array(strlen($region), [2, 3])) {
                 $region = null;
             }
 
-            // Fix improper ISO-3601-2 format for American territories:
-            if (in_array($country, ['AS', 'GU', 'MP', 'PR'])) {
+            // Fix improper format for American territories <https://goo.gl/qzcMyb>:
+            if (in_array($country, ['AS', 'GU', 'MP', 'PR', 'UM', 'VI'])) {
                 $region = $country;
                 $country = 'US';
             }


### PR DESCRIPTION
### What does this PR do?

This pull request adds a quick fix to filter out "bad" geolocation data provided by Fastly. It checks that the country and region codes are the correct number of characters, and massages some specific countries that weren't provided in the correct format.

### Any background context you want to provide?
Mendel [noticed this morning](https://dosomething.slack.com/archives/C3ASB4204/p1552657729291600) that some users are getting validation errors due to bad `location` format. For example, users from Guam are receiving the region of `NO REGION` from Fastly.

From scanning the logs, it looks like only users from US Territories (Guam, Puerto Rico, and American Samoa) were affected, since Fastly provides the territory as the country code (so `GU-NO REGION` instead of [`US-GU`](https://en.wikipedia.org/wiki/ISO_3166-2:GU), and `AS-NO REGION` instead of [`US-AS`](https://en.wikipedia.org/wiki/ISO_3166-2:AS)).

### What are the relevant tickets/cards?

Refs [Pivotal ID #164667891](https://www.pivotaltracker.com/story/show/164667891)

### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.
* [ ] Added screenshot to PR description of related front-end updates on **small** screens.
* [ ] Added screenshot to PR description of related front-end updates on **medium** screens.
* [ ] Added screenshot to PR description of related front-end updates on **large** screens.