### PR TITLE
Petition Submission Action Post-Submission State

### DIFF
--- a/resources/assets/components/actions/PetitionSubmissioncAction/PetitionSubmissionAction.js
+++ b/resources/assets/components/actions/PetitionSubmissioncAction/PetitionSubmissionAction.js
@@ -27,6 +27,8 @@ const USER_POSTS_QUERY = gql`
   }
 `;
 
+const CHARACTER_LIMIT = 500;
+
 class PetitionSubmissionAction extends React.Component {
   constructor(props) {
     super(props);
@@ -152,7 +154,10 @@ class PetitionSubmissionAction extends React.Component {
                         onChange={this.handleChange}
                         disabled={submitted}
                       />
-                      <CharacterLimit limit={500} text={this.state.textValue} />
+                      <CharacterLimit
+                        limit={CHARACTER_LIMIT}
+                        text={this.state.textValue}
+                      />
                     </div>
 
                     <div className="padded">
@@ -171,7 +176,10 @@ class PetitionSubmissionAction extends React.Component {
                       type="submit"
                       attached
                       loading={submissionItem && submissionItem.isPending}
-                      disabled={submitted}
+                      disabled={
+                        submitted ||
+                        this.state.textValue.length > CHARACTER_LIMIT
+                      }
                     >
                       {buttonText}
                     </Button>

--- a/resources/assets/components/actions/PetitionSubmissioncAction/PetitionSubmissionAction.js
+++ b/resources/assets/components/actions/PetitionSubmissioncAction/PetitionSubmissionAction.js
@@ -118,7 +118,7 @@ class PetitionSubmissionAction extends React.Component {
           <Query
             query={USER_POSTS_QUERY}
             variables={{ userId, actionIds: String(actionId) }}
-            queryName="posts"
+            queryName="userPosts"
             skip={!userId}
           >
             {({ loading, data }) => {

--- a/resources/assets/components/actions/PetitionSubmissioncAction/PetitionSubmissionAction.js
+++ b/resources/assets/components/actions/PetitionSubmissioncAction/PetitionSubmissionAction.js
@@ -7,6 +7,7 @@ import { Query } from 'react-apollo';
 import { PuckWaypoint } from '@dosomething/puck-client';
 
 import Card from '../../utilities/Card/Card';
+import Modal from '../../utilities/Modal/Modal';
 import Button from '../../utilities/Button/Button';
 import FormValidation from '../../utilities/Form/FormValidation';
 import TextContent from '../../utilities/TextContent/TextContent';
@@ -21,6 +22,7 @@ class PetitionSubmissionAction extends React.Component {
 
     this.state = {
       showAffirmation: false,
+      showModal: false,
       textValue: '',
     };
   }
@@ -35,6 +37,7 @@ class PetitionSubmissionAction extends React.Component {
       return {
         // @TODO: change this to showModal, and display an affirmation modal in place of the success message.
         showAffirmation: true,
+        showModal: true,
         textValue: '',
       };
     }
@@ -191,6 +194,16 @@ class PetitionSubmissionAction extends React.Component {
             </Card>
           </div>
         ) : null}
+
+        {this.state.showModal ? (
+          <Modal onClose={() => this.setState({ showModal: false })}>
+            <Card className="bordered rounded" title="We got your signature!">
+              <TextContent className="padded">
+                {this.props.affirmationContent}
+              </TextContent>
+            </Card>
+          </Modal>
+        ) : null}
       </React.Fragment>
     );
   }
@@ -198,6 +211,7 @@ class PetitionSubmissionAction extends React.Component {
 
 PetitionSubmissionAction.propTypes = {
   actionId: PropTypes.number.isRequired,
+  affirmationContent: PropTypes.string,
   buttonText: PropTypes.string,
   className: PropTypes.string,
   content: PropTypes.string.isRequired,
@@ -215,6 +229,7 @@ PetitionSubmissionAction.propTypes = {
 };
 
 PetitionSubmissionAction.defaultProps = {
+  affirmationContent: 'Thanks for signing the petition!',
   buttonText: 'Add your name',
   className: null,
   textFieldPlaceholder: 'Add your custom message...',

--- a/resources/assets/components/actions/TextSubmissionAction/TextSubmissionAction.js
+++ b/resources/assets/components/actions/TextSubmissionAction/TextSubmissionAction.js
@@ -15,6 +15,8 @@ import CharacterLimit from '../../utilities/CharacterLimit/CharacterLimit';
 
 import './text-submission-action.scss';
 
+const CHARACTER_LIMIT = 500;
+
 class TextSubmissionAction extends React.Component {
   constructor(props) {
     super(props);
@@ -137,12 +139,18 @@ class TextSubmissionAction extends React.Component {
                   value={this.state.textValue}
                   onChange={this.handleChange}
                 />
-                <CharacterLimit limit={500} text={this.state.textValue} />
+                <CharacterLimit
+                  limit={CHARACTER_LIMIT}
+                  text={this.state.textValue}
+                />
               </div>
               <Button
                 type="submit"
                 loading={submissionItem && submissionItem.isPending}
-                disabled={!this.state.textValue}
+                disabled={
+                  !this.state.textValue ||
+                  this.state.textValue.length > CHARACTER_LIMIT
+                }
                 attached
               >
                 {this.props.buttonText}

--- a/resources/assets/components/utilities/CharacterLimit/CharacterLimit.js
+++ b/resources/assets/components/utilities/CharacterLimit/CharacterLimit.js
@@ -3,10 +3,10 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
 const CharacterLimit = ({ text, limit }) => {
-  const remaining = Math.max(limit - text.length, 0);
+  const remaining = limit - text.length;
 
   return (
-    <p className={classNames('footnote', { 'color-error': remaining === 0 })}>
+    <p className={classNames('footnote', { 'color-error': remaining <= 0 })}>
       {remaining} characters remaining
     </p>
   );


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR adds updated post-submission state to the `PetitionSubmissionAction` component
- https://github.com/DoSomething/phoenix-next/commit/374fb3e7c0877e8fb6086e467507651f24376cb5 displays the affirmation modal post successful submissions
- https://github.com/DoSomething/phoenix-next/commit/fda0a1627eec04084c2aaeb4a475ca413c65f47f (the meat of the thing) adds an updated graphql query to fetch the users posts for this action and their first name for the signature and handles the various submission states accordingly.
- https://github.com/DoSomething/phoenix-next/commit/5f0ab066456a843926ab7c7e31f8ab3c040508cd disables the submission button if the text field length exceeds the character limit (as per [this Slack conversation](https://dosomething.slack.com/archives/C2BPA7M8F/p1552936127277200))
-  https://github.com/DoSomething/phoenix-next/commit/369c65d3af1a9c6887e6ec628844d8dc4e0aaeae (Suggestion! I can roll this back) displays the negative character count (a la Twitter) which I think makes it easier for the user to patch a faulty text submission.

### What are the relevant tickets/cards?

Refs [Pivotal ID #164711433](https://www.pivotaltracker.com/story/show/164711433)

### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.
