### PR TITLE
Richtext hyperlinks

### DIFF
--- a/app/Entities/SectionBlock.php
+++ b/app/Entities/SectionBlock.php
@@ -14,6 +14,7 @@ class SectionBlock extends Entity implements JsonSerializable
             'fields' => [
                 'internalTitle' => $this->internalTitle,
                 'backgroundColor' => $this->backgroundColor,
+                'hyperlinkColor' => $this->hyperlinkColor,
                 'textColor' => $this->textColor,
                 'content' => $this->content,
             ],

--- a/contentful/content-types/sectionBlock.js
+++ b/contentful/content-types/sectionBlock.js
@@ -55,6 +55,26 @@ module.exports = function(migration) {
     .omitted(false);
 
   sectionBlock
+    .createField('hyperlinkColor')
+    .name('Hyperlink Color')
+    .type('Symbol')
+    .localized(false)
+    .required(false)
+    .validations([
+      {
+        regexp: {
+          pattern: '^#[0-9a-f]{6}$',
+          flags: 'i',
+        },
+
+        message:
+          'Hexadecimal value, must start with a "#" and follow it with 6 characters.',
+      },
+    ])
+    .disabled(false)
+    .omitted(false);
+
+  sectionBlock
     .createField('content')
     .name('Content')
     .type('RichText')
@@ -92,7 +112,6 @@ module.exports = function(migration) {
       },
       {
         enabledNodeTypes: [
-          'heading-1',
           'heading-2',
           'heading-3',
           'heading-4',
@@ -103,10 +122,12 @@ module.exports = function(migration) {
           'blockquote',
           'embedded-entry-block',
           'embedded-asset-block',
+          'heading-1',
+          'hyperlink',
         ],
 
         message:
-          'Only heading 1, heading 2, heading 3, heading 4, heading 5, heading 6, ordered list, unordered list, quote, block entry, and asset nodes are allowed',
+          'Only heading 2, heading 3, heading 4, heading 5, heading 6, ordered list, unordered list, quote, block entry, asset, heading 1, and link to Url nodes are allowed',
       },
     ])
     .disabled(false)
@@ -119,5 +140,6 @@ module.exports = function(migration) {
 
   sectionBlock.changeEditorInterface('backgroundColor', 'singleLine', {});
   sectionBlock.changeEditorInterface('textColor', 'singleLine', {});
+  sectionBlock.changeEditorInterface('hyperlinkColor', 'singleLine', {});
   sectionBlock.changeEditorInterface('content', 'richTextEditor', {});
 };

--- a/contentful/content-types/sectionBlock.js
+++ b/contentful/content-types/sectionBlock.js
@@ -127,7 +127,7 @@ module.exports = function(migration) {
         ],
 
         message:
-          'Only heading 2, heading 3, heading 4, heading 5, heading 6, ordered list, unordered list, quote, block entry, asset, heading 1, and link to Url nodes are allowed',
+          'Only heading 1, heading 2, heading 3, heading 4, heading 5, heading 6, ordered list, unordered list, quote, block entry, asset, and link to Url nodes are allowed',
       },
     ])
     .disabled(false)

--- a/resources/assets/components/blocks/SectionBlock/SectionBlock.js
+++ b/resources/assets/components/blocks/SectionBlock/SectionBlock.js
@@ -2,23 +2,34 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 
-import { withoutNulls } from '../../../helpers';
 import TextContent from '../../utilities/TextContent/TextContent';
 
 import './section-block.scss';
 
 const SectionBlock = props => {
-  const { backgroundColor, className, content, id, textColor } = props;
+  const {
+    backgroundColor,
+    className,
+    content,
+    hyperlinkColor,
+    id,
+    textColor,
+  } = props;
+
+  const styles = {
+    hyperlinkColor,
+    textColor,
+  };
 
   return (
     <section
       id={id}
       className={classnames('section-block', className)}
-      style={withoutNulls({ backgroundColor })}
+      style={{ backgroundColor }}
     >
       <TextContent
         className="section-block__content base-16-grid"
-        styles={withoutNulls({ color: textColor })}
+        styles={styles}
       >
         {content}
       </TextContent>
@@ -27,16 +38,18 @@ const SectionBlock = props => {
 };
 
 SectionBlock.propTypes = {
-  className: PropTypes.string,
   backgroundColor: PropTypes.string,
+  className: PropTypes.string,
   content: PropTypes.oneOfType([PropTypes.object]).isRequired,
+  hyperlinkColor: PropTypes.string,
   id: PropTypes.string.isRequired,
   textColor: PropTypes.string,
 };
 
 SectionBlock.defaultProps = {
-  className: null,
   backgroundColor: null,
+  className: null,
+  hyperlinkColor: null,
   textColor: null,
 };
 

--- a/resources/assets/helpers/text.js
+++ b/resources/assets/helpers/text.js
@@ -1,8 +1,8 @@
 import React from 'react';
-import { pick } from 'lodash';
+import { get } from 'lodash';
 import MarkdownIt from 'markdown-it';
 import iterator from 'markdown-it-for-inline';
-import { BLOCKS } from '@contentful/rich-text-types';
+import { BLOCKS, INLINES } from '@contentful/rich-text-types';
 import markdownItFootnote from 'markdown-it-footnote';
 import { documentToReactComponents } from '@contentful/rich-text-react-renderer';
 
@@ -68,66 +68,72 @@ function getMarkdownItInstance() {
  * @return {String}
  */
 export function parseRichTextDocument(document, styles) {
-  const textColor = pick(styles, 'color');
+  const hyperlinkColor = get(styles, 'hyperlinkColor', null);
+  const textColor = get(styles, 'textColor', null);
 
   const options = {
     renderNode: {
+      [BLOCKS.HEADING_1]: (node, children) => (
+        <h1 className="grid-main" style={{ color: textColor }}>
+          <span>{children}</span>
+        </h1>
+      ),
+      [BLOCKS.HEADING_2]: (node, children) => (
+        <h2 className="grid-main" style={{ color: textColor }}>
+          {children}
+        </h2>
+      ),
+      [BLOCKS.HEADING_3]: (node, children) => (
+        <h3 className="grid-main" style={{ color: textColor }}>
+          {children}
+        </h3>
+      ),
+      [BLOCKS.HEADING_4]: (node, children) => (
+        <h4 className="grid-main" style={{ color: textColor }}>
+          {children}
+        </h4>
+      ),
+      [BLOCKS.HEADING_5]: (node, children) => (
+        <h5 className="grid-main" style={{ color: textColor }}>
+          {children}
+        </h5>
+      ),
+      [BLOCKS.HEADING_6]: (node, children) => (
+        <h6 className="grid-main" style={{ color: textColor }}>
+          {children}
+        </h6>
+      ),
+      [BLOCKS.PARAGRAPH]: (node, children) =>
+        children[0] ? (
+          <p className="grid-main" style={{ color: textColor }}>
+            {children}
+          </p>
+        ) : null,
+      [BLOCKS.UL_LIST]: (node, children) => (
+        <ul className="grid-main text-left list" style={{ color: textColor }}>
+          {children}
+        </ul>
+      ),
+      [BLOCKS.OL_LIST]: (node, children) => (
+        <ol className="grid-main text-left list" style={{ color: textColor }}>
+          {children}
+        </ol>
+      ),
+      [BLOCKS.QUOTE]: (node, children) => (
+        <blockquote className="grid-main list" style={{ color: textColor }}>
+          {children}
+        </blockquote>
+      ),
       [BLOCKS.EMBEDDED_ENTRY]: node => (
         <ContentfulEntryLoader
           id={node.data.target.sys.id}
           className="component-entry"
         />
       ),
-      [BLOCKS.HEADING_1]: (node, children) => (
-        <h1 className="grid-main" style={textColor}>
-          <span>{children}</span>
-        </h1>
-      ),
-      [BLOCKS.HEADING_2]: (node, children) => (
-        <h2 className="grid-main" style={textColor}>
-          {children}
-        </h2>
-      ),
-      [BLOCKS.HEADING_3]: (node, children) => (
-        <h3 className="grid-main" style={textColor}>
-          {children}
-        </h3>
-      ),
-      [BLOCKS.HEADING_4]: (node, children) => (
-        <h4 className="grid-main" style={textColor}>
-          {children}
-        </h4>
-      ),
-      [BLOCKS.HEADING_5]: (node, children) => (
-        <h5 className="grid-main" style={textColor}>
-          {children}
-        </h5>
-      ),
-      [BLOCKS.HEADING_6]: (node, children) => (
-        <h6 className="grid-main" style={textColor}>
-          {children}
-        </h6>
-      ),
-      [BLOCKS.PARAGRAPH]: (node, children) =>
-        children[0] ? (
-          <p className="grid-main" style={textColor}>
-            {children}
-          </p>
-        ) : null,
-      [BLOCKS.UL_LIST]: (node, children) => (
-        <ul className="grid-main text-left list" style={textColor}>
-          {children}
-        </ul>
-      ),
-      [BLOCKS.OL_LIST]: (node, children) => (
-        <ol className="grid-main text-left list" style={textColor}>
-          {children}
-        </ol>
-      ),
-      [BLOCKS.QUOTE]: (node, children) => (
-        <blockquote className="grid-main list" style={textColor}>
-          {children}
-        </blockquote>
+      [INLINES.HYPERLINK]: node => (
+        <a href={node.data.uri} style={{ color: hyperlinkColor }}>
+          {node.content[0].value}
+        </a>
       ),
     },
   };


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR updates how we output RichText content to allow support for hyperlinks in the content, and when used in a `SectionBlock` to allow specifying a color for the hyperlink text if the default DS blue doesn't end up working well on a custom `SectionBlock` background color.

![image](https://user-images.githubusercontent.com/105849/54560449-c2965700-4998-11e9-8df7-c313d2e533ae.png)

### What are the relevant tickets/cards?

Refs [Pivotal ID #164701759](https://www.pivotaltracker.com/story/show/164701759)

### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.