### PR TITLE
User Submission Gallery Campaign Independence

### DIFF
--- a/resources/assets/components/ContentfulEntry/ContentfulEntry.js
+++ b/resources/assets/components/ContentfulEntry/ContentfulEntry.js
@@ -221,6 +221,7 @@ class ContentfulEntry extends React.Component<Props, State> {
             <SubmissionGalleryBlockContainer
               className={className}
               type="text"
+              actionId={json.fields.actionId}
             />
           </React.Fragment>
         );

--- a/resources/assets/components/ContentfulEntry/renderers.js
+++ b/resources/assets/components/ContentfulEntry/renderers.js
@@ -89,7 +89,10 @@ export function renderPhotoSubmissionAction(data) {
       />
       <PhotoSubmissionActionContainer id={contentfulId} {...fields} />
       <div className="margin-vertical-md">
-        <SubmissionGalleryBlockContainer type="photo" />
+        <SubmissionGalleryBlockContainer
+          type="photo"
+          actionId={fields.actionId}
+        />
       </div>
       <PuckWaypoint
         name="photo_submission_action-bottom"

--- a/resources/assets/components/blocks/PostGalleryBlock/PostGalleryBlockQuery.js
+++ b/resources/assets/components/blocks/PostGalleryBlock/PostGalleryBlockQuery.js
@@ -46,7 +46,7 @@ const PostGalleryBlockQuery = ({ actionIds, className, itemsPerRow }) => (
 );
 
 PostGalleryBlockQuery.propTypes = {
-  actionIds: PropTypes.arrayOf(PropTypes.number),
+  actionIds: PropTypes.arrayOf(PropTypes.string),
   className: PropTypes.string,
   itemsPerRow: PropTypes.number,
 };

--- a/resources/assets/components/blocks/SubmissionGalleryBlock/SubmissionGalleryBlockContainer.js
+++ b/resources/assets/components/blocks/SubmissionGalleryBlock/SubmissionGalleryBlockContainer.js
@@ -1,5 +1,6 @@
 import { connect } from 'react-redux';
 
+import { getUserId } from '../../../selectors/user';
 import SubmissionGalleryBlockQuery from './SubmissionGalleryBlockQuery';
 
 /**
@@ -8,7 +9,7 @@ import SubmissionGalleryBlockQuery from './SubmissionGalleryBlockQuery';
  */
 const mapStateToProps = state => ({
   campaignId: state.campaign.campaignId,
-  userId: state.user.id,
+  userId: getUserId(state),
 });
 
 // Export the Redux container component.

--- a/resources/assets/components/blocks/SubmissionGalleryBlock/SubmissionGalleryBlockContainer.js
+++ b/resources/assets/components/blocks/SubmissionGalleryBlock/SubmissionGalleryBlockContainer.js
@@ -7,7 +7,7 @@ import SubmissionGalleryBlockQuery from './SubmissionGalleryBlockQuery';
  * case, we just need the campaign ID and user ID for our GraphQL query!)
  */
 const mapStateToProps = state => ({
-  campaignId: String(state.campaign.campaignId),
+  campaignId: state.campaign.campaignId,
   userId: state.user.id,
 });
 

--- a/resources/assets/components/blocks/SubmissionGalleryBlock/SubmissionGalleryBlockQuery.js
+++ b/resources/assets/components/blocks/SubmissionGalleryBlock/SubmissionGalleryBlockQuery.js
@@ -1,6 +1,6 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import gql from 'graphql-tag';
+import PropTypes from 'prop-types';
 
 import PaginatedQuery from '../../PaginatedQuery';
 import PostGallery from '../../utilities/PostGallery/PostGallery';

--- a/resources/assets/components/blocks/SubmissionGalleryBlock/SubmissionGalleryBlockQuery.js
+++ b/resources/assets/components/blocks/SubmissionGalleryBlock/SubmissionGalleryBlockQuery.js
@@ -49,6 +49,7 @@ const SubmissionGalleryBlockQuery = ({
 }) => {
   let variables = withoutNulls({ campaignId, userId, type });
 
+  // @TODO remove this logic and campaignId support when we backfill all TSA's with actionIds.
   // Prefer -the more specific- actionId if available, removing campaignId to prevent clash.
   if (actionId) {
     delete variables.campaignId;

--- a/resources/assets/components/blocks/SubmissionGalleryBlock/SubmissionGalleryBlockQuery.js
+++ b/resources/assets/components/blocks/SubmissionGalleryBlock/SubmissionGalleryBlockQuery.js
@@ -43,6 +43,7 @@ const SUBMISSION_GALLERY_QUERY = gql`
 const SubmissionGalleryBlockQuery = ({
   actionId,
   campaignId,
+  className,
   userId,
   type,
 }) => {
@@ -66,6 +67,7 @@ const SubmissionGalleryBlockQuery = ({
     >
       {({ result, fetching, fetchMore }) => (
         <PostGallery
+          className={className}
           posts={result}
           loading={fetching}
           loadMorePosts={fetchMore}
@@ -78,6 +80,7 @@ const SubmissionGalleryBlockQuery = ({
 SubmissionGalleryBlockQuery.propTypes = {
   actionId: PropTypes.number,
   campaignId: PropTypes.string,
+  className: PropTypes.string,
   type: PropTypes.string.isRequired,
   userId: PropTypes.string,
 };
@@ -85,6 +88,7 @@ SubmissionGalleryBlockQuery.propTypes = {
 SubmissionGalleryBlockQuery.defaultProps = {
   actionId: null,
   campaignId: null,
+  className: null,
   userId: null,
 };
 

--- a/resources/assets/components/blocks/SubmissionGalleryBlock/SubmissionGalleryBlockQuery.js
+++ b/resources/assets/components/blocks/SubmissionGalleryBlock/SubmissionGalleryBlockQuery.js
@@ -12,7 +12,7 @@ import { reactionButtonFragment } from '../../utilities/ReactionButton/ReactionB
  */
 const SUBMISSION_GALLERY_QUERY = gql`
   query SubmissionGalleryQuery(
-    $campaignId: String!
+    $campaignId: String
     $userId: String!
     $type: String!
     $count: Int
@@ -56,12 +56,13 @@ const SubmissionGalleryBlockQuery = ({ campaignId, userId, type }) =>
   ) : null;
 
 SubmissionGalleryBlockQuery.propTypes = {
-  campaignId: PropTypes.string.isRequired,
+  campaignId: PropTypes.string,
   type: PropTypes.string.isRequired,
   userId: PropTypes.string,
 };
 
 SubmissionGalleryBlockQuery.defaultProps = {
+  campaignId: null,
   userId: null,
 };
 


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR updates the Submission Gallery (`SubmissionGalleryBlockQuery` component) to support `actionId`s, to enable functionality on non-campaign pages.

- adds the `className` prop to allow styling modifications to take effect.
- https://github.com/DoSomething/phoenix-next/commit/f8dcdd5695a29314f8dfa47d7401a0e376cdb079 snuck in a quick fix to the prop type definition for the `PostGalleryBlockQuery`. (was seeing [this error](https://user-images.githubusercontent.com/12417657/54633290-3cd8e100-4a56-11e9-9bdd-ef3d9c0034cf.png) in the console)

### Any background context you want to provide?
It would have been nice to just remove the `campaignId` support completely, but we still do have many TSA's with no `actionId`. 😞 
This did require a bit of logic to remove the `campaignId` if the `actionId` is present, to avoid (an admittedly edge case where) a `campaignId` from a different campaign as the `actionId`, which would cause the query to return empty.

We can remove all this once we backfill the action IDs 🍕 


### What are the relevant tickets/cards?

Refs [Pivotal ID #164701658](https://www.pivotaltracker.com/story/show/164701658)

### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.

![image](https://user-images.githubusercontent.com/12417657/54633764-37c86180-4a57-11e9-9518-3407c0a91e61.png)

