### PR TITLE
Hide Petition Signature from Unauthenticated View

### DIFF
--- a/resources/assets/components/actions/PetitionSubmissioncAction/PetitionSubmissionAction.js
+++ b/resources/assets/components/actions/PetitionSubmissioncAction/PetitionSubmissionAction.js
@@ -160,17 +160,19 @@ class PetitionSubmissionAction extends React.Component {
                       />
                     </div>
 
-                    <div className="padded">
-                      <p className="petition-signature-label padding-bottom-sm">
-                        Signed,
-                      </p>
-                      <input
-                        className="text-field petition-signature"
-                        type="text"
-                        disabled
-                        value={signature}
-                      />
-                    </div>
+                    {userId ? (
+                      <div className="padded">
+                        <p className="petition-signature-label padding-bottom-sm">
+                          Signed,
+                        </p>
+                        <input
+                          className="text-field petition-signature"
+                          type="text"
+                          disabled
+                          value={signature}
+                        />
+                      </div>
+                    ) : null}
 
                     <Button
                       type="submit"


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR fixes up a mistake I made in #1321 which inadvertently exposed the petition 'Signature' to unauthenticated users. (Not the biggest deal since we have the "A Doer" default, but not the intended UI for this action.)

### What are the relevant tickets/cards?

Refs [Pivotal ID #164711433](https://www.pivotaltracker.com/story/show/164711433)
