### PR TITLE
Add better error handling to ContentfulEntryLoader.

### DIFF
--- a/resources/assets/components/utilities/ContentfulEntryLoader/ContentfulEntryLoader.js
+++ b/resources/assets/components/utilities/ContentfulEntryLoader/ContentfulEntryLoader.js
@@ -8,6 +8,7 @@ import { Query } from 'react-apollo';
 import Card from '../Card/Card';
 import ContentfulEntry from '../../ContentfulEntry';
 import TextContent from '../TextContent/TextContent';
+import ErrorBlock from '../../ErrorBlock/ErrorBlock';
 
 const CONTENTFUL_BLOCK_QUERY = gql`
   query ContentfulBlockQuery($id: String!) {
@@ -51,20 +52,28 @@ const CONTENTFUL_BLOCK_QUERY = gql`
 const ContentfulEntryLoader = ({ id, className }) => (
   <Query query={CONTENTFUL_BLOCK_QUERY} variables={{ id }}>
     {({ loading, error, data }) => {
+      if (loading) {
+        return (
+          <div className="grid-main spinner -centered margin-vertical-xlg" />
+        );
+      }
+
       if (error) {
         return (
+          <div className="component-entry grid-main margin-bottom-md">
+            <ErrorBlock />
+          </div>
+        );
+      }
+
+      if (!data.block) {
+        return (
           // @TODO: repurpose NotFound component to be customizeable; using basic Card component for now.
-          <Card className="component-entry grid-main margin-bottom-lg rounded bordered">
+          <Card className="component-entry grid-main margin-bottom-md rounded bordered">
             <TextContent className="padded text-center">
               Sorry! The specified content was not found.
             </TextContent>
           </Card>
-        );
-      }
-
-      if (loading) {
-        return (
-          <div className="grid-main spinner -centered margin-vertical-md" />
         );
       }
 

--- a/resources/assets/scss/base.scss
+++ b/resources/assets/scss/base.scss
@@ -358,6 +358,16 @@ p {
   margin-bottom: $half-spacing;
 }
 
+.margin-vertical-lg {
+  margin-top: $base-spacing;
+  margin-bottom: $base-spacing;
+}
+
+.margin-vertical-xlg {
+  margin-top: $section-spacing;
+  margin-bottom: $section-spacing;
+}
+
 .margin-right {
   margin-right: $base-spacing;
 }


### PR DESCRIPTION
### What does this PR do?

This pull request improves error handling in ContentfulEntryLoader.

When loading (added a little padding so things don't shift as much for the average block):

![Screen Shot 2019-03-20 at 1 47 57 PM](https://user-images.githubusercontent.com/583202/54707235-04e5a280-4b17-11e9-9b11-001dbccde936.png)

When the query returns empty (previously exploded the whole section block):

![Screen Shot 2019-03-20 at 1 48 58 PM](https://user-images.githubusercontent.com/583202/54707278-162eaf00-4b17-11e9-854c-2045eea96621.png)

When there's a fatal GraphQL error:

![Screen Shot 2019-03-20 at 1 48 31 PM](https://user-images.githubusercontent.com/583202/54707283-1b8bf980-4b17-11e9-8586-f748054e4091.png)

### Any background context you want to provide?
⚠️ 

### What are the relevant tickets/cards?

References [this conversation](https://dosomething.slack.com/archives/C3ASB4204/p1553100421344300).

### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.
* [ ] Added screenshot to PR description of related front-end updates on **small** screens.
* [ ] Added screenshot to PR description of related front-end updates on **medium** screens.
* [ ] Added screenshot to PR description of related front-end updates on **large** screens.
