### PR TITLE
Add more helpful alt tags to the Images Block.

### DIFF
--- a/app/Entities/ImagesBlock.php
+++ b/app/Entities/ImagesBlock.php
@@ -15,7 +15,10 @@ class ImagesBlock extends Entity implements JsonSerializable
     public function parseImages($images)
     {
         return collect($images)->map(function ($image) {
-            return get_image_url($image, 'square');
+            return [
+                'description' => $image ? $image->getDescription() : null,
+                'url' => get_image_url($image, 'square'),
+            ];
         });
     }
 

--- a/resources/assets/components/ContentfulEntry/ContentfulEntry.js
+++ b/resources/assets/components/ContentfulEntry/ContentfulEntry.js
@@ -134,10 +134,7 @@ class ContentfulEntry extends React.Component<Props, State> {
 
       case 'imagesBlock':
         return (
-          <ImagesBlock
-            className={className}
-            images={json.fields.images.map(url => ({ url }))}
-          />
+          <ImagesBlock className={className} images={json.fields.images} />
         );
 
       case 'ImagesBlock':

--- a/resources/assets/components/ContentfulEntry/ContentfulEntry.js
+++ b/resources/assets/components/ContentfulEntry/ContentfulEntry.js
@@ -134,16 +134,14 @@ class ContentfulEntry extends React.Component<Props, State> {
 
       case 'imagesBlock':
         return (
-          <ImagesBlock className={className} images={json.fields.images} />
+          <ImagesBlock
+            className={className}
+            images={json.fields.images.map(url => ({ url }))}
+          />
         );
 
       case 'ImagesBlock':
-        return (
-          <ImagesBlock
-            className={className}
-            images={json.images.map(asset => asset.url)}
-          />
-        );
+        return <ImagesBlock className={className} images={json.images} />;
 
       case 'landingPage':
         return <LandingPageContainer {...json.fields} />;

--- a/resources/assets/components/blocks/ImagesBlock/ImagesBlock.js
+++ b/resources/assets/components/blocks/ImagesBlock/ImagesBlock.js
@@ -10,18 +10,24 @@ const ImagesBlock = ({ className, images }) => (
     className={classnames('expand-horizontal-md', className)}
   >
     {images.map(image => (
-      <img alt="Images Block" src={image} key={image} />
+      <img alt={image.description} src={image.url} key={image.url} />
     ))}
   </Gallery>
 );
 
 ImagesBlock.propTypes = {
   className: PropTypes.string,
-  images: PropTypes.arrayOf(PropTypes.string).isRequired,
+  images: PropTypes.arrayOf(
+    PropTypes.shape({
+      description: PropTypes.string,
+      url: PropTypes.string.isRequired,
+    }),
+  ),
 };
 
 ImagesBlock.defaultProps = {
   className: null,
+  images: [],
 };
 
 export default ImagesBlock;

--- a/resources/assets/components/utilities/ContentfulEntryLoader/ContentfulEntryLoader.js
+++ b/resources/assets/components/utilities/ContentfulEntryLoader/ContentfulEntryLoader.js
@@ -15,6 +15,7 @@ const CONTENTFUL_BLOCK_QUERY = gql`
       id
       ... on ImagesBlock {
         images {
+          description
           url(w: 500, h: 500, fit: FILL)
         }
       }


### PR DESCRIPTION
### What does this PR do?

This PR adds better* alt tags to Images Blocks loaded via GraphQL, for use by screen readers:

```html
<ul>
  <li><img alt="Woman crossing a sidewalk." src="https://images.ctfassets.net/81iqaqpfd8fy/4rvdH8Yik02wkigooaUeyQ/456d32b3ac1a3cc5df5e535e8dba4a0e/Walking.jpg?w=500&amp;h=500&amp;fit=FILL&amp;f=faces" /></li>
  <li><img alt="A man standing next to a bike." src="https://images.ctfassets.net/81iqaqpfd8fy/1kyUlGhOMkGmaGGOOaGIiY/1985a6ea9817312ae10be062789aa636/Riding_a_Bike.jpg?w=500&amp;h=500&amp;fit=FILL&amp;f=faces" /></li>
  <li><img alt="A passenger in a car using a smartphone." src="https://images.ctfassets.net/81iqaqpfd8fy/2sKIWp8tneaIOA6SyW0maI/ec64972f454b2ea66af246dda7966be3/Passenger.jpg?w=500&amp;h=500&amp;fit=FILL&amp;f=faces" /></li>
</ul>
```

### Any background context you want to provide?

Well, it's _theoretically_ a lot better. Unfortunately, we haven't filled out the `description` field for any of our uploaded media, so this currently does nothing. We should add that step to our editor guide (and briefly explain why it's important for accessibility).

I considered using the asset `title` instead, but looking at some examples (like `t-chick-mcclure-609632-unsplash` or `nfl food guide-01`) doesn't really inspire confidence... 🤦‍♂️

### What are the relevant tickets/cards?

Based on @mendelB's suggestion in #1319!

### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.
* [ ] Added screenshot to PR description of related front-end updates on **small** screens.
* [ ] Added screenshot to PR description of related front-end updates on **medium** screens.
* [ ] Added screenshot to PR description of related front-end updates on **large** screens.
