### PR TITLE
Load gallery-specific items per row.

### DIFF
--- a/resources/assets/components/utilities/ContentfulEntryLoader/ContentfulEntryLoader.js
+++ b/resources/assets/components/utilities/ContentfulEntryLoader/ContentfulEntryLoader.js
@@ -25,6 +25,7 @@ const CONTENTFUL_BLOCK_QUERY = gql`
       }
       ... on PostGalleryBlock {
         actionIds
+        itemsPerRow
       }
       ... on TextSubmissionBlock {
         actionId


### PR DESCRIPTION
### What does this PR do?

This pull request requests `itemsPerRow` when fetching data for a `PostGalleryBlock`, which will make the story page's gallery once again span the correct amount of rows.

![Screen Shot 2019-03-20 at 3 37 27 PM](https://user-images.githubusercontent.com/583202/54714067-7bd66780-4b26-11e9-8681-06ded8007dd0.png)

### Any background context you want to provide?

This is already all hooked up! We just weren't asking for it.

### What are the relevant tickets/cards?

References [this eagle-eyed bug report](https://dosomething.slack.com/archives/C2BPA7M8F/p1553106724337800).

### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.
* [ ] Added screenshot to PR description of related front-end updates on **small** screens.
* [ ] Added screenshot to PR description of related front-end updates on **medium** screens.
* [ ] Added screenshot to PR description of related front-end updates on **large** screens.