### PR TITLE
Adds support for rendering assets in rich text.

### DIFF
--- a/resources/assets/components/utilities/ContentfulAsset/ContentfulAsset.js
+++ b/resources/assets/components/utilities/ContentfulAsset/ContentfulAsset.js
@@ -47,7 +47,7 @@ const ContentfulAsset = ({ className, id, width, height }) => (
       }
 
       return (
-        <div className={className} style={{ width: '100%' }}>
+        <div className={className}>
           <LazyImage src={data.asset.url} alt={data.asset.description} />
         </div>
       );

--- a/resources/assets/components/utilities/ContentfulAsset/ContentfulAsset.js
+++ b/resources/assets/components/utilities/ContentfulAsset/ContentfulAsset.js
@@ -1,0 +1,71 @@
+import React from 'react';
+import gql from 'graphql-tag';
+import PropTypes from 'prop-types';
+import { Query } from 'react-apollo';
+
+import LazyImage from '../LazyImage';
+import Card from '../Card/Card';
+import TextContent from '../TextContent/TextContent';
+import ErrorBlock from '../../ErrorBlock/ErrorBlock';
+
+const CONTENTFUL_ASSET_QUERY = gql`
+  query ContentfulAssetQuery($id: String!, $width: Int!, $height: Int!) {
+    asset(id: $id) {
+      id
+      description
+      url(w: $width, h: $height)
+    }
+  }
+`;
+
+const ContentfulAsset = ({ className, id, width, height }) => (
+  <Query query={CONTENTFUL_ASSET_QUERY} variables={{ id, width, height }}>
+    {({ loading, error, data }) => {
+      if (loading) {
+        return (
+          <div className="grid-main spinner -centered margin-vertical-xlg" />
+        );
+      }
+
+      if (error) {
+        return (
+          <div className="component-entry grid-main margin-bottom-md">
+            <ErrorBlock />
+          </div>
+        );
+      }
+
+      if (!data.asset) {
+        return (
+          // @TODO: repurpose NotFound component to be customizeable; using basic Card component for now.
+          <Card className="component-entry grid-main margin-bottom-md rounded bordered">
+            <TextContent className="padded text-center">
+              Sorry! The specified asset was not found.
+            </TextContent>
+          </Card>
+        );
+      }
+
+      return (
+        <div className={className} style={{ width: '100%' }}>
+          <LazyImage src={data.asset.url} alt={data.asset.description} />
+        </div>
+      );
+    }}
+  </Query>
+);
+
+ContentfulAsset.propTypes = {
+  id: PropTypes.string.isRequired,
+  className: PropTypes.string,
+  width: PropTypes.number,
+  height: PropTypes.number,
+};
+
+ContentfulAsset.defaultProps = {
+  className: null,
+  width: 700,
+  height: 700,
+};
+
+export default ContentfulAsset;

--- a/resources/assets/components/utilities/ContentfulAsset/ContentfulAsset.js
+++ b/resources/assets/components/utilities/ContentfulAsset/ContentfulAsset.js
@@ -3,9 +3,7 @@ import gql from 'graphql-tag';
 import PropTypes from 'prop-types';
 import { Query } from 'react-apollo';
 
-import Card from '../Card/Card';
 import LazyImage from '../LazyImage';
-import TextContent from '../TextContent/TextContent';
 import ErrorBlock from '../../ErrorBlock/ErrorBlock';
 
 const CONTENTFUL_ASSET_QUERY = gql`
@@ -25,19 +23,8 @@ const ContentfulAsset = ({ id, width, height }) => (
         return <div className="spinner -centered margin-vertical-xlg" />;
       }
 
-      if (error) {
+      if (error || !data.asset) {
         return <ErrorBlock />;
-      }
-
-      if (!data.asset) {
-        return (
-          // @TODO: repurpose NotFound component to be customizeable; using basic Card component for now.
-          <Card>
-            <TextContent className="padded text-center">
-              Sorry! The specified asset was not found.
-            </TextContent>
-          </Card>
-        );
       }
 
       const { url, description } = data.asset;

--- a/resources/assets/components/utilities/ContentfulAsset/ContentfulAsset.js
+++ b/resources/assets/components/utilities/ContentfulAsset/ContentfulAsset.js
@@ -3,8 +3,8 @@ import gql from 'graphql-tag';
 import PropTypes from 'prop-types';
 import { Query } from 'react-apollo';
 
-import LazyImage from '../LazyImage';
 import Card from '../Card/Card';
+import LazyImage from '../LazyImage';
 import TextContent from '../TextContent/TextContent';
 import ErrorBlock from '../../ErrorBlock/ErrorBlock';
 
@@ -18,27 +18,21 @@ const CONTENTFUL_ASSET_QUERY = gql`
   }
 `;
 
-const ContentfulAsset = ({ className, id, width, height }) => (
+const ContentfulAsset = ({ id, width, height }) => (
   <Query query={CONTENTFUL_ASSET_QUERY} variables={{ id, width, height }}>
     {({ loading, error, data }) => {
       if (loading) {
-        return (
-          <div className="grid-main spinner -centered margin-vertical-xlg" />
-        );
+        return <div className="spinner -centered margin-vertical-xlg" />;
       }
 
       if (error) {
-        return (
-          <div className="component-entry grid-main margin-bottom-md">
-            <ErrorBlock />
-          </div>
-        );
+        return <ErrorBlock />;
       }
 
       if (!data.asset) {
         return (
           // @TODO: repurpose NotFound component to be customizeable; using basic Card component for now.
-          <Card className="component-entry grid-main margin-bottom-md rounded bordered">
+          <Card>
             <TextContent className="padded text-center">
               Sorry! The specified asset was not found.
             </TextContent>
@@ -46,18 +40,15 @@ const ContentfulAsset = ({ className, id, width, height }) => (
         );
       }
 
-      return (
-        <div className={className}>
-          <LazyImage src={data.asset.url} alt={data.asset.description} />
-        </div>
-      );
+      const { url, description } = data.asset;
+
+      return <LazyImage className="inline" src={url} alt={description} />;
     }}
   </Query>
 );
 
 ContentfulAsset.propTypes = {
   id: PropTypes.string.isRequired,
-  className: PropTypes.string,
   width: PropTypes.number,
   height: PropTypes.number,
 };

--- a/resources/assets/components/utilities/ContentfulEntryLoader/ContentfulEntryLoader.js
+++ b/resources/assets/components/utilities/ContentfulEntryLoader/ContentfulEntryLoader.js
@@ -2,11 +2,10 @@ import React from 'react';
 import { get } from 'lodash';
 import gql from 'graphql-tag';
 import PropTypes from 'prop-types';
+import classNames from 'classnames';
 import { Query } from 'react-apollo';
 
-import Card from '../Card/Card';
 import ContentfulEntry from '../../ContentfulEntry';
-import TextContent from '../TextContent/TextContent';
 import ErrorBlock from '../../ErrorBlock/ErrorBlock';
 
 const CONTENTFUL_BLOCK_QUERY = gql`
@@ -49,25 +48,18 @@ const CONTENTFUL_BLOCK_QUERY = gql`
   }
 `;
 
-const ContentfulEntryLoader = ({ id }) => (
+const ContentfulEntryLoader = ({ id, className }) => (
   <Query query={CONTENTFUL_BLOCK_QUERY} variables={{ id }}>
     {({ loading, error, data }) => {
       if (loading) {
         return <div className="spinner -centered margin-vertical-xlg" />;
       }
 
-      if (error) {
-        return <ErrorBlock />;
-      }
-
-      if (!data.block) {
+      if (error || !data.block) {
         return (
-          // @TODO: repurpose NotFound component to be customizeable; using basic Card component for now.
-          <Card className="margin-bottom-md rounded bordered">
-            <TextContent className="padded text-center">
-              Sorry! The specified content was not found.
-            </TextContent>
-          </Card>
+          <div className={className}>
+            <ErrorBlock />
+          </div>
         );
       }
 
@@ -79,13 +71,19 @@ const ContentfulEntryLoader = ({ id }) => (
       const blockType = data.block.__typename;
       const gridClass = get(entryGridMapping, blockType, 'grid-main');
 
-      return <ContentfulEntry className={gridClass} json={data.block} />;
+      return (
+        <ContentfulEntry
+          className={classNames(className, gridClass)}
+          json={data.block}
+        />
+      );
     }}
   </Query>
 );
 
 ContentfulEntryLoader.propTypes = {
   id: PropTypes.string.isRequired,
+  className: PropTypes.string,
 };
 
 ContentfulEntryLoader.defaultProps = {

--- a/resources/assets/components/utilities/ContentfulEntryLoader/ContentfulEntryLoader.js
+++ b/resources/assets/components/utilities/ContentfulEntryLoader/ContentfulEntryLoader.js
@@ -2,7 +2,6 @@ import React from 'react';
 import { get } from 'lodash';
 import gql from 'graphql-tag';
 import PropTypes from 'prop-types';
-import classnames from 'classnames';
 import { Query } from 'react-apollo';
 
 import Card from '../Card/Card';
@@ -50,27 +49,21 @@ const CONTENTFUL_BLOCK_QUERY = gql`
   }
 `;
 
-const ContentfulEntryLoader = ({ id, className }) => (
+const ContentfulEntryLoader = ({ id }) => (
   <Query query={CONTENTFUL_BLOCK_QUERY} variables={{ id }}>
     {({ loading, error, data }) => {
       if (loading) {
-        return (
-          <div className="grid-main spinner -centered margin-vertical-xlg" />
-        );
+        return <div className="spinner -centered margin-vertical-xlg" />;
       }
 
       if (error) {
-        return (
-          <div className="component-entry grid-main margin-bottom-md">
-            <ErrorBlock />
-          </div>
-        );
+        return <ErrorBlock />;
       }
 
       if (!data.block) {
         return (
           // @TODO: repurpose NotFound component to be customizeable; using basic Card component for now.
-          <Card className="component-entry grid-main margin-bottom-md rounded bordered">
+          <Card className="margin-bottom-md rounded bordered">
             <TextContent className="padded text-center">
               Sorry! The specified content was not found.
             </TextContent>
@@ -86,19 +79,13 @@ const ContentfulEntryLoader = ({ id, className }) => (
       const blockType = data.block.__typename;
       const gridClass = get(entryGridMapping, blockType, 'grid-main');
 
-      return (
-        <ContentfulEntry
-          className={classnames(className, gridClass)}
-          json={data.block}
-        />
-      );
+      return <ContentfulEntry className={gridClass} json={data.block} />;
     }}
   </Query>
 );
 
 ContentfulEntryLoader.propTypes = {
   id: PropTypes.string.isRequired,
-  className: PropTypes.string,
 };
 
 ContentfulEntryLoader.defaultProps = {

--- a/resources/assets/components/utilities/ContentfulEntryLoader/ContentfulEntryLoader.js
+++ b/resources/assets/components/utilities/ContentfulEntryLoader/ContentfulEntryLoader.js
@@ -52,12 +52,14 @@ const ContentfulEntryLoader = ({ id, className }) => (
   <Query query={CONTENTFUL_BLOCK_QUERY} variables={{ id }}>
     {({ loading, error, data }) => {
       if (loading) {
-        return <div className="spinner -centered margin-vertical-xlg" />;
+        return (
+          <div className="grid-main spinner -centered margin-vertical-xlg" />
+        );
       }
 
       if (error || !data.block) {
         return (
-          <div className={className}>
+          <div className={classNames(className, 'grid-main')}>
             <ErrorBlock />
           </div>
         );

--- a/resources/assets/components/utilities/ContentfulEntryLoader/ContentfulEntryLoader.js
+++ b/resources/assets/components/utilities/ContentfulEntryLoader/ContentfulEntryLoader.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { get } from 'lodash';
 import gql from 'graphql-tag';
 import PropTypes from 'prop-types';
-import classNames from 'classnames';
+import classnames from 'classnames';
 import { Query } from 'react-apollo';
 
 import ContentfulEntry from '../../ContentfulEntry';
@@ -59,7 +59,7 @@ const ContentfulEntryLoader = ({ id, className }) => (
 
       if (error || !data.block) {
         return (
-          <div className={classNames(className, 'grid-main')}>
+          <div className={classnames(className, 'grid-main')}>
             <ErrorBlock />
           </div>
         );
@@ -75,7 +75,7 @@ const ContentfulEntryLoader = ({ id, className }) => (
 
       return (
         <ContentfulEntry
-          className={classNames(className, gridClass)}
+          className={classnames(className, gridClass)}
           json={data.block}
         />
       );

--- a/resources/assets/helpers/text.js
+++ b/resources/assets/helpers/text.js
@@ -7,6 +7,7 @@ import markdownItFootnote from 'markdown-it-footnote';
 import { documentToReactComponents } from '@contentful/rich-text-react-renderer';
 
 import { contentfulImageUrl, isExternal } from '../helpers';
+import ContentfulAsset from '../components/utilities/ContentfulAsset/ContentfulAsset';
 import ContentfulEntryLoader from '../components/utilities/ContentfulEntryLoader/ContentfulEntryLoader';
 
 /**
@@ -128,6 +129,12 @@ export function parseRichTextDocument(document, styles) {
         <ContentfulEntryLoader
           id={node.data.target.sys.id}
           className="component-entry"
+        />
+      ),
+      [BLOCKS.EMBEDDED_ASSET]: node => (
+        <ContentfulAsset
+          id={node.data.target.sys.id}
+          className="grid-main component-entry margin-bottom-lg flex-center-xy"
         />
       ),
       [INLINES.HYPERLINK]: node => (

--- a/resources/assets/helpers/text.js
+++ b/resources/assets/helpers/text.js
@@ -126,16 +126,14 @@ export function parseRichTextDocument(document, styles) {
         </blockquote>
       ),
       [BLOCKS.EMBEDDED_ENTRY]: node => (
-        <ContentfulEntryLoader
-          id={node.data.target.sys.id}
-          className="component-entry"
-        />
+        <div className="grid-main component-entry">
+          <ContentfulEntryLoader id={node.data.target.sys.id} />
+        </div>
       ),
       [BLOCKS.EMBEDDED_ASSET]: node => (
-        <ContentfulAsset
-          id={node.data.target.sys.id}
-          className="grid-main component-entry margin-bottom-lg flex-center-xy"
-        />
+        <p className="grid-main component-entry margin-bottom-lg text-center">
+          <ContentfulAsset id={node.data.target.sys.id} />
+        </p>
       ),
       [INLINES.HYPERLINK]: node => (
         <a href={node.data.uri} style={{ color: hyperlinkColor }}>

--- a/resources/assets/helpers/text.js
+++ b/resources/assets/helpers/text.js
@@ -126,12 +126,13 @@ export function parseRichTextDocument(document, styles) {
         </blockquote>
       ),
       [BLOCKS.EMBEDDED_ENTRY]: node => (
-        <div className="grid-main component-entry">
-          <ContentfulEntryLoader id={node.data.target.sys.id} />
-        </div>
+        <ContentfulEntryLoader
+          className="component-entry margin-bottom-md"
+          id={node.data.target.sys.id}
+        />
       ),
       [BLOCKS.EMBEDDED_ASSET]: node => (
-        <p className="grid-main component-entry margin-bottom-lg text-center">
+        <p className="grid-main component-entry text-center">
           <ContentfulAsset id={node.data.target.sys.id} />
         </p>
       ),

--- a/resources/assets/scss/base.scss
+++ b/resources/assets/scss/base.scss
@@ -146,10 +146,16 @@ p {
   clear: none;
 }
 
+// @TODO: Rename to match Tailwind's .block.
 .display-block {
   display: block;
 }
 
+.inline {
+  display: inline;
+}
+
+// @TODO: Rename to match Tailwind's .flex.
 .display-flex {
   display: flex;
 }


### PR DESCRIPTION
### What does this PR do?

This pull request adds support for rendering embedded assets in rich text fields. The asset information is fetched from Contentful using the `asset(id: "…")` query introduced in DoSomething/graphql#83, and then the image itself is loaded via our `LazyImage` component.

If an image is larger than 700x700 (a completely arbitrary size that seemed reasonable for the story page), it will be sized down by Contentful's Image API to fit within that constraint. Otherwise, it'll be loaded as is and given center stage. Remarkable.

![Screen Shot 2019-03-20 at 5 37 01 PM](https://user-images.githubusercontent.com/583202/54720825-c9f36700-4b36-11e9-83b7-75b8dbcd0d81.png)

### Any background context you want to provide?

~This is blocked on DoSomething/graphql#83 being reviewed & deployed.~ No longer!

### What are the relevant tickets/cards?

Refs [Pivotal ID #164712381](https://www.pivotaltracker.com/story/show/164712381).

### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.
* [ ] Added screenshot to PR description of related front-end updates on **small** screens.
* [ ] Added screenshot to PR description of related front-end updates on **medium** screens.
* [ ] Added screenshot to PR description of related front-end updates on **large** screens.