### PR TITLE
Update campaign page footer

### DIFF
--- a/resources/assets/components/pages/LandingPage/LandingPage.js
+++ b/resources/assets/components/pages/LandingPage/LandingPage.js
@@ -67,7 +67,7 @@ const LandingPage = props => {
 
       <div className="info-bar -dark">
         <div className="wrapper">
-          A DoSomething.org campaign. Join over 6 million members taking action.
+          A DoSomething.org campaign. Join over millions members taking action.
           Any cause, anytime, anywhere.
         </div>
       </div>

--- a/resources/assets/components/pages/LandingPage/LandingPage.js
+++ b/resources/assets/components/pages/LandingPage/LandingPage.js
@@ -67,7 +67,7 @@ const LandingPage = props => {
 
       <div className="info-bar -dark">
         <div className="wrapper">
-          A DoSomething.org campaign. Join over millions members taking action.
+          A DoSomething.org campaign. Join over millions of members taking action.
           Any cause, anytime, anywhere.
         </div>
       </div>


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_
### What does this PR do?
Removes `6` from the member count in the campaign footer!

### Any background context you want to provide?
Per staff meeting on 3/20, updating member count to "millions" across site & communications.

### What are the relevant tickets/cards?
Requested in [this](https://docs.google.com/document/d/1kpWstZ18OTnqX5zW4s6m1tDFuvLodD52YSJrw8cAFUg/edit#bookmark=id.ezrnyuy09lpc) document.

Are there other places in the code that mention `6 million`?
