### PR TITLE
Fix that pesky Jest Text Circular Dependency Issue!

### DIFF
--- a/jest-setup.js
+++ b/jest-setup.js
@@ -6,3 +6,6 @@ configure({ adapter: new Adapter() });
 
 // Mock calls to `window.open`:
 global.open = jest.fn().mockReturnValue({ closed: true });
+
+// Mock the ContentfulEntry import to prevent circular dependency issues unique to the jest/node runtime.
+jest.mock('./resources/assets/components/ContentfulEntry/ContentfulEntry');

--- a/resources/assets/components/CampaignUpdate/__snapshots__/CampaignUpdate.test.js.snap
+++ b/resources/assets/components/CampaignUpdate/__snapshots__/CampaignUpdate.test.js.snap
@@ -8,11 +8,12 @@ exports[`it generates a campaign update in affiliate mode snapshot 1`] = `
   onClose={null}
   title="See More Be More Do More"
 >
-  <Markdown
+  <TextContent
     className="padded"
+    styles={Object {}}
   >
     Duis mollis, est non commodo luctus, nisi erat porttitor ligula, eget lacinia odio sem nec elit. Morbi leo risus, porta ac consectetur ac, vestibulum at eros. Sed posuere consectetur est at lobortis. Sed posuere consectetur est at lobortis. Nullam quis risus eget urna mollis ornare vel eu leo. Etiam porta sem malesuada magna mollis euismod. Cras mattis consectetur purus sit amet fermentum.
-  </Markdown>
+  </TextContent>
   <footer
     className="padded clearfix"
   >
@@ -33,11 +34,12 @@ exports[`it generates a campaign update snapshot 1`] = `
   onClose={null}
   title="See More Be More Do More"
 >
-  <Markdown
+  <TextContent
     className="padded"
+    styles={Object {}}
   >
     Duis mollis, est non commodo luctus, nisi erat porttitor ligula, eget lacinia odio sem nec elit. Morbi leo risus, porta ac consectetur ac, vestibulum at eros. Sed posuere consectetur est at lobortis. Sed posuere consectetur est at lobortis. Nullam quis risus eget urna mollis ornare vel eu leo. Etiam porta sem malesuada magna mollis euismod. Cras mattis consectetur purus sit amet fermentum.
-  </Markdown>
+  </TextContent>
   <footer
     className="padded clearfix"
   >

--- a/resources/assets/components/ContentfulEntry/ContentfulEntry.test.js
+++ b/resources/assets/components/ContentfulEntry/ContentfulEntry.test.js
@@ -3,6 +3,9 @@ import { shallow } from 'enzyme';
 
 import ContentfulEntry from './ContentfulEntry';
 
+// Override the mock of this component declared in jest-setup for this test file.
+jest.unmock('./ContentfulEntry');
+
 // Mock Redux containers so we don't need Provider context.
 jest.mock(
   '../CallToAction/CallToActionContainer',

--- a/resources/assets/components/actions/PetitionSubmissioncAction/PetitionSubmissionAction.js
+++ b/resources/assets/components/actions/PetitionSubmissioncAction/PetitionSubmissionAction.js
@@ -16,7 +16,7 @@ import CharacterLimit from '../../utilities/CharacterLimit/CharacterLimit';
 
 import './petition-submission-action.scss';
 
-const USER_POSTS_QUERY = gql`
+export const USER_POSTS_QUERY = gql`
   query UserPostsQuery($userId: String!, $actionIds: [Int]!) {
     posts(userId: $userId, actionIds: $actionIds) {
       text

--- a/resources/assets/components/actions/PetitionSubmissioncAction/PetitionSubmissionAction.test.js
+++ b/resources/assets/components/actions/PetitionSubmissioncAction/PetitionSubmissionAction.test.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { mount } from 'enzyme';
 import { MockedProvider } from 'react-apollo/test-utils';
 
-import { USER_POSTS_QUERY } from './PetitionSubmissionAction';
+import { USER_POSTS_QUERY } from './PetitionSubmissionAction'; // eslint-disable-line import/no-duplicates
 import PetitionSubmissionAction from './PetitionSubmissionAction'; // eslint-disable-line import/no-duplicates
 
 const mocks = [

--- a/resources/assets/components/actions/PetitionSubmissioncAction/PetitionSubmissionAction.test.js
+++ b/resources/assets/components/actions/PetitionSubmissioncAction/PetitionSubmissionAction.test.js
@@ -1,14 +1,44 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { mount } from 'enzyme';
+import { MockedProvider } from 'react-apollo/test-utils';
 
+import { USER_POSTS_QUERY } from './PetitionSubmissionAction';
 import PetitionSubmissionAction from './PetitionSubmissionAction';
 
+const mocks = [
+  {
+    request: {
+      query: USER_POSTS_QUERY,
+      variables: {
+        userId: '1',
+        actionIds: [1],
+      },
+    },
+    result: {
+      data: {
+        posts: {},
+        user: {},
+      },
+    },
+  },
+];
+
 describe('PetitionSubmissionAction component', () => {
-  const wrapper = shallow(
-    <PetitionSubmissionAction
-      id="abcdefghi123456789"
-      content="Test Petition"
-    />,
+  const wrapper = mount(
+    <MockedProvider mocks={mocks} addTypename={false}>
+      <PetitionSubmissionAction
+        id="abcdefghi123456789"
+        content="Test Petition"
+        submissions={{
+          isPending: false,
+          items: {},
+        }}
+        userId="666655554444333322221111"
+        actionId={1}
+        resetPostSubmissionItem={jest.fn()}
+        storePost={jest.fn()}
+      />
+    </MockedProvider>,
   );
 
   test('is rendered as a card component with a form, textarea, submit button, and addtional info card', () => {

--- a/resources/assets/components/actions/PetitionSubmissioncAction/PetitionSubmissionAction.test.js
+++ b/resources/assets/components/actions/PetitionSubmissioncAction/PetitionSubmissionAction.test.js
@@ -3,7 +3,7 @@ import { mount } from 'enzyme';
 import { MockedProvider } from 'react-apollo/test-utils';
 
 import { USER_POSTS_QUERY } from './PetitionSubmissionAction';
-import PetitionSubmissionAction from './PetitionSubmissionAction';
+import PetitionSubmissionAction from './PetitionSubmissionAction'; // eslint-disable-line import/no-duplicates
 
 const mocks = [
   {

--- a/resources/assets/components/actions/PetitionSubmissioncAction/PetitionSubmissionAction.test.js
+++ b/resources/assets/components/actions/PetitionSubmissioncAction/PetitionSubmissionAction.test.js
@@ -28,6 +28,7 @@ describe('PetitionSubmissionAction component', () => {
     <MockedProvider mocks={mocks} addTypename={false}>
       <PetitionSubmissionAction
         id="abcdefghi123456789"
+        campaignContentfulId="1"
         content="Test Petition"
         submissions={{
           isPending: false,

--- a/resources/assets/components/actions/PhotoSubmissionAction/PhotoSubmissionAction.test.js
+++ b/resources/assets/components/actions/PhotoSubmissionAction/PhotoSubmissionAction.test.js
@@ -10,6 +10,7 @@ describe('PhotoSubmissionAction component', () => {
 
   const wrapper = shallow(
     <PhotoSubmissionAction
+      campaignContentfulId="1"
       campaignId="1234"
       id={id}
       resetPostSubmissionItem={jest.fn()}

--- a/resources/assets/components/actions/TextSubmissionAction/TextSubmissionAction.test.js
+++ b/resources/assets/components/actions/TextSubmissionAction/TextSubmissionAction.test.js
@@ -18,6 +18,7 @@ describe('TextSubmissionAction component', () => {
       }}
       type="text"
       userId="666655554444333322221111"
+      storePost={jest.fn()}
     />,
   );
 

--- a/resources/assets/components/blocks/ContentBlock/ContentBlock.test.js
+++ b/resources/assets/components/blocks/ContentBlock/ContentBlock.test.js
@@ -23,7 +23,7 @@ describe('ContentBlock component', () => {
 
     expect(wrapper.find('SectionHeader').length).toEqual(1);
     expect(wrapper.find('Figure').length).toEqual(1);
-    expect(wrapper.find('Markdown').length).toEqual(1);
+    expect(wrapper.find('TextContent').length).toEqual(1);
 
     expect(shallowToJson(wrapper)).toMatchSnapshot();
   });
@@ -41,7 +41,7 @@ describe('ContentBlock component', () => {
 
     expect(wrapper.find('SectionHeader').length).toEqual(1);
     expect(wrapper.find('Figure').length).toEqual(0);
-    expect(wrapper.find('Markdown').length).toEqual(1);
+    expect(wrapper.find('TextContent').length).toEqual(1);
   });
 
   test('it renders the correct alignment class for "left" and "right" image props', () => {

--- a/resources/assets/components/blocks/ContentBlock/__snapshots__/ContentBlock.test.js.snap
+++ b/resources/assets/components/blocks/ContentBlock/__snapshots__/ContentBlock.test.js.snap
@@ -14,11 +14,12 @@ exports[`ContentBlock component does not include SectionHeader when there's no t
       imageClassName={null}
       size="one-third"
     >
-      <Markdown
+      <TextContent
         className={null}
+        styles={Object {}}
       >
         Test Content
-      </Markdown>
+      </TextContent>
     </Figure>
   </div>
 </div>
@@ -46,11 +47,12 @@ exports[`ContentBlock component is rendered with the proper child components whe
       imageClassName={null}
       size="one-third"
     >
-      <Markdown
+      <TextContent
         className={null}
+        styles={Object {}}
       >
         Test Content
-      </Markdown>
+      </TextContent>
     </Figure>
   </div>
 </div>
@@ -63,11 +65,12 @@ exports[`ContentBlock component it works beautifully with content and an empty i
   <div
     className="margin-horizontal-md"
   >
-    <Markdown
+    <TextContent
       className={null}
+      styles={Object {}}
     >
       hi there
-    </Markdown>
+    </TextContent>
   </div>
 </div>
 `;

--- a/resources/assets/components/utilities/Gallery/__snapshots__/Gallery.test.js.snap
+++ b/resources/assets/components/utilities/Gallery/__snapshots__/Gallery.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`it renders correctly with children 1`] = `
 <ul
-  className="gallery -quartet"
+  className="gallery-grid gallery-grid-quartet"
 >
   <li>
     <div>

--- a/wercker.yml
+++ b/wercker.yml
@@ -24,11 +24,6 @@ build:
     - script:
         name: run type checker
         code: npm run flow
-    # @todo We are temporarily disabling running our JS test suite since we currently seem to
-    # have an issue with Jest and a circular dependency on ContentfulEntry. We are  planning
-    # on reassessing our tests and fixing things up post our current big initiative with
-    # StoryPages and ungated actions. (2019-02-27)
-    # @see https://www.pivotaltracker.com/story/show/164282294
-    # - script:
-    #     name: test javascript code
-    #     code: npm run test:ci
+    - script:
+        name: test javascript code
+        code: npm run test:ci


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR updates the Jest test suite setup to mock the `ContentfulEntry` component to avoid a nettlesome cyclic dependency issue causing the test to explode.

Also updates some dusty tests in the suite. Mostly updated snapshots and props to catch up with the work we've done since disabling the tests due to this issue.

Most notable among the test updates would be the `PetitionSubmissionAction.test.js` in https://github.com/DoSomething/phoenix-next/commit/6f252e59a3b11393e5c7bdc7991de0a9d7aa2657. The tests were failing due to the [Apollo `<Query>`](https://github.com/DoSomething/phoenix-next/blob/476c04b7770b68687538985b38db48123529e251/resources/assets/components/actions/PetitionSubmissioncAction/PetitionSubmissionAction.js#L118) component wrapping most of the markup. I didn't want to spend to much time updating the test itself but just added a quick implementation based on their [docs](https://www.apollographql.com/docs/react/recipes/testing.html#MockedProvider) which can perhaps be a nice POC for actually testing this functionality in the future.

Major 🎩tip @DFurnes for figuring this out while I was **jest**ing about.

### What are the relevant tickets/cards?

Refs [Pivotal ID #164282294](https://www.pivotaltracker.com/story/show/164282294)
https://github.com/DoSomething/phoenix-next/pull/1272

### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [x] Added appropriate feature/unit tests. 🎊 
