### PR TITLE
Post Gallery Block Waypoint Tracking

### DIFF
--- a/resources/assets/components/ContentfulEntry/ContentfulEntry.js
+++ b/resources/assets/components/ContentfulEntry/ContentfulEntry.js
@@ -116,6 +116,7 @@ class ContentfulEntry extends React.Component<Props, State> {
       case 'postGallery':
         return (
           <PostGalleryBlockQuery
+            id={json.id}
             className={className}
             {...withoutNulls(json.fields)}
           />
@@ -124,6 +125,7 @@ class ContentfulEntry extends React.Component<Props, State> {
       case 'PostGalleryBlock':
         return (
           <PostGalleryBlockQuery
+            id={json.id}
             className={className}
             {...withoutNulls(json)}
           />

--- a/resources/assets/components/blocks/PostGalleryBlock/PostGalleryBlockQuery.js
+++ b/resources/assets/components/blocks/PostGalleryBlock/PostGalleryBlockQuery.js
@@ -41,6 +41,7 @@ const PostGalleryBlockQuery = ({ id, actionIds, className, itemsPerRow }) => (
           waypointData={{ contentfulId: id }}
         />
         <PostGallery
+          id={id}
           className={classnames(className)}
           posts={result}
           loading={fetching}

--- a/resources/assets/components/blocks/PostGalleryBlock/PostGalleryBlockQuery.js
+++ b/resources/assets/components/blocks/PostGalleryBlock/PostGalleryBlockQuery.js
@@ -2,6 +2,7 @@ import React from 'react';
 import gql from 'graphql-tag';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
+import { PuckWaypoint } from '@dosomething/puck-client';
 
 import PaginatedQuery from '../../PaginatedQuery';
 import PostGallery from '../../utilities/PostGallery/PostGallery';
@@ -26,7 +27,7 @@ const POST_GALLERY_QUERY = gql`
 /**
  * Fetch results via GraphQL using a query component.
  */
-const PostGalleryBlockQuery = ({ actionIds, className, itemsPerRow }) => (
+const PostGalleryBlockQuery = ({ id, actionIds, className, itemsPerRow }) => (
   <PaginatedQuery
     query={POST_GALLERY_QUERY}
     queryName="posts"
@@ -34,24 +35,36 @@ const PostGalleryBlockQuery = ({ actionIds, className, itemsPerRow }) => (
     count={itemsPerRow * 3}
   >
     {({ result, fetching, fetchMore }) => (
-      <PostGallery
-        className={classnames(className)}
-        posts={result}
-        loading={fetching}
-        itemsPerRow={itemsPerRow}
-        loadMorePosts={fetchMore}
-      />
+      <React.Fragment>
+        <PuckWaypoint
+          name="post_gallery_block-top"
+          waypointData={{ contentfulId: id }}
+        />
+        <PostGallery
+          className={classnames(className)}
+          posts={result}
+          loading={fetching}
+          itemsPerRow={itemsPerRow}
+          loadMorePosts={fetchMore}
+        />
+        <PuckWaypoint
+          name="post_gallery_block-bottom"
+          waypointData={{ contentfulId: id }}
+        />
+      </React.Fragment>
     )}
   </PaginatedQuery>
 );
 
 PostGalleryBlockQuery.propTypes = {
+  id: PropTypes.string,
   actionIds: PropTypes.arrayOf(PropTypes.string),
   className: PropTypes.string,
   itemsPerRow: PropTypes.number,
 };
 
 PostGalleryBlockQuery.defaultProps = {
+  id: null,
   actionIds: [],
   className: null,
   itemsPerRow: 3,

--- a/resources/assets/components/blocks/PostGalleryBlock/PostGalleryBlockQuery.js
+++ b/resources/assets/components/blocks/PostGalleryBlock/PostGalleryBlockQuery.js
@@ -2,7 +2,6 @@ import React from 'react';
 import gql from 'graphql-tag';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
-import { PuckWaypoint } from '@dosomething/puck-client';
 
 import PaginatedQuery from '../../PaginatedQuery';
 import PostGallery from '../../utilities/PostGallery/PostGallery';
@@ -36,10 +35,6 @@ const PostGalleryBlockQuery = ({ id, actionIds, className, itemsPerRow }) => (
   >
     {({ result, fetching, fetchMore }) => (
       <React.Fragment>
-        <PuckWaypoint
-          name="post_gallery_block-top"
-          waypointData={{ contentfulId: id }}
-        />
         <PostGallery
           id={id}
           className={classnames(className)}
@@ -47,10 +42,7 @@ const PostGalleryBlockQuery = ({ id, actionIds, className, itemsPerRow }) => (
           loading={fetching}
           itemsPerRow={itemsPerRow}
           loadMorePosts={fetchMore}
-        />
-        <PuckWaypoint
-          name="post_gallery_block-bottom"
-          waypointData={{ contentfulId: id }}
+          waypointName={'post_gallery_block'}
         />
       </React.Fragment>
     )}

--- a/resources/assets/components/utilities/PostGallery/PostGallery.js
+++ b/resources/assets/components/utilities/PostGallery/PostGallery.js
@@ -16,10 +16,10 @@ const galleryTypes = {
 };
 
 const PostGallery = props => {
-  const { className, loading, posts, itemsPerRow, loadMorePosts } = props;
+  const { id, className, loading, posts, itemsPerRow, loadMorePosts } = props;
 
   return posts.length ? (
-    <div className={classnames(className)}>
+    <div id={id} className={classnames(className)}>
       <Gallery
         type={get(galleryTypes, itemsPerRow)}
         className="post-gallery expand-horizontal-md"
@@ -40,6 +40,7 @@ const PostGallery = props => {
 };
 
 PostGallery.propTypes = {
+  id: PropTypes.string,
   className: PropTypes.string,
   posts: PropTypes.array, // eslint-disable-line react/forbid-prop-types
   itemsPerRow: PropTypes.oneOf(Object.keys(galleryTypes).map(Number)),
@@ -48,6 +49,7 @@ PostGallery.propTypes = {
 };
 
 PostGallery.defaultProps = {
+  id: null,
   className: null,
   posts: [],
   itemsPerRow: 3,

--- a/resources/assets/components/utilities/PostGallery/PostGallery.js
+++ b/resources/assets/components/utilities/PostGallery/PostGallery.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { get } from 'lodash';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
+import { PuckWaypoint } from '@dosomething/puck-client';
 
 import Gallery from '../Gallery/Gallery';
 import LoadMore from '../LoadMore/LoadMore';
@@ -16,10 +17,25 @@ const galleryTypes = {
 };
 
 const PostGallery = props => {
-  const { id, className, loading, posts, itemsPerRow, loadMorePosts } = props;
+  const {
+    id,
+    className,
+    loading,
+    posts,
+    itemsPerRow,
+    loadMorePosts,
+    waypointName,
+  } = props;
 
   return posts.length ? (
     <div id={id} className={classnames(className)}>
+      {waypointName ? (
+        <PuckWaypoint
+          name={`${waypointName}-top`}
+          waypointData={{ contentfulId: id }}
+        />
+      ) : null}
+
       <Gallery
         type={get(galleryTypes, itemsPerRow)}
         className="post-gallery expand-horizontal-md"
@@ -35,6 +51,13 @@ const PostGallery = props => {
         onClick={loadMorePosts}
         isLoading={loading}
       />
+
+      {waypointName ? (
+        <PuckWaypoint
+          name={`${waypointName}-bottom`}
+          waypointData={{ contentfulId: id }}
+        />
+      ) : null}
     </div>
   ) : null;
 };
@@ -46,6 +69,7 @@ PostGallery.propTypes = {
   itemsPerRow: PropTypes.oneOf(Object.keys(galleryTypes).map(Number)),
   loading: PropTypes.bool.isRequired,
   loadMorePosts: PropTypes.func.isRequired,
+  waypointName: PropTypes.string,
 };
 
 PostGallery.defaultProps = {
@@ -53,6 +77,7 @@ PostGallery.defaultProps = {
   className: null,
   posts: [],
   itemsPerRow: 3,
+  waypointName: null,
 };
 
 export default PostGallery;


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR adds PuckWaypoint tracking to the `PostGalleryBlockQuery`.
Since we needed the ID for tracking data, it felt like a good time to add an `id` prop to the `PostGallery` component as well and pass that through, so we have anchor linking available for the prom gallery. (@weerd I don't _think_ this interferes with your gallery work but pls lemme know if this clashes at all).
Also, not sure if it's better to throw that `id` outside of the `PostGallery` and within the wrapping query?
 
### Any background context you want to provide?
This is one of the few tracking updates we need for the Prom page.

### What are the relevant tickets/cards?

Refs [Pivotal ID #163910248](https://www.pivotaltracker.com/story/show/163910248)
