### PR TITLE
Track Focus Event on Text Submission Action Text Field

### DIFF
--- a/docs/development/analytics.md
+++ b/docs/development/analytics.md
@@ -61,7 +61,7 @@ The following are all events currently tracked across the Phoenix application:
 | `phoenix_opened_modal_poll_locator_not_found`        | opened the 'Not Found' modal from a Poll Locator                                                                                     | Puck, GA  |
 | `phoenix_clicked_copy_to_clipboard`                  | clicked the clipboard copy button in a Social Drive Action                                                                           | Puck, GA  |
 | `phoenix_failed_post_request`                        | failed to send a POST request                                                                                                        | Puck, GA  |
-| `pgoenix_focused_text_submission_action_text`        | focused on the text field in a Text Submission Action form                                                                           | Puck, GA  |
+| `phoenix_focused_text_submission_action_text`        | focused on the text field in a Text Submission Action form                                                                           | Puck, GA  |
 
 {% hint style="info" %}
 We also track a Google Analytics [Pageview event](https://support.google.com/analytics/answer/6086080?hl=en) for every page view

--- a/docs/development/analytics.md
+++ b/docs/development/analytics.md
@@ -60,7 +60,8 @@ The following are all events currently tracked across the Phoenix application:
 | `phoenix_opened_modal_poll_locator`                  | opened a modal on a Poll Locater (the modal could contain poll location results or be empty)                                         | Puck, GA  |
 | `phoenix_opened_modal_poll_locator_not_found`        | opened the 'Not Found' modal from a Poll Locator                                                                                     | Puck, GA  |
 | `phoenix_clicked_copy_to_clipboard`                  | clicked the clipboard copy button in a Social Drive Action                                                                           | Puck, GA  |
-| `phoenix_failed_post_request`                        | failed to send a POST request                                                                                                        | Puck      |
+| `phoenix_failed_post_request`                        | failed to send a POST request                                                                                                        | Puck, GA  |
+| `pgoenix_focused_text_submission_action_text`        | focused on the text field in a Text Submission Action form                                                                           | Puck, GA  |
 
 {% hint style="info" %}
 We also track a Google Analytics [Pageview event](https://support.google.com/analytics/answer/6086080?hl=en) for every page view

--- a/resources/assets/components/actions/TextSubmissionAction/TextSubmissionAction.js
+++ b/resources/assets/components/actions/TextSubmissionAction/TextSubmissionAction.js
@@ -8,6 +8,7 @@ import Card from '../../utilities/Card/Card';
 import Modal from '../../utilities/Modal/Modal';
 import Button from '../../utilities/Button/Button';
 import { withoutUndefined, withoutNulls } from '../../../helpers';
+import { trackAnalyticsEvent } from '../../../helpers/analytics';
 import FormValidation from '../../utilities/Form/FormValidation';
 import TextContent from '../../utilities/TextContent/TextContent';
 import { getFieldErrors, formatFormFields } from '../../../helpers/forms';
@@ -50,6 +51,17 @@ class TextSubmissionAction extends React.Component {
   handleChange = event => {
     this.setState({
       textValue: event.target.value,
+    });
+  };
+
+  handleFocus = () => {
+    trackAnalyticsEvent({
+      verb: 'focused',
+      noun: 'text_submission_action',
+      adjective: 'text',
+      data: {
+        contentfulId: this.props.id,
+      },
     });
   };
 
@@ -138,6 +150,7 @@ class TextSubmissionAction extends React.Component {
                   placeholder={this.props.textFieldPlaceholder}
                   value={this.state.textValue}
                   onChange={this.handleChange}
+                  onFocus={this.handleFocus}
                 />
                 <CharacterLimit
                   limit={CHARACTER_LIMIT}


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR adds an analytics event to the Text Submission Action tracking when the `text` field emits a `focus` event.

### Any background context you want to provide?
Referenced the setup for a similiar [Northstar event](https://github.com/DoSomething/northstar/blob/71739a06cf3f06119756bd0a57efae96bf9a323f/resources/assets/js/utilities/Analytics.js#L11-L21) for naming inspiration.

I added the `text` adjective although there aren't any other fields on this action form, figuring it doesn't hurt 🤷‍♂️ 


### What are the relevant tickets/cards?

Refs [Pivotal ID #163910248](https://www.pivotaltracker.com/story/show/163910248)

### Checklist

* [x] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.