### PR TITLE
Add (partial) support for more types of blocks via GraphQL.

### DIFF
--- a/app/Entities/LinkAction.php
+++ b/app/Entities/LinkAction.php
@@ -21,7 +21,10 @@ class LinkAction extends Entity implements JsonSerializable
                 'content' => $this->content,
                 'link' => $this->link,
                 'buttonText' => $this->buttonText,
-                'affiliateLogo' => get_image_url($this->affiliateLogo, 'logo'),
+                'affiliateLogo' => [
+                    'description' => $this->affiliateLogo ? $this->affiliateLogo->getDescription() : null,
+                    'url' => get_image_url($this->affiliateLogo, 'logo'),
+                ],
                 'template' => $this->template,
             ],
         ];

--- a/app/Entities/LinkAction.php
+++ b/app/Entities/LinkAction.php
@@ -21,10 +21,10 @@ class LinkAction extends Entity implements JsonSerializable
                 'content' => $this->content,
                 'link' => $this->link,
                 'buttonText' => $this->buttonText,
-                'affiliateLogo' => [
-                    'description' => $this->affiliateLogo ? $this->affiliateLogo->getDescription() : null,
+                'affiliateLogo' => $this->affiliateLogo ? [
+                    'description' => $this->affiliateLogo->getDescription(),
                     'url' => get_image_url($this->affiliateLogo, 'logo'),
-                ],
+                ] : null,
                 'template' => $this->template,
             ],
         ];

--- a/resources/assets/components/ContentfulEntry/ContentfulEntry.js
+++ b/resources/assets/components/ContentfulEntry/ContentfulEntry.js
@@ -17,6 +17,7 @@ import { parseContentfulType, report, withoutNulls } from '../../helpers';
 import CallToActionContainer from '../CallToAction/CallToActionContainer';
 import LinkActionContainer from '../actions/LinkAction/LinkActionContainer';
 import LandingPageContainer from '../pages/LandingPage/LandingPageContainer';
+import ShareActionContainer from '../actions/ShareAction/ShareActionContainer';
 import PostGalleryBlockQuery from '../blocks/PostGalleryBlock/PostGalleryBlockQuery';
 import SocialDriveActionContainer from '../actions/SocialDriveAction/SocialDriveActionContainer';
 import SixpackExperimentContainer from '../utilities/SixpackExperiment/SixpackExperimentContainer';
@@ -28,7 +29,6 @@ import VoterRegistrationActionContainer from '../actions/VoterRegistrationAction
 import PetitionSubmissionActionContainer from '../actions/PetitionSubmissioncAction/PetitionSubmissionActionContainer';
 import {
   renderAffirmation,
-  renderShareAction,
   renderContentBlock,
   renderReferralSubmissionAction,
 } from './renderers';
@@ -240,7 +240,12 @@ class ContentfulEntry extends React.Component<Props, State> {
       }
 
       case 'shareAction':
-        return renderShareAction(json);
+        return (
+          <ShareActionContainer id={json.id} {...withoutNulls(json.fields)} />
+        );
+
+      case 'ShareBlock':
+        return <ShareActionContainer id={json.id} {...withoutNulls(json)} />;
 
       case 'sixpackExperiment':
         return (

--- a/resources/assets/components/ContentfulEntry/ContentfulEntry.js
+++ b/resources/assets/components/ContentfulEntry/ContentfulEntry.js
@@ -24,12 +24,12 @@ import CampaignGalleryBlockContainer from '../blocks/CampaignGalleryBlock/Campai
 import TextSubmissionActionContainer from '../actions/TextSubmissionAction/TextSubmissionActionContainer';
 import PhotoSubmissionActionContainer from '../actions/PhotoSubmissionAction/PhotoSubmissionActionContainer';
 import SubmissionGalleryBlockContainer from '../blocks/SubmissionGalleryBlock/SubmissionGalleryBlockContainer';
+import VoterRegistrationActionContainer from '../actions/VoterRegistrationAction/VoterRegistrationActionContainer';
 import PetitionSubmissionActionContainer from '../actions/PetitionSubmissioncAction/PetitionSubmissionActionContainer';
 import {
   renderAffirmation,
   renderShareAction,
   renderContentBlock,
-  renderVoterRegistrationAction,
   renderReferralSubmissionAction,
 } from './renderers';
 
@@ -299,7 +299,17 @@ class ContentfulEntry extends React.Component<Props, State> {
         );
 
       case 'voterRegistrationAction':
-        return renderVoterRegistrationAction(json);
+        return (
+          <VoterRegistrationActionContainer
+            contentfulId={json.id}
+            {...json.fields}
+          />
+        );
+
+      case 'VoterRegistrationBlock':
+        return (
+          <VoterRegistrationActionContainer contentfulId={json.id} {...json} />
+        );
 
       default:
         return <NotFound />;

--- a/resources/assets/components/ContentfulEntry/ContentfulEntry.js
+++ b/resources/assets/components/ContentfulEntry/ContentfulEntry.js
@@ -22,13 +22,13 @@ import SocialDriveActionContainer from '../actions/SocialDriveAction/SocialDrive
 import SixpackExperimentContainer from '../utilities/SixpackExperiment/SixpackExperimentContainer';
 import CampaignGalleryBlockContainer from '../blocks/CampaignGalleryBlock/CampaignGalleryBlockContainer';
 import TextSubmissionActionContainer from '../actions/TextSubmissionAction/TextSubmissionActionContainer';
+import PhotoSubmissionActionContainer from '../actions/PhotoSubmissionAction/PhotoSubmissionActionContainer';
 import SubmissionGalleryBlockContainer from '../blocks/SubmissionGalleryBlock/SubmissionGalleryBlockContainer';
 import PetitionSubmissionActionContainer from '../actions/PetitionSubmissioncAction/PetitionSubmissionActionContainer';
 import {
   renderAffirmation,
   renderShareAction,
   renderContentBlock,
-  renderPhotoSubmissionAction,
   renderVoterRegistrationAction,
   renderReferralSubmissionAction,
 } from './renderers';
@@ -181,7 +181,33 @@ class ContentfulEntry extends React.Component<Props, State> {
         );
 
       case 'photoSubmissionAction':
-        return renderPhotoSubmissionAction(json);
+        return (
+          <div className="margin-horizontal-md margin-bottom-lg">
+            <PhotoSubmissionActionContainer
+              id={json.id}
+              {...withoutNulls(json.fields)}
+            />
+            <div className="margin-vertical-md">
+              <SubmissionGalleryBlockContainer
+                type="photo"
+                actionId={json.fields.actionId}
+              />
+            </div>
+          </div>
+        );
+
+      case 'PhotoSubmissionBlock':
+        return (
+          <div className="margin-horizontal-md margin-bottom-lg">
+            <PhotoSubmissionActionContainer {...withoutNulls(json)} />
+            <div className="margin-vertical-md">
+              <SubmissionGalleryBlockContainer
+                type="photo"
+                actionId={json.actionId}
+              />
+            </div>
+          </div>
+        );
 
       case 'poll_locator':
         return (

--- a/resources/assets/components/ContentfulEntry/ContentfulEntry.js
+++ b/resources/assets/components/ContentfulEntry/ContentfulEntry.js
@@ -15,6 +15,7 @@ import GalleryBlock from '../blocks/GalleryBlock/GalleryBlock';
 import SectionBlock from '../blocks/SectionBlock/SectionBlock';
 import { parseContentfulType, report, withoutNulls } from '../../helpers';
 import CallToActionContainer from '../CallToAction/CallToActionContainer';
+import LinkActionContainer from '../actions/LinkAction/LinkActionContainer';
 import LandingPageContainer from '../pages/LandingPage/LandingPageContainer';
 import PostGalleryBlockQuery from '../blocks/PostGalleryBlock/PostGalleryBlockQuery';
 import SocialDriveActionContainer from '../actions/SocialDriveAction/SocialDriveActionContainer';
@@ -24,7 +25,6 @@ import TextSubmissionActionContainer from '../actions/TextSubmissionAction/TextS
 import SubmissionGalleryBlockContainer from '../blocks/SubmissionGalleryBlock/SubmissionGalleryBlockContainer';
 import PetitionSubmissionActionContainer from '../actions/PetitionSubmissioncAction/PetitionSubmissionActionContainer';
 import {
-  renderLinkAction,
   renderAffirmation,
   renderShareAction,
   renderContentBlock,
@@ -145,8 +145,13 @@ class ContentfulEntry extends React.Component<Props, State> {
       case 'landingPage':
         return <LandingPageContainer {...json.fields} />;
 
+      case 'LinkBlock':
+        return <LinkActionContainer {...withoutNulls(json)} />;
+
       case 'linkAction':
-        return renderLinkAction(json);
+        return (
+          <LinkActionContainer id={json.id} {...withoutNulls(json.fields)} />
+        );
 
       case 'page':
         return (

--- a/resources/assets/components/ContentfulEntry/renderers.js
+++ b/resources/assets/components/ContentfulEntry/renderers.js
@@ -1,31 +1,9 @@
 import React from 'react';
-import { PuckWaypoint } from '@dosomething/puck-client';
 
 import Affirmation from '../Affirmation';
 import { withoutNulls } from '../../helpers';
 import ContentBlock from '../blocks/ContentBlock/ContentBlock';
-import ShareActionContainer from '../actions/ShareAction/ShareActionContainer';
 import ReferralSubmissionActionContainer from '../actions/ReferralSubmissionAction/ReferralSubmissionActionContainer';
-
-/**
- * Render a share action.
- *
- * @return {Component}
- */
-export function renderShareAction(step) {
-  const contentfulId = step.id;
-
-  return (
-    <div key={`share-action-${contentfulId}`} className="margin-horizontal-md">
-      <PuckWaypoint name="share_action-top" waypointData={{ contentfulId }} />
-      <ShareActionContainer id={step.id} {...withoutNulls(step.fields)} />
-      <PuckWaypoint
-        name="share_action-bottom"
-        waypointData={{ contentfulId }}
-      />
-    </div>
-  );
-}
 
 /**
  * Render a referral submission action.

--- a/resources/assets/components/ContentfulEntry/renderers.js
+++ b/resources/assets/components/ContentfulEntry/renderers.js
@@ -5,8 +5,6 @@ import Affirmation from '../Affirmation';
 import { withoutNulls } from '../../helpers';
 import ContentBlock from '../blocks/ContentBlock/ContentBlock';
 import ShareActionContainer from '../actions/ShareAction/ShareActionContainer';
-import PhotoSubmissionActionContainer from '../actions/PhotoSubmissionAction/PhotoSubmissionActionContainer';
-import SubmissionGalleryBlockContainer from '../blocks/SubmissionGalleryBlock/SubmissionGalleryBlockContainer';
 import VoterRegistrationActionContainer from '../actions/VoterRegistrationAction/VoterRegistrationActionContainer';
 import ReferralSubmissionActionContainer from '../actions/ReferralSubmissionAction/ReferralSubmissionActionContainer';
 
@@ -47,37 +45,6 @@ export function renderShareAction(step) {
       <ShareActionContainer id={step.id} {...withoutNulls(step.fields)} />
       <PuckWaypoint
         name="share_action-bottom"
-        waypointData={{ contentfulId }}
-      />
-    </div>
-  );
-}
-
-/**
- * Render a photo submission action.
- *
- * @param  {Object} data
- * @return {Component}
- */
-export function renderPhotoSubmissionAction(data) {
-  const contentfulId = data.id;
-  const fields = withoutNulls(data.fields);
-
-  return (
-    <div className="margin-horizontal-md margin-bottom-lg">
-      <PuckWaypoint
-        name="photo_submission_action-top"
-        waypointData={{ contentfulId }}
-      />
-      <PhotoSubmissionActionContainer id={contentfulId} {...fields} />
-      <div className="margin-vertical-md">
-        <SubmissionGalleryBlockContainer
-          type="photo"
-          actionId={fields.actionId}
-        />
-      </div>
-      <PuckWaypoint
-        name="photo_submission_action-bottom"
         waypointData={{ contentfulId }}
       />
     </div>

--- a/resources/assets/components/ContentfulEntry/renderers.js
+++ b/resources/assets/components/ContentfulEntry/renderers.js
@@ -5,31 +5,7 @@ import Affirmation from '../Affirmation';
 import { withoutNulls } from '../../helpers';
 import ContentBlock from '../blocks/ContentBlock/ContentBlock';
 import ShareActionContainer from '../actions/ShareAction/ShareActionContainer';
-import VoterRegistrationActionContainer from '../actions/VoterRegistrationAction/VoterRegistrationActionContainer';
 import ReferralSubmissionActionContainer from '../actions/ReferralSubmissionAction/ReferralSubmissionActionContainer';
-
-/**
- * Render the voter registration action container.
- *
- * @return {Component}
- */
-export function renderVoterRegistrationAction(step) {
-  const { title, content, link } = step.fields;
-  const key = `voter-registration-action-${step.id}`;
-
-  return (
-    <div key={key} className="margin-bottom-lg margin-horizontal-md">
-      <PuckWaypoint name="voter_registration_action-top" />
-      <VoterRegistrationActionContainer
-        contentfulId={step.id}
-        content={content}
-        title={title}
-        link={link}
-      />
-      <PuckWaypoint name="voter_registration_action-bottom" />
-    </div>
-  );
-}
 
 /**
  * Render a share action.

--- a/resources/assets/components/ContentfulEntry/renderers.js
+++ b/resources/assets/components/ContentfulEntry/renderers.js
@@ -4,7 +4,6 @@ import { PuckWaypoint } from '@dosomething/puck-client';
 import Affirmation from '../Affirmation';
 import { withoutNulls } from '../../helpers';
 import ContentBlock from '../blocks/ContentBlock/ContentBlock';
-import LinkActionContainer from '../actions/LinkAction/LinkActionContainer';
 import ShareActionContainer from '../actions/ShareAction/ShareActionContainer';
 import PhotoSubmissionActionContainer from '../actions/PhotoSubmissionAction/PhotoSubmissionActionContainer';
 import SubmissionGalleryBlockContainer from '../blocks/SubmissionGalleryBlock/SubmissionGalleryBlockContainer';
@@ -50,23 +49,6 @@ export function renderShareAction(step) {
         name="share_action-bottom"
         waypointData={{ contentfulId }}
       />
-    </div>
-  );
-}
-
-/**
- * Render a link action.
- *
- * @return {Component}
- */
-export function renderLinkAction(step) {
-  const contentfulId = step.id;
-
-  return (
-    <div key={`link-action-${contentfulId}`} className="margin-horizontal-md">
-      <PuckWaypoint name="link_action-top" waypointData={{ contentfulId }} />
-      <LinkActionContainer {...withoutNulls(step.fields)} />
-      <PuckWaypoint name="link_action-bottom" waypointData={{ contentfulId }} />
     </div>
   );
 }

--- a/resources/assets/components/actions/LinkAction/LinkAction.js
+++ b/resources/assets/components/actions/LinkAction/LinkAction.js
@@ -1,18 +1,34 @@
 import React from 'react';
+import { get } from 'lodash';
 import PropTypes from 'prop-types';
+import { PuckWaypoint } from '@dosomething/puck-client';
 
 import CtaTemplate from './templates/CtaTemplate';
 import DefaultTemplate from './templates/DefaultTemplate';
 
-const LinkAction = props => {
-  const { template } = props;
+const templates = {
+  cta: CtaTemplate,
+  default: DefaultTemplate,
+};
 
-  switch (template) {
-    case 'cta':
-      return <CtaTemplate {...props} />;
-    default:
-      return <DefaultTemplate {...props} />;
-  }
+const LinkAction = props => {
+  const { id, template } = props;
+
+  const LinkActionTemplate = get(templates, template, DefaultTemplate);
+
+  return (
+    <div key={`link-action-${id}`} className="margin-horizontal-md">
+      <PuckWaypoint
+        name="link_action-top"
+        waypointData={{ contentfulId: id }}
+      />
+      <LinkActionTemplate {...props} />
+      <PuckWaypoint
+        name="link_action-bottom"
+        waypointData={{ contentfulId: id }}
+      />
+    </div>
+  );
 };
 
 LinkAction.propTypes = {

--- a/resources/assets/components/actions/LinkAction/LinkAction.js
+++ b/resources/assets/components/actions/LinkAction/LinkAction.js
@@ -17,7 +17,7 @@ const LinkAction = props => {
   const LinkActionTemplate = get(templates, template, DefaultTemplate);
 
   return (
-    <div key={`link-action-${id}`} className="margin-horizontal-md">
+    <div className="margin-horizontal-md">
       <PuckWaypoint
         name="link_action-top"
         waypointData={{ contentfulId: id }}

--- a/resources/assets/components/actions/LinkAction/templates/DefaultTemplate.js
+++ b/resources/assets/components/actions/LinkAction/templates/DefaultTemplate.js
@@ -58,7 +58,8 @@ const DefaultTemplate = props => {
         {affiliateLogo ? (
           <SponsorPromotion
             className="affiliate-logo -padded"
-            imgUrl={affiliateLogo}
+            imgUrl={affiliateLogo.url}
+            title={affiliateLogo.description}
           />
         ) : null}
       </div>
@@ -80,7 +81,8 @@ const DefaultTemplate = props => {
         {affiliateLogo ? (
           <SponsorPromotion
             className="affiliate-logo -padded"
-            imgUrl={affiliateLogo}
+            imgUrl={affiliateLogo.url}
+            title={affiliateLogo.description}
           />
         ) : null}
 
@@ -105,7 +107,10 @@ DefaultTemplate.propTypes = {
   title: PropTypes.string.isRequired,
   content: PropTypes.string,
   link: PropTypes.string.isRequired,
-  affiliateLogo: PropTypes.string,
+  affiliateLogo: PropTypes.shape({
+    url: PropTypes.string,
+    description: PropTypes.string,
+  }),
   buttonText: PropTypes.string,
   campaignId: PropTypes.string,
   userId: PropTypes.string,

--- a/resources/assets/components/actions/PhotoSubmissionAction/PhotoSubmissionAction.js
+++ b/resources/assets/components/actions/PhotoSubmissionAction/PhotoSubmissionAction.js
@@ -4,6 +4,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import { get, has, invert, mapValues } from 'lodash';
+import { PuckWaypoint } from '@dosomething/puck-client';
 
 import Card from '../../utilities/Card/Card';
 import Modal from '../../utilities/Modal/Modal';
@@ -249,6 +250,10 @@ class PhotoSubmissionAction extends React.Component {
 
     return (
       <React.Fragment>
+        <PuckWaypoint
+          name="photo_submission_action-top"
+          waypointData={{ contentfulId: this.props.id }}
+        />
         <div className="clearfix">
           <div className="photo-submission-action">
             <Card
@@ -394,6 +399,10 @@ class PhotoSubmissionAction extends React.Component {
             </Card>
           </Modal>
         ) : null}
+        <PuckWaypoint
+          name="photo_submission_action-bottom"
+          waypointData={{ contentfulId: this.props.id }}
+        />
       </React.Fragment>
     );
   }

--- a/resources/assets/components/actions/PhotoSubmissionAction/PhotoSubmissionAction.js
+++ b/resources/assets/components/actions/PhotoSubmissionAction/PhotoSubmissionAction.js
@@ -250,12 +250,12 @@ class PhotoSubmissionAction extends React.Component {
 
     return (
       <React.Fragment>
-        <PuckWaypoint
-          name="photo_submission_action-top"
-          waypointData={{ contentfulId: this.props.id }}
-        />
         <div className="clearfix">
           <div className="photo-submission-action">
+            <PuckWaypoint
+              name="photo_submission_action-top"
+              waypointData={{ contentfulId: this.props.id }}
+            />
             <Card
               className={classnames('bordered rounded', this.props.className)}
               title={this.props.title}
@@ -373,6 +373,10 @@ class PhotoSubmissionAction extends React.Component {
                 </Button>
               </form>
             </Card>
+            <PuckWaypoint
+              name="photo_submission_action-bottom"
+              waypointData={{ contentfulId: this.props.id }}
+            />
           </div>
 
           {this.props.informationContent ? (
@@ -399,10 +403,6 @@ class PhotoSubmissionAction extends React.Component {
             </Card>
           </Modal>
         ) : null}
-        <PuckWaypoint
-          name="photo_submission_action-bottom"
-          waypointData={{ contentfulId: this.props.id }}
-        />
       </React.Fragment>
     );
   }

--- a/resources/assets/components/actions/ShareAction/ShareAction.js
+++ b/resources/assets/components/actions/ShareAction/ShareAction.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { get } from 'lodash';
 import PropTypes from 'prop-types';
+import { PuckWaypoint } from '@dosomething/puck-client';
 
 import Card from '../../utilities/Card/Card';
 import Embed from '../../utilities/Embed/Embed';
@@ -111,6 +112,7 @@ class ShareAction extends React.Component {
 
   render() {
     const {
+      id,
       affirmation, // @TODO: Rename me to 'affirmationText'?
       affirmationBlock,
       content,
@@ -137,7 +139,11 @@ class ShareAction extends React.Component {
 
     return (
       <React.Fragment>
-        <div className="share-action margin-bottom-lg">
+        <div className="share-action margin-bottom-lg margin-horizontal-md">
+          <PuckWaypoint
+            name="share_action-top"
+            waypointData={{ contentfulId: id }}
+          />
           <Card title={title} className="rounded bordered">
             {content ? (
               <TextContent className="padded">{content}</TextContent>
@@ -151,6 +157,10 @@ class ShareAction extends React.Component {
               Share on {isFacebook ? 'Facebook' : 'Twitter'}
             </Button>
           </Card>
+          <PuckWaypoint
+            name="share_action-bottom"
+            waypointData={{ contentfulId: id }}
+          />
         </div>
         {this.state.showModal ? (
           <Modal onClose={() => this.setState({ showModal: false })}>

--- a/resources/assets/components/actions/VoterRegistrationAction/VoterRegistrationAction.js
+++ b/resources/assets/components/actions/VoterRegistrationAction/VoterRegistrationAction.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { PuckWaypoint } from '@dosomething/puck-client';
 
 import Card from '../../utilities/Card/Card';
 import { set } from '../../../helpers/storage';
@@ -33,26 +34,30 @@ const VoterRegistrationAction = props => {
   };
 
   return (
-    <Card
-      className="rounded bordered voter-registration"
-      title="Register to vote"
-    >
-      <div className="padded clearfix">
-        <TextContent>{content}</TextContent>
+    <div className="margin-bottom-lg margin-horizontal-md">
+      <PuckWaypoint name="voter_registration_action-top" />
+      <Card
+        className="rounded bordered voter-registration"
+        title="Register to vote"
+      >
+        <div className="padded clearfix">
+          <TextContent>{content}</TextContent>
 
-        {parsedLink ? (
-          <a
-            className="button"
-            href={parsedLink}
-            onClick={handleClick}
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            Start Registration
-          </a>
-        ) : null}
-      </div>
-    </Card>
+          {parsedLink ? (
+            <a
+              className="button"
+              href={parsedLink}
+              onClick={handleClick}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Start Registration
+            </a>
+          ) : null}
+        </div>
+      </Card>
+      <PuckWaypoint name="voter_registration_action-bottom" />
+    </div>
   );
 };
 

--- a/resources/assets/components/blocks/PostGalleryBlock/PostGalleryBlockQuery.js
+++ b/resources/assets/components/blocks/PostGalleryBlock/PostGalleryBlockQuery.js
@@ -52,6 +52,7 @@ const PostGalleryBlockQuery = ({ id, actionIds, className, itemsPerRow }) => (
 PostGalleryBlockQuery.propTypes = {
   id: PropTypes.string,
   actionIds: PropTypes.arrayOf(PropTypes.string),
+  actionIds: PropTypes.arrayOf(PropTypes.number),
   className: PropTypes.string,
   itemsPerRow: PropTypes.number,
 };

--- a/resources/assets/components/blocks/PostGalleryBlock/PostGalleryBlockQuery.js
+++ b/resources/assets/components/blocks/PostGalleryBlock/PostGalleryBlockQuery.js
@@ -51,7 +51,6 @@ const PostGalleryBlockQuery = ({ id, actionIds, className, itemsPerRow }) => (
 
 PostGalleryBlockQuery.propTypes = {
   id: PropTypes.string,
-  actionIds: PropTypes.arrayOf(PropTypes.string),
   actionIds: PropTypes.arrayOf(PropTypes.number),
   className: PropTypes.string,
   itemsPerRow: PropTypes.number,

--- a/resources/assets/components/utilities/ContentfulEntryLoader/ContentfulEntryLoader.js
+++ b/resources/assets/components/utilities/ContentfulEntryLoader/ContentfulEntryLoader.js
@@ -26,7 +26,10 @@ const CONTENTFUL_BLOCK_QUERY = gql`
         content
         link
         buttonText
-        affiliateLogo
+        affiliateLogo {
+          url(w: 400, h: 200)
+          description
+        }
         template
         additionalContent
       }

--- a/resources/assets/components/utilities/ContentfulEntryLoader/ContentfulEntryLoader.js
+++ b/resources/assets/components/utilities/ContentfulEntryLoader/ContentfulEntryLoader.js
@@ -21,9 +21,44 @@ const CONTENTFUL_BLOCK_QUERY = gql`
       ... on EmbedBlock {
         url
       }
+      ... on LinkBlock {
+        title
+        content
+        link
+        buttonText
+        affiliateLogo
+        template
+        additionalContent
+      }
       ... on PostGalleryBlock {
         actionIds
         itemsPerRow
+      }
+      ... on PhotoSubmissionBlock {
+        actionId
+        title
+        captionFieldLabel
+        captionFieldPlaceholderMessage
+        showQuantityField
+        quantityFieldLabel
+        quantityFieldPlaceholder
+        whyParticipatedFieldLabel
+        whyParticipatedFieldPlaceholder
+        buttonText
+        informationTitle
+        informationContent
+        affirmationContent
+        additionalContent
+      }
+      ... on ShareBlock {
+        actionId
+        title
+        socialPlatform
+        content
+        hideEmbed
+        affirmationBlock
+        affirmation
+        additionalContent
       }
       ... on TextSubmissionBlock {
         actionId
@@ -44,6 +79,12 @@ const CONTENTFUL_BLOCK_QUERY = gql`
         informationTitle
         informationContent
         affirmationContent
+      }
+      ... on VoterRegistrationBlock {
+        title
+        content
+        link
+        additionalContent
       }
     }
   }

--- a/resources/assets/components/utilities/ContentfulEntryLoader/ContentfulEntryLoader.js
+++ b/resources/assets/components/utilities/ContentfulEntryLoader/ContentfulEntryLoader.js
@@ -58,8 +58,11 @@ const CONTENTFUL_BLOCK_QUERY = gql`
         title
         socialPlatform
         content
+        link
         hideEmbed
-        affirmationBlock
+        affirmationBlock {
+          id
+        }
         affirmation
         additionalContent
       }

--- a/resources/assets/components/utilities/ContentfulEntryLoader/ContentfulEntryLoader.js
+++ b/resources/assets/components/utilities/ContentfulEntryLoader/ContentfulEntryLoader.js
@@ -122,10 +122,9 @@ const ContentfulEntryLoader = ({ id, className }) => (
       const gridClass = get(entryGridMapping, blockType, 'grid-main');
 
       return (
-        <ContentfulEntry
-          className={classnames(className, gridClass)}
-          json={data.block}
-        />
+        <div className={classnames(className, gridClass)}>
+          <ContentfulEntry json={data.block} />
+        </div>
       );
     }}
   </Query>

--- a/resources/assets/components/utilities/ContentfulEntryLoader/ContentfulEntryLoader.js
+++ b/resources/assets/components/utilities/ContentfulEntryLoader/ContentfulEntryLoader.js
@@ -122,9 +122,10 @@ const ContentfulEntryLoader = ({ id, className }) => (
       const gridClass = get(entryGridMapping, blockType, 'grid-main');
 
       return (
-        <div className={classnames(className, gridClass)}>
-          <ContentfulEntry json={data.block} />
-        </div>
+        <ContentfulEntry
+          className={classnames(className, gridClass)}
+          json={data.block}
+        />
       );
     }}
   </Query>

--- a/resources/assets/components/utilities/ContentfulEntryLoader/ContentfulEntryLoader.js
+++ b/resources/assets/components/utilities/ContentfulEntryLoader/ContentfulEntryLoader.js
@@ -27,7 +27,7 @@ const CONTENTFUL_BLOCK_QUERY = gql`
         link
         buttonText
         affiliateLogo {
-          url(w: 400, h: 200)
+          url(w: 200, h: 100)
           description
         }
         template


### PR DESCRIPTION
### What does this PR do?

This PR adds partial support for loading the Photo Submission, Link, Share, and Voter Registration blocks via `ContentfulEntryLoader`. These each still make assumptions that they're operating within a traditional campaign page (with a campaign ID, etc...), so they're **not fully functional yet**, but this gets us closer to unifying these two separate experiences.

I've used this as an opportunity to clean up some more of our renderers – moving more code into the `ContentfulEntry` itself & moving Puck waypoints into their respective components.

Finally (and hopefully not too controversially), I updated `ContentfulEntryLoader` to wrap the entire `ContentfulEntry` in the provided `className`, rather than requiring each possible component to implement its own custom `className` prop support.

### Any background context you want to provide?
This closes the loop on some work done in DoSomething/graphql#86.

### What are the relevant tickets/cards?

N/A

### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.
* [ ] Added screenshot to PR description of related front-end updates on **small** screens.
* [ ] Added screenshot to PR description of related front-end updates on **medium** screens.
* [ ] Added screenshot to PR description of related front-end updates on **large** screens.