### PR TITLE
Filtering PostGallery by location.

### DIFF
--- a/app/Entities/PostGallery.php
+++ b/app/Entities/PostGallery.php
@@ -20,6 +20,7 @@ class PostGallery extends Entity implements JsonSerializable
                 'internalTitle' => $this->internalTitle,
                 'actionIds' => $this->actionIds,
                 'itemsPerRow' => $this->itemsPerRow,
+                'filterType' => $this->filterType === 'none' ? null : $this->filterType,
             ],
         ];
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -5563,8 +5563,7 @@
           "version": "2.1.1",
           "resolved": false,
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -5588,15 +5587,13 @@
           "version": "1.0.0",
           "resolved": false,
           "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "resolved": false,
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -5613,22 +5610,19 @@
           "version": "1.1.0",
           "resolved": false,
           "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "resolved": false,
           "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "resolved": false,
           "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -5759,8 +5753,7 @@
           "version": "2.0.3",
           "resolved": false,
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -5774,7 +5767,6 @@
           "resolved": false,
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -5791,7 +5783,6 @@
           "resolved": false,
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -5800,15 +5791,13 @@
           "version": "0.0.8",
           "resolved": false,
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.2.4",
           "resolved": false,
           "integrity": "sha512-hzXIWWet/BzWhYs2b+u7dRHlruXhwdgvlTMDKC6Cb1U7ps6Ac6yQlR39xsbjWJE377YTCtKwIXIpJ5oP+j5y8g==",
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -5829,7 +5818,6 @@
           "resolved": false,
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -5918,8 +5906,7 @@
           "version": "1.0.1",
           "resolved": false,
           "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -5933,7 +5920,6 @@
           "resolved": false,
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -6029,8 +6015,7 @@
           "version": "5.1.1",
           "resolved": false,
           "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -6072,7 +6057,6 @@
           "resolved": false,
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -6094,7 +6078,6 @@
           "resolved": false,
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -6143,15 +6126,13 @@
           "version": "1.0.2",
           "resolved": false,
           "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.2",
           "resolved": false,
           "integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k=",
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -13913,6 +13894,11 @@
           }
         }
       }
+    },
+    "usa-states": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/usa-states/-/usa-states-0.0.5.tgz",
+      "integrity": "sha1-OojJct71NFrpuHGG/EQCOFuGG7c="
     },
     "use": {
       "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -113,7 +113,8 @@
     "redux-logger": "^2.8.1",
     "redux-thunk": "^2.3.0",
     "regenerator-runtime": "^0.11.1",
-    "sixpack-client": "^2.1.0"
+    "sixpack-client": "^2.1.0",
+    "usa-states": "0.0.5"
   },
   "devDependencies": {
     "@dosomething/babel-config": "^2.2.2",

--- a/resources/assets/components/PaginatedQuery.js
+++ b/resources/assets/components/PaginatedQuery.js
@@ -17,7 +17,7 @@ const PaginatedQuery = ({ query, queryName, variables, count, children }) => (
     {result => {
       // On initial load, just display a loading spinner.
       if (result.networkStatus === NetworkStatus.LOADING) {
-        return <div className="spinner -centered" />;
+        return <div className="spinner -centered grid-main" />;
       }
 
       if (result.error) {

--- a/resources/assets/components/blocks/PostGalleryBlock/PostGalleryBlockQuery.js
+++ b/resources/assets/components/blocks/PostGalleryBlock/PostGalleryBlockQuery.js
@@ -58,7 +58,7 @@ class PostGalleryBlockQuery extends React.Component {
   };
 
   render() {
-    const { actionIds, className, filterType, itemsPerRow } = this.props;
+    const { actionIds, className, filterType, id, itemsPerRow } = this.props;
 
     return (
       <React.Fragment>
@@ -83,12 +83,14 @@ class PostGalleryBlockQuery extends React.Component {
         >
           {({ result, fetching, fetchMore }) => (
             <PostGallery
+              id={id}
               className={classnames(className)}
               posts={result}
               loading={fetching}
               itemsPerRow={itemsPerRow}
               filterType={filterType}
               loadMorePosts={fetchMore}
+              waypointName={'post_gallery_block'}
             />
           )}
         </PaginatedQuery>

--- a/resources/assets/components/blocks/PostGalleryBlock/PostGalleryBlockQuery.js
+++ b/resources/assets/components/blocks/PostGalleryBlock/PostGalleryBlockQuery.js
@@ -42,32 +42,30 @@ class PostGalleryBlockQuery extends React.Component {
   constructor(props) {
     super(props);
 
-    const filterType =
-      this.props.filterType === 'none' ? null : this.props.filterType;
-
     this.state = {
-      filterValue: null,
-      enableFiltering: Boolean(filterType),
+      filterValue: '',
+      filterType:
+        this.props.filterType === 'none' ? null : this.props.filterType,
     };
   }
 
   handleSelect = event => {
     this.setState({
-      filterValue: event.target.value || null,
+      filterValue: event.target.value,
     });
   };
 
   render() {
-    const { actionIds, className, filterType, id, itemsPerRow } = this.props;
+    const { actionIds, className, id, itemsPerRow } = this.props;
 
     return (
       <React.Fragment>
-        {this.state.enableFiltering ? (
+        {this.state.filterType === 'location' ? (
           <div className="grid-narrow margin-bottom-lg">
             <SelectLocationDropdown
               locationList="domestic"
               onSelect={this.handleSelect}
-              selectedOption={this.state.filterValue || ''}
+              selectedOption={this.state.filterValue}
             />
           </div>
         ) : null}
@@ -77,7 +75,7 @@ class PostGalleryBlockQuery extends React.Component {
           queryName="posts"
           variables={withoutNulls({
             actionIds,
-            location: this.state.filterValue,
+            location: this.state.filterValue || null,
           })}
           count={itemsPerRow * 3}
         >
@@ -88,7 +86,6 @@ class PostGalleryBlockQuery extends React.Component {
               posts={result}
               loading={fetching}
               itemsPerRow={itemsPerRow}
-              filterType={filterType}
               loadMorePosts={fetchMore}
               waypointName={'post_gallery_block'}
             />

--- a/resources/assets/components/blocks/PostGalleryBlock/PostGalleryBlockQuery.js
+++ b/resources/assets/components/blocks/PostGalleryBlock/PostGalleryBlockQuery.js
@@ -2,9 +2,11 @@ import React from 'react';
 import gql from 'graphql-tag';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
+import { UsaStates } from 'usa-states';
 
 import PaginatedQuery from '../../PaginatedQuery';
 import PostGallery from '../../utilities/PostGallery/PostGallery';
+import { withoutNulls } from '../../../helpers';
 import { postCardFragment } from '../../utilities/PostCard/PostCard';
 import { reactionButtonFragment } from '../../utilities/ReactionButton/ReactionButton';
 
@@ -12,8 +14,18 @@ import { reactionButtonFragment } from '../../utilities/ReactionButton/ReactionB
  * The GraphQL query to load data for this component.
  */
 const POST_GALLERY_QUERY = gql`
-  query PostGalleryQuery($actionIds: [Int], $count: Int, $page: Int) {
-    posts(actionIds: $actionIds, count: $count, page: $page) {
+  query PostGalleryQuery(
+    $actionIds: [Int]
+    $location: String
+    $count: Int
+    $page: Int
+  ) {
+    posts(
+      actionIds: $actionIds
+      location: $location
+      count: $count
+      page: $page
+    ) {
       ...PostCard
       ...ReactionButton
     }
@@ -26,28 +38,90 @@ const POST_GALLERY_QUERY = gql`
 /**
  * Fetch results via GraphQL using a query component.
  */
-const PostGalleryBlockQuery = ({ id, actionIds, className, itemsPerRow }) => (
-  <PaginatedQuery
-    query={POST_GALLERY_QUERY}
-    queryName="posts"
-    variables={{ actionIds }}
-    count={itemsPerRow * 3}
-  >
-    {({ result, fetching, fetchMore }) => (
+class PostGalleryBlockQuery extends React.Component {
+  constructor(props) {
+    super(props);
+
+    const filterType =
+      this.props.filterType === 'none' ? null : this.props.filterType;
+
+    // console.log('⛩', filterType);
+    // console.log('⛩ Filtering enabled: ', Boolean(filterType));
+
+    this.state = {
+      filterValue: null,
+      enableFiltering: Boolean(filterType),
+    };
+  }
+
+  handleSelect = event => {
+    console.log(`US-${event.target.value}`);
+
+    this.setState({
+      filterValue: `US-${event.target.value}`,
+    });
+  };
+
+  componentDidMount() {
+    console.log('🗿 PostGalleryBlockQuery mounted...');
+  }
+
+  componentDidUpdate() {
+    console.log('🗿 PostGalleryBlockQuery updated...');
+  }
+
+  render() {
+    console.log('🗿 PostGalleryBlockQuery render...');
+
+    const { actionIds, className, filterType, itemsPerRow } = this.props;
+    console.log('💎', { actionIds, className, filterType, itemsPerRow });
+
+    const states = new UsaStates({ exclude: ['DC'] }).format({
+      $abbreviation: 'abbr',
+      $name: 'name',
+    });
+
+    return (
       <React.Fragment>
-        <PostGallery
-          id={id}
-          className={classnames(className)}
-          posts={result}
-          loading={fetching}
-          itemsPerRow={itemsPerRow}
-          loadMorePosts={fetchMore}
-          waypointName={'post_gallery_block'}
-        />
+        {this.state.enableFiltering ? (
+          <div className="select grid-narrow margin-bottom-lg">
+            <select value={this.state.filterValue} onChange={this.handleSelect}>
+              <option key="default" value="">
+                Select a state
+              </option>
+              {states.map(state => (
+                <option key={state.name} value={state.abbreviation}>
+                  {state.name}
+                </option>
+              ))}
+            </select>
+          </div>
+        ) : null}
+
+        <PaginatedQuery
+          query={POST_GALLERY_QUERY}
+          queryName="posts"
+          variables={withoutNulls({
+            actionIds,
+            location: this.state.filterValue,
+          })}
+          count={itemsPerRow * 3}
+        >
+          {({ result, fetching, fetchMore }) => (
+            <PostGallery
+              className={classnames(className)}
+              posts={result}
+              loading={fetching}
+              itemsPerRow={itemsPerRow}
+              filterType={filterType}
+              loadMorePosts={fetchMore}
+            />
+          )}
+        </PaginatedQuery>
       </React.Fragment>
-    )}
-  </PaginatedQuery>
-);
+    );
+  }
+}
 
 PostGalleryBlockQuery.propTypes = {
   id: PropTypes.string,

--- a/resources/assets/components/blocks/PostGalleryBlock/PostGalleryBlockQuery.js
+++ b/resources/assets/components/blocks/PostGalleryBlock/PostGalleryBlockQuery.js
@@ -2,13 +2,13 @@ import React from 'react';
 import gql from 'graphql-tag';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
-import { UsaStates } from 'usa-states';
 
+import { withoutNulls } from '../../../helpers';
 import PaginatedQuery from '../../PaginatedQuery';
 import PostGallery from '../../utilities/PostGallery/PostGallery';
-import { withoutNulls } from '../../../helpers';
 import { postCardFragment } from '../../utilities/PostCard/PostCard';
 import { reactionButtonFragment } from '../../utilities/ReactionButton/ReactionButton';
+import SelectLocationDropdown from '../../utilities/SelectLocationDropdown/SelectLocationDropdown';
 
 /**
  * The GraphQL query to load data for this component.
@@ -44,10 +44,6 @@ class PostGalleryBlockQuery extends React.Component {
 
     const filterType =
       this.props.filterType === 'none' ? null : this.props.filterType;
-
-    // console.log('⛩', filterType);
-    // console.log('⛩ Filtering enabled: ', Boolean(filterType));
-
     this.state = {
       filterValue: null,
       enableFiltering: Boolean(filterType),
@@ -55,46 +51,23 @@ class PostGalleryBlockQuery extends React.Component {
   }
 
   handleSelect = event => {
-    console.log(`US-${event.target.value}`);
-
     this.setState({
-      filterValue: `US-${event.target.value}`,
+      filterValue: event.target.value || null,
     });
   };
 
-  componentDidMount() {
-    console.log('🗿 PostGalleryBlockQuery mounted...');
-  }
-
-  componentDidUpdate() {
-    console.log('🗿 PostGalleryBlockQuery updated...');
-  }
-
   render() {
-    console.log('🗿 PostGalleryBlockQuery render...');
-
     const { actionIds, className, filterType, itemsPerRow } = this.props;
-    console.log('💎', { actionIds, className, filterType, itemsPerRow });
-
-    const states = new UsaStates({ exclude: ['DC'] }).format({
-      $abbreviation: 'abbr',
-      $name: 'name',
-    });
 
     return (
       <React.Fragment>
         {this.state.enableFiltering ? (
-          <div className="select grid-narrow margin-bottom-lg">
-            <select value={this.state.filterValue} onChange={this.handleSelect}>
-              <option key="default" value="">
-                Select a state
-              </option>
-              {states.map(state => (
-                <option key={state.name} value={state.abbreviation}>
-                  {state.name}
-                </option>
-              ))}
-            </select>
+          <div className="grid-narrow margin-bottom-lg">
+            <SelectLocationDropdown
+              locationList="domestic"
+              onSelect={this.handleSelect}
+              selectedOption={this.state.filterValue || ''}
+            />
           </div>
         ) : null}
 
@@ -127,6 +100,7 @@ PostGalleryBlockQuery.propTypes = {
   id: PropTypes.string,
   actionIds: PropTypes.arrayOf(PropTypes.number),
   className: PropTypes.string,
+  filterType: PropTypes.string,
   itemsPerRow: PropTypes.number,
 };
 
@@ -134,6 +108,7 @@ PostGalleryBlockQuery.defaultProps = {
   id: null,
   actionIds: [],
   className: null,
+  filterType: null,
   itemsPerRow: 3,
 };
 

--- a/resources/assets/components/blocks/PostGalleryBlock/PostGalleryBlockQuery.js
+++ b/resources/assets/components/blocks/PostGalleryBlock/PostGalleryBlockQuery.js
@@ -44,6 +44,7 @@ class PostGalleryBlockQuery extends React.Component {
 
     const filterType =
       this.props.filterType === 'none' ? null : this.props.filterType;
+
     this.state = {
       filterValue: null,
       enableFiltering: Boolean(filterType),

--- a/resources/assets/components/utilities/ContentfulEntryLoader/ContentfulEntryLoader.js
+++ b/resources/assets/components/utilities/ContentfulEntryLoader/ContentfulEntryLoader.js
@@ -36,6 +36,7 @@ const CONTENTFUL_BLOCK_QUERY = gql`
       ... on PostGalleryBlock {
         actionIds
         itemsPerRow
+        filterType
       }
       ... on PhotoSubmissionBlock {
         actionId

--- a/resources/assets/components/utilities/SelectLocationDropdown/SelectLocationDropdown.js
+++ b/resources/assets/components/utilities/SelectLocationDropdown/SelectLocationDropdown.js
@@ -8,10 +8,11 @@ class SelectLocationDropdown extends React.Component {
     this.state = {
       locations: [],
       prefix: '',
+      defaultText: this.props.defaultText,
     };
 
     if (this.props.locationList === 'domestic') {
-      this.addDomesticOptions();
+      this.addDomesticOptions({ includeTerritories: true });
     }
   }
 
@@ -23,6 +24,7 @@ class SelectLocationDropdown extends React.Component {
       });
 
       this.setState({
+        defaultText: 'Select a state',
         locations: states,
         prefix: 'US-',
       });
@@ -37,7 +39,7 @@ class SelectLocationDropdown extends React.Component {
           onChange={this.props.onSelect}
         >
           <option key="default" value="">
-            Select a state
+            {this.state.defaultText}
           </option>
           {this.state.locations.map(location => (
             <option
@@ -54,12 +56,14 @@ class SelectLocationDropdown extends React.Component {
 }
 
 SelectLocationDropdown.propTypes = {
+  defaultText: PropTypes.string,
   locationList: PropTypes.string,
   onSelect: PropTypes.func.isRequired,
   selectedOption: PropTypes.string,
 };
 
 SelectLocationDropdown.defaultProps = {
+  defaultText: 'All Locations',
   locationList: null,
   selectedOption: '',
 };

--- a/resources/assets/components/utilities/SelectLocationDropdown/SelectLocationDropdown.js
+++ b/resources/assets/components/utilities/SelectLocationDropdown/SelectLocationDropdown.js
@@ -1,0 +1,67 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+class SelectLocationDropdown extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      locations: [],
+      prefix: '',
+    };
+
+    if (this.props.locationList === 'domestic') {
+      this.addDomesticOptions();
+    }
+  }
+
+  addDomesticOptions = (config = {}) => {
+    import('usa-states').then(({ UsaStates }) => {
+      const states = new UsaStates(config).format({
+        key: 'abbr',
+        value: 'name',
+      });
+
+      this.setState({
+        locations: states,
+        prefix: 'US-',
+      });
+    });
+  };
+
+  render() {
+    return (
+      <div className="select">
+        <select
+          value={this.props.selectedOption}
+          onChange={this.props.onSelect}
+        >
+          <option key="default" value="">
+            Select a state
+          </option>
+          {this.state.locations.map(location => (
+            <option
+              key={location.value}
+              value={`${this.state.prefix}${location.key}`}
+            >
+              {location.value}
+            </option>
+          ))}
+        </select>
+      </div>
+    );
+  }
+}
+
+SelectLocationDropdown.propTypes = {
+  locationList: PropTypes.string,
+  onSelect: PropTypes.func.isRequired,
+  selectedOption: PropTypes.string,
+};
+
+SelectLocationDropdown.defaultProps = {
+  locationList: null,
+  selectedOption: '',
+};
+
+export default SelectLocationDropdown;

--- a/resources/assets/scss/base.scss
+++ b/resources/assets/scss/base.scss
@@ -501,6 +501,10 @@ p {
 .grid-narrow {
   grid-column: full-start / full-end;
 
+  @include media($medium) {
+    grid-column: main-start / main-end;
+  }
+
   @include media($large) {
     grid-column: narrow-start / narrow-end;
   }


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR enables filtering a rendered PostGallery by location, and in this particular case, by US locations. I tried making the `SelectLocationDropdown` component versatile for other potential location-based selections (#global or potentially a limited sub-group of US states, for use in a voting related campaign or something), and only importing a package that provides the listing if needed.

![Kapture 2019-03-26 at 14 49 32](https://user-images.githubusercontent.com/105849/55025048-7d94a500-4fd6-11e9-9195-95df413e8a54.gif)

### Any background context you want to provide?
Upcoming PRs will address showing something suitable if the selected location does not have any items (right now it just collapses the area since nothing is found), and also need to address passing a location via URL params.

### What are the relevant tickets/cards?

Refs [Pivotal ID #164737236](https://www.pivotaltracker.com/story/show/164737236)

### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.