### PR TITLE
Allow Hiding Reactions in a Post Gallery

### DIFF
--- a/app/Entities/PostGallery.php
+++ b/app/Entities/PostGallery.php
@@ -21,6 +21,7 @@ class PostGallery extends Entity implements JsonSerializable
                 'actionIds' => $this->actionIds,
                 'itemsPerRow' => $this->itemsPerRow,
                 'filterType' => $this->filterType === 'none' ? null : $this->filterType,
+                'hideReactions' => $this->hideReactions,
             ],
         ];
     }

--- a/app/Entities/PostGallery.php
+++ b/app/Entities/PostGallery.php
@@ -7,6 +7,19 @@ use JsonSerializable;
 class PostGallery extends Entity implements JsonSerializable
 {
     /**
+     * Cast ActionIds as integers
+     *
+     * @param  array $actionIds
+     * @return Collection
+     */
+    public function parseActionIds($actionIds)
+    {
+        return collect($this->actionIds)->map(function ($actionId) {
+            return (int) $actionId;
+        });
+    }
+
+    /**
      * Convert the object into something JSON serializable.
      *
      * @return array
@@ -18,7 +31,7 @@ class PostGallery extends Entity implements JsonSerializable
             'type' => $this->getContentType(),
             'fields' => [
                 'internalTitle' => $this->internalTitle,
-                'actionIds' => $this->actionIds,
+                'actionIds' => $this->parseActionIds($this->actionIds),
                 'itemsPerRow' => $this->itemsPerRow,
                 'filterType' => $this->filterType === 'none' ? null : $this->filterType,
                 'hideReactions' => $this->hideReactions,

--- a/contentful/content-types/postGallery.js
+++ b/contentful/content-types/postGallery.js
@@ -43,6 +43,16 @@ module.exports = function(migration) {
     .required(true)
     .localized(false);
 
+  postGallery
+    .createField('hideReactions')
+    .name('Hide Reactions')
+    .type('Boolean')
+    .localized(false)
+    .required(false)
+    .validations([])
+    .disabled(false)
+    .omitted(false);
+
   postGallery.changeEditorInterface('internalTitle', 'singleLine', {});
 
   postGallery.changeEditorInterface('actionIds', 'listInput', {
@@ -53,5 +63,11 @@ module.exports = function(migration) {
   postGallery.changeEditorInterface('itemsPerRow', 'radio', {
     helpText:
       'The maximum number of items in a single row when viewing the gallery in a large display.',
+  });
+
+  postGallery.changeEditorInterface('hideReactions', 'boolean', {
+    helpText: 'Hide post reactions in this gallery.',
+    trueLabel: 'Yes',
+    falseLabel: 'No',
   });
 };

--- a/resources/assets/components/blocks/PostGalleryBlock/PostGalleryBlockQuery.js
+++ b/resources/assets/components/blocks/PostGalleryBlock/PostGalleryBlockQuery.js
@@ -114,7 +114,7 @@ class PostGalleryBlockQuery extends React.Component {
   };
 
   render() {
-    const { actionIds, className, id, itemsPerRow } = this.props;
+    const { actionIds, className, id, hideReactions, itemsPerRow } = this.props;
 
     return (
       <React.Fragment>
@@ -147,6 +147,7 @@ class PostGalleryBlockQuery extends React.Component {
               itemsPerRow={itemsPerRow}
               loadMorePosts={fetchMore}
               onRender={this.galleryReady}
+              hideReactions={hideReactions}
               waypointName={'post_gallery_block'}
             />
           )}
@@ -161,6 +162,7 @@ PostGalleryBlockQuery.propTypes = {
   actionIds: PropTypes.arrayOf(PropTypes.number),
   className: PropTypes.string,
   filterType: PropTypes.string,
+  hideReactions: PropTypes.bool,
   itemsPerRow: PropTypes.number,
 };
 
@@ -169,6 +171,7 @@ PostGalleryBlockQuery.defaultProps = {
   actionIds: [],
   className: null,
   filterType: null,
+  hideReactions: false,
   itemsPerRow: 3,
 };
 

--- a/resources/assets/components/utilities/ContentfulEntryLoader/ContentfulEntryLoader.js
+++ b/resources/assets/components/utilities/ContentfulEntryLoader/ContentfulEntryLoader.js
@@ -37,6 +37,7 @@ const CONTENTFUL_BLOCK_QUERY = gql`
         actionIds
         itemsPerRow
         filterType
+        hideReactions
       }
       ... on PhotoSubmissionBlock {
         actionId

--- a/resources/assets/components/utilities/PostCard/PostCard.js
+++ b/resources/assets/components/utilities/PostCard/PostCard.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { get } from 'lodash';
 import gql from 'graphql-tag';
 import { format } from 'date-fns';
+import PropTypes from 'prop-types';
 import { propType } from 'graphql-anywhere';
 
 import Card from '../Card/Card';
@@ -37,7 +38,7 @@ export const postCardFragment = gql`
   }
 `;
 
-const PostCard = ({ post }) => {
+const PostCard = ({ post, hideReactions }) => {
   const isAnonymous = post.actionDetails.anonymous;
 
   // If this post is for an anonymous action, label it with the state (if available).
@@ -46,9 +47,8 @@ const PostCard = ({ post }) => {
     ? post.location || 'Anonymous'
     : get(post, 'user.firstName', 'A Doer');
 
-  const reactionElement = isAuthenticated() ? (
-    <ReactionButton post={post} />
-  ) : null;
+  const reactionElement =
+    !hideReactions && isAuthenticated() ? <ReactionButton post={post} /> : null;
 
   // Render the appropriate media for this post:
   let media = null;
@@ -103,7 +103,12 @@ const PostCard = ({ post }) => {
 };
 
 PostCard.propTypes = {
+  hideReactions: PropTypes.bool,
   post: propType(postCardFragment).isRequired,
+};
+
+PostCard.defaultProps = {
+  hideReactions: false,
 };
 
 export default PostCard;

--- a/resources/assets/components/utilities/PostGallery/PostGallery.js
+++ b/resources/assets/components/utilities/PostGallery/PostGallery.js
@@ -25,6 +25,7 @@ const PostGallery = props => {
     posts,
     itemsPerRow,
     loadMorePosts,
+    hideReactions,
     waypointName,
   } = props;
 
@@ -47,7 +48,7 @@ const PostGallery = props => {
         className="post-gallery expand-horizontal-md"
       >
         {posts.map(post => (
-          <PostCard key={post.id} post={post} />
+          <PostCard key={post.id} post={post} hideReactions={hideReactions} />
         ))}
       </Gallery>
       <LoadMore
@@ -80,6 +81,7 @@ PostGallery.propTypes = {
   loadMorePosts: PropTypes.func.isRequired,
   onRender: PropTypes.func,
   posts: PropTypes.array, // eslint-disable-line react/forbid-prop-types
+  hideReactions: PropTypes.bool,
   waypointName: PropTypes.string,
 };
 
@@ -89,6 +91,7 @@ PostGallery.defaultProps = {
   itemsPerRow: 3,
   onRender: null,
   posts: [],
+  hideReactions: false,
   waypointName: null,
 };
 


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR allows toggling a new `hideReactions` field in the Post Gallery Contentful content type to hide reactions from all posts within the displayed gallery.

- adds a new `hideReactions` field to the Post Gallery content type migration script, PHP Entity, and Graphql query.
- adds the `hideReactions` prop to `PostCard`s (and passed through from the top level `ContentfulEntry`) which will not render the `ReactionButton` for the post if set to `true`
- parsing `actionId`s as `int`s since Contentful sends them through as strings 😩

### Any background context you want to provide?
~Next up - updating the graphql schema!~ https://github.com/DoSomething/graphql/pull/90
### What are the relevant tickets/cards?

Refs [Pivotal ID #164701705](https://www.pivotaltracker.com/story/show/164701705)

### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.

🚫Reactions!
![image](https://user-images.githubusercontent.com/12417657/55090286-3a453f80-5085-11e9-9ad4-9635061fd3cf.png)
