### PR TITLE
Social Share Tray In Story Page / Social Share Tray Updates

### DIFF
--- a/resources/assets/components/actions/SocialDriveAction/SocialDriveAction.js
+++ b/resources/assets/components/actions/SocialDriveAction/SocialDriveAction.js
@@ -83,7 +83,12 @@ class SocialDriveAction extends React.Component {
               </div>
             </div>
 
-            <SocialShareTray shareLink={shortenedLink} trackLink={link} />
+            <SocialShareTray
+              shareLink={shortenedLink}
+              trackLink={link}
+              title="Share on Social Media"
+              responsive
+            />
           </Card>
         </div>
 

--- a/resources/assets/components/pages/GeneralPage/GeneralPage.js
+++ b/resources/assets/components/pages/GeneralPage/GeneralPage.js
@@ -101,6 +101,7 @@ const GeneralPage = props => {
               shareLink={window.location.href}
               platforms={['facebook', 'twitter']}
               title="found this useful?"
+              responsive
             />
           ) : null}
 

--- a/resources/assets/components/pages/StoryPage/StoryPage.js
+++ b/resources/assets/components/pages/StoryPage/StoryPage.js
@@ -42,7 +42,8 @@ const StoryPage = props => {
         </header>
 
         <SocialShareTray
-          shareLink={window.location.href}
+          // Pass through the current URL without the query parameters.
+          shareLink={window.location.href.split('?')[0]}
           platforms={['facebook', 'twitter']}
         />
 

--- a/resources/assets/components/pages/StoryPage/StoryPage.js
+++ b/resources/assets/components/pages/StoryPage/StoryPage.js
@@ -1,9 +1,12 @@
+/* global window */
+
 import React from 'react';
 import PropTypes from 'prop-types';
 
 import InfoBar from '../../InfoBar/InfoBar';
 import ContentfulEntry from '../../ContentfulEntry';
 import { contentfulImageUrl, withoutNulls } from '../../../helpers';
+import SocialShareTray from '../../utilities/SocialShareTray/SocialShareTray';
 
 import './story-page.scss';
 
@@ -37,6 +40,11 @@ const StoryPage = props => {
             ) : null}
           </div>
         </header>
+
+        <SocialShareTray
+          shareLink={window.location.href}
+          platforms={['facebook', 'twitter']}
+        />
 
         {blocks.map(block => (
           <ContentfulEntry

--- a/resources/assets/components/utilities/SocialShareTray/SocialShareTray.js
+++ b/resources/assets/components/utilities/SocialShareTray/SocialShareTray.js
@@ -121,7 +121,7 @@ class SocialShareTray extends React.Component {
 
     return (
       <div className="social-share-tray padded text-center">
-        <p className="title caps-lock font-bold">{title}</p>
+        {title ? <p className="title caps-lock font-bold">{title}</p> : null}
 
         <div className="share-buttons">
           {platforms.includes('facebook') ? (
@@ -186,7 +186,7 @@ SocialShareTray.defaultProps = {
   shareLink: null,
   trackLink: null,
   platforms: ['facebook', 'twitter', 'messenger', 'email'],
-  title: 'Share on Social Media',
+  title: null,
 };
 
 export default SocialShareTray;

--- a/resources/assets/components/utilities/SocialShareTray/SocialShareTray.js
+++ b/resources/assets/components/utilities/SocialShareTray/SocialShareTray.js
@@ -2,6 +2,7 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
+import classNames from 'classnames';
 
 import ShareButton from './ShareButton';
 import emailIcon from './emailIcon.svg';
@@ -116,14 +117,14 @@ class SocialShareTray extends React.Component {
   };
 
   render() {
-    const { shareLink, platforms, title } = this.props;
+    const { shareLink, platforms, responsive, title } = this.props;
     const trackLink = this.props.trackLink || this.props.shareLink;
 
     return (
       <div className="social-share-tray padded text-center">
         {title ? <p className="title caps-lock font-bold">{title}</p> : null}
 
-        <div className="share-buttons">
+        <div className={classNames('share-buttons', { responsive })}>
           {platforms.includes('facebook') ? (
             <ShareButton
               className="facebook"
@@ -180,6 +181,7 @@ SocialShareTray.propTypes = {
   trackLink: PropTypes.string,
   platforms: PropTypes.arrayOf(PropTypes.string),
   title: PropTypes.string,
+  responsive: PropTypes.bool,
 };
 
 SocialShareTray.defaultProps = {
@@ -187,6 +189,7 @@ SocialShareTray.defaultProps = {
   trackLink: null,
   platforms: ['facebook', 'twitter', 'messenger', 'email'],
   title: null,
+  responsive: false,
 };
 
 export default SocialShareTray;

--- a/resources/assets/components/utilities/SocialShareTray/social-share-tray.scss
+++ b/resources/assets/components/utilities/SocialShareTray/social-share-tray.scss
@@ -60,7 +60,9 @@
         content: '';
         border-left: 1px solid $white;
       }
+    }
 
+    &.responsive .share-button {
       // Hide button text unless on desktop
       @include media('(max-width: 960px)') {
         .button-text {


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR adds the `SocialShareTray` to the `StoryPage` and adds some minor updates to the `SocialShareTray` to match the social share buttons on [story page mock](https://app.goabstract.com/projects/fadf0790-f1f9-11e6-9a30-b54ba7e8e705/branches/898261ee-c324-4dc7-b37e-a4377ddd3df4/collections/a7f93b19-401c-44a0-8e31-90ef3037516d/presentation).

- `title` will now only optionally display if prop is manually set
- a new `responsive` prop will control whether the buttons are styled responsively for smaller screens


### What are the relevant tickets/cards?

Refs [Pivotal ID #164608340](https://www.pivotaltracker.com/story/show/164608340)

### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.
* [x] Added screenshot to PR description of related front-end updates on **small** screens.
* [ ] Added screenshot to PR description of related front-end updates on **medium** screens.
* [x] Added screenshot to PR description of related front-end updates on **large** screens.

📸 
- [**Desktop**](https://user-images.githubusercontent.com/12417657/55169305-f0bf2800-514a-11e9-8600-5ae6f638d908.png)
- [**Mobile**](https://user-images.githubusercontent.com/12417657/55169334-ff0d4400-514a-11e9-8eb6-ceb6a0ac7bf5.png)
