### PR TITLE
Allow filtering and scrolling to gallery via URL params.

### DIFF
--- a/resources/assets/components/utilities/PostGallery/PostGallery.js
+++ b/resources/assets/components/utilities/PostGallery/PostGallery.js
@@ -66,7 +66,7 @@ const PostGallery = props => {
       ) : null}
     </div>
   ) : (
-    <div className="rounded bg-white grid-narrow padding-lg margin-bottom-md color-gray">
+    <div className="rounded bg-white grid-narrow padding-lg margin-bottom-lg color-gray">
       <em>No Results Found</em>
     </div>
   );

--- a/resources/assets/components/utilities/PostGallery/PostGallery.js
+++ b/resources/assets/components/utilities/PostGallery/PostGallery.js
@@ -21,11 +21,17 @@ const PostGallery = props => {
     id,
     className,
     loading,
+    onRender,
     posts,
     itemsPerRow,
     loadMorePosts,
     waypointName,
   } = props;
+
+  // If specified, execute callback to let parent component know PostGallery is rendered.
+  if (onRender) {
+    onRender();
+  }
 
   return posts.length ? (
     <div id={id} className={classnames(className)}>
@@ -59,24 +65,30 @@ const PostGallery = props => {
         />
       ) : null}
     </div>
-  ) : null;
+  ) : (
+    <div className="rounded bg-white grid-narrow padding-lg margin-bottom-md color-gray">
+      <em>No Results Found</em>
+    </div>
+  );
 };
 
 PostGallery.propTypes = {
   id: PropTypes.string,
   className: PropTypes.string,
-  posts: PropTypes.array, // eslint-disable-line react/forbid-prop-types
   itemsPerRow: PropTypes.oneOf(Object.keys(galleryTypes).map(Number)),
   loading: PropTypes.bool.isRequired,
   loadMorePosts: PropTypes.func.isRequired,
+  onRender: PropTypes.func,
+  posts: PropTypes.array, // eslint-disable-line react/forbid-prop-types
   waypointName: PropTypes.string,
 };
 
 PostGallery.defaultProps = {
   id: null,
   className: null,
-  posts: [],
   itemsPerRow: 3,
+  onRender: null,
+  posts: [],
   waypointName: null,
 };
 


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR updates the `PostGalleryBlockQuery` to allow being filtered via URL params. If valid URL params are provided for filtering the gallery, the PostGallery will load entries based on that filter and also scroll to the location of the gallery, with the select dropdown filter in view so that the user has context of what the gallery is showing.

Only valid URL options will trigger the feature. The pattern for specifying the options is as follows:
`?options[post_gallery_contentful_id]=location:US-XX` where `XX` is the 2 character state abbreviation.

Eg:
`?options[7Jf7ViPBQEveJx0bpPDRpV]=location:US-NY`

### Any background context you want to provide?

Here it is in action:
![PostGallery URL Param Filter   Scroll](https://user-images.githubusercontent.com/105849/55175304-6e883100-5155-11e9-8db5-520b37dc43d0.gif)

This PR also includes an update to add a very basic "No Results Found" block to help let the user know that no entries were found for the selected state, which is better than showing nothing and having it seem like the experience is broken 😬  

### What are the relevant tickets/cards?

Refs [Pivotal ID #164737236](https://www.pivotaltracker.com/story/show/164737236)

### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.