### PR TITLE
Updates and fixes to the Post Gallery.

### DIFF
--- a/resources/assets/components/ErrorBlock/ErrorBlock.js
+++ b/resources/assets/components/ErrorBlock/ErrorBlock.js
@@ -6,7 +6,7 @@ import Card from '../utilities/Card/Card';
 import TextContent from '../utilities/TextContent/TextContent';
 
 const ErrorBlock = () => (
-  <Card className="error-block rounded bordered padded">
+  <Card className="error-block rounded bordered padded margin-bottom-lg grid-main">
     <Figure image={errorIcon}>
       <TextContent>
         __Something went wrong!__ Try refreshing the page or [reach

--- a/resources/assets/components/blocks/PostGalleryBlock/PostGalleryBlockQuery.js
+++ b/resources/assets/components/blocks/PostGalleryBlock/PostGalleryBlockQuery.js
@@ -75,7 +75,11 @@ class PostGalleryBlockQuery extends React.Component {
    * @return {Boolean}
    */
   validQueryOptions = (options, filterType) => {
-    const validFilterType = options && options[0] === filterType;
+    if (!options || options.length <= 1) {
+      return false;
+    }
+
+    const validFilterType = options[0] === filterType;
 
     let validFilterValue = false;
 
@@ -114,7 +118,7 @@ class PostGalleryBlockQuery extends React.Component {
   };
 
   render() {
-    const { actionIds, className, id, hideReactions, itemsPerRow } = this.props;
+    const { actionIds, className, hideReactions, id, itemsPerRow } = this.props;
 
     return (
       <React.Fragment>
@@ -142,12 +146,13 @@ class PostGalleryBlockQuery extends React.Component {
             <PostGallery
               id={id}
               className={classnames(className)}
-              posts={result}
-              loading={fetching}
+              hideReactions={hideReactions}
               itemsPerRow={itemsPerRow}
+              loading={fetching}
               loadMorePosts={fetchMore}
               onRender={this.galleryReady}
-              hideReactions={hideReactions}
+              posts={result}
+              shouldShowNoResults
               waypointName={'post_gallery_block'}
             />
           )}

--- a/resources/assets/components/utilities/PostGallery/PostGallery.js
+++ b/resources/assets/components/utilities/PostGallery/PostGallery.js
@@ -16,16 +16,24 @@ const galleryTypes = {
   3: 'triad',
 };
 
+const noPostsOutput = shouldShowNoResults =>
+  shouldShowNoResults ? (
+    <div className="rounded bg-white grid-narrow padding-lg margin-bottom-lg color-gray">
+      <em>No Results Found</em>
+    </div>
+  ) : null;
+
 const PostGallery = props => {
   const {
     id,
     className,
+    hideReactions,
+    itemsPerRow,
     loading,
+    loadMorePosts,
     onRender,
     posts,
-    itemsPerRow,
-    loadMorePosts,
-    hideReactions,
+    shouldShowNoResults,
     waypointName,
   } = props;
 
@@ -67,31 +75,31 @@ const PostGallery = props => {
       ) : null}
     </div>
   ) : (
-    <div className="rounded bg-white grid-narrow padding-lg margin-bottom-lg color-gray">
-      <em>No Results Found</em>
-    </div>
+    noPostsOutput(shouldShowNoResults)
   );
 };
 
 PostGallery.propTypes = {
   id: PropTypes.string,
   className: PropTypes.string,
+  hideReactions: PropTypes.bool,
   itemsPerRow: PropTypes.oneOf(Object.keys(galleryTypes).map(Number)),
   loading: PropTypes.bool.isRequired,
   loadMorePosts: PropTypes.func.isRequired,
   onRender: PropTypes.func,
   posts: PropTypes.array, // eslint-disable-line react/forbid-prop-types
-  hideReactions: PropTypes.bool,
+  shouldShowNoResults: PropTypes.bool,
   waypointName: PropTypes.string,
 };
 
 PostGallery.defaultProps = {
   id: null,
   className: null,
+  hideReactions: false,
   itemsPerRow: 3,
   onRender: null,
   posts: [],
-  hideReactions: false,
+  shouldShowNoResults: false,
   waypointName: null,
 };
 


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR fixes some bugs with logic that got introduced in #1345. It addresses not having any `options` URL param (before the logic in the `validQueryOptions()` would still execute if `options` was `null`, which is no bueno. It also ensures the `options` is an array of at minimum 2 items (a "key" and a "value") to validate against.

I also addressed an issue with the "No Results Found" block I added in #1345, where it would show up on the User Submission Gallery if they hadn't submitted anything yet, which was odd. So instead, you can now pass a prop to let the gallery know in a particular case if it's ok to show the "No Results Found" block.

### What are the relevant tickets/cards?

Refs [Pivotal ID #164737236](https://www.pivotaltracker.com/story/show/164737236)

### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.