### PR TITLE
Some more layout cleanup.

### DIFF
--- a/resources/assets/components/pages/CampaignPage/campaign-page.scss
+++ b/resources/assets/components/pages/CampaignPage/campaign-page.scss
@@ -24,8 +24,4 @@
       width: 33.3333333333333%;
     }
   }
-
-  > div {
-    margin: $base-spacing 0;
-  }
 }

--- a/resources/assets/scss/base.scss
+++ b/resources/assets/scss/base.scss
@@ -98,11 +98,11 @@ p {
 }
 
 .bg-light-gray {
-  background-color: $light-gray;
+  background-color: $light-gray !important;
 }
 
 .bg-off-white {
-  background-color: $off-white;
+  background-color: $off-white !important;
 }
 
 .bg-transparent {


### PR DESCRIPTION
### What does this PR do?

This pull request fixes two more little issues I noticed after merging #1340: an unexpected margin on the text content in the pitch page & the background color of the pitch page CTA not being applied correctly. Before:

<img width="1391" alt="Screen Shot 2019-03-29 at 1 04 34 PM" src="https://user-images.githubusercontent.com/583202/55249922-92b24380-5223-11e9-8d9a-3530dd5bc5c6.png">

And after:

<img width="1391" alt="Screen Shot 2019-03-29 at 1 04 37 PM" src="https://user-images.githubusercontent.com/583202/55249931-95149d80-5223-11e9-84b1-8a1add1b3fda.png">

### Any background context you want to provide?

I've paged around and this doesn't seem to negatively affect any other pages.

### What are the relevant tickets/cards?

N/A

### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.
* [ ] Added screenshot to PR description of related front-end updates on **small** screens.
* [ ] Added screenshot to PR description of related front-end updates on **medium** screens.
* [ ] Added screenshot to PR description of related front-end updates on **large** screens.
