### PR TITLE
Colocate GraphQL fragments with components.

### DIFF
--- a/jest-setup.js
+++ b/jest-setup.js
@@ -9,3 +9,6 @@ global.open = jest.fn().mockReturnValue({ closed: true });
 
 // Mock the ContentfulEntry import to prevent circular dependency issues unique to the jest/node runtime.
 jest.mock('./resources/assets/components/ContentfulEntry/ContentfulEntry');
+jest.mock(
+  './resources/assets/components/utilities/ContentfulEntryLoader/ContentfulEntryLoader',
+);

--- a/resources/assets/components/actions/LinkAction/LinkAction.js
+++ b/resources/assets/components/actions/LinkAction/LinkAction.js
@@ -1,10 +1,26 @@
 import React from 'react';
 import { get } from 'lodash';
 import PropTypes from 'prop-types';
+import gql from 'graphql-tag';
 import { PuckWaypoint } from '@dosomething/puck-client';
 
 import CtaTemplate from './templates/CtaTemplate';
 import DefaultTemplate from './templates/DefaultTemplate';
+
+export const LinkBlockFragment = gql`
+  fragment LinkBlockFragment on LinkBlock {
+    title
+    content
+    link
+    buttonText
+    affiliateLogo {
+      url(w: 200, h: 100)
+      description
+    }
+    template
+    additionalContent
+  }
+`;
 
 const templates = {
   cta: CtaTemplate,

--- a/resources/assets/components/actions/PetitionSubmissioncAction/PetitionSubmissionAction.js
+++ b/resources/assets/components/actions/PetitionSubmissioncAction/PetitionSubmissionAction.js
@@ -16,6 +16,19 @@ import CharacterLimit from '../../utilities/CharacterLimit/CharacterLimit';
 
 import './petition-submission-action.scss';
 
+export const PetitionSubmissionBlockFragment = gql`
+  fragment PetitionSubmissionBlockFragment on PetitionSubmissionBlock {
+    actionId
+    title
+    content
+    textFieldPlaceholderMessage
+    buttonText
+    informationTitle
+    informationContent
+    affirmationContent
+  }
+`;
+
 export const USER_POSTS_QUERY = gql`
   query UserPostsQuery($userId: String!, $actionIds: [Int]!) {
     posts(userId: $userId, actionIds: $actionIds) {

--- a/resources/assets/components/actions/PhotoSubmissionAction/PhotoSubmissionAction.js
+++ b/resources/assets/components/actions/PhotoSubmissionAction/PhotoSubmissionAction.js
@@ -1,6 +1,7 @@
 /* eslint-disable react/sort-comp */
 
 import React from 'react';
+import gql from 'graphql-tag';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import { get, has, invert, mapValues } from 'lodash';
@@ -21,6 +22,25 @@ import {
 } from '../../../helpers/forms';
 
 import './photo-submission-action.scss';
+
+export const PhotoSubmissionBlockFragment = gql`
+  fragment PhotoSubmissionBlockFragment on PhotoSubmissionBlock {
+    actionId
+    title
+    captionFieldLabel
+    captionFieldPlaceholderMessage
+    showQuantityField
+    quantityFieldLabel
+    quantityFieldPlaceholder
+    whyParticipatedFieldLabel
+    whyParticipatedFieldPlaceholder
+    buttonText
+    informationTitle
+    informationContent
+    affirmationContent
+    additionalContent
+  }
+`;
 
 class PhotoSubmissionAction extends React.Component {
   /**

--- a/resources/assets/components/actions/ShareAction/ShareAction.js
+++ b/resources/assets/components/actions/ShareAction/ShareAction.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { get } from 'lodash';
+import gql from 'graphql-tag';
 import PropTypes from 'prop-types';
 import { PuckWaypoint } from '@dosomething/puck-client';
 
@@ -19,6 +20,22 @@ import {
   showTwitterSharePrompt,
   withoutNulls,
 } from '../../../helpers';
+
+export const ShareBlockFragment = gql`
+  fragment ShareBlockFragment on ShareBlock {
+    actionId
+    title
+    socialPlatform
+    content
+    link
+    hideEmbed
+    affirmationBlock {
+      id
+    }
+    affirmation
+    additionalContent
+  }
+`;
 
 class ShareAction extends React.Component {
   state = { showModal: false };

--- a/resources/assets/components/actions/TextSubmissionAction/TextSubmissionAction.js
+++ b/resources/assets/components/actions/TextSubmissionAction/TextSubmissionAction.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import gql from 'graphql-tag';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import { get, has, invert, mapValues } from 'lodash';
@@ -17,6 +18,19 @@ import CharacterLimit from '../../utilities/CharacterLimit/CharacterLimit';
 import './text-submission-action.scss';
 
 const CHARACTER_LIMIT = 500;
+
+export const TextSubmissionBlockFragment = gql`
+  fragment TextSubmissionBlockFragment on TextSubmissionBlock {
+    actionId
+    title
+    textFieldLabel
+    textFieldPlaceholderMessage
+    buttonText
+    informationTitle
+    informationContent
+    affirmationContent
+  }
+`;
 
 class TextSubmissionAction extends React.Component {
   constructor(props) {

--- a/resources/assets/components/actions/VoterRegistrationAction/VoterRegistrationAction.js
+++ b/resources/assets/components/actions/VoterRegistrationAction/VoterRegistrationAction.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import gql from 'graphql-tag';
 import PropTypes from 'prop-types';
 import { PuckWaypoint } from '@dosomething/puck-client';
 
@@ -9,6 +10,15 @@ import { trackAnalyticsEvent } from '../../../helpers/analytics';
 import TextContent from '../../utilities/TextContent/TextContent';
 
 import './voter-registration-action.scss';
+
+export const VoterRegistrationBlockFragment = gql`
+  fragment VoterRegistrationBlockFragment on VoterRegistrationBlock {
+    title
+    content
+    link
+    additionalContent
+  }
+`;
 
 const VoterRegistrationAction = props => {
   const { campaignId, content, contentfulId, link, modalType, userId } = props;

--- a/resources/assets/components/blocks/ImagesBlock/ImagesBlock.js
+++ b/resources/assets/components/blocks/ImagesBlock/ImagesBlock.js
@@ -1,8 +1,18 @@
 import React from 'react';
+import gql from 'graphql-tag';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 
 import Gallery from '../../utilities/Gallery/Gallery';
+
+export const ImagesBlockFragment = gql`
+  fragment ImagesBlockFragment on ImagesBlock {
+    images {
+      description
+      url(w: 500, h: 500, fit: FILL)
+    }
+  }
+`;
 
 const ImagesBlock = ({ className, images }) => (
   <Gallery

--- a/resources/assets/components/blocks/PostGalleryBlock/PostGalleryBlockQuery.js
+++ b/resources/assets/components/blocks/PostGalleryBlock/PostGalleryBlockQuery.js
@@ -14,6 +14,15 @@ import SelectLocationDropdown from '../../utilities/SelectLocationDropdown/Selec
 
 import './post-gallery-block.scss';
 
+export const PostGalleryBlockFragment = gql`
+  fragment PostGalleryBlockFragment on PostGalleryBlock {
+    actionIds
+    itemsPerRow
+    filterType
+    hideReactions
+  }
+`;
+
 /**
  * The GraphQL query to load data for this component.
  */

--- a/resources/assets/components/utilities/ContentfulEntryLoader/ContentfulEntryLoader.js
+++ b/resources/assets/components/utilities/ContentfulEntryLoader/ContentfulEntryLoader.js
@@ -7,95 +7,41 @@ import { Query } from 'react-apollo';
 
 import ContentfulEntry from '../../ContentfulEntry';
 import ErrorBlock from '../../ErrorBlock/ErrorBlock';
+import { EmbedBlockFragment } from '../../utilities/Iframe';
+import { LinkBlockFragment } from '../../actions/LinkAction/LinkAction';
+import { ImagesBlockFragment } from '../../blocks/ImagesBlock/ImagesBlock';
+import { ShareBlockFragment } from '../../actions/ShareAction/ShareAction';
+import { PostGalleryBlockFragment } from '../../blocks/PostGalleryBlock/PostGalleryBlockQuery';
+import { TextSubmissionBlockFragment } from '../../actions/TextSubmissionAction/TextSubmissionAction';
+import { PhotoSubmissionBlockFragment } from '../../actions/PhotoSubmissionAction/PhotoSubmissionAction';
+import { VoterRegistrationBlockFragment } from '../../actions/VoterRegistrationAction/VoterRegistrationAction';
+import { PetitionSubmissionBlockFragment } from '../../actions/PetitionSubmissioncAction/PetitionSubmissionAction';
 
 const CONTENTFUL_BLOCK_QUERY = gql`
   query ContentfulBlockQuery($id: String!) {
     block(id: $id) {
       id
-      ... on ImagesBlock {
-        images {
-          description
-          url(w: 500, h: 500, fit: FILL)
-        }
-      }
-      ... on EmbedBlock {
-        url
-      }
-      ... on LinkBlock {
-        title
-        content
-        link
-        buttonText
-        affiliateLogo {
-          url(w: 200, h: 100)
-          description
-        }
-        template
-        additionalContent
-      }
-      ... on PostGalleryBlock {
-        actionIds
-        itemsPerRow
-        filterType
-        hideReactions
-      }
-      ... on PhotoSubmissionBlock {
-        actionId
-        title
-        captionFieldLabel
-        captionFieldPlaceholderMessage
-        showQuantityField
-        quantityFieldLabel
-        quantityFieldPlaceholder
-        whyParticipatedFieldLabel
-        whyParticipatedFieldPlaceholder
-        buttonText
-        informationTitle
-        informationContent
-        affirmationContent
-        additionalContent
-      }
-      ... on ShareBlock {
-        actionId
-        title
-        socialPlatform
-        content
-        link
-        hideEmbed
-        affirmationBlock {
-          id
-        }
-        affirmation
-        additionalContent
-      }
-      ... on TextSubmissionBlock {
-        actionId
-        title
-        textFieldLabel
-        textFieldPlaceholderMessage
-        buttonText
-        informationTitle
-        informationContent
-        affirmationContent
-      }
-      ... on PetitionSubmissionBlock {
-        actionId
-        title
-        content
-        textFieldPlaceholderMessage
-        buttonText
-        informationTitle
-        informationContent
-        affirmationContent
-      }
-      ... on VoterRegistrationBlock {
-        title
-        content
-        link
-        additionalContent
-      }
+      ...LinkBlockFragment
+      ...ShareBlockFragment
+      ...EmbedBlockFragment
+      ...ImagesBlockFragment
+      ...PostGalleryBlockFragment
+      ...TextSubmissionBlockFragment
+      ...PhotoSubmissionBlockFragment
+      ...VoterRegistrationBlockFragment
+      ...PetitionSubmissionBlockFragment
     }
   }
+
+  ${LinkBlockFragment}
+  ${ShareBlockFragment}
+  ${EmbedBlockFragment}
+  ${ImagesBlockFragment}
+  ${PostGalleryBlockFragment}
+  ${TextSubmissionBlockFragment}
+  ${PhotoSubmissionBlockFragment}
+  ${VoterRegistrationBlockFragment}
+  ${PetitionSubmissionBlockFragment}
 `;
 
 const ContentfulEntryLoader = ({ id, className }) => (

--- a/resources/assets/components/utilities/Iframe.js
+++ b/resources/assets/components/utilities/Iframe.js
@@ -11,6 +11,12 @@ import ErrorBlock from '../ErrorBlock/ErrorBlock';
 
 const PERMITTED_HOSTNAMES = ['dosomething.carto.com'];
 
+export const EmbedBlockFragment = gql`
+  fragment EmbedBlockFragment on EmbedBlock {
+    url
+  }
+`;
+
 const EMBED_QUERY = gql`
   query EmbedQuery($url: AbsoluteUrl!) {
     embed(url: $url) {


### PR DESCRIPTION
### What does this PR do?

This pull request colocates GraphQL fragments with the components that render that data, following the same pattern we established with [`PostCard`](https://github.com/DoSomething/phoenix-next/blob/1692e88b7c313be82fdaa6cd9e82b699eb40a780/resources/assets/components/utilities/PostCard/PostCard.js#L17-L40), [`ReactionButton`](https://github.com/DoSomething/phoenix-next/blob/master/resources/assets/components/utilities/ReactionButton/ReactionButton.js), and [`PostGalleryBlockQuery`](https://github.com/DoSomething/phoenix-next/blob/1692e88b7c313be82fdaa6cd9e82b699eb40a780/resources/assets/components/blocks/PostGalleryBlock/PostGalleryBlockQuery.js#L17-L40).

This makes it easier to find and change data dependencies (since when adding or removing a field, both changes will now happen in one file), and makes `ContentfulEntryLoader` easier to read.

### Any background context you want to provide?

It'd also be smort to use [`graphql-anywhere`](https://github.com/apollographql/apollo-client/tree/master/packages/graphql-anywhere#utilities) to automatically start building prop-types for these components, but that'll get hairy and so probably makes more sense for another PR.

Finally, I think it could be a smart idea to rename relevant blocks to match the GraphQL type names for consistency across the board (e.g. `PhotoSubmissionAction` to `PhotoSubmissionBlock`). But another one that makes sense in its own PR!

### What are the relevant tickets/cards?

N/A

### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.
* [ ] Added screenshot to PR description of related front-end updates on **small** screens.
* [ ] Added screenshot to PR description of related front-end updates on **medium** screens.
* [ ] Added screenshot to PR description of related front-end updates on **large** screens.