### PR TITLE
Add proper margin to text submission gallery.

### DIFF
--- a/resources/assets/components/ContentfulEntry/ContentfulEntry.js
+++ b/resources/assets/components/ContentfulEntry/ContentfulEntry.js
@@ -187,12 +187,11 @@ class ContentfulEntry extends React.Component<Props, State> {
               id={json.id}
               {...withoutNulls(json.fields)}
             />
-            <div className="margin-top-md">
-              <SubmissionGalleryBlockContainer
-                type="photo"
-                actionId={json.fields.actionId}
-              />
-            </div>
+            <SubmissionGalleryBlockContainer
+              type="photo"
+              className="margin-top-md"
+              actionId={json.fields.actionId}
+            />
           </React.Fragment>
         );
 
@@ -200,12 +199,11 @@ class ContentfulEntry extends React.Component<Props, State> {
         return (
           <React.Fragment>
             <PhotoSubmissionActionContainer {...withoutNulls(json)} />
-            <div className="margin-top-md">
-              <SubmissionGalleryBlockContainer
-                type="photo"
-                actionId={json.actionId}
-              />
-            </div>
+            <SubmissionGalleryBlockContainer
+              type="photo"
+              className="margin-top-md"
+              actionId={json.actionId}
+            />
           </React.Fragment>
         );
 
@@ -272,12 +270,11 @@ class ContentfulEntry extends React.Component<Props, State> {
         return (
           <React.Fragment>
             <TextSubmissionActionContainer
-              className={className}
               id={json.id}
               {...withoutNulls(json.fields)}
             />
             <SubmissionGalleryBlockContainer
-              className={className}
+              className="margin-top-md"
               type="text"
               actionId={json.fields.actionId}
             />
@@ -288,12 +285,11 @@ class ContentfulEntry extends React.Component<Props, State> {
         return (
           <React.Fragment>
             <TextSubmissionActionContainer
-              className={className}
               id={json.id}
               {...withoutNulls(json)}
             />
             <SubmissionGalleryBlockContainer
-              className={className}
+              className="margin-top-md"
               actionId={json.actionId}
               type="text"
             />


### PR DESCRIPTION
### What does this PR do?

This pull request adds a missing margin to the text submission gallery:

<img width="628" alt="Screen Shot 2019-03-29 at 4 30 19 PM" src="https://user-images.githubusercontent.com/583202/55260972-1da13700-5240-11e9-83be-6b7e3123e8a0.png">

<img width="640" alt="Screen Shot 2019-03-29 at 4 30 30 PM" src="https://user-images.githubusercontent.com/583202/55260977-20039100-5240-11e9-9d60-b2f2b113bb74.png">

Thanks @weerd for flagging this!

### Any background context you want to provide?

I went back and forth on whether to just use a wrapping `div` like in the photo submission gallery. Anyone have strong feels one way or the other?

### What are the relevant tickets/cards?

N/A

### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.
* [ ] Added screenshot to PR description of related front-end updates on **small** screens.
* [ ] Added screenshot to PR description of related front-end updates on **medium** screens.
* [ ] Added screenshot to PR description of related front-end updates on **large** screens.