### PR TITLE
Pass Contentful referrerD to Northstar. (& General Northstar Data Updates)

### DIFF
--- a/resources/assets/middleware/requiresAuthentication.js
+++ b/resources/assets/middleware/requiresAuthentication.js
@@ -4,8 +4,8 @@ import { get } from 'lodash';
 import localforage from 'localforage';
 
 import { buildLoginRedirectUrl } from '../helpers';
+import { getDataForNorthstar } from '../selectors';
 import { isAuthenticated } from '../selectors/user';
-import { getCampaignDataForNorthstar } from '../selectors/campaign';
 
 /**
  * Middleware for handling Authenticated actions.
@@ -19,7 +19,7 @@ const requiresAuthenticationMiddleware = ({ getState }) => next => action => {
 
     localforage.setItem(actionId, action).then(() => {
       window.location.href = buildLoginRedirectUrl(
-        getCampaignDataForNorthstar(state),
+        getDataForNorthstar(state),
         actionId,
       );
     });

--- a/resources/assets/selectors/campaign.js
+++ b/resources/assets/selectors/campaign.js
@@ -19,20 +19,17 @@ export function getCampaignAdditionalContent(state) {
  * @return {Object}
  */
 export function getCampaignDataForNorthstar(state) {
-  const data = {};
-
-  if (get(state, 'campaign.type', null) === 'campaign') {
-    data.callToAction = state.campaign.callToAction;
-    data.coverImage = contentfulImageUrl(
-      state.campaign.coverImage.url,
-      '800',
-      '600',
-      'fill',
-    );
-    data.title = state.campaign.title;
+  if (get(state, 'campaign.type', null) !== 'campaign') {
+    return {};
   }
 
-  return data;
+  const { title, callToAction, coverImage } = state.campaign;
+
+  return {
+    title,
+    callToAction,
+    coverImage: contentfulImageUrl(coverImage.url, '800', '600', 'fill'),
+  };
 }
 
 export default null;

--- a/resources/assets/selectors/campaign.js
+++ b/resources/assets/selectors/campaign.js
@@ -1,6 +1,6 @@
 import { get } from 'lodash';
 
-import { contentfulImageUrl, query } from '../helpers';
+import { contentfulImageUrl } from '../helpers';
 
 /**
  * Get the Campaign additional content from the state.
@@ -31,8 +31,6 @@ export function getCampaignDataForNorthstar(state) {
     );
     data.title = state.campaign.title;
   }
-
-  data.trafficSource = query('utm_medium');
 
   return data;
 }

--- a/resources/assets/selectors/index.js
+++ b/resources/assets/selectors/index.js
@@ -7,7 +7,7 @@ export function getDataForNorthstar(state) {
     ...getCampaignDataForNorthstar(state),
     ...getStoryPageDataForNorthstar(state),
     trafficSource: query('utm_medium'),
-    refferalId: state.campaign.id || state.page.id,
+    reffererId: state.campaign.id || state.page.id,
   };
 }
 

--- a/resources/assets/selectors/index.js
+++ b/resources/assets/selectors/index.js
@@ -1,0 +1,14 @@
+import { query } from '../helpers';
+import { getCampaignDataForNorthstar } from './campaign';
+import { getStoryPageDataForNorthstar } from './storyPage';
+
+export function getDataForNorthstar(state) {
+  return {
+    ...getCampaignDataForNorthstar(state),
+    ...getStoryPageDataForNorthstar(state),
+    trafficSource: query('utm_medium'),
+    refferalId: state.campaign.id || state.page.id,
+  };
+}
+
+export default null;

--- a/resources/assets/selectors/index.js
+++ b/resources/assets/selectors/index.js
@@ -7,7 +7,7 @@ export function getDataForNorthstar(state) {
     ...getCampaignDataForNorthstar(state),
     ...getStoryPageDataForNorthstar(state),
     trafficSource: query('utm_medium'),
-    reffererId: state.campaign.id || state.page.id,
+    referrerId: state.campaign.id || state.page.id,
   };
 }
 

--- a/resources/assets/selectors/storyPage.js
+++ b/resources/assets/selectors/storyPage.js
@@ -1,0 +1,25 @@
+import { get } from 'lodash';
+
+import { contentfulImageUrl } from '../helpers';
+
+/**
+ * Get Story Page data to showcase story page context in Northstar login interface.
+ *
+ * @param  {Object} state
+ * @return {Object}
+ */
+export function getStoryPageDataForNorthstar(state) {
+  const data = {};
+
+  if (get(state, 'page.type', null) === 'storyPage') {
+    const { title, subTitle, coverImage } = state.page.fields;
+
+    data.title = title;
+    data.callToAction = subTitle;
+    data.coverImage = contentfulImageUrl(coverImage.url, '800', '600', 'fill');
+  }
+
+  return data;
+}
+
+export default null;

--- a/resources/assets/selectors/storyPage.js
+++ b/resources/assets/selectors/storyPage.js
@@ -9,17 +9,17 @@ import { contentfulImageUrl } from '../helpers';
  * @return {Object}
  */
 export function getStoryPageDataForNorthstar(state) {
-  const data = {};
-
-  if (get(state, 'page.type', null) === 'storyPage') {
-    const { title, subTitle, coverImage } = state.page.fields;
-
-    data.title = title;
-    data.callToAction = subTitle;
-    data.coverImage = contentfulImageUrl(coverImage.url, '800', '600', 'fill');
+  if (get(state, 'page.type', null) !== 'storyPage') {
+    return {};
   }
 
-  return data;
+  const { title, subTitle, coverImage } = state.page.fields;
+
+  return {
+    title,
+    callToAction: subTitle,
+    coverImage: contentfulImageUrl(coverImage.url, '800', '600', 'fill'),
+  };
 }
 
 export default null;


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR updates the data we pass to Northstar during authentication redirects to include the new `referrerId` (Contentful ID) field.

Since this is meant to apply to `StoryPages` as well, this required updating the `selector`s we use for this functionality to include a new general `getDataForNorthstar` selector, in addition to the campaign specific `getCampaignDataForNorthstar`, and brand new `getStoryPageDataForNorthstar` selectors.

### What are the relevant tickets/cards?

Refs [Pivotal ID #164935945](https://www.pivotaltracker.com/story/show/164935945)

### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.
