### PR TITLE
Add Default Redirect Path for Auth Requests From Different Origin

### DIFF
--- a/app/Http/Controllers/AuthController.php
+++ b/app/Http/Controllers/AuthController.php
@@ -46,7 +46,9 @@ class AuthController extends Controller
         // page (if logging in to view a page protected by the 'auth' middleware), or the previous
         // page (if the user clicked "Log In" in the top navigation).
         if (! array_has($queryParams, 'code')) {
-            $intended = session()->pull('url.intended', url()->previous());
+            $defaultIntended = is_same_origin(url()->previous()) ? url()->previous() : $this->redirectTo;
+
+            $intended = session()->pull('url.intended', $defaultIntended);
 
             session(['login.intended' => $intended]);
 

--- a/app/Http/Controllers/AuthController.php
+++ b/app/Http/Controllers/AuthController.php
@@ -42,12 +42,14 @@ class AuthController extends Controller
     {
         $queryParams = $request->getQueryParams();
 
-        // Save the post-login redirect for when the user completes the flow: either to the intended
-        // page (if logging in to view a page protected by the 'auth' middleware), or the previous
-        // page (if the user clicked "Log In" in the top navigation).
+        // Save the post-login redirect for when the user completes the flow.
         if (! array_has($queryParams, 'code')) {
+            // The default post-login redirect will be to the previous page (if the user clicked
+            // "Log In" in the top navigation), or to the path defined in the $redirectTo property.
             $defaultIntended = is_same_origin(url()->previous()) ? url()->previous() : $this->redirectTo;
 
+            // The post-login redirect will be to the intended page (if logging in to view a page
+            // protected by the 'auth' middleware), or to the default path determined above.
             $intended = session()->pull('url.intended', $defaultIntended);
 
             session(['login.intended' => $intended]);

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -450,7 +450,7 @@ function generate_streamed_csv($columns, $records)
  * @param  string $url
  * @return bool
  */
-function is_same_origin($url)
+function is_same_domain($url)
 {
     $urlHost = parse_url($url)['host'];
     $appUrlHost = parse_url(config('app.url'))['host'];

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -452,8 +452,12 @@ function generate_streamed_csv($columns, $records)
  */
 function is_same_domain($url)
 {
-    $urlHost = parse_url($url)['host'];
-    $appUrlHost = parse_url(config('app.url'))['host'];
+    $urlHost = data_get(parse_url($url), 'host');
+    $appUrlHost = data_get(parse_url(config('app.url')), 'host');
+
+    if (! $urlHost || ! $appUrlHost) {
+        return false;
+    }
 
     return $urlHost === $appUrlHost;
 }

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -443,3 +443,16 @@ function generate_streamed_csv($columns, $records)
 
     return fclose($file);
 }
+
+/**
+ * Determine if URL is of the same origin as the app's URL.
+ *
+ * @param  string $url
+ * @return boolean
+ */
+function is_same_origin($url) {
+    $urlHost = parse_url($url)['host'];
+    $appUrlHost = parse_url(config('app.url'))['host'];
+
+    return $urlHost === $appUrlHost;
+}

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -448,9 +448,10 @@ function generate_streamed_csv($columns, $records)
  * Determine if URL is of the same origin as the app's URL.
  *
  * @param  string $url
- * @return boolean
+ * @return bool
  */
-function is_same_origin($url) {
+function is_same_origin($url)
+{
     $urlHost = parse_url($url)['host'];
     $appUrlHost = parse_url(config('app.url'))['host'];
 


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR ensures that authentication requests to `/next/login` originating from URL's of a different domain will be redirected post-auth to the default `$this->redirectTo` path and not the previous page from whence they came.

### Any background context you want to provide?
Over at Northstar, password reset form submissions are redirected to `/next/login` to authenticate but are then abruptly returned to the reset password form. Cases such as those (where the previous URL is not of the same domain as the Phoenix application) will be better redirected to a sensible Phoenix location (currently set to `/campaigns`).

### What are the relevant tickets/cards?

Refs [Pivotal ID #164504959](https://www.pivotaltracker.com/story/show/164504959)
