### PR TITLE
BUG Fix - Update Call to Renamed Helper Method in AuthController!

### DIFF
--- a/app/Http/Controllers/AuthController.php
+++ b/app/Http/Controllers/AuthController.php
@@ -46,7 +46,7 @@ class AuthController extends Controller
         if (! array_has($queryParams, 'code')) {
             // The default post-login redirect will be to the previous page (if the user clicked
             // "Log In" in the top navigation), or to the path defined in the $redirectTo property.
-            $defaultIntended = is_same_origin(url()->previous()) ? url()->previous() : $this->redirectTo;
+            $defaultIntended = is_same_domain(url()->previous()) ? url()->previous() : $this->redirectTo;
 
             // The post-login redirect will be to the intended page (if logging in to view a page
             // protected by the 'auth' middleware), or to the default path determined above.


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR fixes a bug introduced by moi in #1352. We'd updated the name of a helper function, but failed to update the call to said function!

![image](https://memegenerator.net/img/instances/18812669/your-method-calls-are-deprecated-and-you-should-feel-deprecated.jpg)