### PR TITLE
Add support for using Preview API with GraphQL.

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -36,6 +36,7 @@ class AppServiceProvider extends ServiceProvider
                 'SIXPACK_ENABLED' => config('services.sixpack.enabled'),
                 'SIXPACK_TIMEOUT' => config('services.sixpack.timeout'),
                 'VOTER_REG_MODAL_ENABLED' => config('services.timed_modals.voter_reg_modal.enabled'),
+                'CONTENTFUL_USE_PREVIEW_API' => config('contentful')['delivery.preview'],
             ]);
         });
 

--- a/resources/assets/components/utilities/ContentfulAsset/ContentfulAsset.js
+++ b/resources/assets/components/utilities/ContentfulAsset/ContentfulAsset.js
@@ -4,11 +4,17 @@ import PropTypes from 'prop-types';
 import { Query } from 'react-apollo';
 
 import LazyImage from '../LazyImage';
+import { env } from '../../../helpers';
 import ErrorBlock from '../../ErrorBlock/ErrorBlock';
 
 const CONTENTFUL_ASSET_QUERY = gql`
-  query ContentfulAssetQuery($id: String!, $width: Int!, $height: Int!) {
-    asset(id: $id) {
+  query ContentfulAssetQuery(
+    $id: String!
+    $width: Int!
+    $height: Int!
+    $preview: Boolean!
+  ) {
+    asset(id: $id, preview: $preview) {
       id
       description
       url(w: $width, h: $height)
@@ -17,7 +23,15 @@ const CONTENTFUL_ASSET_QUERY = gql`
 `;
 
 const ContentfulAsset = ({ id, width, height }) => (
-  <Query query={CONTENTFUL_ASSET_QUERY} variables={{ id, width, height }}>
+  <Query
+    query={CONTENTFUL_ASSET_QUERY}
+    variables={{
+      id,
+      width,
+      height,
+      preview: env('CONTENTFUL_USE_PREVIEW_API'),
+    }}
+  >
     {({ loading, error, data }) => {
       if (loading) {
         return <div className="spinner -centered margin-vertical-xlg" />;

--- a/resources/assets/components/utilities/ContentfulEntryLoader/ContentfulEntryLoader.js
+++ b/resources/assets/components/utilities/ContentfulEntryLoader/ContentfulEntryLoader.js
@@ -5,6 +5,7 @@ import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import { Query } from 'react-apollo';
 
+import { env } from '../../../helpers';
 import ContentfulEntry from '../../ContentfulEntry';
 import ErrorBlock from '../../ErrorBlock/ErrorBlock';
 import { EmbedBlockFragment } from '../../utilities/Iframe';
@@ -18,8 +19,8 @@ import { VoterRegistrationBlockFragment } from '../../actions/VoterRegistrationA
 import { PetitionSubmissionBlockFragment } from '../../actions/PetitionSubmissioncAction/PetitionSubmissionAction';
 
 const CONTENTFUL_BLOCK_QUERY = gql`
-  query ContentfulBlockQuery($id: String!) {
-    block(id: $id) {
+  query ContentfulBlockQuery($id: String!, $preview: Boolean!) {
+    block(id: $id, preview: $preview) {
       id
       ...LinkBlockFragment
       ...ShareBlockFragment
@@ -45,7 +46,10 @@ const CONTENTFUL_BLOCK_QUERY = gql`
 `;
 
 const ContentfulEntryLoader = ({ id, className }) => (
-  <Query query={CONTENTFUL_BLOCK_QUERY} variables={{ id }}>
+  <Query
+    query={CONTENTFUL_BLOCK_QUERY}
+    variables={{ id, preview: env('CONTENTFUL_USE_PREVIEW_API') }}
+  >
     {({ loading, error, data }) => {
       if (loading) {
         return (


### PR DESCRIPTION
### What does this PR do?

This pull request adds support for using the Contentful Preview API via GraphQL, based on the work done in DoSomething/graphql#93. Once merged & deployed, this will allow editors to preview unpublished changes to embedded blocks on story pages.

### Any background context you want to provide?

🍀

### What are the relevant tickets/cards?

[#165037961](https://www.pivotaltracker.com/story/show/165037961)

### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.
* [ ] Added screenshot to PR description of related front-end updates on **small** screens.
* [ ] Added screenshot to PR description of related front-end updates on **medium** screens.
* [ ] Added screenshot to PR description of related front-end updates on **large** screens.