### PR TITLE
Ensure that 'CONTENTFUL_USE_PREVIEW_API' ends up as a boolean.

### DIFF
--- a/config/contentful.php
+++ b/config/contentful.php
@@ -23,7 +23,7 @@ return [
     /*
      * Controls whether Contentful's Delivery or Preview API is accessed
      */
-    'delivery.preview' => env('CONTENTFUL_USE_PREVIEW_API', false),
+    'delivery.preview' => (bool) env('CONTENTFUL_USE_PREVIEW_API', false),
 
     /*
      * Sets the locale in which to fetch content by default. NULL means the space'd default locale will be used


### PR DESCRIPTION
### What does this PR do?

This PR fixes up `CONTENTFUL_USE_PREVIEW_API` to be a boolean, even when converted to an integer by Terraform. This will be fixed [in Terraform 0.12](https://www.terraform.io/docs/configuration/types.html#conversion-of-primitive-types) (currently in beta).

### Any background context you want to provide?

I've tested this on my local with an integer for this environment variable, and it clears things up.

### What are the relevant tickets/cards?

N/A

### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.
* [ ] Added screenshot to PR description of related front-end updates on **small** screens.
* [ ] Added screenshot to PR description of related front-end updates on **medium** screens.
* [ ] Added screenshot to PR description of related front-end updates on **large** screens.