### PR TITLE
Preview Image Field for Embed Content Type

### DIFF
--- a/contentful/content-types/embed.js
+++ b/contentful/content-types/embed.js
@@ -41,7 +41,7 @@ module.exports = function(migration) {
     .name('Preview Image')
     .type('Link')
     .localized(false)
-    .required(true)
+    .required(false)
     .validations([
       {
         linkMimetypeGroup: ['image'],
@@ -68,6 +68,6 @@ module.exports = function(migration) {
 
   embed.changeEditorInterface('previewImage', 'assetLinkEditor', {
     helpText:
-      'Preview image for the embed content. Replaces the embed on smaller screens.',
+      'If set, replaces the embed on smaller screens as a preview of the embed content.',
   });
 };

--- a/contentful/content-types/embed.js
+++ b/contentful/content-types/embed.js
@@ -36,6 +36,26 @@ module.exports = function(migration) {
     .disabled(false)
     .omitted(false);
 
+  embed
+    .createField('previewImage')
+    .name('Preview Image')
+    .type('Link')
+    .localized(false)
+    .required(true)
+    .validations([
+      {
+        linkMimetypeGroup: ['image'],
+      },
+      {
+        assetFileSize: {
+          max: 20971520,
+        },
+      },
+    ])
+    .disabled(false)
+    .omitted(false)
+    .linkType('Asset');
+
   embed.changeEditorInterface('internalTitle', 'singleLine', {
     helpText:
       'This title is used internally to help find this content. It will not be displayed anywhere on the rendered web page.',
@@ -44,5 +64,10 @@ module.exports = function(migration) {
   embed.changeEditorInterface('url', 'singleLine', {
     helpText:
       'The URL for the embed. (Currently only supporting Carto map embed URLs. (https://dosomething.carto.com/dashboard)).',
+  });
+
+  embed.changeEditorInterface('previewImage', 'assetLinkEditor', {
+    helpText:
+      'Preview image for the embed content. Replaces the embed on smaller screens.',
   });
 };


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR adds a `previewImage` field to the `Embed` content type migration script.

### What are the relevant tickets/cards?

Refs [Pivotal ID #165039475](https://www.pivotaltracker.com/story/show/165039475)