### PR TITLE
Render preview image

### DIFF
--- a/app/Entities/Embed.php
+++ b/app/Entities/Embed.php
@@ -18,7 +18,7 @@ class Embed extends Entity implements JsonSerializable
             'type' => $this->getContentType(),
             'fields' => [
                 'url' => $this->url,
-            'previewImage' => $this->previewImage ? [
+                'previewImage' => $this->previewImage ? [
                     'description' => $this->previewImage->getDescription(),
                     'url' => get_image_url($this->previewImage, 'square'),
                 ] : null,

--- a/app/Entities/Embed.php
+++ b/app/Entities/Embed.php
@@ -18,6 +18,10 @@ class Embed extends Entity implements JsonSerializable
             'type' => $this->getContentType(),
             'fields' => [
                 'url' => $this->url,
+            'previewImage' => $this->previewImage ? [
+                    'description' => $this->previewImage->getDescription(),
+                    'url' => get_image_url($this->previewImage, 'square'),
+                ] : null,
             ],
         ];
     }

--- a/resources/assets/components/ContentfulEntry/ContentfulEntry.js
+++ b/resources/assets/components/ContentfulEntry/ContentfulEntry.js
@@ -108,7 +108,13 @@ class ContentfulEntry extends React.Component<Props, State> {
         );
 
       case 'EmbedBlock':
-        return <Iframe className={className} url={json.url} id={json.id} />;
+        return (
+          <Iframe
+            className={className}
+            id={json.id}
+            {...withoutNulls(json.fields)}
+          />
+        );
 
       case 'gallery':
         return <CampaignGalleryBlockContainer />;

--- a/resources/assets/components/ContentfulEntry/ContentfulEntry.js
+++ b/resources/assets/components/ContentfulEntry/ContentfulEntry.js
@@ -109,11 +109,7 @@ class ContentfulEntry extends React.Component<Props, State> {
 
       case 'EmbedBlock':
         return (
-          <Iframe
-            className={className}
-            id={json.id}
-            {...withoutNulls(json.fields)}
-          />
+          <Iframe className={className} id={json.id} {...withoutNulls(json)} />
         );
 
       case 'gallery':

--- a/resources/assets/components/utilities/Iframe.js
+++ b/resources/assets/components/utilities/Iframe.js
@@ -3,7 +3,6 @@ import gql from 'graphql-tag';
 import Media from 'react-media';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
-import { Query } from 'react-apollo';
 import { PuckWaypoint } from '@dosomething/puck-client';
 
 import LazyImage from './LazyImage';
@@ -14,18 +13,14 @@ const PERMITTED_HOSTNAMES = ['dosomething.carto.com'];
 export const EmbedBlockFragment = gql`
   fragment EmbedBlockFragment on EmbedBlock {
     url
-  }
-`;
-
-const EMBED_QUERY = gql`
-  query EmbedQuery($url: AbsoluteUrl!) {
-    embed(url: $url) {
-      thumbnailUrl
+    previewImage {
+      url(w: 700, h: 700)
+      description
     }
   }
 `;
 
-const Iframe = ({ className, id, url }) => {
+const Iframe = ({ className, id, url, previewImage }) => {
   const hostname = new URL(url).hostname;
 
   if (!PERMITTED_HOSTNAMES.includes(hostname)) {
@@ -33,35 +28,35 @@ const Iframe = ({ className, id, url }) => {
     return <ErrorBlock />;
   }
 
+  const iframeElement = () => (
+    <iframe title={`embed ${id}`} src={url} width="100%" height="520" />
+  );
+
   return (
     <div id={id} className={classnames('embed', className)}>
       <PuckWaypoint name="embed-top" waypointData={{ contentfulId: id }} />
-      <Media query="(max-width: 759px)">
-        {matches =>
-          matches ? (
-            <Query query={EMBED_QUERY} variables={{ url }}>
-              {({ loading, error, data }) => {
-                const isLoaded = !loading;
-                const { embed } = data;
 
-                if (error) {
-                  return <ErrorBlock />;
+      {previewImage ? (
+        <Media query="(max-width: 759px)">
+          {matches =>
+            matches ? (
+              <LazyImage
+                className="rounded"
+                src={previewImage.url}
+                alt={
+                  previewImage.description ||
+                  'Preview image for embedded content'
                 }
+              />
+            ) : (
+              iframeElement()
+            )
+          }
+        </Media>
+      ) : (
+        iframeElement()
+      )}
 
-                return (
-                  <LazyImage
-                    className="rounded"
-                    src={isLoaded ? embed.thumbnailUrl : null}
-                    alt="Preview image for embedded content"
-                  />
-                );
-              }}
-            </Query>
-          ) : (
-            <iframe title={`embed ${id}`} src={url} width="100%" height="520" />
-          )
-        }
-      </Media>
       <PuckWaypoint name="embed-bottom" waypointData={{ contentfulId: id }} />
     </div>
   );
@@ -71,10 +66,15 @@ Iframe.propTypes = {
   className: PropTypes.string,
   id: PropTypes.string.isRequired,
   url: PropTypes.string.isRequired,
+  previewImage: PropTypes.shape({
+    url: PropTypes.string.isRequired,
+    description: PropTypes.string,
+  }),
 };
 
 Iframe.defaultProps = {
   className: null,
+  previewImage: null,
 };
 
 export default Iframe;


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR updates the `Iframe` component to use the new `previewImage` prop when rendering the image for smaller screens. If the prop is not set, it will always render the `<iframe>`.

### Any background context you want to provide?
See this discussion https://github.com/DoSomething/phoenix-next/pull/1359#discussion_r271501378 for context for this update!

### What are the relevant tickets/cards?

Refs [Pivotal ID #165039475](https://www.pivotaltracker.com/story/show/165039475)

### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.
* [x] Added screenshot to PR description of related front-end updates on **small** screens.

**That's an image!**
![image](https://user-images.githubusercontent.com/12417657/55509257-a7c71200-5629-11e9-9564-58809fa6d7eb.png)

