### PR TITLE
Handle Unpublished Asset References in get_image_url Helper

### DIFF
--- a/app/helpers.php
+++ b/app/helpers.php
@@ -264,6 +264,10 @@ function get_image_url($asset, $style = null)
     /** @var \Contentful\Core\File\ImageFile $file */
     $file = $asset->getFile();
 
+    if (! $file) {
+        return null;
+    }
+
     if (! $file instanceof \Contentful\Core\File\ImageFile) {
         throw new \InvalidArgumentException('Cannot use file ' . $file->getFileName() . ' as an image.');
     }


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR ensures that unpublished assets don't break the site by adding a hard return from our `get_image_url` helper if the linked asset doesn't contain an actual file.

### Any background context you want to provide?
The `get_image_url` is invoked with an `$asset` parameter (A contentful asset entry). We then grab the asset file from this Asset entry storing it in `$file`. Sometimes (often in a preview environment) this `$file` might just be a `null` value if no file was actually uploaded or published within the asset.

Previously, this helper would presume otherwise, invoking the `getFileName` method on the `$file` which would explode if the `$file` is `null` of course.

Now, we'd just hard return a `null` value, which'd generally mean a `null` `$image->url` value being passed to the front end, which should not result in any errors down the line.

### What are the relevant tickets/cards?

Refs [Pivotal ID #164287924](https://www.pivotaltracker.com/story/show/164287924)

### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.
