### PR TITLE
Scrolling WIP

### DIFF
--- a/resources/assets/components/PaginatedQuery.js
+++ b/resources/assets/components/PaginatedQuery.js
@@ -2,8 +2,9 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Query } from 'react-apollo';
 
-import ErrorBlock from './ErrorBlock/ErrorBlock';
+import { queryObserver } from '../helpers';
 import { NetworkStatus } from '../constants';
+import ErrorBlock from './ErrorBlock/ErrorBlock';
 
 /**
  * Fetch results via GraphQL using a query component.
@@ -13,6 +14,7 @@ const PaginatedQuery = ({ query, queryName, variables, count, children }) => (
     query={query}
     variables={{ ...variables, count, page: 1 }}
     notifyOnNetworkStatusChange
+    onCompleted={() => queryObserver().remove(queryName)}
   >
     {result => {
       // On initial load, just display a loading spinner.

--- a/resources/assets/components/blocks/PostGalleryBlock/PostGalleryBlockQuery.js
+++ b/resources/assets/components/blocks/PostGalleryBlock/PostGalleryBlockQuery.js
@@ -6,9 +6,9 @@ import classnames from 'classnames';
 
 import PaginatedQuery from '../../PaginatedQuery';
 import ScrollConcierge from '../../ScrollConcierge';
-import { query, withoutNulls } from '../../../helpers';
 import PostGallery from '../../utilities/PostGallery/PostGallery';
 import { postCardFragment } from '../../utilities/PostCard/PostCard';
+import { query, withoutNulls, queryObserver } from '../../../helpers';
 import { reactionButtonFragment } from '../../utilities/ReactionButton/ReactionButton';
 import SelectLocationDropdown from '../../utilities/SelectLocationDropdown/SelectLocationDropdown';
 
@@ -54,6 +54,8 @@ const POST_GALLERY_QUERY = gql`
 class PostGalleryBlockQuery extends React.Component {
   constructor(props) {
     super(props);
+
+    queryObserver().add('posts');
 
     // FilterType specified on Contentful PostGallery entry.
     const filterType =

--- a/resources/assets/helpers/createHistoryHashObserver.js
+++ b/resources/assets/helpers/createHistoryHashObserver.js
@@ -44,7 +44,7 @@ export default (history, timeout = 1000) => {
     return false;
   };
 
-  history.listen(location => {
+  const run = location => {
     if (timeoutId) {
       reset();
     }
@@ -74,7 +74,13 @@ export default (history, timeout = 1000) => {
 
       timeoutId = setTimeout(reset, timeout);
     });
+  };
+
+  history.listen(location => {
+    run(location);
   });
+
+  run(window.location);
 
   return history;
 };

--- a/resources/assets/helpers/index.js
+++ b/resources/assets/helpers/index.js
@@ -5,6 +5,7 @@ import { getTime, isBefore, isWithinInterval } from 'date-fns';
 import { get, find, isNull, isUndefined, omitBy } from 'lodash';
 
 import Sixpack from '../services/Sixpack';
+import QueryObserver from '../services/QueryObserver';
 import { trackAnalyticsEvent } from './analytics';
 import { isSignedUp } from '../selectors/signup';
 
@@ -753,6 +754,16 @@ export function sixpack() {
   }
 
   return sixpackInstance;
+}
+
+let queryObserverInstance = null;
+
+export function queryObserver() {
+  if (!queryObserverInstance) {
+    queryObserverInstance = new QueryObserver();
+  }
+
+  return queryObserverInstance;
 }
 
 /**

--- a/resources/assets/helpers/scroll.js
+++ b/resources/assets/helpers/scroll.js
@@ -2,6 +2,8 @@
 
 import FontFaceObserver from 'fontfaceobserver';
 
+import { queryObserver } from '../helpers';
+
 /**
  * Wait until we're *really* sure page has rendered
  * so we don't read the wrong values for layout.
@@ -74,6 +76,15 @@ export const scrollToElement = element => {
     const VISUAL_OFFSET = 95;
 
     // Wait until the page has finished layout, then scroll.
-    waitForLayout(() => scrollTo(pageOffset - VISUAL_OFFSET));
+    waitForLayout(() => {
+      const queryObserverTimeout = setInterval(() => {
+        if (queryObserver().isLoading()) {
+          return;
+        }
+
+        clearInterval(queryObserverTimeout);
+        scrollTo(pageOffset - VISUAL_OFFSET);
+      }, 500);
+    });
   });
 };

--- a/resources/assets/history.js
+++ b/resources/assets/history.js
@@ -18,7 +18,7 @@ export function get() {
  * @return {History}
  */
 export function init() {
-  history = createHistoryHashObserver(createHistory(), 1000);
+  history = createHistoryHashObserver(createHistory(), 10000);
 
   return history;
 }

--- a/resources/assets/services/QueryObserver.js
+++ b/resources/assets/services/QueryObserver.js
@@ -1,0 +1,18 @@
+/* global window */
+
+class QueryObserver {
+  constructor() {
+    window.DS = window.DS || {};
+    window.DS.QueryObserver = this;
+  }
+
+  pendingQueries = [];
+
+  add = id => this.pendingQueries.push(id);
+
+  remove = id => this.pendingQueries.splice(this.pendingQueries.indexOf(id), 1);
+
+  isLoading = () => this.pendingQueries.length;
+}
+
+export default QueryObserver;


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR is a WIP to enable us to scroll the user to a specific location or anchor on the page without worrying about asynchronously loaded content mucking up the scroll location.

It adds a `QueryObserver` service, (that name may need to be workshopped lol) which is meant to keep track of any content/spacing affecting pending graphql queries, or anything other async thing we'd need to track, and allows us to have a definitive idea of when we can start scrolling the user.

### Any background context you want to provide?
One caveat(?) with this approach -- it'd require any content consequential things e.g. `<Queries>` to register manually with this `QueryObserver` (ugh what a bad temp name) and then update it when complete. So it adds an assured amount of responsibility to wherever we render those out. So perhaps not as passive as we'd like? Or is that ok? I was hoping there would be someplace baked in where we could just observe those graphql batched queries from their end but wasn't able to find anything in the docs.

### What are the relevant tickets/cards?

Refs [Pivotal ID #]()

### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.
* [ ] Added screenshot to PR description of related front-end updates on **small** screens.
* [ ] Added screenshot to PR description of related front-end updates on **medium** screens.
* [ ] Added screenshot to PR description of related front-end updates on **large** screens.
