### PR TITLE
Add Request ID and Other Info to Logs

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -3,6 +3,7 @@
 namespace App\Providers;
 
 use Illuminate\Routing\Router;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\View;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\ServiceProvider;
@@ -69,6 +70,15 @@ class AppServiceProvider extends ServiceProvider
                 'source' => request()->query('utm_source'),
                 'now' => now()->timestamp,
             ]);
+        });
+
+        // Attach the user & request ID to context for all log messages.
+        Log::getMonolog()->pushProcessor(function ($record) {
+            $record['extra']['user_id'] = auth()->id();
+            $record['extra']['client_id'] = token()->client();
+            $record['extra']['request_id'] = request()->header('X-Request-Id');
+
+            return $record;
         });
     }
 

--- a/app/Services/Bertly.php
+++ b/app/Services/Bertly.php
@@ -4,10 +4,12 @@ namespace App\Services;
 
 use DoSomething\Gateway\AuthorizesWithApiKey;
 use DoSomething\Gateway\Common\RestApiClient;
+use DoSomething\Gateway\ForwardsTransactionIds;
 
 class Bertly extends RestApiClient
 {
     use AuthorizesWithApiKey;
+    use ForwardsTransactionIds;
 
     /**
      * The header to provide the API key in.

--- a/app/Services/Bertly.php
+++ b/app/Services/Bertly.php
@@ -8,8 +8,7 @@ use DoSomething\Gateway\ForwardsTransactionIds;
 
 class Bertly extends RestApiClient
 {
-    use AuthorizesWithApiKey;
-    use ForwardsTransactionIds;
+    use AuthorizesWithApiKey, ForwardsTransactionIds;
 
     /**
      * The header to provide the API key in.

--- a/app/Services/RogueClient.php
+++ b/app/Services/RogueClient.php
@@ -4,11 +4,13 @@ namespace App\Services;
 
 use DoSomething\Gateway\AuthorizesWithOAuth2;
 use DoSomething\Gateway\Common\RestApiClient;
+use DoSomething\Gateway\ForwardsTransactionIds;
 use DoSomething\Gateway\Exceptions\ValidationException;
 
 class RogueClient extends RestApiClient
 {
     use AuthorizesWithOAuth2;
+    use ForwardsTransactionIds;
 
     /**
      * Create a new RogueClient instance.

--- a/app/Services/RogueClient.php
+++ b/app/Services/RogueClient.php
@@ -9,8 +9,7 @@ use DoSomething\Gateway\Exceptions\ValidationException;
 
 class RogueClient extends RestApiClient
 {
-    use AuthorizesWithOAuth2;
-    use ForwardsTransactionIds;
+    use AuthorizesWithOAuth2, ForwardsTransactionIds;
 
     /**
      * Create a new RogueClient instance.


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR adds some pertinent identifying information to logs to enable tracking across apps/lifecycle

### Any background context you want to provide?
This is a much belated follow up to #1218 (see https://github.com/DoSomething/phoenix-next/pull/1218#issuecomment-452379803 and that thread in general)

**Question**: Do we need to explicitly set the [`use ForwardsTransactionIds;`](https://github.com/DoSomething/gateway/blob/master/docs/traits/ForwardsTransactionIds.md) in our Client configurations? (I didn't see this set in Rogue anywhere).
