### PR TITLE
Update eslint to allow plain 'object' prop type

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -8,6 +8,9 @@ module.exports = {
     'jsx-a11y/alt-text': 'warn',
     'jsx-a11y/media-has-caption': 'warn',
 
+    // Allowing 'object' since we've deemed that warning more of a nuisance.
+    'react/forbid-prop-types': ['warn', { forbid: ['any', 'array'] }],
+
     // Don't warn when using GraphQL's meta fields.
     'no-underscore-dangle': ['warn', { allow: ['__typename', '__schema'] }],
 

--- a/resources/assets/components/Affirmation/Affirmation.js
+++ b/resources/assets/components/Affirmation/Affirmation.js
@@ -50,7 +50,7 @@ const Affirmation = ({
 );
 
 Affirmation.propTypes = {
-  author: PropTypes.object, // eslint-disable-line react/forbid-prop-types
+  author: PropTypes.object,
   callToActionDescription: PropTypes.string,
   callToActionHeader: PropTypes.string,
   header: PropTypes.string,

--- a/resources/assets/components/App.js
+++ b/resources/assets/components/App.js
@@ -47,8 +47,8 @@ const App = ({ store, history }) => {
 };
 
 App.propTypes = {
-  store: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
-  history: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
+  store: PropTypes.object.isRequired,
+  history: PropTypes.object.isRequired,
 };
 
 export default App;

--- a/resources/assets/components/Campaign/CampaignRoute/CampaignRoute.js
+++ b/resources/assets/components/Campaign/CampaignRoute/CampaignRoute.js
@@ -67,9 +67,9 @@ const CampaignRoute = props => {
 };
 
 CampaignRoute.propTypes = {
-  affiliatePartners: PropTypes.array.isRequired, // eslint-disable-line react/forbid-prop-types
-  affiliateSponsors: PropTypes.array.isRequired, // eslint-disable-line react/forbid-prop-types
-  affirmation: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
+  affiliatePartners: PropTypes.arrayOf(PropTypes.object).isRequired,
+  affiliateSponsors: PropTypes.arrayOf(PropTypes.object).isRequired,
+  affirmation: PropTypes.object.isRequired,
   campaignLead: PropTypes.shape({
     name: PropTypes.string,
     email: PropTypes.string,

--- a/resources/assets/components/LegacyQuiz/Question.js
+++ b/resources/assets/components/LegacyQuiz/Question.js
@@ -36,7 +36,7 @@ Question.propTypes = {
   quizId: PropTypes.string.isRequired,
   pickQuizAnswer: PropTypes.func.isRequired,
   title: PropTypes.string.isRequired,
-  answers: PropTypes.array.isRequired, // eslint-disable-line react/forbid-prop-types
+  answers: PropTypes.arrayOf(PropTypes.object).isRequired,
   activeAnswer: PropTypes.string,
 };
 

--- a/resources/assets/components/Quiz/Quiz.js
+++ b/resources/assets/components/Quiz/Quiz.js
@@ -274,7 +274,7 @@ Quiz.propTypes = {
     isNestedQuiz: PropTypes.bool,
   }).isRequired,
   clickedSignupAction: PropTypes.func.isRequired,
-  defaultResultBlock: PropTypes.object, // eslint-disable-line react/forbid-prop-types
+  defaultResultBlock: PropTypes.object,
   history: ReactRouterPropTypes.history.isRequired,
   isAuthenticated: PropTypes.bool.isRequired,
   campaignId: PropTypes.string.isRequired,

--- a/resources/assets/components/blocks/SectionBlock/SectionBlock.js
+++ b/resources/assets/components/blocks/SectionBlock/SectionBlock.js
@@ -51,7 +51,7 @@ const SectionBlock = props => {
 SectionBlock.propTypes = {
   backgroundColor: PropTypes.string,
   className: PropTypes.string,
-  content: PropTypes.oneOfType([PropTypes.object]).isRequired,
+  content: PropTypes.object.isRequired,
   hyperlinkColor: PropTypes.string,
   id: PropTypes.string.isRequired,
   textColor: PropTypes.string,

--- a/resources/assets/components/pages/CampaignPage/CampaignPage.js
+++ b/resources/assets/components/pages/CampaignPage/CampaignPage.js
@@ -59,7 +59,7 @@ CampaignPage.propTypes = {
     type: PropTypes.string,
     fields: PropTypes.object,
   }),
-  entryContent: PropTypes.object, // eslint-disable-line react/forbid-prop-types
+  entryContent: PropTypes.object,
   landingPage: PropTypes.shape({
     id: PropTypes.string,
     type: PropTypes.string,

--- a/resources/assets/components/pages/CampaignPage/CampaignPageContent.js
+++ b/resources/assets/components/pages/CampaignPage/CampaignPageContent.js
@@ -102,7 +102,11 @@ const CampaignPageContent = props => {
 
 CampaignPageContent.propTypes = {
   campaignEndDate: PropTypes.string,
-  match: PropTypes.object, // eslint-disable-line react/forbid-prop-types
+  match: PropTypes.shape({
+    params: PropTypes.shape({
+      slug: PropTypes.string.isRequired,
+    }).isRequired,
+  }),
   pages: PropTypes.arrayOf(
     PropTypes.shape({
       fields: PropTypes.shape({

--- a/resources/assets/components/pages/CompanyPage/CompanyPage.js
+++ b/resources/assets/components/pages/CompanyPage/CompanyPage.js
@@ -16,7 +16,7 @@ const CompanyPage = props => {
 
 CompanyPage.propTypes = {
   title: PropTypes.string.isRequired,
-  content: PropTypes.oneOfType([PropTypes.object]).isRequired,
+  content: PropTypes.object.isRequired,
 };
 
 export default CompanyPage;

--- a/resources/assets/components/utilities/PostGallery/PostGallery.js
+++ b/resources/assets/components/utilities/PostGallery/PostGallery.js
@@ -87,7 +87,7 @@ PostGallery.propTypes = {
   loading: PropTypes.bool.isRequired,
   loadMorePosts: PropTypes.func.isRequired,
   onRender: PropTypes.func,
-  posts: PropTypes.array, // eslint-disable-line react/forbid-prop-types
+  posts: PropTypes.arrayOf(PropTypes.object),
   shouldShowNoResults: PropTypes.bool,
   waypointName: PropTypes.string,
 };

--- a/resources/assets/components/utilities/TextContent/RichTextDocument.js
+++ b/resources/assets/components/utilities/TextContent/RichTextDocument.js
@@ -20,7 +20,7 @@ const RichTextDocument = ({ className = null, children, styles }) => (
 );
 
 RichTextDocument.propTypes = {
-  children: PropTypes.oneOfType([PropTypes.object]).isRequired,
+  children: PropTypes.object.isRequired,
   className: PropTypes.string,
   styles: PropTypes.shape({
     textColor: PropTypes.string,

--- a/resources/assets/components/utilities/TextContent/RichTextDocument.js
+++ b/resources/assets/components/utilities/TextContent/RichTextDocument.js
@@ -22,7 +22,10 @@ const RichTextDocument = ({ className = null, children, styles }) => (
 RichTextDocument.propTypes = {
   children: PropTypes.oneOfType([PropTypes.object]).isRequired,
   className: PropTypes.string,
-  styles: PropTypes.object, // eslint-disable-line react/forbid-prop-types
+  styles: PropTypes.shape({
+    textColor: PropTypes.string,
+    hyperlinkColor: PropTypes.string,
+  }),
 };
 
 RichTextDocument.defaultProps = {

--- a/resources/assets/components/utilities/TextContent/TextContent.js
+++ b/resources/assets/components/utilities/TextContent/TextContent.js
@@ -38,7 +38,10 @@ TextContent.propTypes = {
     PropTypes.object,
   ]).isRequired,
   className: PropTypes.string,
-  styles: PropTypes.object, // eslint-disable-line react/forbid-prop-types
+  styles: PropTypes.shape({
+    textColor: PropTypes.string,
+    hyperlinkColor: PropTypes.string,
+  }),
 };
 
 TextContent.defaultProps = {


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR updates our eslint config to allow the plain `PropTypes.object` definition. 

(Also, where possible, updates some PropType definitions to be more explicit.)

### Any background context you want to provide?
Since we quite occasionally need to circumvent this rule due to unpredictable object fields, we've opted to reluctantly remove this warning for now.

(I needed to allow a plain `object` prototype for the opt-in work, so this felt like a good time to quickly tackle this.)

### What are the relevant tickets/cards?

Refs [Pivotal ID #164285068](https://www.pivotaltracker.com/story/show/164285068)

### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.
