### PR TITLE
Fix low resolution logos on retina displays.

### DIFF
--- a/app/helpers.php
+++ b/app/helpers.php
@@ -292,7 +292,7 @@ function get_image_url($asset, $style = null)
 
     $options['logo'] = (new ImageOptions)
         ->setFormat('png')
-        ->setHeight(50)
+        ->setHeight(100)
         ->setResizeFit('scale');
 
     // Provide cropped image if specified, or just the original image by default.

--- a/resources/assets/components/SponsorPromotion/sponsor-promotion.scss
+++ b/resources/assets/components/SponsorPromotion/sponsor-promotion.scss
@@ -126,6 +126,13 @@ $btw-mobile-and-tablet: '(min-width: 860px)';
   }
 }
 
+// Sponsor Specific
+.promotion--sponsor {
+  img {
+    height: 50px;
+  }
+}
+
 // Override styling for affiliate logo appearing on affiliate content (LinkAction, CampaignUpdate)
 .affiliate-logo {
   float: left;


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR fixes a small bug with how sponsor logos are showing up on retina screens. The logos look fine on non-retina screens, but on retina screens they look a little blurry. So to fix this, we've doubled the resolution of the logo, while keeping the visual height the same to ideally make them look crisper on retina screens.

### Any background context you want to provide?

🌵 👁 

### What are the relevant tickets/cards?

Refs [Pivotal ID #165263073](https://www.pivotaltracker.com/story/show/165263073)
