### PR TITLE
Report Failed api GET Requests to New Relic

### DIFF
--- a/resources/assets/middleware/api.js
+++ b/resources/assets/middleware/api.js
@@ -31,6 +31,8 @@ const getRequestAction = (payload, dispatch) => {
       });
     })
     .catch(error => {
+      report(error);
+
       if (window.ENV.APP_ENV !== 'production') {
         console.log('🚫 failed response? caught the error!', error);
       }


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR ensures we report failed ('caught') API GET requests made using our API middleware to New Relic (and/or whichever analytics is configured) using the `report` helper.

### Any background context you want to provide?
I wasn't seeing these in our NR's browser dashboard and figured this would be good to be reporting (especially given our open issue re `500`s to the `.../signups` API endpoint)

I didn't add a general analytics event as we have for the [POST requests](https://github.com/DoSomething/phoenix-next/blob/80cc4393d180161076c2c6433619ea9623be3b4c/resources/assets/middleware/api.js#L114-L123) -- do you think that'd be helpful too?

### What are the relevant tickets/cards?

Refs [Pivotal ID #165315689](https://www.pivotaltracker.com/story/show/165315689)

### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.
