### PR TITLE
Open external links from rich text in new tab

### DIFF
--- a/resources/assets/helpers/text.js
+++ b/resources/assets/helpers/text.js
@@ -136,11 +136,20 @@ export function parseRichTextDocument(document, styles) {
           <ContentfulAsset id={node.data.target.sys.id} />
         </p>
       ),
-      [INLINES.HYPERLINK]: node => (
-        <a href={node.data.uri} style={{ color: hyperlinkColor }}>
-          {node.content[0].value}
-        </a>
-      ),
+      [INLINES.HYPERLINK]: node => {
+        const external = isExternal(node.data.uri);
+
+        return (
+          <a
+            href={node.data.uri}
+            target={external ? '_blank' : '_self'}
+            rel={external ? 'noopener noreferrer' : ''}
+            style={{ color: hyperlinkColor }}
+          >
+            {node.content[0].value}
+          </a>
+        );
+      },
     },
   };
 


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR opens links in a new tab for external URI's provided in a Rich Text field on Contentful.

### Any background context you want to provide?
This ensures parity with the current functionality in [Markdown fields](https://github.com/DoSomething/phoenix-next/blob/b96abb3a0df3a61ee8caa05f54a9f5b8b8b34dac/resources/assets/helpers/text.js#L56-L58), where external URl's are set to open in a new tab.

You may notice we only conditionally set the `rel` to `noopener noreferrer` as well. It felt like this might be helpful so as to not block the `document.referrer` being set for internal links. (I noticed similar functionality on NYT articles.) 
I don't *think* it's an issue to have an empty `rel` attribute for internal links, right?

### What are the relevant tickets/cards?

Refs [Pivotal ID #165226084](https://www.pivotaltracker.com/story/show/165226084)

### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.
