### PR TITLE
Temporarily disable custom ID fields in log records

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -73,13 +73,14 @@ class AppServiceProvider extends ServiceProvider
         });
 
         // Attach the user & request ID to context for all log messages.
-        Log::getMonolog()->pushProcessor(function ($record) {
-            $record['extra']['user_id'] = auth()->id();
-            $record['extra']['client_id'] = token()->client();
-            $record['extra']['request_id'] = request()->header('X-Request-Id');
+        // @TODO Re-enable this once we resolve https://www.pivotaltracker.com/story/show/165315689.
+        // Log::getMonolog()->pushProcessor(function ($record) {
+        //     $record['extra']['user_id'] = auth()->id();
+        //     $record['extra']['client_id'] = token()->client();
+        //     $record['extra']['request_id'] = request()->header('X-Request-Id');
 
-            return $record;
-        });
+        //     return $record;
+        // });
     }
 
     /**


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR temporarily disables the added request ID fields dynamically added to the logs until we can resolve the ongoing investigation into `/signups` breakage (https://www.pivotaltracker.com/story/show/165315689)

### Any background context you want to provide?
See this [Slack thread](https://dosomething.slack.com/archives/C02BBP0CU/p1555351880003100) for more context

### What are the relevant tickets/cards?

Refs [Pivotal ID #](https://www.pivotaltracker.com/story/show/165315689)
