### PR TITLE
Sixpack Experiment participation documentation.

### DIFF
--- a/docs/development/features/sixpack-a-b-testing.md
+++ b/docs/development/features/sixpack-a-b-testing.md
@@ -4,6 +4,10 @@
 
 The Phoenix platform has the capability of running a variety of A/B Test Experiments to gather insight on what small changes on the web experience between a set of variants perform better. The overall aim is to find what small changes lead to more conversions from our existing website visitor traffic.
 
+{% hint style="info"%}
+While the terms "test" and "experiment" are generally used interchangeably, within the Phoenix framework, we like to think of "experiment" as the encompassing name for a specific A/B test experiment, and "tests" as the alternative options or test variants within the experiment.
+{% endhint %}
+
 ## Test Experiment Types
 
 Depending on the context for the kind of test being performed, there are 2 test approaches that Phoenix supports, A/B Tests executed in code, or A/B Tests executed using our Contentful CMS.
@@ -24,6 +28,21 @@ The [Contentful Tests](sixpack-contentful-tests.md) section provides more inform
 
 To perform all these A/B Test Experiments, we utilize an open-source, language-agnostic A/B testing framework called [Sixpack](https://github.com/sixpack/sixpack). Sixpack runs as an instance on a server that Phoenix communicates with to exchange data and also pass along information to Sixpack regarding successful conversions on different experiments.
 
-To communicate with the Sixpack server, Phoenix has a `Sixpack` service class located in `/resources/assets/services/Sixpack.js`. This class is only instantiated _once_ during the page request cycle, and contains a key-value store of all the experiments running on the current page being viewed.
+To communicate with the Sixpack server, Phoenix has a `Sixpack` service class located in `/resources/assets/services/Sixpack.js`. This class is only instantiated _once_ during the page request cycle and only if an experiment is initiated; it contains a key-value store of all the experiments running on the current page being viewed.
 
-_more to come..._
+There is a convenient `sixpack()` helper function you should use as an alias, which creates a new instance, or retrieves an existing instance of the `Sixpack` service class, ensuring that only one instance of the `Sixpack` is ever called. This function can be found in `/resources/assets/helpers/index.js`.
+
+### SixpackExperiment Component
+
+Regardless of whether a Sixpack A/B Test Experiment is a code test or a Ccontentful test, in both cases the core component that initiates the experiment in Phoenix is the `SixpackExperiment` React component.
+
+The `SixpackExperiment` component can be found in `/resources/assets/components/utilities/SixpackExperiment/` directory, along with a corresponding `SixpackExperimentContainer.js`.
+
+When a `SixpackExperiment` component is rendered on a page, upon mounting the following takes place:
+
+1. The component configures some settings to set the name for the experiment, and define what the alternative test options are to choose from.
+2. It then calls the `participate()` method on the `Sixpack` class via the `sixpack()` helper function, which makes an API request to the Sixpack server, and participates the current user in the specified A/B test experiment.
+3. The response from the Sixpack server returns with the name of the selected alternative test option that the current user has been participated in.
+4. Within the `Sixpack` service class, this experiment along with the associated alternative test option that was selected for the user is added to the `experiments` object property on the class.
+5. The `participate()` method resolves and returns the name of the selected alternative option for the user to the `SixpackExperiment` component, and assigns it to the `selectedAlternative` component state property.
+6. When the `SixpackExperiment` component state changes with the name of the selected alternative test, it re-renders with the component specified by the selected alternative test name.

--- a/docs/development/features/sixpack-a-b-testing.md
+++ b/docs/development/features/sixpack-a-b-testing.md
@@ -37,7 +37,7 @@ There is a convenient `sixpack()` helper function you should use as an alias, wh
 Regardless of whether a Sixpack A/B Test Experiment is a code test or a Contentful test, in both cases the core component that initiates and participates the current user in the experiment within Phoenix is the `SixpackExperiment` React component.
 
 {% hint style="info"%}
-Within Sixpack and A/B testing in general, the term "participate" indicates that a user is about to take part in an A/B test experiment and will be assigned one of the test alternative varients for the duration of the experiment.
+Within Sixpack and A/B testing in general, the term "participate" indicates that a user is about to take part in an A/B test experiment and will be assigned one of the test alternative variants for the duration of the experiment.
 {% endhint %}
 
 The `SixpackExperiment` component can be found in `/resources/assets/components/utilities/SixpackExperiment/` directory, along with a corresponding `SixpackExperimentContainer.js`.

--- a/docs/development/features/sixpack-a-b-testing.md
+++ b/docs/development/features/sixpack-a-b-testing.md
@@ -32,13 +32,17 @@ To communicate with the Sixpack server, Phoenix has a `Sixpack` service class lo
 
 There is a convenient `sixpack()` helper function you should use as an alias, which creates a new instance, or retrieves an existing instance of the `Sixpack` service class, ensuring that only one instance of the `Sixpack` is ever called. This function can be found in `/resources/assets/helpers/index.js`.
 
-### SixpackExperiment Component
+### Experiment Participation
 
-Regardless of whether a Sixpack A/B Test Experiment is a code test or a Ccontentful test, in both cases the core component that initiates the experiment in Phoenix is the `SixpackExperiment` React component.
+Regardless of whether a Sixpack A/B Test Experiment is a code test or a Contentful test, in both cases the core component that initiates and participates the current user in the experiment within Phoenix is the `SixpackExperiment` React component.
+
+{% hint style="info"%}
+Within Sixpack and A/B testing in general, the term "participate" indicates that a user is about to take part in an A/B test experiment and will be assigned one of the test alternative varients for the duration of the experiment.
+{% endhint %}
 
 The `SixpackExperiment` component can be found in `/resources/assets/components/utilities/SixpackExperiment/` directory, along with a corresponding `SixpackExperimentContainer.js`.
 
-When a `SixpackExperiment` component is rendered on a page, upon mounting the following takes place:
+When a `SixpackExperiment` component is rendered on a page, upon mounting the following series of steps occur:
 
 1. The component configures some settings to set the name for the experiment, and define what the alternative test options are to choose from.
 2. It then calls the `participate()` method on the `Sixpack` class via the `sixpack()` helper function, which makes an API request to the Sixpack server, and participates the current user in the specified A/B test experiment.
@@ -46,3 +50,10 @@ When a `SixpackExperiment` component is rendered on a page, upon mounting the fo
 4. Within the `Sixpack` service class, this experiment along with the associated alternative test option that was selected for the user is added to the `experiments` object property on the class.
 5. The `participate()` method resolves and returns the name of the selected alternative option for the user to the `SixpackExperiment` component, and assigns it to the `selectedAlternative` component state property.
 6. When the `SixpackExperiment` component state changes with the name of the selected alternative test, it re-renders with the component specified by the selected alternative test name.
+7. On the rendered page, the current user sees one of the various test alternatives; specifically the test alternative that they have been assigned by the Sixpack server.
+
+### Experiment Conversion
+
+A user is converted on a Sixpack A/B test experiment and associated test alternative when they take a particular action that triggers the conversion.
+
+_more about the `sixpackExperiment` middleware..._

--- a/docs/development/features/sixpack-code-tests.md
+++ b/docs/development/features/sixpack-code-tests.md
@@ -1,3 +1,6 @@
 # Sixpack Code Tests
 
 _more to come..._
+
+_notes:_
+To override components that contain a React container, thes container needs to allow overriding properties by any props that get passed into it.


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR expands on how the `SixpackExperiment` component initiates a Sixpack A/B test experiment within Phoenix and "participates" a user into the experiment.

### Any background context you want to provide?

[Current updates](https://dosomething.gitbook.io/phoenix-documentation/v/docs-sixpack-experiment-component-flow/development/features/sixpack-a-b-testing) for review visually.

🌵 

### What are the relevant tickets/cards?

Refs [Pivotal ID #165256862](https://www.pivotaltracker.com/story/show/165256862)
