### PR TITLE
Add NFL to Homepage Sponsor List

### DIFF
--- a/resources/assets/components/pages/HomePage/sponsor-list.js
+++ b/resources/assets/components/pages/HomePage/sponsor-list.js
@@ -104,6 +104,11 @@ const sponsorList = [
     image:
       'https://images.ctfassets.net/81iqaqpfd8fy/3KpmgDJDHGOO482eoqckkS/bf348e66f940f513905535e35557fc5a/target_tag_logo.jpg',
   },
+  {
+    name: 'NFL',
+    image:
+      'https://images.ctfassets.net/81iqaqpfd8fy/4GkuPYrBnKPSKDcfyYppsL/dab4a609b2e5ed03f0bc42fea22ffb8d/nfl_huddle_for_100_dark-01.png',
+  },
 ];
 
 export default sponsorList;


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR adds the NFL to our sponsor list on the Homepage.

https://dosomething.slack.com/archives/C09ANFQLA/p1556116203001100