### PR TITLE
Affiliates Content Type Migration Script (New UTM Label Field)

### DIFF
--- a/contentful/content-types/affiliate.js
+++ b/contentful/content-types/affiliate.js
@@ -84,7 +84,7 @@ module.exports = function(migration) {
         },
 
         message:
-          'The UTM Label field can only contain lower case letters or numbers and must be snake cased (http://bit.ly/2Pxkxv9).',
+          'The UTM Label field can only contain lower case, alphanumeric characters and must be snake cased (http://bit.ly/2Pxkxv9).',
       },
     ])
     .disabled(false)

--- a/contentful/content-types/affiliate.js
+++ b/contentful/content-types/affiliate.js
@@ -60,7 +60,47 @@ module.exports = function(migration) {
     .omitted(false)
     .linkType('Asset');
 
+  affiliates
+    .createField('utmLabel')
+    .name('UTM Label')
+    .type('Symbol')
+    .localized(false)
+    .required(false)
+    .validations([
+      {
+        unique: true,
+      },
+      {
+        size: {
+          max: 50,
+        },
+
+        message: 'The UTM Label field may not exceed 50 characters.',
+      },
+      {
+        regexp: {
+          pattern: '^[a-z0-9_]*$',
+          flags: null,
+        },
+
+        message:
+          'The UTM Label field can only contain lower case letters or numbers and must be snake cased (http://bit.ly/2Pxkxv9).',
+      },
+    ])
+    .disabled(false)
+    .omitted(false);
+
+  affiliates.changeEditorInterface('internalTitle', 'singleLine', {
+    helpText:
+      'This title is used internally to help find this content in the CMS. It will not be displayed anywhere on the website.',
+  });
+
   affiliates.changeEditorInterface('title', 'singleLine', {});
   affiliates.changeEditorInterface('link', 'urlEditor', {});
   affiliates.changeEditorInterface('logo', 'assetLinkEditor', {});
+
+  affiliates.changeEditorInterface('utmLabel', 'singleLine', {
+    helpText:
+      'The UTM parameter label identifying this affiliate. (Primarily used to identify referring scholarship affiliate partners).',
+  });
 };

--- a/contentful/content-types/affiliate.js
+++ b/contentful/content-types/affiliate.js
@@ -1,0 +1,66 @@
+module.exports = function(migration) {
+  const affiliates = migration
+    // Sigh at this very OG content type using a pluralized id :)
+    .createContentType('affiliates')
+    .name('Affiliates')
+    .description(
+      'Sponsors, partners, or other third-party affiliates for a campaign.',
+    )
+    .displayField('internalTitle');
+
+  affiliates
+    .createField('internalTitle')
+    .name('Internal Title')
+    .type('Symbol')
+    .localized(false)
+    .required(false)
+    .validations([])
+    .disabled(false)
+    .omitted(false);
+
+  affiliates
+    .createField('title')
+    .name('Title')
+    .type('Symbol')
+    .localized(false)
+    .required(true)
+    .validations([])
+    .disabled(false)
+    .omitted(false);
+
+  affiliates
+    .createField('link')
+    .name('Link')
+    .type('Symbol')
+    .localized(false)
+    .required(false)
+    .validations([
+      {
+        regexp: {
+          pattern:
+            '^(ftp|http|https):\\/\\/(\\w+:{0,1}\\w*@)?(\\S+)(:[0-9]+)?(\\/|\\/([\\w#!:.?+=&%@!\\-\\/]))?$',
+        },
+      },
+    ])
+    .disabled(false)
+    .omitted(false);
+
+  affiliates
+    .createField('logo')
+    .name('Logo')
+    .type('Link')
+    .localized(false)
+    .required(false)
+    .validations([
+      {
+        linkMimetypeGroup: ['image'],
+      },
+    ])
+    .disabled(false)
+    .omitted(false)
+    .linkType('Asset');
+
+  affiliates.changeEditorInterface('title', 'singleLine', {});
+  affiliates.changeEditorInterface('link', 'urlEditor', {});
+  affiliates.changeEditorInterface('logo', 'assetLinkEditor', {});
+};


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR adds a Contentful Migration script for the Affiliate content type, and most importantly - adding a new UTM Label field (https://github.com/DoSomething/phoenix-next/pull/1394/commits/e485722b455a95ee169b19850c7b6ed72f42f243)!

### Any background context you want to provide?
Adding this field so that we can query affiliates responsibly using the UTM query parameter values for referring affiliate scholarship partners. (See [this Pivotal comment](https://www.pivotaltracker.com/story/show/165299110/comments/201990521) (as well as the attached card) for more context.)

### What are the relevant tickets/cards?

Refs [Pivotal ID #165299110](https://www.pivotaltracker.com/story/show/165299110)

### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.
