### PR TITLE
Sixpack removing extra dispatch for conversion

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5912,7 +5912,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -5933,12 +5934,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -5953,17 +5956,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -6080,7 +6086,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -6092,6 +6099,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -6106,6 +6114,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -6113,12 +6122,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -6137,6 +6148,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -6217,7 +6229,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -6229,6 +6242,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -6314,7 +6328,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -6350,6 +6365,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -6369,6 +6385,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -6412,12 +6429,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/resources/assets/actions/signup.js
+++ b/resources/assets/actions/signup.js
@@ -118,7 +118,7 @@ export function getCampaignSignups(id = null, query = {}) {
  * @param  {Object} data
  * @return {Function}
  */
-export function storeCampaignSignup(campaignId, data) {
+export function storeCampaignSignup(campaignId, data = {}) {
   const analytics = get(data, 'analytics', {});
   const path = join('api/v2/campaigns', campaignId, 'signups');
   const type = 'signup';

--- a/resources/assets/components/SignupButton/SignupButton.js
+++ b/resources/assets/components/SignupButton/SignupButton.js
@@ -8,16 +8,16 @@ const SignupButton = props => {
   const {
     affiliateMessagingOptIn,
     campaignActionText,
+    campaignContentfulId,
+    campaignId,
     className,
-    clickedSignupAction,
     disableSignup,
     source,
     sourceActionText,
+    storeCampaignSignup,
     template,
     text,
     trafficSource,
-    campaignId,
-    campaignContentfulId,
   } = props;
 
   // Decorate click handler for A/B tests & analytics.
@@ -29,7 +29,7 @@ const SignupButton = props => {
       details.affiliateOptIn = true;
     }
 
-    clickedSignupAction(campaignId, {
+    storeCampaignSignup(campaignId, {
       body: { details: JSON.stringify(details) },
       analytics: {
         campaignContentfulId,
@@ -59,13 +59,13 @@ const SignupButton = props => {
 SignupButton.propTypes = {
   affiliateMessagingOptIn: PropTypes.bool.isRequired,
   campaignActionText: PropTypes.string,
-  className: PropTypes.string,
-  clickedSignupAction: PropTypes.func.isRequired,
-  disableSignup: PropTypes.bool,
-  campaignId: PropTypes.string.isRequired,
   campaignContentfulId: PropTypes.string.isRequired,
+  campaignId: PropTypes.string.isRequired,
+  className: PropTypes.string,
+  disableSignup: PropTypes.bool,
   source: PropTypes.string.isRequired,
   sourceActionText: PropTypes.objectOf(PropTypes.string),
+  storeCampaignSignup: PropTypes.func.isRequired,
   template: PropTypes.string,
   text: PropTypes.string,
   trafficSource: PropTypes.string,

--- a/resources/assets/components/SignupButton/SignupButtonContainer.js
+++ b/resources/assets/components/SignupButton/SignupButtonContainer.js
@@ -2,7 +2,7 @@ import { connect } from 'react-redux';
 import { get } from 'lodash';
 
 import SignupButton from './SignupButton';
-import { clickedSignupAction } from '../../actions/signup';
+import { storeCampaignSignup } from '../../actions/signup';
 
 /**
  * Provide state from the Redux store as props for this component.
@@ -23,7 +23,7 @@ const mapStateToProps = state => ({
  * actions to the Redux store as props for this component.
  */
 const actionCreators = {
-  clickedSignupAction,
+  storeCampaignSignup,
 };
 
 // Export the container component.

--- a/resources/assets/components/pages/LandingPage/LandingPage.js
+++ b/resources/assets/components/pages/LandingPage/LandingPage.js
@@ -27,7 +27,8 @@ const LandingPage = props => {
 
   return (
     <div>
-      {campaignId === '3pwxnRZxociqMaQCMcGOyc' ? (
+      {campaignId === '3pwxnRZxociqMaQCMcGOyc' ||
+      campaignId === '2YnPcG3G8EgAmWOAC48aWU' ? (
         <SixpackExperimentContainer
           title="LedeBanner Layout Experiment"
           convertableActions={['signup']}

--- a/resources/assets/components/pages/LandingPage/LandingPage.js
+++ b/resources/assets/components/pages/LandingPage/LandingPage.js
@@ -27,8 +27,7 @@ const LandingPage = props => {
 
   return (
     <div>
-      {campaignId === '3pwxnRZxociqMaQCMcGOyc' ||
-      campaignId === '2YnPcG3G8EgAmWOAC48aWU' ? (
+      {campaignId === '3pwxnRZxociqMaQCMcGOyc' ? (
         <SixpackExperimentContainer
           title="LedeBanner Layout Experiment"
           convertableActions={['signup']}


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR removes an [extra dispatch action](https://github.com/DoSomething/phoenix-next/pull/1067/files#diff-9e724eddc3f7ebfa3cb156868580310aR32) to convert a Sixpack test on signup that was added back in August of 2018, when the signup code was much more convoluted. We have since simplified it, but this dispatch was not removed. 

The result was that when a test converted on signup, 2 calls to convert the test were sent to the Sixpack server. While this isn't a big deal, since the test converts on the first call and any follow up calls to convert on the same test by the same user are ignored, it did make things more confusing.

### Any background context you want to provide?

We had [a bit of a discussion](https://dosomething.slack.com/archives/C3ASB4204/p1556136273131400) regarding whether to keep the dispatched action for Sixpack within the `clickedSignupButton()` function or with the rest of the dispatched info in the `storeCampaignSignup()`. Ultimately we decided removing the isolated call would allow simplifying the code a bunch, and having it dispatch with the rest of the info for a signup still makes sense (also it follows how we do it when posting a reportback), allowing the button that ultimately calls the `storeCampaignSignup()` be the decorator that adds the Sixpack info along with other analytics info.

### What are the relevant tickets/cards?

Refs [Pivotal ID #165429184](https://www.pivotaltracker.com/story/show/165429184)

### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.