### PR TITLE
Adds Softedge Widget Component to Page 

### DIFF
--- a/app/Entities/Entity.php
+++ b/app/Entities/Entity.php
@@ -108,12 +108,14 @@ class Entity implements ArrayAccess, JsonSerializable
                 return new SectionBlock($block->entry);
             case 'shareAction':
                 return new ShareAction($block->entry);
-            case 'storyPage':
-                return new TruncatedStoryPage($block->entry);
             case 'sixpackExperiment':
                 return new SixpackExperiment($block->entry);
             case 'socialDriveAction':
                 return new SocialDriveAction($block->entry);
+            case 'softEdgeWidgetAction':
+                return new SoftEdgeWidgetAction($block->entry);
+            case 'storyPage':
+                return new TruncatedStoryPage($block->entry);
             case 'textSubmissionAction':
                 return new TextSubmissionAction($block->entry);
             case 'voterRegistrationAction':

--- a/app/Http/Controllers/CampaignController.php
+++ b/app/Http/Controllers/CampaignController.php
@@ -59,7 +59,7 @@ class CampaignController extends Controller
     public function show($slug, Request $request)
     {
         $campaign = $this->campaignRepository->findBySlug($slug);
-
+        dd($campaign);
         return view('app', [
             // This is used to build campaign-specific login links in the
             // server-rendered top navigation bar.

--- a/app/Http/Controllers/CampaignController.php
+++ b/app/Http/Controllers/CampaignController.php
@@ -59,7 +59,7 @@ class CampaignController extends Controller
     public function show($slug, Request $request)
     {
         $campaign = $this->campaignRepository->findBySlug($slug);
-        dd($campaign);
+
         return view('app', [
             // This is used to build campaign-specific login links in the
             // server-rendered top navigation bar.

--- a/resources/assets/components/ContentfulEntry/ContentfulEntry.js
+++ b/resources/assets/components/ContentfulEntry/ContentfulEntry.js
@@ -59,7 +59,6 @@ class ContentfulEntry extends React.Component<Props, State> {
     // Otherwise, find the corresponding component & render it!
     const { json = DEFAULT_BLOCK, className = null } = this.props;
     const type = parseContentfulType(json);
-    console.log('🐶', type);
 
     switch (type) {
       case 'affirmation':

--- a/resources/assets/components/ContentfulEntry/ContentfulEntry.js
+++ b/resources/assets/components/ContentfulEntry/ContentfulEntry.js
@@ -21,6 +21,7 @@ import LinkActionContainer from '../actions/LinkAction/LinkActionContainer';
 import LandingPageContainer from '../pages/LandingPage/LandingPageContainer';
 import ShareActionContainer from '../actions/ShareAction/ShareActionContainer';
 import PostGalleryBlockQuery from '../blocks/PostGalleryBlock/PostGalleryBlockQuery';
+import SoftEdgeWidgetAction from '../actions/SoftEdgeWidgetAction/SoftEdgeWidgetAction';
 import SocialDriveActionContainer from '../actions/SocialDriveAction/SocialDriveActionContainer';
 import SixpackExperimentContainer from '../utilities/SixpackExperiment/SixpackExperimentContainer';
 import CampaignGalleryBlockContainer from '../blocks/CampaignGalleryBlock/CampaignGalleryBlockContainer';
@@ -30,7 +31,6 @@ import SubmissionGalleryBlockContainer from '../blocks/SubmissionGalleryBlock/Su
 import VoterRegistrationActionContainer from '../actions/VoterRegistrationAction/VoterRegistrationActionContainer';
 import PetitionSubmissionActionContainer from '../actions/PetitionSubmissioncAction/PetitionSubmissionActionContainer';
 import ReferralSubmissionActionContainer from '../actions/ReferralSubmissionAction/ReferralSubmissionActionContainer';
-
 // If no block is passed, just render an empty "placeholder".
 const DEFAULT_BLOCK: ContentfulEntryJson = { fields: { type: null } };
 
@@ -59,6 +59,7 @@ class ContentfulEntry extends React.Component<Props, State> {
     // Otherwise, find the corresponding component & render it!
     const { json = DEFAULT_BLOCK, className = null } = this.props;
     const type = parseContentfulType(json);
+    console.log('🐶', type);
 
     switch (type) {
       case 'affirmation':
@@ -258,6 +259,9 @@ class ContentfulEntry extends React.Component<Props, State> {
 
       case 'socialDriveAction':
         return <SocialDriveActionContainer {...json.fields} />;
+
+      case 'softEdgeWidgetAction':
+        return <SoftEdgeWidgetAction {...json.fields} />;
 
       case 'static':
         return (

--- a/resources/assets/components/actions/SoftEdgeWidgetAction/SoftEdgeWidgetAction.js
+++ b/resources/assets/components/actions/SoftEdgeWidgetAction/SoftEdgeWidgetAction.js
@@ -14,19 +14,14 @@ class SoftEdgeWidgetAction extends React.Component {
    * Append the SoftEdge to the DOM and add event listener for when it loads.
    */
   initSoftEdgeScript = () => {
-    // Create an item in memory.
     const script = document.createElement('script');
-
-    // Make the source attribute equal to this URL.
     script.src = '//www.congressweb.com/cweb/js/jquery.congressweb.iframe.js';
-
-    // Attach the new script tag to the head of the document.
     document.head.append(script);
     script.addEventListener('load', this.loadSoftEdgeWidget);
   };
 
   /**
-   * Call the SoftEdge method if the congressweb-action-{softEdgeId} object has been added to the window.
+   * Call the SoftEdge method once the SoftEdge script has finished loading and appended to the page.
    */
   loadSoftEdgeWidget = () => {
     const softEdgeId = this.props.softEdgeId;

--- a/resources/assets/components/actions/SoftEdgeWidgetAction/SoftEdgeWidgetAction.js
+++ b/resources/assets/components/actions/SoftEdgeWidgetAction/SoftEdgeWidgetAction.js
@@ -1,13 +1,11 @@
+/* global window, document, $cweb */
+
 import React from 'react';
 import PropTypes from 'prop-types';
 
 import Card from '../../utilities/Card/Card';
 
 class SoftEdgeWidgetAction extends React.Component {
-  constructor(props) {
-    super(props);
-  }
-
   componentDidMount() {
     this.initSoftEdgeScript();
   }
@@ -31,9 +29,9 @@ class SoftEdgeWidgetAction extends React.Component {
    * Call the SoftEdge method if the congressweb-action-{softEdgeId} object has been added to the window.
    */
   loadSoftEdgeWidget = () => {
-    let softEdgeId = this.props.softEdgeId;
+    const softEdgeId = this.props.softEdgeId;
 
-    window.$cweb(function() {
+    window.$cweb(() => {
       $cweb(`#congressweb-action-${softEdgeId}`).congressweb({
         url: `//www.congressweb.com/dosomething/${softEdgeId}`,
         responsive: true,
@@ -51,8 +49,13 @@ class SoftEdgeWidgetAction extends React.Component {
 }
 
 SoftEdgeWidgetAction.propTypes = {
-  title: PropTypes.string,
-  softEdgeId: PropTypes.int,
+  title: PropTypes.string.isRequired,
+  softEdgeId: PropTypes.number.isRequired,
+};
+
+SoftEdgeWidgetAction.defaultProps = {
+  title: null,
+  softEdgeId: null,
 };
 
 export default SoftEdgeWidgetAction;

--- a/resources/assets/components/actions/SoftEdgeWidgetAction/SoftEdgeWidgetAction.js
+++ b/resources/assets/components/actions/SoftEdgeWidgetAction/SoftEdgeWidgetAction.js
@@ -50,4 +50,9 @@ class SoftEdgeWidgetAction extends React.Component {
   }
 }
 
+SoftEdgeWidgetAction.propTypes = {
+  title: PropTypes.string,
+  softEdgeId: PropTypes.int,
+};
+
 export default SoftEdgeWidgetAction;

--- a/resources/assets/components/actions/SoftEdgeWidgetAction/SoftEdgeWidgetAction.js
+++ b/resources/assets/components/actions/SoftEdgeWidgetAction/SoftEdgeWidgetAction.js
@@ -9,7 +9,7 @@ class SoftEdgeWidgetAction extends React.Component {
   }
 
   componentDidMount() {
-    // this.initSoftEdgeScript();
+    this.initSoftEdgeScript();
   }
 
   /**
@@ -17,17 +17,36 @@ class SoftEdgeWidgetAction extends React.Component {
    */
   initSoftEdgeScript = () => {
     // Create an item in memory.
-    const script = document.createElement('script');
+    const softEdgeWidget = document.createElement('softEdgeWidget');
 
     // Make the source attribute equal to this URL.
-    script.src = '//www.congressweb.com/cweb/js/jquery.congressweb.iframe.js';
+    softEdgeWidget.src =
+      '//www.congressweb.com/cweb/js/jquery.congressweb.iframe.js';
 
     // Attach the new script tag to the head of the document.
-    document.head.append(script);
+    document.head.append(softEdgeWidget);
 
-    // @TODO: in the below this.loadSoftEdgeWidget, that is where you'll run the $cweb function.
-    // Maybe something like window.vit.load.$cweb...
-    script.addEventListener('load', this.loadSoftEdgeWidget);
+    softEdgeWidget.addEventListener('load', this.loadSoftEdgeWidget);
+  };
+
+  /**
+   * Call the SoftEdge method if the congressweb-action-{softEdgeId} object has been added to the window.
+   */
+  loadSoftEdgeWidget = () => {
+    console.log('🍑');
+    let softEdgeWidget = `congressweb-action-${this.props.softEdgeId}`;
+
+    if (!window.softEdgeWidget) {
+      console.log('🙊');
+      return;
+    }
+
+    window.load.$cweb(function() {
+      $cweb('#congressweb-action-1').congressweb({
+        url: '//www.congressweb.com/dosomething/1',
+        responsive: true,
+      });
+    });
   };
 
   render() {

--- a/resources/assets/components/actions/SoftEdgeWidgetAction/SoftEdgeWidgetAction.js
+++ b/resources/assets/components/actions/SoftEdgeWidgetAction/SoftEdgeWidgetAction.js
@@ -17,33 +17,25 @@ class SoftEdgeWidgetAction extends React.Component {
    */
   initSoftEdgeScript = () => {
     // Create an item in memory.
-    const softEdgeWidget = document.createElement('softEdgeWidget');
+    const script = document.createElement('script');
 
     // Make the source attribute equal to this URL.
-    softEdgeWidget.src =
-      '//www.congressweb.com/cweb/js/jquery.congressweb.iframe.js';
+    script.src = '//www.congressweb.com/cweb/js/jquery.congressweb.iframe.js';
 
     // Attach the new script tag to the head of the document.
-    document.head.append(softEdgeWidget);
-
-    softEdgeWidget.addEventListener('load', this.loadSoftEdgeWidget);
+    document.head.append(script);
+    script.addEventListener('load', this.loadSoftEdgeWidget);
   };
 
   /**
    * Call the SoftEdge method if the congressweb-action-{softEdgeId} object has been added to the window.
    */
   loadSoftEdgeWidget = () => {
-    console.log('🍑');
-    let softEdgeWidget = `congressweb-action-${this.props.softEdgeId}`;
+    let softEdgeId = this.props.softEdgeId;
 
-    if (!window.softEdgeWidget) {
-      console.log('🙊');
-      return;
-    }
-
-    window.load.$cweb(function() {
-      $cweb('#congressweb-action-1').congressweb({
-        url: '//www.congressweb.com/dosomething/1',
+    window.$cweb(function() {
+      $cweb(`#congressweb-action-${softEdgeId}`).congressweb({
+        url: `//www.congressweb.com/dosomething/${softEdgeId}`,
         responsive: true,
       });
     });
@@ -59,10 +51,3 @@ class SoftEdgeWidgetAction extends React.Component {
 }
 
 export default SoftEdgeWidgetAction;
-
-// <!-- Plugin BEGIN -->
-// <script language="javascript" src="//www.congressweb.com/cweb/js/jquery.congressweb.iframe.js"></script>
-// The below might be the function instead of this.loadVit...play around with this.
-// <script language="javascript">$cweb(function(){ $cweb('#congressweb-action-1').congressweb({ url : '//www.congressweb.com/dosomething/1', responsive  : true }); });</script>
-// <div id="congressweb-action-1"></div>
-// <!-- Plugin END -->

--- a/resources/assets/components/actions/SoftEdgeWidgetAction/SoftEdgeWidgetAction.js
+++ b/resources/assets/components/actions/SoftEdgeWidgetAction/SoftEdgeWidgetAction.js
@@ -1,15 +1,15 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
+import Card from '../../utilities/Card/Card';
+
 class SoftEdgeWidgetAction extends React.Component {
   constructor(props) {
     super(props);
-    console.log('🐶', props);
   }
 
   componentDidMount() {
     // this.initSoftEdgeScript();
-    console.log('👍');
   }
 
   /**
@@ -32,8 +32,9 @@ class SoftEdgeWidgetAction extends React.Component {
 
   render() {
     return (
-      // @TODO: Use JS string literal to add SoftEdge ID.
-      <div id="congressweb-action-1" />
+      <Card className="bordered rounded" title={this.props.title}>
+        <div id={`congressweb-action-${this.props.softEdgeId}`} />
+      </Card>
     );
   }
 }

--- a/resources/assets/components/actions/SoftEdgeWidgetAction/SoftEdgeWidgetAction.js
+++ b/resources/assets/components/actions/SoftEdgeWidgetAction/SoftEdgeWidgetAction.js
@@ -1,0 +1,48 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+class SoftEdgeWidgetAction extends React.Component {
+  constructor(props) {
+    super(props);
+    console.log('🐶', props);
+  }
+
+  componentDidMount() {
+    // this.initSoftEdgeScript();
+    console.log('👍');
+  }
+
+  /**
+   * Append the SoftEdge to the DOM and add event listener for when it loads.
+   */
+  initSoftEdgeScript = () => {
+    // Create an item in memory.
+    const script = document.createElement('script');
+
+    // Make the source attribute equal to this URL.
+    script.src = '//www.congressweb.com/cweb/js/jquery.congressweb.iframe.js';
+
+    // Attach the new script tag to the head of the document.
+    document.head.append(script);
+
+    // @TODO: in the below this.loadSoftEdgeWidget, that is where you'll run the $cweb function.
+    // Maybe something like window.vit.load.$cweb...
+    script.addEventListener('load', this.loadSoftEdgeWidget);
+  };
+
+  render() {
+    return (
+      // @TODO: Use JS string literal to add SoftEdge ID.
+      <div id="congressweb-action-1" />
+    );
+  }
+}
+
+export default SoftEdgeWidgetAction;
+
+// <!-- Plugin BEGIN -->
+// <script language="javascript" src="//www.congressweb.com/cweb/js/jquery.congressweb.iframe.js"></script>
+// The below might be the function instead of this.loadVit...play around with this.
+// <script language="javascript">$cweb(function(){ $cweb('#congressweb-action-1').congressweb({ url : '//www.congressweb.com/dosomething/1', responsive  : true }); });</script>
+// <div id="congressweb-action-1"></div>
+// <!-- Plugin END -->


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR adds the SoftEdge Widget Component to add as an action on a campaign. 

### Any background context you want to provide?
Here are the screenshots before you submit the action: 
![Screen Shot 2019-04-29 at 12 13 25 PM](https://user-images.githubusercontent.com/9019452/56910450-9cc09f80-6a78-11e9-93cf-fbc44bbf00bb.png)

And after the action is submitted: 
![Screen Shot 2019-04-29 at 12 12 17 PM](https://user-images.githubusercontent.com/9019452/56910713-3b4d0080-6a79-11e9-92bf-64f8cebdbba3.png)

We'll need to push this to QA for SoftEdge to view and then customize the CSS for us. [We will ask them to:](https://www.pivotaltracker.com/n/projects/2019313/stories/165456113)
- Remove everything except for the form and email message body.
- Move the send button below the message. 
- Remove fields like prefix, phone number. 
- Isolate parts of the message preview like "Subject" so they aren't in plain text above the body. 
- Ask for code to pre-populate fields and add `northstar_id` and `campaign_id` as hidden fields.

### What are the relevant tickets/cards?

Refs [Pivotal ID #165449125](https://www.pivotaltracker.com/n/projects/2019313/stories/165449125)

@lkpttn do we need to update anything in the campaign playbook for this? 

### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.
* [ ] Added screenshot to PR description of related front-end updates on **small** screens.
* [ ] Added screenshot to PR description of related front-end updates on **medium** screens.
* [ ] Added screenshot to PR description of related front-end updates on **large** screens.
