### PR TITLE
Don't set XSRF-Token cookie if we don't have a persistent session.

### DIFF
--- a/app/Http/Middleware/VerifyCsrfToken.php
+++ b/app/Http/Middleware/VerifyCsrfToken.php
@@ -14,4 +14,22 @@ class VerifyCsrfToken extends BaseVerifier
     protected $except = [
         // ...
     ];
+
+    /**
+     * Add the CSRF token to the response cookies.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Symfony\Component\HttpFoundation\Response  $response
+     * @return \Symfony\Component\HttpFoundation\Response
+     */
+    protected function addCookieToResponse($request, $response)
+    {
+        // If we're not using a persistent session for this request (see logic in
+        // our `StartSession` middleware), then don't set a XSRF-TOKEN cookie:
+        if (config('session.driver') === 'array') {
+            return $response;
+        }
+
+        return parent::addCookieToResponse($request, $response);
+    }
 }


### PR DESCRIPTION
### What does this PR do?

This pull request updates the `VerifyCsrfToken` middleware to _not_ set a `XSRF-Token` cookie if we're not using a persistent session for the request. This is necessary for two reasons:

1. If we're not using a persistent session, the following request's `_token` session variable would never match this cookie (so there's no scenario where this would ever be useful to have).
2. By setting a cookie on the response, we automatically bypass caching with Fastly's default VCL.

I've run through core flows on my local and everything still works as expected.

### Any background context you want to provide?

This is a quick follow-up to #1395.

### What are the relevant tickets/cards?

Refs [Pivotal ID #165515770](https://www.pivotaltracker.com/story/show/165515770).

### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.
* [ ] Added screenshot to PR description of related front-end updates on **small** screens.
* [ ] Added screenshot to PR description of related front-end updates on **medium** screens.
* [ ] Added screenshot to PR description of related front-end updates on **large** screens.