### PR TITLE
Wait until document is ready to render environment badge.

### DIFF
--- a/resources/assets/init.js
+++ b/resources/assets/init.js
@@ -15,6 +15,7 @@
 import React from 'react';
 import ReactDom from 'react-dom';
 import thunk from 'redux-thunk';
+import renderEnvironmentBadge from 'environment-badge';
 import { routerReducer, routerMiddleware } from 'react-router-redux';
 
 import * as reducers from './reducers';
@@ -46,11 +47,8 @@ import { bindNavigationEvents } from './helpers/navigation';
 import { bindFlashMessageEvents } from './helpers/flash-message';
 import { bindAdminDashboardEvents } from './helpers/admin-dashboard';
 
-// Display environment badge on local, dev, or QA:
-require('environment-badge')();
-
-// Configure store & history.
 ready(() => {
+  // Configure store & history.
   const history = historyInit();
   const middleware = [thunk, routerMiddleware(history)];
   const preloadedState = window.STATE || {};
@@ -71,6 +69,9 @@ ready(() => {
 
   // Add event listeners for the Flash Message.
   bindFlashMessageEvents();
+
+  // Display environment badge on local, dev, or QA:
+  renderEnvironmentBadge();
 
   // Add event listeners for the Admin Dashboard.
   if (window.AUTH.isAuthenticated && window.AUTH.role !== 'user') {


### PR DESCRIPTION
### What does this PR do?

This pull request waits until our "document ready" event has fired to render [our environment badge](https://github.com/DoSomething/environment-badge) into the page. This should hopefully clear up a sporadic error (thrown [here](https://git.io/fjZL3)) that I started seeing on QA after deploying the Fastly caching logic in #1395 & #1399 :

```
Exception with thrown value: TypeError: null is not an object (evaluating 'u.appendChild')
```

### Any background context you want to provide?

This is wild! My best guess here is that we were previously "saved" by the time it'd take to download the script ensuring that the rest of the document had already loaded? 😯

### What are the relevant tickets/cards?

Sorta references [Pivotal ID #165515770](https://www.pivotaltracker.com/story/show/165515770).

### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.
* [ ] Added screenshot to PR description of related front-end updates on **small** screens.
* [ ] Added screenshot to PR description of related front-end updates on **medium** screens.
* [ ] Added screenshot to PR description of related front-end updates on **large** screens.