### PR TITLE
Only cache anonymous responses in CDN, not browser caches.

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -29,7 +29,7 @@ class AppServiceProvider extends ServiceProvider
             // If this is an anonymous request, this macro tells Fastly to cache for
             // N seconds so we can handle sudden traffic spikes, e.g. https://git.io/fjs2W
             if (Auth::guest()) {
-                $this->setPublic()->setMaxAge($seconds);
+                $this->setPublic()->setSharedMaxAge($seconds);
             }
 
             return $this;


### PR DESCRIPTION
### What does this PR do?

This pull request swaps our cache headers from `Cache-Control: max-age` into the slightly less aggressive `s-maxage`, which [instructs Fastly to cache the response, but not local browser caches](https://docs.fastly.com/guides/tutorials/cache-control-tutorial).

This should solve an issue we ran into on QA where returning to a page you'd previously visited anonymously would still show the "anonymous" version even after you'd logged in.

### Any background context you want to provide?

💰 

### What are the relevant tickets/cards?

Refs [Pivotal ID #165515770](https://www.pivotaltracker.com/story/show/165515770).

### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.
* [ ] Added screenshot to PR description of related front-end updates on **small** screens.
* [ ] Added screenshot to PR description of related front-end updates on **medium** screens.
* [ ] Added screenshot to PR description of related front-end updates on **large** screens.