### PR TITLE
Affiliate Scholarship Block (Querying & Rendering)

### DIFF
--- a/resources/assets/components/SponsorPromotion/sponsor-promotion.scss
+++ b/resources/assets/components/SponsorPromotion/sponsor-promotion.scss
@@ -71,6 +71,20 @@ $btw-mobile-and-tablet: '(min-width: 860px)';
       }
     }
   }
+
+  // Override styling for affiliate logo appearing on affiliate content (LinkAction, CampaignUpdate)
+  &.affiliate-logo {
+    float: left;
+
+    &.-padded {
+      padding: 0 0 12px 12px;
+    }
+
+    .__copy {
+      color: rgba(173, 173, 173, 1);
+      text-shadow: none;
+    }
+  }
 }
 
 // Promotion Individual
@@ -130,19 +144,5 @@ $btw-mobile-and-tablet: '(min-width: 860px)';
 .promotion--sponsor {
   img {
     height: 50px;
-  }
-}
-
-// Override styling for affiliate logo appearing on affiliate content (LinkAction, CampaignUpdate)
-.affiliate-logo {
-  float: left;
-
-  &.-padded {
-    padding: 0 0 12px 12px;
-  }
-
-  .__copy {
-    color: rgba(173, 173, 173, 1);
-    text-shadow: none;
   }
 }

--- a/resources/assets/components/blocks/AffiliateScholarshipBlock/AffiliateScholarshipBlock.js
+++ b/resources/assets/components/blocks/AffiliateScholarshipBlock/AffiliateScholarshipBlock.js
@@ -38,7 +38,9 @@ const AffiliateScholarshipBlock = ({
         <div className="scholarship-information__amount">
           <p className="font-bold">AMOUNT</p>
           <p className="scholarship-amount league-gothic margin-top-none">
-            ${scholarshipAmount.toLocaleString()}
+            {scholarshipAmount
+              ? `$${scholarshipAmount.toLocaleString()}`
+              : 'N/A'}
           </p>
         </div>
 
@@ -46,9 +48,11 @@ const AffiliateScholarshipBlock = ({
           <div className="scholarship-deadline">
             <p className="font-bold">DEADLINE</p>
             <p className="margin-top-sm">
-              {format(scholarshipDeadline, 'MMMM do, YYYY', {
-                awareOfUnicodeTokens: true,
-              })}
+              {scholarshipDeadline
+                ? format(scholarshipDeadline, 'MMMM do, YYYY', {
+                    awareOfUnicodeTokens: true,
+                  })
+                : 'N/A'}
             </p>
           </div>
 

--- a/resources/assets/components/blocks/AffiliateScholarshipBlock/AffiliateScholarshipBlock.js
+++ b/resources/assets/components/blocks/AffiliateScholarshipBlock/AffiliateScholarshipBlock.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { format } from 'date-fns';
 import PropTypes from 'prop-types';
+import classNames from 'classnames';
 
 import Card from '../../utilities/Card/Card';
 
@@ -9,10 +10,16 @@ import './affiliate-scholarship-block.scss';
 const AffiliateScholarshipBlock = ({
   affiliateLogo,
   affiliateTitle,
+  className,
   scholarshipAmount,
   scholarshipDeadline,
 }) => (
-  <Card className="rounded bordered padded affiliate-scholarship-block">
+  <Card
+    className={classNames(
+      'rounded bordered padded affiliate-scholarship-block',
+      className,
+    )}
+  >
     {affiliateLogo ? (
       <img
         className="affiliate-logo"
@@ -69,6 +76,7 @@ AffiliateScholarshipBlock.propTypes = {
     url: PropTypes.string.isRequired,
     description: PropTypes.string,
   }),
+  className: PropTypes.string,
   scholarshipAmount: PropTypes.number.isRequired,
   scholarshipDeadline: PropTypes.string.isRequired,
 };
@@ -76,6 +84,7 @@ AffiliateScholarshipBlock.propTypes = {
 AffiliateScholarshipBlock.defaultProps = {
   affiliateTitle: null,
   affiliateLogo: null,
+  className: null,
 };
 
 export default AffiliateScholarshipBlock;

--- a/resources/assets/components/blocks/AffiliateScholarshipBlock/AffiliateScholarshipBlock.js
+++ b/resources/assets/components/blocks/AffiliateScholarshipBlock/AffiliateScholarshipBlock.js
@@ -11,63 +11,57 @@ const AffiliateScholarshipBlock = ({
   affiliateTitle,
   scholarshipAmount,
   scholarshipDeadline,
-}) =>
-  affiliateLogo &&
-  affiliateTitle &&
-  scholarshipAmount &&
-  scholarshipDeadline ? (
-    <Card className="rounded bordered padded affiliate-scholarship-block">
-      {affiliateLogo ? (
-        <img
-          className="affiliate-logo"
-          src={affiliateLogo.url}
-          alt={affiliateLogo.description || 'Affiliate logo'}
-        />
-      ) : null}
+}) => (
+  <Card className="rounded bordered padded affiliate-scholarship-block">
+    {affiliateLogo ? (
+      <img
+        className="affiliate-logo"
+        src={affiliateLogo.url}
+        alt={affiliateLogo.description || 'Affiliate logo'}
+      />
+    ) : null}
 
-      <p className="margin-top-sm padding-bottom-md">
-        <strong>
-          Welcome to DoSomething.org
-          {affiliateTitle ? ` via ${affiliateTitle.toUpperCase()}` : null}!
-        </strong>{' '}
-        Ready to earn scholarships for doing good? Just follow the simple
-        instructions below for the chance to win. Let’s Do This!
-      </p>
+    <p className="margin-top-sm padding-bottom-md">
+      <strong>
+        Welcome to DoSomething.org
+        {affiliateTitle ? ` via ${affiliateTitle.toUpperCase()}` : null}!
+      </strong>{' '}
+      Ready to earn scholarships for doing good? Just follow the simple
+      instructions below for the chance to win. Let’s Do This!
+    </p>
 
-      <div className="scholarship-information">
-        <div className="scholarship-information__amount">
-          <p className="font-bold">AMOUNT</p>
-          <p className="scholarship-amount league-gothic margin-top-none">
-            {scholarshipAmount
-              ? `$${scholarshipAmount.toLocaleString()}`
+    <div className="scholarship-information">
+      <div className="scholarship-information__amount">
+        <p className="font-bold">AMOUNT</p>
+        <p className="scholarship-amount league-gothic margin-top-none">
+          {scholarshipAmount ? `$${scholarshipAmount.toLocaleString()}` : 'N/A'}
+        </p>
+      </div>
+
+      <div className="scholarship-information__details">
+        <div className="scholarship-deadline">
+          <p className="font-bold">DEADLINE</p>
+          <p className="margin-top-sm">
+            {scholarshipDeadline
+              ? format(scholarshipDeadline, 'MMMM do, YYYY', {
+                  awareOfUnicodeTokens: true,
+                })
               : 'N/A'}
           </p>
         </div>
 
-        <div className="scholarship-information__details">
-          <div className="scholarship-deadline">
-            <p className="font-bold">DEADLINE</p>
-            <p className="margin-top-sm">
-              {scholarshipDeadline
-                ? format(scholarshipDeadline, 'MMMM do, YYYY', {
-                    awareOfUnicodeTokens: true,
-                  })
-                : 'N/A'}
-            </p>
-          </div>
-
-          <div className="scholarship-requirements">
-            <p className="font-bold">REQUIREMENTS</p>
-            <ul className="margin-top-sm list">
-              <li>13-25 years old</li>
-              <li>No minimum GPA</li>
-              <li>No essay</li>
-            </ul>
-          </div>
+        <div className="scholarship-requirements">
+          <p className="font-bold">REQUIREMENTS</p>
+          <ul className="margin-top-sm list">
+            <li>13-25 years old</li>
+            <li>No minimum GPA</li>
+            <li>No essay</li>
+          </ul>
         </div>
       </div>
-    </Card>
-  ) : null;
+    </div>
+  </Card>
+);
 
 AffiliateScholarshipBlock.propTypes = {
   affiliateTitle: PropTypes.string,

--- a/resources/assets/components/blocks/AffiliateScholarshipBlock/AffiliateScholarshipBlock.js
+++ b/resources/assets/components/blocks/AffiliateScholarshipBlock/AffiliateScholarshipBlock.js
@@ -3,7 +3,6 @@ import { format } from 'date-fns';
 import PropTypes from 'prop-types';
 
 import Card from '../../utilities/Card/Card';
-import { contentfulImageUrl } from '../../../helpers';
 
 import './affiliate-scholarship-block.scss';
 
@@ -18,14 +17,18 @@ const AffiliateScholarshipBlock = ({
   scholarshipAmount &&
   scholarshipDeadline ? (
     <Card className="rounded bordered padded affiliate-scholarship-block">
-      <img
-        src={contentfulImageUrl(affiliateLogo, '100')}
-        alt="Affiliate logo"
-      />
+      {affiliateLogo ? (
+        <img
+          className="affiliate-logo"
+          src={affiliateLogo.url}
+          alt={affiliateLogo.description || 'Affiliate logo'}
+        />
+      ) : null}
 
       <p className="margin-top-sm padding-bottom-md">
         <strong>
-          Welcome to DoSomething.org via {affiliateTitle.toUpperCase()}!
+          Welcome to DoSomething.org
+          {affiliateTitle ? ` via ${affiliateTitle.toUpperCase()}` : null}!
         </strong>{' '}
         Ready to earn scholarships for doing good? Just follow the simple
         instructions below for the chance to win. Let’s Do This!
@@ -63,10 +66,18 @@ const AffiliateScholarshipBlock = ({
   ) : null;
 
 AffiliateScholarshipBlock.propTypes = {
-  affiliateTitle: PropTypes.string.isRequired,
-  affiliateLogo: PropTypes.string.isRequired,
+  affiliateTitle: PropTypes.string,
+  affiliateLogo: PropTypes.shape({
+    url: PropTypes.string.isRequired,
+    description: PropTypes.string,
+  }),
   scholarshipAmount: PropTypes.number.isRequired,
   scholarshipDeadline: PropTypes.string.isRequired,
+};
+
+AffiliateScholarshipBlock.defaultProps = {
+  affiliateTitle: null,
+  affiliateLogo: null,
 };
 
 export default AffiliateScholarshipBlock;

--- a/resources/assets/components/blocks/AffiliateScholarshipBlock/AffiliateScholarshipBlock.js
+++ b/resources/assets/components/blocks/AffiliateScholarshipBlock/AffiliateScholarshipBlock.js
@@ -38,24 +38,26 @@ const AffiliateScholarshipBlock = ({
     </p>
 
     <div className="scholarship-information">
-      <div className="scholarship-information__amount">
-        <p className="font-bold">AMOUNT</p>
-        <p className="scholarship-amount league-gothic margin-top-none">
-          {scholarshipAmount ? `$${scholarshipAmount.toLocaleString()}` : 'N/A'}
-        </p>
-      </div>
-
-      <div className="scholarship-information__details">
-        <div className="scholarship-deadline">
-          <p className="font-bold">DEADLINE</p>
-          <p className="margin-top-sm">
-            {scholarshipDeadline
-              ? format(scholarshipDeadline, 'MMMM do, YYYY', {
-                  awareOfUnicodeTokens: true,
-                })
-              : 'N/A'}
+      {scholarshipAmount ? (
+        <div className="scholarship-information__amount">
+          <p className="font-bold">AMOUNT</p>
+          <p className="scholarship-amount league-gothic margin-top-none">
+            ${scholarshipAmount.toLocaleString()}
           </p>
         </div>
+      ) : null}
+
+      <div className="scholarship-information__details">
+        {scholarshipDeadline ? (
+          <div className="scholarship-deadline">
+            <p className="font-bold">DEADLINE</p>
+            <p className="margin-top-sm">
+              {format(scholarshipDeadline, 'MMMM do, YYYY', {
+                awareOfUnicodeTokens: true,
+              })}
+            </p>
+          </div>
+        ) : null}
 
         <div className="scholarship-requirements">
           <p className="font-bold">REQUIREMENTS</p>

--- a/resources/assets/components/blocks/AffiliateScholarshipBlock/AffiliateScholarshipBlockQuery.js
+++ b/resources/assets/components/blocks/AffiliateScholarshipBlock/AffiliateScholarshipBlockQuery.js
@@ -16,7 +16,7 @@ const AFFILIATE_QUERY = gql`
       title
       logo {
         description
-        url(w: 300, h: 100)
+        url(h: 100)
       }
     }
   }

--- a/resources/assets/components/blocks/AffiliateScholarshipBlock/AffiliateScholarshipBlockQuery.js
+++ b/resources/assets/components/blocks/AffiliateScholarshipBlock/AffiliateScholarshipBlockQuery.js
@@ -1,0 +1,61 @@
+import React from 'react';
+import { get } from 'lodash';
+import gql from 'graphql-tag';
+import PropTypes from 'prop-types';
+import { Query } from 'react-apollo';
+
+import { env } from '../../../helpers';
+import AffiliateScholarshipBlock from './AffiliateScholarshipBlock';
+
+/**
+ * The GraphQL query to load data for this component.
+ */
+const AFFILIATE_QUERY = gql`
+  query AffiliateQuery($utmLabel: String!, $preview: Boolean!) {
+    affiliate(utmLabel: $utmLabel, preview: $preview) {
+      title
+      logo {
+        description
+        url(w: 300, h: 100)
+      }
+    }
+  }
+`;
+
+/**
+ * Fetch results via GraphQL using a query component.
+ */
+const AffiliateScholarshipBlockQuery = props => (
+  <Query
+    query={AFFILIATE_QUERY}
+    queryName="affiliateByUtmLabel"
+    variables={{
+      utmLabel: props.utmLabel,
+      preview: env('CONTENTFUL_USE_PREVIEW_API'),
+    }}
+  >
+    {({ loading, data }) => {
+      if (loading) {
+        return <div className="spinner -centered" />;
+      }
+
+      const title = get(data, 'affiliate.title');
+      const logo = get(data, 'affiliate.logo');
+
+      return (
+        <AffiliateScholarshipBlock
+          affiliateTitle={title}
+          affiliateLogo={logo}
+          {...props}
+        />
+      );
+    }}
+  </Query>
+);
+
+AffiliateScholarshipBlockQuery.propTypes = {
+  utmLabel: PropTypes.string.isRequired,
+};
+
+// Export the GraphQL query component.
+export default AffiliateScholarshipBlockQuery;

--- a/resources/assets/components/blocks/AffiliateScholarshipBlock/affiliate-scholarship-block.scss
+++ b/resources/assets/components/blocks/AffiliateScholarshipBlock/affiliate-scholarship-block.scss
@@ -39,4 +39,8 @@
   .scholarship-amount {
     font-size: 85px;
   }
+
+  .affiliate-logo {
+    max-height: 50px;
+  }
 }

--- a/resources/assets/components/blocks/AffiliateScholarshipBlock/affiliate-scholarship-block.scss
+++ b/resources/assets/components/blocks/AffiliateScholarshipBlock/affiliate-scholarship-block.scss
@@ -5,8 +5,10 @@
   $border-style: 1px solid $primary-border-color;
 
   .scholarship-information,
-  .scholarship-deadline,
-  .scholarship-requirements {
+  // Only add border-top to first scholarship detail item *if* scholarship amount is present.
+  .scholarship-information__amount + .scholarship-information__details > :first-child,
+  // Any children following the first one should definitely have a border-top.
+  .scholarship-information__details > :nth-child(n+2) {
     border-top: $border-style;
     padding-top: $half-spacing;
   }
@@ -22,14 +24,16 @@
       .scholarship-information__amount {
         flex-basis: 50%;
         border-right: $border-style;
+        margin-right: $half-spacing;
       }
 
       .scholarship-information__details {
         flex-basis: 50%;
-        padding-left: $half-spacing;
+        // Will grow to full width if scholarship amount is missing.
+        flex-grow: 1;
       }
 
-      .scholarship-deadline {
+      .scholarship-information__details > :first-child {
         border-top: none;
         padding-top: 0;
       }

--- a/resources/assets/components/pages/LandingPage/templates/PitchTemplate.js
+++ b/resources/assets/components/pages/LandingPage/templates/PitchTemplate.js
@@ -12,16 +12,16 @@ const PitchTemplate = ({
   scholarshipDeadline,
   sidebarCTA,
 }) => {
-  const scholarshipAffiliate = getScholarshipAffiliateLabel();
+  const scholarshipAffiliateLabel = getScholarshipAffiliateLabel();
   const displayAffiliateScholarshipBlock =
-    scholarshipAffiliate && scholarshipAmount && scholarshipDeadline;
+    scholarshipAffiliateLabel && scholarshipAmount && scholarshipDeadline;
 
   return (
     <div className="campaign-page">
       <div className="primary">
         {displayAffiliateScholarshipBlock ? (
           <AffiliateScholarshipBlockQuery
-            utmLabel={scholarshipAffiliate}
+            utmLabel={scholarshipAffiliateLabel}
             scholarshipAmount={scholarshipAmount}
             scholarshipDeadline={scholarshipDeadline}
             className="margin-bottom-lg"

--- a/resources/assets/components/pages/LandingPage/templates/PitchTemplate.js
+++ b/resources/assets/components/pages/LandingPage/templates/PitchTemplate.js
@@ -2,23 +2,46 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import Card from '../../../utilities/Card/Card';
+import { getScholarshipAffiliateLabel } from '../../../../helpers';
 import TextContent from '../../../utilities/TextContent/TextContent';
+import AffiliateScholarshipBlockQuery from '../../../blocks/AffiliateScholarshipBlock/AffiliateScholarshipBlockQuery';
 
-const PitchTemplate = ({ content, sidebarCTA }) => (
-  <div className="campaign-page pitch-page">
-    <div className="primary">
-      <TextContent>{content}</TextContent>
+const PitchTemplate = ({
+  content,
+  scholarshipAmount,
+  scholarshipDeadline,
+  sidebarCTA,
+}) => {
+  const scholarshipAffiliate = getScholarshipAffiliateLabel();
+  const displayAffiliateScholarshipBlock =
+    scholarshipAffiliate && scholarshipAmount && scholarshipDeadline;
+
+  return (
+    <div className="campaign-page">
+      <div className="primary">
+        {displayAffiliateScholarshipBlock ? (
+          <AffiliateScholarshipBlockQuery
+            utmLabel={scholarshipAffiliate}
+            scholarshipAmount={scholarshipAmount}
+            scholarshipDeadline={scholarshipDeadline}
+            className="margin-bottom-lg"
+          />
+        ) : null}
+        <TextContent>{content}</TextContent>
+      </div>
+      <div className="secondary">
+        <Card title={sidebarCTA.title} className="rounded bordered">
+          <TextContent className="padded">{sidebarCTA.content}</TextContent>
+        </Card>
+      </div>
     </div>
-    <div className="secondary">
-      <Card title={sidebarCTA.title} className="rounded bordered">
-        <TextContent className="padded">{sidebarCTA.content}</TextContent>
-      </Card>
-    </div>
-  </div>
-);
+  );
+};
 
 PitchTemplate.propTypes = {
   content: PropTypes.string.isRequired,
+  scholarshipAmount: PropTypes.number,
+  scholarshipDeadline: PropTypes.string,
   sidebarCTA: PropTypes.shape({
     title: PropTypes.string,
     content: PropTypes.string,
@@ -26,6 +49,8 @@ PitchTemplate.propTypes = {
 };
 
 PitchTemplate.defaultProps = {
+  scholarshipAmount: null,
+  scholarshipDeadline: null,
   sidebarCTA: {
     title: 'what you get',
     content: '*You could win a $5,000 dollar scholarship!*',

--- a/resources/assets/helpers/index.js
+++ b/resources/assets/helpers/index.js
@@ -787,6 +787,20 @@ export function isActionPage(page) {
 }
 
 /**
+ * Get the Scholarship Affiliate Referrer's UTM Label.
+ *
+ * @return {String|Undefined|Null}
+ */
+export function getScholarshipAffiliateLabel() {
+  const utmMedium = query('utm_medium');
+  const utmCampaign = query('utm_campaign');
+
+  // If the utm_medium contains 'scholarship', we assume this visit to be a scholarship
+  // affiliate referral, and use the utm_campaign to determine the affiliate UTM label.
+  return utmMedium && utmMedium.includes('scholarship') ? utmCampaign : null;
+}
+
+/**
  * Toggle the specified class on the given target element
  * when the button element is clicked or touched.
  *


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR adds more fleshed out rendering and logic to display the Affiliate Scholarship card!

- https://github.com/DoSomething/phoenix-next/commit/6981b83b106c1c52a9961deb67d7fa9c54ced5b9 Adds an `AffiliateScholarshipBlockQuery` which attempts to find the corrosponding Affiliate entry from graphQL and renders the `AffiliateScholarshipBlock`.
- https://github.com/DoSomething/phoenix-next/commit/6bb685ccdac4661bc928cc436e921497ee88df4d, https://github.com/DoSomething/phoenix-next/commit/504d47ea03158e7044576b726fa068a0550cf619, https://github.com/DoSomething/phoenix-next/commit/504d47ea03158e7044576b726fa068a0550cf619, https://github.com/DoSomething/phoenix-next/commit/29b87d4b1fe689f9c19e72dbc88069719d858284 and https://github.com/DoSomething/phoenix-next/commit/de3af7ae26e15762c7f3028b7d5944005df2a2e0 update and fully flesh out the `AffiliateScholarshipBlock` component to support the proper affiliate `props`, scholarship props, and `className`
- https://github.com/DoSomething/phoenix-next/commit/5453d88c1bc7d6b92d9f7a99b22be1e39cd1039c adds a new helper to fetch the UTM Label - if applicable - from the referring scholarship affiliate via the UTM params.
- https://github.com/DoSomething/phoenix-next/commit/e941e01fa1d7c7b31bfea5e3e0e8e73f7d1f6518 Updates the `PitchPage` to render out the `AffiliateScholarshipBlockQuery` if we have the necessary information to do so.


### What are the relevant tickets/cards?

Refs [Pivotal ID #165599975](https://www.pivotaltracker.com/story/show/165599975)
https://github.com/DoSomething/graphql/pull/104

### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.

Visually, this should be the same as it was in #1387 
