### PR TITLE
Downcase UTM label passed to scholarship affiliate block query

### DIFF
--- a/resources/assets/components/pages/LandingPage/templates/PitchTemplate.js
+++ b/resources/assets/components/pages/LandingPage/templates/PitchTemplate.js
@@ -21,7 +21,7 @@ const PitchTemplate = ({
       <div className="primary">
         {displayAffiliateScholarshipBlock ? (
           <AffiliateScholarshipBlockQuery
-            utmLabel={scholarshipAffiliateLabel}
+            utmLabel={scholarshipAffiliateLabel.toLowerCase()}
             scholarshipAmount={scholarshipAmount}
             scholarshipDeadline={scholarshipDeadline}
             className="margin-bottom-lg"


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR ensures the UTM label that we pass to the `AffiliateScholarshipBlockQuery` in the `PitchPage` is lowercased. 

### Any background context you want to provide?
We've found some capitalized letters in use in some of the `utm` parameters used for scholarship listings. We've opted to only allow Affiliates to be `utmLabel`ed with lower case letters (for searchability purposes), so this will ensure that the proper affiliate is surfaced!

### What are the relevant tickets/cards?
https://github.com/DoSomething/phoenix-next/pull/1394#discussion_r278691258
Refs [Pivotal ID #165599975](https://www.pivotaltracker.com/story/show/165599975)

### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.
