### PR TITLE
Pre-populated SoftEdge form

### DIFF
--- a/resources/assets/components/ContentfulEntry/ContentfulEntry.js
+++ b/resources/assets/components/ContentfulEntry/ContentfulEntry.js
@@ -22,7 +22,7 @@ import LandingPageContainer from '../pages/LandingPage/LandingPageContainer';
 import ShareActionContainer from '../actions/ShareAction/ShareActionContainer';
 import SixpackExperiment from '../utilities/SixpackExperiment/SixpackExperiment';
 import PostGalleryBlockQuery from '../blocks/PostGalleryBlock/PostGalleryBlockQuery';
-import SoftEdgeWidgetAction from '../actions/SoftEdgeWidgetAction/SoftEdgeWidgetAction';
+import SoftEdgeWidgetActionContainer from '../actions/SoftEdgeWidgetAction/SoftEdgeWidgetActionContainer';
 import SocialDriveActionContainer from '../actions/SocialDriveAction/SocialDriveActionContainer';
 import CampaignGalleryBlockContainer from '../blocks/CampaignGalleryBlock/CampaignGalleryBlockContainer';
 import TextSubmissionActionContainer from '../actions/TextSubmissionAction/TextSubmissionActionContainer';
@@ -257,7 +257,7 @@ class ContentfulEntry extends React.Component<Props, State> {
         return <SocialDriveActionContainer {...json.fields} />;
 
       case 'softEdgeWidgetAction':
-        return <SoftEdgeWidgetAction {...json.fields} />;
+        return <SoftEdgeWidgetActionContainer {...json.fields} />;
 
       case 'static':
         return (

--- a/resources/assets/components/actions/SoftEdgeWidgetAction/SoftEdgeWidgetAction.js
+++ b/resources/assets/components/actions/SoftEdgeWidgetAction/SoftEdgeWidgetAction.js
@@ -25,10 +25,15 @@ class SoftEdgeWidgetAction extends React.Component {
    */
   loadSoftEdgeWidget = () => {
     const softEdgeId = this.props.softEdgeId;
+    let url = '//www.congressweb.com/dosomething/' + softEdgeId;
+
+    console.log('🍎', this.props);
+
+    // + '?acceptAuthor=true&firstName=Chloe';
 
     window.$cweb(() => {
       $cweb(`#congressweb-action-${softEdgeId}`).congressweb({
-        url: `//www.congressweb.com/dosomething/${softEdgeId}`,
+        url: `${url}`,
         responsive: true,
       });
     });

--- a/resources/assets/components/actions/SoftEdgeWidgetAction/SoftEdgeWidgetAction.js
+++ b/resources/assets/components/actions/SoftEdgeWidgetAction/SoftEdgeWidgetAction.js
@@ -4,10 +4,6 @@ import PropTypes from 'prop-types';
 
 import Card from '../../utilities/Card/Card';
 
-// const SoftEdgeWidgetAction = props => (
-//   console.log('🔮', props);
-// );
-
 class SoftEdgeWidgetAction extends React.Component {
   componentDidMount() {
     this.initSoftEdgeScript();
@@ -28,12 +24,24 @@ class SoftEdgeWidgetAction extends React.Component {
    */
   loadSoftEdgeWidget = () => {
     const softEdgeId = this.props.softEdgeId;
-    // const url = '//www.congressweb.com/dosomething/' + softEdgeId;
-    // + '?acceptAuthor=true&firstName=Chloe';
-    console.log('🐶', this.props);
+    let url = `//www.congressweb.com/dosomething/${softEdgeId}?acceptAuthor=true`;
+
+    const prepopulatedFields = {
+      firstName: this.props.user.firstName,
+      lastName: this.props.user.lastName,
+      email: this.props.user.email,
+      mobile: this.props.user.mobile,
+    };
+
+    Object.keys(prepopulatedFields).forEach(key => {
+      if (prepopulatedFields[key] != null) {
+        url += `&${key}=${prepopulatedFields[key]}`;
+      }
+    });
+
     window.$cweb(() => {
       $cweb(`#congressweb-action-${softEdgeId}`).congressweb({
-        url: `//www.congressweb.com/dosomething/${softEdgeId}`,
+        url: `${url}`,
         responsive: true,
       });
     });
@@ -51,11 +59,13 @@ class SoftEdgeWidgetAction extends React.Component {
 SoftEdgeWidgetAction.propTypes = {
   title: PropTypes.string.isRequired,
   softEdgeId: PropTypes.number.isRequired,
+  user: PropTypes.object.isRequired,
 };
 
 SoftEdgeWidgetAction.defaultProps = {
   title: null,
   softEdgeId: null,
+  user: null,
 };
 
 export default SoftEdgeWidgetAction;

--- a/resources/assets/components/actions/SoftEdgeWidgetAction/SoftEdgeWidgetAction.js
+++ b/resources/assets/components/actions/SoftEdgeWidgetAction/SoftEdgeWidgetAction.js
@@ -72,7 +72,7 @@ SoftEdgeWidgetAction.propTypes = {
 SoftEdgeWidgetAction.defaultProps = {
   title: null,
   softEdgeId: null,
-  user: null,
+  user: {},
   userId: null,
 };
 

--- a/resources/assets/components/actions/SoftEdgeWidgetAction/SoftEdgeWidgetAction.js
+++ b/resources/assets/components/actions/SoftEdgeWidgetAction/SoftEdgeWidgetAction.js
@@ -64,12 +64,14 @@ SoftEdgeWidgetAction.propTypes = {
   title: PropTypes.string.isRequired,
   softEdgeId: PropTypes.number.isRequired,
   user: PropTypes.object.isRequired,
+  userId: PropTypes.string.isRequired,
 };
 
 SoftEdgeWidgetAction.defaultProps = {
   title: null,
   softEdgeId: null,
   user: null,
+  userId: null,
 };
 
 export default SoftEdgeWidgetAction;

--- a/resources/assets/components/actions/SoftEdgeWidgetAction/SoftEdgeWidgetAction.js
+++ b/resources/assets/components/actions/SoftEdgeWidgetAction/SoftEdgeWidgetAction.js
@@ -25,19 +25,20 @@ class SoftEdgeWidgetAction extends React.Component {
    */
   loadSoftEdgeWidget = () => {
     const softEdgeId = this.props.softEdgeId;
+    const user = this.props.user;
     let url = `//www.congressweb.com/dosomething/${softEdgeId}?acceptAuthor=true&memberId=${
       this.props.userId
     }`;
 
     const prepopulatedFields = withoutNulls({
-      firstName: this.props.user.firstName,
-      lastName: this.props.user.lastName,
-      email: this.props.user.email,
-      mobile: this.props.user.mobile,
-      address: this.props.user.addrStreet1,
-      city: this.props.user.addrCity,
-      state: this.props.user.addrState,
-      zip: this.props.user.addrZip,
+      firstName: user.firstName,
+      lastName: user.lastName,
+      email: user.email,
+      mobile: user.mobile,
+      address: user.addrStreet1,
+      city: user.addrCity,
+      state: user.addrState,
+      zip: user.addrZip,
     });
 
     Object.keys(prepopulatedFields).forEach(key => {

--- a/resources/assets/components/actions/SoftEdgeWidgetAction/SoftEdgeWidgetAction.js
+++ b/resources/assets/components/actions/SoftEdgeWidgetAction/SoftEdgeWidgetAction.js
@@ -47,7 +47,7 @@ class SoftEdgeWidgetAction extends React.Component {
 
     window.$cweb(() => {
       $cweb(`#congressweb-action-${softEdgeId}`).congressweb({
-        url: `${url}`,
+        url,
         responsive: true,
       });
     });

--- a/resources/assets/components/actions/SoftEdgeWidgetAction/SoftEdgeWidgetAction.js
+++ b/resources/assets/components/actions/SoftEdgeWidgetAction/SoftEdgeWidgetAction.js
@@ -3,6 +3,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import Card from '../../utilities/Card/Card';
+import { withoutNulls } from '../../../helpers';
 
 class SoftEdgeWidgetAction extends React.Component {
   componentDidMount() {
@@ -28,7 +29,7 @@ class SoftEdgeWidgetAction extends React.Component {
       this.props.userId
     }`;
 
-    const prepopulatedFields = {
+    const prepopulatedFields = withoutNulls({
       firstName: this.props.user.firstName,
       lastName: this.props.user.lastName,
       email: this.props.user.email,
@@ -37,12 +38,10 @@ class SoftEdgeWidgetAction extends React.Component {
       city: this.props.user.addrCity,
       state: this.props.user.addrState,
       zip: this.props.user.addrZip,
-    };
+    });
 
     Object.keys(prepopulatedFields).forEach(key => {
-      if (prepopulatedFields[key] != null) {
-        url += `&${key}=${prepopulatedFields[key]}`;
-      }
+      url += `&${key}=${prepopulatedFields[key]}`;
     });
 
     window.$cweb(() => {

--- a/resources/assets/components/actions/SoftEdgeWidgetAction/SoftEdgeWidgetAction.js
+++ b/resources/assets/components/actions/SoftEdgeWidgetAction/SoftEdgeWidgetAction.js
@@ -31,6 +31,10 @@ class SoftEdgeWidgetAction extends React.Component {
       lastName: this.props.user.lastName,
       email: this.props.user.email,
       mobile: this.props.user.mobile,
+      address: this.props.user.addrStreet1,
+      city: this.props.user.addrCity,
+      state: this.props.user.addrState,
+      zip: this.props.user.addrZip,
     };
 
     Object.keys(prepopulatedFields).forEach(key => {

--- a/resources/assets/components/actions/SoftEdgeWidgetAction/SoftEdgeWidgetAction.js
+++ b/resources/assets/components/actions/SoftEdgeWidgetAction/SoftEdgeWidgetAction.js
@@ -1,9 +1,12 @@
 /* global window, document, $cweb */
-
 import React from 'react';
 import PropTypes from 'prop-types';
 
 import Card from '../../utilities/Card/Card';
+
+// const SoftEdgeWidgetAction = props => (
+//   console.log('🔮', props);
+// );
 
 class SoftEdgeWidgetAction extends React.Component {
   componentDidMount() {
@@ -25,15 +28,12 @@ class SoftEdgeWidgetAction extends React.Component {
    */
   loadSoftEdgeWidget = () => {
     const softEdgeId = this.props.softEdgeId;
-    let url = '//www.congressweb.com/dosomething/' + softEdgeId;
-
-    console.log('🍎', this.props);
-
+    // const url = '//www.congressweb.com/dosomething/' + softEdgeId;
     // + '?acceptAuthor=true&firstName=Chloe';
-
+    console.log('🐶', this.props);
     window.$cweb(() => {
       $cweb(`#congressweb-action-${softEdgeId}`).congressweb({
-        url: `${url}`,
+        url: `//www.congressweb.com/dosomething/${softEdgeId}`,
         responsive: true,
       });
     });

--- a/resources/assets/components/actions/SoftEdgeWidgetAction/SoftEdgeWidgetAction.js
+++ b/resources/assets/components/actions/SoftEdgeWidgetAction/SoftEdgeWidgetAction.js
@@ -24,7 +24,9 @@ class SoftEdgeWidgetAction extends React.Component {
    */
   loadSoftEdgeWidget = () => {
     const softEdgeId = this.props.softEdgeId;
-    let url = `//www.congressweb.com/dosomething/${softEdgeId}?acceptAuthor=true`;
+    let url = `//www.congressweb.com/dosomething/${softEdgeId}?acceptAuthor=true&memberId=${
+      this.props.userId
+    }`;
 
     const prepopulatedFields = {
       firstName: this.props.user.firstName,

--- a/resources/assets/components/actions/SoftEdgeWidgetAction/SoftEdgeWidgetActionContainer.js
+++ b/resources/assets/components/actions/SoftEdgeWidgetAction/SoftEdgeWidgetActionContainer.js
@@ -1,0 +1,1 @@
+SoftEdgeWidgetActionContainer.js;

--- a/resources/assets/components/actions/SoftEdgeWidgetAction/SoftEdgeWidgetActionContainer.js
+++ b/resources/assets/components/actions/SoftEdgeWidgetAction/SoftEdgeWidgetActionContainer.js
@@ -1,1 +1,15 @@
-SoftEdgeWidgetActionContainer.js;
+import { connect } from 'react-redux';
+
+import UserQuery from './UserQuery';
+import { getUserId } from '../../../selectors/user';
+
+/**
+ * Provide state from the Redux store as props for this component.
+ */
+const mapStateToProps = state => ({
+  userId: getUserId(state),
+  title: state.title,
+  softEdgeId: state.softEdgeId,
+});
+
+export default connect(mapStateToProps)(UserQuery);

--- a/resources/assets/components/actions/SoftEdgeWidgetAction/SoftEdgeWidgetActionContainer.js
+++ b/resources/assets/components/actions/SoftEdgeWidgetAction/SoftEdgeWidgetActionContainer.js
@@ -8,8 +8,6 @@ import { getUserId } from '../../../selectors/user';
  */
 const mapStateToProps = state => ({
   userId: getUserId(state),
-  title: state.title,
-  softEdgeId: state.softEdgeId,
 });
 
 export default connect(mapStateToProps)(UserQuery);

--- a/resources/assets/components/actions/SoftEdgeWidgetAction/UserQuery.js
+++ b/resources/assets/components/actions/SoftEdgeWidgetAction/UserQuery.js
@@ -6,8 +6,8 @@ import ErrorBlock from '../../ErrorBlock/ErrorBlock';
 import SoftEdgeWidgetAction from './SoftEdgeWidgetAction';
 
 const ACCOUNT_QUERY = gql`
-  query AccountQuery(props.userId: String!) {
-    user(id: props.userId) {
+  query AccountQuery($userId: String!) {
+    user(id: $userId) {
       id
       firstName
       lastName
@@ -17,25 +17,22 @@ const ACCOUNT_QUERY = gql`
   }
 `;
 
-const UserQuery = ({ props }) => (
+const UserQuery = props => (
   <Query
     query={ACCOUNT_QUERY}
     queryName="user"
     variables={{ userId: props.userId }}
   >
-    {({ error, data }) => {
-      // const isLoaded = !loading;
-      // const { embed } = data;
+    {({ loading, error, data }) => {
+      if (loading) {
+        return <div className="spinner -centered" />;
+      }
 
       if (error) {
         return <ErrorBlock />;
       }
 
-      // If an <iframe> code snippet is provided, use that.
-      // Otherwise, fill in our "embed card".
-      // return isLoaded && embed && embed.html ? (
       return <SoftEdgeWidgetAction {...data} {...props} />;
-      // );
     }}
   </Query>
 );

--- a/resources/assets/components/actions/SoftEdgeWidgetAction/UserQuery.js
+++ b/resources/assets/components/actions/SoftEdgeWidgetAction/UserQuery.js
@@ -23,11 +23,7 @@ const ACCOUNT_QUERY = gql`
 `;
 
 const UserQuery = props => (
-  <Query
-    query={ACCOUNT_QUERY}
-    queryName="user"
-    variables={{ userId: props.userId }}
-  >
+  <Query query={ACCOUNT_QUERY} variables={{ userId: props.userId }}>
     {({ loading, error, data }) => {
       if (loading) {
         return <div className="spinner -centered" />;

--- a/resources/assets/components/actions/SoftEdgeWidgetAction/UserQuery.js
+++ b/resources/assets/components/actions/SoftEdgeWidgetAction/UserQuery.js
@@ -13,6 +13,10 @@ const ACCOUNT_QUERY = gql`
       lastName
       mobile
       email
+      addrStreet1
+      addrCity
+      addrState
+      addrZip
     }
   }
 `;

--- a/resources/assets/components/actions/SoftEdgeWidgetAction/UserQuery.js
+++ b/resources/assets/components/actions/SoftEdgeWidgetAction/UserQuery.js
@@ -1,7 +1,7 @@
 import React from 'react';
+import gql from 'graphql-tag';
 import PropTypes from 'prop-types';
 import { Query } from 'react-apollo';
-import gql from 'graphql-tag';
 
 import ErrorBlock from '../../ErrorBlock/ErrorBlock';
 import SoftEdgeWidgetAction from './SoftEdgeWidgetAction';

--- a/resources/assets/components/actions/SoftEdgeWidgetAction/UserQuery.js
+++ b/resources/assets/components/actions/SoftEdgeWidgetAction/UserQuery.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { Query } from 'react-apollo';
 import gql from 'graphql-tag';
 
@@ -40,5 +41,9 @@ const UserQuery = props => (
     }}
   </Query>
 );
+
+UserQuery.propTypes = {
+  userId: PropTypes.string.isRequired,
+};
 
 export default UserQuery;

--- a/resources/assets/components/actions/SoftEdgeWidgetAction/UserQuery.js
+++ b/resources/assets/components/actions/SoftEdgeWidgetAction/UserQuery.js
@@ -1,0 +1,43 @@
+import React from 'react';
+import { Query } from 'react-apollo';
+import gql from 'graphql-tag';
+
+import ErrorBlock from '../../ErrorBlock/ErrorBlock';
+import SoftEdgeWidgetAction from './SoftEdgeWidgetAction';
+
+const ACCOUNT_QUERY = gql`
+  query AccountQuery(props.userId: String!) {
+    user(id: props.userId) {
+      id
+      firstName
+      lastName
+      mobile
+      email
+    }
+  }
+`;
+
+const UserQuery = ({ props }) => (
+  <Query
+    query={ACCOUNT_QUERY}
+    queryName="user"
+    variables={{ userId: props.userId }}
+  >
+    {({ error, data }) => {
+      // const isLoaded = !loading;
+      // const { embed } = data;
+
+      if (error) {
+        return <ErrorBlock />;
+      }
+
+      // If an <iframe> code snippet is provided, use that.
+      // Otherwise, fill in our "embed card".
+      // return isLoaded && embed && embed.html ? (
+      return <SoftEdgeWidgetAction {...data} {...props} />;
+      // );
+    }}
+  </Query>
+);
+
+export default UserQuery;


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?
Pre-populates the SoftEdge form with data we have on the user. 
- Adds `SoftEdgeWidgetActionContainer` to get the `userId` from the state.
- Adds the UserQuery` file to get user information based on the `userId` using GQL to pass to the `SoftEdgeWidgetAction` file. 
- Updates the SoftEdge URL based on what user data we have to pre-populate the fields in the form. 
![Screen Shot 2019-05-06 at 3 17 08 PM](https://user-images.githubusercontent.com/9019452/57249094-0c530380-7012-11e9-8582-5a1b4e119c1f.png)

### What are the relevant tickets/cards?

Refs [Pivotal ID #165399561](https://www.pivotaltracker.com/n/projects/2019313/stories/165399561)

### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.
* [ ] Added screenshot to PR description of related front-end updates on **small** screens.
* [ ] Added screenshot to PR description of related front-end updates on **medium** screens.
* [ ] Added screenshot to PR description of related front-end updates on **large** screens.
