### PR TITLE
Updates Sixpack to be more flexible and a little simpler.

### DIFF
--- a/app/Entities/SixpackExperiment.php
+++ b/app/Entities/SixpackExperiment.php
@@ -28,7 +28,7 @@ class SixpackExperiment extends Entity implements JsonSerializable
             'type' => $this->getContentType(),
             'fields' => [
                 'alternatives' => $this->parseBlocks($this->alternatives),
-                'control' => $this->control ? $this->parseBlocks($this->control) : null,
+                'control' => $this->control ? $this->parseBlock($this->control) : null,
                 'convertableActions' => $this->convertableActions,
                 'kpi' => $this->kpi,
                 'title' => $this->internalTitle,

--- a/app/Entities/SixpackExperiment.php
+++ b/app/Entities/SixpackExperiment.php
@@ -28,6 +28,7 @@ class SixpackExperiment extends Entity implements JsonSerializable
             'type' => $this->getContentType(),
             'fields' => [
                 'alternatives' => $this->parseBlocks($this->alternatives),
+                'control' => $this->control ? $this->parseBlocks($this->control) : null,
                 'convertableActions' => $this->convertableActions,
                 'kpi' => $this->kpi,
                 'title' => $this->internalTitle,

--- a/resources/assets/components/utilities/Empty.js
+++ b/resources/assets/components/utilities/Empty.js
@@ -1,0 +1,5 @@
+import React from 'react';
+
+const Empty = () => <React.Fragment />;
+
+export default Empty;

--- a/resources/assets/components/utilities/SixpackExperiment/SixpackExperiment.js
+++ b/resources/assets/components/utilities/SixpackExperiment/SixpackExperiment.js
@@ -30,7 +30,7 @@ class SixpackExperiment extends React.Component {
     const controlAlternative = control || <Empty testName="No Alternative" />;
     const alternativeOptions = [controlAlternative, ...alternatives];
 
-    // Get names of  all test alternatives
+    // Get names of all test alternatives
     const alternativeOptionNames = alternativeOptions.map((item, index) => {
       let testAlternativeName = `Test Alternative ${index + 1}`;
 
@@ -74,7 +74,7 @@ class SixpackExperiment extends React.Component {
    * Get the name for the provided test alternative.
    *
    * @param  {Object} alternative
-   * @return {String}
+   * @return {String|Null}
    */
   getTestAlternativeName = alternative => {
     let testAlternativeName;


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR updates the `SixpackExperiment` component to allow for "the absence of an alternative" to be an alternative. That is to say, an Sixpack A/B test can now experiment between having a block be present or missing and deciding which converts better. The component has also now be updated to specify a `control` when running an experiment. If no `control` is supplied, then the assumption is that the `control` is the empty alternative state.

### Any background context you want to provide?

This PR also adds a new `<Empty />` component. We utilize this component to specify the desire to have the lack of content as a test. Having it as a dedicated component makes it easier to insert in Sixpack code-based tests, or include dynamically if a Sixpack Contentful-based test. Overall it just allows us to keep the Sixpack logic within a set of limited options (a React component or a Contentful Entry).

As an example with a Code Test:

```js
// In CampaignPage.js

<SixpackExperiment
  title="Campaign Dashboard Experiment"
  convertableActions={['signup']}
  control={<Empty testName="Without Dashboard" />}
  alternatives={[
    <DashboardContainer
      endDate={{ date: '2019-07-04T04:00:00Z' }}
      content={dashboardContentA}
    />,
    <DashboardContainer
      endDate={{ date: '2019-08-04T04:00:00Z' }}
      content={dashboardContentB}
    />,
  ]}
/>
```
And the resulting experiment in the Sixpack Web UI:
![image](https://user-images.githubusercontent.com/105849/57259294-0cacc800-702d-11e9-88b4-9080902f0bd1.png)

### What are the relevant tickets/cards?

Refs [Pivotal ID #165801497](https://www.pivotaltracker.com/story/show/165801497)

### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.