### PR TITLE
Higher Resolution Tile Images on Homepage

### DIFF
--- a/resources/assets/components/pages/HomePage/HomePage.js
+++ b/resources/assets/components/pages/HomePage/HomePage.js
@@ -14,13 +14,16 @@ class HomePage extends React.Component {
     this.state = get(window.HOMEPAGE, 'fields', {});
   }
 
-  renderGalleryBlock = block => {
+  renderGalleryBlock = (block, index) => {
     const { id, type, staffPick } = block;
 
     const isCampaign = type === 'campaign';
 
     const fields = isCampaign ? block : block.fields;
     const { slug, title, coverImage } = fields;
+
+    // Set more generous crop dimensions for 'featured' (first) homepage tile.
+    const imageCrop = index === 0 ? '1600' : '800';
 
     return (
       <article className="tile" key={id}>
@@ -38,7 +41,12 @@ class HomePage extends React.Component {
           </div>
 
           <img
-            src={contentfulImageUrl(coverImage.url, '400', '400', 'fill')}
+            src={contentfulImageUrl(
+              coverImage.url,
+              imageCrop,
+              imageCrop,
+              'fill',
+            )}
             alt={coverImage.description || `${title} cover image`}
           />
         </a>


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR enhances the image resolution via the Contentful Image API crop setting for the Gallery tiles on the Homepage, with a higher setting for the 'featured' larger tile.

### Any background context you want to provide?
We were seeing some blurry images on the homepage! No good!

### What are the relevant tickets/cards?

Refs [Pivotal ID #165746052](https://www.pivotaltracker.com/story/show/165746052)

### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.
* [ ] Added screenshot to PR description of related front-end updates on **small** screens.
* [ ] Added screenshot to PR description of related front-end updates on **medium** screens.
* [x] Added screenshot to PR description of related front-end updates on **large** screens.

**Before**
![image](https://user-images.githubusercontent.com/12417657/57318429-57c7e900-70c8-11e9-9d32-798c0f995710.png)


**After**
![image](https://user-images.githubusercontent.com/12417657/57318456-644c4180-70c8-11e9-9179-f2aa540e2386.png)

(The "I Voted" sticker on the featured tile has a nice visible contrast)