### PR TITLE
Selection Submission Action Component

### DIFF
--- a/resources/assets/components/ContentfulEntry/ContentfulEntry.js
+++ b/resources/assets/components/ContentfulEntry/ContentfulEntry.js
@@ -31,6 +31,8 @@ import SubmissionGalleryBlockContainer from '../blocks/SubmissionGalleryBlock/Su
 import VoterRegistrationActionContainer from '../actions/VoterRegistrationAction/VoterRegistrationActionContainer';
 import PetitionSubmissionActionContainer from '../actions/PetitionSubmissioncAction/PetitionSubmissionActionContainer';
 import ReferralSubmissionActionContainer from '../actions/ReferralSubmissionAction/ReferralSubmissionActionContainer';
+import SelectionSubmissionActionContainer from '../actions/SelectionSubmissionAction/SelectionSubmissionActionContainer';
+
 // If no block is passed, just render an empty "placeholder".
 const DEFAULT_BLOCK: ContentfulEntryJson = { fields: { type: null } };
 
@@ -239,6 +241,14 @@ class ContentfulEntry extends React.Component<Props, State> {
           />
         );
       }
+
+      case 'selectionSubmissionAction':
+        return (
+          <SelectionSubmissionActionContainer
+            id={json.id}
+            {...withoutNulls(json.fields)}
+          />
+        );
 
       case 'shareAction':
         return (

--- a/resources/assets/components/ContentfulEntry/ContentfulEntry.js
+++ b/resources/assets/components/ContentfulEntry/ContentfulEntry.js
@@ -22,15 +22,15 @@ import LandingPageContainer from '../pages/LandingPage/LandingPageContainer';
 import ShareActionContainer from '../actions/ShareAction/ShareActionContainer';
 import SixpackExperiment from '../utilities/SixpackExperiment/SixpackExperiment';
 import PostGalleryBlockQuery from '../blocks/PostGalleryBlock/PostGalleryBlockQuery';
-import SoftEdgeWidgetActionContainer from '../actions/SoftEdgeWidgetAction/SoftEdgeWidgetActionContainer';
 import SocialDriveActionContainer from '../actions/SocialDriveAction/SocialDriveActionContainer';
 import CampaignGalleryBlockContainer from '../blocks/CampaignGalleryBlock/CampaignGalleryBlockContainer';
+import SoftEdgeWidgetActionContainer from '../actions/SoftEdgeWidgetAction/SoftEdgeWidgetActionContainer';
 import TextSubmissionActionContainer from '../actions/TextSubmissionAction/TextSubmissionActionContainer';
 import PhotoSubmissionActionContainer from '../actions/PhotoSubmissionAction/PhotoSubmissionActionContainer';
 import SubmissionGalleryBlockContainer from '../blocks/SubmissionGalleryBlock/SubmissionGalleryBlockContainer';
 import VoterRegistrationActionContainer from '../actions/VoterRegistrationAction/VoterRegistrationActionContainer';
-import PetitionSubmissionActionContainer from '../actions/PetitionSubmissioncAction/PetitionSubmissionActionContainer';
 import ReferralSubmissionActionContainer from '../actions/ReferralSubmissionAction/ReferralSubmissionActionContainer';
+import PetitionSubmissionActionContainer from '../actions/PetitionSubmissioncAction/PetitionSubmissionActionContainer';
 import SelectionSubmissionActionContainer from '../actions/SelectionSubmissionAction/SelectionSubmissionActionContainer';
 
 // If no block is passed, just render an empty "placeholder".

--- a/resources/assets/components/actions/SelectionSubmissionAction/SelectionSubmissionAction.js
+++ b/resources/assets/components/actions/SelectionSubmissionAction/SelectionSubmissionAction.js
@@ -1,0 +1,215 @@
+import React from 'react';
+import gql from 'graphql-tag';
+import { get, has } from 'lodash';
+import PropTypes from 'prop-types';
+import classNames from 'classnames';
+import { Query } from 'react-apollo';
+
+import Card from '../../utilities/Card/Card';
+import Button from '../../utilities/Button/Button';
+import FormValidation from '../../utilities/Form/FormValidation';
+import TextContent from '../../utilities/TextContent/TextContent';
+import { formatFormFields, getFieldErrors } from '../../../helpers/forms';
+
+import './selection-submission-action.scss';
+
+const USER_POSTS_QUERY = gql`
+  query UserPostsQuery($userId: String!, $actionIds: [Int]!) {
+    posts(userId: $userId, actionIds: $actionIds) {
+      text
+    }
+  }
+`;
+
+class SelectionSubmissionAction extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      selection: this.props.selectionPlaceholderOption,
+      submitted: false,
+    };
+  }
+
+  static getDerivedStateFromProps(nextProps) {
+    const response = nextProps.submissions.items[nextProps.id] || null;
+
+    if (has(response, 'status.success')) {
+      // Resetting the submission item so that this won't be triggered continually for further renders.
+      nextProps.resetPostSubmissionItem(nextProps.id);
+
+      return {
+        submitted: true,
+      };
+    }
+
+    return null;
+  }
+
+  // Is the current user selection one of the defined selection options?
+  isSelectionValid = () =>
+    this.props.selectionOptions.indexOf(this.state.selection) !== -1;
+
+  handleChange = event => this.setState({ selection: event.target.value });
+
+  handleSubmit = event => {
+    event.preventDefault();
+
+    // Run a validation as an edge case measure (e.g. to prevent submitting custom data via dom manipulation).
+    if (!this.isSelectionValid()) {
+      return;
+    }
+
+    const { id, actionId, storePost } = this.props;
+
+    // Reset any straggling post submission data for this action.
+    this.props.resetPostSubmissionItem(id);
+
+    const type = 'text';
+
+    // Trigger request to store the selection submission post.
+    storePost({
+      body: formatFormFields({
+        action_id: actionId,
+        text: this.state.selection,
+        type,
+      }),
+      type,
+      actionId,
+      id,
+    });
+  };
+
+  render() {
+    const {
+      actionId,
+      buttonText,
+      id,
+      title,
+      content,
+      postSubmissionLabel,
+      selectionFieldLabel,
+      selectionPlaceholderOption,
+      selectionOptions,
+      submissions,
+      userId,
+    } = this.props;
+
+    const submissionItem = submissions.items[id];
+
+    const formResponse = has(submissionItem, 'status') ? submissionItem : null;
+
+    const formErrors = getFieldErrors(formResponse);
+
+    const isSelectionInvalid = !this.isSelectionValid();
+
+    return (
+      <Card
+        className="selection-submission-action bordered rounded"
+        title={title}
+      >
+        {formResponse ? <FormValidation response={formResponse} /> : null}
+
+        <TextContent className="padded">{content}</TextContent>
+
+        <Query
+          query={USER_POSTS_QUERY}
+          variables={{ userId, actionIds: [actionId] }}
+        >
+          {({ loading, data }) => {
+            if (loading) {
+              return <div className="spinner -centered margin-bottom-md" />;
+            }
+
+            const post = get(data, 'posts', [])[0];
+            const selection = get(post, 'text');
+
+            // If the user successfuly submitted the form, or a pre-existing submission is found,
+            // display the post-submission state.
+            if (selection || this.state.submitted) {
+              return (
+                <div className="padding-horizontal-md padding-bottom-md">
+                  <p className="submission-text caps-lock">
+                    {selection || this.state.selection}
+                  </p>
+                  <p className="caps-lock color-gray font-bold margin-top-none">
+                    {postSubmissionLabel}
+                  </p>
+                </div>
+              );
+            }
+
+            return (
+              <form onSubmit={this.handleSubmit}>
+                <div className="padding-horizontal-md">
+                  <label
+                    className={classNames('field-label', {
+                      'has-error': has(formErrors, 'text'),
+                    })}
+                    htmlFor="selections"
+                  >
+                    {selectionFieldLabel}
+                  </label>
+                  <div className="select">
+                    <select
+                      id="selections"
+                      className={classNames('text-field', {
+                        'color-gray': isSelectionInvalid,
+                        'has-error shake': has(formErrors, 'text'),
+                      })}
+                      value={this.state.selection}
+                      onChange={this.handleChange}
+                    >
+                      <option disabled>{selectionPlaceholderOption}</option>
+                      {selectionOptions.map(selectionOption => (
+                        <option key={selectionOption} value={selectionOption}>
+                          {selectionOption}
+                        </option>
+                      ))}
+                    </select>
+                  </div>
+                </div>
+
+                <Button
+                  type="submit"
+                  attached
+                  disabled={isSelectionInvalid}
+                  loading={submissionItem && submissionItem.isPending}
+                >
+                  {buttonText}
+                </Button>
+              </form>
+            );
+          }}
+        </Query>
+      </Card>
+    );
+  }
+}
+
+SelectionSubmissionAction.propTypes = {
+  actionId: PropTypes.number.isRequired,
+  buttonText: PropTypes.string,
+  content: PropTypes.object.isRequired,
+  id: PropTypes.string.isRequired,
+  postSubmissionLabel: PropTypes.string.isRequired,
+  resetPostSubmissionItem: PropTypes.func.isRequired,
+  selectionFieldLabel: PropTypes.string,
+  selectionOptions: PropTypes.arrayOf(PropTypes.string).isRequired,
+  selectionPlaceholderOption: PropTypes.string,
+  storePost: PropTypes.func.isRequired,
+  submissions: PropTypes.shape({
+    items: PropTypes.object,
+  }).isRequired,
+  userId: PropTypes.string.isRequired,
+  title: PropTypes.string,
+};
+
+SelectionSubmissionAction.defaultProps = {
+  buttonText: 'Submit',
+  selectionFieldLabel: 'Make your selection below',
+  selectionPlaceholderOption: '---',
+  title: 'Make a selection',
+};
+
+export default SelectionSubmissionAction;

--- a/resources/assets/components/actions/SelectionSubmissionAction/SelectionSubmissionActionContainer.js
+++ b/resources/assets/components/actions/SelectionSubmissionAction/SelectionSubmissionActionContainer.js
@@ -1,0 +1,24 @@
+import { connect } from 'react-redux';
+
+import { getUserId } from '../../../selectors/user';
+import SelectionSubmissionAction from './SelectionSubmissionAction';
+import { resetPostSubmissionItem, storePost } from '../../../actions/post';
+
+/**
+ * Provide state from the Redux store as props for this component.
+ */
+const mapStateToProps = state => ({
+  submissions: state.postSubmissions,
+  userId: getUserId(state),
+});
+
+/**
+ * Provide pre-bound functions that allow the component to dispatch
+ * actions to the Redux store as props for this component.
+ */
+const actionCreators = { resetPostSubmissionItem, storePost };
+
+export default connect(
+  mapStateToProps,
+  actionCreators,
+)(SelectionSubmissionAction);

--- a/resources/assets/components/actions/SelectionSubmissionAction/selection-submission-action.scss
+++ b/resources/assets/components/actions/SelectionSubmissionAction/selection-submission-action.scss
@@ -1,0 +1,9 @@
+@import '../../../scss/next-toolbox';
+
+.selection-submission-action {
+  .submission-text {
+    font-size: 56px;
+    font-family: $secondary-font-family;
+    line-height: 1;
+  }
+}


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR adds the brand spanking new `SelectionSubmissionAction` component!

### Any background context you want to provide?
There's nothing too novel going on relative to the current Text actions. This will be especially reminiscent of the [`PetitionSubmissionAction`](https://github.com/DoSomething/phoenix-next/blob/726b007915d8a4dbb7fefd8d02fb2088649a3def/resources/assets/components/actions/PetitionSubmissioncAction/PetitionSubmissionAction.js).

There's a validation checker method (`isSelectionValid`), which helps control the submit button's `disabled` status and some other styling. This is also triggered from the `handleSubmit` as an edge case if for some reason a user manipulates the dom and attempts to submit custom data.

### What are the relevant tickets/cards?

Refs [Pivotal ID #165885837](https://www.pivotaltracker.com/story/show/165885837)

### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.
* [x] Added screenshot to PR description of related front-end updates on **small** screens.
* [x] Added screenshot to PR description of related front-end updates on **medium** screens.
* [x] Added screenshot to PR description of related front-end updates on **large** screens.

📷 📸 🎥 🎦 🍿 

- [Large Screen - no selection](https://user-images.githubusercontent.com/12417657/57541435-03697700-731d-11e9-9107-deaf56694615.png)

- [Large Screen - selection](https://user-images.githubusercontent.com/12417657/57541538-41669b00-731d-11e9-88a7-2fc9e6b527fb.png)

- [Large Screen - post submission](https://user-images.githubusercontent.com/12417657/57541552-46c3e580-731d-11e9-836f-bc2de651fc6f.png)


- [Medium Screen](https://user-images.githubusercontent.com/12417657/57541478-21cf7280-731d-11e9-8684-539e41995bc4.png)

- [Small Screen](https://user-images.githubusercontent.com/12417657/57541505-301d8e80-731d-11e9-9fbd-9e5caf6ba883.png)


