### PR TITLE
Selection Submission Action Content Type

### DIFF
--- a/app/Entities/Entity.php
+++ b/app/Entities/Entity.php
@@ -106,6 +106,8 @@ class Entity implements ArrayAccess, JsonSerializable
                 return new ReferralSubmissionAction($block->entry);
             case 'sectionBlock':
                 return new SectionBlock($block->entry);
+            case 'selectionSubmissionAction':
+                return new SelectionSubmissionAction($block->entry);
             case 'shareAction':
                 return new ShareAction($block->entry);
             case 'sixpackExperiment':

--- a/app/Entities/SelectionSubmissionAction.php
+++ b/app/Entities/SelectionSubmissionAction.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Entities;
+
+use JsonSerializable;
+
+class SelectionSubmissionAction extends Entity implements JsonSerializable
+{
+    public function jsonSerialize()
+    {
+        return [
+            'id' => $this->entry->getId(),
+            'type' => $this->getContentType(),
+            'fields' => [
+                'actionId' => $this->actionId,
+                'title' => $this->title,
+                'content' => $this->content,
+                'selectionFieldLabel' => $this->selectionFieldLabel,
+                'selectionOptions' => $this->selectionOptions,
+                'selectionPlaceholderOption' => $this->selectionPlaceholderOption,
+                'buttonText' => $this->buttonText,
+                'postSubmissionLabel' => $this->postSubmissionLabel,
+            ],
+        ];
+    }
+}

--- a/contentful/content-types/selectionSubmissionAction.js
+++ b/contentful/content-types/selectionSubmissionAction.js
@@ -2,7 +2,9 @@ module.exports = function(migration) {
   const selectionSubmissionAction = migration
     .createContentType('selectionSubmissionAction')
     .name('SelectionSubmissionAction')
-    .description('')
+    .description(
+      'Action block for submitting text posts via a predefined selection drop-down list.',
+    )
     .displayField('internalTitle');
 
   selectionSubmissionAction

--- a/contentful/content-types/selectionSubmissionAction.js
+++ b/contentful/content-types/selectionSubmissionAction.js
@@ -1,0 +1,195 @@
+module.exports = function(migration) {
+  const selectionSubmissionAction = migration
+    .createContentType('selectionSubmissionAction')
+    .name('SelectionSubmissionAction')
+    .description('')
+    .displayField('internalTitle');
+
+  selectionSubmissionAction
+    .createField('internalTitle')
+    .name('Internal Title')
+    .type('Symbol')
+    .localized(false)
+    .required(true)
+    .validations([])
+    .disabled(false)
+    .omitted(false);
+
+  selectionSubmissionAction
+    .createField('actionId')
+    .name('Action ID')
+    .type('Integer')
+    .localized(false)
+    .required(true)
+    .validations([])
+    .disabled(false)
+    .omitted(false);
+
+  selectionSubmissionAction
+    .createField('title')
+    .name('Title')
+    .type('Symbol')
+    .localized(true)
+    .required(false)
+    .validations([
+      {
+        size: {
+          max: 65,
+        },
+      },
+    ])
+    .disabled(false)
+    .omitted(false);
+
+  selectionSubmissionAction
+    .createField('content')
+    .name('Content')
+    .type('RichText')
+    .localized(true)
+    .required(true)
+    .validations([
+      {
+        nodes: {},
+      },
+      {
+        enabledNodeTypes: [
+          'blockquote',
+          'unordered-list',
+          'ordered-list',
+          'hyperlink',
+          'hr',
+          'heading-6',
+          'heading-5',
+          'heading-4',
+          'heading-3',
+        ],
+
+        message:
+          'Only quote, unordered list, ordered list, link to Url, horizontal rule, heading 6, heading 5, heading 4, and heading 3 nodes are allowed',
+      },
+    ])
+    .disabled(false)
+    .omitted(false);
+
+  selectionSubmissionAction
+    .createField('selectionFieldLabel')
+    .name('Selection Field Label')
+    .type('Symbol')
+    .localized(true)
+    .required(false)
+    .validations([])
+    .disabled(false)
+    .omitted(false);
+
+  selectionSubmissionAction
+    .createField('selectionOptions')
+    .name('Selection Options')
+    .type('Array')
+    .localized(true)
+    .required(true)
+    .validations([])
+    .disabled(false)
+    .omitted(false)
+    .items({
+      type: 'Symbol',
+      validations: [],
+    });
+
+  selectionSubmissionAction
+    .createField('selectionPlaceholderOption')
+    .name('Selection Placeholder Option')
+    .type('Symbol')
+    .localized(false)
+    .required(false)
+    .validations([])
+    .disabled(false)
+    .omitted(false);
+
+  selectionSubmissionAction
+    .createField('buttonText')
+    .name('Button Text')
+    .type('Symbol')
+    .localized(true)
+    .required(false)
+    .validations([
+      {
+        size: {
+          max: 25,
+        },
+      },
+    ])
+    .disabled(false)
+    .omitted(false);
+
+  selectionSubmissionAction
+    .createField('postSubmissionLabel')
+    .name('Post Submission Label')
+    .type('Symbol')
+    .localized(true)
+    .required(true)
+    .validations([])
+    .disabled(false)
+    .omitted(false);
+
+  selectionSubmissionAction.changeEditorInterface(
+    'internalTitle',
+    'singleLine',
+    {
+      helpText: 'This title is used internally to help find this content.',
+    },
+  );
+
+  selectionSubmissionAction.changeEditorInterface('actionId', 'numberEditor', {
+    helpText:
+      'The Action ID associated with this action. Action IDs can be found in Rogue: https://dosome.click/nyshrf',
+  });
+
+  selectionSubmissionAction.changeEditorInterface('title', 'singleLine', {
+    helpText:
+      'The title for the selection block. (Defaults to "Make a selection").',
+  });
+
+  selectionSubmissionAction.changeEditorInterface('content', 'richTextEditor', {
+    helpText: 'The content displayed in the submission block.',
+  });
+
+  selectionSubmissionAction.changeEditorInterface(
+    'selectionFieldLabel',
+    'singleLine',
+    {
+      helpText:
+        'The label displayed above the selection field. (Defaults to "Select one of the options below").',
+    },
+  );
+
+  selectionSubmissionAction.changeEditorInterface(
+    'selectionOptions',
+    'listInput',
+    {
+      helpText:
+        'The selection options for the selection block. Insert comma separated values.',
+    },
+  );
+
+  selectionSubmissionAction.changeEditorInterface(
+    'selectionPlaceholderOption',
+    'singleLine',
+    {
+      helpText:
+        'The placeholder selection value. This will not be a valid selection. (Defaults to "---").',
+    },
+  );
+
+  selectionSubmissionAction.changeEditorInterface('buttonText', 'singleLine', {
+    helpText:
+      'Text to display on the submission button (defaults to "Submit").',
+  });
+
+  selectionSubmissionAction.changeEditorInterface(
+    'postSubmissionLabel',
+    'singleLine',
+    {
+      helpText: 'The text displayed under the user selection, post submission.',
+    },
+  );
+};


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR adds a Contentful Content Type migration script for the `SelectionSubmissionAction` as well as the Entity and block parsing functionality.

### What are the relevant tickets/cards?

Refs [Pivotal ID #165839774](https://www.pivotaltracker.com/story/show/165839774)
(Some conversation about the content type on the feature's main [Pivotal ticket](https://www.pivotaltracker.com/story/show/165534429/comments/202472798))

### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.


