### PR TITLE
Campaign Page width styling for Page Gallery

### DIFF
--- a/resources/assets/components/pages/CampaignPage/CampaignPageContent.js
+++ b/resources/assets/components/pages/CampaignPage/CampaignPageContent.js
@@ -32,6 +32,7 @@ const CampaignPageContent = props => {
       [
         'photoSubmissionAction',
         'gallery',
+        'postGallery',
         'imagesBlock',
         'socialDriveAction',
       ].includes(type)


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_


### What does this PR do?

This PR adds the `postGallery` to the list of block types allotted full width in a campaign page (for larger screens).

### Any background context you want to provide?
I needed to add this block to a campaign, and noticed in Preview that this wasn't getting the full-width treatment 😱
(I'm not sure that many (any?) campaigns are even using this new block yet, as we haven't had a chance to formally retire the legacy custom block setup, but needed this for Huddle against Hunger since we're adding a Text (selection/affiliation) post which we don't want in the gallery).

### What are the relevant tickets/cards?

Refs [Pivotal ID #]()

### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.
* [ ] Added screenshot to PR description of related front-end updates on **small** screens.
* [ ] Added screenshot to PR description of related front-end updates on **medium** screens.
* [x] Added screenshot to PR description of related front-end updates on **large** screens.

**Before**
![image](https://user-images.githubusercontent.com/12417657/57554251-f3fb2580-733e-11e9-9f78-5d74b8ff1780.png)


**After**
![image](https://user-images.githubusercontent.com/12417657/57554265-fe1d2400-733e-11e9-9caa-2ba21f1f5da5.png)
