### PR TITLE
Bumps up the font-size of paragraphs in section blocks

### DIFF
--- a/resources/assets/components/blocks/SectionBlock/section-block.scss
+++ b/resources/assets/components/blocks/SectionBlock/section-block.scss
@@ -22,4 +22,9 @@
       }
     }
   }
+
+  // @TODO: Reassess when changing sizes for whole site
+  > p {
+    font-size: 21px;
+  }
 }


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_


### What does this PR do?

This PR changes the `font-size` of paragraphs in Section Blocks from 18px to 21px. This currently only effects the main content of Story Pages.

### Any background context you want to provide?

With the centered, text heavy design of the Story Pages, our normal 18px font size can get swallowed up by empty surrounding space. A larger font size allows for the text to stand stronger as the primary element of the page.

![Screen Shot 2019-05-14 at 14 10 58](https://user-images.githubusercontent.com/1865372/57721464-421b6c00-7652-11e9-9caf-18ab65bc15f3.png)
![Screen Shot 2019-05-14 at 14 11 03](https://user-images.githubusercontent.com/1865372/57721465-421b6c00-7652-11e9-86b8-c5eb04bf9045.png)
![Screen Shot 2019-05-14 at 14 11 38](https://user-images.githubusercontent.com/1865372/57721466-421b6c00-7652-11e9-96ad-88203c2c61b3.png)


### Checklist
* [x] Added screenshot to PR description of related front-end updates on **small** screens.
* [x] Added screenshot to PR description of related front-end updates on **medium** screens.
* [x] Added screenshot to PR description of related front-end updates on **large** screens.
