### PR TITLE
Survey modal component updates

### DIFF
--- a/resources/assets/components/Campaign/Campaign.js
+++ b/resources/assets/components/Campaign/Campaign.js
@@ -30,7 +30,9 @@ const Campaign = props => (
       <ModalLauncherContainer
         type="nps_survey"
         countdown={60}
-        render={() => <SurveyModalContainer />}
+        render={() => (
+          <SurveyModalContainer typeformUrl="https://dosomething.typeform.com/to/Bvcwvm" />
+        )}
       />
     </TrafficDistribution>
 

--- a/resources/assets/components/pages/SurveyModal/SurveyModal.js
+++ b/resources/assets/components/pages/SurveyModal/SurveyModal.js
@@ -3,7 +3,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import { makeUrl } from '../../../helpers';
+import { makeUrl, withoutNulls } from '../../../helpers';
 
 class SurveyModal extends React.Component {
   componentDidMount() {
@@ -19,7 +19,7 @@ class SurveyModal extends React.Component {
       location_pathname: window.location.pathname,
     };
 
-    const url = makeUrl(typeformUrl, typeformQuery);
+    const url = makeUrl(typeformUrl, withoutNulls(typeformQuery));
 
     return (
       <div

--- a/resources/assets/components/pages/SurveyModal/SurveyModal.js
+++ b/resources/assets/components/pages/SurveyModal/SurveyModal.js
@@ -5,15 +5,13 @@ import PropTypes from 'prop-types';
 
 import { makeUrl } from '../../../helpers';
 
-const SURVEY_DATA_URL = 'https://dosomething.typeform.com/to/Bvcwvm';
-
 class SurveyModal extends React.Component {
   componentDidMount() {
     window.typeformInit();
   }
 
   render() {
-    const { northstarId, campaignId } = this.props;
+    const { campaignId, northstarId, typeformUrl } = this.props;
 
     const typeformQuery = {
       northstar_id: northstarId,
@@ -21,12 +19,12 @@ class SurveyModal extends React.Component {
       origin: window.location.pathname,
     };
 
-    const typeformUrl = makeUrl(SURVEY_DATA_URL, typeformQuery);
+    const url = makeUrl(typeformUrl, typeformQuery);
 
     return (
       <div
         className="modal__slide typeform-widget"
-        data-url={typeformUrl.href}
+        data-url={url.href}
         style={{ width: '100%', height: '500px' }}
       />
     );
@@ -34,8 +32,14 @@ class SurveyModal extends React.Component {
 }
 
 SurveyModal.propTypes = {
-  northstarId: PropTypes.string.isRequired,
-  campaignId: PropTypes.string.isRequired,
+  typeformUrl: PropTypes.string.isRequired,
+  northstarId: PropTypes.string,
+  campaignId: PropTypes.string,
+};
+
+SurveyModal.defaultProps = {
+  northstarId: null,
+  campaignId: null,
 };
 
 export default SurveyModal;

--- a/resources/assets/components/pages/SurveyModal/SurveyModal.js
+++ b/resources/assets/components/pages/SurveyModal/SurveyModal.js
@@ -16,7 +16,7 @@ class SurveyModal extends React.Component {
     const typeformQuery = {
       northstar_id: northstarId,
       campaign_id: campaignId,
-      origin: window.location.pathname,
+      location_pathname: window.location.pathname,
     };
 
     const url = makeUrl(typeformUrl, typeformQuery);

--- a/resources/assets/components/pages/SurveyModal/SurveyModal.js
+++ b/resources/assets/components/pages/SurveyModal/SurveyModal.js
@@ -16,7 +16,7 @@ class SurveyModal extends React.Component {
     const typeformQuery = {
       northstar_id: northstarId,
       campaign_id: campaignId,
-      location_pathname: window.location.pathname,
+      redirect_pathname: window.location.pathname,
     };
 
     const url = makeUrl(typeformUrl, withoutNulls(typeformQuery));


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR makes some incremental updates to the `SurveyModal` component. This is one of a few updates coming up to allow showcasing a Typeform survey on other pages apart from the campaign page. This update allows passing in the typeform survey url as a prop instead of hardcoding it as a constant in the component. It also allows for only passing variables in URL params to the survey if available and doesn't make the Northstar and Campaign IDs a requirement.

### Any background context you want to provide?

There's a bunch of updates I have planned for this component (like removing the container, renaming it, not making it a modal but a component that gets placed inside the modal portal, etc). But taking it in baby steps so that I don't break anything!

### What are the relevant tickets/cards?

Refs [Pivotal ID #165397335](https://www.pivotaltracker.com/story/show/165397335)
