### PR TITLE
Fix bug with missing parameter in redirect url.

### DIFF
--- a/resources/assets/components/Campaign/Campaign.js
+++ b/resources/assets/components/Campaign/Campaign.js
@@ -36,6 +36,8 @@ const Campaign = props => (
             queryParameters={{
               campaign_id: props.campaignId,
               northstar_id: props.userId,
+            }}
+            redirectParameters={{
               hide_nps_survey: 1,
             }}
           />

--- a/resources/assets/components/pages/SurveyModal/SurveyModal.js
+++ b/resources/assets/components/pages/SurveyModal/SurveyModal.js
@@ -3,7 +3,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import { makeUrl, withoutNulls } from '../../../helpers';
+import { appendToQuery, makeUrl, withoutNulls } from '../../../helpers';
 
 class SurveyModal extends React.Component {
   componentDidMount() {
@@ -11,10 +11,12 @@ class SurveyModal extends React.Component {
   }
 
   render() {
-    const { typeformUrl, queryParameters } = this.props;
+    const { queryParameters, redirectParameters, typeformUrl } = this.props;
+
+    const redirectUrl = appendToQuery(redirectParameters, window.location.href);
 
     const typeformQuery = {
-      redirect_url: window.location.href,
+      redirect_url: redirectUrl.href,
       ...queryParameters,
     };
 
@@ -32,11 +34,13 @@ class SurveyModal extends React.Component {
 
 SurveyModal.propTypes = {
   queryParameters: PropTypes.object,
+  redirectParameters: PropTypes.object,
   typeformUrl: PropTypes.string.isRequired,
 };
 
 SurveyModal.defaultProps = {
   queryParameters: {},
+  redirectParameters: {},
 };
 
 export default SurveyModal;

--- a/resources/assets/helpers/index.js
+++ b/resources/assets/helpers/index.js
@@ -2,7 +2,7 @@
 
 import queryString from 'query-string';
 import { getTime, isBefore, isWithinInterval } from 'date-fns';
-import { get, find, isNull, isUndefined, omitBy } from 'lodash';
+import { get, find, isNull, isUndefined, merge, omitBy } from 'lodash';
 
 import Sixpack from '../services/Sixpack';
 import { trackAnalyticsEvent } from './analytics';
@@ -11,6 +11,29 @@ import { isSignedUp } from '../selectors/signup';
 // Helper Constants
 export const EMPTY_IMAGE =
   'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7';
+
+/**
+ * Append query parameters to a URL even if it already has existing parameters.
+ *
+ * @param  {Object} additionalParameters
+ * @param  {String} href
+ * @return {URL}
+ */
+export function appendToQuery(
+  additionalParameters,
+  href = window.location.href,
+) {
+  const urlObject = new URL(href);
+
+  const mergedParameters = merge(
+    queryString.parse(urlObject.search),
+    additionalParameters,
+  );
+
+  urlObject.search = queryString.stringify(mergedParameters);
+
+  return urlObject;
+}
 
 /**
  * Build login redirect URL with optional context data.


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR fixes a bug I introduced in #1431. The `hide_nps_survey` url parameter is being added to the main Typeform URL instead of the redirect URL that the user is sent to after completing the survey. This would mean they get redirected and the survey potentially pops up again due to the missing parameter.

The approach in this PR fixes the bug while ensuring that other URL parameters originally in the URL are preserved.

### Any background context you want to provide?

🌵 

### What are the relevant tickets/cards?

Refs [Pivotal ID #165397335](https://www.pivotaltracker.com/story/show/165397335)
