### PR TITLE
Adding NPS Survey to Homepage.

### DIFF
--- a/resources/assets/components/Campaign/Campaign.js
+++ b/resources/assets/components/Campaign/Campaign.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import ReactRouterPropTypes from 'react-router-prop-types';
 
 import NotificationContainer from '../Notification';
-import SurveyModal from '../pages/SurveyModal/SurveyModal';
+import TypeFormSurvey from '../utilities/TypeFormSurvey/TypeFormSurvey';
 import ModalRoute from '../utilities/ModalRoute/ModalRoute';
 import ModalLauncher from '../utilities/Modal/ModalLauncher';
 import CampaignRouteContainer from './CampaignRoute/CampaignRouteContainer';
@@ -32,7 +32,7 @@ const Campaign = props => (
           type="nps_survey"
           countdown={60}
           render={() => (
-            <SurveyModal
+            <TypeFormSurvey
               typeformUrl="https://dosomething.typeform.com/to/Bvcwvm"
               queryParameters={{
                 campaign_id: props.campaignId,

--- a/resources/assets/components/Campaign/Campaign.js
+++ b/resources/assets/components/Campaign/Campaign.js
@@ -3,9 +3,9 @@ import PropTypes from 'prop-types';
 import ReactRouterPropTypes from 'react-router-prop-types';
 
 import NotificationContainer from '../Notification';
-import TypeFormSurvey from '../utilities/TypeFormSurvey/TypeFormSurvey';
 import ModalRoute from '../utilities/ModalRoute/ModalRoute';
 import ModalLauncher from '../utilities/Modal/ModalLauncher';
+import TypeFormSurvey from '../utilities/TypeFormSurvey/TypeFormSurvey';
 import CampaignRouteContainer from './CampaignRoute/CampaignRouteContainer';
 import TrafficDistribution from '../utilities/TrafficDistribution/TrafficDistribution';
 import VoterRegistrationModal from '../pages/VoterRegistrationModal/VoterRegistrationModal';

--- a/resources/assets/components/pages/HomePage/HomePage.js
+++ b/resources/assets/components/pages/HomePage/HomePage.js
@@ -81,11 +81,6 @@ class HomePage extends React.Component {
           <section className="container container--sponsors">
             <div className="wrapper">
               <div className="container__block">
-                {/*
-                Workaround for this jsx-a11y bug https://git.io/fN814.
-                @TODO: Update once the eslint-config package is updated (https://git.io/fjejY).
-               */}
-                {/* eslint-disable-next-line jsx-a11y/heading-has-content */}
                 <h4>Sponsors</h4>
                 <ul>
                   {sponsorList.map(sponsor => (

--- a/resources/assets/components/pages/HomePage/HomePage.js
+++ b/resources/assets/components/pages/HomePage/HomePage.js
@@ -5,6 +5,9 @@ import { get } from 'lodash';
 
 import sponsorList from './sponsor-list';
 import { contentfulImageUrl } from '../../../helpers';
+import TypeFormSurvey from '../../utilities/TypeFormSurvey/TypeFormSurvey';
+import ModalLauncher from '../../utilities/Modal/ModalLauncher';
+import TrafficDistribution from '../../utilities/TrafficDistribution/TrafficDistribution';
 
 import './home-page.scss';
 
@@ -62,42 +65,62 @@ class HomePage extends React.Component {
     }
 
     return (
-      <div className="home-page">
-        <header role="banner" className="header header--home">
-          <div className="wrapper">
-            <h1 className="header__title">{title}</h1>
-            <h2 className="header__subtitle">{subTitle}</h2>
-          </div>
-        </header>
+      <React.Fragment>
+        <div className="home-page">
+          <header role="banner" className="header header--home">
+            <div className="wrapper">
+              <h1 className="header__title">{title}</h1>
+              <h2 className="header__subtitle">{subTitle}</h2>
+            </div>
+          </header>
 
-        <section className="home-page__gallery">
-          {blocks.map(this.renderGalleryBlock)}
-        </section>
+          <section className="home-page__gallery">
+            {blocks.map(this.renderGalleryBlock)}
+          </section>
 
-        <section className="container container--sponsors">
-          <div className="wrapper">
-            <div className="container__block">
-              {/*
+          <section className="container container--sponsors">
+            <div className="wrapper">
+              <div className="container__block">
+                {/*
                 Workaround for this jsx-a11y bug https://git.io/fN814.
                 @TODO: Update once the eslint-config package is updated (https://git.io/fjejY).
                */}
-              {/* eslint-disable-next-line jsx-a11y/heading-has-content */}
-              <h4>Sponsors</h4>
-              <ul>
-                {sponsorList.map(sponsor => (
-                  <li key={sponsor.name}>
-                    <img
-                      src={contentfulImageUrl(sponsor.image, '125', '40')}
-                      title={sponsor.name}
-                      alt={sponsor.name}
-                    />
-                  </li>
-                ))}
-              </ul>
+                {/* eslint-disable-next-line jsx-a11y/heading-has-content */}
+                <h4>Sponsors</h4>
+                <ul>
+                  {sponsorList.map(sponsor => (
+                    <li key={sponsor.name}>
+                      <img
+                        src={contentfulImageUrl(sponsor.image, '125', '40')}
+                        title={sponsor.name}
+                        alt={sponsor.name}
+                      />
+                    </li>
+                  ))}
+                </ul>
+              </div>
             </div>
-          </div>
-        </section>
-      </div>
+          </section>
+        </div>
+
+        <TrafficDistribution percentage={5} feature="nps_survey">
+          <ModalLauncher
+            type="nps_survey"
+            countdown={30}
+            render={() => (
+              <TypeFormSurvey
+                typeformUrl="https://dosomething.typeform.com/to/iEdy7C"
+                queryParameters={{
+                  northstar_id: get(window.AUTH, 'id', null),
+                }}
+                redirectParameters={{
+                  hide_nps_survey: 1,
+                }}
+              />
+            )}
+          />
+        </TrafficDistribution>
+      </React.Fragment>
     );
   }
 }

--- a/resources/assets/components/pages/HomePage/HomePage.js
+++ b/resources/assets/components/pages/HomePage/HomePage.js
@@ -5,8 +5,8 @@ import { get } from 'lodash';
 
 import sponsorList from './sponsor-list';
 import { contentfulImageUrl } from '../../../helpers';
-import TypeFormSurvey from '../../utilities/TypeFormSurvey/TypeFormSurvey';
 import ModalLauncher from '../../utilities/Modal/ModalLauncher';
+import TypeFormSurvey from '../../utilities/TypeFormSurvey/TypeFormSurvey';
 import TrafficDistribution from '../../utilities/TrafficDistribution/TrafficDistribution';
 
 import './home-page.scss';

--- a/resources/assets/components/utilities/TypeFormSurvey/TypeFormSurvey.js
+++ b/resources/assets/components/utilities/TypeFormSurvey/TypeFormSurvey.js
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 
 import { appendToQuery, makeUrl, withoutNulls } from '../../../helpers';
 
-class SurveyModal extends React.Component {
+class TypeFormSurvey extends React.Component {
   componentDidMount() {
     window.typeformInit();
   }
@@ -32,15 +32,15 @@ class SurveyModal extends React.Component {
   }
 }
 
-SurveyModal.propTypes = {
+TypeFormSurvey.propTypes = {
   queryParameters: PropTypes.object,
   redirectParameters: PropTypes.object,
   typeformUrl: PropTypes.string.isRequired,
 };
 
-SurveyModal.defaultProps = {
+TypeFormSurvey.defaultProps = {
   queryParameters: {},
   redirectParameters: {},
 };
 
-export default SurveyModal;
+export default TypeFormSurvey;


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR renames the `SurveyModal` component to `TypeFormSurvey`, so it makes a bit more sense; not necessarily a modal (can potentially appear in other contexts) and very specifically just for TypeForm based surveys.

It also more importantly, adds a modal pop-up on the Homepage for a new NPS survey.

### Any background context you want to provide?

If the user submits or closes either the Homepage NPS survey OR the Campaign NPS survey, it will stop any other NPS surveys from potentially showing; better user experience 😉 

### What are the relevant tickets/cards?

Refs [Pivotal ID #165397335](https://www.pivotaltracker.com/story/show/165397335)
