### PR TITLE
Analytics reconfiguring

### DIFF
--- a/resources/assets/actions/post.js
+++ b/resources/assets/actions/post.js
@@ -92,13 +92,18 @@ export function storeCampaignPost(campaignId, data) {
 
   // Track post submission event.
   trackAnalyticsEvent({
-    verb: 'submitted',
-    noun: formatEventNoun(type),
-    data: {
+    metaData: {
+      category: 'campaign_action',
+      target: 'form',
+      label: type,
+      noun: formatEventNoun(type),
+      verb: 'submitted',
+    },
+    contextData: {
       action,
       actionId,
-      campaignId,
       campaignContentfulId,
+      campaignId,
     },
   });
 
@@ -144,9 +149,14 @@ export function storePost(data) {
 
   // Track post submission event.
   trackAnalyticsEvent({
-    verb: 'submitted',
-    noun: formatEventNoun(type),
-    data: {
+    metaData: {
+      category: 'campaign_action',
+      target: 'form',
+      label: type,
+      noun: formatEventNoun(type),
+      verb: 'submitted',
+    },
+    contextData: {
       actionId,
     },
   });

--- a/resources/assets/actions/post.js
+++ b/resources/assets/actions/post.js
@@ -92,18 +92,18 @@ export function storeCampaignPost(campaignId, data) {
 
   // Track post submission event.
   trackAnalyticsEvent({
+    contextData: {
+      action,
+      actionId,
+      campaignContentfulId,
+      campaignId,
+    },
     metaData: {
       category: 'campaign_action',
       target: 'form',
       label: type,
       noun: formatEventNoun(type),
       verb: 'submitted',
-    },
-    contextData: {
-      action,
-      actionId,
-      campaignContentfulId,
-      campaignId,
     },
   });
 
@@ -149,15 +149,15 @@ export function storePost(data) {
 
   // Track post submission event.
   trackAnalyticsEvent({
+    contextData: {
+      actionId,
+    },
     metaData: {
       category: 'campaign_action',
       target: 'form',
       label: type,
       noun: formatEventNoun(type),
       verb: 'submitted',
-    },
-    contextData: {
-      actionId,
     },
   });
 

--- a/resources/assets/actions/post.js
+++ b/resources/assets/actions/post.js
@@ -100,9 +100,9 @@ export function storeCampaignPost(campaignId, data) {
     },
     metaData: {
       category: 'campaign_action',
-      target: 'form',
       label: type,
       noun: formatEventNoun(type),
+      target: 'form',
       verb: 'submitted',
     },
   });
@@ -154,9 +154,9 @@ export function storePost(data) {
     },
     metaData: {
       category: 'campaign_action',
-      target: 'form',
       label: type,
       noun: formatEventNoun(type),
+      target: 'form',
       verb: 'submitted',
     },
   });

--- a/resources/assets/actions/signup.js
+++ b/resources/assets/actions/signup.js
@@ -108,13 +108,18 @@ export function storeCampaignSignup(campaignId, data = {}) {
 
   // Track signup click submission event.
   trackAnalyticsEvent({
-    category: 'signup',
-    data: {
-      campaignId,
-      ...analytics,
+    metaData: {
+      adjective: get(analytics, 'adjective', null),
+      category: 'signup',
+      element: get(analytics, 'element', null),
+      label: get(analytics, 'label', null),
+      noun: type,
+      verb: 'clicked',
     },
-    noun: type,
-    verb: 'clicked',
+    contextData: {
+      campaignId,
+      ...get(analytics, 'context', {}),
+    },
   });
 
   return dispatch => {

--- a/resources/assets/actions/signup.js
+++ b/resources/assets/actions/signup.js
@@ -111,9 +111,9 @@ export function storeCampaignSignup(campaignId, data = {}) {
     metaData: {
       adjective: get(analytics, 'adjective', null),
       category: 'signup',
-      element: get(analytics, 'element', null),
       label: get(analytics, 'label', null),
       noun: type,
+      target: get(analytics, 'target', null),
       verb: 'clicked',
     },
     contextData: {

--- a/resources/assets/actions/signup.js
+++ b/resources/assets/actions/signup.js
@@ -108,12 +108,13 @@ export function storeCampaignSignup(campaignId, data = {}) {
 
   // Track signup click submission event.
   trackAnalyticsEvent({
-    verb: 'clicked',
-    noun: type,
+    category: 'signup',
     data: {
       campaignId,
       ...analytics,
     },
+    noun: type,
+    verb: 'clicked',
   });
 
   return dispatch => {

--- a/resources/assets/actions/signup.js
+++ b/resources/assets/actions/signup.js
@@ -108,6 +108,10 @@ export function storeCampaignSignup(campaignId, data = {}) {
 
   // Track signup click submission event.
   trackAnalyticsEvent({
+    contextData: {
+      campaignId,
+      ...get(analytics, 'context', {}),
+    },
     metaData: {
       adjective: get(analytics, 'adjective', null),
       category: 'signup',
@@ -115,10 +119,6 @@ export function storeCampaignSignup(campaignId, data = {}) {
       noun: type,
       target: get(analytics, 'target', null),
       verb: 'clicked',
-    },
-    contextData: {
-      campaignId,
-      ...get(analytics, 'context', {}),
     },
   });
 

--- a/resources/assets/components/LedeBanner/templates/MosaicTemplate.js
+++ b/resources/assets/components/LedeBanner/templates/MosaicTemplate.js
@@ -46,7 +46,6 @@ const MosaicTemplate = props => {
 
       <SignupButton
         className={classnames({ '-float': affiliateSponsors.length })}
-        source="lede banner"
       />
       {signupArrowContent ? (
         <CampaignSignupArrow

--- a/resources/assets/components/LegacyQuiz/LegacyQuiz.js
+++ b/resources/assets/components/LegacyQuiz/LegacyQuiz.js
@@ -71,10 +71,12 @@ const LegacyQuiz = props => {
 
   if (shouldSeeResult) {
     trackAnalyticsEvent({
-      verb: 'submitted',
-      noun: 'quiz',
-      data: {
-        responses: data.questions,
+      contextData: { responses: data.questions },
+      metaData: {
+        category: 'campaign_action',
+        noun: 'quiz',
+        target: 'form',
+        verb: 'submitted',
       },
     });
   }

--- a/resources/assets/components/PollLocator/PollLocator.js
+++ b/resources/assets/components/PollLocator/PollLocator.js
@@ -18,8 +18,12 @@ class PollLocator extends React.Component {
 
   handleSearchButtonClick = () => {
     trackAnalyticsEvent({
-      verb: 'clicked',
-      noun: 'poll_locator',
+      metaData: {
+        category: 'campaign_action',
+        noun: 'poll_locator',
+        target: 'button',
+        verb: 'clicked',
+      },
     });
   };
 
@@ -37,9 +41,14 @@ class PollLocator extends React.Component {
         .querySelector('#address-not-found');
       if (get(addressNotFoundModal, 'style.display') === 'block') {
         trackAnalyticsEvent({
-          verb: 'opened',
-          noun: 'modal',
-          adjective: 'poll_locator_not_found',
+          metaData: {
+            adjective: 'poll_locator_not_found',
+            category: 'modal',
+            label: 'poll_locator',
+            noun: 'modal',
+            target: 'modal',
+            verb: 'opened',
+          },
         });
       }
 
@@ -59,9 +68,15 @@ class PollLocator extends React.Component {
       const modal = document.querySelector('html > #_vitModal');
       if (modal) {
         trackAnalyticsEvent({
-          verb: 'opened',
-          noun: 'modal',
-          adjective: 'poll_locator',
+          contextData: {},
+          metaData: {
+            adjective: 'poll_locator',
+            category: 'modal',
+            label: 'poll_locator',
+            noun: 'modal',
+            target: 'modal',
+            verb: 'opened',
+          },
         });
       }
     });

--- a/resources/assets/components/Quiz/Quiz.js
+++ b/resources/assets/components/Quiz/Quiz.js
@@ -84,10 +84,12 @@ class Quiz extends React.Component {
     }
 
     trackAnalyticsEvent({
-      verb: 'abandoned',
-      noun: 'quiz',
-      data: {
-        responses: this.state.choices,
+      contextData: { responses: this.state.choices },
+      metaData: {
+        category: 'campaign_action',
+        noun: 'quiz',
+        target: 'form',
+        verb: 'abandoned',
       },
     });
   };
@@ -126,10 +128,12 @@ class Quiz extends React.Component {
     );
 
     trackAnalyticsEvent({
-      verb: 'submitted',
-      noun: 'quiz',
-      data: {
-        responses: this.state.choices,
+      contextData: { responses: this.state.choices },
+      metaData: {
+        category: 'campaign_action',
+        noun: 'quiz',
+        target: 'form',
+        verb: 'submitted',
       },
     });
 

--- a/resources/assets/components/SignupButton/SignupButton.js
+++ b/resources/assets/components/SignupButton/SignupButton.js
@@ -31,11 +31,11 @@ const SignupButton = props => {
     storeCampaignSignup(campaignId, {
       body: { details: JSON.stringify(details) },
       analytics: {
-        target: 'button',
         context: {
           campaignContentfulId,
         },
         label: campaignTitle,
+        target: 'button',
       },
     });
   };

--- a/resources/assets/components/SignupButton/SignupButton.js
+++ b/resources/assets/components/SignupButton/SignupButton.js
@@ -10,18 +10,17 @@ const SignupButton = props => {
     campaignActionText,
     campaignContentfulId,
     campaignId,
+    campaignTitle,
     className,
     disableSignup,
-    source,
     sourceActionText,
     storeCampaignSignup,
-    template,
     text,
     trafficSource,
   } = props;
 
   // Decorate click handler for A/B tests & analytics.
-  const onSignup = buttonText => {
+  const onSignup = () => {
     const details = { campaignContentfulId };
 
     // Set affiliate opt in field if user has opted in.
@@ -32,10 +31,11 @@ const SignupButton = props => {
     storeCampaignSignup(campaignId, {
       body: { details: JSON.stringify(details) },
       analytics: {
-        campaignContentfulId,
-        source,
-        sourceData: { text: buttonText },
-        template,
+        target: 'button',
+        context: {
+          campaignContentfulId,
+        },
+        label: campaignTitle,
       },
     });
   };
@@ -50,7 +50,7 @@ const SignupButton = props => {
   const buttonCopy = text || sourceOverride || campaignActionText;
 
   return (
-    <Button className={className} onClick={() => onSignup(buttonCopy)}>
+    <Button className={className} onClick={() => onSignup()}>
       {buttonCopy}
     </Button>
   );
@@ -61,22 +61,21 @@ SignupButton.propTypes = {
   campaignActionText: PropTypes.string,
   campaignContentfulId: PropTypes.string.isRequired,
   campaignId: PropTypes.string.isRequired,
+  campaignTitle: PropTypes.string,
   className: PropTypes.string,
   disableSignup: PropTypes.bool,
-  source: PropTypes.string.isRequired,
   sourceActionText: PropTypes.objectOf(PropTypes.string),
   storeCampaignSignup: PropTypes.func.isRequired,
-  template: PropTypes.string,
   text: PropTypes.string,
   trafficSource: PropTypes.string,
 };
 
 SignupButton.defaultProps = {
   campaignActionText: 'Take Action',
+  campaignTitle: null,
   className: null,
   disableSignup: false,
   sourceActionText: null,
-  template: null,
   text: null,
   trafficSource: null,
 };

--- a/resources/assets/components/SignupButton/SignupButtonContainer.js
+++ b/resources/assets/components/SignupButton/SignupButtonContainer.js
@@ -10,11 +10,11 @@ import { storeCampaignSignup } from '../../actions/signup';
 const mapStateToProps = state => ({
   affiliateMessagingOptIn: state.signups.affiliateMessagingOptIn,
   campaignActionText: state.campaign.actionText,
-  campaignId: state.campaign.campaignId,
   campaignContentfulId: state.campaign.id,
+  campaignId: state.campaign.campaignId,
+  campaignTitle: state.campaign.title,
   disableSignup: get(state.campaign, 'additionalContent.disableSignup', false),
   sourceActionText: get(state.campaign, 'additionalContent.sourceActionText'),
-  template: state.campaign.template,
   trafficSource: state.user.source,
 });
 

--- a/resources/assets/components/actions/LinkAction/templates/CtaTemplate.js
+++ b/resources/assets/components/actions/LinkAction/templates/CtaTemplate.js
@@ -13,10 +13,15 @@ import './cta-template.scss';
 
 const onLinkClick = link => {
   window.open(link, isExternal(link) ? '_blank' : '_self');
+
   trackAnalyticsEvent({
-    verb: 'clicked',
-    noun: 'link_action',
-    data: { link },
+    contextData: { link },
+    metaData: {
+      category: 'campaign_action',
+      noun: 'link_action',
+      target: 'button',
+      verb: 'clicked',
+    },
   });
 };
 

--- a/resources/assets/components/actions/LinkAction/templates/CtaTemplate.js
+++ b/resources/assets/components/actions/LinkAction/templates/CtaTemplate.js
@@ -15,7 +15,7 @@ const onLinkClick = link => {
   window.open(link, isExternal(link) ? '_blank' : '_self');
 
   trackAnalyticsEvent({
-    contextData: { link },
+    contextData: { url: link },
     metaData: {
       category: 'campaign_action',
       noun: 'link_action',

--- a/resources/assets/components/actions/LinkAction/templates/DefaultTemplate.js
+++ b/resources/assets/components/actions/LinkAction/templates/DefaultTemplate.js
@@ -14,10 +14,15 @@ import TextContent from '../../../utilities/TextContent/TextContent';
 
 const onLinkClick = link => {
   window.open(link, isExternal(link) ? '_blank' : '_self');
+
   trackAnalyticsEvent({
-    verb: 'clicked',
-    noun: 'link_action',
-    data: { link },
+    contextData: { url: link },
+    metaData: {
+      category: 'campaign_action',
+      noun: 'link_action',
+      target: 'button',
+      verb: 'clicked',
+    },
   });
 };
 

--- a/resources/assets/components/actions/ShareAction/ShareAction.js
+++ b/resources/assets/components/actions/ShareAction/ShareAction.js
@@ -76,54 +76,65 @@ class ShareAction extends React.Component {
     });
   };
 
+  /**
+   * Component helper method for tracking analytics events.
+   *
+   * @param  {String} service
+   * @param  {String} target
+   * @param  {String} verb
+   * @param  {Object} data
+   * @return {Void}
+   */
+  trackEvent = (service, target, verb, data = {}) => {
+    trackAnalyticsEvent({
+      contextData: { ...data },
+      metaData: {
+        adjective: service,
+        category: 'campaign_action',
+        label: service,
+        noun: 'share_action',
+        target,
+        verb,
+      },
+    });
+  };
+
   handleFacebookClick = url => {
     const { link, userId } = this.props;
 
-    const trackingData = { url: link };
-    let trackingOptions = {
-      noun: 'share_action',
-      adjective: 'facebook',
-      data: trackingData,
-    };
+    let trackingData = { url: link };
 
-    trackAnalyticsEvent({
-      verb: 'clicked',
-      ...trackingOptions,
-    });
+    this.trackEvent('facebook', 'button', 'clicked', { url: link });
 
     showFacebookShareDialog(url)
       .then(() => {
         // Send share post to Rogue for authenticated users
         if (this.props.isAuthenticated && this.props.campaignId) {
           const puckId = `phoenix_${userId}_${Date.now()}`;
-          trackingOptions = {
-            ...trackingOptions,
-            data: { ...trackingData, puck_id: puckId },
-          };
+
+          trackingData = { ...trackingData, puck_id: puckId };
+
           this.storeSharePost(puckId);
         }
 
-        trackAnalyticsEvent({
-          verb: 'completed',
-          ...trackingOptions,
+        this.trackEvent('facebook', 'action', 'completed', {
+          ...trackingData,
         });
+
         this.setState({ showModal: true });
       })
       .catch(() => {
-        trackAnalyticsEvent({
-          verb: 'cancelled',
-          ...trackingOptions,
+        this.trackEvent('facebook', 'action', 'cancelled', {
+          ...trackingData,
         });
       });
   };
 
   handleTwitterClick = url => {
-    trackAnalyticsEvent({
-      verb: 'clicked',
-      noun: 'share_action',
-      adjective: 'twitter',
-      data: { url: this.props.link },
+    this.trackEvent('twitter', 'button', 'clicked', {
+      url: this.props.link,
     });
+
     showTwitterSharePrompt(url, '', () => this.setState({ showModal: true }));
   };
 

--- a/resources/assets/components/actions/ShareAction/ShareAction.test.js
+++ b/resources/assets/components/actions/ShareAction/ShareAction.test.js
@@ -78,10 +78,15 @@ describe('ShareAction component', () => {
 
       expect(trackEventMock.mock.calls[0]).toEqual([
         {
-          verb: 'clicked',
-          noun: 'share_action',
-          adjective: 'facebook',
-          data: trackingData,
+          contextData: trackingData,
+          metaData: {
+            adjective: 'facebook',
+            category: 'campaign_action',
+            noun: 'share_action',
+            label: 'facebook',
+            target: 'button',
+            verb: 'clicked',
+          },
         },
       ]);
     });
@@ -123,10 +128,15 @@ describe('ShareAction component', () => {
 
       expect(trackEventMock.mock.calls[0]).toEqual([
         {
-          verb: 'clicked',
-          noun: 'share_action',
-          adjective: 'twitter',
-          data: trackingData,
+          contextData: trackingData,
+          metaData: {
+            adjective: 'twitter',
+            category: 'campaign_action',
+            noun: 'share_action',
+            label: 'twitter',
+            target: 'button',
+            verb: 'clicked',
+          },
         },
       ]);
     });

--- a/resources/assets/components/actions/SocialDriveAction/SocialDriveAction.js
+++ b/resources/assets/components/actions/SocialDriveAction/SocialDriveAction.js
@@ -36,12 +36,16 @@ class SocialDriveAction extends React.Component {
 
   handleCopyLinkClick = () => {
     this.linkInput.current.select();
+
     document.execCommand('copy');
+
     trackAnalyticsEvent({
-      verb: 'clicked',
-      noun: 'copy_to_clipboard',
-      data: {
-        url: this.props.link,
+      contextData: { url: this.props.link },
+      metaData: {
+        category: 'campaign_action',
+        noun: 'copy_to_clipboard',
+        target: 'button',
+        verb: 'clicked',
       },
     });
   };

--- a/resources/assets/components/actions/TextSubmissionAction/TextSubmissionAction.js
+++ b/resources/assets/components/actions/TextSubmissionAction/TextSubmissionAction.js
@@ -70,11 +70,13 @@ class TextSubmissionAction extends React.Component {
 
   handleFocus = () => {
     trackAnalyticsEvent({
-      verb: 'focused',
-      noun: 'text_submission_action',
-      adjective: 'text',
-      data: {
-        contentfulId: this.props.id,
+      contextData: { contentfulId: this.props.id },
+      metaData: {
+        adjective: 'text',
+        category: 'campaign_action',
+        noun: 'text_submission_action', // @TODO: maybe set this using the formatEventNoun() helper?
+        target: 'field',
+        verb: 'focused',
       },
     });
   };

--- a/resources/assets/components/actions/VoterRegistrationAction/VoterRegistrationAction.js
+++ b/resources/assets/components/actions/VoterRegistrationAction/VoterRegistrationAction.js
@@ -21,7 +21,7 @@ export const VoterRegistrationBlockFragment = gql`
 `;
 
 const VoterRegistrationAction = props => {
-  const { campaignId, content, contentfulId, link, modalType, userId } = props;
+  const { campaignId, content, contentfulId, link, userId } = props;
 
   const tokens = {
     userId,
@@ -34,12 +34,20 @@ const VoterRegistrationAction = props => {
   const parsedLink = link && dynamicString(link, tokens);
 
   const handleClick = () => {
-    const trackingData = { contentfulId, url: parsedLink, modal: modalType };
     trackAnalyticsEvent({
-      verb: 'clicked',
-      noun: 'voter_registration_action',
-      data: trackingData,
+      contextData: {
+        campaignContentfulId: contentfulId,
+        campaignId,
+        url: parsedLink,
+      },
+      metaData: {
+        category: 'campaign_action',
+        label: 'voter_registration',
+        noun: 'voter_registration_action',
+        verb: 'clicked',
+      },
     });
+
     set(`${props.userId}_hide_voter_reg_modal`, 'boolean', true);
   };
 
@@ -74,13 +82,11 @@ VoterRegistrationAction.propTypes = {
   content: PropTypes.string,
   contentfulId: PropTypes.string.isRequired,
   link: PropTypes.string.isRequired,
-  modalType: PropTypes.string,
   userId: PropTypes.string.isRequired,
 };
 
 VoterRegistrationAction.defaultProps = {
   content: 'Register to vote!',
-  modalType: null,
 };
 
 export default VoterRegistrationAction;

--- a/resources/assets/components/utilities/Modal/Modal.js
+++ b/resources/assets/components/utilities/Modal/Modal.js
@@ -31,12 +31,18 @@ class Modal extends React.Component {
     this.modalPortal.appendChild(this.el);
 
     // Track in analytics that the modal opened:
+    // @TODO: A bit of duplication with analytics events; refactor to pass in the verb which
+    // is the only real difference, along with eventually passing modalType as the label.
     if (this.props.trackingId) {
       trackAnalyticsEvent({
-        verb: 'opened',
-        noun: 'modal',
-        data: {
+        contextData: {
           modalType: this.props.trackingId,
+        },
+        metaData: {
+          category: 'modal',
+          noun: 'modal',
+          target: 'modal',
+          verb: 'opened',
         },
       });
     }
@@ -52,10 +58,14 @@ class Modal extends React.Component {
     // Track in analytics that the modal closed:
     if (this.props.trackingId) {
       trackAnalyticsEvent({
-        verb: 'closed',
-        noun: 'modal',
-        data: {
+        contextData: {
           modalType: this.props.trackingId,
+        },
+        metaData: {
+          category: 'modal',
+          noun: 'modal',
+          target: 'modal',
+          verb: 'closed',
         },
       });
     }

--- a/resources/assets/components/utilities/SocialShareTray/SocialShareTray.js
+++ b/resources/assets/components/utilities/SocialShareTray/SocialShareTray.js
@@ -26,93 +26,105 @@ class SocialShareTray extends React.Component {
     loadFacebookSDK();
   }
 
-  handleFacebookShareClick = (shareLink, trackLink) => {
-    const trackingOptions = {
-      noun: 'share',
-      adjective: 'facebook',
-      data: {
-        url: trackLink,
-      },
-    };
-
+  /**
+   * Component helper method for tracking analytics events.
+   *
+   * @param  {String} service
+   * @param  {String} noun
+   * @param  {String} target
+   * @param  {String} verb
+   * @param  {Object} data
+   * @return {Void}
+   */
+  trackEvent = (service, noun, target, verb, data = {}) => {
     trackAnalyticsEvent({
-      verb: 'clicked',
-      ...trackingOptions,
+      contextData: { ...data },
+      metaData: {
+        adjective: service,
+        category: 'social_share',
+        label: service,
+        noun,
+        target,
+        verb,
+      },
+    });
+  };
+
+  handleFacebookShareClick = (shareLink, trackLink) => {
+    this.trackEvent('facebook', 'share', 'button', 'clicked', {
+      url: trackLink,
     });
 
     showFacebookShareDialog(shareLink)
       .then(() => {
-        trackAnalyticsEvent({
-          verb: 'completed',
-          ...trackingOptions,
+        this.trackEvent('facebook', 'share', 'action', 'completed', {
+          url: trackLink,
         });
       })
       .catch(() => {
-        trackAnalyticsEvent({
-          verb: 'cancelled',
-          ...trackingOptions,
+        this.trackEvent('facebook', 'share', 'action', 'cancelled', {
+          url: trackLink,
         });
       });
   };
 
   handleFacebookMessengerClick = (shareLink, trackLink) => {
-    const trackingData = { url: trackLink };
-    let trackingOptions = {
-      noun: 'share',
-      adjective: 'facebook_messenger',
-      data: trackingData,
-    };
-
-    trackAnalyticsEvent({
-      verb: 'clicked',
-      ...trackingOptions,
+    this.trackEvent('facebook_messenger', 'share', 'button', 'clicked', {
+      url: trackLink,
     });
 
     if (getFormattedScreenSize() === 'large') {
       // Show Send Dialog for Desktop clients.
       showFacebookSendDialog(shareLink)
         .then(() => {
-          trackAnalyticsEvent({
-            verb: 'completed',
-            ...trackingOptions,
-          });
+          this.trackEvent(
+            'facebook_messenger',
+            'share',
+            'action',
+            'completed',
+            {
+              url: trackLink,
+            },
+          );
         })
         .catch(() => {
-          trackAnalyticsEvent({
-            verb: 'cancelled',
-            ...trackingOptions,
-          });
+          this.trackEvent(
+            'facebook_messenger',
+            'share',
+            'action',
+            'cancelled',
+            {
+              url: trackLink,
+            },
+          );
         });
     } else {
-      trackingOptions = {
-        noun: 'redirect',
-        adjective: 'facebook_messenger_app',
-        data: trackingData,
-      };
       // Redirect mobile / tablet clients to the Messenger app.
       facebookMessengerShare(shareLink)
         .then(() => {
-          trackAnalyticsEvent({
-            verb: 'successful',
-            ...trackingOptions,
-          });
+          this.trackEvent(
+            'facebook_messenger_app',
+            'redirect',
+            'redirect',
+            'successful',
+            { url: trackLink },
+          );
         })
         .catch(() => {
-          trackAnalyticsEvent({
-            verb: 'failed',
-            ...trackingOptions,
-          });
+          this.trackEvent(
+            'facebook_messenger_app',
+            'redirect',
+            'redirect',
+            'failed',
+            { url: trackLink },
+          );
         });
     }
   };
 
   handleEmailShareClick = (shareLink, trackLink) => {
-    trackAnalyticsEvent({
-      verb: 'clicked',
-      noun: 'share',
-      adjective: 'email',
-      data: { url: trackLink },
-    });
+    this.trackEvent('email', 'share', 'button', 'clicked', { url: trackLink });
+
     window.location = `mailto:?body=${encodeURIComponent(shareLink)}`;
   };
 

--- a/resources/assets/helpers/analytics.js
+++ b/resources/assets/helpers/analytics.js
@@ -39,6 +39,8 @@ const formatEventName = (verb, noun, adjective = null) => {
  *
  * @param  {String} category
  * @param  {String} action
+ * @param  {String} label
+ * @param  {Object} data
  * @return {void}
  */
 export function analyzeWithGoogleAnalytics(
@@ -170,7 +172,7 @@ export function googleAnalyticsInit(history) {
  * @param  {String} options.service
  * @return {void}
  */
-export function trackAnalyticsEvent({ metaData, contextData, service }) {
+export function trackAnalyticsEvent({ metaData, contextData = {}, service }) {
   if (!metaData) {
     console.error('The metaData object is missing!');
     return;

--- a/resources/assets/helpers/analytics.js
+++ b/resources/assets/helpers/analytics.js
@@ -167,6 +167,14 @@ export function trackAnalyticsEvent({ verb, noun, adjective, data, service }) {
     return;
   }
 
+  console.log('🚁', {
+    verb,
+    noun,
+    adjective,
+    data,
+    service,
+  });
+
   const eventName = formatEventName(verb, noun, adjective);
 
   // Define category parameter for Google Analytics.

--- a/resources/assets/helpers/auth.js
+++ b/resources/assets/helpers/auth.js
@@ -33,10 +33,15 @@ export function bindTokenRefreshEvent() {
 
       if (expiresIn < 0) {
         console.log('Token has expired! Refreshing...');
+
         trackAnalyticsEvent({
-          verb: 'refreshed',
-          noun: 'token',
-          data: { skew },
+          contextData: { skew },
+          metaData: {
+            category: 'authentication',
+            noun: 'token',
+            target: 'token',
+            verb: 'refreshed',
+          },
         });
 
         clearInterval(authCheck);

--- a/resources/assets/helpers/index.js
+++ b/resources/assets/helpers/index.js
@@ -679,11 +679,17 @@ export function showTwitterSharePrompt(href, quote = '', callback) {
  */
 export function handleFacebookShareClick(href, trackingData) {
   trackAnalyticsEvent({
-    verb: 'clicked',
-    noun: 'share',
-    adjective: 'facebook',
-    data: trackingData,
+    contextData: { trackingData, url: href },
+    metaData: {
+      category: 'social_share',
+      adjective: 'facebook',
+      label: 'facebook',
+      noun: 'share',
+      target: 'button',
+      verb: 'clicked',
+    },
   });
+
   // @todo 12/13/2018: Use the showFacebookShareDialog to track
   // 'completed' and 'cancelled' events as well.
   showFacebookSharePrompt(href);
@@ -698,11 +704,17 @@ export function handleFacebookShareClick(href, trackingData) {
  */
 export function handleTwitterShareClick(href, trackingData, quote = '') {
   trackAnalyticsEvent({
-    verb: 'clicked',
-    noun: 'share',
-    adjective: 'twitter',
-    data: trackingData,
+    contextData: { trackingData, url: href },
+    metaData: {
+      category: 'social_share',
+      adjective: 'twitter',
+      label: 'twitter',
+      noun: 'share',
+      target: 'button',
+      verb: 'clicked',
+    },
   });
+
   showTwitterSharePrompt(href, quote);
 }
 

--- a/resources/assets/middleware/api.js
+++ b/resources/assets/middleware/api.js
@@ -93,14 +93,19 @@ const postRequest = (payload, dispatch, getState) => {
       };
 
       trackAnalyticsEvent({
-        verb:
-          statusCode === 200 && postType === 'signup' ? 'found' : 'completed',
-        noun: formatEventNoun(postType),
-        data: {
-          activityId: response.data.id,
+        contextData: {
           actionId,
+          activityId: response.data.id,
           campaignContentfulId,
           campaignId,
+        },
+        metaData: {
+          category: 'campaign_action', // @TODO: this may need to get passed in as an argument.
+          label: campaignId, // @TODO: make this the campaign title if available; but also may need to get passed in as an argument.
+          noun: formatEventNoun(postType),
+          target: postType,
+          verb:
+            statusCode === 200 && postType === 'signup' ? 'found' : 'completed',
         },
       });
 
@@ -114,13 +119,18 @@ const postRequest = (payload, dispatch, getState) => {
       report(error);
 
       trackAnalyticsEvent({
-        verb: 'failed',
-        noun: formatEventNoun(postType),
-        data: {
+        contextData: {
           actionId,
           campaignContentfulId,
           campaignId,
           error,
+        },
+        metaData: {
+          category: 'campaign_action', // @TODO: this may need to get passed in as an argument.
+          label: campaignId, // @TODO: make this the campaign title if available; but also may need to get passed in as an argument.
+          noun: formatEventNoun(postType),
+          target: postType,
+          verb: 'failed',
         },
       });
 


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR updates our analytics system to conform to the new requirements the data team has defined moving forward.

### Any background context you want to provide?

One of the bigger changes happening to help structure calls to `trackAnalyticsEvent()` a little better is that it now only accepts 3 params:
 - `metaData` (required) // all data around describing the event (noun, verb, adjective, category, etc)
- `contextData` (defaults to empty object) // all additional contextual data (campaignId, actionId, etc)
- `service` (optional) // specifying to only send to a specific service (rarely used but still seems useful; for example if we restore waypoints in the future maybe only Snowplow cares about them)

Most of the PR is actually related to updating ALL calls to `trackAnalyticsEvent()` to pass through the new argument structure.

### What are the relevant tickets/cards?

Refs [Pivotal ID #]()

### Checklist

* [ ] Documentation added for new features/changed endpoints.