### PR TITLE
Renaming trackAnalyticsEvent properties.

### DIFF
--- a/resources/assets/actions/post.js
+++ b/resources/assets/actions/post.js
@@ -92,13 +92,13 @@ export function storeCampaignPost(campaignId, data) {
 
   // Track post submission event.
   trackAnalyticsEvent({
-    contextData: {
+    context: {
       action,
       actionId,
       campaignContentfulId,
       campaignId,
     },
-    metaData: {
+    metadata: {
       category: 'campaign_action',
       label: type,
       noun: formatEventNoun(type),
@@ -149,10 +149,10 @@ export function storePost(data) {
 
   // Track post submission event.
   trackAnalyticsEvent({
-    contextData: {
+    context: {
       actionId,
     },
-    metaData: {
+    metadata: {
       category: 'campaign_action',
       label: type,
       noun: formatEventNoun(type),

--- a/resources/assets/actions/signup.js
+++ b/resources/assets/actions/signup.js
@@ -108,11 +108,11 @@ export function storeCampaignSignup(campaignId, data = {}) {
 
   // Track signup click submission event.
   trackAnalyticsEvent({
-    contextData: {
+    context: {
       campaignId,
       ...get(analytics, 'context', {}),
     },
-    metaData: {
+    metadata: {
       adjective: get(analytics, 'adjective', null),
       category: 'signup',
       label: get(analytics, 'label', null),

--- a/resources/assets/components/LegacyQuiz/LegacyQuiz.js
+++ b/resources/assets/components/LegacyQuiz/LegacyQuiz.js
@@ -71,8 +71,8 @@ const LegacyQuiz = props => {
 
   if (shouldSeeResult) {
     trackAnalyticsEvent({
-      contextData: { responses: data.questions },
-      metaData: {
+      context: { responses: data.questions },
+      metadata: {
         category: 'campaign_action',
         noun: 'quiz',
         target: 'form',

--- a/resources/assets/components/PollLocator/PollLocator.js
+++ b/resources/assets/components/PollLocator/PollLocator.js
@@ -18,7 +18,7 @@ class PollLocator extends React.Component {
 
   handleSearchButtonClick = () => {
     trackAnalyticsEvent({
-      metaData: {
+      metadata: {
         category: 'campaign_action',
         noun: 'poll_locator',
         target: 'button',
@@ -41,7 +41,7 @@ class PollLocator extends React.Component {
         .querySelector('#address-not-found');
       if (get(addressNotFoundModal, 'style.display') === 'block') {
         trackAnalyticsEvent({
-          metaData: {
+          metadata: {
             adjective: 'poll_locator_not_found',
             category: 'modal',
             label: 'poll_locator',
@@ -68,8 +68,7 @@ class PollLocator extends React.Component {
       const modal = document.querySelector('html > #_vitModal');
       if (modal) {
         trackAnalyticsEvent({
-          contextData: {},
-          metaData: {
+          metadata: {
             adjective: 'poll_locator',
             category: 'modal',
             label: 'poll_locator',

--- a/resources/assets/components/Quiz/Quiz.js
+++ b/resources/assets/components/Quiz/Quiz.js
@@ -84,8 +84,8 @@ class Quiz extends React.Component {
     }
 
     trackAnalyticsEvent({
-      contextData: { responses: this.state.choices },
-      metaData: {
+      context: { responses: this.state.choices },
+      metadata: {
         category: 'campaign_action',
         noun: 'quiz',
         target: 'form',
@@ -128,8 +128,8 @@ class Quiz extends React.Component {
     );
 
     trackAnalyticsEvent({
-      contextData: { responses: this.state.choices },
-      metaData: {
+      context: { responses: this.state.choices },
+      metadata: {
         category: 'campaign_action',
         noun: 'quiz',
         target: 'form',

--- a/resources/assets/components/SignupButton/SignupButton.js
+++ b/resources/assets/components/SignupButton/SignupButton.js
@@ -20,7 +20,7 @@ const SignupButton = props => {
   } = props;
 
   // Decorate click handler for A/B tests & analytics.
-  const onSignup = () => {
+  const handleSignup = () => {
     const details = { campaignContentfulId };
 
     // Set affiliate opt in field if user has opted in.
@@ -50,7 +50,7 @@ const SignupButton = props => {
   const buttonCopy = text || sourceOverride || campaignActionText;
 
   return (
-    <Button className={className} onClick={() => onSignup()}>
+    <Button className={className} onClick={handleSignup}>
       {buttonCopy}
     </Button>
   );

--- a/resources/assets/components/actions/LinkAction/templates/CtaTemplate.js
+++ b/resources/assets/components/actions/LinkAction/templates/CtaTemplate.js
@@ -15,8 +15,8 @@ const onLinkClick = link => {
   window.open(link, isExternal(link) ? '_blank' : '_self');
 
   trackAnalyticsEvent({
-    contextData: { url: link },
-    metaData: {
+    context: { url: link },
+    metadata: {
       category: 'campaign_action',
       noun: 'link_action',
       target: 'button',

--- a/resources/assets/components/actions/LinkAction/templates/DefaultTemplate.js
+++ b/resources/assets/components/actions/LinkAction/templates/DefaultTemplate.js
@@ -16,8 +16,8 @@ const onLinkClick = link => {
   window.open(link, isExternal(link) ? '_blank' : '_self');
 
   trackAnalyticsEvent({
-    contextData: { url: link },
-    metaData: {
+    context: { url: link },
+    metadata: {
       category: 'campaign_action',
       noun: 'link_action',
       target: 'button',

--- a/resources/assets/components/actions/ShareAction/ShareAction.js
+++ b/resources/assets/components/actions/ShareAction/ShareAction.js
@@ -87,8 +87,8 @@ class ShareAction extends React.Component {
    */
   trackEvent = (service, target, verb, data = {}) => {
     trackAnalyticsEvent({
-      contextData: { ...data },
-      metaData: {
+      context: { ...data },
+      metadata: {
         adjective: service,
         category: 'campaign_action',
         label: service,

--- a/resources/assets/components/actions/ShareAction/ShareAction.test.js
+++ b/resources/assets/components/actions/ShareAction/ShareAction.test.js
@@ -78,8 +78,8 @@ describe('ShareAction component', () => {
 
       expect(trackEventMock.mock.calls[0]).toEqual([
         {
-          contextData: trackingData,
-          metaData: {
+          context: trackingData,
+          metadata: {
             adjective: 'facebook',
             category: 'campaign_action',
             noun: 'share_action',
@@ -128,8 +128,8 @@ describe('ShareAction component', () => {
 
       expect(trackEventMock.mock.calls[0]).toEqual([
         {
-          contextData: trackingData,
-          metaData: {
+          context: trackingData,
+          metadata: {
             adjective: 'twitter',
             category: 'campaign_action',
             noun: 'share_action',

--- a/resources/assets/components/actions/SocialDriveAction/SocialDriveAction.js
+++ b/resources/assets/components/actions/SocialDriveAction/SocialDriveAction.js
@@ -40,8 +40,8 @@ class SocialDriveAction extends React.Component {
     document.execCommand('copy');
 
     trackAnalyticsEvent({
-      contextData: { url: this.props.link },
-      metaData: {
+      context: { url: this.props.link },
+      metadata: {
         category: 'campaign_action',
         noun: 'copy_to_clipboard',
         target: 'button',

--- a/resources/assets/components/actions/TextSubmissionAction/TextSubmissionAction.js
+++ b/resources/assets/components/actions/TextSubmissionAction/TextSubmissionAction.js
@@ -70,8 +70,8 @@ class TextSubmissionAction extends React.Component {
 
   handleFocus = () => {
     trackAnalyticsEvent({
-      contextData: { contentfulId: this.props.id },
-      metaData: {
+      context: { contentfulId: this.props.id },
+      metadata: {
         adjective: 'text',
         category: 'campaign_action',
         noun: 'text_submission_action', // @TODO: maybe set this using the formatEventNoun() helper?

--- a/resources/assets/components/actions/VoterRegistrationAction/VoterRegistrationAction.js
+++ b/resources/assets/components/actions/VoterRegistrationAction/VoterRegistrationAction.js
@@ -35,12 +35,12 @@ const VoterRegistrationAction = props => {
 
   const handleClick = () => {
     trackAnalyticsEvent({
-      contextData: {
+      context: {
         campaignContentfulId: contentfulId,
         campaignId,
         url: parsedLink,
       },
-      metaData: {
+      metadata: {
         category: 'campaign_action',
         label: 'voter_registration',
         noun: 'voter_registration_action',

--- a/resources/assets/components/utilities/Modal/Modal.js
+++ b/resources/assets/components/utilities/Modal/Modal.js
@@ -35,10 +35,10 @@ class Modal extends React.Component {
     // is the only real difference, along with eventually passing modalType as the label.
     if (this.props.trackingId) {
       trackAnalyticsEvent({
-        contextData: {
+        context: {
           modalType: this.props.trackingId,
         },
-        metaData: {
+        metadata: {
           category: 'modal',
           noun: 'modal',
           target: 'modal',
@@ -58,10 +58,10 @@ class Modal extends React.Component {
     // Track in analytics that the modal closed:
     if (this.props.trackingId) {
       trackAnalyticsEvent({
-        contextData: {
+        context: {
           modalType: this.props.trackingId,
         },
-        metaData: {
+        metadata: {
           category: 'modal',
           noun: 'modal',
           target: 'modal',

--- a/resources/assets/components/utilities/SocialShareTray/SocialShareTray.js
+++ b/resources/assets/components/utilities/SocialShareTray/SocialShareTray.js
@@ -38,8 +38,8 @@ class SocialShareTray extends React.Component {
    */
   trackEvent = (service, noun, target, verb, data = {}) => {
     trackAnalyticsEvent({
-      contextData: { ...data },
-      metaData: {
+      context: { ...data },
+      metadata: {
         adjective: service,
         category: 'social_share',
         label: service,

--- a/resources/assets/helpers/analytics.js
+++ b/resources/assets/helpers/analytics.js
@@ -180,13 +180,11 @@ export function trackAnalyticsEvent({ metadata, context = {}, service }) {
   }
 
   const { adjective, category, target, noun, verb } = metadata;
-  let { label } = metadata;
+  const label = metadata.label || noun;
 
   const name = formatEventName(verb, noun, adjective);
 
   const action = snakeCase(`${target}_${verb}`);
-
-  label = label || noun;
 
   sendToServices(name, category, action, label, context, service);
 }

--- a/resources/assets/helpers/analytics.js
+++ b/resources/assets/helpers/analytics.js
@@ -164,22 +164,23 @@ export function googleAnalyticsInit(history) {
 }
 
 /**
- * Track an analytics event with a specified service. (Defaults to tracking with all services.)
+ * Track an analytics event with a specified service.
+ * (Defaults to tracking with all services.)
  *
  * @param  {Object} options
- * @param  {Object} options.metaData
- * @param  {Object} options.contextData
+ * @param  {Object} options.metadata
+ * @param  {Object} options.context
  * @param  {String} options.service
  * @return {void}
  */
-export function trackAnalyticsEvent({ metaData, contextData = {}, service }) {
-  if (!metaData) {
-    console.error('The metaData object is missing!');
+export function trackAnalyticsEvent({ metadata, context = {}, service }) {
+  if (!metadata) {
+    console.error('The metadata object is missing!');
     return;
   }
 
-  const { adjective, category, target, noun, verb } = metaData;
-  let { label } = metaData;
+  const { adjective, category, target, noun, verb } = metadata;
+  let { label } = metadata;
 
   const name = formatEventName(verb, noun, adjective);
 
@@ -187,5 +188,5 @@ export function trackAnalyticsEvent({ metaData, contextData = {}, service }) {
 
   label = label || noun;
 
-  sendToServices(name, category, action, label, contextData, service);
+  sendToServices(name, category, action, label, context, service);
 }

--- a/resources/assets/helpers/analytics.js
+++ b/resources/assets/helpers/analytics.js
@@ -63,10 +63,10 @@ export function analyzeWithGoogleAnalytics(
   // Push event action to Google Tag Manager's data layer.
   window.dataLayer = window.dataLayer || [];
   window.dataLayer.push({
+    event: name,
     eventAction: startCase(action),
     eventCategory: startCase(category),
     eventLabel: startCase(label),
-    eventName: name,
     eventContext: data,
   });
 }

--- a/resources/assets/helpers/auth.js
+++ b/resources/assets/helpers/auth.js
@@ -35,8 +35,8 @@ export function bindTokenRefreshEvent() {
         console.log('Token has expired! Refreshing...');
 
         trackAnalyticsEvent({
-          contextData: { skew },
-          metaData: {
+          context: { skew },
+          metadata: {
             category: 'authentication',
             noun: 'token',
             target: 'token',

--- a/resources/assets/helpers/index.js
+++ b/resources/assets/helpers/index.js
@@ -679,8 +679,8 @@ export function showTwitterSharePrompt(href, quote = '', callback) {
  */
 export function handleFacebookShareClick(href, trackingData) {
   trackAnalyticsEvent({
-    contextData: { trackingData, url: href },
-    metaData: {
+    context: { trackingData, url: href },
+    metadata: {
       category: 'social_share',
       adjective: 'facebook',
       label: 'facebook',
@@ -704,8 +704,8 @@ export function handleFacebookShareClick(href, trackingData) {
  */
 export function handleTwitterShareClick(href, trackingData, quote = '') {
   trackAnalyticsEvent({
-    contextData: { trackingData, url: href },
-    metaData: {
+    context: { trackingData, url: href },
+    metadata: {
       category: 'social_share',
       adjective: 'twitter',
       label: 'twitter',

--- a/resources/assets/middleware/api.js
+++ b/resources/assets/middleware/api.js
@@ -93,13 +93,13 @@ const postRequest = (payload, dispatch, getState) => {
       };
 
       trackAnalyticsEvent({
-        contextData: {
+        context: {
           actionId,
           activityId: response.data.id,
           campaignContentfulId,
           campaignId,
         },
-        metaData: {
+        metadata: {
           category: 'campaign_action', // @TODO: this may need to get passed in as an argument.
           label: campaignId, // @TODO: make this the campaign title if available; but also may need to get passed in as an argument.
           noun: formatEventNoun(postType),
@@ -119,13 +119,13 @@ const postRequest = (payload, dispatch, getState) => {
       report(error);
 
       trackAnalyticsEvent({
-        contextData: {
+        context: {
           actionId,
           campaignContentfulId,
           campaignId,
           error,
         },
-        metaData: {
+        metadata: {
           category: 'campaign_action', // @TODO: this may need to get passed in as an argument.
           label: campaignId, // @TODO: make this the campaign title if available; but also may need to get passed in as an argument.
           noun: formatEventNoun(postType),


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR address recommendation in [#1446](https://github.com/DoSomething/phoenix-next/pull/1446#discussion_r290037530) regarding the naming of `metaData` and `contextData` properties. It changes these to be `metadata` and `context` to simplify things and keep `metadata` as one word! 

It also does a little bit of [cleanup with the `SignupButton` component](https://github.com/DoSomething/phoenix-next/pull/1447/commits/f7c7aba217a8dd28e19eb3164c4a1c0d7cdb208f) and [renames the `eventName` data layer property to just `event`](https://github.com/DoSomething/phoenix-next/pull/1447/commits/702820db3325cf2ae3137adff50a616e14d35105) since this is what GTM prefers.

### Any background context you want to provide?
🛁 

### What are the relevant tickets/cards?

Refs [Pivotal ID #166243697](https://www.pivotaltracker.com/story/show/166243697)
