### PR TITLE
Updates url parameter name that passes along the actionId to SoftEdge

### DIFF
--- a/resources/assets/components/actions/SoftEdgeWidgetAction/SoftEdgeWidgetAction.js
+++ b/resources/assets/components/actions/SoftEdgeWidgetAction/SoftEdgeWidgetAction.js
@@ -28,10 +28,9 @@ class SoftEdgeWidgetAction extends React.Component {
     const actionId = this.props.actionId;
     const user = this.props.user;
 
-    // Note: the actionId sent in the campaignId query string is not a typo. This is to not conflict with SoftEdge's internal actionIds.
     let url = `//www.congressweb.com/dosomething/${softEdgeId}?acceptAuthor=true&memberId=${
       this.props.userId
-    }&campaignId=${actionId}`;
+    }&externalActionId=${actionId}`;
 
     const prepopulatedFields = withoutNulls({
       firstName: user.firstName,

--- a/resources/assets/components/actions/SoftEdgeWidgetAction/SoftEdgeWidgetAction.js
+++ b/resources/assets/components/actions/SoftEdgeWidgetAction/SoftEdgeWidgetAction.js
@@ -28,8 +28,10 @@ class SoftEdgeWidgetAction extends React.Component {
     const actionId = this.props.actionId;
     const user = this.props.user;
 
+    // Note: the actionId sent in the campaignId query string is not a typo. This is to not conflict with SoftEdge's internal actionIds.
     let url = `//www.congressweb.com/dosomething/${softEdgeId}?acceptAuthor=true&memberId=${
-      this.props.userId}&dosomething_action_id=${actionId}`;
+      this.props.userId
+    }&campaignId=${actionId}`;
 
     const prepopulatedFields = withoutNulls({
       firstName: user.firstName,


### PR DESCRIPTION
### What does this PR do?

This PR updates `dosomething_action_id` to `externalActionId` in the query string when sending info. to the SoftEdge widget.

### What are the relevant tickets/cards?

Refs [Pivotal ID #165974086](https://www.pivotaltracker.com/n/projects/2019313/stories/165974086)

### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.
* [ ] Added screenshot to PR description of related front-end updates on **small** screens.
* [ ] Added screenshot to PR description of related front-end updates on **medium** screens.
* [ ] Added screenshot to PR description of related front-end updates on **large** screens.
