### PR TITLE
Format socialPlatform field from ShareActionContainer

### DIFF
--- a/app/Entities/ShareAction.php
+++ b/app/Entities/ShareAction.php
@@ -24,7 +24,7 @@ class ShareAction extends Entity implements JsonSerializable
                 'hideEmbed' => $this->hideEmbed,
                 'affirmation' => $this->affirmation,
                 'affirmationBlock' => $this->parseBlock($this->affirmationBlock),
-                'socialPlatform' => $this->socialPlatform->first() ?: 'facebook',
+                'socialPlatform' => $this->socialPlatform,
                 'additionalContent' => $this->additionalContent,
             ],
         ];

--- a/resources/assets/components/actions/ShareAction/ShareActionContainer.js
+++ b/resources/assets/components/actions/ShareAction/ShareActionContainer.js
@@ -7,11 +7,14 @@ import { storeCampaignPost } from '../../../actions/post';
 /**
  * Provide state from the Redux store as props for this component.
  */
-const mapStateToProps = state => ({
+const mapStateToProps = (state, ownProps) => ({
   userId: getUserId(state),
   campaignId: state.campaign.campaignId,
   isAuthenticated: isAuthenticated(state),
   campaignContentfulId: state.campaign.id,
+  // Value comes through as Array, but component expects a String value.
+  // @TODO: Update this Contentful field to be a String value.
+  socialPlatform: ownProps.socialPlatform[0] || 'facebook',
 });
 
 /**

--- a/resources/assets/components/actions/ShareAction/ShareActionContainer.js
+++ b/resources/assets/components/actions/ShareAction/ShareActionContainer.js
@@ -1,3 +1,4 @@
+import { isArray } from 'lodash';
 import { connect } from 'react-redux';
 
 import ShareAction from './ShareAction';
@@ -7,15 +8,21 @@ import { storeCampaignPost } from '../../../actions/post';
 /**
  * Provide state from the Redux store as props for this component.
  */
-const mapStateToProps = (state, ownProps) => ({
-  userId: getUserId(state),
-  campaignId: state.campaign.campaignId,
-  isAuthenticated: isAuthenticated(state),
-  campaignContentfulId: state.campaign.id,
-  // Value comes through as Array, but component expects a String value.
-  // @TODO: Update this Contentful field to be a String value.
-  socialPlatform: ownProps.socialPlatform[0] || 'facebook',
-});
+const mapStateToProps = (state, ownProps) => {
+  // Support Array or String value. (This should be an Array until we update the Contentful field (https://git.io/fjzkh)).
+  // @TODO: Clean this up when we update the field to return a String.
+  const socialPlatform = isArray(ownProps.socialPlatform)
+    ? ownProps.socialPlatform[0]
+    : ownProps.socialPlatform;
+
+  return {
+    userId: getUserId(state),
+    campaignId: state.campaign.campaignId,
+    isAuthenticated: isAuthenticated(state),
+    campaignContentfulId: state.campaign.id,
+    socialPlatform: socialPlatform || 'facebook',
+  };
+};
 
 /**
  * Provide pre-bound functions that allow the component to dispatch


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR format the `ShareAction.socialPlatform` field from the `ShareActionContainer` instead of from the `ShareAction` Entity.  

### Any background context you want to provide?
The `ShareAction` component expects a String value:
 https://github.com/DoSomething/phoenix-next/blob/f3864e63dd720d9011544daaf6454bad4857821f/resources/assets/components/actions/ShareAction/ShareAction.js#L226

On Contentful, the field is returned as an Array value:
https://github.com/DoSomething/phoenix-next/blob/f3864e63dd720d9011544daaf6454bad4857821f/contentful/content-types/shareAction.js#L45
(I believe the single Short Text radio button option was not available when we added this field, and this was the only way to allow multiple predefined selections).

We format this on the Entity:
https://github.com/DoSomething/phoenix-next/blob/98856187db42eb366b639dcb835a522f71775705/app/Entities/ShareAction.php#L27

But this formatting wouldn't apply to entries fetched directly from GraphQL via the [`ContentfulEntryLoader`](https://github.com/DoSomething/phoenix-next/blob/f3864e63dd720d9011544daaf6454bad4857821f/resources/assets/components/utilities/ContentfulEntryLoader/ContentfulEntryLoader.js#L69).

ideally, we'll want to run a script to transform this field to use the plain Short Text, with a radio button interface (I left a TODO), but for now, I figured moving the formatting over to the Container would be a nice way to apply this formatting across the board without extra finageling in the component logic itself.

### What are the relevant tickets/cards?
https://dosomething.slack.com/archives/C09ANFQLA/p1559687038006100