### PR TITLE
Send all the UTMs to Northstar and Rogue!

### DIFF
--- a/resources/assets/components/SignupButton/SignupButton.js
+++ b/resources/assets/components/SignupButton/SignupButton.js
@@ -22,8 +22,7 @@ const SignupButton = props => {
 
   // Decorate click handler for A/B tests & analytics.
   const handleSignup = () => {
-    // @TODO: Do we need this if we store refferer_id on source_details?
-    const details = { campaignContentfulId: referrerId };
+    const details = {};
 
     // Set affiliate opt in field if user has opted in.
     if (affiliateMessagingOptIn) {

--- a/resources/assets/components/SignupButton/SignupButton.js
+++ b/resources/assets/components/SignupButton/SignupButton.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { get } from 'lodash';
 
+import { query, withoutNulls } from '../../helpers';
 import Button from '../utilities/Button/Button';
 
 const SignupButton = props => {
@@ -30,7 +31,17 @@ const SignupButton = props => {
     }
 
     storeCampaignSignup(campaignId, {
-      body: { details: JSON.stringify(details) },
+      body: {
+        details: JSON.stringify(details),
+        source_details: JSON.stringify(
+          withoutNulls({
+            referrer_id: referrerId,
+            utm_source: query('utm_source'),
+            utm_medium: query('utm_medium'),
+            utm_campaign: query('utm_campaign'),
+          }),
+        ),
+      },
       analytics: {
         context: {
           campaignContentfulId: referrerId,

--- a/resources/assets/components/SignupButton/SignupButton.js
+++ b/resources/assets/components/SignupButton/SignupButton.js
@@ -11,9 +11,9 @@ const SignupButton = props => {
     campaignActionText,
     campaignId,
     campaignTitle,
+    contentfulId,
     className,
     disableSignup,
-    referrerId,
     sourceActionText,
     storeCampaignSignup,
     text,
@@ -34,7 +34,7 @@ const SignupButton = props => {
         details: JSON.stringify(details),
         source_details: JSON.stringify(
           withoutNulls({
-            referrer_id: referrerId,
+            contentful_id: contentfulId,
             utm_source: query('utm_source'),
             utm_medium: query('utm_medium'),
             utm_campaign: query('utm_campaign'),
@@ -43,7 +43,7 @@ const SignupButton = props => {
       },
       analytics: {
         context: {
-          campaignContentfulId: referrerId,
+          contentfulId,
         },
         label: campaignTitle,
         target: 'button',
@@ -70,9 +70,9 @@ const SignupButton = props => {
 SignupButton.propTypes = {
   affiliateMessagingOptIn: PropTypes.bool.isRequired,
   campaignActionText: PropTypes.string,
-  referrerId: PropTypes.string.isRequired,
   campaignId: PropTypes.string.isRequired,
   campaignTitle: PropTypes.string,
+  contentfulId: PropTypes.string.isRequired,
   className: PropTypes.string,
   disableSignup: PropTypes.bool,
   sourceActionText: PropTypes.objectOf(PropTypes.string),

--- a/resources/assets/components/SignupButton/SignupButton.js
+++ b/resources/assets/components/SignupButton/SignupButton.js
@@ -8,11 +8,11 @@ const SignupButton = props => {
   const {
     affiliateMessagingOptIn,
     campaignActionText,
-    campaignContentfulId,
     campaignId,
     campaignTitle,
     className,
     disableSignup,
+    referrerId,
     sourceActionText,
     storeCampaignSignup,
     text,
@@ -21,7 +21,8 @@ const SignupButton = props => {
 
   // Decorate click handler for A/B tests & analytics.
   const handleSignup = () => {
-    const details = { campaignContentfulId };
+    // @TODO: Do we need this if we store refferer_id on source_details?
+    const details = { campaignContentfulId: referrerId };
 
     // Set affiliate opt in field if user has opted in.
     if (affiliateMessagingOptIn) {
@@ -32,7 +33,7 @@ const SignupButton = props => {
       body: { details: JSON.stringify(details) },
       analytics: {
         context: {
-          campaignContentfulId,
+          campaignContentfulId: referrerId,
         },
         label: campaignTitle,
         target: 'button',
@@ -59,7 +60,7 @@ const SignupButton = props => {
 SignupButton.propTypes = {
   affiliateMessagingOptIn: PropTypes.bool.isRequired,
   campaignActionText: PropTypes.string,
-  campaignContentfulId: PropTypes.string.isRequired,
+  referrerId: PropTypes.string.isRequired,
   campaignId: PropTypes.string.isRequired,
   campaignTitle: PropTypes.string,
   className: PropTypes.string,

--- a/resources/assets/components/SignupButton/SignupButtonContainer.js
+++ b/resources/assets/components/SignupButton/SignupButtonContainer.js
@@ -10,9 +10,9 @@ import { storeCampaignSignup } from '../../actions/signup';
 const mapStateToProps = state => ({
   affiliateMessagingOptIn: state.signups.affiliateMessagingOptIn,
   campaignActionText: state.campaign.actionText,
-  referrerId: state.campaign.id,
   campaignId: state.campaign.campaignId,
   campaignTitle: state.campaign.title,
+  contentfulId: state.campaign.id,
   disableSignup: get(state.campaign, 'additionalContent.disableSignup', false),
   sourceActionText: get(state.campaign, 'additionalContent.sourceActionText'),
   trafficSource: state.user.source,

--- a/resources/assets/components/SignupButton/SignupButtonContainer.js
+++ b/resources/assets/components/SignupButton/SignupButtonContainer.js
@@ -10,7 +10,7 @@ import { storeCampaignSignup } from '../../actions/signup';
 const mapStateToProps = state => ({
   affiliateMessagingOptIn: state.signups.affiliateMessagingOptIn,
   campaignActionText: state.campaign.actionText,
-  campaignContentfulId: state.campaign.id,
+  referrerId: state.campaign.id,
   campaignId: state.campaign.campaignId,
   campaignTitle: state.campaign.title,
   disableSignup: get(state.campaign, 'additionalContent.disableSignup', false),

--- a/resources/assets/components/actions/PetitionSubmissioncAction/PetitionSubmissionAction.js
+++ b/resources/assets/components/actions/PetitionSubmissioncAction/PetitionSubmissionAction.js
@@ -11,7 +11,7 @@ import Modal from '../../utilities/Modal/Modal';
 import Button from '../../utilities/Button/Button';
 import FormValidation from '../../utilities/Form/FormValidation';
 import TextContent from '../../utilities/TextContent/TextContent';
-import { formatFormFields, getFieldErrors } from '../../../helpers/forms';
+import { formatPostPayload, getFieldErrors } from '../../../helpers/forms';
 import CharacterLimit from '../../utilities/CharacterLimit/CharacterLimit';
 
 import './petition-submission-action.scss';
@@ -84,7 +84,7 @@ class PetitionSubmissionAction extends React.Component {
 
     // Send request to store the petition submission post.
     storePost({
-      body: formatFormFields({
+      body: formatPostPayload({
         action_id: actionId,
         text: this.state.textValue,
         type,

--- a/resources/assets/components/actions/PhotoSubmissionAction/PhotoSubmissionAction.js
+++ b/resources/assets/components/actions/PhotoSubmissionAction/PhotoSubmissionAction.js
@@ -18,7 +18,7 @@ import TextContent from '../../utilities/TextContent/TextContent';
 import {
   calculateDifference,
   getFieldErrors,
-  formatFormFields,
+  formatPostPayload,
 } from '../../../helpers/forms';
 
 import './photo-submission-action.scss';
@@ -206,7 +206,7 @@ class PhotoSubmissionAction extends React.Component {
     this.props.storeCampaignPost(this.props.campaignId, {
       action,
       actionId: this.props.actionId,
-      body: formatFormFields(formFields),
+      body: formatPostPayload(formFields),
       id: this.props.id,
       campaignContentfulId: this.props.campaignContentfulId,
       type,

--- a/resources/assets/components/actions/ReferralSubmissionAction/ReferralSubmissionAction.js
+++ b/resources/assets/components/actions/ReferralSubmissionAction/ReferralSubmissionAction.js
@@ -12,7 +12,7 @@ import Button from '../../utilities/Button/Button';
 import { withoutUndefined } from '../../../helpers';
 import FormValidation from '../../utilities/Form/FormValidation';
 import TextContent from '../../utilities/TextContent/TextContent';
-import { getFieldErrors, formatFormFields } from '../../../helpers/forms';
+import { getFieldErrors, formatPostPayload } from '../../../helpers/forms';
 
 class ReferralSubmissionAction extends React.Component {
   static getDerivedStateFromProps(nextProps) {
@@ -63,7 +63,7 @@ class ReferralSubmissionAction extends React.Component {
 
     const action = get(this.props.additionalContent, 'action', 'default');
 
-    const formData = formatFormFields({
+    const formData = formatPostPayload({
       action,
       type,
       id: this.props.id,

--- a/resources/assets/components/actions/SelectionSubmissionAction/SelectionSubmissionAction.js
+++ b/resources/assets/components/actions/SelectionSubmissionAction/SelectionSubmissionAction.js
@@ -9,7 +9,7 @@ import Card from '../../utilities/Card/Card';
 import Button from '../../utilities/Button/Button';
 import FormValidation from '../../utilities/Form/FormValidation';
 import TextContent from '../../utilities/TextContent/TextContent';
-import { formatFormFields, getFieldErrors } from '../../../helpers/forms';
+import { formatPostPayload, getFieldErrors } from '../../../helpers/forms';
 
 import './selection-submission-action.scss';
 
@@ -69,7 +69,7 @@ class SelectionSubmissionAction extends React.Component {
 
     // Trigger request to store the selection submission post.
     storePost({
-      body: formatFormFields({
+      body: formatPostPayload({
         action_id: actionId,
         text: this.state.selection,
         type,

--- a/resources/assets/components/actions/ShareAction/ShareAction.js
+++ b/resources/assets/components/actions/ShareAction/ShareAction.js
@@ -9,7 +9,7 @@ import Embed from '../../utilities/Embed/Embed';
 import Modal from '../../utilities/Modal/Modal';
 import Button from '../../utilities/Button/Button';
 import ContentfulEntry from '../../ContentfulEntry';
-import { formatFormFields } from '../../../helpers/forms';
+import { formatPostPayload } from '../../../helpers/forms';
 import { trackAnalyticsEvent } from '../../../helpers/analytics';
 import { SOCIAL_SHARE_TYPE } from '../../../constants/post-types';
 import TextContent from '../../utilities/TextContent/TextContent';
@@ -70,7 +70,7 @@ class ShareAction extends React.Component {
       action,
       actionId,
       campaignContentfulId,
-      body: formatFormFields(formFields),
+      body: formatPostPayload(formFields),
       id: this.props.id,
       type: SOCIAL_SHARE_TYPE,
     });

--- a/resources/assets/components/actions/TextSubmissionAction/TextSubmissionAction.js
+++ b/resources/assets/components/actions/TextSubmissionAction/TextSubmissionAction.js
@@ -12,7 +12,7 @@ import { withoutUndefined, withoutNulls } from '../../../helpers';
 import { trackAnalyticsEvent } from '../../../helpers/analytics';
 import FormValidation from '../../utilities/Form/FormValidation';
 import TextContent from '../../utilities/TextContent/TextContent';
-import { getFieldErrors, formatFormFields } from '../../../helpers/forms';
+import { getFieldErrors, formatPostPayload } from '../../../helpers/forms';
 import CharacterLimit from '../../utilities/CharacterLimit/CharacterLimit';
 
 import './text-submission-action.scss';
@@ -102,7 +102,7 @@ class TextSubmissionAction extends React.Component {
     const data = {
       action,
       actionId: this.props.actionId,
-      body: formatFormFields(formFields),
+      body: formatPostPayload(formFields),
       id: this.props.id,
       campaignContentfulId: this.props.campaignContentfulId,
       type,

--- a/resources/assets/helpers/forms.js
+++ b/resources/assets/helpers/forms.js
@@ -110,7 +110,7 @@ export function getFormData(formData) {
  * @param {Undefined|String} data.type
  * @return FormData|Object
  */
-export function formatFormFields(data = {}) {
+export function formatPostPayload(data = {}) {
   let formattedData = data;
 
   // JSON serialize details field which gets validated as JSON.

--- a/resources/assets/helpers/forms.js
+++ b/resources/assets/helpers/forms.js
@@ -2,6 +2,8 @@
 
 import { forEach, get, isInteger } from 'lodash';
 
+import { query, withoutNulls } from '.';
+
 /**
  * Calculate the difference between a total value and a submitted value.
  * Returns submitted value if calculation cannot be completed.
@@ -117,6 +119,17 @@ export function formatPostPayload(data = {}) {
   if (data.details) {
     formattedData.details = JSON.stringify(data.details);
   }
+
+  // Attach 'source_details' based on referring page/block & UTMs:
+  formattedData.source_details = JSON.stringify(
+    withoutNulls({
+      // @TODO: Pass in 'referrer_id' parameter here w/ the containing page ID.
+      // referrer_id: referrerId,
+      utm_source: query('utm_source'),
+      utm_medium: query('utm_medium'),
+      utm_campaign: query('utm_campaign'),
+    }),
+  );
 
   // Attach location information, provided by Fastly.
   if (window.AUTH.location) {

--- a/resources/assets/helpers/forms.js
+++ b/resources/assets/helpers/forms.js
@@ -123,8 +123,8 @@ export function formatPostPayload(data = {}) {
   // Attach 'source_details' based on referring page/block & UTMs:
   formattedData.source_details = JSON.stringify(
     withoutNulls({
-      // @TODO: Pass in 'referrer_id' parameter here w/ the containing page ID.
-      // referrer_id: referrerId,
+      // @TODO: Pass in 'contentful_id' parameter here w/ the containing page ID.
+      // contentful_id: contentfulId,
       utm_source: query('utm_source'),
       utm_medium: query('utm_medium'),
       utm_campaign: query('utm_campaign'),

--- a/resources/assets/selectors/index.js
+++ b/resources/assets/selectors/index.js
@@ -6,8 +6,16 @@ export function getDataForNorthstar(state) {
   return {
     ...getCampaignDataForNorthstar(state),
     ...getStoryPageDataForNorthstar(state),
+
+    // @TODO: Remove this once Northstar uses standard names, below.
     trafficSource: query('utm_medium'),
     referrerId: state.campaign.id || state.page.id,
+
+    // For 'source_details':
+    referrer_id: state.campaign.id || state.page.id,
+    utm_source: query('utm_source'),
+    utm_medium: query('utm_medium'),
+    utm_campaign: query('utm_campaign'),
   };
 }
 

--- a/resources/assets/selectors/index.js
+++ b/resources/assets/selectors/index.js
@@ -12,7 +12,7 @@ export function getDataForNorthstar(state) {
     referrerId: state.campaign.id || state.page.id,
 
     // For 'source_details':
-    referrer_id: state.campaign.id || state.page.id,
+    contentful_id: state.campaign.id || state.page.id,
     utm_source: query('utm_source'),
     utm_medium: query('utm_medium'),
     utm_campaign: query('utm_campaign'),


### PR DESCRIPTION
### What does this PR do?

This pull request sends along _all the UTMs(!!!)_ in `source_details` to Rogue for signups & posts, and to Northstar for registrations (pending a little work over there). Since we had existing JSON data (or inconsistent strings & JSON) for `source_details` in Rogue, I opted to start sending as JSON now.

### Any background context you want to provide?

I removed `campaignContentfulId` from details [per Sohaib's confirmation that it's not used](https://dosomething.slack.com/archives/C6J24ADQW/p1559839322010200?thread_ts=1559835260.008300&cid=C6J24ADQW). We can use the `referrer_id` field now included on `source_details` for the same purpose in the future.

I renamed the `formatFormFields` to `formatPostPayload` because it has post-specific logic in it (such as using a FormData when the type field is "photo").

Finally, I added `utm_source` and `utm_campaign` fields to Northstar's `&options=` payload, and renamed `trafficSource` to `utm_medium` so it's a little bit clearer how that's used & easier to search for. I'll remove the old fields once I've made and deployed the corresponding change in Northstar.

### What are the relevant tickets/cards?

Refs [Pivotal ID #166250944](https://www.pivotaltracker.com/story/show/166250944).

### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.
* [ ] Added screenshot to PR description of related front-end updates on **small** screens.
* [ ] Added screenshot to PR description of related front-end updates on **medium** screens.
* [ ] Added screenshot to PR description of related front-end updates on **large** screens.
