### PR TITLE
Adds Privacy Language to Reportback Forms 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1652,11 +1652,19 @@
       }
     },
     "@wry/context": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/@wry/context/-/context-0.4.2.tgz",
-      "integrity": "sha512-P3IsTHNeQLVjy3Bi9eiyqUwSu4Hai9vpzgueJai8wfibr6JPjyM9KVi2b7uixk1py7aGyOU15cBNvD/l1eZ2eg==",
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@wry/context/-/context-0.4.3.tgz",
+      "integrity": "sha512-CzjOb1sSDPT+uqCItFq7edIoNTBzeg53ye2h81hrfd24lcD2YiSkpJNKJ8jm2Q3UZf6Jth1vDHbS6ub8bGczxw==",
       "requires": {
         "@types/node": ">=6",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@wry/equality": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/@wry/equality/-/equality-0.1.7.tgz",
+      "integrity": "sha512-p1rhJ6PQzpsBr9cMJMHvvx3LQEA28HFX7fAQx6khAX+1lufFeBuk+iRCAyHwj3v6JbpGKvHNa66f+9cpU8c7ew==",
+      "requires": {
         "tslib": "^1.9.3"
       }
     },
@@ -1812,39 +1820,78 @@
       }
     },
     "apollo-cache": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/apollo-cache/-/apollo-cache-1.3.1.tgz",
-      "integrity": "sha512-BJ/Mehr3u6XCaHYSmgZ6DM71Fh30OkW6aEr828WjHvs+7i0RUuP51/PM7K6T0jPXtuw7UbArFFPZZsNgXnyyJA==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/apollo-cache/-/apollo-cache-1.3.2.tgz",
+      "integrity": "sha512-+KA685AV5ETEJfjZuviRTEImGA11uNBp/MJGnaCvkgr+BYRrGLruVKBv6WvyFod27WEB2sp7SsG8cNBKANhGLg==",
       "requires": {
-        "apollo-utilities": "^1.3.1",
+        "apollo-utilities": "^1.3.2",
         "tslib": "^1.9.3"
+      },
+      "dependencies": {
+        "apollo-utilities": {
+          "version": "1.3.2",
+          "resolved": "https://registry.npmjs.org/apollo-utilities/-/apollo-utilities-1.3.2.tgz",
+          "integrity": "sha512-JWNHj8XChz7S4OZghV6yc9FNnzEXj285QYp/nLNh943iObycI5GTDO3NGR9Dth12LRrSFMeDOConPfPln+WGfg==",
+          "requires": {
+            "@wry/equality": "^0.1.2",
+            "fast-json-stable-stringify": "^2.0.0",
+            "ts-invariant": "^0.4.0",
+            "tslib": "^1.9.3"
+          }
+        }
       }
     },
     "apollo-cache-inmemory": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/apollo-cache-inmemory/-/apollo-cache-inmemory-1.6.1.tgz",
-      "integrity": "sha512-c/WJjh9MTWcdussCTjLKufpPjTx3qOFkBPHIDOOpQ+U0B7K1PczPl9N0LaC4ir3wAWL7s4A0t2EKtoR+6UP92g==",
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/apollo-cache-inmemory/-/apollo-cache-inmemory-1.6.2.tgz",
+      "integrity": "sha512-AyCl3PGFv5Qv1w4N9vlg63GBPHXgMCekZy5mhlS042ji0GW84uTySX+r3F61ZX3+KM1vA4m9hQyctrEGiv5XjQ==",
       "requires": {
-        "apollo-cache": "^1.3.1",
-        "apollo-utilities": "^1.3.1",
+        "apollo-cache": "^1.3.2",
+        "apollo-utilities": "^1.3.2",
         "optimism": "^0.9.0",
         "ts-invariant": "^0.4.0",
         "tslib": "^1.9.3"
+      },
+      "dependencies": {
+        "apollo-utilities": {
+          "version": "1.3.2",
+          "resolved": "https://registry.npmjs.org/apollo-utilities/-/apollo-utilities-1.3.2.tgz",
+          "integrity": "sha512-JWNHj8XChz7S4OZghV6yc9FNnzEXj285QYp/nLNh943iObycI5GTDO3NGR9Dth12LRrSFMeDOConPfPln+WGfg==",
+          "requires": {
+            "@wry/equality": "^0.1.2",
+            "fast-json-stable-stringify": "^2.0.0",
+            "ts-invariant": "^0.4.0",
+            "tslib": "^1.9.3"
+          }
+        }
       }
     },
     "apollo-client": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/apollo-client/-/apollo-client-2.6.1.tgz",
-      "integrity": "sha512-Tb6ZthPZUHlGqeoH1WC8Qg/tLnkk9H5+xj4e5nzOAC6dCOW3pVU9tYXscrWdmZ65UDUg1khvTNjrQgPhdf4aTQ==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/apollo-client/-/apollo-client-2.6.2.tgz",
+      "integrity": "sha512-oks1MaT5x7gHcPeC8vPC1UzzsKaEIC0tye+jg72eMDt5OKc7BobStTeS/o2Ib3e0ii40nKxGBnMdl/Xa/p56Yg==",
       "requires": {
         "@types/zen-observable": "^0.8.0",
-        "apollo-cache": "1.3.1",
+        "apollo-cache": "1.3.2",
         "apollo-link": "^1.0.0",
-        "apollo-utilities": "1.3.1",
+        "apollo-utilities": "1.3.2",
         "symbol-observable": "^1.0.2",
         "ts-invariant": "^0.4.0",
         "tslib": "^1.9.3",
         "zen-observable": "^0.8.0"
+      },
+      "dependencies": {
+        "apollo-utilities": {
+          "version": "1.3.2",
+          "resolved": "https://registry.npmjs.org/apollo-utilities/-/apollo-utilities-1.3.2.tgz",
+          "integrity": "sha512-JWNHj8XChz7S4OZghV6yc9FNnzEXj285QYp/nLNh943iObycI5GTDO3NGR9Dth12LRrSFMeDOConPfPln+WGfg==",
+          "requires": {
+            "@wry/equality": "^0.1.2",
+            "fast-json-stable-stringify": "^2.0.0",
+            "ts-invariant": "^0.4.0",
+            "tslib": "^1.9.3"
+          }
+        }
       }
     },
     "apollo-link": {
@@ -5218,8 +5265,7 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -5237,13 +5283,11 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -5256,18 +5300,15 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -5370,8 +5411,7 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "ini": {
           "version": "1.3.5",
@@ -5381,7 +5421,6 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -5394,20 +5433,17 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -5424,7 +5460,6 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -5497,8 +5532,7 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -5508,7 +5542,6 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -5584,8 +5617,7 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -5615,7 +5647,6 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -5633,7 +5664,6 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -5672,13 +5702,11 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "yallist": {
           "version": "3.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         }
       }
     },
@@ -5918,15 +5946,36 @@
       }
     },
     "graphql-anywhere": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/graphql-anywhere/-/graphql-anywhere-4.2.3.tgz",
-      "integrity": "sha512-kJiwe/I8rm+GivwwMmlVCLS3cneNXwqEyUIdo9npjEI0NtGBSNJnt8KNww7A450JvO/v+ubM5zQMh1e9LjTnBg==",
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/graphql-anywhere/-/graphql-anywhere-4.2.4.tgz",
+      "integrity": "sha512-rN6Op5vle0Ucqo8uOVPuFzRz1L/MB+ZVa+XezhFcQ6iP13vy95HOXRysrRtWcu2kQQTLyukSGmfU08D8LXWSIw==",
       "requires": {
-        "apollo-utilities": "^1.3.1",
+        "apollo-utilities": "^1.3.2",
         "ts-invariant": "^0.3.2",
         "tslib": "^1.9.3"
       },
       "dependencies": {
+        "apollo-utilities": {
+          "version": "1.3.2",
+          "resolved": "https://registry.npmjs.org/apollo-utilities/-/apollo-utilities-1.3.2.tgz",
+          "integrity": "sha512-JWNHj8XChz7S4OZghV6yc9FNnzEXj285QYp/nLNh943iObycI5GTDO3NGR9Dth12LRrSFMeDOConPfPln+WGfg==",
+          "requires": {
+            "@wry/equality": "^0.1.2",
+            "fast-json-stable-stringify": "^2.0.0",
+            "ts-invariant": "^0.4.0",
+            "tslib": "^1.9.3"
+          },
+          "dependencies": {
+            "ts-invariant": {
+              "version": "0.4.2",
+              "resolved": "https://registry.npmjs.org/ts-invariant/-/ts-invariant-0.4.2.tgz",
+              "integrity": "sha512-PTAAn8lJPEdRBJJEs4ig6MVZWfO12yrFzV7YaPslmyhG7+4MA279y4BXT3f72gXeVl0mC1aAWq2rMX4eKTWU/Q==",
+              "requires": {
+                "tslib": "^1.9.3"
+              }
+            }
+          }
+        },
         "ts-invariant": {
           "version": "0.3.3",
           "resolved": "https://registry.npmjs.org/ts-invariant/-/ts-invariant-0.3.3.tgz",

--- a/resources/assets/components/actions/PetitionSubmissioncAction/PetitionSubmissionAction.js
+++ b/resources/assets/components/actions/PetitionSubmissioncAction/PetitionSubmissionAction.js
@@ -13,6 +13,7 @@ import FormValidation from '../../utilities/Form/FormValidation';
 import TextContent from '../../utilities/TextContent/TextContent';
 import { formatPostPayload, getFieldErrors } from '../../../helpers/forms';
 import CharacterLimit from '../../utilities/CharacterLimit/CharacterLimit';
+import PrivacyLanguage from '../../utilities/PrivacyLanguage/PrivacyLanguage';
 
 import './petition-submission-action.scss';
 
@@ -198,6 +199,7 @@ class PetitionSubmissionAction extends React.Component {
                     >
                       {buttonText}
                     </Button>
+                    <PrivacyLanguage />
                   </form>
                 </Card>
               );

--- a/resources/assets/components/actions/PhotoSubmissionAction/PhotoSubmissionAction.js
+++ b/resources/assets/components/actions/PhotoSubmissionAction/PhotoSubmissionAction.js
@@ -10,11 +10,12 @@ import { PuckWaypoint } from '@dosomething/puck-client';
 import Card from '../../utilities/Card/Card';
 import Modal from '../../utilities/Modal/Modal';
 import Button from '../../utilities/Button/Button';
-import { withoutUndefined, withoutNulls } from '../../../helpers';
 import MediaUploader from '../../utilities/MediaUploader';
 import { getUserCampaignSignups } from '../../../helpers/api';
 import FormValidation from '../../utilities/Form/FormValidation';
+import { withoutUndefined, withoutNulls } from '../../../helpers';
 import TextContent from '../../utilities/TextContent/TextContent';
+import PrivacyLanguage from '../../utilities/PrivacyLanguage/PrivacyLanguage';
 import {
   calculateDifference,
   getFieldErrors,
@@ -391,23 +392,7 @@ class PhotoSubmissionAction extends React.Component {
                 >
                   {this.props.buttonText}
                 </Button>
-                <p className="footnote padding-horizontal-md padding-bottom-md">
-                  The data you submit in this form will be handled in accordance
-                  with the DoSomething website{' '}
-                  {/*
-                    Workaround for this jsx-a11y bug https://git.io/fN814.
-                    @TODO: Update once the eslint-config package is updated (https://git.io/fjejY).
-                  */}
-                  {/* eslint-disable-next-line jsx-a11y/anchor-has-content */}
-                  <a
-                    href="https://www.dosomething.org/us/about/privacy-policy"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >
-                    privacy policy
-                  </a>
-                  . It will be reviewed by a DoSomething staff member.
-                </p>
+                <PrivacyLanguage />
               </form>
             </Card>
             <PuckWaypoint

--- a/resources/assets/components/actions/PhotoSubmissionAction/PhotoSubmissionAction.js
+++ b/resources/assets/components/actions/PhotoSubmissionAction/PhotoSubmissionAction.js
@@ -391,6 +391,23 @@ class PhotoSubmissionAction extends React.Component {
                 >
                   {this.props.buttonText}
                 </Button>
+                <p className="footnote padding-horizontal-md padding-bottom-md">
+                  The data you submit in this form will be handled in accordance
+                  with the DoSomething website{' '}
+                  {/*
+                    Workaround for this jsx-a11y bug https://git.io/fN814.
+                    @TODO: Update once the eslint-config package is updated (https://git.io/fjejY).
+                  */}
+                  {/* eslint-disable-next-line jsx-a11y/anchor-has-content */}
+                  <a
+                    href="https://www.dosomething.org/us/about/privacy-policy"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    privacy policy
+                  </a>
+                  . It will be reviewed by a DoSomething staff member.
+                </p>
               </form>
             </Card>
             <PuckWaypoint

--- a/resources/assets/components/actions/TextSubmissionAction/TextSubmissionAction.js
+++ b/resources/assets/components/actions/TextSubmissionAction/TextSubmissionAction.js
@@ -8,12 +8,13 @@ import { PuckWaypoint } from '@dosomething/puck-client';
 import Card from '../../utilities/Card/Card';
 import Modal from '../../utilities/Modal/Modal';
 import Button from '../../utilities/Button/Button';
-import { withoutUndefined, withoutNulls } from '../../../helpers';
 import { trackAnalyticsEvent } from '../../../helpers/analytics';
 import FormValidation from '../../utilities/Form/FormValidation';
+import { withoutUndefined, withoutNulls } from '../../../helpers';
 import TextContent from '../../utilities/TextContent/TextContent';
 import { getFieldErrors, formatPostPayload } from '../../../helpers/forms';
 import CharacterLimit from '../../utilities/CharacterLimit/CharacterLimit';
+import PrivacyLanguage from '../../utilities/PrivacyLanguage/PrivacyLanguage';
 
 import './text-submission-action.scss';
 
@@ -184,23 +185,7 @@ class TextSubmissionAction extends React.Component {
               >
                 {this.props.buttonText}
               </Button>
-              <p className="footnote padding-horizontal-md padding-bottom-md">
-                The data you submit in this form will be handled in accordance
-                with the DoSomething website{' '}
-                {/*
-                  Workaround for this jsx-a11y bug https://git.io/fN814.
-                  @TODO: Update once the eslint-config package is updated (https://git.io/fjejY).
-                */}
-                {/* eslint-disable-next-line jsx-a11y/anchor-has-content */}
-                <a
-                  href="https://www.dosomething.org/us/about/privacy-policy"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  privacy policy
-                </a>
-                . It will be reviewed by a DoSomething staff member.
-              </p>
+              <PrivacyLanguage />
             </form>
           </Card>
           <PuckWaypoint

--- a/resources/assets/components/utilities/PrivacyLanguage/PrivacyLanguage.js
+++ b/resources/assets/components/utilities/PrivacyLanguage/PrivacyLanguage.js
@@ -11,7 +11,7 @@ const PrivacyLanguage = () => {
       */}
       {/* eslint-disable-next-line jsx-a11y/anchor-has-content */}
       <a
-        href="https://www.dosomething.org/us/about/privacy-policy"
+        href="/us/about/privacy-policy"
         target="_blank"
         rel="noopener noreferrer"
       >

--- a/resources/assets/components/utilities/PrivacyLanguage/PrivacyLanguage.js
+++ b/resources/assets/components/utilities/PrivacyLanguage/PrivacyLanguage.js
@@ -5,11 +5,6 @@ const PrivacyLanguage = () => {
     <p className="footnote padding-horizontal-md padding-bottom-md">
       The data you submit in this form will be handled in accordance with the
       DoSomething website{' '}
-      {/*
-        Workaround for this jsx-a11y bug https://git.io/fN814.
-        @TODO: Update once the eslint-config package is updated (https://git.io/fjejY).
-      */}
-      {/* eslint-disable-next-line jsx-a11y/anchor-has-content */}
       <a
         href="/us/about/privacy-policy"
         target="_blank"

--- a/resources/assets/components/utilities/PrivacyLanguage/PrivacyLanguage.js
+++ b/resources/assets/components/utilities/PrivacyLanguage/PrivacyLanguage.js
@@ -1,0 +1,27 @@
+import React from 'react';
+
+const PrivacyLanguage = () => {
+  const privacyLanguage = (
+    <p className="footnote padding-horizontal-md padding-bottom-md">
+      The data you submit in this form will be handled in accordance with the
+      DoSomething website{' '}
+      {/*
+        Workaround for this jsx-a11y bug https://git.io/fN814.
+        @TODO: Update once the eslint-config package is updated (https://git.io/fjejY).
+      */}
+      {/* eslint-disable-next-line jsx-a11y/anchor-has-content */}
+      <a
+        href="https://www.dosomething.org/us/about/privacy-policy"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        privacy policy
+      </a>
+      . It will be reviewed by a DoSomething staff member.
+    </p>
+  );
+
+  return privacyLanguage;
+};
+
+export default PrivacyLanguage;

--- a/resources/assets/components/utilities/PrivacyLanguage/PrivacyLanguage.js
+++ b/resources/assets/components/utilities/PrivacyLanguage/PrivacyLanguage.js
@@ -1,7 +1,7 @@
 import React from 'react';
 
 const PrivacyLanguage = () => {
-  const privacyLanguage = (
+  return (
     <p className="footnote padding-horizontal-md padding-bottom-md">
       The data you submit in this form will be handled in accordance with the
       DoSomething website{' '}
@@ -15,8 +15,6 @@ const PrivacyLanguage = () => {
       . It will be reviewed by a DoSomething staff member.
     </p>
   );
-
-  return privacyLanguage;
 };
 
 export default PrivacyLanguage;

--- a/resources/assets/components/utilities/PrivacyLanguage/PrivacyLanguage.js
+++ b/resources/assets/components/utilities/PrivacyLanguage/PrivacyLanguage.js
@@ -1,20 +1,18 @@
 import React from 'react';
 
-const PrivacyLanguage = () => {
-  return (
-    <p className="footnote padding-horizontal-md padding-bottom-md">
-      The data you submit in this form will be handled in accordance with the
-      DoSomething website{' '}
-      <a
-        href="/us/about/privacy-policy"
-        target="_blank"
-        rel="noopener noreferrer"
-      >
-        privacy policy
-      </a>
-      . It will be reviewed by a DoSomething staff member.
-    </p>
-  );
-};
+const PrivacyLanguage = () => (
+  <p className="footnote padding-horizontal-md padding-bottom-md">
+    The data you submit in this form will be handled in accordance with the
+    DoSomething website{' '}
+    <a
+      href="/us/about/privacy-policy"
+      target="_blank"
+      rel="noopener noreferrer"
+    >
+      privacy policy
+    </a>
+    . It will be reviewed by a DoSomething staff member.
+  </p>
+);
 
 export default PrivacyLanguage;


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_
### What does this PR do?

This PR adds privacy language to reportback forms via a new `PrivacyLanguge` component to be added to: 
- Photo Reportbacks
![Screen Shot 2019-06-06 at 5 08 25 PM](https://user-images.githubusercontent.com/9019452/59110927-16686a80-890e-11e9-8f15-e4e783219d85.png)
- Text Reportbacks
![Screen Shot 2019-06-07 at 10 24 56 AM](https://user-images.githubusercontent.com/9019452/59111181-837c0000-890e-11e9-8ec4-79c3b65e898a.png)

- Petition Reportbacks
![Screen Shot 2019-06-07 at 9 49 27 AM](https://user-images.githubusercontent.com/9019452/59110912-0d779900-890e-11e9-8065-22c0deb674fe.png)


### Any background context you want to provide?
- SoftEdge already includes their [privacy policy](https://thesoftedge.com/about-us/privacy-statement/) in the widget.
- Voter Reg - goes through third parties. I don't think we need to add privacy language here? 
- Share Social - not relevant since they're not submitting information, just sharing on their personal social media pages. 
- Tell Us Your Story is a text submission action.
- Phone Calls are linked to third party sources. 

### What are the relevant tickets/cards?

Refs [Pivotal ID #166289134](https://www.pivotaltracker.com/n/projects/2328687/stories/166289134)

### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.
* [ ] Added screenshot to PR description of related front-end updates on **small** screens.
* [ ] Added screenshot to PR description of related front-end updates on **medium** screens.
* [ ] Added screenshot to PR description of related front-end updates on **large** screens.
