### PR TITLE
Adding Snowplow config and setting User ID.

### DIFF
--- a/resources/assets/init.js
+++ b/resources/assets/init.js
@@ -71,6 +71,11 @@ ready(() => {
   // Display environment badge on local, dev, or QA:
   renderEnvironmentBadge();
 
+  // If available, set User ID for Snowplow analytics.
+  if (typeof window.snowplow === 'function' && window.AUTH.id) {
+    window.snowplow('setUserId', window.AUTH.id);
+  }
+
   // Add event listeners for the Admin Dashboard.
   if (window.AUTH.isAuthenticated && window.AUTH.role !== 'user') {
     bindAdminDashboardEvents();

--- a/resources/views/partials/snowplow_script.blade.php
+++ b/resources/views/partials/snowplow_script.blade.php
@@ -6,7 +6,8 @@
           n.src=w;g.parentNode.insertBefore(n,g)}}(window,document,'script','//d1fc8wv8zag5ca.cloudfront.net/2.5.3/sp.js','snowplow'));
           window.snowplow('newTracker', 'cf', '{{config('services.analytics.snowplow_url')}}', {
             appId: 'dosomething-web',
-            cookieDomain: null
+            cookieDomain: null,
+            discoverRootDomain: true
         });
 
         window.snowplow('trackPageView');


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR updates the Snowplow tracker configuration to `discoverRootDomain` and also makes sure to set the User ID for Snowplow during JS initialization once the DOM is ready.

### What are the relevant tickets/cards?

Refs [Pivotal ID #166194848](https://www.pivotaltracker.com/story/show/166194848)
