### PR TITLE
Cleaning up the SignupButton to use container.

### DIFF
--- a/resources/assets/components/CallToAction/CallToAction.js
+++ b/resources/assets/components/CallToAction/CallToAction.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import classnames from 'classnames';
 
 import Card from '../utilities/Card/Card';
-import SignupButton from '../SignupButton';
+import SignupButtonContainer from '../SignupButton/SignupButtonContainer';
 
 import './cta.scss';
 
@@ -60,7 +60,7 @@ const CallToAction = ({
         <div className="cta__message margin-bottom-lg">{content}</div>
       ) : null}
 
-      {isSignedUp ? null : <SignupButton source="call to action" />}
+      {isSignedUp ? null : <SignupButtonContainer />}
     </Card>
   );
 };

--- a/resources/assets/components/CallToAction/__snapshots__/CallToAction.test.js.snap
+++ b/resources/assets/components/CallToAction/__snapshots__/CallToAction.test.js.snap
@@ -12,8 +12,6 @@ exports[`CallToAction snapshot test 1`] = `
   >
     Aenean eu leo quam. Pellentesque ornare sem vestibulum.
   </div>
-  <Connect(SignupButton)
-    source="call to action"
-  />
+  <Connect(SignupButton) />
 </Card>
 `;

--- a/resources/assets/components/CampaignPageNavigation/CampaignPageNavigation.js
+++ b/resources/assets/components/CampaignPageNavigation/CampaignPageNavigation.js
@@ -34,10 +34,7 @@ const CampaignPageNavigation = ({
   return campaignPages.length ? (
     <PageNavigation pages={campaignPages}>
       {isAffiliated ? null : (
-        <SignupButtonContainer
-          className="-inline nav-button"
-          source="tabbed navigation"
-        />
+        <SignupButtonContainer className="-inline nav-button" />
       )}
     </PageNavigation>
   ) : null;

--- a/resources/assets/components/LedeBanner/templates/CoverTemplate.js
+++ b/resources/assets/components/LedeBanner/templates/CoverTemplate.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom';
 
-import SignupButton from '../../SignupButton';
+import SignupButtonContainer from '../../SignupButton/SignupButtonContainer';
 import SponsorPromotion from '../../SponsorPromotion';
 import { contentfulImageUrl } from '../../../helpers';
 import TextContent from '../../utilities/TextContent/TextContent';
@@ -59,7 +59,7 @@ const CoverTemplate = props => {
           actionButton
         ) : (
           <div className="cover-lede-banner__signup">
-            <SignupButton source="cover lede banner" />
+            <SignupButtonContainer />
           </div>
         )}
 

--- a/resources/assets/components/LedeBanner/templates/JumboTemplate.js
+++ b/resources/assets/components/LedeBanner/templates/JumboTemplate.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import SignupButton from '../../SignupButton';
+import SignupButtonContainer from '../../SignupButton/SignupButtonContainer';
 import SponsorPromotion from '../../SponsorPromotion';
 import { contentfulImageUrl } from '../../../helpers';
 import TextContent from '../../utilities/TextContent/TextContent';
@@ -46,7 +46,7 @@ const JumboTemplate = props => {
 
         {isAffiliated ? null : (
           <div className="jumbo-lede-banner__signup">
-            <SignupButton source="jumbo lede banner" />
+            <SignupButtonContainer />
           </div>
         )}
 

--- a/resources/assets/components/LedeBanner/templates/LegacyTemplate.js
+++ b/resources/assets/components/LedeBanner/templates/LegacyTemplate.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { format } from 'date-fns';
 import PropTypes from 'prop-types';
 
-import SignupButton from '../../SignupButton';
+import SignupButtonContainer from '../../SignupButton/SignupButtonContainer';
 import SponsorPromotion from '../../SponsorPromotion';
 import { contentfulImageUrl } from '../../../helpers';
 import CampaignSignupArrow from '../../CampaignSignupArrow';
@@ -52,7 +52,7 @@ const LegacyTemplate = props => {
               <CampaignSignupArrow content={signupArrowContent} />
             ) : null}
             <div>
-              <SignupButton source="legacy lede banner" />
+              <SignupButtonContainer />
               {showPartnerMsgOptIn ? <AffiliateOptInToggleContainer /> : null}
             </div>
           </div>

--- a/resources/assets/components/LedeBanner/templates/MosaicTemplate.js
+++ b/resources/assets/components/LedeBanner/templates/MosaicTemplate.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import { Link } from 'react-router-dom';
 
-import SignupButton from '../../SignupButton';
+import SignupButtonContainer from '../../SignupButton/SignupButtonContainer';
 import SponsorPromotion from '../../SponsorPromotion';
 import { contentfulImageUrl } from '../../../helpers';
 import CampaignSignupArrow from '../../CampaignSignupArrow';
@@ -45,7 +45,7 @@ const MosaicTemplate = props => {
         />
       ) : null}
 
-      <SignupButton
+      <SignupButtonContainer
         className={classnames({ '-float': affiliateSponsors.length })}
       />
       {signupArrowContent ? (

--- a/resources/assets/components/Revealer/index.js
+++ b/resources/assets/components/Revealer/index.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import SignupButton from '../SignupButton';
+import SignupButtonContainer from '../SignupButton/SignupButtonContainer';
 import Button from '../utilities/Button/Button';
 
 import './revealer.scss';
@@ -17,7 +17,7 @@ const Revealer = props => {
           {title}
         </Button>
       ) : (
-        <SignupButton className="is-cta" source="revealer" />
+        <SignupButtonContainer className="is-cta" />
       )}
     </div>
   );

--- a/resources/assets/components/SignupButton/index.js
+++ b/resources/assets/components/SignupButton/index.js
@@ -1,1 +1,0 @@
-export default from './SignupButtonContainer';

--- a/resources/assets/helpers/analytics.js
+++ b/resources/assets/helpers/analytics.js
@@ -44,13 +44,7 @@ const formatEventName = (verb, noun, adjective = null) => {
  * @param  {Object} data
  * @return {void}
  */
-export function analyzeWithGoogleAnalytics(
-  name,
-  category,
-  action,
-  label,
-  data,
-) {
+export function analyzeWithGoogle(name, category, action, label, data) {
   if (!category || !action) {
     console.error('The Category or Action is missing!');
     return;
@@ -140,7 +134,7 @@ export function analyzeWithSnowplow(name, category, action, label, data) {
 const sendToServices = (name, category, action, label, data, service) => {
   switch (service) {
     case 'ga':
-      analyzeWithGoogleAnalytics(name, category, action, label, data);
+      analyzeWithGoogle(name, category, action, label, data);
       break;
 
     case 'puck':
@@ -148,7 +142,7 @@ const sendToServices = (name, category, action, label, data, service) => {
       break;
 
     default:
-      analyzeWithGoogleAnalytics(name, category, action, label, data);
+      analyzeWithGoogle(name, category, action, label, data);
       analyzeWithPuck(name, data);
       analyzeWithSnowplow(name, category, action, label, data);
   }


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR cleans up the `SignupButton` to specifically call the `SignupButtonContainer` when it's being used (it threw me off for a hot second, how it was getting all the props without calling the container, and it was thanks to the `SignupButton/index.js` returning the container). Anyhoo, this follows more the pattern we've been establishing to avoid confusion and call the container directly when used.

It also removes the `source` prop from `SignupButtonContainer` usage, since we removed its use in prior PR. Lastly, it renames `analyzeWithGoogleAnalytics()` to `analyzeWithGoogle()` to simplify naming.

### Any background context you want to provide?

🛁 cleanup

### What are the relevant tickets/cards?

🌵 
