### PR TITLE
Analytics payload updates

### DIFF
--- a/app/Http/Controllers/Api/LinkController.php
+++ b/app/Http/Controllers/Api/LinkController.php
@@ -2,7 +2,6 @@
 
 namespace App\Http\Controllers\Api;
 
-use Auth;
 use App\Services\Bertly;
 use Illuminate\Http\Request;
 use App\Http\Controllers\Controller;

--- a/resources/assets/actions/post.js
+++ b/resources/assets/actions/post.js
@@ -65,12 +65,12 @@ export function resetPostSubmissionItem(id) {
 /**
  * Store posts for the specified campaign.
  *
- * @param {String} campaignId
+ * @param  {String} campaignId
  * @param  {Object} data
  * @return {function}
  */
 export function storeCampaignPost(campaignId, data) {
-  const { action, actionId, body, campaignContentfulId, id, type } = data;
+  const { action, actionId, blockId, body, pageId, type } = data;
 
   if (type === 'photo' && !(body instanceof FormData)) {
     throw Error(
@@ -94,9 +94,9 @@ export function storeCampaignPost(campaignId, data) {
   trackAnalyticsEvent({
     context: {
       actionId,
-      blockId: id,
+      blockId,
       campaignId,
-      pageId: campaignContentfulId,
+      pageId,
     },
     metadata: {
       category: 'campaign_action',
@@ -116,8 +116,8 @@ export function storeCampaignPost(campaignId, data) {
           action,
           actionId,
           campaignId,
-          campaignContentfulId,
-          id,
+          id: blockId, // @TODO: rename property to blockId
+          pageId,
           sixpackExperiments,
           type,
         },
@@ -135,13 +135,15 @@ export function storeCampaignPost(campaignId, data) {
  *
  * @param  {Object} data
  * @param  {Number} data.actionId
+ * @param  {String} data.blockId
  * @param  {Object} data.body
- * @param  {String} data.id
+ * @param  {String} data.campaignId
+ * @param  {String} data.pageId
  * @param  {String} data.type
  * @return {function}
  */
 export function storePost(data) {
-  const { actionId, body, campaignContentfulId, campaignId, id, type } = data;
+  const { actionId, blockId, body, campaignId, pageId, type } = data;
 
   const sixpackExperiments = {
     conversion: 'reportbackPost',
@@ -151,9 +153,9 @@ export function storePost(data) {
   trackAnalyticsEvent({
     context: {
       actionId,
-      blockId: id,
+      blockId,
       campaignId,
-      pageId: campaignContentfulId,
+      pageId,
     },
     metadata: {
       category: 'campaign_action',
@@ -170,10 +172,10 @@ export function storePost(data) {
         body,
         failure: POST_SUBMISSION_FAILED,
         meta: {
-          sixpackExperiments,
           actionId,
+          id: blockId, // @TODO: rename property to blockId
+          sixpackExperiments,
           type,
-          id,
         },
         requiresAuthentication: type === 'text',
         pending: POST_SUBMISSION_PENDING,

--- a/resources/assets/actions/post.js
+++ b/resources/assets/actions/post.js
@@ -93,10 +93,10 @@ export function storeCampaignPost(campaignId, data) {
   // Track post submission event.
   trackAnalyticsEvent({
     context: {
-      action,
       actionId,
-      campaignContentfulId,
+      blockId: id,
       campaignId,
+      pageId: campaignContentfulId,
     },
     metadata: {
       category: 'campaign_action',
@@ -141,7 +141,7 @@ export function storeCampaignPost(campaignId, data) {
  * @return {function}
  */
 export function storePost(data) {
-  const { actionId, body, id, type } = data;
+  const { actionId, body, campaignContentfulId, campaignId, id, type } = data;
 
   const sixpackExperiments = {
     conversion: 'reportbackPost',
@@ -151,6 +151,9 @@ export function storePost(data) {
   trackAnalyticsEvent({
     context: {
       actionId,
+      blockId: id,
+      campaignId,
+      pageId: campaignContentfulId,
     },
     metadata: {
       category: 'campaign_action',

--- a/resources/assets/components/actions/PetitionSubmissioncAction/PetitionSubmissionAction.js
+++ b/resources/assets/components/actions/PetitionSubmissioncAction/PetitionSubmissionAction.js
@@ -76,7 +76,7 @@ class PetitionSubmissionAction extends React.Component {
   handleSubmit = event => {
     event.preventDefault();
 
-    const { id, actionId, storePost } = this.props;
+    const { actionId, id, pageId, storePost } = this.props;
 
     // Reset any straggling post submission data for this action.
     this.props.resetPostSubmissionItem(id);
@@ -85,14 +85,15 @@ class PetitionSubmissionAction extends React.Component {
 
     // Send request to store the petition submission post.
     storePost({
+      actionId,
+      blockId: id,
       body: formatPostPayload({
         action_id: actionId,
         text: this.state.textValue,
         type,
       }),
+      pageId,
       type,
-      actionId,
-      id,
     });
   };
 
@@ -127,7 +128,7 @@ class PetitionSubmissionAction extends React.Component {
         >
           <PuckWaypoint
             name="petition_submission_action-top"
-            waypointData={{ contentfulId: id }}
+            waypointData={{ blockId: id }}
           />
           <Query
             query={USER_POSTS_QUERY}
@@ -207,7 +208,7 @@ class PetitionSubmissionAction extends React.Component {
           </Query>
           <PuckWaypoint
             name="petition_submission_action-bottom"
-            waypointData={{ contentfulId: id }}
+            waypointData={{ blockId: id }}
           />
         </div>
 
@@ -246,9 +247,10 @@ PetitionSubmissionAction.propTypes = {
   buttonText: PropTypes.string,
   className: PropTypes.string,
   content: PropTypes.string.isRequired,
-  id: PropTypes.string.isRequired,
+  id: PropTypes.string.isRequired, // @TODO: rename property to blockId
   informationContent: PropTypes.string,
   informationTitle: PropTypes.string,
+  pageId: PropTypes.string.isRequired,
   resetPostSubmissionItem: PropTypes.func.isRequired,
   storePost: PropTypes.func.isRequired,
   submissions: PropTypes.shape({

--- a/resources/assets/components/actions/PetitionSubmissioncAction/PetitionSubmissionActionContainer.js
+++ b/resources/assets/components/actions/PetitionSubmissioncAction/PetitionSubmissionActionContainer.js
@@ -8,6 +8,7 @@ import { resetPostSubmissionItem, storePost } from '../../../actions/post';
  * Provide state from the Redux store as props for this component.
  */
 const mapStateToProps = state => ({
+  pageId: state.page.id,
   submissions: state.postSubmissions,
   userId: getUserId(state),
 });

--- a/resources/assets/components/actions/PhotoSubmissionAction/PhotoSubmissionAction.js
+++ b/resources/assets/components/actions/PhotoSubmissionAction/PhotoSubmissionAction.js
@@ -193,9 +193,9 @@ class PhotoSubmissionAction extends React.Component {
     }
 
     const formFields = withoutNulls({
-      action,
+      action, // @TODO: deprecate
       type,
-      id: this.props.id,
+      id: this.props.id, // @TODO: rename property to blockId?
       action_id: this.props.actionId,
       // Associate state values to fields.
       ...values,
@@ -205,11 +205,11 @@ class PhotoSubmissionAction extends React.Component {
 
     // Send request to store the campaign photo submission post.
     this.props.storeCampaignPost(this.props.campaignId, {
-      action,
+      action, // @TODO: deprecate
       actionId: this.props.actionId,
+      blockId: this.props.id,
       body: formatPostPayload(formFields),
-      id: this.props.id,
-      campaignContentfulId: this.props.campaignContentfulId,
+      pageId: this.props.pageId,
       type,
     });
   };
@@ -275,7 +275,7 @@ class PhotoSubmissionAction extends React.Component {
           <div className="photo-submission-action">
             <PuckWaypoint
               name="photo_submission_action-top"
-              waypointData={{ contentfulId: this.props.id }}
+              waypointData={{ blockId: this.props.id }}
             />
             <Card
               className={classnames('bordered rounded', this.props.className)}
@@ -397,7 +397,7 @@ class PhotoSubmissionAction extends React.Component {
             </Card>
             <PuckWaypoint
               name="photo_submission_action-bottom"
-              waypointData={{ contentfulId: this.props.id }}
+              waypointData={{ blockId: this.props.id }}
             />
           </div>
 
@@ -438,13 +438,13 @@ PhotoSubmissionAction.propTypes = {
   }),
   buttonText: PropTypes.string,
   campaignId: PropTypes.string.isRequired,
-  campaignContentfulId: PropTypes.string.isRequired,
   captionFieldLabel: PropTypes.string,
   captionFieldPlaceholder: PropTypes.string,
   className: PropTypes.string,
-  id: PropTypes.string.isRequired,
+  id: PropTypes.string.isRequired, // @TODO: rename property to blockId
   informationContent: PropTypes.string,
   informationTitle: PropTypes.string,
+  pageId: PropTypes.string.isRequired,
   quantityFieldLabel: PropTypes.string,
   quantityFieldPlaceholder: PropTypes.string,
   resetPostSubmissionItem: PropTypes.func.isRequired,

--- a/resources/assets/components/actions/PhotoSubmissionAction/PhotoSubmissionActionContainer.js
+++ b/resources/assets/components/actions/PhotoSubmissionAction/PhotoSubmissionActionContainer.js
@@ -8,8 +8,8 @@ import {
 } from '../../../actions/post';
 
 const mapStateToProps = state => ({
-  campaignId: state.campaign.campaignId,
   campaignContentfulId: state.campaign.id,
+  campaignId: state.campaign.campaignId,
   submissions: state.postSubmissions,
   userId: getUserId(state),
 });

--- a/resources/assets/components/actions/PhotoSubmissionAction/PhotoSubmissionActionContainer.js
+++ b/resources/assets/components/actions/PhotoSubmissionAction/PhotoSubmissionActionContainer.js
@@ -8,8 +8,8 @@ import {
 } from '../../../actions/post';
 
 const mapStateToProps = state => ({
-  campaignContentfulId: state.campaign.id,
   campaignId: state.campaign.campaignId,
+  pageId: state.campaign.id,
   submissions: state.postSubmissions,
   userId: getUserId(state),
 });

--- a/resources/assets/components/actions/ReferralSubmissionAction/ReferralSubmissionAction.js
+++ b/resources/assets/components/actions/ReferralSubmissionAction/ReferralSubmissionAction.js
@@ -64,9 +64,9 @@ class ReferralSubmissionAction extends React.Component {
     const action = get(this.props.additionalContent, 'action', 'default');
 
     const formData = formatPostPayload({
-      action,
+      action, // @TODO: deprecate
       type,
-      id: this.props.id,
+      id: this.props.id, // @TODO: rename property to pageId? Other actions use the blockId?
       // Associate state values to fields.
       ...mapValues(this.fields, value => this.state[`${value}Value`]),
       details: this.props,
@@ -74,9 +74,10 @@ class ReferralSubmissionAction extends React.Component {
 
     // Send request to store the campaign text submission post.
     this.props.storeCampaignPost(this.props.campaignId, {
-      action,
+      action, // @TODO: deprecate
+      blockId: this.props.id,
       body: formData,
-      id: this.props.id,
+      pageId: this.props.pageId,
       type,
     });
   };
@@ -188,7 +189,8 @@ ReferralSubmissionAction.propTypes = {
   buttonText: PropTypes.string,
   campaignId: PropTypes.string.isRequired,
   className: PropTypes.string,
-  id: PropTypes.string.isRequired,
+  id: PropTypes.string.isRequired, // @TODO: rename property to blockId
+  pageId: PropTypes.string.isRequired,
   resetPostSubmissionItem: PropTypes.func.isRequired,
   storeCampaignPost: PropTypes.func.isRequired,
   submissions: PropTypes.shape({

--- a/resources/assets/components/actions/ReferralSubmissionAction/ReferralSubmissionActionContainer.js
+++ b/resources/assets/components/actions/ReferralSubmissionAction/ReferralSubmissionActionContainer.js
@@ -11,6 +11,7 @@ import {
  */
 const mapStateToProps = state => ({
   campaignId: state.campaign.campaignId,
+  pageId: state.campaign.id,
   submissions: state.postSubmissions,
 });
 

--- a/resources/assets/components/actions/SelectionSubmissionAction/SelectionSubmissionAction.js
+++ b/resources/assets/components/actions/SelectionSubmissionAction/SelectionSubmissionAction.js
@@ -60,13 +60,7 @@ class SelectionSubmissionAction extends React.Component {
       return;
     }
 
-    const {
-      actionId,
-      campaignId,
-      campaignContentfulId,
-      id,
-      storePost,
-    } = this.props;
+    const { actionId, campaignId, id, pageId, storePost } = this.props;
 
     // Reset any straggling post submission data for this action.
     this.props.resetPostSubmissionItem(id);
@@ -75,14 +69,16 @@ class SelectionSubmissionAction extends React.Component {
 
     // Trigger request to store the selection submission post.
     storePost({
+      actionId,
+      blockId: id,
       body: formatPostPayload({
         action_id: actionId,
         text: this.state.selection,
         type,
       }),
+      campaignId,
+      pageId,
       type,
-      actionId,
-      id,
     });
   };
 
@@ -196,8 +192,10 @@ class SelectionSubmissionAction extends React.Component {
 SelectionSubmissionAction.propTypes = {
   actionId: PropTypes.number.isRequired,
   buttonText: PropTypes.string,
+  campaignId: PropTypes.string.isRequired,
   content: PropTypes.object.isRequired,
-  id: PropTypes.string.isRequired,
+  id: PropTypes.string.isRequired, // @TODO: rename property to blockId
+  pageId: PropTypes.string.isRequired,
   postSubmissionLabel: PropTypes.string.isRequired,
   resetPostSubmissionItem: PropTypes.func.isRequired,
   selectionFieldLabel: PropTypes.string,

--- a/resources/assets/components/actions/SelectionSubmissionAction/SelectionSubmissionAction.js
+++ b/resources/assets/components/actions/SelectionSubmissionAction/SelectionSubmissionAction.js
@@ -60,7 +60,13 @@ class SelectionSubmissionAction extends React.Component {
       return;
     }
 
-    const { id, actionId, storePost } = this.props;
+    const {
+      actionId,
+      campaignId,
+      campaignContentfulId,
+      id,
+      storePost,
+    } = this.props;
 
     // Reset any straggling post submission data for this action.
     this.props.resetPostSubmissionItem(id);

--- a/resources/assets/components/actions/SelectionSubmissionAction/SelectionSubmissionActionContainer.js
+++ b/resources/assets/components/actions/SelectionSubmissionAction/SelectionSubmissionActionContainer.js
@@ -8,8 +8,8 @@ import { resetPostSubmissionItem, storePost } from '../../../actions/post';
  * Provide state from the Redux store as props for this component.
  */
 const mapStateToProps = state => ({
-  campaignContentfulId: state.campaign.id,
   campaignId: state.campaign.campaignId,
+  pageId: state.campaign.id,
   submissions: state.postSubmissions,
   userId: getUserId(state),
 });

--- a/resources/assets/components/actions/SelectionSubmissionAction/SelectionSubmissionActionContainer.js
+++ b/resources/assets/components/actions/SelectionSubmissionAction/SelectionSubmissionActionContainer.js
@@ -8,6 +8,8 @@ import { resetPostSubmissionItem, storePost } from '../../../actions/post';
  * Provide state from the Redux store as props for this component.
  */
 const mapStateToProps = state => ({
+  campaignContentfulId: state.campaign.id,
+  campaignId: state.campaign.campaignId,
   submissions: state.postSubmissions,
   userId: getUserId(state),
 });

--- a/resources/assets/components/actions/ShareAction/ShareAction.js
+++ b/resources/assets/components/actions/ShareAction/ShareAction.js
@@ -109,7 +109,7 @@ class ShareAction extends React.Component {
 
     let trackingData = { url: link };
 
-    this.trackEvent('facebook', 'button', 'clicked', { ...trackingData });
+    this.trackEvent('facebook', 'button', 'clicked', trackingData);
 
     showFacebookShareDialog(url)
       .then(() => {
@@ -122,16 +122,12 @@ class ShareAction extends React.Component {
           this.storeSharePost(puckId);
         }
 
-        this.trackEvent('facebook', 'action', 'completed', {
-          ...trackingData,
-        });
+        this.trackEvent('facebook', 'action', 'completed', trackingData);
 
         this.setState({ showModal: true });
       })
       .catch(() => {
-        this.trackEvent('facebook', 'action', 'cancelled', {
-          ...trackingData,
-        });
+        this.trackEvent('facebook', 'action', 'cancelled', trackingData);
       });
   };
 

--- a/resources/assets/components/actions/ShareAction/ShareAction.js
+++ b/resources/assets/components/actions/ShareAction/ShareAction.js
@@ -50,12 +50,12 @@ class ShareAction extends React.Component {
   storeSharePost = puckId => {
     const action = get(this.props.additionalContent, 'action', 'default');
 
-    const { actionId, campaignContentfulId, campaignId, link } = this.props;
+    const { actionId, pageId, campaignId, link } = this.props;
 
     const formFields = withoutNulls({
-      action,
+      action, // @TODO: deprecate
       type: SOCIAL_SHARE_TYPE,
-      id: campaignContentfulId,
+      id: pageId, // @TODO: rename property to pageId? Other actions use the blockId?
       action_id: actionId,
       details: {
         url: link,
@@ -67,11 +67,11 @@ class ShareAction extends React.Component {
 
     // Send request to store the social share post.
     this.props.storeCampaignPost(campaignId, {
-      action,
+      action, // @TODO: deprecate
       actionId,
-      campaignContentfulId,
+      blockId: this.props.id,
       body: formatPostPayload(formFields),
-      id: this.props.id,
+      pageId,
       type: SOCIAL_SHARE_TYPE,
     });
   };
@@ -87,7 +87,12 @@ class ShareAction extends React.Component {
    */
   trackEvent = (service, target, verb, data = {}) => {
     trackAnalyticsEvent({
-      context: { ...data },
+      context: {
+        ...data,
+        blockId: this.props.id,
+        campaignId: this.props.campaignId,
+        pageId: this.props.pageId,
+      },
       metadata: {
         adjective: service,
         category: 'campaign_action',
@@ -104,7 +109,7 @@ class ShareAction extends React.Component {
 
     let trackingData = { url: link };
 
-    this.trackEvent('facebook', 'button', 'clicked', { url: link });
+    this.trackEvent('facebook', 'button', 'clicked', { ...trackingData });
 
     showFacebookShareDialog(url)
       .then(() => {
@@ -170,7 +175,7 @@ class ShareAction extends React.Component {
         <div className="share-action">
           <PuckWaypoint
             name="share_action-top"
-            waypointData={{ contentfulId: id }}
+            waypointData={{ blockId: id }}
           />
           <Card title={title} className="rounded bordered">
             {content ? (
@@ -187,7 +192,7 @@ class ShareAction extends React.Component {
           </Card>
           <PuckWaypoint
             name="share_action-bottom"
-            waypointData={{ contentfulId: id }}
+            waypointData={{ blockId: id }}
           />
         </div>
         {this.state.showModal ? (
@@ -217,10 +222,10 @@ ShareAction.propTypes = {
   affirmation: PropTypes.string,
   affirmationBlock: PropTypes.object, // eslint-disable-line
   campaignId: PropTypes.string.isRequired,
-  campaignContentfulId: PropTypes.string.isRequired,
+  pageId: PropTypes.string.isRequired,
   content: PropTypes.string,
   hideEmbed: PropTypes.bool,
-  id: PropTypes.string.isRequired,
+  id: PropTypes.string.isRequired, // @TODO: rename property to blockId
   isAuthenticated: PropTypes.bool.isRequired,
   link: PropTypes.string.isRequired,
   socialPlatform: PropTypes.oneOf(['twitter', 'facebook']).isRequired,

--- a/resources/assets/components/actions/ShareAction/ShareAction.test.js
+++ b/resources/assets/components/actions/ShareAction/ShareAction.test.js
@@ -12,7 +12,12 @@ jest.useFakeTimers();
 
 describe('ShareAction component', () => {
   const url = 'https://dosomething.org';
-  const trackingData = { url };
+  const trackingData = {
+    blockId: '1234',
+    campaignId: '1234',
+    pageId: 'abcdefghijklmn0123456789',
+    url,
+  };
 
   const getShallow = socialPlatform =>
     shallow(
@@ -21,7 +26,7 @@ describe('ShareAction component', () => {
         content="This is a great link"
         socialPlatform={socialPlatform}
         link={url}
-        campaignContentfulId="abcdefghijklmn0123456789"
+        pageId="abcdefghijklmn0123456789"
         campaignId="1234"
         id="1234"
         isAuthenticated={false}

--- a/resources/assets/components/actions/ShareAction/ShareActionContainer.js
+++ b/resources/assets/components/actions/ShareAction/ShareActionContainer.js
@@ -16,11 +16,11 @@ const mapStateToProps = (state, ownProps) => {
     : ownProps.socialPlatform;
 
   return {
-    userId: getUserId(state),
     campaignId: state.campaign.campaignId,
     isAuthenticated: isAuthenticated(state),
-    campaignContentfulId: state.campaign.id,
+    pageId: state.campaign.id,
     socialPlatform: socialPlatform || 'facebook',
+    userId: getUserId(state),
   };
 };
 

--- a/resources/assets/components/actions/TextSubmissionAction/TextSubmissionAction.js
+++ b/resources/assets/components/actions/TextSubmissionAction/TextSubmissionAction.js
@@ -104,8 +104,9 @@ class TextSubmissionAction extends React.Component {
       action,
       actionId: this.props.actionId,
       body: formatPostPayload(formFields),
-      id: this.props.id,
       campaignContentfulId: this.props.campaignContentfulId,
+      campaignId: this.props.campaignId,
+      id: this.props.id,
       type,
     };
 

--- a/resources/assets/components/actions/TextSubmissionAction/TextSubmissionAction.js
+++ b/resources/assets/components/actions/TextSubmissionAction/TextSubmissionAction.js
@@ -35,7 +35,6 @@ export const TextSubmissionBlockFragment = gql`
 
 class TextSubmissionAction extends React.Component {
   static getDerivedStateFromProps(nextProps) {
-    console.log('👾', nextProps);
     const response = nextProps.submissions.items[nextProps.id] || null;
 
     if (has(response, 'status.success')) {
@@ -110,8 +109,6 @@ class TextSubmissionAction extends React.Component {
       pageId: this.props.pageId,
       type,
     };
-
-    console.log('🔥', data);
 
     // Send request to store the text submission post.
     // (Use campaign ID independant post method if actionId is provided).
@@ -240,7 +237,7 @@ TextSubmissionAction.propTypes = {
   buttonText: PropTypes.string,
   campaignId: PropTypes.string,
   className: PropTypes.string,
-  id: PropTypes.string.isRequired, // @TODO: rename property to blockId
+  id: PropTypes.string.isRequired,
   informationTitle: PropTypes.string,
   informationContent: PropTypes.string,
   pageId: PropTypes.string,

--- a/resources/assets/components/actions/TextSubmissionAction/TextSubmissionAction.js
+++ b/resources/assets/components/actions/TextSubmissionAction/TextSubmissionAction.js
@@ -35,6 +35,7 @@ export const TextSubmissionBlockFragment = gql`
 
 class TextSubmissionAction extends React.Component {
   static getDerivedStateFromProps(nextProps) {
+    console.log('👾', nextProps);
     const response = nextProps.submissions.items[nextProps.id] || null;
 
     if (has(response, 'status.success')) {
@@ -71,7 +72,7 @@ class TextSubmissionAction extends React.Component {
 
   handleFocus = () => {
     trackAnalyticsEvent({
-      context: { contentfulId: this.props.id },
+      context: { blockId: this.props.id, pageId: this.props.pageId },
       metadata: {
         adjective: 'text',
         category: 'campaign_action',
@@ -92,23 +93,25 @@ class TextSubmissionAction extends React.Component {
     const action = get(this.props.additionalContent, 'action', 'default');
 
     const formFields = withoutNulls({
-      action,
+      action, // @TODO: deprecate
       type,
-      id: this.props.id,
+      id: this.props.id, // @TODO: rename property to blockId?
       action_id: this.props.actionId,
       // Associate state values to fields.
       ...mapValues(this.fields, value => this.state[`${value}Value`]),
     });
 
     const data = {
-      action,
+      action, // @TODO: deprecate
       actionId: this.props.actionId,
+      blockId: this.props.id,
       body: formatPostPayload(formFields),
-      campaignContentfulId: this.props.campaignContentfulId,
       campaignId: this.props.campaignId,
-      id: this.props.id,
+      pageId: this.props.pageId,
       type,
     };
+
+    console.log('🔥', data);
 
     // Send request to store the text submission post.
     // (Use campaign ID independant post method if actionId is provided).
@@ -144,7 +147,7 @@ class TextSubmissionAction extends React.Component {
         >
           <PuckWaypoint
             name="text_submission_action-top"
-            waypointData={{ contentfulId: this.props.id }}
+            waypointData={{ blockId: this.props.id }}
           />
           <Card className="bordered rounded" title={this.props.title}>
             {formResponse ? <FormValidation response={formResponse} /> : null}
@@ -191,7 +194,7 @@ class TextSubmissionAction extends React.Component {
           </Card>
           <PuckWaypoint
             name="text_submission_action-bottom"
-            waypointData={{ contentfulId: this.props.id }}
+            waypointData={{ blockId: this.props.id }}
           />
         </div>
 
@@ -236,11 +239,11 @@ TextSubmissionAction.propTypes = {
   }),
   buttonText: PropTypes.string,
   campaignId: PropTypes.string,
-  campaignContentfulId: PropTypes.string,
   className: PropTypes.string,
-  id: PropTypes.string.isRequired,
+  id: PropTypes.string.isRequired, // @TODO: rename property to blockId
   informationTitle: PropTypes.string,
   informationContent: PropTypes.string,
+  pageId: PropTypes.string,
   resetPostSubmissionItem: PropTypes.func.isRequired,
   storeCampaignPost: PropTypes.func.isRequired,
   storePost: PropTypes.func.isRequired,
@@ -260,10 +263,10 @@ TextSubmissionAction.defaultProps = {
     "Thanks for joining the movement, and submitting your message! After we review your submission, we'll add it to the public gallery alongside submissions from all the other members taking action in this campaign.",
   buttonText: 'Submit',
   campaignId: null,
-  campaignContentfulId: null,
   className: null,
   informationContent: null,
   informationTitle: 'More Info',
+  pageId: null,
   textFieldLabel: 'I did something by...',
   textFieldPlaceholder: 'Indicate what you did to make a difference.',
   title: 'Submit your text',

--- a/resources/assets/components/actions/TextSubmissionAction/TextSubmissionAction.js
+++ b/resources/assets/components/actions/TextSubmissionAction/TextSubmissionAction.js
@@ -237,7 +237,7 @@ TextSubmissionAction.propTypes = {
   buttonText: PropTypes.string,
   campaignId: PropTypes.string,
   className: PropTypes.string,
-  id: PropTypes.string.isRequired,
+  id: PropTypes.string.isRequired, // @TODO: rename property to blockId
   informationTitle: PropTypes.string,
   informationContent: PropTypes.string,
   pageId: PropTypes.string,

--- a/resources/assets/components/actions/TextSubmissionAction/TextSubmissionActionContainer.js
+++ b/resources/assets/components/actions/TextSubmissionAction/TextSubmissionActionContainer.js
@@ -11,8 +11,8 @@ import {
  * Provide state from the Redux store as props for this component.
  */
 const mapStateToProps = state => ({
-  campaignId: state.campaign.campaignId,
   campaignContentfulId: state.campaign.id,
+  campaignId: state.campaign.campaignId,
   submissions: state.postSubmissions,
 });
 

--- a/resources/assets/components/actions/TextSubmissionAction/TextSubmissionActionContainer.js
+++ b/resources/assets/components/actions/TextSubmissionAction/TextSubmissionActionContainer.js
@@ -11,7 +11,7 @@ import {
  * Provide state from the Redux store as props for this component.
  */
 const mapStateToProps = state => ({
-  campaignContentfulId: state.campaign.id,
+  pageId: state.campaign.id,
   campaignId: state.campaign.campaignId,
   submissions: state.postSubmissions,
 });

--- a/resources/assets/helpers/analytics.js
+++ b/resources/assets/helpers/analytics.js
@@ -60,7 +60,7 @@ export function analyzeWithGoogle(name, category, action, label, data) {
   const flattenedData = stringifyNestedObjects(data);
 
   if (window.AUTH.id) {
-    flattenedData.userID = window.AUTH.id;
+    flattenedData.userId = window.AUTH.id;
   }
 
   const analyticsEvent = {

--- a/resources/assets/middleware/requiresAuthentication.js
+++ b/resources/assets/middleware/requiresAuthentication.js
@@ -1,4 +1,4 @@
-/* global window */
+/* global window document */
 
 import { get } from 'lodash';
 import localforage from 'localforage';

--- a/resources/views/partials/snowplow_script.blade.php
+++ b/resources/views/partials/snowplow_script.blade.php
@@ -5,7 +5,7 @@
           };p[i].q=p[i].q||[];n=l.createElement(o);g=l.getElementsByTagName(o)[0];n.async=1;
           n.src=w;g.parentNode.insertBefore(n,g)}}(window,document,'script','//d1fc8wv8zag5ca.cloudfront.net/2.5.3/sp.js','snowplow'));
           window.snowplow('newTracker', 'cf', '{{config('services.analytics.snowplow_url')}}', {
-            appId: 'dosomething-web',
+            appId: 'phoenix',
             cookieDomain: null,
             discoverRootDomain: true
         });


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR mostly updates the payload data from events to be more consistent across events and simplify/unify the naming of properties in the payload. We're renaming `campaignContentfulID` to `pageId` and the very generic `id` on components (which would correspond to the content type instance on Contentful) to `blockId` to make it more evident what it is.

It also corrects a typo in the `userId` payload prop (was `userID`), and renames the `app-id` Snowplow config setting from `dosomething-web` to `phoenix`.

### Any background context you want to provide?

🌵 

### What are the relevant tickets/cards?

Refs [Pivotal ID #166595074](https://www.pivotaltracker.com/story/show/166595074)
