### PR TITLE
Update Post Card staff review permalink

### DIFF
--- a/resources/assets/components/utilities/PostCard/PostCard.js
+++ b/resources/assets/components/utilities/PostCard/PostCard.js
@@ -27,14 +27,11 @@ export const postCardFragment = gql`
     location(format: HUMAN_FORMAT)
     signupId
     createdAt
+    permalink
 
     actionDetails {
       anonymous
       noun
-    }
-
-    signup {
-      permalink
     }
 
     user {
@@ -90,7 +87,7 @@ const PostCard = ({ post, hideReactions }) => {
         >
           <h4>
             {authorLabel}
-            {isStaff() ? <ReviewLink url={post.signup.permalink} /> : null}
+            {isStaff() ? <ReviewLink url={post.permalink} /> : null}
             <PostBadge status={post.status} tags={post.tags} />
           </h4>
           {post.quantity ? (


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR updates the `PostCard` to pull the `permalink` property directly from the post instead of the post's signup. 

### Any background context you want to provide?
This would break if a `signup` were deleted on Rogue when attempting to display the stray post. 
@DFurnes already did the work to enable pulling this permalink directly from the post!

### What are the relevant tickets/cards?
https://dosomething.slack.com/archives/C0YGXUE01/p1560532709006200
