### PR TITLE
ENHANCE cover image resolution on mosaic template.

### DIFF
--- a/app/helpers.php
+++ b/app/helpers.php
@@ -295,14 +295,14 @@ function get_image_url($asset, $style = null)
 
     $options['landscape'] = (new ImageOptions)
         ->setFormat('jpg')
-        ->setWidth(1440)
-        ->setHeight(620)
+        ->setWidth(2880)
+        ->setHeight(1240)
         ->setResizeFit('fill');
 
     $options['square'] = (new ImageOptions)
         ->setFormat('jpg')
-        ->setWidth(600)
-        ->setHeight(600)
+        ->setWidth(1200)
+        ->setHeight(1200)
         ->setResizeFit('fill');
 
     $options['logo'] = (new ImageOptions)

--- a/resources/assets/components/LedeBanner/templates/MosaicTemplate.js
+++ b/resources/assets/components/LedeBanner/templates/MosaicTemplate.js
@@ -31,8 +31,8 @@ const MosaicTemplate = props => {
   const backgroundImageStyle = {
     backgroundImage: `url(${contentfulImageUrl(
       coverImage.url,
-      '800',
-      '600',
+      '1600',
+      '1200',
       'fill',
     )})`,
   };


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR *enhances* the cover image resolution for the lede banner on mosaic template. It also updates our PHP helper (which is used less now in favor of client side image URL processing), but wanted to plug up any other areas that might be providing low resolution images.

### What are the relevant tickets/cards?

Refs [Pivotal ID #166677667](https://www.pivotaltracker.com/story/show/166677667)
