### PR TITLE
Campaign routing updates.

### DIFF
--- a/app/Entities/Campaign.php
+++ b/app/Entities/Campaign.php
@@ -129,7 +129,7 @@ class Campaign extends Entity implements JsonSerializable
             'id' => $this->entry->getId(),
             'campaignId' => $this->legacyCampaignId,
             'type' => $this->entry->getContentType()->getId(),
-            'template' => $this->template->first() ?: 'mosaic',
+            'template' => 'mosaic',
             'title' => $this->title,
             'slug' => $this->slug,
             'metadata' => $this->metadata ? new Metadata($this->metadata->entry) : null,

--- a/resources/assets/components/Campaign/CampaignRoute/CampaignRoute.js
+++ b/resources/assets/components/Campaign/CampaignRoute/CampaignRoute.js
@@ -8,6 +8,8 @@ import InfoBar from '../../InfoBar/InfoBar';
 import Modal from '../../utilities/Modal/Modal';
 import BlockPage from '../../pages/BlockPage/BlockPage';
 import PostSignupModal from '../../pages/PostSignupModal/PostSignupModal';
+import CampaignClosedPage from '../../pages/CampaignPage/CampaignClosedPage';
+import LandingPageContainer from '../../pages/LandingPage/LandingPageContainer';
 import CampaignPageContainer from '../../pages/CampaignPage/CampaignPageContainer';
 
 const CampaignRoute = props => {
@@ -48,25 +50,41 @@ const CampaignRoute = props => {
               });
 
               if (isCampaignClosed) {
-                console.log('🚫 Campaign is closed!');
-
                 if (hasCommunityPage) {
-                  console.log('👩‍❤️‍💋‍👨 send to community page...');
-                  return;
+                  console.log(
+                    '🚫 Campaign is closed! send to community page...',
+                  );
+
+                  return (
+                    <Redirect
+                      to={{
+                        pathname: join(match.url, 'community'),
+                        search: location.search,
+                      }}
+                    />
+                  );
                 } else {
                   console.log(
-                    '🤷🏽‍♂️ show some default closed campaign content...',
+                    '🚫 Campaign is closed! show default closed campaign content...',
                   );
-                  return;
+                  return <CampaignClosedPage />;
                 }
               }
 
               if (isSignedUp) {
                 console.log('💪 head to the action page');
-                return;
+                return (
+                  <Redirect
+                    to={{
+                      pathname: join(match.url, 'action'),
+                      search: location.search,
+                    }}
+                  />
+                );
               }
 
               console.log('⚽️ Hit the end, lets show the landing page.');
+              return <LandingPageContainer {...props} />;
             }}
           />
 
@@ -74,6 +92,11 @@ const CampaignRoute = props => {
 
           <Route
             path={join(match.url, 'quiz/:slug')}
+            component={CampaignPageContainer}
+          />
+
+          <Route
+            path={join(match.url, ':slug')}
             component={CampaignPageContainer}
           />
         </Switch>

--- a/resources/assets/components/Campaign/CampaignRoute/CampaignRoute.js
+++ b/resources/assets/components/Campaign/CampaignRoute/CampaignRoute.js
@@ -20,6 +20,7 @@ const CampaignRoute = props => {
     clickedHideAffirmation,
     hasCommunityPage,
     isCampaignClosed,
+    isSignedUp,
     location,
     match,
     shouldShowAffirmation,
@@ -39,17 +40,33 @@ const CampaignRoute = props => {
             path={`${match.url}`}
             exact
             render={() => {
-              const path =
-                isCampaignClosed && hasCommunityPage ? 'community' : 'action';
+              console.log('🔥', {
+                match,
+                isCampaignClosed,
+                hasCommunityPage,
+                isSignedUp,
+              });
 
-              return (
-                <Redirect
-                  to={{
-                    pathname: join(match.url, path),
-                    search: location.search,
-                  }}
-                />
-              );
+              if (isCampaignClosed) {
+                console.log('🚫 Campaign is closed!');
+
+                if (hasCommunityPage) {
+                  console.log('👩‍❤️‍💋‍👨 send to community page...');
+                  return;
+                } else {
+                  console.log(
+                    '🤷🏽‍♂️ show some default closed campaign content...',
+                  );
+                  return;
+                }
+              }
+
+              if (isSignedUp) {
+                console.log('💪 head to the action page');
+                return;
+              }
+
+              console.log('⚽️ Hit the end, lets show the landing page.');
             }}
           />
 
@@ -57,11 +74,6 @@ const CampaignRoute = props => {
 
           <Route
             path={join(match.url, 'quiz/:slug')}
-            component={CampaignPageContainer}
-          />
-
-          <Route
-            path={join(match.url, ':slug')}
             component={CampaignPageContainer}
           />
         </Switch>

--- a/resources/assets/components/Campaign/CampaignRoute/CampaignRoute.js
+++ b/resources/assets/components/Campaign/CampaignRoute/CampaignRoute.js
@@ -33,6 +33,8 @@ const CampaignRoute = props => {
 
   const isClosed = isCampaignClosed(endDate);
 
+  const baseUrl = match.url;
+
   return (
     <div>
       <div>
@@ -43,23 +45,23 @@ const CampaignRoute = props => {
         ) : null}
 
         <Switch>
-          <Route path={join(match.url, 'blocks/:id')} component={BlockPage} />
+          <Route path={join(baseUrl, 'blocks/:id')} component={BlockPage} />
 
           <Route
-            path={join(match.url, 'quiz/:slug')}
+            path={join(baseUrl, 'quiz/:slug')}
             component={CampaignPageContainer}
           />
 
           <Route
             exact
-            path={`${match.url}`}
+            path={baseUrl}
             render={() => {
               if (isClosed) {
                 if (hasCommunityPage) {
                   return (
                     <Redirect
                       to={{
-                        pathname: join(match.url, 'community'),
+                        pathname: join(baseUrl, 'community'),
                         search: location.search,
                       }}
                     />
@@ -73,7 +75,7 @@ const CampaignRoute = props => {
                 return (
                   <Redirect
                     to={{
-                      pathname: join(match.url, 'action'),
+                      pathname: join(baseUrl, 'action'),
                       search: location.search,
                     }}
                   />
@@ -91,7 +93,7 @@ const CampaignRoute = props => {
           />
 
           <Route
-            path={join(match.url, ':slug')}
+            path={join(baseUrl, ':slug')}
             render={routeProps => {
               const slug = get(routeProps, 'match.params.slug', null);
 
@@ -103,7 +105,7 @@ const CampaignRoute = props => {
                 return (
                   <Redirect
                     to={{
-                      pathname: `${match.url}`,
+                      pathname: baseUrl,
                       search: location.search,
                     }}
                   />
@@ -114,7 +116,7 @@ const CampaignRoute = props => {
                 return (
                   <Redirect
                     to={{
-                      pathname: `${match.url}`,
+                      pathname: baseUrl,
                       search: location.search,
                     }}
                   />
@@ -146,7 +148,7 @@ CampaignRoute.propTypes = {
     email: PropTypes.string,
   }),
   clickedHideAffirmation: PropTypes.func.isRequired,
-  endDate: PropTypes.string.isRequired,
+  endDate: PropTypes.string,
   hasCommunityPage: PropTypes.bool.isRequired,
   isSignedUp: PropTypes.bool.isRequired,
   landingPage: PropTypes.object,
@@ -158,6 +160,7 @@ CampaignRoute.propTypes = {
 CampaignRoute.defaultProps = {
   affiliateCreditText: undefined,
   campaignLead: null,
+  endDate: null,
   landingPage: {},
 };
 

--- a/resources/assets/components/Campaign/CampaignRoute/CampaignRouteContainer.js
+++ b/resources/assets/components/Campaign/CampaignRoute/CampaignRouteContainer.js
@@ -2,7 +2,6 @@ import get from 'lodash/get';
 import { connect } from 'react-redux';
 
 import CampaignRoute from './CampaignRoute';
-import { isCampaignClosed } from '../../../helpers';
 import { clickedHideAffirmation } from '../../../actions';
 import { isCampaignSignUpInState } from '../../../selectors/signup';
 
@@ -19,12 +18,12 @@ const mapStateToProps = state => ({
   affiliatePartners: state.campaign.affiliatePartners,
   affirmation: state.campaign.affirmation,
   campaignLead: get(state, 'campaign.campaignLead.fields', null),
+  endDate: state.campaign.endDate,
   hasCommunityPage: Boolean(
     state.campaign.pages.find(
       page => page.type === 'page' && page.fields.slug.endsWith('community'),
     ),
   ),
-  isCampaignClosed: isCampaignClosed(state.campaign.endDate),
   isSignedUp: isCampaignSignUpInState(state),
   landingPage: get(state.campaign, 'landingPage', null),
   shouldShowAffirmation: state.signups.shouldShowAffirmation,

--- a/resources/assets/components/Campaign/CampaignRoute/CampaignRouteContainer.js
+++ b/resources/assets/components/Campaign/CampaignRoute/CampaignRouteContainer.js
@@ -4,6 +4,7 @@ import { connect } from 'react-redux';
 import CampaignRoute from './CampaignRoute';
 import { isCampaignClosed } from '../../../helpers';
 import { clickedHideAffirmation } from '../../../actions';
+import { isCampaignSignUpInState } from '../../../selectors/signup';
 
 /**
  * Provide state from the Redux store as props for this component.
@@ -24,6 +25,7 @@ const mapStateToProps = state => ({
     ),
   ),
   isCampaignClosed: isCampaignClosed(state.campaign.endDate),
+  isSignedUp: isCampaignSignUpInState(state),
   shouldShowAffirmation: state.signups.shouldShowAffirmation,
 });
 

--- a/resources/assets/components/Campaign/CampaignRoute/CampaignRouteContainer.js
+++ b/resources/assets/components/Campaign/CampaignRoute/CampaignRouteContainer.js
@@ -26,6 +26,7 @@ const mapStateToProps = state => ({
   ),
   isCampaignClosed: isCampaignClosed(state.campaign.endDate),
   isSignedUp: isCampaignSignUpInState(state),
+  landingPage: get(state.campaign, 'landingPage', null),
   shouldShowAffirmation: state.signups.shouldShowAffirmation,
 });
 

--- a/resources/assets/components/ContentfulEntry/ContentfulEntry.js
+++ b/resources/assets/components/ContentfulEntry/ContentfulEntry.js
@@ -164,6 +164,8 @@ class ContentfulEntry extends React.Component<Props, State> {
         );
 
       case 'page':
+        console.log('🔥', json.fields);
+
         return (
           <StaticBlock
             content={json.fields.content}

--- a/resources/assets/components/ContentfulEntry/ContentfulEntry.js
+++ b/resources/assets/components/ContentfulEntry/ContentfulEntry.js
@@ -164,8 +164,6 @@ class ContentfulEntry extends React.Component<Props, State> {
         );
 
       case 'page':
-        console.log('🔥', json.fields);
-
         return (
           <StaticBlock
             content={json.fields.content}

--- a/resources/assets/components/pages/CampaignPage/CampaignClosedPage.js
+++ b/resources/assets/components/pages/CampaignPage/CampaignClosedPage.js
@@ -1,0 +1,20 @@
+import React from 'react';
+
+import Enclosure from '../../Enclosure';
+import LedeBannerContainer from '../../LedeBanner/LedeBannerContainer';
+
+const CampaignClosedPage = props => {
+  return (
+    <div>
+      <LedeBannerContainer />
+      <div className="main clearfix">
+        <Enclosure className="default-container margin-top-lg margin-bottom-lg">
+          <h1>No campaign for you!</h1>
+          <p>This campaign has already closed. Try again later.</p>
+        </Enclosure>
+      </div>
+    </div>
+  );
+};
+
+export default CampaignClosedPage;

--- a/resources/assets/components/pages/CampaignPage/CampaignClosedPage.js
+++ b/resources/assets/components/pages/CampaignPage/CampaignClosedPage.js
@@ -1,4 +1,6 @@
 import React from 'react';
+import { format } from 'date-fns';
+import PropTypes from 'prop-types';
 
 import Enclosure from '../../Enclosure';
 import LedeBannerContainer from '../../LedeBanner/LedeBannerContainer';
@@ -6,15 +8,27 @@ import LedeBannerContainer from '../../LedeBanner/LedeBannerContainer';
 const CampaignClosedPage = props => {
   return (
     <div>
-      <LedeBannerContainer />
+      <LedeBannerContainer displaySignup={false} />
+
       <div className="main clearfix">
         <Enclosure className="default-container margin-top-lg margin-bottom-lg">
-          <h1>No campaign for you!</h1>
-          <p>This campaign has already closed. Try again later.</p>
+          <h1>Great work!</h1>
+          <p>
+            This campaign closed on{' '}
+            {format(props.endDate, 'MMMM do, yyyy', {
+              awareOfUnicodeTokens: true,
+            })}
+            . Thank you to all the members who participated and the incredible
+            impact you made!
+          </p>
         </Enclosure>
       </div>
     </div>
   );
+};
+
+CampaignClosedPage.propTypes = {
+  endDate: PropTypes.string.isRequired,
 };
 
 export default CampaignClosedPage;

--- a/resources/assets/components/pages/CampaignPage/CampaignPage.js
+++ b/resources/assets/components/pages/CampaignPage/CampaignPage.js
@@ -17,6 +17,13 @@ import './campaign-page.scss';
  * @returns {XML}
  */
 const CampaignPage = props => {
+  console.log('👻 Campaign Page: ', {
+    endDate: props.campaignEndDate,
+    location: props.location,
+    match: props.match,
+    showLandingPage: props.shouldShowLandingPage,
+  });
+
   // @TODO: temporary fucntion to select component to use based on type.
   // Will be removed once all landing pages use the LandingPage content type.
   const landingPageComponent = () =>

--- a/resources/assets/components/pages/CampaignPage/CampaignPage.js
+++ b/resources/assets/components/pages/CampaignPage/CampaignPage.js
@@ -21,6 +21,7 @@ const CampaignPage = props => {
     endDate: props.campaignEndDate,
     location: props.location,
     match: props.match,
+    slug: props.match.params.slug,
     showLandingPage: props.shouldShowLandingPage,
   });
 
@@ -38,6 +39,7 @@ const CampaignPage = props => {
   ) : (
     <div>
       <LedeBannerContainer displaySignup={Boolean(!props.entryContent)} />
+
       <div className="main clearfix">
         {props.dashboard ? <ContentfulEntry json={props.dashboard} /> : null}
 

--- a/resources/assets/components/pages/CampaignPage/CampaignPage.js
+++ b/resources/assets/components/pages/CampaignPage/CampaignPage.js
@@ -6,7 +6,6 @@ import ContentfulEntry from '../../ContentfulEntry';
 import CampaignPageContent from './CampaignPageContent';
 import { CallToActionContainer } from '../../CallToAction';
 import LedeBannerContainer from '../../LedeBanner/LedeBannerContainer';
-import LandingPageContainer from '../LandingPage/LandingPageContainer';
 import CampaignPageNavigationContainer from '../../CampaignPageNavigation/CampaignPageNavigationContainer';
 
 import './campaign-page.scss';
@@ -17,33 +16,18 @@ import './campaign-page.scss';
  * @returns {XML}
  */
 const CampaignPage = props => {
-  console.log('👻 Campaign Page: ', {
-    endDate: props.campaignEndDate,
-    location: props.location,
-    match: props.match,
-    slug: props.match.params.slug,
-    showLandingPage: props.shouldShowLandingPage,
-  });
+  console.log('🗿 campaign page props: ', props);
 
-  // @TODO: temporary fucntion to select component to use based on type.
-  // Will be removed once all landing pages use the LandingPage content type.
-  const landingPageComponent = () =>
-    props.landingPage.type === 'page' ? (
-      <LandingPageContainer {...props} />
-    ) : (
-      <ContentfulEntry json={props.landingPage} />
-    );
-
-  return props.shouldShowLandingPage ? (
-    landingPageComponent()
-  ) : (
+  return (
     <div>
       <LedeBannerContainer displaySignup={Boolean(!props.entryContent)} />
 
       <div className="main clearfix">
         {props.dashboard ? <ContentfulEntry json={props.dashboard} /> : null}
 
-        {!props.entryContent ? <CampaignPageNavigationContainer /> : null}
+        {!props.isCampaignClosed && !props.entryContent ? (
+          <CampaignPageNavigationContainer />
+        ) : null}
 
         <Enclosure className="default-container margin-top-lg margin-bottom-lg">
           {/* @TODO: after Action page migration, refactor and combine CampaignPage & CampaignSubPage and render Contentful Entry within CampaignPage component */}
@@ -68,6 +52,7 @@ CampaignPage.propTypes = {
     fields: PropTypes.object,
   }),
   entryContent: PropTypes.object,
+  isCampaignClosed: PropTypes.bool,
   landingPage: PropTypes.shape({
     id: PropTypes.string,
     type: PropTypes.string,
@@ -79,6 +64,7 @@ CampaignPage.propTypes = {
 CampaignPage.defaultProps = {
   dashboard: null,
   entryContent: null,
+  isCampaignClosed: false,
   landingPage: null,
 };
 

--- a/resources/assets/components/pages/CampaignPage/CampaignPage.js
+++ b/resources/assets/components/pages/CampaignPage/CampaignPage.js
@@ -16,8 +16,6 @@ import './campaign-page.scss';
  * @returns {XML}
  */
 const CampaignPage = props => {
-  console.log('🗿 campaign page props: ', props);
-
   return (
     <div>
       <LedeBannerContainer displaySignup={Boolean(!props.entryContent)} />

--- a/resources/assets/components/pages/CampaignPage/CampaignPageContainer.js
+++ b/resources/assets/components/pages/CampaignPage/CampaignPageContainer.js
@@ -2,7 +2,11 @@ import { get, has } from 'lodash';
 import { connect } from 'react-redux';
 
 import CampaignPage from './CampaignPage';
-import { findContentfulEntry, shouldShowLandingPage } from '../../../helpers';
+import {
+  findContentfulEntry,
+  isCampaignClosed,
+  shouldShowLandingPage,
+} from '../../../helpers';
 
 /**
  * Provide state from the Redux store as props for this component.
@@ -13,6 +17,8 @@ const mapStateToProps = (state, ownProps) => {
   if (has(ownProps, 'match.params', null)) {
     const { id, slug } = ownProps.match.params;
 
+    console.log('⛺️', { id, slug, ownProps });
+
     // @TODO: temporary retrieval of single campaign page (quiz) based on matched id or slug.
     entryContent = findContentfulEntry(state, id || slug);
   }
@@ -21,6 +27,7 @@ const mapStateToProps = (state, ownProps) => {
     campaignEndDate: state.campaign.endDate,
     dashboard: state.campaign.dashboard,
     entryContent,
+    isCampaignClosed: isCampaignClosed(state.campaign.endDate),
     landingPage: get(state.campaign, 'landingPage', null),
     noun: get(state.campaign.additionalContent, 'noun'),
     pages: state.campaign.pages,

--- a/resources/assets/components/pages/CampaignPage/CampaignPageContainer.js
+++ b/resources/assets/components/pages/CampaignPage/CampaignPageContainer.js
@@ -17,8 +17,6 @@ const mapStateToProps = (state, ownProps) => {
   if (has(ownProps, 'match.params', null)) {
     const { id, slug } = ownProps.match.params;
 
-    console.log('⛺️', { id, slug, ownProps });
-
     // @TODO: temporary retrieval of single campaign page (quiz) based on matched id or slug.
     entryContent = findContentfulEntry(state, id || slug);
   }


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR addresses a long-standing issue that has been giving us headaches in the past. It updates campaign routing logic to ensure that the landing page is found at the root campaign URL, `/us/campaigns/test-campaign/`, and all other sub pages found at their respective URLs, `/us/campaigns/test-campaign/action`, `/us/campaigns/test-campaign/community`, etc. It also adds logic to handle issues when the campaign is closed and if there's a community page present; if closed and no community page then it shows a new `CampaignClosedPage` component which is suuuuuper basic for now and we can update after obtaining some input.

To make this all work, I needed to remove the campaign sub-nav for the time being for ALL closed campaigns. However, during a cleanup sprint I would like to propose eliminating showing the `/community` page for a closed campaign and instead always showing the `CampaignClosedPage` component with a dedicated message (potentially new rich text field in Campaign content type). We could then still show `/community`, `/faq` etc pages in the nav, but having a dedicated "closed" component would make all the logic easier and eliminate the crazy logic needed to decide whether or not to show the community page if the campaign is closed.

### Any background context you want to provide?
The following is a series of routes tested and their end location:

**Anonymous user/Unsigned-up user & Campaign Open**
- [x] /us/campaigns/test-campaign -> landing page
- [x] /us/campaigns/test-campaign/action -> redirect to / and show landing page.
- [x] /us/campaigns/test-campaign/community -> redirect to / and show landing page.
- [x] /us/campaigns/test-campaign/anything -> redirect to / and show landing page.

**Signed-up user & Campaign Open**
- [x] /us/campaigns/test-campaign -> redirect to /action.
- [x] /us/campaigns/test-campaign/action -> show /action.
- [x] /us/campaigns/test-campaign/community -> show /community.
- [x] /us/campaigns/test-campaign/anything -> show /anything.

**Anonymous user/Unsigned-up user & Campaign Closed**
- [x] /us/campaigns/test-campaign -> redirect to /community page OR redirect to / generic closed campaign page.
- [x] /us/campaigns/test-campaign/action -> redirect to /community page OR redirect to / generic closed campaign page.
- [x] /us/campaigns/test-campaign/community -> show /community page OR redirect to / generic closed campaign page.
- [x] /us/campaigns/test-campaign/anything -> redirect to /community page OR redirect to / generic closed campaign page.

**Signed-up user & Campaign Closed**
- [x] /us/campaigns/test-campaign -> redirect to /community page OR redirect to / generic closed campaign page.
- [x] /us/campaigns/test-campaign/action -> redirect to /community page OR redirect to / generic closed campaign page.
- [x] /us/campaigns/test-campaign/community -> show /community page OR redirect to / generic closed campaign page.
- [x] /us/campaigns/test-campaign/anything -> redirect to /community page OR redirect to / generic closed campaign page.

### What are the relevant tickets/cards?

Refs [Pivotal ID #163792659](https://www.pivotaltracker.com/story/show/163792659)

### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.