### PR TITLE
Manually setting Snowplow cookie domain to ds root domain.

### DIFF
--- a/resources/views/partials/snowplow_script.blade.php
+++ b/resources/views/partials/snowplow_script.blade.php
@@ -7,8 +7,7 @@
 
           window.snowplow('newTracker', 'cf', '{{config('services.analytics.snowplow_url')}}', {
             appId: 'phoenix',
-            cookieDomain: null,
-            discoverRootDomain: true
+            cookieDomain: '.dosomething.org'
         });
     </script>
 @else


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR removes `discoverRootDomain` function which isn't valid in Snowplow Tracker 2.5.3 and manually adds the root domain.

### Any background context you want to provide?

@mendelB Tracked down that the version of the Snowplow Tracker we use from Fivetran doesn't support the `discoverRootDomain` functionality, and this was validated by Megha in Quasar that we're not seeing cross-domain sessions and `domain_userid` between Northstar and Phoenix. 😡 

It is possible to set the cookie domain for cross-domain tracking in Snowplow Tracker version 2.5.3 as noted [here](https://github.com/snowplow/snowplow/wiki/1-General-parameters-for-the-Javascript-tracker-v2.5#223-configuring-the-cookie-domain). 

This PR removes the root domain discovery and manually sets the domain to be wildcard as [described](https://github.com/snowplow/snowplow/wiki/1-General-parameters-for-the-Javascript-tracker-v2.5#223-configuring-the-cookie-domain) in the 2.5.3 documentation.

### What are the relevant tickets/cards?

https://dosomething.slack.com/archives/CJU7WCQG4/p1561414915100800

[Northstar corollary PR](https://github.com/DoSomething/northstar/pull/886).