### PR TITLE
Add browser test for gallery & reacting to a post.

### DIFF
--- a/cypress/fixtures/graphql.js
+++ b/cypress/fixtures/graphql.js
@@ -1,6 +1,15 @@
 import faker from 'faker';
 import { ObjectID } from 'bson';
-import { MockList } from 'graphql-tools';
+
+/**
+ * Return a list of N items for a field, with an optional
+ * list of field overrides for the items in the list.
+ *
+ * @param {*} count
+ * @param {*} overrides
+ */
+export const MockList = (count, overrides = {}) =>
+  new Array(count).fill().map(() => overrides);
 
 /**
  * Default "operation" resolvers. These can be replaced or extended by
@@ -12,6 +21,10 @@ export const operations = {
   // By default, return empty submission galleries:
   SubmissionGalleryQuery: {
     posts: [],
+  },
+  // By default, return the requested number of posts:
+  PostGalleryQuery: {
+    posts: (root, { count }) => MockList(count),
   },
 };
 

--- a/cypress/fixtures/graphql.js
+++ b/cypress/fixtures/graphql.js
@@ -5,8 +5,8 @@ import { ObjectID } from 'bson';
  * Return a list of N items for a field, with an optional
  * list of field overrides for the items in the list.
  *
- * @param {*} count
- * @param {*} overrides
+ * @param {Number} count
+ * @param {Object} overrides
  */
 export const MockList = (count, overrides = {}) =>
   new Array(count).fill().map(() => overrides);

--- a/cypress/fixtures/graphql.js
+++ b/cypress/fixtures/graphql.js
@@ -52,7 +52,7 @@ export const mocks = {
   }),
   Post: () => ({
     type: () => faker.random.arrayElement(['photo', 'text']),
-    url: (post, { w = 400, h = 400 }) => faker.image.dataUri(w, h),
+    url: (post, { w = 400, h = 400 }) => faker.image.dataUri(w, h), // eslint-disable-line id-length
     text: () => faker.lorem.sentence(),
     quantity: () => Math.ceil(Math.random() * 99),
     reactions: () => Math.floor(Math.random() * 30),

--- a/cypress/fixtures/graphql.js
+++ b/cypress/fixtures/graphql.js
@@ -2,7 +2,27 @@ import faker from 'faker';
 import { ObjectID } from 'bson';
 import { MockList } from 'graphql-tools';
 
-export default {
+/**
+ * Default "operation" resolvers. These can be replaced or extended by
+ * calling `cy.mockGraphQLOps({ operations: ... })` in a test.
+ *
+ * @var {Object}
+ */
+export const operations = {
+  // By default, return empty submission galleries:
+  SubmissionGalleryQuery: {
+    posts: [],
+  },
+};
+
+/**
+ * Customized "mock" resolvers for our schema. Any types or fields
+ * not defined here will automatically resolve a value that makes
+ * sense based on their defined type.
+ *
+ * @var {Object}
+ */
+export const mocks = {
   // Custom scalars:
   AbsoluteUrl: () => 'https://www.example.com/',
   DateTime: () => new Date().toISOString(),
@@ -23,12 +43,5 @@ export default {
     text: () => faker.lorem.sentence(),
     quantity: () => Math.ceil(Math.random() * 99),
     reactions: () => Math.floor(Math.random() * 30),
-  }),
-
-  // Query root:
-  Query: () => ({
-    // Return empty submission gallery, but standard campaign gallery...
-    // TODO: Can we customize this per named query?
-    posts: (root, { userId, count }) => new MockList(userId ? 0 : count),
   }),
 };

--- a/cypress/integration/campaign-gallery.js
+++ b/cypress/integration/campaign-gallery.js
@@ -1,0 +1,49 @@
+/// <reference types="Cypress" />
+
+import { MockList } from '../fixtures/graphql';
+import { userFactory } from '../fixtures/user';
+import { exampleCampaign } from '../fixtures/contentful';
+
+describe('Campaign Gallery', () => {
+  // Configure a new "mock" server before each test:
+  beforeEach(() => cy.configureMocks());
+
+  it('React to a post', () => {
+    const user = userFactory();
+
+    cy.mockGraphqlOps({
+      operations: {
+        // Make sure we haven't yet reacted to anything:
+        PostGalleryQuery: {
+          posts: MockList(9, { reacted: false, reactions: 0 }),
+        },
+
+        // And a predictable response when we toggle a reaction:
+        ToggleReaction: ({ postId }) => ({
+          toggleReaction: {
+            id: postId,
+            reactions: 1,
+            reacted: true,
+          },
+        }),
+      },
+    });
+
+    // Log in & visit the campaign action page:
+    cy.login(user)
+      .withState(exampleCampaign)
+      .withSignup(exampleCampaign.campaign.campaignId)
+      .visit('/us/campaigns/test-example-campaign');
+
+    // Let's pick a post & react to it...
+    cy.get('.post-gallery .post')
+      .eq(4)
+      .within(() => {
+        cy.get('.reaction__button').click();
+
+        // The post should get a filled-in heart & updated total.
+        cy.get('.reaction__button').should('have.class', '-reacted');
+        cy.get('.reaction__meta').contains('1');
+      });
+  });
+});

--- a/cypress/integration/campaign-gallery.js
+++ b/cypress/integration/campaign-gallery.js
@@ -36,14 +36,12 @@ describe('Campaign Gallery', () => {
       .visit('/us/campaigns/test-example-campaign');
 
     // Let's pick a post & react to it...
-    cy.get('.post-gallery .post')
-      .eq(4)
-      .within(() => {
-        cy.get('.reaction__button').click();
+    cy.nth('.post-gallery .post', 4).within(() => {
+      cy.get('.reaction__button').click();
 
-        // The post should get a filled-in heart & updated total.
-        cy.get('.reaction__button').should('have.class', '-reacted');
-        cy.get('.reaction__meta').contains('1');
-      });
+      // The post should get a filled-in heart & updated total.
+      cy.get('.reaction__button').should('have.class', '-reacted');
+      cy.get('.reaction__meta').contains('1');
+    });
   });
 });

--- a/cypress/integration/campaign-post.js
+++ b/cypress/integration/campaign-post.js
@@ -17,15 +17,10 @@ describe('Campaign Post', () => {
   it('Create a text post', () => {
     const user = userFactory();
 
-    // Mock the "existing" signup response:
-    cy.route(
-      `${SIGNUPS_API}?filter[northstar_id]=${user.id}`,
-      existingSignup(campaignId, user),
-    );
-
-    // Log in & visit the campaign pitch page:
+    // Log in & visit the campaign action page:
     cy.login(user)
       .withState(exampleCampaign)
+      .withSignup(exampleCampaign.campaign.campaignId)
       .visit('/us/campaigns/test-example-campaign');
 
     const text = 'I made my cat a full English breakfast, with coffee & cream.';
@@ -41,15 +36,10 @@ describe('Campaign Post', () => {
   it('Create a photo post', () => {
     const user = userFactory();
 
-    // Mock the "existing" signup response:
-    cy.route(
-      `${SIGNUPS_API}?filter[northstar_id]=${user.id}`,
-      existingSignup(campaignId, user),
-    );
-
-    // Log in & visit the campaign pitch page:
+    // Log in & visit the campaign action page:
     cy.login(user)
       .withState(exampleCampaign)
+      .withSignup(exampleCampaign.campaign.campaignId)
       .visit('/us/campaigns/test-example-campaign');
 
     cy.get('.photo-submission-action').within(() => {

--- a/cypress/integration/campaign-signup.js
+++ b/cypress/integration/campaign-signup.js
@@ -2,7 +2,7 @@
 
 import { userFactory } from '../fixtures/user';
 import { exampleCampaign } from '../fixtures/contentful';
-import { emptyResponse, existingSignup, newSignup } from '../fixtures/signups';
+import { emptyResponse, newSignup } from '../fixtures/signups';
 
 const campaignId = '9002';
 const API = `/api/v2/campaigns/${campaignId}`;
@@ -14,6 +14,7 @@ describe('Campaign Signup', () => {
   it('Create signup, as an anonymous user', () => {
     const user = userFactory();
 
+    // Visit the campaign pitch page:
     cy.withState(exampleCampaign).visit('/us/campaigns/test-example-campaign');
 
     cy.contains('Example Campaign');
@@ -34,12 +35,10 @@ describe('Campaign Signup', () => {
   it('Create signup, as an authenticated user', () => {
     const user = userFactory();
 
-    // Mock the "empty" signup response:
-    cy.route(`${API}/signups?filter[northstar_id]=${user.id}`, emptyResponse);
-
     // Log in & visit the campaign pitch page:
     cy.login(user)
       .withState(exampleCampaign)
+      .withoutSignup(exampleCampaign.campaign.campaignId)
       .visit('/us/campaigns/test-example-campaign');
 
     cy.contains('Example Campaign');
@@ -56,15 +55,10 @@ describe('Campaign Signup', () => {
   it('Visit with existing signup, as an authenticated user', () => {
     const user = userFactory();
 
-    // Mock the "existing" signup response:
-    cy.route(
-      `${API}/signups?filter[northstar_id]=${user.id}`,
-      existingSignup(campaignId, user),
-    );
-
-    // Log in & visit the campaign pitch page:
+    // Log in & visit the campaign action page:
     cy.login(user)
       .withState(exampleCampaign)
+      .withSignup(exampleCampaign.campaign.campaignId)
       .visit('/us/campaigns/test-example-campaign');
 
     cy.contains('Example Campaign');

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -29,6 +29,15 @@ Cypress.Commands.add('configureMocks', () => {
 });
 
 /**
+ * Get the Nth element with the given selector.
+ *
+ * @return {Cypress.Chainable}
+ */
+Cypress.Commands.add('nth', (selector, offset) => {
+  return cy.get(selector).eq(offset);
+});
+
+/**
  * Set authentication state for the given user.
  *
  * @param {String} userId

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -9,6 +9,7 @@ import qs from 'query-string';
 
 import schema from '../../schema.json';
 import mocks from '../fixtures/graphql';
+import { existingSignup, emptyResponse } from '../fixtures/signups';
 
 // Register Cypress plugins:
 import 'cypress-graphql-mock';
@@ -32,8 +33,11 @@ Cypress.Commands.add('configureMocks', () => {
  *
  * @param {String} userId
  */
-Cypress.Commands.add('login', user => {
+Cypress.Commands.add('login', function(user) {
   Cypress.log({ name: 'Login', message: 'Mocking authentication flow...' });
+
+  // Store user context for later...
+  this.user = user;
 
   cy.on('window:before:load', window => {
     const now = Math.floor(Date.now() / 1000);
@@ -82,4 +86,35 @@ Cypress.Commands.add('withState', state => {
     // eslint-disable-next-line no-param-reassign
     window.STATE = state;
   });
+});
+
+/**
+ * Mock an existing signup for the logged-in user & given campaign.
+ *
+ * @param {Object} state
+ */
+Cypress.Commands.add('withSignup', function(campaignId) {
+  if (!this.user) {
+    throw new Error("The 'withSignup' helper requires a logged-in user.");
+  }
+
+  // Mock the "existing" signup response for this campaign:
+  const SIGNUP_API = `/api/v2/campaigns/${campaignId}/signups`;
+  const response = existingSignup(campaignId, this.user);
+  cy.route(`${SIGNUP_API}?filter[northstar_id]=${this.user.id}`, response);
+});
+
+/**
+ * Mock a missing signup for the logged-in user & given campaign.
+ *
+ * @param {Object} state
+ */
+Cypress.Commands.add('withoutSignup', function(campaignId) {
+  if (!this.user) {
+    throw new Error("The 'withoutSignup' helper requires a logged-in user.");
+  }
+
+  // Mock an "empty" signup response for this campaign:
+  const SIGNUP_API = `/api/v2/campaigns/${campaignId}/signups`;
+  cy.route(`${SIGNUP_API}?filter[northstar_id]=${this.user.id}`, emptyResponse);
 });

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -8,7 +8,7 @@ import url from 'url';
 import qs from 'query-string';
 
 import schema from '../../schema.json';
-import mocks from '../fixtures/graphql';
+import { mocks, operations } from '../fixtures/graphql';
 import { existingSignup, emptyResponse } from '../fixtures/signups';
 
 // Register Cypress plugins:
@@ -25,7 +25,7 @@ Cypress.Commands.add('configureMocks', () => {
 
   // Configure in-memory GraphQL mock server, based on a snapshot of our
   // schema & some custom mock resolvers. <https://git.io/fjwO3>
-  cy.mockGraphql({ schema, mocks });
+  cy.mockGraphql({ schema, mocks, operations });
 });
 
 /**


### PR DESCRIPTION
### What does this PR do?

This pull request adds a browser test for visiting the campaign gallery & reacting to a post, and improved mocking abilities & cleanup for existing tests. 💞 

⛑ Adds `withSignup` and `withoutSignup` helpers since we mock initial signup state on nearly all of our test cases in the exact same way. Let's save some keystrokes! f507e09

🔩 Sets default results for common [operations](https://graphql.org/learn/queries/#operation-name), such as returning an empty submission gallery. This replaces a less explicit conditional which returned an empty `posts()` query response when a user ID was included as an argument, and makes it easier to override results within specific tests. 2ddaa79

🤡 Adds a custom [`MockList`](https://www.apollographql.com/docs/graphql-tools/mocking/#using-mocklist-in-resolvers) to work around [some gnarly `instanceof` behavior](https://git.io/fjrA2). 7b21721

💟And finally, adds a browser test to simulate reacting to a post in the gallery! 00be9e9

### Any background context you want to provide?

In the interest of keeping this manageable to review, I'm stopping here! I'd like to return to this test before the end of the sprint to add some coverage for pagination as well.

### What are the relevant tickets/cards?

References [#166290295](https://www.pivotaltracker.com/story/show/166290295).

### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.
* [ ] Added screenshot to PR description of related front-end updates on **small** screens.
* [ ] Added screenshot to PR description of related front-end updates on **medium** screens.
* [ ] Added screenshot to PR description of related front-end updates on **large** screens.
