### PR TITLE
Add test coverage for gallery pagination & text/photo submission galleries.

### DIFF
--- a/cypress/fixtures/graphql.js
+++ b/cypress/fixtures/graphql.js
@@ -51,6 +51,7 @@ export const mocks = {
     anonymous: false,
   }),
   Post: () => ({
+    status: 'ACCEPTED', // Most users will only see accepted posts!
     type: () => faker.random.arrayElement(['photo', 'text']),
     url: (post, { w = 400, h = 400 }) => faker.image.dataUri(w, h), // eslint-disable-line id-length
     text: () => faker.lorem.sentence(),

--- a/cypress/integration/campaign-gallery.js
+++ b/cypress/integration/campaign-gallery.js
@@ -44,4 +44,28 @@ describe('Campaign Gallery', () => {
       cy.get('.reaction__meta').contains('1');
     });
   });
+
+  it('Load additional pages', () => {
+    const user = userFactory();
+
+    // Start with a full page of posts...
+    cy.mockGraphqlOp('PostGalleryQuery', { posts: MockList(9) });
+
+    // Log in & visit the campaign action page:
+    cy.login(user)
+      .withState(exampleCampaign)
+      .withSignup(exampleCampaign.campaign.campaignId)
+      .visit('/us/campaigns/test-example-campaign');
+
+    cy.get('.post-gallery').within(() => {
+      cy.get('.post').should('have.length', 9);
+
+      // Click the "view more" link and get a partial set of results:
+      cy.mockGraphqlOp('PostGalleryQuery', { posts: MockList(4) });
+      cy.contains('view more').click();
+
+      // We should now have 13 total posts in the gallery.
+      cy.get('.post').should('have.length', 13);
+    });
+  });
 });

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -29,6 +29,20 @@ Cypress.Commands.add('configureMocks', () => {
 });
 
 /**
+ * Mock a single GraphQL operation by name.
+ *
+ * @param {String} operation
+ * @param {Object} response
+ */
+Cypress.Commands.add('mockGraphqlOp', (operation, response) => {
+  cy.mockGraphqlOps({
+    operations: {
+      [operation]: response,
+    },
+  });
+});
+
+/**
  * Get the Nth element with the given selector.
  *
  * @return {Cypress.Chainable}

--- a/resources/assets/components/utilities/PostGallery/PostGallery.js
+++ b/resources/assets/components/utilities/PostGallery/PostGallery.js
@@ -43,7 +43,7 @@ const PostGallery = props => {
   }
 
   return posts.length ? (
-    <div id={id} className={classnames(className)}>
+    <div id={id} className={classnames('post-gallery', className)}>
       {waypointName ? (
         <PuckWaypoint
           name={`${waypointName}-top`}
@@ -53,7 +53,7 @@ const PostGallery = props => {
 
       <Gallery
         type={get(galleryTypes, itemsPerRow)}
-        className="post-gallery expand-horizontal-md"
+        className="expand-horizontal-md"
       >
         {posts.map(post => (
           <PostCard key={post.id} post={post} hideReactions={hideReactions} />


### PR DESCRIPTION
### What does this PR do?

This pull request adds browser test coverage for gallery pagination & the text and photo action blocks' submission galleries. I've also added a `mockGraphqlOp` helper method to make it a little simpler to mock individual operations within tests.

### Any background context you want to provide?

It looks like the [suggested best practice](https://docs.cypress.io/guides/references/best-practices.html#Selecting-Elements) is to add `data-cy` attributes to select elements in tests (rather than IDs or class-names), which makes good sense to me... might do that in a follow-up PR.

### What are the relevant tickets/cards?

Refs [Pivotal ID #166290295](https://www.pivotaltracker.com/story/show/166290295).

### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.
* [ ] Added screenshot to PR description of related front-end updates on **small** screens.
* [ ] Added screenshot to PR description of related front-end updates on **medium** screens.
* [ ] Added screenshot to PR description of related front-end updates on **large** screens.
