### PR TITLE
Add a browser test for rendering 11 Facts.

### DIFF
--- a/cypress/fixtures/contentful.js
+++ b/cypress/fixtures/contentful.js
@@ -189,4 +189,25 @@ export const exampleCampaign = {
   },
 };
 
-export default null;
+export const exampleFactPage = {
+  page: {
+    id: '1Ek0Dt7Uur4aRfKW0vsby7',
+    type: 'page',
+    fields: {
+      internalTitle: '[Test] 11 Facts About Testing',
+      title: '11 Facts About Testing',
+      subTitle: null,
+      slug: 'facts/test-11-facts-about-testing',
+      metadata: null,
+      authors: [],
+      coverImage: { description: '', url: null },
+      content:
+        'Welcome to [DoSomething.org](https://www.dosomething.org), a global movement of millions of young people making positive change, online and off! The 11 facts you want are below, and the sources for the facts are at the very bottom of the page. After you learn something, Do Something! Find out how to [take action here](https://www.dosomething.org/us/campaigns).\n &nbsp; \n &#32;&#32; \n &nbsp; \n &#32;&#32; \n1. Cypress is an open-source JavaScript test runner. Cypress takes snapshots as your tests run. Simply hover over commands in the Command Log to see exactly what happened at each step.^[Cypress.io. "Open Source JavaScript Test Runner." Web Accessed June, 27 2019.]\n2. Cypress automatically retries assertions, so you don\'t have to explicitly set timeouts or wait for a selector to be visible. A single command followed by multiple assertions retries each one of them \u2013 in order.^[Cypress.io. "Core Concepts: Retry-ability." Web Accessed June 27, 2019.]\n3. If you have a very simple model layer, but your UI is complex, then you should focus your time on higher level browser tests.^[David Heinemeier Hansson. "Test-induced design damage." Web Accessed March 3, 2015.]\n4. Up to 90% of animals used in U.S. labs are not counted in the official statistics of animals tested. Take a stand by kidnapping your friends\u2019 products that were tested on animals (seriously!). Sign up for [Kidnapped Cosmetics](/us/campaigns/kidnapped-cosmetics?source=facts/11-facts-about-animal-testing).^[Humane Society International. "About Animal Testing." Web Accessed March 3, 2015.]\n5. Europe, the world\u2019s largest cosmetic market, Israel and India have already banned animal testing for cosmetics, and the sale or import of newly animal-tested beauty products.^[Humane Society International & The Humane Society of the United States. "Infographic: Ending Animal Testing For Cosmetics." Web Accessed March 2, 2015.]\n6. Even animals that are protected under the AWA can be abused and tortured. And the law doesn\u2019t require the use of valid alternatives to animals, even if they are available.^[Vanderau, Melanie L. "Science at any cost: The ineffectiveness and underenforcement of the Animal Welfare Act." Penn St. Envtl. L. Rev. 14 (2006): 721-721.]\n7. According to the Humane Society, registration of a single pesticide requires more than 50 experiments and the use of as many as 12,000 animals.^[Moxley, Angela. "The End of Animal Testing." The Humane Society of the United States, 2010. Web Accessed March 3, 2015.]\n8. In tests of potential carcinogens, subjects are given a substance every day for 2 years. Others tests involve killing pregnant animals and testing their fetuses.^[Moxley, Angela. "The End of Animal Testing." The Humane Society of the United States, 2010. Web Accessed March 3, 2015.]\n9. The real-life applications for some of the tested substances are as trivial as an \u201cimproved\u201d laundry detergent, new eye shadow, or copycat drugs to replace a profitable pharmaceutical whose patent expired.^[Moxley, Angela. "The End of Animal Testing." The Humane Society of the United States, 2010. Web Accessed March 3, 2015.]\n10. Alternative tests achieve one or more of the \u201c3 R\u2019s:\u201d replaces a procedure that uses animals with a procedure that doesn\u2019t, reduces the number of animals used in a procedure, refines a procedure to alleviate or minimize potential animal pain.^[Ibrahim, Darian M. "Reduce, refine, replace: The failure of the three R\'s and the future of animal experimentation." U. Chi. Legal F, 2006. Web Accessed March 20, 2015.]\n11. Several cosmetic tests commonly performed on mice, rats, rabbits, and guinea pigs include: skin and eye irritation tests where chemicals are rubbed on shaved skin or dripped into the eyes without any pain relief.^[Humane Society of the United States. "Fact Sheet: Animal Testing." Web accessed November 2, 2015.]',
+      sidebar: [],
+      blocks: [],
+      displaySocialShare: null,
+      hideFromNavigation: null,
+      socialOverride: null,
+    },
+  },
+};

--- a/cypress/integration/page.js
+++ b/cypress/integration/page.js
@@ -1,0 +1,26 @@
+/// <reference types="Cypress" />
+
+import { exampleFactPage } from '../fixtures/contentful';
+
+describe('Pages', () => {
+  // Configure a new "mock" server before each test:
+  beforeEach(() => cy.configureMocks());
+
+  it('Renders a simple 11 Facts page', () => {
+    cy.withState(exampleFactPage).visit(
+      '/us/facts/test-11-facts-about-testing',
+    );
+
+    // Ensure the page has successfully parsed Markdown & rendered:
+    cy.contains('h1', '11 Facts About Testing');
+    cy.contains(
+      'Cypress is an open-source JavaScript test runner. Cypress takes snapshots as your tests run.',
+    );
+
+    // The footnotes should have been processed and placed below the content:
+    cy.contains(
+      '.footnotes',
+      'Cypress.io. "Open Source JavaScript Test Runner." Web Accessed June, 27 2019.',
+    );
+  });
+});


### PR DESCRIPTION
### What does this PR do?

This pull request adds a simple browser test for the page content type, and specifically the ability to render Markdown & [the "footnote" syntax extension](https://github.com/markdown-it/markdown-it-footnote) that we use for 11 Facts.

### Any background context you want to provide?

In the future, we might consider using [a (visual) snapshot plugin](https://docs.cypress.io/guides/tooling/visual-testing.html) to ensure the whole page renders as expected, but this should cover most errors we could run into (by checking that each "type" of content is properly parsed and placed on the page).

### What are the relevant tickets/cards?

Refs [Pivotal ID #166290295](https://www.pivotaltracker.com/story/show/166290295).

### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.
* [ ] Added screenshot to PR description of related front-end updates on **small** screens.
* [ ] Added screenshot to PR description of related front-end updates on **medium** screens.
* [ ] Added screenshot to PR description of related front-end updates on **large** screens.
