### PR TITLE
Progress on splitting out a campaign and action gallery.

### DIFF
--- a/cypress/fixtures/graphql.js
+++ b/cypress/fixtures/graphql.js
@@ -23,7 +23,7 @@ export const operations = {
     posts: [],
   },
   // By default, return the requested number of posts:
-  PostGalleryQuery: {
+  ActionGalleryQuery: {
     posts: (root, { count }) => MockList(count),
   },
 };

--- a/cypress/integration/campaign-gallery.js
+++ b/cypress/integration/campaign-gallery.js
@@ -14,7 +14,7 @@ describe('Campaign Gallery', () => {
     cy.mockGraphqlOps({
       operations: {
         // Make sure we haven't yet reacted to anything:
-        PostGalleryQuery: {
+        ActionGalleryQuery: {
           posts: MockList(9, { reacted: false, reactions: 0 }),
         },
 
@@ -49,7 +49,7 @@ describe('Campaign Gallery', () => {
     const user = userFactory();
 
     // Start with a full page of posts...
-    cy.mockGraphqlOp('PostGalleryQuery', { posts: MockList(9) });
+    cy.mockGraphqlOp('ActionGalleryQuery', { posts: MockList(9) });
 
     // Log in & visit the campaign action page:
     cy.login(user)
@@ -61,7 +61,7 @@ describe('Campaign Gallery', () => {
       cy.get('.post').should('have.length', 9);
 
       // Click the "view more" link and get a partial set of results:
-      cy.mockGraphqlOp('PostGalleryQuery', { posts: MockList(4) });
+      cy.mockGraphqlOp('ActionGalleryQuery', { posts: MockList(4) });
       cy.contains('view more').click();
 
       // We should now have 13 total posts in the gallery.

--- a/package-lock.json
+++ b/package-lock.json
@@ -7043,8 +7043,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "optional": true
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
         },
         "aproba": {
           "version": "1.2.0",
@@ -7065,14 +7064,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-          "optional": true
+          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
         },
         "brace-expansion": {
           "version": "1.1.11",
           "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -7087,20 +7084,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-          "optional": true
+          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
         },
         "concat-map": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-          "optional": true
+          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
         },
         "console-control-strings": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-          "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-          "optional": true
+          "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -7217,8 +7211,7 @@
         "inherits": {
           "version": "2.0.3",
           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-          "optional": true
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
         },
         "ini": {
           "version": "1.3.5",
@@ -7230,7 +7223,6 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -7245,7 +7237,6 @@
           "version": "3.0.4",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -7253,14 +7244,12 @@
         "minimist": {
           "version": "0.0.8",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "optional": true
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
         },
         "minipass": {
           "version": "2.3.5",
           "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
           "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -7279,7 +7268,6 @@
           "version": "0.5.1",
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -7360,8 +7348,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-          "optional": true
+          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
         },
         "object-assign": {
           "version": "4.1.1",
@@ -7373,7 +7360,6 @@
           "version": "1.4.0",
           "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -7459,8 +7445,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-          "optional": true
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -7496,7 +7481,6 @@
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -7516,7 +7500,6 @@
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -7560,14 +7543,12 @@
         "wrappy": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-          "optional": true
+          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
         },
         "yallist": {
           "version": "3.0.3",
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
-          "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
-          "optional": true
+          "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A=="
         }
       }
     },

--- a/resources/assets/components/blocks/PostGalleryBlock/PostGalleryBlockQuery.js
+++ b/resources/assets/components/blocks/PostGalleryBlock/PostGalleryBlockQuery.js
@@ -27,7 +27,7 @@ export const PostGalleryBlockFragment = gql`
 `;
 
 /**
- * The GraphQL query to load data for this component.
+ * The GraphQL query to load data for this component by action ID(s).
  */
 const ACTION_GALLERY_QUERY = gql`
   query ActionGalleryQuery(
@@ -51,6 +51,9 @@ const ACTION_GALLERY_QUERY = gql`
   ${reactionButtonFragment}
 `;
 
+/**
+ * The GraphQL query to load data for this component by campaign ID.
+ */
 const CAMPAIGN_GALLERY_QUERY = gql`
   query CampaignGalleryQuery(
     $campaignId: String
@@ -175,8 +178,6 @@ class PostGalleryBlockQuery extends React.Component {
     const queryName = campaignId
       ? CAMPAIGN_GALLERY_QUERY
       : ACTION_GALLERY_QUERY;
-
-    console.log('📦', this.props);
 
     return (
       <React.Fragment>

--- a/resources/assets/components/blocks/PostGalleryBlock/PostGalleryBlockQuery.js
+++ b/resources/assets/components/blocks/PostGalleryBlock/PostGalleryBlockQuery.js
@@ -14,6 +14,9 @@ import SelectLocationDropdown from '../../utilities/SelectLocationDropdown/Selec
 
 import './post-gallery-block.scss';
 
+/**
+ * Shared query logic when querying PostGallery content type from Contentful.
+ */
 export const PostGalleryBlockFragment = gql`
   fragment PostGalleryBlockFragment on PostGalleryBlock {
     actionIds
@@ -26,7 +29,7 @@ export const PostGalleryBlockFragment = gql`
 /**
  * The GraphQL query to load data for this component.
  */
-const POST_GALLERY_QUERY = gql`
+const ACTION_GALLERY_QUERY = gql`
   query PostGalleryQuery(
     $actionIds: [Int]
     $location: String
@@ -35,6 +38,28 @@ const POST_GALLERY_QUERY = gql`
   ) {
     posts(
       actionIds: $actionIds
+      location: $location
+      count: $count
+      page: $page
+    ) {
+      ...PostCard
+      ...ReactionButton
+    }
+  }
+
+  ${postCardFragment}
+  ${reactionButtonFragment}
+`;
+
+const CAMPAIGN_GALLERY_QUERY = gql`
+  query PostGalleryQuery(
+    $campaignId: [Int]
+    $location: String
+    $count: Int
+    $page: Int
+  ) {
+    posts(
+      campaignId: $campaignId
       location: $location
       count: $count
       page: $page
@@ -145,7 +170,7 @@ class PostGalleryBlockQuery extends React.Component {
         ) : null}
 
         <PaginatedQuery
-          query={POST_GALLERY_QUERY}
+          query={ACTION_GALLERY_QUERY}
           queryName="posts"
           variables={withoutNulls({
             actionIds,

--- a/resources/assets/components/pages/LandingPage/templates/PitchTemplate.js
+++ b/resources/assets/components/pages/LandingPage/templates/PitchTemplate.js
@@ -59,5 +59,3 @@ PitchTemplate.defaultProps = {
 };
 
 export default PitchTemplate;
-
-// actionIds={[3]}

--- a/resources/assets/components/pages/LandingPage/templates/PitchTemplate.js
+++ b/resources/assets/components/pages/LandingPage/templates/PitchTemplate.js
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 import Card from '../../../utilities/Card/Card';
 import { getScholarshipAffiliateLabel } from '../../../../helpers';
 import TextContent from '../../../utilities/TextContent/TextContent';
+import PostGalleryBlockQuery from '../../../blocks/PostGalleryBlock/PostGalleryBlockQuery';
 import AffiliateScholarshipBlockQuery from '../../../blocks/AffiliateScholarshipBlock/AffiliateScholarshipBlockQuery';
 
 const PitchTemplate = ({
@@ -27,7 +28,16 @@ const PitchTemplate = ({
             className="margin-bottom-lg"
           />
         ) : null}
+
         <TextContent>{content}</TextContent>
+
+        <PostGalleryBlockQuery
+          className="margin-top-xlg"
+          id="1234567890"
+          actionIds={[3]}
+          hideReactions
+          itemsPerRow={3}
+        />
       </div>
       <div className="secondary">
         <Card title={sidebarCTA.title} className="rounded bordered">

--- a/resources/assets/components/pages/LandingPage/templates/PitchTemplate.js
+++ b/resources/assets/components/pages/LandingPage/templates/PitchTemplate.js
@@ -4,7 +4,6 @@ import PropTypes from 'prop-types';
 import Card from '../../../utilities/Card/Card';
 import { getScholarshipAffiliateLabel } from '../../../../helpers';
 import TextContent from '../../../utilities/TextContent/TextContent';
-import PostGalleryBlockQuery from '../../../blocks/PostGalleryBlock/PostGalleryBlockQuery';
 import AffiliateScholarshipBlockQuery from '../../../blocks/AffiliateScholarshipBlock/AffiliateScholarshipBlockQuery';
 
 const PitchTemplate = ({
@@ -30,14 +29,6 @@ const PitchTemplate = ({
         ) : null}
 
         <TextContent>{content}</TextContent>
-
-        <PostGalleryBlockQuery
-          className="margin-top-xlg"
-          id="1234567890"
-          actionIds={[3]}
-          hideReactions
-          itemsPerRow={3}
-        />
       </div>
       <div className="secondary">
         <Card title={sidebarCTA.title} className="rounded bordered">
@@ -68,3 +59,5 @@ PitchTemplate.defaultProps = {
 };
 
 export default PitchTemplate;
+
+// actionIds={[3]}

--- a/resources/assets/components/utilities/PostCard/PostCard.js
+++ b/resources/assets/components/utilities/PostCard/PostCard.js
@@ -40,7 +40,7 @@ export const postCardFragment = gql`
   }
 `;
 
-const PostCard = ({ post, hideReactions }) => {
+const PostCard = ({ post, hideCaption, hideQuantity, hideReactions }) => {
   const isAnonymous = post.actionDetails.anonymous;
 
   // If this post is for an anonymous action, label it with the state (if available).
@@ -90,15 +90,20 @@ const PostCard = ({ post, hideReactions }) => {
             {isStaff() ? <ReviewLink url={post.permalink} /> : null}
             <PostBadge status={post.status} tags={post.tags} />
           </h4>
-          {post.quantity ? (
+
+          {post.quantity && !hideQuantity ? (
             <p className="footnote">
               {post.quantity} {post.actionDetails.noun}
             </p>
           ) : null}
+
           {isAnonymous ? (
             <p className="footnote">{format(post.createdAt, 'PPP')}</p>
           ) : null}
-          {post.type !== 'text' && post.text ? <p>{post.text}</p> : null}
+
+          {post.type !== 'text' && post.text && !hideCaption ? (
+            <p>{post.text}</p>
+          ) : null}
         </BaseFigure>
       </div>
     </Card>
@@ -106,11 +111,15 @@ const PostCard = ({ post, hideReactions }) => {
 };
 
 PostCard.propTypes = {
+  hideCaption: PropTypes.bool,
+  hideQuantity: PropTypes.bool,
   hideReactions: PropTypes.bool,
   post: propType(postCardFragment).isRequired,
 };
 
 PostCard.defaultProps = {
+  hideCaption: false,
+  hideQuantity: false,
   hideReactions: false,
 };
 

--- a/resources/assets/components/utilities/PostGallery/PostGallery.js
+++ b/resources/assets/components/utilities/PostGallery/PostGallery.js
@@ -27,6 +27,8 @@ const PostGallery = props => {
   const {
     id,
     className,
+    hideCaption,
+    hideQuantity,
     hideReactions,
     itemsPerRow,
     loading,
@@ -56,16 +58,25 @@ const PostGallery = props => {
         className="expand-horizontal-md"
       >
         {posts.map(post => (
-          <PostCard key={post.id} post={post} hideReactions={hideReactions} />
+          <PostCard
+            key={post.id}
+            post={post}
+            hideCaption={hideCaption}
+            hideQuantity={hideQuantity}
+            hideReactions={hideReactions}
+          />
         ))}
       </Gallery>
-      <LoadMore
-        buttonClassName="-tertiary"
-        className="padding-lg text-center"
-        text="view more"
-        onClick={loadMorePosts}
-        isLoading={loading}
-      />
+
+      {loadMorePosts ? (
+        <LoadMore
+          buttonClassName="-tertiary"
+          className="padding-lg text-center"
+          text="view more"
+          onClick={loadMorePosts}
+          isLoading={loading}
+        />
+      ) : null}
 
       {waypointName ? (
         <PuckWaypoint
@@ -80,12 +91,14 @@ const PostGallery = props => {
 };
 
 PostGallery.propTypes = {
-  id: PropTypes.string,
   className: PropTypes.string,
+  hideCaption: PropTypes.bool,
+  hideQuantity: PropTypes.bool,
   hideReactions: PropTypes.bool,
+  id: PropTypes.string,
   itemsPerRow: PropTypes.oneOf(Object.keys(galleryTypes).map(Number)),
   loading: PropTypes.bool.isRequired,
-  loadMorePosts: PropTypes.func.isRequired,
+  loadMorePosts: PropTypes.func,
   onRender: PropTypes.func,
   posts: PropTypes.arrayOf(PropTypes.object),
   shouldShowNoResults: PropTypes.bool,
@@ -93,10 +106,13 @@ PostGallery.propTypes = {
 };
 
 PostGallery.defaultProps = {
-  id: null,
   className: null,
+  hideCaption: false,
+  hideQuantity: false,
   hideReactions: false,
+  id: null,
   itemsPerRow: 3,
+  loadMorePosts: null,
   onRender: null,
   posts: [],
   shouldShowNoResults: false,

--- a/resources/assets/helpers/index.js
+++ b/resources/assets/helpers/index.js
@@ -5,6 +5,8 @@ import { getTime, isBefore, isWithinInterval } from 'date-fns';
 import {
   get,
   find,
+  isArray,
+  isEmpty,
   isNil,
   isNull,
   isObjectLike,
@@ -75,13 +77,27 @@ export function isExternal(url) {
 }
 
 /**
- * Return a boolean indicating whether the provided argument is a string.
+ * Return a boolean indicating whether the provided argument is an empty string.
  *
  * @param  {Mixed}  string
  * @return {Boolean}
  */
 export function isEmptyString(string) {
   return string === '';
+}
+
+/**
+ * Return a boolean indicating whether the provided argument is an empty array.
+ *
+ * @param  {Mixed}  data
+ * @return {Boolean}
+ */
+export function isEmptyArray(data) {
+  if (!isArray(data)) {
+    return false;
+  }
+
+  return isEmpty(data);
 }
 
 /**
@@ -363,9 +379,7 @@ export function makeShareLink(
 ) {
   switch (resource) {
     case 'campaigns':
-      return `${options.domain}/us/campaigns/${options.slug}/${options.type}/${
-        options.key
-      }`;
+      return `${options.domain}/us/campaigns/${options.slug}/${options.type}/${options.key}`;
 
     default:
       throw new Error(
@@ -854,7 +868,7 @@ export function withoutUndefined(data) {
  * @return {Object}
  */
 export function withoutValueless(data) {
-  return omitBy(omitBy(data, isNil), isEmptyString);
+  return omitBy(omitBy(omitBy(data, isNil), isEmptyArray), isEmptyString);
 }
 
 /**


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR splits the `POST_GALLERY_QUERY` into an `ACTION_GALLERY_QUERY` and a `CAMPAIGN_GALLERY_QUERY` depending on whether an action ID(s) or a campaign ID is provided. Along with this update it allows filtering the query for posts by specified tags completed in https://github.com/DoSomething/graphql/pull/114.

Additionally, it also allows passing in more props that can help dictate how the post gallery will render on a page (ie: hiding caption, hiding quantity).

This update is for an upcoming A/B test for campaign landing pages to show a small gallery of user submitted photos.

### Any background context you want to provide?

- [Small Screenshot](https://user-images.githubusercontent.com/105849/60546450-52170a00-9ceb-11e9-97f2-c4bbc009e885.png)
- [Medium Screenshot](https://user-images.githubusercontent.com/105849/60546455-53e0cd80-9ceb-11e9-8591-5d3d73e74a4b.png)
- [Large Screenshot](https://user-images.githubusercontent.com/105849/60546464-580ceb00-9ceb-11e9-9738-dee1eaca2467.png)


### What are the relevant tickets/cards?

Refs [Pivotal ID #165970311](https://www.pivotaltracker.com/story/show/165970311)

### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.
* [x] Added screenshot to PR description of related front-end updates on **small** screens.
* [x] Added screenshot to PR description of related front-end updates on **medium** screens.
* [x] Added screenshot to PR description of related front-end updates on **large** screens.
