### PR TITLE
Signup badge in Affirmation modal

### DIFF
--- a/resources/assets/components/Affirmation/Affirmation.js
+++ b/resources/assets/components/Affirmation/Affirmation.js
@@ -55,6 +55,7 @@ const Affirmation = ({
                 <Badge
                   earned
                   boldText
+                  className="badge padded"
                   size="medium"
                   name="signupBadge"
                   text="1 Sign-Up"

--- a/resources/assets/components/Affirmation/Affirmation.js
+++ b/resources/assets/components/Affirmation/Affirmation.js
@@ -45,30 +45,23 @@ const Affirmation = ({
         {quote}
       </TextContent>
     ) : null}
+
     <Query query={BADGE_QUERY} variables={{ userId }}>
       {badgeData =>
         badgeData.user.hasBadgesFlag ? (
           <Query query={SIGNUP_COUNT_BADGE} variables={{ userId }}>
             {signupData =>
               signupData.signupsCount === 1 ? (
-                <Flex className="flex-center-xy">
-                  <FlexCell className="padded" width="one-third">
-                    <Badge
-                      earned
-                      boldText
-                      name="signupBadge"
-                      text="1 Sign-Up"
-                    />
-                  </FlexCell>
-
-                  <FlexCell className="padded" width="full">
-                    <TextContent className="padding-top-md padding-horizontal-md">
-                      Congratulations! You signed up for your first
-                      campaign...and earned your first badge. NICE. Ready to
-                      earn *another* badge? Complete this campaign!
-                    </TextContent>
-                  </FlexCell>
-                </Flex>
+                <Badge
+                  earned
+                  boldText
+                  size="medium"
+                  name="signupBadge"
+                  text="1 Sign-Up"
+                  explainerText="Congratulations! You signed up for your first campaign...and
+                    earned your first badge. NICE. Ready to earn *another*
+                    badge? Complete this campaign!"
+                />
               ) : null
             }
           </Query>

--- a/resources/assets/components/Affirmation/Affirmation.js
+++ b/resources/assets/components/Affirmation/Affirmation.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import gql from 'graphql-tag';
 
 import { Flex, FlexCell } from '../Flex';
 import Card from '../utilities/Card/Card';
@@ -7,8 +8,24 @@ import Share from '../utilities/Share/Share';
 import Byline from '../utilities/Byline/Byline';
 import TextContent from '../utilities/TextContent/TextContent';
 import { contentfulImageUrl, withoutNulls } from '../../helpers';
+import Badge from '../pages/AccountPage/Badge';
+import Query from '../Query';
 
 import './affirmation.scss';
+
+const SIGNUP_COUNT_BADGE = gql`
+  query SignupsCountQuery($userId: String!) {
+    signupsCount(userId: $userId, limit: 2)
+  }
+`;
+
+const BADGE_QUERY = gql`
+  query AccountQuery($userId: String!) {
+    user(id: $userId) {
+      hasBadgesFlag: hasFeatureFlag(feature: "badges")
+    }
+  }
+`;
 
 // @TODO: Refactor/redesign.
 // We seem to have removed the content "photo" from being used in the actual output.
@@ -20,6 +37,7 @@ const Affirmation = ({
   callToActionHeader,
   header,
   quote,
+  userId,
 }) => (
   <Card className="affirmation rounded" title={header}>
     {quote ? (
@@ -27,6 +45,36 @@ const Affirmation = ({
         {quote}
       </TextContent>
     ) : null}
+    <Query query={BADGE_QUERY} variables={{ userId }}>
+      {badgeData =>
+        badgeData.user.hasBadgesFlag ? (
+          <Query query={SIGNUP_COUNT_BADGE} variables={{ userId }}>
+            {signupData =>
+              signupData.signupsCount === 1 ? (
+                <Flex className="flex-center-xy">
+                  <FlexCell className="padded" width="one-third">
+                    <Badge
+                      earned
+                      boldText
+                      name="signupBadge"
+                      text="1 Sign-Up"
+                    />
+                  </FlexCell>
+
+                  <FlexCell className="padded" width="full">
+                    <TextContent className="padding-top-md padding-horizontal-md">
+                      Congratulations! You signed up for your first
+                      campaign...and earned your first badge. NICE. Ready to
+                      earn *another* badge? Complete this campaign!
+                    </TextContent>
+                  </FlexCell>
+                </Flex>
+              ) : null
+            }
+          </Query>
+        ) : null
+      }
+    </Query>
 
     <Flex className="flex-align-center">
       <FlexCell className="affirmation__cta padded" width="half">
@@ -55,6 +103,7 @@ Affirmation.propTypes = {
   callToActionHeader: PropTypes.string,
   header: PropTypes.string,
   quote: PropTypes.string,
+  userId: PropTypes.string.isRequired,
 };
 
 Affirmation.defaultProps = {

--- a/resources/assets/components/Affirmation/AffirmationContainer.js
+++ b/resources/assets/components/Affirmation/AffirmationContainer.js
@@ -1,0 +1,10 @@
+import { connect } from 'react-redux';
+
+import Affirmation from './Affirmation';
+import { getUserId } from '../../selectors/user';
+
+const mapStateToProps = state => ({
+  userId: getUserId(state),
+});
+
+export default connect(mapStateToProps)(Affirmation);

--- a/resources/assets/components/ContentfulEntry/ContentfulEntry.js
+++ b/resources/assets/components/ContentfulEntry/ContentfulEntry.js
@@ -5,7 +5,7 @@ import * as React from 'react';
 import NotFound from '../NotFound';
 import Iframe from '../utilities/Iframe';
 import Loader from '../utilities/Loader';
-import Affirmation from '../Affirmation';
+import AffirmationContainer from '../Affirmation/AffirmationContainer';
 import StaticBlock from '../StaticBlock';
 import ErrorBlock from '../ErrorBlock/ErrorBlock';
 import { ContentfulEntryJson } from '../../types';
@@ -65,7 +65,7 @@ class ContentfulEntry extends React.Component<Props, State> {
 
     switch (type) {
       case 'affirmation':
-        return <Affirmation {...withoutNulls(json.fields)} />;
+        return <AffirmationContainer {...withoutNulls(json.fields)} />;
 
       case 'callToAction':
         return (

--- a/resources/assets/components/Figure/figure.scss
+++ b/resources/assets/components/Figure/figure.scss
@@ -84,3 +84,19 @@
     }
   }
 }
+
+// @TODO: temporary for badges, will need clean-up later - added on 07/09/19
+.figure.badge {
+  @include media($small) {
+    > .figure__media {
+      width: 150px;
+    }
+  }
+
+  @include media($medium) {
+    > .figure__body {
+      margin: 0 auto;
+      max-width: 80%;
+    }
+  }
+}

--- a/resources/assets/components/pages/AccountPage/Badge.js
+++ b/resources/assets/components/pages/AccountPage/Badge.js
@@ -5,13 +5,14 @@ import { Figure } from '../../Figure';
 import badgeImages from './BadgeImages';
 
 const Badge = props => {
-  const { name, text, earned, boldText } = props;
+  const { name, text, earned, boldText, explainerText, size } = props;
   const badgeImageIndex = earned ? name : `${name}Locked`;
 
   return (
     <div>
-      <Figure image={badgeImages[badgeImageIndex]} alt={text}>
-        {boldText ? <strong>{text}</strong> : text}
+      <Figure image={badgeImages[badgeImageIndex]} alt={text} size={size}>
+        <p>{boldText ? <strong>{text}</strong> : text}</p>
+        <p>{explainerText}</p>
       </Figure>
     </div>
   );
@@ -22,10 +23,14 @@ Badge.propTypes = {
   name: PropTypes.string.isRequired,
   text: PropTypes.string.isRequired,
   boldText: PropTypes.bool,
+  explainerText: PropTypes.string,
+  size: PropTypes.string,
 };
 
 Badge.defaultProps = {
   boldText: false,
+  explainerText: null,
+  size: null,
 };
 
 export default Badge;

--- a/resources/assets/components/pages/AccountPage/Badge.js
+++ b/resources/assets/components/pages/AccountPage/Badge.js
@@ -5,13 +5,13 @@ import { Figure } from '../../Figure';
 import badgeImages from './BadgeImages';
 
 const Badge = props => {
-  const { name, text, earned } = props;
+  const { name, text, earned, boldText } = props;
   const badgeImageIndex = earned ? name : `${name}Locked`;
 
   return (
     <div>
       <Figure image={badgeImages[badgeImageIndex]} alt={text}>
-        {text}
+        {boldText ? <strong>{text}</strong> : text}
       </Figure>
     </div>
   );
@@ -21,6 +21,11 @@ Badge.propTypes = {
   earned: PropTypes.bool.isRequired,
   name: PropTypes.string.isRequired,
   text: PropTypes.string.isRequired,
+  boldText: PropTypes.bool,
+};
+
+Badge.defaultProps = {
+  boldText: false,
 };
 
 export default Badge;

--- a/resources/assets/components/pages/AccountPage/Badge.js
+++ b/resources/assets/components/pages/AccountPage/Badge.js
@@ -5,16 +5,27 @@ import { Figure } from '../../Figure';
 import badgeImages from './BadgeImages';
 
 const Badge = props => {
-  const { name, text, earned, boldText, explainerText, size } = props;
+  const {
+    name,
+    text,
+    earned,
+    boldText,
+    explainerText,
+    size,
+    className,
+  } = props;
   const badgeImageIndex = earned ? name : `${name}Locked`;
 
   return (
-    <div>
-      <Figure image={badgeImages[badgeImageIndex]} alt={text} size={size}>
-        <p>{boldText ? <strong>{text}</strong> : text}</p>
-        <p>{explainerText}</p>
-      </Figure>
-    </div>
+    <Figure
+      image={badgeImages[badgeImageIndex]}
+      alt={text}
+      size={size}
+      className={className}
+    >
+      <p>{boldText ? <strong>{text}</strong> : text}</p>
+      <p>{explainerText}</p>
+    </Figure>
   );
 };
 
@@ -25,12 +36,14 @@ Badge.propTypes = {
   boldText: PropTypes.bool,
   explainerText: PropTypes.string,
   size: PropTypes.string,
+  className: PropTypes.string,
 };
 
 Badge.defaultProps = {
   boldText: false,
   explainerText: null,
   size: null,
+  className: null,
 };
 
 export default Badge;


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR adds the welcome badge to the affirmation modal after signup. The badge will only appear to users who:
- are opted in to the badge experience
- have exactly one signup

Props have been added to the Badge component to allow for differences of styling and additional information without changing the appearance of the badges on the user profile.

Small Screen
![image](https://user-images.githubusercontent.com/4240292/60916947-9c950b00-a244-11e9-98c5-bf7f7068eb6c.png)

Medium Screen
![image](https://user-images.githubusercontent.com/4240292/60916966-aa4a9080-a244-11e9-9f41-02f3d0ed5f08.png)

Large Screen
![image](https://user-images.githubusercontent.com/4240292/60916982-b59dbc00-a244-11e9-8be6-4eef8d0a3383.png)


### Any background context you want to provide?

I think it's mostly in the card! Prototypes/wireframes are linked from there.

### What are the relevant tickets/cards?

Refs [Pivotal ID #165719621](https://www.pivotaltracker.com/story/show/165719621)

### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.
* [x] Added screenshot to PR description of related front-end updates on **small** screens.
* [x] Added screenshot to PR description of related front-end updates on **medium** screens.
* [x] Added screenshot to PR description of related front-end updates on **large** screens.
