### PR TITLE
Enabling Sixpack landing page gallery experiments.

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -53,7 +53,7 @@ MAIL_ENCRYPTION=null
 
 SIXPACK_ENABLED=true
 SIXPACK_BASE_URL=https://experiments-qa.dosomething.org/api
-SIXPACK_COOKIE_PREFIX=null
+SIXPACK_COOKIE_PREFIX=phoenix_local_sixpack
 SIXPACK_TIMEOUT=null
 
 PUSHER_APP_ID=

--- a/resources/assets/components/pages/LandingPage/LandingPage.js
+++ b/resources/assets/components/pages/LandingPage/LandingPage.js
@@ -13,10 +13,10 @@ import './landing-page.scss';
 
 const LandingPage = props => {
   const {
+    additionalContent,
     campaignId,
     campaignTitle,
     content,
-    contentfulId,
     scholarshipAmount,
     scholarshipDeadline,
     showPartnerMsgOptIn,
@@ -38,10 +38,10 @@ const LandingPage = props => {
       <div className="clearfix bg-white">
         <Enclosure className="default-container margin-lg pitch-landing-page">
           <PitchTemplate
+            additionalContent={additionalContent}
             campaignId={campaignId}
             campaignTitle={campaignTitle}
             content={content}
-            contentfulId={contentfulId}
             sidebarCTA={sidebarCTA}
             scholarshipAmount={scholarshipAmount}
             scholarshipDeadline={scholarshipDeadline}
@@ -69,10 +69,10 @@ const LandingPage = props => {
 };
 
 LandingPage.propTypes = {
+  additionalContent: PropTypes.object,
   campaignId: PropTypes.string.isRequired,
   campaignTitle: PropTypes.string.isRequired,
   content: PropTypes.string.isRequired,
-  contentfulId: PropTypes.string.isRequired,
   scholarshipAmount: PropTypes.number,
   scholarshipDeadline: PropTypes.string,
   showPartnerMsgOptIn: PropTypes.bool,
@@ -82,6 +82,7 @@ LandingPage.propTypes = {
 };
 
 LandingPage.defaultProps = {
+  additionalContent: null,
   scholarshipAmount: null,
   scholarshipDeadline: null,
   showPartnerMsgOptIn: false,

--- a/resources/assets/components/pages/LandingPage/LandingPage.js
+++ b/resources/assets/components/pages/LandingPage/LandingPage.js
@@ -69,7 +69,10 @@ const LandingPage = props => {
 };
 
 LandingPage.propTypes = {
+  campaignId: PropTypes.string.isRequired,
+  campaignTitle: PropTypes.string.isRequired,
   content: PropTypes.string.isRequired,
+  contentfulId: PropTypes.string.isRequired,
   scholarshipAmount: PropTypes.number,
   scholarshipDeadline: PropTypes.string,
   showPartnerMsgOptIn: PropTypes.bool,

--- a/resources/assets/components/pages/LandingPage/LandingPage.js
+++ b/resources/assets/components/pages/LandingPage/LandingPage.js
@@ -13,7 +13,10 @@ import './landing-page.scss';
 
 const LandingPage = props => {
   const {
+    campaignId,
+    campaignTitle,
     content,
+    contentfulId,
     scholarshipAmount,
     scholarshipDeadline,
     showPartnerMsgOptIn,
@@ -35,7 +38,10 @@ const LandingPage = props => {
       <div className="clearfix bg-white">
         <Enclosure className="default-container margin-lg pitch-landing-page">
           <PitchTemplate
+            campaignId={campaignId}
+            campaignTitle={campaignTitle}
             content={content}
+            contentfulId={contentfulId}
             sidebarCTA={sidebarCTA}
             scholarshipAmount={scholarshipAmount}
             scholarshipDeadline={scholarshipDeadline}

--- a/resources/assets/components/pages/LandingPage/LandingPageContainer.js
+++ b/resources/assets/components/pages/LandingPage/LandingPageContainer.js
@@ -31,6 +31,7 @@ const mapStateToProps = (state, ownProps) => {
       null,
     ),
     tagline: get(state.campaign.additionalContent, 'tagline'),
+    additionalContent: landingPage.additionalContent,
   };
 };
 

--- a/resources/assets/components/pages/LandingPage/LandingPageContainer.js
+++ b/resources/assets/components/pages/LandingPage/LandingPageContainer.js
@@ -13,7 +13,9 @@ const mapStateToProps = (state, ownProps) => {
   const landingPage = get(ownProps, 'landingPage.fields', ownProps);
 
   return {
-    campaignId: state.campaign.id,
+    campaignId: state.campaign.campaignId,
+    campaignTitle: state.campaign.title,
+    contentfulId: state.campaign.id,
     content: landingPage.content,
     scholarshipAmount: state.campaign.scholarshipAmount,
     scholarshipDeadline: state.campaign.scholarshipDeadline,

--- a/resources/assets/components/pages/LandingPage/templates/PitchTemplate.js
+++ b/resources/assets/components/pages/LandingPage/templates/PitchTemplate.js
@@ -4,10 +4,15 @@ import PropTypes from 'prop-types';
 import Card from '../../../utilities/Card/Card';
 import { getScholarshipAffiliateLabel } from '../../../../helpers';
 import TextContent from '../../../utilities/TextContent/TextContent';
+import SixpackExperiment from '../../../utilities/SixpackExperiment/SixpackExperiment';
+import PostGalleryBlockQuery from '../../../blocks/PostGalleryBlock/PostGalleryBlockQuery';
 import AffiliateScholarshipBlockQuery from '../../../blocks/AffiliateScholarshipBlock/AffiliateScholarshipBlockQuery';
 
 const PitchTemplate = ({
+  campaignId,
+  campaignTitle,
   content,
+  contentfulId,
   scholarshipAmount,
   scholarshipDeadline,
   sidebarCTA,
@@ -15,6 +20,14 @@ const PitchTemplate = ({
   const scholarshipAffiliateLabel = getScholarshipAffiliateLabel();
   const displayAffiliateScholarshipBlock =
     scholarshipAffiliateLabel && scholarshipAmount && scholarshipDeadline;
+
+  const testableCampaigns = [
+    '6LQzMvDNQcYQYwso8qSkQ8', // Dev
+    '6tgfJeVQIQXw8xfsgyNkHI', // QA
+    '6tgfJeVQIQXw8xfsgyNkHI', // Prod
+    '6ATBgGEQEeJoIcxs1qbwaC', // Prod
+    '5Jp8I6l0e9GVZzuHSgZ9Qp', // Prod
+  ];
 
   return (
     <div className="campaign-page">
@@ -29,6 +42,30 @@ const PitchTemplate = ({
         ) : null}
 
         <TextContent>{content}</TextContent>
+
+        {/* @SIXPACK Code Test: 2019-07-03 */}
+        {testableCampaigns.includes(contentfulId) ? (
+          <SixpackExperiment
+            title={`Landing Page Gallery ${campaignTitle}`}
+            convertableActions={['signup']}
+            alternatives={[
+              <div>
+                <h3 className="margin-top-xlg">Photos from our members</h3>
+                <PostGalleryBlockQuery
+                  campaignId={campaignId}
+                  className="margin-top-md"
+                  count={6}
+                  hideCaption
+                  hideQuantity
+                  hideReactions
+                  paginated={false}
+                  type="photo"
+                />
+              </div>,
+            ]}
+          />
+        ) : null}
+        {/* @SIXPACK Code Test: 2019-07-03 */}
       </div>
       <div className="secondary">
         <Card title={sidebarCTA.title} className="rounded bordered">

--- a/resources/assets/components/pages/LandingPage/templates/PitchTemplate.js
+++ b/resources/assets/components/pages/LandingPage/templates/PitchTemplate.js
@@ -77,7 +77,10 @@ const PitchTemplate = ({
 };
 
 PitchTemplate.propTypes = {
+  campaignId: PropTypes.string.isRequired,
+  campaignTitle: PropTypes.string.isRequired,
   content: PropTypes.string.isRequired,
+  contentfulId: PropTypes.string.isRequired,
   scholarshipAmount: PropTypes.number,
   scholarshipDeadline: PropTypes.string,
   sidebarCTA: PropTypes.shape({

--- a/resources/assets/components/pages/LandingPage/templates/PitchTemplate.js
+++ b/resources/assets/components/pages/LandingPage/templates/PitchTemplate.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { get } from 'lodash';
 import PropTypes from 'prop-types';
 
 import Card from '../../../utilities/Card/Card';
@@ -9,10 +10,10 @@ import PostGalleryBlockQuery from '../../../blocks/PostGalleryBlock/PostGalleryB
 import AffiliateScholarshipBlockQuery from '../../../blocks/AffiliateScholarshipBlock/AffiliateScholarshipBlockQuery';
 
 const PitchTemplate = ({
+  additionalContent,
   campaignId,
   campaignTitle,
   content,
-  contentfulId,
   scholarshipAmount,
   scholarshipDeadline,
   sidebarCTA,
@@ -20,14 +21,6 @@ const PitchTemplate = ({
   const scholarshipAffiliateLabel = getScholarshipAffiliateLabel();
   const displayAffiliateScholarshipBlock =
     scholarshipAffiliateLabel && scholarshipAmount && scholarshipDeadline;
-
-  const testableCampaigns = [
-    '6LQzMvDNQcYQYwso8qSkQ8', // Dev
-    '6tgfJeVQIQXw8xfsgyNkHI', // QA
-    '6tgfJeVQIQXw8xfsgyNkHI', // Prod
-    '6ATBgGEQEeJoIcxs1qbwaC', // Prod
-    '5Jp8I6l0e9GVZzuHSgZ9Qp', // Prod
-  ];
 
   return (
     <div className="campaign-page">
@@ -44,7 +37,7 @@ const PitchTemplate = ({
         <TextContent>{content}</TextContent>
 
         {/* @SIXPACK Code Test: 2019-07-03 */}
-        {testableCampaigns.includes(contentfulId) ? (
+        {get(additionalContent, 'sixpackLandingPageGallery', false) ? (
           <SixpackExperiment
             title={`Landing Page Gallery ${campaignTitle}`}
             convertableActions={['signup']}
@@ -77,10 +70,10 @@ const PitchTemplate = ({
 };
 
 PitchTemplate.propTypes = {
+  additionalContent: PropTypes.object,
   campaignId: PropTypes.string.isRequired,
   campaignTitle: PropTypes.string.isRequired,
   content: PropTypes.string.isRequired,
-  contentfulId: PropTypes.string.isRequired,
   scholarshipAmount: PropTypes.number,
   scholarshipDeadline: PropTypes.string,
   sidebarCTA: PropTypes.shape({
@@ -90,6 +83,7 @@ PitchTemplate.propTypes = {
 };
 
 PitchTemplate.defaultProps = {
+  additionalContent: null,
   scholarshipAmount: null,
   scholarshipDeadline: null,
   sidebarCTA: {


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR enables select campaigns to run a Sixpack A/B experiment on their respective landing pages. I've also included a Dev and QA campaign to help with testing after merging this PR.

You can enable this test on a Campaign's landing page, by adding the following JSON to the `additionalContent` field on the `LandingPage` attached to a campaign:

```json
{
	"sixpackLandingPageGallery": true
}
```

### What are the relevant tickets/cards?

Refs [Pivotal ID #165970311](https://www.pivotaltracker.com/story/show/165970311)

### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.