### PR TITLE
Update grid column naming and classes where used.

### DIFF
--- a/resources/assets/components/utilities/ContentfulEntryLoader/ContentfulEntryLoader.js
+++ b/resources/assets/components/utilities/ContentfulEntryLoader/ContentfulEntryLoader.js
@@ -53,25 +53,25 @@ const ContentfulEntryLoader = ({ id, className }) => (
     {({ loading, error, data }) => {
       if (loading) {
         return (
-          <div className="grid-main spinner -centered margin-vertical-xlg" />
+          <div className="grid-narrow spinner -centered margin-vertical-xlg" />
         );
       }
 
       if (error || !data.block) {
         return (
-          <div className={classnames(className, 'grid-main')}>
+          <div className={classnames(className, 'grid-narrow')}>
             <ErrorBlock />
           </div>
         );
       }
 
       const entryGridMapping = {
-        EmbedBlock: 'grid-wide', // @TODO: may need to reassess, since maybe not all embeds should align to wide?
-        PostGalleryBlock: 'grid-wide',
+        EmbedBlock: 'grid-main', // @TODO: may need to reassess, since maybe not all embeds should align to main?
+        PostGalleryBlock: 'grid-main',
       };
 
       const blockType = data.block.__typename;
-      const gridClass = get(entryGridMapping, blockType, 'grid-main');
+      const gridClass = get(entryGridMapping, blockType, 'grid-narrow');
 
       return (
         <div className={classnames(className, gridClass)}>

--- a/resources/assets/helpers/text.js
+++ b/resources/assets/helpers/text.js
@@ -75,53 +75,53 @@ export function parseRichTextDocument(document, styles) {
   const options = {
     renderNode: {
       [BLOCKS.HEADING_1]: (node, children) => (
-        <h1 className="grid-main" style={{ color: textColor }}>
+        <h1 className="grid-narrow" style={{ color: textColor }}>
           <span>{children}</span>
         </h1>
       ),
       [BLOCKS.HEADING_2]: (node, children) => (
-        <h2 className="grid-main" style={{ color: textColor }}>
+        <h2 className="grid-narrow" style={{ color: textColor }}>
           {children}
         </h2>
       ),
       [BLOCKS.HEADING_3]: (node, children) => (
-        <h3 className="grid-main" style={{ color: textColor }}>
+        <h3 className="grid-narrow" style={{ color: textColor }}>
           {children}
         </h3>
       ),
       [BLOCKS.HEADING_4]: (node, children) => (
-        <h4 className="grid-main" style={{ color: textColor }}>
+        <h4 className="grid-narrow" style={{ color: textColor }}>
           {children}
         </h4>
       ),
       [BLOCKS.HEADING_5]: (node, children) => (
-        <h5 className="grid-main" style={{ color: textColor }}>
+        <h5 className="grid-narrow" style={{ color: textColor }}>
           {children}
         </h5>
       ),
       [BLOCKS.HEADING_6]: (node, children) => (
-        <h6 className="grid-main" style={{ color: textColor }}>
+        <h6 className="grid-narrow" style={{ color: textColor }}>
           {children}
         </h6>
       ),
       [BLOCKS.PARAGRAPH]: (node, children) =>
         children[0] ? (
-          <p className="grid-main" style={{ color: textColor }}>
+          <p className="grid-narrow" style={{ color: textColor }}>
             {children}
           </p>
         ) : null,
       [BLOCKS.UL_LIST]: (node, children) => (
-        <ul className="grid-main text-left list" style={{ color: textColor }}>
+        <ul className="grid-narrow text-left list" style={{ color: textColor }}>
           {children}
         </ul>
       ),
       [BLOCKS.OL_LIST]: (node, children) => (
-        <ol className="grid-main text-left list" style={{ color: textColor }}>
+        <ol className="grid-narrow text-left list" style={{ color: textColor }}>
           {children}
         </ol>
       ),
       [BLOCKS.QUOTE]: (node, children) => (
-        <blockquote className="grid-main list" style={{ color: textColor }}>
+        <blockquote className="grid-narrow list" style={{ color: textColor }}>
           {children}
         </blockquote>
       ),
@@ -132,7 +132,7 @@ export function parseRichTextDocument(document, styles) {
         />
       ),
       [BLOCKS.EMBEDDED_ASSET]: node => (
-        <p className="grid-main component-entry text-center">
+        <p className="grid-narrow component-entry text-center">
           <ContentfulAsset id={node.data.target.sys.id} />
         </p>
       ),

--- a/resources/assets/scss/base.scss
+++ b/resources/assets/scss/base.scss
@@ -676,25 +676,37 @@ p {
 .base-16-grid {
   display: grid;
   // 4 columns
-  grid-template-columns: [full-start] 1fr 1fr 1fr 1fr [full-end];
+  grid-template-columns: [full-start] 1fr 1fr [midway] 1fr 1fr [full-end];
   grid-column-gap: $half-spacing;
   padding: $half-spacing;
 
   @include media($medium) {
     // 8 columns
-    grid-template-columns: [full-start] 1fr [main-start] 1fr 1fr 1fr 1fr 1fr 1fr [main-end] 1fr [full-end];
+    grid-template-columns: [full-start] 1fr [main-start] 1fr 1fr 1fr [midway] 1fr 1fr 1fr [main-end] 1fr [full-end];
     grid-column-gap: $base-spacing;
     padding: $base-spacing;
   }
 
   @include media($large) {
     // 16 columns
-    grid-template-columns: [full-start] 1fr 1fr [wide-start] 1fr 1fr [main-start] 1fr [narrow-start] 1fr 1fr 1fr 1fr 1fr 1fr [narrow-end] 1fr [main-end] 1fr 1fr [wide-end] 1fr 1fr [full-end];
+    grid-template-columns: [full-start] 1fr [wide-start] 1fr [main-start] 1fr 1fr [narrow-start] 1fr [compact-start] 1fr 1fr 1fr [midway] 1fr 1fr 1fr [compact-end] 1fr [narrow-end] 1fr 1fr [main-end] 1fr [wide-end] 1fr [full-end];
   }
 }
 
 .grid-full {
   grid-column: full-start / full-end;
+}
+
+.grid-compact {
+  grid-column: full-start / full-end;
+
+  @include media($medium) {
+    grid-column: main-start / main-end;
+  }
+
+  @include media($large) {
+    grid-column: compact-start / compact-end;
+  }
 }
 
 .grid-main {


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR updates the "named lines" for our grid template columns to better match how we think they'll be used in the future. What was previously labeled as `main` and used on the Story Page is technically a bit narrower than our actual "main" area of content. So this PR revises to the following line naming if referencing the named columns from left to right:

```
full-start > wide-start > main-start > narrow-start > compact-start > midway > compact-end > narrow-end > main-end > wide-end > full-end
```

### Any background context you want to provide?

This update relates to current work happening for the new Marquee Landing Page template, and I wanted to break it out into a separate PR to keep changes in stages :)

### What are the relevant tickets/cards?

Refs [Pivotal ID #165970217](https://www.pivotaltracker.com/story/show/165970217)

### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.