### PR TITLE
Switch our grid from base 16 to base 12.

### DIFF
--- a/resources/assets/components/blocks/SectionBlock/SectionBlock.js
+++ b/resources/assets/components/blocks/SectionBlock/SectionBlock.js
@@ -34,7 +34,7 @@ const SectionBlock = props => {
       />
 
       <TextContent
-        className="section-block__content base-16-grid"
+        className="section-block__content base-12-grid"
         styles={styles}
       >
         {content}

--- a/resources/assets/components/pages/StoryPage/StoryPage.js
+++ b/resources/assets/components/pages/StoryPage/StoryPage.js
@@ -26,7 +26,7 @@ const StoryPage = props => {
       <article className="story-page">
         <header
           role="banner"
-          className="lede-banner base-16-grid"
+          className="lede-banner base-12-grid"
           style={withoutNulls(styles)}
         >
           <div className="wrapper text-center">

--- a/resources/assets/scss/base.scss
+++ b/resources/assets/scss/base.scss
@@ -746,6 +746,6 @@ p {
   }
 
   @include media($large) {
-    grid-column: auto / span 8;
+    grid-column: auto / span 6;
   }
 }

--- a/resources/assets/scss/base.scss
+++ b/resources/assets/scss/base.scss
@@ -673,8 +673,9 @@ p {
 | Large - 16 columns
 */
 
-.base-16-grid {
+.base-12-grid {
   display: grid;
+
   // 4 columns
   grid-template-columns: [full-start] 1fr 1fr [midway] 1fr 1fr [full-end];
   grid-column-gap: $half-spacing;
@@ -684,12 +685,12 @@ p {
     // 8 columns
     grid-template-columns: [full-start] 1fr [main-start] 1fr 1fr 1fr [midway] 1fr 1fr 1fr [main-end] 1fr [full-end];
     grid-column-gap: $base-spacing;
-    padding: $base-spacing;
+    padding: $base-spacing $section-spacing;
   }
 
   @include media($large) {
-    // 16 columns
-    grid-template-columns: [full-start] 1fr [wide-start] 1fr [main-start] 1fr 1fr [narrow-start] 1fr [compact-start] 1fr 1fr 1fr [midway] 1fr 1fr 1fr [compact-end] 1fr [narrow-end] 1fr 1fr [main-end] 1fr [wide-end] 1fr [full-end];
+    // 12 columns
+    grid-template-columns: [full-start] 1fr [wide-start] 1fr [main-start] 1fr [narrow-start] 1fr 1fr 1fr [midway] 1fr 1fr 1fr [narrow-end] 1fr [main-end] 1fr [wide-end] 1fr [full-end];
   }
 }
 

--- a/resources/views/partials/admin-dashboard.blade.php
+++ b/resources/views/partials/admin-dashboard.blade.php
@@ -1,5 +1,5 @@
 <div id="admin-dashboard" class="admin-dashboard">
-    <div class="wrapper base-16-grid">
+    <div class="wrapper base-12-grid">
         <h1 class="admin-dashboard-title grid-full font-normal uppercase text-base text-gray-400 margin-bottom-lg"><span>Admin Dashboard</span></h1>
 
         <section class="panel grid-1/2 margin-bottom-lg">

--- a/resources/views/partials/flash-message.blade.php
+++ b/resources/views/partials/flash-message.blade.php
@@ -1,5 +1,5 @@
 <div id="flash-message" class="flash-message {{session('flash_message')['class'] ?? ''}} is-visible">
-    <div class="wrapper base-16-grid">
+    <div class="wrapper base-12-grid">
         <p class="flash-content">
             <em>{{ session('flash_message')['text'] }}</em>
         </p>


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

Based on upcoming new designs we are switching our base CSS Grid on large sizes from a base 16 grid to a base 12 grid. Based on mocks and recommendations from @lkpttn a base 12 grid will be more useful especially with a base 12 being easily divisible by 2, 3, or 4 items.

We're also accounting for more padding on the left and right edges for the grid containing element so that the `full` definition of the grid can be used more readily.

### Any background context you want to provide?

🎨 

### What are the relevant tickets/cards?

Refs [Pivotal ID #165970217](https://www.pivotaltracker.com/story/show/165970217)

### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.