### PR TITLE
Switches firing order of setUserId() and trackAnalyticsPageView()

### DIFF
--- a/resources/assets/init.js
+++ b/resources/assets/init.js
@@ -62,6 +62,11 @@ ready(() => {
   // Add event listeners for top-level navigation.
   bindNavigationEvents();
 
+  // If available, set User ID for Snowplow analytics.
+  if (typeof window.snowplow === 'function' && window.AUTH.id) {
+    window.snowplow('setUserId', window.AUTH.id);
+  }
+
   // Add page view event listeners for History interface changes.
   trackAnalyticsPageView(history);
 
@@ -70,11 +75,6 @@ ready(() => {
 
   // Display environment badge on local, dev, or QA:
   renderEnvironmentBadge();
-
-  // If available, set User ID for Snowplow analytics.
-  if (typeof window.snowplow === 'function' && window.AUTH.id) {
-    window.snowplow('setUserId', window.AUTH.id);
-  }
 
   // Add event listeners for the Admin Dashboard.
   if (window.AUTH.isAuthenticated && window.AUTH.role !== 'user') {


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This change flips the firing order of these two events to match the [order in Northstar](https://github.com/DoSomething/northstar/blob/712626d4fb66bda01251b95890d02832e118e26b/resources/assets/js/utilities/Analytics.js#L267-#L282).

### Any background context you want to provide?

It seems as though the firing order in this file doesn't matter for many of the events in the middle lines of this file. Still, I moved the user ID event up, rather than moving the page view event down, on the off-chance there are downstream events from the page view that rely on it.

### What are the relevant tickets/cards?

Refs [Pivotal ID #167071912](https://www.pivotaltracker.com/n/projects/2076969/stories/167071912)

### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.
* [ ] Added screenshot to PR description of related front-end updates on **small** screens.
* [ ] Added screenshot to PR description of related front-end updates on **medium** screens.
* [ ] Added screenshot to PR description of related front-end updates on **large** screens.
