### PR TITLE
Only show date on Post Cards for anonymous posts

### DIFF
--- a/resources/assets/components/utilities/PostCard/PostCard.js
+++ b/resources/assets/components/utilities/PostCard/PostCard.js
@@ -100,12 +100,13 @@ const PostCard = ({ post, hideCaption, hideQuantity, hideReactions }) => {
             </p>
           ) : null}
 
-          <p className="footnote">{format(post.createdAt, 'PPP')}</p>
+          {isAnonymous ? (
+            <p className="footnote">{format(post.createdAt, 'PPP')}</p>
+          ) : null}
 
           {post.type !== 'text' && post.text && !hideCaption ? (
             <p>{post.text}</p>
           ) : null}
-
         </BaseFigure>
       </div>
     </Card>


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR reverts a change from https://github.com/DoSomething/phoenix-next/pull/1485/commits/564091ba8e78712e0de6adac82f18660bc14cb43 to again only show the date on Post Cards for 'anonymous' posts.

### Any background context you want to provide?
See [this Slack convo](https://dosomething.slack.com/archives/C3ASB4204/p1562867895026900) for context. We'd like to rethink how we display these fields in a separate ticket