### PR TITLE
Page Breaks Under Certain Conditions

### DIFF
--- a/resources/assets/components/Campaign/CampaignRoute/CampaignRoute.js
+++ b/resources/assets/components/Campaign/CampaignRoute/CampaignRoute.js
@@ -5,6 +5,7 @@ import PropTypes from 'prop-types';
 import ReactRouterPropTypes from 'react-router-prop-types';
 import { Switch, Route, Redirect } from 'react-router-dom';
 
+import NotFound from '../../NotFound';
 import InfoBar from '../../InfoBar/InfoBar';
 import Modal from '../../utilities/Modal/Modal';
 import { isCampaignClosed } from '../../../helpers';
@@ -80,6 +81,10 @@ const CampaignRoute = props => {
                     }}
                   />
                 );
+              }
+
+              if (!props.landingPage) {
+                return <NotFound />;
               }
 
               // @TODO: temporary function to select component to use based on type.


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR display a NotFound page in the case a user tries to unsign on a page that has not landing page. Right now, If a user tries to sign out of an open campaign that has no landing page, the website is still going to assume there is a default landing page and try to display something based on the 'type' of this non-existent component.

### Any background context you want to provide?

<img width="721" alt="Screen Shot 2019-07-12 at 10 19 45 AM" src="https://user-images.githubusercontent.com/11726211/61134901-97c39780-a48e-11e9-9e74-7199fa4a78b9.png">


<img width="494" alt="Screen Shot 2019-07-12 at 9 56 45 AM" src="https://user-images.githubusercontent.com/11726211/61133467-7e6d1c00-a48b-11e9-83c3-61fcc8150ed1.png">


### What are the relevant tickets/cards?

(I was working on this ticket when it happened)
Refs [Pivotal ID #163772916](https://www.pivotaltracker.com/n/projects/2019313/stories/163772916)

### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.
* [ ] Added screenshot to PR description of related front-end updates on **small** screens.
* [ ] Added screenshot to PR description of related front-end updates on **medium** screens.
* [ ] Added screenshot to PR description of related front-end updates on **large** screens.
