### PR TITLE
Allow <Query> to hide spinner

### DIFF
--- a/resources/assets/components/Affirmation/Affirmation.js
+++ b/resources/assets/components/Affirmation/Affirmation.js
@@ -46,10 +46,10 @@ const Affirmation = ({
       </TextContent>
     ) : null}
 
-    <Query query={BADGE_QUERY} variables={{ userId }}>
+    <Query query={BADGE_QUERY} variables={{ userId }} hideSpinner>
       {badgeData =>
         badgeData.user.hasBadgesFlag ? (
-          <Query query={SIGNUP_COUNT_BADGE} variables={{ userId }}>
+          <Query query={SIGNUP_COUNT_BADGE} variables={{ userId }} hideSpinner>
             {signupData =>
               signupData.signupsCount === 1 ? (
                 <Badge

--- a/resources/assets/components/Query.js
+++ b/resources/assets/components/Query.js
@@ -8,12 +8,12 @@ import { NetworkStatus } from '../constants';
 /**
  * Fetch results via GraphQL using a query component.
  */
-const Query = ({ query, variables, children }) => (
+const Query = ({ query, variables, children, hideSpinner }) => (
   <ApolloQuery query={query} variables={variables} notifyOnNetworkStatusChange>
     {result => {
       // On initial load, just display a loading spinner.
       if (result.networkStatus === NetworkStatus.LOADING) {
-        return <div className="spinner -centered" />;
+        return hideSpinner ? null : <div className="spinner -centered" />;
       }
 
       if (result.error) {
@@ -29,10 +29,12 @@ Query.propTypes = {
   query: PropTypes.object.isRequired,
   children: PropTypes.func.isRequired,
   variables: PropTypes.object,
+  hideSpinner: PropTypes.bool,
 };
 
 Query.defaultProps = {
   variables: {},
+  hideSpinner: false,
 };
 
 export default Query;


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR adds a prop to `<Query>` to allow hiding the loading spinner. In some cases, this may not be relevant as the query may be helping us decide whether to display anything at all!

![affirmation](https://user-images.githubusercontent.com/4240292/61152544-964d9b80-a49d-11e9-9e8c-854e5d66ee21.gif)


### Any background context you want to provide?

[Here](https://dosomething.slack.com/archives/C3ASB4204/p1562942726004200), in Slack!

### What are the relevant tickets/cards?

Refs [Pivotal ID #165719621](https://www.pivotaltracker.com/story/show/165719621)

### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.
* [ ] Added screenshot to PR description of related front-end updates on **small** screens.
* [ ] Added screenshot to PR description of related front-end updates on **medium** screens.
* [ ] Added screenshot to PR description of related front-end updates on **large** screens.
