### PR TITLE
Enabling Marquee template experiment.

### DIFF
--- a/resources/assets/components/pages/LandingPage/LandingPage.js
+++ b/resources/assets/components/pages/LandingPage/LandingPage.js
@@ -6,6 +6,7 @@ import PropTypes from 'prop-types';
 
 import PitchTemplate from './templates/PitchTemplate';
 import MarqueeTemplate from './templates/MarqueeTemplate';
+import SixpackExperiment from '../../utilities/SixpackExperiment/SixpackExperiment';
 
 import './landing-page.scss';
 
@@ -32,16 +33,39 @@ const LandingPage = props => {
 
   return (
     <React.Fragment>
+      {/* @SIXPACK Code Test: 2019-07-17 */}
       {get(additionalContent, 'sixpackLandingPageMarqueeTemplate', false) ? (
-        <MarqueeTemplate
-          additionalContent={additionalContent}
-          affiliateSponsors={affiliateSponsors}
-          content={content}
-          coverImage={coverImage}
-          endDate={endDate}
-          scholarshipAmount={scholarshipAmount}
-          subtitle={subtitle}
-          title={title}
+        <SixpackExperiment
+          title={`Marquee Template ${title}`}
+          convertableActions={['signup']}
+          control={
+            <PitchTemplate
+              additionalContent={additionalContent}
+              campaignId={campaignId}
+              content={content}
+              scholarshipAmount={scholarshipAmount}
+              scholarshipDeadline={scholarshipDeadline}
+              showPartnerMsgOptIn={showPartnerMsgOptIn}
+              sidebarCTA={sidebarCTA}
+              signupArrowContent={signupArrowContent}
+              tagline={tagline}
+              testName="Pitch Template"
+              title={title}
+            />
+          }
+          alternatives={[
+            <MarqueeTemplate
+              additionalContent={additionalContent}
+              affiliateSponsors={affiliateSponsors}
+              content={content}
+              coverImage={coverImage}
+              endDate={endDate}
+              scholarshipAmount={scholarshipAmount}
+              subtitle={subtitle}
+              testName="Marquee Template"
+              title={title}
+            />,
+          ]}
         />
       ) : (
         <PitchTemplate
@@ -57,6 +81,7 @@ const LandingPage = props => {
           title={title}
         />
       )}
+      {/* @SIXPACK Code Test: 2019-07-17 */}
     </React.Fragment>
   );
 };


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR adds the code-based Sixpack Experiment for the Marquee Template on landing pages. To activate this test for a campaign, you need to add the following JSON on the `additionalContent` field in the `LandingPage` content type referenced on a campaign in Contentful:

```json
{
	"campaignActionType": "collect something",
	"campaignTimeCommitment": "5-10 hours",
	"sixpackLandingPageMarqueeTemplate": true
}
```
With respective info for action type and time commitment related to the campaign it's being added to.

### Any background context you want to provide?

...

### What are the relevant tickets/cards?

Refs [Pivotal ID #165970217](https://www.pivotaltracker.com/story/show/165970217)

### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.