### PR TITLE
Quick fixes to finalize the Marquee Template experiment.

### DIFF
--- a/resources/assets/components/pages/LandingPage/landing-page.scss
+++ b/resources/assets/components/pages/LandingPage/landing-page.scss
@@ -31,10 +31,23 @@
     font-size: $text-2xl;
     font-family: $font-league-gothic;
     font-weight: $weight-normal;
+
+    @include media($medium) {
+      font-size: $text-4xl;
+    }
   }
 
   .primary {
     margin-bottom: $base-spacing;
+
+    h1,
+    h2,
+    h3,
+    h4,
+    h5,
+    h6 {
+      display: none;
+    }
   }
 
   .secondary {

--- a/resources/assets/components/pages/LandingPage/templates/MarqueeTemplate.js
+++ b/resources/assets/components/pages/LandingPage/templates/MarqueeTemplate.js
@@ -90,7 +90,7 @@ const MarqueeTemplate = ({
                         Win A Scholarship
                       </dt>
                       <dd className="campaign-info__scholarship">
-                        {scholarshipAmount}
+                        {`$${scholarshipAmount}`}
                       </dd>
                     </React.Fragment>
                   ) : null}
@@ -100,7 +100,13 @@ const MarqueeTemplate = ({
               {affiliateSponsors.length ? (
                 <AffiliatePromotion
                   className="margin-top-md"
-                  imgUrl={affiliateSponsors[0].fields.logo.url}
+                  imgUrl={
+                    get(
+                      additionalContent,
+                      'campaignSponsorLogoAlternativeUrl',
+                      null,
+                    ) || affiliateSponsors[0].fields.logo.url
+                  }
                   textClassName="text-gray-400"
                   title={affiliateSponsors[0].fields.logo.title}
                 />

--- a/resources/assets/scss/next-toolbox.scss
+++ b/resources/assets/scss/next-toolbox.scss
@@ -80,3 +80,4 @@ $purple-500: #141493;
 // Tailwind Font Sizes
 // @TODO: add the rest!
 $text-2xl: 47px;
+$text-4xl: 60px;


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR makes a few tweaks and updates to finalize the Marquee Template and get it ready for the experiment:

- Remove any heading tags from the content on the page.
- Add `$` before the scholarship amount.
- Increase the subtitle size to 60px on medium+ sizes as per mock. Missed this before 🤦‍♂ 
- Allow overriding the sponsor logo, since it's usually used on a black background in lede banner, most logos are uploaded as white, but now on this template they rest on a white background; this update allows passing a new url (making sure to add `?h=100`) for a logo on Contentful that works better on a white background.

Example override of the sponsor logo via additional content JSON:
```json
{
  "campaignSponsorLogoAlternativeUrl": "https://images.ctfassets.net/81iqaqpfd8fy/6mgOTUK7fOaCqMIaSKwai/4a90610abe1b1d98f0eeef4c941db774/thestreet-vector-logo.png?h=100",
}
```

### Any background context you want to provide?

🌵 

### What are the relevant tickets/cards?

Refs [Pivotal ID #165970217](https://www.pivotaltracker.com/story/show/165970217)

### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.