### PR TITLE
Run (another :) Sixpack Experiment for Source Overridden Signup Button Copy

### DIFF
--- a/resources/assets/components/SignupButton/SignupButton.js
+++ b/resources/assets/components/SignupButton/SignupButton.js
@@ -51,6 +51,12 @@ const SignupButton = props => {
     });
   };
 
+  const signupButton = copy => (
+    <Button className={className} onClick={handleSignup}>
+      {copy}
+    </Button>
+  );
+
   // Have signups been disabled for this campaign?
   if (disableSignup) {
     return null;
@@ -60,11 +66,7 @@ const SignupButton = props => {
   const sourceOverride = get(sourceActionText, trafficSource);
   const buttonCopy = text || sourceOverride || campaignActionText;
 
-  return (
-    <Button className={className} onClick={handleSignup}>
-      {buttonCopy}
-    </Button>
-  );
+  return signupButton(buttonCopy);
 };
 
 SignupButton.propTypes = {

--- a/resources/assets/components/SignupButton/SignupButton.js
+++ b/resources/assets/components/SignupButton/SignupButton.js
@@ -2,8 +2,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { get } from 'lodash';
 
-import { query, withoutNulls } from '../../helpers';
 import Button from '../utilities/Button/Button';
+import { query, withoutNulls } from '../../helpers';
 
 const SignupButton = props => {
   const {

--- a/resources/assets/components/SignupButton/SignupButton.js
+++ b/resources/assets/components/SignupButton/SignupButton.js
@@ -4,6 +4,7 @@ import { get } from 'lodash';
 
 import Button from '../utilities/Button/Button';
 import { query, withoutNulls } from '../../helpers';
+import SixpackExperiment from '../utilities/SixpackExperiment/SixpackExperiment';
 
 const SignupButton = props => {
   const {
@@ -62,11 +63,27 @@ const SignupButton = props => {
     return null;
   }
 
-  // If a user has a traffic source w/ an override, try it!
-  const sourceOverride = get(sourceActionText, trafficSource);
-  const buttonCopy = text || sourceOverride || campaignActionText;
+  // In descending priority: button-specific text prop,
+  // campaign action text override, or standard "Take Action" copy.
+  const buttonCopy = text || campaignActionText;
 
-  return signupButton(buttonCopy);
+  // Button copy override based on the user's traffic source.
+  const sourceOverride = get(sourceActionText, trafficSource);
+
+  return sourceOverride ? (
+    /* @SIXPACK Code Test: 2019-07-18 */
+    <SixpackExperiment
+      title={`Source Action Text Override ${campaignTitle}`}
+      convertableActions={['signup']}
+      control={signupButton(sourceOverride)}
+      alternatives={[
+        // Don't show the sourceOverride for the alternative.
+        signupButton(buttonCopy),
+      ]}
+    />
+  ) : (
+    signupButton(buttonCopy)
+  );
 };
 
 SignupButton.propTypes = {

--- a/resources/assets/components/SignupButton/SignupButton.js
+++ b/resources/assets/components/SignupButton/SignupButton.js
@@ -15,6 +15,7 @@ const SignupButton = props => {
     className,
     disableSignup,
     pageId,
+    sixpackSourceActionText,
     sourceActionText,
     storeCampaignSignup,
     text,
@@ -70,7 +71,7 @@ const SignupButton = props => {
   // Button copy override based on the user's traffic source.
   const sourceOverride = get(sourceActionText, trafficSource);
 
-  return sourceOverride ? (
+  return sixpackSourceActionText && sourceOverride ? (
     /* @SIXPACK Code Test: 2019-07-18 */
     <SixpackExperiment
       title={`Source Action Text Override ${campaignTitle}`}
@@ -94,6 +95,7 @@ SignupButton.propTypes = {
   className: PropTypes.string,
   disableSignup: PropTypes.bool,
   pageId: PropTypes.string.isRequired,
+  sixpackSourceActionText: PropTypes.bool,
   sourceActionText: PropTypes.objectOf(PropTypes.string),
   storeCampaignSignup: PropTypes.func.isRequired,
   text: PropTypes.string,
@@ -105,6 +107,7 @@ SignupButton.defaultProps = {
   campaignTitle: null,
   className: null,
   disableSignup: false,
+  sixpackSourceActionText: false,
   sourceActionText: null,
   text: null,
   trafficSource: null,

--- a/resources/assets/components/SignupButton/SignupButtonContainer.js
+++ b/resources/assets/components/SignupButton/SignupButtonContainer.js
@@ -14,6 +14,11 @@ const mapStateToProps = state => ({
   campaignTitle: state.campaign.title,
   pageId: state.campaign.id || state.page.id,
   disableSignup: get(state.campaign, 'additionalContent.disableSignup', false),
+  sixpackSourceActionText: get(
+    state.campaign,
+    'additionalContent.sixpackSourceActionText',
+    false,
+  ),
   sourceActionText: get(state.campaign, 'additionalContent.sourceActionText'),
   trafficSource: state.user.source,
 });


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR moves the existing Signup Button feature allowing custom button copy overrides based on user's traffic source into a Sixpack Experiment so we can test the conversion metrics around this feature.

Also updated some of the comments for -hopefully- clarity.

### Any background context you want to provide?
We have this test before (see Pivotal ID#](https://www.pivotaltracker.com/n/projects/2019313/stories/155625023)). 

This will effectively deprecate this existing feature (albeit not completely since it'll just split it into an AB test). I've confirmed that we do not have any live campaigns utilizing this feature currently so we should be 👍

Our goal with this ticket was to run this on the Shred Hate campaign specifically, but I've opted to allow the test generally for any campaign using the `additionalContent.sourceActionText` (similiarly to what we've recently done with #1487 and #1509), ~instead of adding a separate 'run the source copy experiment' feature flag attribute.~ (I misunderstood -- and we _did_ add an explicit 'feature flag' field to control running the experiment in https://github.com/DoSomething/phoenix-next/pull/1512/commits/861797b15712dcaf40fd47aec16e822359c74b88)

### What are the relevant tickets/cards?

Refs [Pivotal ID #165972814](https://www.pivotaltracker.com/story/show/165972814)

![image](https://user-images.githubusercontent.com/12417657/61547135-caced380-aa18-11e9-8fc3-98923ecff4ce.png)



![image](https://user-images.githubusercontent.com/12417657/61493542-d1f6d280-a981-11e9-9918-423b47ccb512.png)
