### PR TITLE
Pass referrer_user_id query parameter to signup/user source_details

### DIFF
--- a/resources/assets/components/SignupButton/SignupButton.js
+++ b/resources/assets/components/SignupButton/SignupButton.js
@@ -35,6 +35,7 @@ const SignupButton = props => {
         source_details: JSON.stringify(
           withoutNulls({
             contentful_id: pageId,
+            referrer_user_id: query('referrer_user_id'),
             utm_source: query('utm_source'),
             utm_medium: query('utm_medium'),
             utm_campaign: query('utm_campaign'),

--- a/resources/assets/selectors/index.js
+++ b/resources/assets/selectors/index.js
@@ -13,6 +13,7 @@ export function getDataForNorthstar(state) {
 
     // For 'source_details':
     contentful_id: state.campaign.id || state.page.id,
+    referrer_user_id: query('referrer_user_id'),
     utm_source: query('utm_source'),
     utm_medium: query('utm_medium'),
     utm_campaign: query('utm_campaign'),


### PR DESCRIPTION
### What does this PR do?

This PR adds a `referrer_user_id` property to the `source_details` of a campaign signup, if the campaign URL contains a `referrer_user_id` query parameter. It also passes along the `referrer_user_id` query parameter to Northstar for user creation.

e.g. Signing up at http://phoenix.test/us/campaigns/shes-first?referrer_user_id=poppins adds the `referrer_user_id` to the Signup `source_details`: 

<img width="400" alt="Screen Shot 2019-07-18 at 5 03 25 PM" src="https://user-images.githubusercontent.com/1236811/61499981-fcdf2780-a97d-11e9-8253-7a4ef19dde77.png">

### Any background context you want to provide?

There will be a corresponding Northstar PR that checks for a `referrer_user_id` query parameter, and saves it to the user's `source_detail`.

The personalized Referral Page that referrers will use to refer their friends to DS campaigns will contain links with these `referrer_user_id` query parameters. When their friends visit the Referral Page and click on the link with this new query parameter, the referrer's user ID will be saved to the source details of their signup (and user, if registered)

### What are the relevant tickets/cards?

* [Technical Spec (still in draft)](https://docs.google.com/document/d/1hzw8eBNLTwFFG2KQFdEHdljJbDpgW1awjG3wYjy_A_Q/edit?disco=AAAADRHqDyw&ts=5d2e5495&usp_dm=false)
* https://www.pivotaltracker.com/n/projects/2019429/stories/166457198/comments/204714050

