### PR TITLE
Add Petition Submission Action to valid linked references for Page Blocks

### DIFF
--- a/contentful/content-types/page.js
+++ b/contentful/content-types/page.js
@@ -175,6 +175,7 @@ module.exports = function(migration) {
             'galleryBlock',
             'imagesBlock',
             'linkAction',
+            'petitionSubmissionAction',
             'photoSubmissionAction',
             'postGallery',
             'quiz',


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR adds the `petitionSubmissionAction` content type to the list of valid linked entries for the Page->blocks Contentful field

### Any background context you want to provide?
We're aiming to utilize this action for an upcoming campaign! It's all set to work with Campaigns and tested on Dev/QA.

### What are the relevant tickets/cards?
Luke

