### PR TITLE
Fixed signup button on small screen devices for Marquee template.

### DIFF
--- a/resources/assets/components/pages/LandingPage/landing-page.scss
+++ b/resources/assets/components/pages/LandingPage/landing-page.scss
@@ -63,10 +63,35 @@
 }
 
 .marquee-signup-button {
-  display: block;
-  margin: 0 auto $half-spacing;
-  max-width: 450px;
-  padding: $base-spacing;
+  background-color: $white;
+  border-top: 1px solid $gray-200;
+  bottom: 0;
+  left: 0;
+  padding: $half-spacing;
+  position: fixed;
+  width: 100%;
+  z-index: 10;
+
+  @include media($medium) {
+    background-color: none;
+    bottom: auto;
+    left: auto;
+    padding: 0;
+    position: static;
+    width: auto;
+    z-index: auto;
+  }
+
+  .button {
+    display: block;
+    margin: 0 auto;
+    max-width: 450px;
+    padding: $base-spacing;
+
+    @include media($medium) {
+      margin: 0 auto $half-spacing;
+    }
+  }
 }
 
 // @TODO: this could become its own component (KeyValueInformationCard or some better name)

--- a/resources/assets/components/pages/LandingPage/templates/MarqueeTemplate.js
+++ b/resources/assets/components/pages/LandingPage/templates/MarqueeTemplate.js
@@ -57,7 +57,9 @@ const MarqueeTemplate = ({
             </div>
 
             <div className="grid-wide-3/10 secondary">
-              <SignupButtonContainer className="w-full marquee-signup-button" />
+              <div className="marquee-signup-button">
+                <SignupButtonContainer className="w-full" />
+              </div>
 
               <Card className="bordered padded rounded campaign-info">
                 <h1 className="mb-4 text-m uppercase">Campaign Info</h1>

--- a/resources/assets/scss/base.scss
+++ b/resources/assets/scss/base.scss
@@ -51,10 +51,8 @@ p {
 // @TODO: Added for the Marquee template experiment, so the full footer
 // can be viewed when fixed signup button reaches the bottom of the page.
 .footer {
-  padding-bottom: 105px;
-
-  @include media($medium) {
-    padding-bottom: 0;
+  @include media($small) {
+    padding-bottom: 105px;
   }
 }
 

--- a/resources/assets/scss/base.scss
+++ b/resources/assets/scss/base.scss
@@ -48,6 +48,16 @@ p {
   }
 }
 
+// @TODO: Added for the Marquee template experiment, so the full footer
+// can be viewed when fixed signup button reaches the bottom of the page.
+.footer {
+  padding-bottom: 105px;
+
+  @include media($medium) {
+    padding-bottom: 0;
+  }
+}
+
 // @TODO: for cleanup. Adding to base for now since needed
 // for validation in all forms.
 .field-label {


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR updates the Marquee Template for the Landing Page to make the signup button behave as a fixed button on the bottom of the viewport, only for small screen devices. From medium sized devices and up, it returns to the normal flow of the page. 

Example of behavior below:
![Fixed Signup Button Marquee Template](https://user-images.githubusercontent.com/105849/61551439-2d2cd180-aa23-11e9-8ce3-1a2aaa0d3d1b.gif)

### What are the relevant tickets/cards?

Refs [Pivotal ID #166250301](https://www.pivotaltracker.com/story/show/166250301)

### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.
* [ ] Added screenshot to PR description of related front-end updates on **small** screens.
* [ ] Added screenshot to PR description of related front-end updates on **medium** screens.
* [ ] Added screenshot to PR description of related front-end updates on **large** screens.
