### PR TITLE
Add Test Names to Signup Button Source Action text Sixpack Experiment

### DIFF
--- a/resources/assets/components/SignupButton/SignupButton.js
+++ b/resources/assets/components/SignupButton/SignupButton.js
@@ -54,8 +54,8 @@ const SignupButton = props => {
     });
   };
 
-  const signupButton = copy => (
-    <Button className={className} onClick={handleSignup}>
+  const signupButton = (copy, testName = undefined) => (
+    <Button className={className} onClick={handleSignup} testName={testName}>
       {copy}
     </Button>
   );
@@ -77,10 +77,10 @@ const SignupButton = props => {
     <SixpackExperiment
       title={`Source Action Text Override ${campaignTitle}`}
       convertableActions={['signup']}
-      control={signupButton(sourceOverride)}
+      control={signupButton(sourceOverride, 'Default Copy')}
       alternatives={[
         // Don't show the sourceOverride for the alternative.
-        signupButton(buttonCopy),
+        signupButton(buttonCopy, 'Source Action Text Override'),
       ]}
     />
   ) : (

--- a/resources/assets/components/SignupButton/SignupButton.js
+++ b/resources/assets/components/SignupButton/SignupButton.js
@@ -77,7 +77,7 @@ const SignupButton = props => {
           onClick={handleSignup}
           testName="Default Copy"
         >
-          {sourceOverride}
+          {buttonCopy}
         </Button>
       }
       alternatives={[
@@ -87,7 +87,7 @@ const SignupButton = props => {
           testName="Source Action Text Override"
         >
           {/* Don't show the sourceOverride for this alternative. */}
-          {buttonCopy}
+          {sourceOverride}
         </Button>,
       ]}
     />

--- a/resources/assets/components/SignupButton/SignupButton.js
+++ b/resources/assets/components/SignupButton/SignupButton.js
@@ -86,7 +86,6 @@ const SignupButton = props => {
           onClick={handleSignup}
           testName="Source Action Text Override"
         >
-          {/* Don't show the sourceOverride for this alternative. */}
           {sourceOverride}
         </Button>,
       ]}

--- a/resources/assets/components/SignupButton/SignupButton.js
+++ b/resources/assets/components/SignupButton/SignupButton.js
@@ -92,11 +92,7 @@ const SignupButton = props => {
     />
   ) : (
     /* @SIXPACK Code Test: 2019-07-19 */
-    <Button
-      className={className}
-      onClick={handleSignup}
-      testName="Source Action Text Override"
-    >
+    <Button className={className} onClick={handleSignup}>
       {buttonCopy}
     </Button>
   );

--- a/resources/assets/components/SignupButton/SignupButton.js
+++ b/resources/assets/components/SignupButton/SignupButton.js
@@ -54,12 +54,6 @@ const SignupButton = props => {
     });
   };
 
-  const signupButton = (copy, testName = undefined) => (
-    <Button className={className} onClick={handleSignup} testName={testName}>
-      {copy}
-    </Button>
-  );
-
   // Have signups been disabled for this campaign?
   if (disableSignup) {
     return null;
@@ -73,18 +67,39 @@ const SignupButton = props => {
   const sourceOverride = get(sourceActionText, trafficSource);
 
   return sixpackSourceActionText && sourceOverride ? (
-    /* @SIXPACK Code Test: 2019-07-18 */
+    /* @SIXPACK Code Test: 2019-07-19 */
     <SixpackExperiment
       title={`Source Action Text Override ${campaignTitle}`}
       convertableActions={['signup']}
-      control={signupButton(sourceOverride, 'Default Copy')}
+      control={
+        <Button
+          className={className}
+          onClick={handleSignup}
+          testName="Default Copy"
+        >
+          {sourceOverride}
+        </Button>
+      }
       alternatives={[
-        // Don't show the sourceOverride for the alternative.
-        signupButton(buttonCopy, 'Source Action Text Override'),
+        <Button
+          className={className}
+          onClick={handleSignup}
+          testName="Source Action Text Override"
+        >
+          {/* Don't show the sourceOverride for this alternative. */}
+          {buttonCopy}
+        </Button>,
       ]}
     />
   ) : (
-    signupButton(buttonCopy)
+    /* @SIXPACK Code Test: 2019-07-19 */
+    <Button
+      className={className}
+      onClick={handleSignup}
+      testName="Source Action Text Override"
+    >
+      {buttonCopy}
+    </Button>
   );
 };
 


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR is a patch/follow up to #1512 to include the `testName` prop in the Signup button (while swapping to explicitly render the `<Button/>` component for each scenario instead of relying on a helper method), so we can name the alternatives for the sixpack experiment.

### What are the relevant tickets/cards?
https://dosomething.slack.com/archives/C2BPA7M8F/p1563555248026200?thread_ts=1563553108.020900&cid=C2BPA7M8F

[Pivotal ID#165972814](https://www.pivotaltracker.com/story/show/165972814)
