### PR TITLE
Hide Reaction Amount from Reaction Button if there are none!

### DIFF
--- a/cypress/integration/campaign-gallery.js
+++ b/cypress/integration/campaign-gallery.js
@@ -37,9 +37,13 @@ describe('Campaign Gallery', () => {
 
     // Let's pick a post & react to it...
     cy.nth('.post-gallery .post', 4).within(() => {
+      // The post should not display the reaction total, since it's currently at zero:
+      cy.get('.reaction__meta').should('not.exist');
+
+      // React to the post.
       cy.get('.reaction__button').click();
 
-      // The post should get a filled-in heart & updated total.
+      // The post should get a filled-in heart & display the total.
       cy.get('.reaction__button').should('have.class', '-reacted');
       cy.get('.reaction__meta').contains('1');
     });

--- a/resources/assets/components/utilities/ReactionButton/ReactionButton.js
+++ b/resources/assets/components/utilities/ReactionButton/ReactionButton.js
@@ -41,10 +41,12 @@ const ReactionButton = ({ post }) => (
         <button type="button" className="reaction" onClick={toggleReaction}>
           <BaseFigure
             media={button}
-            alignment="left"
+            alignment={post.reactions ? 'left' : null}
             className="margin-bottom-none"
           >
-            <span className="reaction__meta">{post.reactions}</span>
+            {post.reactions ? (
+              <span className="reaction__meta">{post.reactions}</span>
+            ) : null}
           </BaseFigure>
         </button>
       );


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR updates the `ReactionButton` component (rendered primarilly from [`PostCard`s](https://github.com/DoSomething/phoenix-next/blob/d4b097403395381535b61e78ab1cefc2a7cd66b8/resources/assets/components/utilities/PostCard/PostCard.js#L54)) to not show the reaction amount if it's zero.

Also removes the `left` alignment setting in such cases, so that the heart icon isn't unnecessarily nudged to the left.

Also, look ma I added a test! https://github.com/DoSomething/phoenix-next/pull/1517/commits/09d7321a499993ad5110cf77e045086c61850727 (Did I do this right? It felt like it since we're testing reaction functionality in that test, but is it too specific?)

### Any background context you want to provide?
We don't want to make people sad 🙅 

### What are the relevant tickets/cards?

Refs [Pivotal ID #163236356](https://www.pivotaltracker.com/story/show/163236356)

😢 
![image](https://user-images.githubusercontent.com/12417657/61668160-ed2b5000-aca9-11e9-841d-e411f2cb7008.png)


☺️ 
![image](https://user-images.githubusercontent.com/12417657/61668184-ff0cf300-aca9-11e9-915a-f5a3d1025992.png)

(Same across breakpoints.)


### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [x] Added appropriate feature/unit tests.
* [ ] Added screenshot to PR description of related front-end updates on **small** screens.
* [ ] Added screenshot to PR description of related front-end updates on **medium** screens.
* [x] Added screenshot to PR description of related front-end updates on **large** screens.
