### PR TITLE
Add support for showing custom affiliate text on Marquee template.

### DIFF
--- a/resources/assets/components/pages/LandingPage/LandingPage.js
+++ b/resources/assets/components/pages/LandingPage/LandingPage.js
@@ -13,6 +13,7 @@ import './landing-page.scss';
 const LandingPage = props => {
   const {
     additionalContent,
+    affiliateCreditText,
     affiliateSponsors,
     campaignId,
     content,
@@ -56,6 +57,7 @@ const LandingPage = props => {
           alternatives={[
             <MarqueeTemplate
               additionalContent={additionalContent}
+              affiliateCreditText={affiliateCreditText}
               affiliateSponsors={affiliateSponsors}
               content={content}
               coverImage={coverImage}
@@ -88,6 +90,7 @@ const LandingPage = props => {
 
 LandingPage.propTypes = {
   additionalContent: PropTypes.object,
+  affiliateCreditText: PropTypes.string,
   affiliateSponsors: PropTypes.arrayOf(PropTypes.object),
   campaignId: PropTypes.string.isRequired,
   content: PropTypes.string.isRequired,
@@ -105,6 +108,7 @@ LandingPage.propTypes = {
 
 LandingPage.defaultProps = {
   additionalContent: null,
+  affiliateCreditText: undefined,
   affiliateSponsors: [],
   endDate: null,
   scholarshipAmount: null,

--- a/resources/assets/components/pages/LandingPage/LandingPageContainer.js
+++ b/resources/assets/components/pages/LandingPage/LandingPageContainer.js
@@ -14,6 +14,11 @@ const mapStateToProps = (state, ownProps) => {
 
   return {
     additionalContent: landingPage.additionalContent,
+    affiliateCreditText: get(
+      state,
+      'campaign.additionalContent.affiliateCreditText',
+      undefined,
+    ),
     affiliateSponsors: state.campaign.affiliateSponsors,
     campaignId: state.campaign.campaignId,
     contentfulId: state.campaign.id,

--- a/resources/assets/components/pages/LandingPage/templates/MarqueeTemplate.js
+++ b/resources/assets/components/pages/LandingPage/templates/MarqueeTemplate.js
@@ -12,6 +12,7 @@ import AffiliatePromotion from '../../../utilities/AffiliatePromotion/AffiliateP
 
 const MarqueeTemplate = ({
   additionalContent,
+  affiliateCreditText,
   affiliateSponsors,
   content,
   coverImage,
@@ -109,6 +110,7 @@ const MarqueeTemplate = ({
                       null,
                     ) || affiliateSponsors[0].fields.logo.url
                   }
+                  text={affiliateCreditText}
                   textClassName="text-gray-400"
                   title={affiliateSponsors[0].fields.logo.title}
                 />
@@ -123,6 +125,7 @@ const MarqueeTemplate = ({
 
 MarqueeTemplate.propTypes = {
   additionalContent: PropTypes.object,
+  affiliateCreditText: PropTypes.string,
   affiliateSponsors: PropTypes.arrayOf(PropTypes.object),
   content: PropTypes.string.isRequired,
   coverImage: PropTypes.object.isRequired,
@@ -134,6 +137,7 @@ MarqueeTemplate.propTypes = {
 
 MarqueeTemplate.defaultProps = {
   additionalContent: null,
+  affiliateCreditText: undefined,
   affiliateSponsors: [],
   endDate: null,
   scholarshipAmount: null,


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR updates the Marquee template to support showing affiliate credit text override if one is present in the additional content JSON for a campaign.

### Any background context you want to provide?

🌵 

### What are the relevant tickets/cards?

Refs [Pivotal ID #167442656](https://www.pivotaltracker.com/story/show/167442656)
