### PR TITLE
Progress on adding Admin Dashboard to Campaign pages.

### DIFF
--- a/app/Http/Controllers/CampaignController.php
+++ b/app/Http/Controllers/CampaignController.php
@@ -63,7 +63,6 @@ class CampaignController extends Controller
         return response()->view('app', [
             'admin' => [
                 'page' => get_page_settings($campaign, 'campaign', $slug),
-                'additionalSettings' => '',
             ],
             // This is used to build campaign-specific login links in the
             // server-rendered top navigation bar.

--- a/app/Http/Controllers/CampaignController.php
+++ b/app/Http/Controllers/CampaignController.php
@@ -61,6 +61,10 @@ class CampaignController extends Controller
         $campaign = $this->campaignRepository->findBySlug($slug);
 
         return response()->view('app', [
+            'admin' => [
+                'page' => get_page_settings($campaign, 'campaign', $slug),
+                'additionalSettings' => '',
+            ],
             // This is used to build campaign-specific login links in the
             // server-rendered top navigation bar.
             'campaign' => $campaign,

--- a/resources/assets/components/AdminDashboard/CampaignDashboard/CampaignDashboard.js
+++ b/resources/assets/components/AdminDashboard/CampaignDashboard/CampaignDashboard.js
@@ -3,16 +3,11 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Link } from 'react-router-dom';
 
 const CampaignDashboard = props => {
   const {
     campaignId,
-    hasLandingPage,
-    slug,
     clickedShowAffirmation,
-    clickedShowLandingPage,
-    clickedShowActionPage,
     clickedRemoveSignUp,
     hasReferralRB,
     signupCreated,
@@ -36,14 +31,6 @@ const CampaignDashboard = props => {
 
   return (
     <div>
-      <a
-        className="button -secondary margin-md"
-        href={`/next/cache/campaign_${slug}?redirect=${
-          window.location.pathname
-        }`}
-      >
-        Clear Cache
-      </a>
       <button
         type="button"
         className="button -secondary margin-md"
@@ -51,22 +38,6 @@ const CampaignDashboard = props => {
       >
         Show Affirmation
       </button>
-      {hasLandingPage ? (
-        <button
-          type="button"
-          className="button -secondary margin-md"
-          onClick={clickedShowLandingPage}
-        >
-          Show Landing Page
-        </button>
-      ) : null}
-      <Link
-        className="button -secondary margin-md"
-        to={`/us/campaigns/${slug}/action`}
-        onClick={clickedShowActionPage}
-      >
-        Show Action Page
-      </Link>
       <button
         type="button"
         className="button -secondary margin-md"
@@ -89,20 +60,12 @@ const CampaignDashboard = props => {
 
 CampaignDashboard.propTypes = {
   campaignId: PropTypes.string.isRequired,
-  hasLandingPage: PropTypes.bool,
-  slug: PropTypes.string.isRequired,
   isAdmin: PropTypes.bool.isRequired,
   isSignedUp: PropTypes.bool.isRequired,
   clickedShowAffirmation: PropTypes.func.isRequired,
-  clickedShowLandingPage: PropTypes.func.isRequired,
-  clickedShowActionPage: PropTypes.func.isRequired,
   clickedRemoveSignUp: PropTypes.func.isRequired,
   signupCreated: PropTypes.func.isRequired,
   hasReferralRB: PropTypes.bool.isRequired,
-};
-
-CampaignDashboard.defaultProps = {
-  hasLandingPage: false,
 };
 
 export default CampaignDashboard;

--- a/resources/views/layouts/master.blade.php
+++ b/resources/views/layouts/master.blade.php
@@ -26,7 +26,7 @@
 </head>
 
 <body>
-    @if (has_staff_access() && isset($admin))
+    @if (has_staff_access() && isset($admin) && data_get($admin, 'page'))
         @include('partials.admin-dashboard')
     @endif
 

--- a/resources/views/partials/admin-dashboard.blade.php
+++ b/resources/views/partials/admin-dashboard.blade.php
@@ -4,7 +4,7 @@
             <span>Admin Dashboard</span>
         </h1>
 
-        <h2 class="grid-full margin-bottom-md uppercase">{{ $admin['page']['type'] }} Settings &amp; Data</h2>
+        <h2 class="font-normal grid-full margin-bottom-md text-gray-800 uppercase">{{ $admin['page']['type'] }} Settings &amp; Data</h2>
 
         <section class="panel grid-full-1/2 margin-bottom-lg">
             <div class="wrapper rounded bg-gray-400">
@@ -20,23 +20,13 @@
                             </a>
                         @else
                             <a class="icon-link font-normal" href="{{ $admin['page']['editUrl'] }}" target="_blank">
-                                @include('svg.edit-pencil-icon', ['class' => 'icon icon-edit-pencil']) Edit the content on Contentful
+                                @include('svg.edit-pencil-icon', ['class' => 'icon icon-edit-pencil']) Edit this content on Contentful
                             </a>
                         @endif
                     </li>
                     <li class="margin-bottom-md">
                         <a class="icon-link font-normal" href="{{ $admin['page']['cacheUrl'] }}">
                             @include('svg.trash-icon', ['class' => 'icon icon-trash']) Clear the cache for this page
-                        </a>
-                    </li>
-                    <li class="margin-bottom-md">
-                        <a class="icon-link font-normal" href="">
-                            View Campaign reportbacks in Rogue
-                        </a>
-                    </li>
-                    <li class="margin-bottom-md">
-                        <a class="icon-link font-normal" href="">
-                            View Campaign metadata in Rogue
                         </a>
                     </li>
                 </ul>

--- a/resources/views/partials/admin-dashboard.blade.php
+++ b/resources/views/partials/admin-dashboard.blade.php
@@ -1,13 +1,17 @@
 <div id="admin-dashboard" class="admin-dashboard">
     <div class="wrapper base-12-grid">
-        <h1 class="admin-dashboard-title grid-full font-normal uppercase text-base text-gray-400 margin-bottom-lg"><span>Admin Dashboard</span></h1>
+        <h1 class="admin-dashboard-title grid-full font-normal uppercase text-base text-gray-400 margin-bottom-lg">
+            <span>Admin Dashboard</span>
+        </h1>
+
+        <h2 class="grid-full margin-bottom-md uppercase">{{ $admin['page']['type'] }} Settings &amp; Data</h2>
 
         <section class="panel grid-full-1/2 margin-bottom-lg">
-            <h1 class="panel-title font-normal text-m margin-bottom-md">
-                @include('svg.cog-icon', ['class' => 'icon icon-cog']) {{ $admin['page']['type'] }} Configuration
-            </h1>
-
             <div class="wrapper rounded bg-gray-400">
+                <h1 class="panel-title font-normal text-m margin-bottom-md">
+                    @include('svg.cog-icon', ['class' => 'icon icon-cog']) Configuration
+                </h1>
+
                 <ul class="list-reset">
                     <li class="margin-bottom-md">
                         @if ($admin['page']['type'] === 'Page Not Found')
@@ -16,7 +20,7 @@
                             </a>
                         @else
                             <a class="icon-link font-normal" href="{{ $admin['page']['editUrl'] }}" target="_blank">
-                                @include('svg.edit-pencil-icon', ['class' => 'icon icon-edit-pencil']) Edit this page on Contentful
+                                @include('svg.edit-pencil-icon', ['class' => 'icon icon-edit-pencil']) Edit the content on Contentful
                             </a>
                         @endif
                     </li>
@@ -25,15 +29,26 @@
                             @include('svg.trash-icon', ['class' => 'icon icon-trash']) Clear the cache for this page
                         </a>
                     </li>
+                    <li class="margin-bottom-md">
+                        <a class="icon-link font-normal" href="">
+                            View Campaign reportbacks in Rogue
+                        </a>
+                    </li>
+                    <li class="margin-bottom-md">
+                        <a class="icon-link font-normal" href="">
+                            View Campaign metadata in Rogue
+                        </a>
+                    </li>
                 </ul>
             </div>
         </section>
 
         <section class="panel grid-full-1/2">
-            <h1 class="panel-title font-normal text-m margin-bottom-md">
-                @include('svg.chart-bar-icon', ['class' => 'icon icon-chart-bar']) {{ $admin['page']['type'] }} Metrics
-            </h1>
             <div class="wrapper rounded bg-gray-400">
+                <h1 class="panel-title font-normal text-m margin-bottom-md">
+                    @include('svg.chart-bar-icon', ['class' => 'icon icon-chart-bar']) Metrics
+                </h1>
+
                 <p class="text-gray-600"><em>What's this? We're not sure yet, but let the tech team know if you have ideas!</em></p>
             </div>
         </section>

--- a/routes/web.php
+++ b/routes/web.php
@@ -62,7 +62,6 @@ $router->get('{slug}', function ($slug) {
 
 // Cache
 $router->get('cache/{cacheId}', 'CacheController');
-$router->get('next/cache/{cacheId}', 'CacheController');
 
 // Referrals CSV export
 $router->get('next/referrals/export', 'ReferralController@csvExport');


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR updates Campaign pages to enable the Admin Dashboard (🐞) and provides link to clear the cache and edit the corresponding Campaign page content on Contentful (respective of environment too). It removes the links to "mock" the landing page and action page, which haven't worked anyhoo since the updates to fix the URL routing for `/`, `/action`, `/community`, etc.

This also slightly changes the look of the Admin Dashboard (more changes to come!):
![image](https://user-images.githubusercontent.com/105849/61735815-b8bf9e80-ad52-11e9-992e-7932c4785ba7.png)


### Any background context you want to provide?

It still leaves the old admin bar with buttons to "Show Affirmation" and "Mock Sign Up" which still work and are useful. Some upcoming changes will allow for moving those into the new Admin Dashboard.

### What are the relevant tickets/cards?

Refs [Pivotal ID #162482793](https://www.pivotaltracker.com/story/show/162482793)

### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.
* [ ] Added screenshot to PR description of related front-end updates on **small** screens.
* [ ] Added screenshot to PR description of related front-end updates on **medium** screens.
* [ ] Added screenshot to PR description of related front-end updates on **large** screens.
