### PR TITLE
Adding Debug class to help with visualizing console output.

### DIFF
--- a/resources/assets/helpers/analytics.js
+++ b/resources/assets/helpers/analytics.js
@@ -5,7 +5,7 @@ import { Engine as PuckClient } from '@dosomething/puck-client';
 
 import { PUCK_URL } from '../constants';
 import { get as getHistory } from '../history';
-import { debug, stringifyNestedObjects, withoutValueless, query } from '.';
+import { stringifyNestedObjects, withoutValueless, query } from '.';
 
 // App name prefix used for event naming.
 const APP_PREFIX = 'phoenix';
@@ -95,17 +95,6 @@ export function analyzeWithPuck(name, data) {
  * @return {void}
  */
 export function analyzeWithSnowplow(name, category, action, label, data) {
-  // console.log('🔥');
-
-  // debug().log('snowplow', {
-  //   method: 'trackStructEvent',
-  //   name,
-  //   category,
-  //   action,
-  //   label,
-  //   data,
-  // });
-
   if (!window.snowplow) {
     return;
   }

--- a/resources/assets/helpers/analytics.js
+++ b/resources/assets/helpers/analytics.js
@@ -4,8 +4,8 @@ import { get, snakeCase, startCase } from 'lodash';
 import { Engine as PuckClient } from '@dosomething/puck-client';
 
 import { PUCK_URL } from '../constants';
-import { stringifyNestedObjects, withoutValueless, query } from '.';
 import { get as getHistory } from '../history';
+import { debug, stringifyNestedObjects, withoutValueless, query } from '.';
 
 // App name prefix used for event naming.
 const APP_PREFIX = 'phoenix';
@@ -95,6 +95,17 @@ export function analyzeWithPuck(name, data) {
  * @return {void}
  */
 export function analyzeWithSnowplow(name, category, action, label, data) {
+  // console.log('🔥');
+
+  // debug().log('snowplow', {
+  //   method: 'trackStructEvent',
+  //   name,
+  //   category,
+  //   action,
+  //   label,
+  //   data,
+  // });
+
   if (!window.snowplow) {
     return;
   }

--- a/resources/assets/helpers/index.js
+++ b/resources/assets/helpers/index.js
@@ -16,6 +16,7 @@ import {
   omitBy,
 } from 'lodash';
 
+import Debug from '../services/Debug';
 import Sixpack from '../services/Sixpack';
 import { trackAnalyticsEvent } from './analytics';
 import { isSignedUp } from '../selectors/signup';
@@ -822,6 +823,16 @@ export function sixpack() {
   }
 
   return sixpackInstance;
+}
+
+let debugInstance = null;
+
+export function debug() {
+  if (!debugInstance) {
+    debugInstance = new Debug();
+  }
+
+  return debugInstance;
 }
 
 /**

--- a/resources/assets/helpers/loggers.js
+++ b/resources/assets/helpers/loggers.js
@@ -1,3 +1,5 @@
+import { toDate } from 'date-fns';
+
 /**
  * Custom formatting for Phoenix triggers events to analytics services.
  *
@@ -28,21 +30,21 @@ export function phoenixEventLog(data) {
  */
 export function googleLog(...args) {
   const trackerName = args[0];
-  const data = args[1];
+  const data = { ...args[1] };
 
   const { event: eventName } = data;
-
   delete data.event;
 
   console.groupCollapsed(
-    '%c ANALYTICS: %s %c %c %s %c@%c dataLayer.push %c',
+    '%c ANALYTICS: %s %c %c %s %c@%c %s %c',
     'background-color: rgba(96,47,175,0.5); color: rgba(97,68,144,1); display: inline-block; font-weight: bold; line-height: 1.5;',
     trackerName.toUpperCase(),
     'background-color: transparent; color: rgba(165, 162, 162, 1); font-weight: normal; letter-spacing: 3px; line-height: 1.5;',
     'color: black; font-weight: bold; letter-spacing: normal; line-height: 1.5;',
-    'Method Name',
+    'Event',
     'color: rgba(165, 162, 162, 0.8); font-weight: normal;',
     'color: black; font-weight: bold;',
+    eventName.startsWith('phoenix_') ? 'Custom Event' : eventName,
     'background-color: rgba(105,157,215,0.5);',
   );
 
@@ -57,7 +59,15 @@ export function googleLog(...args) {
       eventContext,
     });
   } else {
-    console.log('Data: ', args[1]); // @TODO: temporary; need to expand on this for different types of GTM events.
+    switch (eventName) {
+      case 'gtm.js':
+        console.log('Start:', toDate(args[1]['gtm.start']));
+        console.log('Data: ', args[1]);
+        break;
+
+      default:
+        console.log('Data: ', args[1]);
+    }
   }
 
   console.groupEnd();
@@ -107,10 +117,12 @@ export function snowplowLog(...args) {
     trackerName.toUpperCase(),
     'background-color: transparent; color: rgba(165, 162, 162, 1); font-weight: normal; letter-spacing: 3px; line-height: 1.5;',
     'color: black; font-weight: bold; letter-spacing: normal; line-height: 1.5;',
-    'Method Name',
+    'Event',
     'color: rgba(165, 162, 162, 0.8); font-weight: normal;',
     'color: black; font-weight: bold;',
-    methodName,
+    methodName === 'trackStructEvent'
+      ? `Custom Event (${methodName})`
+      : methodName,
     'background-color: rgba(105,157,215,0.5);',
   );
 

--- a/resources/assets/helpers/loggers.js
+++ b/resources/assets/helpers/loggers.js
@@ -1,5 +1,3 @@
-/* eslint-disable import/prefer-default-export */
-
 export function sixpackLog(client, action, experimentName, experiment) {
   console.groupCollapsed(
     '%c SIXPACK: %c %c %s %c▷%c %s %c',
@@ -15,5 +13,59 @@ export function sixpackLog(client, action, experimentName, experiment) {
   console.log('Experiment:', experiment);
   console.log('Client ID: %s', client.client_id);
   console.log('Sixpack URL: %s', client.base_url);
+  console.groupEnd();
+}
+
+export function googleLog() {
+  console.groupCollapsed(
+    '%c ANALYTICS: %s %c %c %s %c@%c dataLayer.push() %c',
+    'background-color: rgba(96,47,175,0.5); color: rgba(97,68,144,1); display: inline-block; font-weight: bold; line-height: 1.5;',
+    arguments[0].toUpperCase(),
+    'background-color: transparent; color: rgba(165, 162, 162, 1); font-weight: normal; letter-spacing: 3px; line-height: 1.5;',
+    'color: black; font-weight: bold; letter-spacing: normal; line-height: 1.5;',
+    'Function Name',
+    'color: rgba(165, 162, 162, 0.8); font-weight: normal;',
+    'color: black; font-weight: bold;',
+    'background-color: rgba(105,157,215,0.5);',
+  );
+  console.log(arguments);
+  console.groupEnd();
+}
+
+export function snowplowLog() {
+  console.groupCollapsed(
+    '%c ANALYTICS: %s %c %c %s %c@%c %s %c',
+    'background-color: rgba(96,47,175,0.5); color: rgba(97,68,144,1); display: inline-block; font-weight: bold; line-height: 1.5;',
+    arguments[0].toUpperCase(),
+    'background-color: transparent; color: rgba(165, 162, 162, 1); font-weight: normal; letter-spacing: 3px; line-height: 1.5;',
+    'color: black; font-weight: bold; letter-spacing: normal; line-height: 1.5;',
+    'Function Name',
+    'color: rgba(165, 162, 162, 0.8); font-weight: normal;',
+    'color: black; font-weight: bold;',
+    arguments[1],
+    'background-color: rgba(105,157,215,0.5);',
+  );
+
+  switch (arguments[1]) {
+    case 'setUserId':
+      console.log('User ID:', arguments[2]);
+      break;
+
+    case 'trackStructEvent':
+      console.log('Category: ', arguments[2]);
+      console.log('Action: ', arguments[3]);
+      console.log('Label: ', arguments[4]);
+      console.log('Name: ', arguments[5]);
+      // arguments[5] is always null
+      console.log('Context: ', JSON.parse(arguments[7][0]['data']['payload']));
+      break;
+
+    case 'trackPageView':
+      console.log('Context: ', JSON.parse(arguments[3][0]['data']['payload']));
+      break;
+
+    default:
+      console.log(arguments);
+  }
   console.groupEnd();
 }

--- a/resources/assets/helpers/loggers.js
+++ b/resources/assets/helpers/loggers.js
@@ -25,20 +25,18 @@ export function phoenixEventLog(data) {
 /**
  * Log Google Tag Manager events to the console.
  *
- * @param  {Array} args
+ * @param  {Object} providedData
  * @return {void}
  */
-export function googleLog(...args) {
-  const trackerName = args[0];
-  const data = { ...args[1] };
+export function googleLog(providedData) {
+  const { event: eventName } = providedData;
 
-  const { event: eventName } = data;
+  const data = { ...providedData };
   delete data.event;
 
   console.groupCollapsed(
-    '%c ANALYTICS: %s %c %c %s %c@%c %s %c',
+    '%c ANALYTICS: GOOGLE %c %c %s %c@%c %s %c',
     'background-color: rgba(96,47,175,0.5); color: rgba(97,68,144,1); display: inline-block; font-weight: bold; line-height: 1.5;',
-    trackerName.toUpperCase(),
     'background-color: transparent; color: rgba(165, 162, 162, 1); font-weight: normal; letter-spacing: 3px; line-height: 1.5;',
     'color: black; font-weight: bold; letter-spacing: normal; line-height: 1.5;',
     'Event',
@@ -49,7 +47,7 @@ export function googleLog(...args) {
   );
 
   if (eventName.startsWith('phoenix_')) {
-    const { eventAction, eventCategory, eventLabel, ...eventContext } = args[1];
+    const { eventAction, eventCategory, eventLabel, ...eventContext } = data;
 
     phoenixEventLog({
       eventName,
@@ -61,12 +59,12 @@ export function googleLog(...args) {
   } else {
     switch (eventName) {
       case 'gtm.js':
-        console.log('Start:', toDate(args[1]['gtm.start']));
-        console.log('Data: ', args[1]);
+        console.log('Start:', toDate(data['gtm.start']));
+        console.log('Data: ', data);
         break;
 
       default:
-        console.log('Data: ', args[1]);
+        console.log('Data: ', data);
     }
   }
 
@@ -103,18 +101,15 @@ export function sixpackLog(client, action, experimentName, experiment) {
 /**
  * Log Snowplow events to the console.
  *
- * @param  {Array} args
+ * @param  {Array} data
  * @return {void}
  */
-export function snowplowLog(...args) {
-  const trackerName = args[0];
-
-  const methodName = args[1];
+export function snowplowLog(data) {
+  const methodName = data[0];
 
   console.groupCollapsed(
-    '%c ANALYTICS: %s %c %c %s %c@%c %s %c',
+    '%c ANALYTICS: SNOWPLOW %c %c %s %c@%c %s %c',
     'background-color: rgba(96,47,175,0.5); color: rgba(97,68,144,1); display: inline-block; font-weight: bold; line-height: 1.5;',
-    trackerName.toUpperCase(),
     'background-color: transparent; color: rgba(165, 162, 162, 1); font-weight: normal; letter-spacing: 3px; line-height: 1.5;',
     'color: black; font-weight: bold; letter-spacing: normal; line-height: 1.5;',
     'Event',
@@ -128,25 +123,25 @@ export function snowplowLog(...args) {
 
   switch (methodName) {
     case 'setUserId':
-      console.log('User ID:', args[2]);
+      console.log('User ID:', data[1]);
       break;
 
     case 'trackStructEvent':
       phoenixEventLog({
-        eventName: args[5],
-        eventAction: args[3],
-        eventCategory: args[2],
-        eventLabel: args[4],
-        eventContext: JSON.parse(args[7][0].data.payload),
+        eventName: data[4],
+        eventAction: data[2],
+        eventCategory: data[1],
+        eventLabel: data[3],
+        eventContext: JSON.parse(data[6][0].data.payload),
       });
       break;
 
     case 'trackPageView':
-      console.log('Context: ', JSON.parse(args[3][0].data.payload));
+      console.log('Context: ', JSON.parse(data[2][0].data.payload));
       break;
 
     default:
-      console.log(args);
+      console.log(data);
   }
   console.groupEnd();
 }

--- a/resources/assets/init.js
+++ b/resources/assets/init.js
@@ -47,7 +47,8 @@ import { bindFlashMessageEvents } from './helpers/flash-message';
 import { bindAdminDashboardEvents } from './helpers/admin-dashboard';
 
 ready(() => {
-  debug().setupTrackerWrappers();
+  // Enable Debug tools.
+  debug();
 
   // Configure store & history.
   const history = historyInit();

--- a/resources/assets/init.js
+++ b/resources/assets/init.js
@@ -38,7 +38,7 @@ import './scss/gallery-grid.scss';
 import App from './components/App';
 
 // DOM Helpers
-import { ready } from './helpers';
+import { ready, debug } from './helpers';
 import { init as historyInit } from './history';
 import { bindTokenRefreshEvent } from './helpers/auth';
 import { trackAnalyticsPageView } from './helpers/analytics';
@@ -47,6 +47,8 @@ import { bindFlashMessageEvents } from './helpers/flash-message';
 import { bindAdminDashboardEvents } from './helpers/admin-dashboard';
 
 ready(() => {
+  debug().setupWrappers();
+
   // Configure store & history.
   const history = historyInit();
   const middleware = [thunk];
@@ -61,6 +63,13 @@ ready(() => {
 
   // Add event listeners for top-level navigation.
   bindNavigationEvents();
+
+  // const nativeSnowplow = window.snowplow;
+
+  // window.snowplow = function() {
+  //   nativeSnowplow.call(window, ...arguments);
+  //   debug().log('snowplow', ...arguments);
+  // };
 
   // If available, set User ID for Snowplow analytics.
   if (typeof window.snowplow === 'function' && window.AUTH.id) {

--- a/resources/assets/init.js
+++ b/resources/assets/init.js
@@ -47,7 +47,7 @@ import { bindFlashMessageEvents } from './helpers/flash-message';
 import { bindAdminDashboardEvents } from './helpers/admin-dashboard';
 
 ready(() => {
-  debug().setupWrappers();
+  debug().setupTrackerWrappers();
 
   // Configure store & history.
   const history = historyInit();
@@ -63,13 +63,6 @@ ready(() => {
 
   // Add event listeners for top-level navigation.
   bindNavigationEvents();
-
-  // const nativeSnowplow = window.snowplow;
-
-  // window.snowplow = function() {
-  //   nativeSnowplow.call(window, ...arguments);
-  //   debug().log('snowplow', ...arguments);
-  // };
 
   // If available, set User ID for Snowplow analytics.
   if (typeof window.snowplow === 'function' && window.AUTH.id) {

--- a/resources/assets/services/Debug.js
+++ b/resources/assets/services/Debug.js
@@ -11,6 +11,8 @@ class Debug {
 
     window.DS = window.DS || {};
     window.DS.Debug = this;
+
+    this.logExistingDataLayerEvents();
   }
 
   /**
@@ -46,6 +48,23 @@ class Debug {
       default:
         console.error('No custom log formatter specified.');
     }
+  }
+
+  /**
+   * Log any initial events already in the GTM dataLayer array.
+   *
+   * @return {void}
+   */
+  logExistingDataLayerEvents() {
+    // Note: if GTM is not active, no initial events will be pushed to the mocked dataLayer array.
+    const events = Object.keys(window.dataLayer);
+
+    events.forEach(item => {
+      if (typeof window.dataLayer[item] === 'function') {
+        return;
+      }
+      this.log('google', window.dataLayer[item]);
+    });
   }
 
   /**

--- a/resources/assets/services/Debug.js
+++ b/resources/assets/services/Debug.js
@@ -7,18 +7,86 @@ const KEY = 'DS_SHOW_LOGS';
 
 class Debug {
   constructor() {
-    this.showLogs = Boolean(this.getToggleValue());
+    this.showLogs = Boolean(Debug.getToggleValue());
 
     window.DS = window.DS || {};
     window.DS.Debug = this;
   }
 
   /**
-   * [toggleLogs description]
-   * @return {[type]} [description]
+   * Get the toggle logs boolean value from local storage.
+   *
+   * @return {Number}
+   */
+  static getToggleValue() {
+    return Number(localStorage.getItem(KEY));
+  }
+
+  /**
+   * Log data in the console with a specified log formatter function
+   * based on the specified event type.
+   *
+   * @param  {String} type
+   * @return {void}
+   */
+  log(type, ...args) {
+    if (!this.showLogs) {
+      return;
+    }
+
+    switch (type) {
+      case 'google':
+        googleLog(type, ...args);
+        break;
+
+      case 'snowplow':
+        snowplowLog(type, ...args);
+        break;
+
+      default:
+        console.error('No custom log formatter specified.');
+    }
+  }
+
+  /**
+   * Wrap specified event trackers in a custom fu nction to allow logging
+   * when events fire into the console for debugging.
+   *
+   * @return {void}
+   */
+  setupTrackerWrappers() {
+    if (typeof window.snowplow !== 'function') {
+      return;
+    }
+
+    const debug = this;
+
+    // Wrap the Snowplow function to allow logging events.
+    const nativeSnowplow = window.snowplow;
+
+    window.snowplow = function() {
+      // Do not use rest params for these wrappers since it would convert the prototype object
+      // from an Object to an Array and potentially disable the native functionality!
+      nativeSnowplow.call(window, ...arguments); // eslint-disable-line prefer-rest-params
+      debug.log('snowplow', ...arguments); // eslint-disable-line prefer-rest-params
+    };
+
+    // Wrap the Google Tag Manager dataLayer push function to allow logging events.
+    const nativeGtmDataLayerPush = window.dataLayer.push;
+
+    window.dataLayer.push = function() {
+      nativeGtmDataLayerPush.call(window, ...arguments); // eslint-disable-line prefer-rest-params
+      debug.log('google', ...arguments); // eslint-disable-line prefer-rest-params
+    };
+  }
+
+  /**
+   * Toggle whether to show or hide the DoSomething Debug logs in the console.
+   *
+   * @return {void}
    */
   toggleLogs() {
-    const toggle = this.getToggleValue();
+    const toggle = Debug.getToggleValue();
 
     if (!isStaff() && !toggle) {
       return console.warn('Sorry friend, you are not authorized.');
@@ -34,72 +102,12 @@ class Debug {
           padding: 20px 30px;
         `;
 
-    this.showLogs = Boolean(this.getToggleValue());
+    this.showLogs = Boolean(Debug.getToggleValue());
 
-    console.log(
+    return console.log(
       `%c📝 DoSomething logs have been turned ${!toggle ? 'ON' : 'OFF'}.`,
       messageStyles,
     );
-  }
-
-  /**
-   * [getToggleValue description]
-   * @return {[type]} [description]
-   */
-  getToggleValue() {
-    return Number(localStorage.getItem(KEY));
-  }
-
-  /**
-   * [log description]
-   * @param  {[type]} type [description]
-   * @return {[type]}      [description]
-   */
-  log(type) {
-    if (!this.showLogs) {
-      return;
-    }
-
-    switch (type) {
-      case 'google':
-        googleLog(...arguments);
-        break;
-
-      case 'snowplow':
-        snowplowLog(...arguments);
-        break;
-
-      default:
-        console.error('No custom log formatter specified.');
-    }
-  }
-
-  /**
-   * [setupWrappers description]
-   * @return {[type]} [description]
-   */
-  setupWrappers() {
-    if (typeof window.snowplow !== 'function') {
-      return;
-    }
-
-    const debug = this;
-
-    // Wrap the Snowplow function to allow logging events.
-    const nativeSnowplow = window.snowplow;
-
-    window.snowplow = function() {
-      nativeSnowplow.call(window, ...arguments);
-      debug.log('snowplow', ...arguments);
-    };
-
-    // Wrap the Google Tag Manager dataLayer push function to allow logging events.
-    const nativeGtmDataLayerPush = window.dataLayer.push;
-
-    window.dataLayer.push = function() {
-      nativeGtmDataLayerPush.call(window, ...arguments);
-      debug.log('google', ...arguments);
-    };
   }
 }
 

--- a/resources/assets/services/Debug.js
+++ b/resources/assets/services/Debug.js
@@ -36,8 +36,6 @@ class Debug {
       return;
     }
 
-    console.log(data);
-
     switch (type) {
       case 'google':
         googleLog(data);
@@ -87,6 +85,10 @@ class Debug {
    * @return {void}
    */
   wrapGoogleTracker() {
+    if (!Array.isArray(window.dataLayer)) {
+      return;
+    }
+
     const debug = this;
 
     const nativeGtmDataLayerPush = window.dataLayer.push;
@@ -104,11 +106,11 @@ class Debug {
    * @return {void}
    */
   wrapSnowplowTracker() {
-    const debug = this;
-
     if (typeof window.snowplow !== 'function') {
       return;
     }
+
+    const debug = this;
 
     const nativeSnowplow = window.snowplow;
 

--- a/resources/assets/services/Debug.js
+++ b/resources/assets/services/Debug.js
@@ -1,0 +1,106 @@
+/* global window */
+
+import { isStaff } from '../helpers';
+import { googleLog, snowplowLog } from '../helpers/loggers';
+
+const KEY = 'DS_SHOW_LOGS';
+
+class Debug {
+  constructor() {
+    this.showLogs = Boolean(this.getToggleValue());
+
+    window.DS = window.DS || {};
+    window.DS.Debug = this;
+  }
+
+  /**
+   * [toggleLogs description]
+   * @return {[type]} [description]
+   */
+  toggleLogs() {
+    const toggle = this.getToggleValue();
+
+    if (!isStaff() && !toggle) {
+      return console.warn('Sorry friend, you are not authorized.');
+    }
+
+    localStorage.setItem(KEY, Number(!toggle));
+
+    const messageStyles = `
+          background-color: #141493;
+          color: #fafafa;
+          display: block;
+          font-size: 14px;
+          padding: 20px 30px;
+        `;
+
+    this.showLogs = Boolean(this.getToggleValue());
+
+    console.log(
+      `%c📝 DoSomething logs have been turned ${!toggle ? 'ON' : 'OFF'}.`,
+      messageStyles,
+    );
+  }
+
+  /**
+   * [getToggleValue description]
+   * @return {[type]} [description]
+   */
+  getToggleValue() {
+    return Number(localStorage.getItem(KEY));
+  }
+
+  /**
+   * [log description]
+   * @param  {[type]} type [description]
+   * @return {[type]}      [description]
+   */
+  log(type) {
+    if (!this.showLogs) {
+      return;
+    }
+
+    switch (type) {
+      case 'google':
+        googleLog(...arguments);
+        break;
+
+      case 'snowplow':
+        snowplowLog(...arguments);
+        break;
+
+      default:
+        console.error('No custom log formatter specified.');
+    }
+  }
+
+  /**
+   * [setupWrappers description]
+   * @return {[type]} [description]
+   */
+  setupWrappers() {
+    if (typeof window.snowplow !== 'function') {
+      return;
+    }
+
+    const debug = this;
+
+    // Wrap the Snowplow function to allow logging events.
+    const nativeSnowplow = window.snowplow;
+
+    window.snowplow = function() {
+      nativeSnowplow.call(window, ...arguments);
+      debug.log('snowplow', ...arguments);
+    };
+
+    // Wrap the Google Tag Manager dataLayer push function to allow logging events.
+    const nativeGtmDataLayerPush = window.dataLayer.push;
+
+    window.dataLayer.push = function() {
+      nativeGtmDataLayerPush.call(window, ...arguments);
+      debug.log('google', ...arguments);
+    };
+  }
+}
+
+export default Debug;

--- a/resources/assets/services/Debug.js
+++ b/resources/assets/services/Debug.js
@@ -93,14 +93,12 @@ class Debug {
       return;
     }
 
-    const debug = this;
-
     const nativeGtmDataLayerPush = window.dataLayer.push;
 
-    window.dataLayer.push = function(...args) {
+    window.dataLayer.push = (...args) => {
       nativeGtmDataLayerPush.apply(window.dataLayer, args);
 
-      debug.log('google', args[0]);
+      this.log('google', args[0]);
     };
   }
 
@@ -114,14 +112,12 @@ class Debug {
       return;
     }
 
-    const debug = this;
-
     const nativeSnowplow = window.snowplow;
 
-    window.snowplow = function(...args) {
+    window.snowplow = (...args) => {
       nativeSnowplow.apply(window, args);
 
-      debug.log('snowplow', args);
+      this.log('snowplow', args);
     };
   }
 

--- a/resources/assets/services/Debug.js
+++ b/resources/assets/services/Debug.js
@@ -11,7 +11,7 @@ class Debug {
     window.DS = window.DS || {};
     window.DS.Debug = this;
 
-    this.logExistingDataLayerEvents();
+    this.setupTrackerWrappers();
   }
 
   /**
@@ -74,9 +74,13 @@ class Debug {
    * @return {void}
    */
   setupTrackerWrappers() {
-    this.wrapGoogleTracker();
+    if (Debug.getToggleValue()) {
+      this.logExistingDataLayerEvents();
 
-    this.wrapSnowplowTracker();
+      this.wrapGoogleTracker();
+
+      this.wrapSnowplowTracker();
+    }
   }
 
   /**
@@ -127,9 +131,15 @@ class Debug {
    * @return {void}
    */
   toggleLogs() {
-    const toggle = Debug.getToggleValue();
+    const currentValue = Debug.getToggleValue();
 
-    localStorage.setItem(KEY, Number(!toggle));
+    const updatedValue = Number(!currentValue);
+
+    localStorage.setItem(KEY, updatedValue);
+
+    this.showLogs = Boolean(updatedValue);
+
+    this.setupTrackerWrappers();
 
     const messageStyles = `
           background-color: #141493;
@@ -139,10 +149,8 @@ class Debug {
           padding: 20px 30px;
         `;
 
-    this.showLogs = Boolean(Debug.getToggleValue());
-
     return console.log(
-      `%c📝 DoSomething logs have been turned ${!toggle ? 'ON' : 'OFF'}.`,
+      `%c📝 DoSomething logs have been turned ${updatedValue ? 'ON' : 'OFF'}.`,
       messageStyles,
     );
   }

--- a/resources/assets/services/Debug.js
+++ b/resources/assets/services/Debug.js
@@ -80,12 +80,14 @@ class Debug {
 
     const debug = this;
 
+    // We do not use rest params for these wrapper functions below, since it would convert the
+    // prototype object from an Object to an Array and potentially disable the native functionality!
+    // @see https://eslint.org/docs/rules/prefer-rest-params#suggest-using-the-rest-parameters-instead-of-arguments-prefer-rest-params
+
     // Wrap the Snowplow function to allow logging events.
     const nativeSnowplow = window.snowplow;
 
     window.snowplow = function() {
-      // Do not use rest params for these wrappers since it would convert the prototype object
-      // from an Object to an Array and potentially disable the native functionality!
       nativeSnowplow.call(window, ...arguments); // eslint-disable-line prefer-rest-params
       debug.log('snowplow', ...arguments); // eslint-disable-line prefer-rest-params
     };

--- a/resources/assets/services/Debug.js
+++ b/resources/assets/services/Debug.js
@@ -1,6 +1,5 @@
 /* global window */
 
-import { isStaff } from '../helpers';
 import { googleLog, snowplowLog } from '../helpers/loggers';
 
 const KEY = 'DS_SHOW_LOGS';
@@ -109,9 +108,9 @@ class Debug {
   toggleLogs() {
     const toggle = Debug.getToggleValue();
 
-    if (!isStaff() && !toggle) {
-      return console.warn('Sorry friend, you are not authorized.');
-    }
+    // if (!isStaff() && !toggle) {
+    //   return console.warn('Sorry friend, you are not authorized.');
+    // }
 
     localStorage.setItem(KEY, Number(!toggle));
 

--- a/resources/views/partials/google_tag_manager_script.blade.php
+++ b/resources/views/partials/google_tag_manager_script.blade.php
@@ -6,6 +6,12 @@
         'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
         })(window,document,'script','dataLayer','GTM-{{config('services.analytics.google_tag_manager_id')}}');
     </script>
+@else
+    {{-- Custom --}}
+    <script type='text/javascript'>
+        window.dataLayer = {};
+        window.dataLayer.push = function() {};
+    </script>
 @endif
 
 {{-- When/if we implement server-side rendering of React, we should add the noscript code back in! --}}

--- a/resources/views/partials/google_tag_manager_script.blade.php
+++ b/resources/views/partials/google_tag_manager_script.blade.php
@@ -7,10 +7,9 @@
         })(window,document,'script','dataLayer','GTM-{{config('services.analytics.google_tag_manager_id')}}');
     </script>
 @else
-    {{-- Mocked function to allow showing console logs. --}}
+    {{-- Mocked GTM dataLayer to allow showing console logs. --}}
     <script type='text/javascript'>
-        window.dataLayer = {};
-        window.dataLayer.push = function() {};
+        window.dataLayer = [];
     </script>
 @endif
 

--- a/resources/views/partials/google_tag_manager_script.blade.php
+++ b/resources/views/partials/google_tag_manager_script.blade.php
@@ -7,7 +7,7 @@
         })(window,document,'script','dataLayer','GTM-{{config('services.analytics.google_tag_manager_id')}}');
     </script>
 @else
-    {{-- Custom --}}
+    {{-- Mocked function to allow showing console logs. --}}
     <script type='text/javascript'>
         window.dataLayer = {};
         window.dataLayer.push = function() {};

--- a/resources/views/partials/snowplow_script.blade.php
+++ b/resources/views/partials/snowplow_script.blade.php
@@ -11,7 +11,7 @@
         });
     </script>
 @else
-    {{-- Custom script for logging Snowplow events to the console when no ENV variable provided. --}}
+    {{-- Mocked function to allow showing console logs. --}}
     <script type='text/javascript'>
         window.snowplow = function () {};
     </script>

--- a/resources/views/partials/snowplow_script.blade.php
+++ b/resources/views/partials/snowplow_script.blade.php
@@ -13,41 +13,6 @@
 @else
     {{-- Custom script for logging Snowplow events to the console when no ENV variable provided. --}}
     <script type='text/javascript'>
-        window.snowplow = function () {
-            console.groupCollapsed(
-                '%c SNOWPLOW: %c %c %s %c@%c %s %c',
-                'background-color: rgba(96,47,175,0.5); color: rgba(97,68,144,1); display: inline-block; font-weight: bold; line-height: 1.5;',
-                'background-color: transparent; color: rgba(165, 162, 162, 1); font-weight: normal; letter-spacing: 3px; line-height: 1.5;',
-                'color: black; font-weight: bold; letter-spacing: normal; line-height: 1.5;',
-                'Function Name',
-                'color: rgba(165, 162, 162, 0.8); font-weight: normal;',
-                'color: black; font-weight: bold;',
-                arguments[0],
-                'background-color: rgba(105,157,215,0.5);',
-            );
-
-            switch (arguments[0]) {
-                case 'setUserId':
-                    console.log('User ID:', arguments[1]);
-                    break;
-
-                case 'trackStructEvent':
-                    console.log('Category: ', arguments[1]);
-                    console.log('Action: ', arguments[2]);
-                    console.log('Label: ', arguments[3]);
-                    console.log('Name: ', arguments[4]);
-                    // arguments[5] is always null
-                    console.log('Context: ', JSON.parse(arguments[6][0]['data']['payload']));
-                    break;
-
-                case 'trackPageView':
-                    console.log('Context: ', JSON.parse(arguments[2][0]['data']['payload']));
-                    break;
-
-                default:
-                    console.log(arguments);
-            }
-            console.groupEnd();
-        };
+        window.snowplow = function () {};
     </script>
 @endif


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR adds a new `Dedug` service to help toggle showing/hiding of app specific console logs within any of our environments. Currently, we only really log useful event information to the console if we're on our local development environment, but it would be nice to be able to toggle whether to show or hide console logs on both QA and Production to easily be able to see what is firing. Now we can!

![DS Logs Toggle](https://user-images.githubusercontent.com/105849/62073857-8d83f600-b20f-11e9-9bbb-d597928608cd.gif)

This new `Debug` class and associated `toggleLogs()` method can only be triggered from any Phoenix environment. 

The toggle value is stored in local storage and once toggled the Debug class will provide visual logs in the console for pre-setup custom event logs. To turn them back off, just toggle the setting back off. This setting only affects a user's personal browser client.

### Any background context you want to provide?

To help better track when analytics events are firing and coordinate that they are firing as expected and in what sequence, we would like to be able to see the events fired in the console, not only locally, but also on QA and Prod

I initially used `localForage` for the toggle value setting, but it's Promise-based approach proved to not be super helpful when events are firing and the page reloads. Since this is _only_ for debugging purposes, I figured it was alright to directly use the `localStorage` API.

Additionally, to be able to log when Google or Snowplow events fire, I needed to wrap the specific method each uses when triggering events. It allowed me to log and then continue the native event as expected. I'll be doing a bit of testing to ensure this all works as expected.

Lastly, the aim is to follow-up with an additional PR that adds a toggle to the Admin Dashboard dropdown that calls the same `Debug` class method you can otherwise call manually in the console!

### What are the relevant tickets/cards?

:cactus:

### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.