### PR TITLE
Quick fix to not show unnecessary clear cache link if page is not cached.

### DIFF
--- a/app/helpers.php
+++ b/app/helpers.php
@@ -63,7 +63,7 @@ function get_contentful_url()
 function get_page_settings($page, $prefix, $slug = null)
 {
     return [
-        'cacheUrl' => get_cache_url($prefix, $slug),
+        'cacheUrl' => config('services.contentful.cache') ? get_cache_url($prefix, $slug) : null,
         'editUrl' => get_contentful_url().'entries/'.$page->id,
         'type' => readable_title($page->type),
     ];

--- a/resources/views/partials/admin-dashboard.blade.php
+++ b/resources/views/partials/admin-dashboard.blade.php
@@ -25,9 +25,13 @@
                         @endif
                     </li>
                     <li class="margin-bottom-md">
-                        <a class="icon-link font-normal" href="{{ $admin['page']['cacheUrl'] }}">
-                            @include('svg.trash-icon', ['class' => 'icon icon-trash']) Clear the cache for this page
-                        </a>
+                        @if($admin['page']['cacheUrl'])
+                            <a class="icon-link font-normal" href="{{ $admin['page']['cacheUrl'] }}">
+                                @include('svg.trash-icon', ['class' => 'icon icon-trash']) Clear the cache for this page
+                            </a>
+                        @else
+                            <em class="text-gray-600">Current page is not cached</em>
+                        @endif
                     </li>
                 </ul>
             </div>


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR updates the Admin Dashboard to remove the "Clear the cache for this page" link if the environment variable `CONTENTFUL_CACHE` is set to `false` and thus not cache any content. The button ends up not really doing anything if caching is turned off (like on the Preview environment) and could be confusing.

If caching is turned off, instead we show a little message to let the user know:

![image](https://user-images.githubusercontent.com/105849/62243728-e7b9be00-b3ab-11e9-88d4-5a8e19d3f350.png)


### Any background context you want to provide?

🌵 

### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.