### PR TITLE
Rethinking Debug class approach

### DIFF
--- a/resources/assets/helpers/analytics.js
+++ b/resources/assets/helpers/analytics.js
@@ -84,8 +84,8 @@ export function analyzeWithGoogle(name, category, action, label, data) {
   // Push event action to Google Tag Manager's data layer.
   window.dataLayer = window.dataLayer || [];
 
-  analyze('google', analyticsEvent, data => {
-    window.dataLayer.push(data);
+  analyze('google', analyticsEvent, payload => {
+    window.dataLayer.push(payload);
   });
 }
 
@@ -142,8 +142,8 @@ export function analyzeWithSnowplow(name, category, action, label, data) {
     ],
   ];
 
-  analyze('snowplow', analyticsEvent, data => {
-    window.snowplow(...data);
+  analyze('snowplow', analyticsEvent, payload => {
+    window.snowplow(...payload);
   });
 }
 
@@ -240,13 +240,13 @@ export function trackAnalyticsPageView(history) {
   const analyticsEvent = ['trackPageView', null, [data]];
 
   history.listen(() => {
-    analyze('snowplow', analyticsEvent, data => {
-      window.snowplow(...data);
+    analyze('snowplow', analyticsEvent, payload => {
+      window.snowplow(...payload);
     });
   });
 
-  analyze('snowplow', analyticsEvent, data => {
-    window.snowplow(...data);
+  analyze('snowplow', analyticsEvent, payload => {
+    window.snowplow(...payload);
   });
 }
 

--- a/resources/assets/helpers/analytics.js
+++ b/resources/assets/helpers/analytics.js
@@ -46,6 +46,7 @@ export function analyze(type, callback, args, thisArg = window) {
  */
 const formatEventName = (verb, noun, adjective = null) => {
   let eventName = `${APP_PREFIX}_${snakeCase(verb)}_${snakeCase(noun)}`;
+
   // Append adjective if defined.
   eventName += adjective ? `_${snakeCase(adjective)}` : '';
 
@@ -84,7 +85,6 @@ export function analyzeWithGoogle(name, category, action, label, data) {
   // Push event action to Google Tag Manager's data layer.
   window.dataLayer = window.dataLayer || [];
 
-  // window.dataLayer.push(analyticsEvent)
   analyze('google', window.dataLayer.push, [analyticsEvent], window.dataLayer);
 }
 

--- a/resources/assets/helpers/analytics.js
+++ b/resources/assets/helpers/analytics.js
@@ -84,9 +84,7 @@ export function analyzeWithGoogle(name, category, action, label, data) {
   // Push event action to Google Tag Manager's data layer.
   window.dataLayer = window.dataLayer || [];
 
-  analyze('google', analyticsEvent, payload => {
-    window.dataLayer.push(payload);
-  });
+  window.dataLayer.push(analyticsEvent);
 }
 
 /**

--- a/resources/assets/helpers/analytics.js
+++ b/resources/assets/helpers/analytics.js
@@ -85,7 +85,7 @@ export function analyzeWithGoogle(name, category, action, label, data) {
   window.dataLayer = window.dataLayer || [];
 
   // window.dataLayer.push(analyticsEvent)
-  analyze('google', window.dataLayer.push, analyticsEvent, window.dataLayer);
+  analyze('google', window.dataLayer.push, [analyticsEvent], window.dataLayer);
 }
 
 /**

--- a/resources/assets/helpers/loggers.js
+++ b/resources/assets/helpers/loggers.js
@@ -29,7 +29,7 @@ export function phoenixEventLog(data) {
  * @return {void}
  */
 export function googleLog(providedData) {
-  const data = { ...providedData[0] };
+  const data = { ...providedData };
 
   const { event: eventName } = data;
 

--- a/resources/assets/helpers/loggers.js
+++ b/resources/assets/helpers/loggers.js
@@ -25,13 +25,14 @@ export function phoenixEventLog(data) {
 /**
  * Log Google Tag Manager events to the console.
  *
- * @param  {Object} providedData
+ * @param  {Array} providedData
  * @return {void}
  */
 export function googleLog(providedData) {
-  const { event: eventName } = providedData;
+  const data = { ...providedData[0] };
 
-  const data = { ...providedData };
+  const { event: eventName } = data;
+
   delete data.event;
 
   console.groupCollapsed(

--- a/resources/assets/init.js
+++ b/resources/assets/init.js
@@ -69,8 +69,8 @@ ready(() => {
   if (typeof window.snowplow === 'function' && window.AUTH.id) {
     const analyticsEvent = ['setUserId', window.AUTH.id];
 
-    analyze('snowplow', analyticsEvent, data => {
-      window.snowplow(...data);
+    analyze('snowplow', analyticsEvent, payload => {
+      window.snowplow(...payload);
     });
   }
 

--- a/resources/assets/init.js
+++ b/resources/assets/init.js
@@ -41,10 +41,10 @@ import App from './components/App';
 import { ready, debug } from './helpers';
 import { init as historyInit } from './history';
 import { bindTokenRefreshEvent } from './helpers/auth';
-import { trackAnalyticsPageView } from './helpers/analytics';
 import { bindNavigationEvents } from './helpers/navigation';
 import { bindFlashMessageEvents } from './helpers/flash-message';
 import { bindAdminDashboardEvents } from './helpers/admin-dashboard';
+import { analyze, trackAnalyticsPageView } from './helpers/analytics';
 
 ready(() => {
   // Enable Debug tools.
@@ -67,7 +67,7 @@ ready(() => {
 
   // If available, set User ID for Snowplow analytics.
   if (typeof window.snowplow === 'function' && window.AUTH.id) {
-    window.snowplow('setUserId', window.AUTH.id);
+    analyze('snowplow', window.snowplow, ['setUserId', window.AUTH.id]);
   }
 
   // Add page view event listeners for History interface changes.

--- a/resources/assets/init.js
+++ b/resources/assets/init.js
@@ -67,7 +67,13 @@ ready(() => {
 
   // If available, set User ID for Snowplow analytics.
   if (typeof window.snowplow === 'function' && window.AUTH.id) {
-    analyze('snowplow', window.snowplow, ['setUserId', window.AUTH.id]);
+    const analyticsEvent = ['setUserId', window.AUTH.id];
+
+    // analyze('snowplow', window.snowplow, ['setUserId', window.AUTH.id]);
+
+    analyze('snowplow', analyticsEvent, data => {
+      window.snowplow(...data);
+    });
   }
 
   // Add page view event listeners for History interface changes.

--- a/resources/assets/init.js
+++ b/resources/assets/init.js
@@ -69,8 +69,6 @@ ready(() => {
   if (typeof window.snowplow === 'function' && window.AUTH.id) {
     const analyticsEvent = ['setUserId', window.AUTH.id];
 
-    // analyze('snowplow', window.snowplow, ['setUserId', window.AUTH.id]);
-
     analyze('snowplow', analyticsEvent, data => {
       window.snowplow(...data);
     });

--- a/resources/assets/services/Debug.js
+++ b/resources/assets/services/Debug.js
@@ -14,6 +14,7 @@ class Debug {
     window.DS = window.DS || {};
     window.DS.Debug = this;
 
+    // @TODO: call this once once document is ready?
     this.logExistingDataLayerEvents();
   }
 
@@ -49,7 +50,7 @@ class Debug {
 
     switch (type) {
       case 'google':
-        googleLog(data[0]);
+        googleLog(data);
         break;
 
       case 'snowplow':

--- a/resources/assets/services/Debug.js
+++ b/resources/assets/services/Debug.js
@@ -74,7 +74,7 @@ class Debug {
         break;
 
       default:
-        console.error('😢 No custom log formatter found.');
+        console.error(`😢 No ${type} log formatter found.`);
     }
   }
 

--- a/resources/assets/services/Debug.js
+++ b/resources/assets/services/Debug.js
@@ -11,8 +11,9 @@ class Debug {
     window.DS = window.DS || {};
     window.DS.Debug = this;
 
-    // @TODO: call this once once document is ready?
-    // this.logExistingDataLayerEvents();
+    // Set up any supported trackers that allow being wrapped in an override
+    // function, to help easily output logs whenever native event called.
+    this.setupTrackerWrappers();
   }
 
   /**
@@ -73,7 +74,7 @@ class Debug {
         break;
 
       default:
-        console.error('No custom log formatter found.');
+        console.error('😢 No custom log formatter found.');
     }
   }
 
@@ -107,7 +108,7 @@ class Debug {
   enableLogs(specifiedLogs) {
     if (!Array.isArray(specifiedLogs)) {
       return console.error(
-        'To enable showing logs, please provide an array of string names of the logs to show.',
+        '💁‍♀️ To enable showing logs, please provide an array of string names of the logs to show.',
       );
     }
 
@@ -123,8 +124,6 @@ class Debug {
     );
 
     console.log(`%c✅ Showing logs for ${logs}.`, Debug.getMessageStyles());
-
-    return;
   }
 
   /**
@@ -137,10 +136,32 @@ class Debug {
 
     this.enabledLoggers = Debug.getEnabledLoggers();
 
-    return console.log(
+    console.log(
       '%c📝 DoSomething logs have been turned OFF.',
       Debug.getMessageStyles(),
     );
+  }
+
+  setupTrackerWrappers() {
+    if (this.enabledLoggers.includes('google')) {
+      this.logExistingDataLayerEvents();
+
+      this.wrapGoogleTracker();
+    }
+  }
+
+  wrapGoogleTracker() {
+    if (!Array.isArray(window.dataLayer)) {
+      return;
+    }
+
+    const nativeGtmDataLayerPush = window.dataLayer.push;
+
+    window.dataLayer.push = (...args) => {
+      nativeGtmDataLayerPush.apply(window.dataLayer, args);
+
+      this.log('google', args[0]);
+    };
   }
 }
 

--- a/resources/assets/services/Debug.js
+++ b/resources/assets/services/Debug.js
@@ -14,6 +14,8 @@ class Debug {
     window.DS = window.DS || {};
     window.DS.Debug = this;
 
+    console.log('🤪', document.readyState);
+
     // @TODO: call this once once document is ready?
     this.logExistingDataLayerEvents();
   }
@@ -79,7 +81,7 @@ class Debug {
         return;
       }
 
-      this.log('google', [window.dataLayer[item]]);
+      this.log('google', window.dataLayer[item]);
     });
   }
 

--- a/resources/assets/services/Debug.js
+++ b/resources/assets/services/Debug.js
@@ -94,12 +94,11 @@ class Debug {
 
     localStorage.setItem(STORAGE_TOGGLE_KEY, updatedValue);
 
-    !updatedValue
-      ? localStorage.setItem(STORAGE_LOGGERS_KEY, JSON.stringify([]))
-      : localStorage.setItem(
-          STORAGE_LOGGERS_KEY,
-          JSON.stringify(specifiedLogs),
-        );
+    // If toggling logs off, then set item to empty array, otherwise the array of logs specified.
+    localStorage.setItem(
+      STORAGE_LOGGERS_KEY,
+      JSON.stringify(!updatedValue ? [] : specifiedLogs),
+    );
 
     this.showLogs = Boolean(updatedValue);
     this.enabledLoggers = Debug.getEnabledLoggers();

--- a/resources/assets/services/Debug.js
+++ b/resources/assets/services/Debug.js
@@ -107,7 +107,7 @@ class Debug {
    */
   enableLogs(specifiedLogs) {
     if (!Array.isArray(specifiedLogs)) {
-      return console.error(
+      return console.warn(
         '💁‍♀️ To enable showing logs, please provide an array of string names of the logs to show.',
       );
     }
@@ -123,7 +123,7 @@ class Debug {
       Debug.getMessageStyles(),
     );
 
-    console.log(`%c✅ Showing logs for ${logs}.`, Debug.getMessageStyles());
+    console.log(`%c🔍 Showing logs for ${logs}.`, Debug.getMessageStyles());
   }
 
   /**

--- a/resources/assets/services/Debug.js
+++ b/resources/assets/services/Debug.js
@@ -71,7 +71,7 @@ class Debug {
       return;
     }
 
-    const events = Object.STORAGE_TOGGLE_KEYs(window.dataLayer);
+    const events = Object.keys(window.dataLayer);
 
     events.forEach(item => {
       if (typeof window.dataLayer[item] === 'function') {

--- a/resources/assets/services/Debug.js
+++ b/resources/assets/services/Debug.js
@@ -2,35 +2,52 @@
 
 import { googleLog, snowplowLog } from '../helpers/loggers';
 
-const STORAGE_TOGGLE_KEY = 'DS_SHOW_LOGS';
 const STORAGE_LOGGERS_KEY = 'DS_ENABLED_LOGGERS';
 
 class Debug {
   constructor() {
-    this.showLogs = Boolean(Debug.getToggleValue());
-
     this.enabledLoggers = Debug.getEnabledLoggers();
 
     window.DS = window.DS || {};
     window.DS.Debug = this;
 
-    console.log('🤪', document.readyState);
-
     // @TODO: call this once once document is ready?
-    this.logExistingDataLayerEvents();
+    // this.logExistingDataLayerEvents();
   }
 
+  /**
+   * Get list of enabled loggers from local storage.
+   *
+   * @return {Array}
+   */
   static getEnabledLoggers() {
     return JSON.parse(localStorage.getItem(STORAGE_LOGGERS_KEY)) || [];
   }
 
   /**
-   * Get the toggle logs boolean value from local storage.
+   * Get styles for console log message.
    *
-   * @return {Number}
+   * @return {String}
    */
-  static getToggleValue() {
-    return Number(localStorage.getItem(STORAGE_TOGGLE_KEY));
+  static getMessageStyles() {
+    return `
+    background-color: #141493;
+    color: #fafafa;
+    display: block;
+    font-size: 14px;
+    line-height: 1.5;
+    padding: 20px 30px;
+  `;
+  }
+
+  /**
+   * Set list of enalbed loggers into local storage.
+   *
+   * @param  {Array} specifiedLogs
+   * @return {undefined}
+   */
+  static setEnabledLoggers(specifiedLogs) {
+    localStorage.setItem(STORAGE_LOGGERS_KEY, JSON.stringify(specifiedLogs));
   }
 
   /**
@@ -39,13 +56,9 @@ class Debug {
    *
    * @param  {String} type
    * @param  {Array|Object} data
-   * @return {void}
+   * @return {undefined}
    */
   log(type, data) {
-    if (!this.showLogs) {
-      return;
-    }
-
     if (!this.enabledLoggers.includes(type)) {
       return;
     }
@@ -67,10 +80,10 @@ class Debug {
   /**
    * Log any initial events already in the GTM dataLayer array.
    *
-   * @return {void}
+   * @return {undefined}
    */
   logExistingDataLayerEvents() {
-    if (!Debug.getToggleValue()) {
+    if (!this.enabledLoggers.includes('google')) {
       return;
     }
 
@@ -86,37 +99,47 @@ class Debug {
   }
 
   /**
-   * Toggle whether to show or hide the DoSomething Debug logs in the console.
+   * Enable showing the specified logs.
    *
-   * @return {void}
+   * @param  {Array} specifiedLogs
+   * @return {undefined}
    */
-  toggleLogs(specifiedLogs = []) {
-    const currentValue = Debug.getToggleValue();
+  enableLogs(specifiedLogs) {
+    if (!Array.isArray(specifiedLogs)) {
+      return console.error(
+        'To enable showing logs, please provide an array of string names of the logs to show.',
+      );
+    }
 
-    const updatedValue = Number(!currentValue);
+    Debug.setEnabledLoggers(specifiedLogs);
 
-    localStorage.setItem(STORAGE_TOGGLE_KEY, updatedValue);
-
-    // If toggling logs off, then set item to empty array, otherwise the array of logs specified.
-    localStorage.setItem(
-      STORAGE_LOGGERS_KEY,
-      JSON.stringify(!updatedValue ? [] : specifiedLogs),
-    );
-
-    this.showLogs = Boolean(updatedValue);
     this.enabledLoggers = Debug.getEnabledLoggers();
 
-    const messageStyles = `
-          background-color: #141493;
-          color: #fafafa;
-          display: block;
-          font-size: 14px;
-          padding: 20px 30px;
-        `;
+    const logs = specifiedLogs.join(', ');
+
+    console.log(
+      `%c📝 DoSomething logs have been turned ON.`,
+      Debug.getMessageStyles(),
+    );
+
+    console.log(`%c✅ Showing logs for ${logs}.`, Debug.getMessageStyles());
+
+    return;
+  }
+
+  /**
+   * Disable showing any logs.
+   *
+   * @return {undefined}
+   */
+  disableLogs() {
+    Debug.setEnabledLoggers([]);
+
+    this.enabledLoggers = Debug.getEnabledLoggers();
 
     return console.log(
-      `%c📝 DoSomething logs have been turned ${updatedValue ? 'ON' : 'OFF'}.`,
-      messageStyles,
+      '%c📝 DoSomething logs have been turned OFF.',
+      Debug.getMessageStyles(),
     );
   }
 }

--- a/resources/assets/services/Debug.js
+++ b/resources/assets/services/Debug.js
@@ -107,9 +107,11 @@ class Debug {
    */
   enableLogs(specifiedLogs) {
     if (!Array.isArray(specifiedLogs)) {
-      return console.warn(
+      console.warn(
         '💁‍♀️ To enable showing logs, please provide an array of string names of the logs to show.',
       );
+
+      return;
     }
 
     Debug.setEnabledLoggers(specifiedLogs);


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR updates the `Debug` class to work a little better and not have issues with `window.snowplow()`. It takes a different approach specifically for Snowplow and instead of overriding the existing service function, `window.snowplow()`, it just wraps calls to this function within an `analyze()` helper.

While this should catch the majority of triggered Snowplow analytics events within Phoenix, it won't catch events where the script third-party Snowplow script makes calls to `window.snowplow()` on its own, since they won' be wrapped in the `analyze()` helper. It was a caveat that was hard to avoid given that the `window.snowplow()` would break if we tried to override it 😢, but for the most part, Phoenix directly triggers the majority of Snowplow events, so this tool is still useful in understanding whether they're firing as expected.

While reworking, it provided an opportunity to tackle an approach to also specifying _which_ logs to actually show!  I've removed the `toggleLogs()` method in favor of two distinct methods that are clearer (and easier to control), called `enableLogs()` and `disableLogs()`. The `enabledLogs()` method requires an array with the specified logs you want to display in the console. This will help reduce the noise in the console when wanting to only show a particular set of event logs that the developer cares about in the moment.

```js
window.DS.Debug.enableLogs(['google', 'snowplow']);
```

![image](https://user-images.githubusercontent.com/105849/62634017-2945ee00-b903-11e9-9051-fa634252e847.png)


### Any background context you want to provide?

🌵 

### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.
* [ ] Added screenshot to PR description of related front-end updates on **small** screens.
* [ ] Added screenshot to PR description of related front-end updates on **medium** screens.
* [ ] Added screenshot to PR description of related front-end updates on **large** screens.
