### PR TITLE
Remove legacy Referrals code: Part 3

### DIFF
--- a/database/migrations/2019_08_06_000000_drop_referrals_table.php
+++ b/database/migrations/2019_08_06_000000_drop_referrals_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class DropReferralsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::dropIfExists('referrals');
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::create('referrals', function (Blueprint $table) {
+            $table->increments('id');
+            $table->timestamps();
+            $table->string('friend_name');
+            $table->string('friend_email');
+            $table->text('friend_story');
+            $table->string('referrer_northstar_id');
+        });
+    }
+}


### PR DESCRIPTION
### What does this PR do?

This PR drops the `migrations` SQL table, which is no longer used per Part 1 (#1528). This should conclude the "Remove legacy Referrals code" series (refs Part 2 #1531)

I ran `php artisan migrate` locally to verify the `referrals` table was dropped.

### Any background context you want to provide?

This table was used to upload CSV's into Customer.io, and send an email to the referred user (see [Product Brief](https://docs.google.com/document/d/1T0X1qltOwmG0gpRUPUNffOHFqZaRwOt1YIAT5GyyS_c/edit#heading=h.f68k8ccmho5). I imagine we don't need to worry about salvaging this data, as all relevant records would have been ingested by Customer.io at this point cc @mjain-1

### What are the relevant tickets/cards?

Fixes https://www.pivotaltracker.com/story/show/167655423
