### PR TITLE
Badges in the modal after action submission

### DIFF
--- a/resources/assets/components/actions/PetitionSubmissioncAction/PetitionSubmissionAction.js
+++ b/resources/assets/components/actions/PetitionSubmissioncAction/PetitionSubmissionAction.js
@@ -3,7 +3,7 @@ import gql from 'graphql-tag';
 import { get, has } from 'lodash';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
-import { Query } from 'react-apollo';
+import { Query as ApolloQuery } from 'react-apollo';
 import { PuckWaypoint } from '@dosomething/puck-client';
 
 import Card from '../../utilities/Card/Card';
@@ -14,6 +14,8 @@ import TextContent from '../../utilities/TextContent/TextContent';
 import { formatPostPayload, getFieldErrors } from '../../../helpers/forms';
 import CharacterLimit from '../../utilities/CharacterLimit/CharacterLimit';
 import PrivacyLanguage from '../../utilities/PrivacyLanguage/PrivacyLanguage';
+import Badge from '../../pages/AccountPage/Badge';
+import Query from '../../Query';
 
 import './petition-submission-action.scss';
 
@@ -42,6 +44,20 @@ export const USER_POSTS_QUERY = gql`
 `;
 
 const CHARACTER_LIMIT = 500;
+
+const BADGE_QUERY = gql`
+  query AccountQuery($userId: String!) {
+    user(id: $userId) {
+      hasBadgesFlag: hasFeatureFlag(feature: "badges")
+    }
+  }
+`;
+
+const POST_COUNT_BADGE = gql`
+  query PostsCountQuery($userId: String!) {
+    postsCount(userId: $userId, limit: 4)
+  }
+`;
 
 class PetitionSubmissionAction extends React.Component {
   constructor(props) {
@@ -130,7 +146,7 @@ class PetitionSubmissionAction extends React.Component {
             name="petition_submission_action-top"
             waypointData={{ blockId: id }}
           />
-          <Query
+          <ApolloQuery
             query={USER_POSTS_QUERY}
             variables={{ userId, actionIds: [actionId] }}
             queryName="userPosts"
@@ -205,7 +221,7 @@ class PetitionSubmissionAction extends React.Component {
                 </Card>
               );
             }}
-          </Query>
+          </ApolloQuery>
           <PuckWaypoint
             name="petition_submission_action-bottom"
             waypointData={{ blockId: id }}
@@ -230,6 +246,85 @@ class PetitionSubmissionAction extends React.Component {
         {this.state.showModal ? (
           <Modal onClose={() => this.setState({ showModal: false })}>
             <Card className="bordered rounded" title="We got your signature!">
+              <Query
+                query={BADGE_QUERY}
+                variables={{ userId: this.props.userId }}
+                hideSpinner
+              >
+                {badgeData =>
+                  badgeData.user.hasBadgesFlag ? (
+                    <Query
+                      query={POST_COUNT_BADGE}
+                      variables={{ userId: this.props.userId }}
+                      hideSpinner
+                    >
+                      {postData => {
+                        if (postData.postsCount === 1) {
+                          return (
+                            <Badge
+                              earned
+                              className="badge padded"
+                              size="medium"
+                              name="onePostBadge"
+                            >
+                              <h4>1 Action</h4>
+                              <p>
+                                Ohhh HECK yes! You just earned a new badge for
+                                completing your first campaign. Congratulations!
+                              </p>
+                              <a href="/us/account/profile/badges">
+                                View all my badges
+                              </a>
+                            </Badge>
+                          );
+                        }
+                        if (postData.postsCount === 2) {
+                          return (
+                            <Badge
+                              earned
+                              className="badge padded"
+                              size="medium"
+                              name="twoPostsBadge"
+                            >
+                              <h4>2 Actions</h4>
+                              <p>
+                                Ohhh HECK yes! You just earned a new badge for
+                                completing your second campaign.
+                                Congratulations!
+                              </p>
+                              <a href="/us/account/profile/badges">
+                                View all my badges
+                              </a>
+                            </Badge>
+                          );
+                        }
+                        if (postData.postsCount === 3) {
+                          return (
+                            <Badge
+                              earned
+                              className="badge padded"
+                              size="medium"
+                              name="threePostsBadge"
+                            >
+                              <h4>3 Actions</h4>
+                              <p>
+                                Ohhh HECK yes! You just earned a new badge for
+                                completing your third campaign. Congratulations!
+                              </p>
+                              <a href="/us/account/profile/badges">
+                                View all my badges
+                              </a>
+                            </Badge>
+                          );
+                        }
+
+                        return null;
+                      }}
+                    </Query>
+                  ) : null
+                }
+              </Query>
+
               <TextContent className="padded">
                 {this.props.affirmationContent}
               </TextContent>

--- a/resources/assets/components/actions/PhotoSubmissionAction/PhotoSubmissionAction.js
+++ b/resources/assets/components/actions/PhotoSubmissionAction/PhotoSubmissionAction.js
@@ -21,6 +21,8 @@ import {
   getFieldErrors,
   formatPostPayload,
 } from '../../../helpers/forms';
+import Badge from '../../pages/AccountPage/Badge';
+import Query from '../../Query';
 
 import './photo-submission-action.scss';
 
@@ -40,6 +42,20 @@ export const PhotoSubmissionBlockFragment = gql`
     informationContent
     affirmationContent
     additionalContent
+  }
+`;
+
+const BADGE_QUERY = gql`
+  query AccountQuery($userId: String!) {
+    user(id: $userId) {
+      hasBadgesFlag: hasFeatureFlag(feature: "badges")
+    }
+  }
+`;
+
+const POST_COUNT_BADGE = gql`
+  query PostsCountQuery($userId: String!) {
+    postsCount(userId: $userId, limit: 3)
   }
 `;
 
@@ -418,6 +434,85 @@ class PhotoSubmissionAction extends React.Component {
         {this.state.showModal ? (
           <Modal onClose={() => this.setState({ showModal: false })}>
             <Card className="bordered rounded" title="We got your photo!">
+              <Query
+                query={BADGE_QUERY}
+                variables={{ userId: this.props.userId }}
+                hideSpinner
+              >
+                {badgeData =>
+                  badgeData.user.hasBadgesFlag ? (
+                    <Query
+                      query={POST_COUNT_BADGE}
+                      variables={{ userId: this.props.userId }}
+                      hideSpinner
+                    >
+                      {postData => {
+                        if (postData.postsCount === 1) {
+                          return (
+                            <Badge
+                              earned
+                              className="badge padded"
+                              size="medium"
+                              name="onePostBadge"
+                            >
+                              <h4>1 Action</h4>
+                              <p>
+                                Ohhh HECK yes! You just earned a new badge for
+                                completing your first campaign. Congratulations!
+                              </p>
+                              <a href="/us/account/profile/badges">
+                                View all my badges
+                              </a>
+                            </Badge>
+                          );
+                        }
+                        if (postData.postsCount === 2) {
+                          return (
+                            <Badge
+                              earned
+                              className="badge padded"
+                              size="medium"
+                              name="twoPostsBadge"
+                            >
+                              <h4>2 Actions</h4>
+                              <p>
+                                Ohhh HECK yes! You just earned a new badge for
+                                completing your second campaign.
+                                Congratulations!
+                              </p>
+                              <a href="/us/account/profile/badges">
+                                View all my badges
+                              </a>
+                            </Badge>
+                          );
+                        }
+                        if (postData.postsCount === 3) {
+                          return (
+                            <Badge
+                              earned
+                              className="badge padded"
+                              size="medium"
+                              name="threePostsBadge"
+                            >
+                              <h4>3 Actions</h4>
+                              <p>
+                                Ohhh HECK yes! You just earned a new badge for
+                                completing your third campaign. Congratulations!
+                              </p>
+                              <a href="/us/account/profile/badges">
+                                View all my badges
+                              </a>
+                            </Badge>
+                          );
+                        }
+
+                        return null;
+                      }}
+                    </Query>
+                  ) : null
+                }
+              </Query>
+
               <TextContent className="padded">
                 {this.props.affirmationContent ||
                   PhotoSubmissionAction.defaultProps.affirmationContent}

--- a/resources/assets/components/actions/PhotoSubmissionAction/PhotoSubmissionAction.js
+++ b/resources/assets/components/actions/PhotoSubmissionAction/PhotoSubmissionAction.js
@@ -55,7 +55,7 @@ const BADGE_QUERY = gql`
 
 const POST_COUNT_BADGE = gql`
   query PostsCountQuery($userId: String!) {
-    postsCount(userId: $userId, limit: 3)
+    postsCount(userId: $userId, limit: 4)
   }
 `;
 

--- a/resources/assets/components/actions/ShareAction/ShareAction.js
+++ b/resources/assets/components/actions/ShareAction/ShareAction.js
@@ -249,7 +249,7 @@ class ShareAction extends React.Component {
                               </Badge>
                             );
                           }
-                          if (postData.postsCount > 0) {
+                          if (postData.postsCount === 2) {
                             return (
                               <Badge
                                 earned

--- a/resources/assets/components/actions/ShareAction/ShareAction.js
+++ b/resources/assets/components/actions/ShareAction/ShareAction.js
@@ -20,6 +20,8 @@ import {
   showTwitterSharePrompt,
   withoutNulls,
 } from '../../../helpers';
+import Badge from '../../pages/AccountPage/Badge';
+import Query from '../../Query';
 
 export const ShareBlockFragment = gql`
   fragment ShareBlockFragment on ShareBlock {
@@ -34,6 +36,20 @@ export const ShareBlockFragment = gql`
     }
     affirmation
     additionalContent
+  }
+`;
+
+const BADGE_QUERY = gql`
+  query AccountQuery($userId: String!) {
+    user(id: $userId) {
+      hasBadgesFlag: hasFeatureFlag(feature: "badges")
+    }
+  }
+`;
+
+const POST_COUNT_BADGE = gql`
+  query PostsCountQuery($userId: String!) {
+    postsCount(userId: $userId, limit: 4)
   }
 `;
 
@@ -200,6 +216,87 @@ class ShareAction extends React.Component {
                 title="Thanks for sharing!"
                 className="modal__slide bordered rounded"
               >
+                <Query
+                  query={BADGE_QUERY}
+                  variables={{ userId: this.props.userId }}
+                  hideSpinner
+                >
+                  {badgeData =>
+                    badgeData.user.hasBadgesFlag ? (
+                      <Query
+                        query={POST_COUNT_BADGE}
+                        variables={{ userId: this.props.userId }}
+                        hideSpinner
+                      >
+                        {postData => {
+                          if (postData.postsCount === 1) {
+                            return (
+                              <Badge
+                                earned
+                                className="badge padded"
+                                size="medium"
+                                name="onePostBadge"
+                              >
+                                <h4>1 Action</h4>
+                                <p>
+                                  Ohhh HECK yes! You just earned a new badge for
+                                  completing your first campaign.
+                                  Congratulations!
+                                </p>
+                                <a href="/us/account/profile/badges">
+                                  View all my badges
+                                </a>
+                              </Badge>
+                            );
+                          }
+                          if (postData.postsCount > 0) {
+                            return (
+                              <Badge
+                                earned
+                                className="badge padded"
+                                size="medium"
+                                name="twoPostsBadge"
+                              >
+                                <h4>2 Actions</h4>
+                                <p>
+                                  Ohhh HECK yes! You just earned a new badge for
+                                  completing your second campaign.
+                                  Congratulations!
+                                </p>
+                                <a href="/us/account/profile/badges">
+                                  View all my badges
+                                </a>
+                              </Badge>
+                            );
+                          }
+                          if (postData.postsCount === 3) {
+                            return (
+                              <Badge
+                                earned
+                                className="badge padded"
+                                size="medium"
+                                name="threePostsBadge"
+                              >
+                                <h4>3 Actions</h4>
+                                <p>
+                                  Ohhh HECK yes! You just earned a new badge for
+                                  completing your third campaign.
+                                  Congratulations!
+                                </p>
+                                <a href="/us/account/profile/badges">
+                                  View all my badges
+                                </a>
+                              </Badge>
+                            );
+                          }
+
+                          return null;
+                        }}
+                      </Query>
+                    ) : null
+                  }
+                </Query>
+
                 <TextContent className="padded">{affirmation}</TextContent>
               </Card>
             )}

--- a/resources/assets/components/actions/TextSubmissionAction/TextSubmissionAction.js
+++ b/resources/assets/components/actions/TextSubmissionAction/TextSubmissionAction.js
@@ -15,10 +15,26 @@ import TextContent from '../../utilities/TextContent/TextContent';
 import { getFieldErrors, formatPostPayload } from '../../../helpers/forms';
 import CharacterLimit from '../../utilities/CharacterLimit/CharacterLimit';
 import PrivacyLanguage from '../../utilities/PrivacyLanguage/PrivacyLanguage';
+import Badge from '../../pages/AccountPage/Badge';
+import Query from '../../Query';
 
 import './text-submission-action.scss';
 
 const CHARACTER_LIMIT = 500;
+
+const BADGE_QUERY = gql`
+  query AccountQuery($userId: String!) {
+    user(id: $userId) {
+      hasBadgesFlag: hasFeatureFlag(feature: "badges")
+    }
+  }
+`;
+
+const POST_COUNT_BADGE = gql`
+  query PostsCountQuery($userId: String!) {
+    postsCount(userId: $userId, limit: 4)
+  }
+`;
 
 export const TextSubmissionBlockFragment = gql`
   fragment TextSubmissionBlockFragment on TextSubmissionBlock {
@@ -225,6 +241,85 @@ class TextSubmissionAction extends React.Component {
             onClose={() => this.setState({ showModal: false })}
           >
             <Card className="bordered rounded" title="We got your message!">
+              <Query
+                query={BADGE_QUERY}
+                variables={{ userId: this.props.userId }}
+                hideSpinner
+              >
+                {badgeData =>
+                  badgeData.user.hasBadgesFlag ? (
+                    <Query
+                      query={POST_COUNT_BADGE}
+                      variables={{ userId: this.props.userId }}
+                      hideSpinner
+                    >
+                      {postData => {
+                        if (postData.postsCount === 1) {
+                          return (
+                            <Badge
+                              earned
+                              className="badge padded"
+                              size="medium"
+                              name="onePostBadge"
+                            >
+                              <h4>1 Action</h4>
+                              <p>
+                                Ohhh HECK yes! You just earned a new badge for
+                                completing your first campaign. Congratulations!
+                              </p>
+                              <a href="/us/account/profile/badges">
+                                View all my badges
+                              </a>
+                            </Badge>
+                          );
+                        }
+                        if (postData.postsCount === 2) {
+                          return (
+                            <Badge
+                              earned
+                              className="badge padded"
+                              size="medium"
+                              name="twoPostsBadge"
+                            >
+                              <h4>2 Actions</h4>
+                              <p>
+                                Ohhh HECK yes! You just earned a new badge for
+                                completing your second campaign.
+                                Congratulations!
+                              </p>
+                              <a href="/us/account/profile/badges">
+                                View all my badges
+                              </a>
+                            </Badge>
+                          );
+                        }
+                        if (postData.postsCount === 3) {
+                          return (
+                            <Badge
+                              earned
+                              className="badge padded"
+                              size="medium"
+                              name="threePostsBadge"
+                            >
+                              <h4>3 Actions</h4>
+                              <p>
+                                Ohhh HECK yes! You just earned a new badge for
+                                completing your third campaign. Congratulations!
+                              </p>
+                              <a href="/us/account/profile/badges">
+                                View all my badges
+                              </a>
+                            </Badge>
+                          );
+                        }
+
+                        return null;
+                      }}
+                    </Query>
+                  ) : null
+                }
+              </Query>
+
               <TextContent className="padded">
                 {this.props.affirmationContent ||
                   TextSubmissionAction.defaultProps.affirmationContent}
@@ -260,6 +355,7 @@ TextSubmissionAction.propTypes = {
   textFieldLabel: PropTypes.string,
   textFieldPlaceholder: PropTypes.string,
   title: PropTypes.string,
+  userId: PropTypes.string.isRequired,
 };
 
 TextSubmissionAction.defaultProps = {

--- a/resources/assets/components/actions/TextSubmissionAction/TextSubmissionActionContainer.js
+++ b/resources/assets/components/actions/TextSubmissionAction/TextSubmissionActionContainer.js
@@ -6,6 +6,7 @@ import {
   storeCampaignPost,
   storePost,
 } from '../../../actions/post';
+import { getUserId } from '../../../selectors/user';
 
 /**
  * Provide state from the Redux store as props for this component.
@@ -14,6 +15,7 @@ const mapStateToProps = state => ({
   pageId: state.campaign.id || state.page.id,
   campaignId: state.campaign.campaignId,
   submissions: state.postSubmissions,
+  userId: getUserId(state),
 });
 
 /**


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR adds action badges to the modal that comes up after a user completes an action. Whenever a user completes a share, photo, petition, or text action, if it was their 1st, 2nd, or 3rd action, the corresponding badge shows up in the modal that comes up after the action (only if the user is in the badge test group). In the modal is also a link to the badge area of the user profile.

I started extracting all the repeated badge code into a separate component, but ultimately I think it doesn't make sense to have a component that renders an action badge if a user has just earned one. Also, the way things stand now we can adjust copy across the 4 different actions if we end up needing to do that.

### Screenshots
Small
<img width="384" alt="badge_modal_small" src="https://user-images.githubusercontent.com/4240292/62742866-1ad7ff00-b9f5-11e9-8948-0b6ed1f1ba18.png">

Medium
![image](https://user-images.githubusercontent.com/4240292/62742871-21ff0d00-b9f5-11e9-9178-193d91b2943b.png)

Large
![image](https://user-images.githubusercontent.com/4240292/62742891-33e0b000-b9f5-11e9-8f31-334dbed2ca1b.png)



### Any background context you want to provide?

Wireframes are linked in the card.

### What are the relevant tickets/cards?

Refs [Pivotal ID #165721183](https://www.pivotaltracker.com/story/show/165721183)

### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.
* [ ] Added screenshot to PR description of related front-end updates on **small** screens.
* [ ] Added screenshot to PR description of related front-end updates on **medium** screens.
* [ ] Added screenshot to PR description of related front-end updates on **large** screens.
