### PR TITLE
Use Embed in Referral Page beta template

### DIFF
--- a/app/helpers.php
+++ b/app/helpers.php
@@ -400,7 +400,7 @@ function get_metadata($entry)
     return [
         'title' => data_get($entry, 'metadata.fields.title', $entry->title),
         'type' => 'article',
-        'description' => data_get($entry, 'metadata.fields.description', $entry->callToAction ? str_limit($entry->callToAction, 150) : null),
+        'description' => data_get($entry, 'metadata.fields.description', isset($entry->callToAction) ? str_limit($entry->callToAction, 150) : null),
         'url' => $entryType === 'campaign' ? $baseUrl.'/campaigns/'.$entry->slug : $baseUrl.'/'.$entry->slug,
         'facebook_app_id' => config('services.analytics.facebook_id'),
         'image' => [

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -400,7 +400,7 @@ function get_metadata($entry)
     return [
         'title' => data_get($entry, 'metadata.fields.title', $entry->title),
         'type' => 'article',
-        'description' => data_get($entry, 'metadata.fields.description', str_limit($entry->callToAction, 150)),
+        'description' => data_get($entry, 'metadata.fields.description', $entry->callToAction ? str_limit($entry->callToAction, 150) : null),
         'url' => $entryType === 'campaign' ? $baseUrl.'/campaigns/'.$entry->slug : $baseUrl.'/'.$entry->slug,
         'facebook_app_id' => config('services.analytics.facebook_id'),
         'image' => [

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -400,7 +400,7 @@ function get_metadata($entry)
     return [
         'title' => data_get($entry, 'metadata.fields.title', $entry->title),
         'type' => 'article',
-        'description' => data_get($entry, 'metadata.fields.description', null),
+        'description' => data_get($entry, 'metadata.fields.description', str_limit($entry->callToAction, 150)),
         'url' => $entryType === 'campaign' ? $baseUrl.'/campaigns/'.$entry->slug : $baseUrl.'/'.$entry->slug,
         'facebook_app_id' => config('services.analytics.facebook_id'),
         'image' => [

--- a/resources/assets/components/pages/ReferralPage/ReferralPage.js
+++ b/resources/assets/components/pages/ReferralPage/ReferralPage.js
@@ -55,6 +55,7 @@ const ReferralPage = props => {
                   />
                 ) : (
                   <BetaTemplate
+                    blockClassName={blockClassName}
                     firstName={firstName}
                     primaryCampaignId={campaignId}
                     userId={userId}

--- a/resources/assets/components/pages/ReferralPage/ReferralPage.js
+++ b/resources/assets/components/pages/ReferralPage/ReferralPage.js
@@ -31,7 +31,8 @@ const ReferralPage = props => {
         if (!data.user) {
           return <ErrorBlock />;
         }
-
+        const blockClassName =
+          'general-page__block margin-vertical margin-horizontal-md';
         const firstName = data.user.firstName;
 
         return (
@@ -47,6 +48,7 @@ const ReferralPage = props => {
                 </div>
                 {isAlphaTemplate ? (
                   <AlphaTemplate
+                    blockClassName={blockClassName}
                     firstName={firstName}
                     primaryCampaignId={campaignId}
                     userId={userId}

--- a/resources/assets/components/pages/ReferralPage/ReferralPage.js
+++ b/resources/assets/components/pages/ReferralPage/ReferralPage.js
@@ -31,8 +31,7 @@ const ReferralPage = props => {
         if (!data.user) {
           return <ErrorBlock />;
         }
-        const blockClassName =
-          'general-page__block margin-vertical margin-horizontal-md';
+
         const firstName = data.user.firstName;
 
         return (
@@ -46,21 +45,21 @@ const ReferralPage = props => {
                       : `Hi, ${firstName}’s friend!`}
                   </h1>
                 </div>
-                {isAlphaTemplate ? (
-                  <AlphaTemplate
-                    blockClassName={blockClassName}
-                    firstName={firstName}
-                    primaryCampaignId={campaignId}
-                    userId={userId}
-                  />
-                ) : (
-                  <BetaTemplate
-                    blockClassName={blockClassName}
-                    firstName={firstName}
-                    primaryCampaignId={campaignId}
-                    userId={userId}
-                  />
-                )}
+                <div className="margin-horizontal-md">
+                  {isAlphaTemplate ? (
+                    <AlphaTemplate
+                      firstName={firstName}
+                      primaryCampaignId={campaignId}
+                      userId={userId}
+                    />
+                  ) : (
+                    <BetaTemplate
+                      firstName={firstName}
+                      primaryCampaignId={campaignId}
+                      userId={userId}
+                    />
+                  )}
+                </div>
               </div>
             </div>
           </div>

--- a/resources/assets/components/pages/ReferralPage/ReferralPageCampaignLink.js
+++ b/resources/assets/components/pages/ReferralPage/ReferralPageCampaignLink.js
@@ -3,17 +3,14 @@ import PropTypes from 'prop-types';
 import gql from 'graphql-tag';
 
 import Query from '../../Query';
+import Embed from '../../utilities/Embed/Embed';
+import { PHOENIX_URL } from '../../../constants';
 import ErrorBlock from '../../ErrorBlock/ErrorBlock';
 
 const REFERRAL_PAGE_CAMPAIGN = gql`
   query ReferralPageCampaignQuery($campaignId: String!) {
     campaignWebsiteByCampaignId(campaignId: $campaignId) {
-      title
       slug
-      callToAction
-      coverImage {
-        url(w: 150)
-      }
     }
   }
 `;
@@ -28,21 +25,12 @@ const ReferralPageCampaignLink = props => (
       if (!data) {
         return <ErrorBlock />;
       }
-      const url = `/us/campaigns/${data.slug}?referrer_user_id=${props.userId}`;
 
       return (
-        <article className="figure -left -center">
-          <div className="figure__media">
-            <img alt={data.title} src={data.coverImage.url} />
-          </div>
-          <div className="figure__body">
-            <h2>
-              <a href={url}>{data.title}</a>
-            </h2>
-            <p>{data.callToAction}</p>
-            <p>DOSOMETHING.ORG</p>
-          </div>
-        </article>
+        <Embed
+          url={`${PHOENIX_URL}/us/campaigns/${data.slug}?referrer_user_id=${props.userId}`}
+          badged
+        />
       );
     }}
   </Query>

--- a/resources/assets/components/pages/ReferralPage/templates/BetaTemplate.js
+++ b/resources/assets/components/pages/ReferralPage/templates/BetaTemplate.js
@@ -4,12 +4,14 @@ import PropTypes from 'prop-types';
 import CampaignLink from '../ReferralPageCampaignLink';
 
 // @TODO: Allow override via config variables.
-const SECONDARY_CAMPAIGN_ID = 7951;
+const SECONDARY_CAMPAIGN_ID = '7951';
 const SECONDARY_CAMPAIGN_PROMPT =
   'In less than 5 minutes, you can join 193,242 young people putting an end to gun violence.';
 
 const BetaTemplate = props => {
   const { firstName, primaryCampaignId, userId } = props;
+  const displayPrimaryCampaign =
+    primaryCampaignId && primaryCampaignId !== SECONDARY_CAMPAIGN_ID;
 
   return (
     <React.Fragment>
@@ -18,7 +20,7 @@ const BetaTemplate = props => {
         you and {props.firstName} complete the campaign, you’ll both earn a $5
         gift card!
       </p>
-      {props.primaryCampaignId ? (
+      {displayPrimaryCampaign ? (
         <div>
           <CampaignLink campaignId={primaryCampaignId} userId={userId} />
           <p>
@@ -30,7 +32,7 @@ const BetaTemplate = props => {
         </div>
       ) : null}
       <div>
-        <CampaignLink campaignId={`${SECONDARY_CAMPAIGN_ID}`} userId={userId} />
+        <CampaignLink campaignId={SECONDARY_CAMPAIGN_ID} userId={userId} />
       </div>
       <h3>About Us</h3>
       DoSomething is the largest not-for-profit for young people and social

--- a/resources/assets/components/pages/ReferralPage/templates/BetaTemplate.js
+++ b/resources/assets/components/pages/ReferralPage/templates/BetaTemplate.js
@@ -9,13 +9,13 @@ const SECONDARY_CAMPAIGN_PROMPT =
   'In less than 5 minutes, you can join 193,242 young people putting an end to gun violence.';
 
 const BetaTemplate = props => {
-  const { blockClassName, firstName, primaryCampaignId, userId } = props;
+  const { firstName, primaryCampaignId, userId } = props;
   const displayPrimaryCampaign =
     primaryCampaignId && primaryCampaignId !== SECONDARY_CAMPAIGN_ID;
 
   return (
     <React.Fragment>
-      <div className={blockClassName}>
+      <div className="margin-vertical">
         <p>
           {firstName} just signed up for this campaign from DoSomething.org.
           Once you and {props.firstName} complete the campaign, you’ll both earn
@@ -24,10 +24,10 @@ const BetaTemplate = props => {
       </div>
       {displayPrimaryCampaign ? (
         <React.Fragment>
-          <div className={blockClassName}>
+          <div className="margin-vertical">
             <CampaignLink campaignId={primaryCampaignId} userId={userId} />
           </div>
-          <div className={blockClassName}>
+          <div className="margin-vertical">
             <p>
               <strong>
                 Interested in doing a different campaign to get your gift card?
@@ -37,10 +37,10 @@ const BetaTemplate = props => {
           </div>
         </React.Fragment>
       ) : null}
-      <div className={blockClassName}>
+      <div className="margin-vertical">
         <CampaignLink campaignId={SECONDARY_CAMPAIGN_ID} userId={userId} />
       </div>
-      <div className={blockClassName}>
+      <div className="margin-vertical">
         <h3>About Us</h3>
         <p>
           DoSomething is the largest not-for-profit for young people and social
@@ -56,14 +56,12 @@ const BetaTemplate = props => {
 };
 
 BetaTemplate.propTypes = {
-  blockClassName: PropTypes.string,
   firstName: PropTypes.string.isRequired,
   primaryCampaignId: PropTypes.string,
   userId: PropTypes.string.isRequired,
 };
 
 BetaTemplate.defaultProps = {
-  blockClassName: null,
   primaryCampaignId: null,
 };
 

--- a/resources/assets/components/pages/ReferralPage/templates/BetaTemplate.js
+++ b/resources/assets/components/pages/ReferralPage/templates/BetaTemplate.js
@@ -3,31 +3,31 @@ import PropTypes from 'prop-types';
 
 import CampaignLink from '../ReferralPageCampaignLink';
 
-const BLOCK_CLASSNAME =
-  'general-page__block margin-vertical margin-horizontal-md';
 // @TODO: Allow override via config variables.
 const SECONDARY_CAMPAIGN_ID = '7951';
 const SECONDARY_CAMPAIGN_PROMPT =
   'In less than 5 minutes, you can join 193,242 young people putting an end to gun violence.';
 
 const BetaTemplate = props => {
-  const { firstName, primaryCampaignId, userId } = props;
+  const { blockClassName, firstName, primaryCampaignId, userId } = props;
   const displayPrimaryCampaign =
     primaryCampaignId && primaryCampaignId !== SECONDARY_CAMPAIGN_ID;
 
   return (
     <React.Fragment>
-      <p>
-        {firstName} just signed up for this campaign from DoSomething.org. Once
-        you and {props.firstName} complete the campaign, you’ll both earn a $5
-        gift card!
-      </p>
+      <div className={blockClassName}>
+        <p>
+          {firstName} just signed up for this campaign from DoSomething.org.
+          Once you and {props.firstName} complete the campaign, you’ll both earn
+          a $5 gift card!
+        </p>
+      </div>
       {displayPrimaryCampaign ? (
         <React.Fragment>
-          <div className={BLOCK_CLASSNAME}>
+          <div className={blockClassName}>
             <CampaignLink campaignId={primaryCampaignId} userId={userId} />
           </div>
-          <div className={BLOCK_CLASSNAME}>
+          <div className={blockClassName}>
             <p>
               <strong>
                 Interested in doing a different campaign to get your gift card?
@@ -37,10 +37,10 @@ const BetaTemplate = props => {
           </div>
         </React.Fragment>
       ) : null}
-      <div className={BLOCK_CLASSNAME}>
+      <div className={blockClassName}>
         <CampaignLink campaignId={SECONDARY_CAMPAIGN_ID} userId={userId} />
       </div>
-      <div className={BLOCK_CLASSNAME}>
+      <div className={blockClassName}>
         <h3>About Us</h3>
         <p>
           DoSomething is the largest not-for-profit for young people and social
@@ -56,12 +56,14 @@ const BetaTemplate = props => {
 };
 
 BetaTemplate.propTypes = {
+  blockClassName: PropTypes.string,
   firstName: PropTypes.string.isRequired,
   primaryCampaignId: PropTypes.string,
   userId: PropTypes.string.isRequired,
 };
 
 BetaTemplate.defaultProps = {
+  blockClassName: null,
   primaryCampaignId: null,
 };
 

--- a/resources/assets/components/pages/ReferralPage/templates/BetaTemplate.js
+++ b/resources/assets/components/pages/ReferralPage/templates/BetaTemplate.js
@@ -3,6 +3,8 @@ import PropTypes from 'prop-types';
 
 import CampaignLink from '../ReferralPageCampaignLink';
 
+const BLOCK_CLASSNAME =
+  'general-page__block margin-vertical margin-horizontal-md';
 // @TODO: Allow override via config variables.
 const SECONDARY_CAMPAIGN_ID = '7951';
 const SECONDARY_CAMPAIGN_PROMPT =
@@ -21,25 +23,34 @@ const BetaTemplate = props => {
         gift card!
       </p>
       {displayPrimaryCampaign ? (
-        <div>
-          <CampaignLink campaignId={primaryCampaignId} userId={userId} />
-          <p>
-            <strong>
-              Interested in doing a different campaign to get your gift card?
-            </strong>{' '}
-            {SECONDARY_CAMPAIGN_PROMPT}
-          </p>
-        </div>
+        <React.Fragment>
+          <div className={BLOCK_CLASSNAME}>
+            <CampaignLink campaignId={primaryCampaignId} userId={userId} />
+          </div>
+          <div className={BLOCK_CLASSNAME}>
+            <p>
+              <strong>
+                Interested in doing a different campaign to get your gift card?
+              </strong>{' '}
+              {SECONDARY_CAMPAIGN_PROMPT}
+            </p>
+          </div>
+        </React.Fragment>
       ) : null}
-      <div>
+      <div className={BLOCK_CLASSNAME}>
         <CampaignLink campaignId={SECONDARY_CAMPAIGN_ID} userId={userId} />
       </div>
-      <h3>About Us</h3>
-      DoSomething is the largest not-for-profit for young people and social
-      change. Using our digital platform, millions of young people make
-      real-world impact through our volunteer, social change, and civic action
-      campaigns. We’ve got hundreds of campaigns to choose from (but only the
-      two above are offering the gift card reward right now). Let’s do this!
+      <div className={BLOCK_CLASSNAME}>
+        <h3>About Us</h3>
+        <p>
+          DoSomething is the largest not-for-profit for young people and social
+          change. Using our digital platform, millions of young people make
+          real-world impact through our volunteer, social change, and civic
+          action campaigns. We’ve got hundreds of campaigns to choose from (but
+          only the two above are offering the gift card reward right now). Let’s
+          do this!
+        </p>
+      </div>
     </React.Fragment>
   );
 };


### PR DESCRIPTION
### What does this PR do?

This PR uses the `Embed` component in the ReferralPage beta template to render campaign links per https://github.com/DoSomething/phoenix-next/pull/1521#discussion_r309872224.

It also ensures we don't display duplicate campaign links if the referral page happens to be shared from the secondary campaign, fixing https://www.pivotaltracker.com/story/show/167680643

### Any background context you want to provide?

Holding off on @mendelB's suggestion about adding additional logic into the `Embed` component https://github.com/DoSomething/phoenix-next/pull/1521#discussion_r309872224 for now:

> I guess we'd still need to wrap it in a graphql query for the slug, but once you have the URL, you should be able to simply pass it to an Embed with a badged prop for the link icon, and it'll do the rest of the work!
>
>(Ooh and maybe even just pass the slug over as another param from the referral link to avoid another graphql query altogether?)

We may revisit this if there's time before launch, but I think the 2 extra GraphQL queries we need to get the slug for a campaignId should be fine for our MVP. 

### What are the relevant tickets/cards?

Fixes https://www.pivotaltracker.com/n/projects/2019429
Refs https://www.pivotaltracker.com/story/show/167633963

### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.
* [ ] Added screenshot to PR description of related front-end updates on **small** screens.
* [ ] Added screenshot to PR description of related front-end updates on **medium** screens.
* [ ] Added screenshot to PR description of related front-end updates on **large** screens.
