### PR TITLE
Use SocialActionDrive in Referral Page alpha template

### DIFF
--- a/app/Http/Controllers/Api/LinkController.php
+++ b/app/Http/Controllers/Api/LinkController.php
@@ -35,6 +35,7 @@ class LinkController extends Controller
         // Only allow users to create short-links for
         // whitelisted "safe" sites:
         $whitelist = [
+//            'phoenix.test',
             'www.dosomething.org',
             'vote.dosomething.org',
             'www.dosomething.vote',

--- a/app/Http/Controllers/Api/LinkController.php
+++ b/app/Http/Controllers/Api/LinkController.php
@@ -35,7 +35,6 @@ class LinkController extends Controller
         // Only allow users to create short-links for
         // whitelisted "safe" sites:
         $whitelist = [
-//            'phoenix.test',
             'www.dosomething.org',
             'vote.dosomething.org',
             'www.dosomething.vote',

--- a/resources/assets/components/actions/SocialDriveAction/SocialDriveAction.js
+++ b/resources/assets/components/actions/SocialDriveAction/SocialDriveAction.js
@@ -55,13 +55,24 @@ class SocialDriveAction extends React.Component {
   };
 
   render() {
-    const { link, showPageViews } = this.props;
+    const {
+      link,
+      shareCardDescription,
+      shareCardTitle,
+      showPageViews,
+    } = this.props;
     const shortenedLink = this.state.shortenedLink;
 
     return (
       <div className="clearfix padding-bottom-lg">
         <div className="social-drive-action">
-          <Card title="Your Online Drive" className="rounded bordered">
+          <Card title={shareCardTitle} className="rounded bordered">
+            {shareCardDescription ? (
+              <div className="padded">
+                <p>{shareCardDescription}</p>
+              </div>
+            ) : null}
+
             <div className="padded">
               <Embed url={link} />
             </div>
@@ -134,6 +145,8 @@ SocialDriveAction.propTypes = {
   campaignId: PropTypes.string,
   link: PropTypes.string.isRequired,
   pageId: PropTypes.string,
+  shareCardTitle: PropTypes.string,
+  shareCardDescription: PropTypes.string,
   showPageViews: PropTypes.bool,
   token: PropTypes.string.isRequired,
   userId: PropTypes.string.isRequired,
@@ -141,6 +154,8 @@ SocialDriveAction.propTypes = {
 
 SocialDriveAction.defaultProps = {
   campaignId: null,
+  shareCardDescription: null,
+  shareCardTitle: 'Your Online Drive',
   pageId: null,
   showPageViews: true,
 };

--- a/resources/assets/components/pages/ReferralPage/ReferralPage.js
+++ b/resources/assets/components/pages/ReferralPage/ReferralPage.js
@@ -48,7 +48,6 @@ const ReferralPage = props => {
                 <div className="margin-horizontal-md">
                   {isAlphaTemplate ? (
                     <AlphaTemplate
-                      firstName={firstName}
                       primaryCampaignId={campaignId}
                       userId={userId}
                     />

--- a/resources/assets/components/pages/ReferralPage/templates/AlphaTemplate.js
+++ b/resources/assets/components/pages/ReferralPage/templates/AlphaTemplate.js
@@ -1,22 +1,25 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
+import { PHOENIX_URL } from '../../../../constants';
+import SocialDriveActionContainer from '../../../actions/SocialDriveAction/SocialDriveActionContainer';
+
 const AlphaTemplate = props => {
   const { firstName, primaryCampaignId, userId } = props;
-  // @TODO: This URL should be shortened via Bertly.
-  let url = `/us/join?user_id=${userId}`;
+
+  let url = `${PHOENIX_URL}/us/join?user_id=${userId}`;
   if (primaryCampaignId) {
     url = `${url}&campaign_id=${primaryCampaignId}`;
   }
 
   return (
     <React.Fragment>
-      <h2>Refer A Friend</h2>
-      <p>
-        When you and a friend complete this campaign, you’ll both earn a $5 gift
-        card! The more friends you refer, the more gift cards you earn.
-        (Psst...there’s no limit on how many you can refer!)
-      </p>
+      <SocialDriveActionContainer
+        shareCardDescription="When you and a friend complete this campaign, you’ll both earn a $5 gift card! The more friends you refer, the more gift cards you earn. (Psst...there’s no limit on how many you can refer!)"
+        shareCardTitle="Refer A Friend"
+        link={url}
+        showPageViews={false}
+      />
       <h3>
         <a href={url}>Check Out Your Referral Page</a>
       </h3>

--- a/resources/assets/components/pages/ReferralPage/templates/AlphaTemplate.js
+++ b/resources/assets/components/pages/ReferralPage/templates/AlphaTemplate.js
@@ -5,7 +5,7 @@ import { PHOENIX_URL } from '../../../../constants';
 import SocialDriveActionContainer from '../../../actions/SocialDriveAction/SocialDriveActionContainer';
 
 const AlphaTemplate = props => {
-  const { firstName, primaryCampaignId, userId } = props;
+  const { primaryCampaignId, userId } = props;
 
   let url = `${PHOENIX_URL}/us/join?user_id=${userId}`;
   if (primaryCampaignId) {
@@ -20,19 +20,11 @@ const AlphaTemplate = props => {
         link={url}
         showPageViews={false}
       />
-      <h3>
-        <a href={url}>Check Out Your Referral Page</a>
-      </h3>
-      <p>
-        Welcome to {firstName}’s refer a friend page. Do something, get
-        something...
-      </p>
     </React.Fragment>
   );
 };
 
 AlphaTemplate.propTypes = {
-  firstName: PropTypes.string.isRequired,
   primaryCampaignId: PropTypes.string,
   userId: PropTypes.string.isRequired,
 };

--- a/resources/assets/components/pages/ReferralPage/templates/AlphaTemplate.js
+++ b/resources/assets/components/pages/ReferralPage/templates/AlphaTemplate.js
@@ -6,8 +6,8 @@ import SocialDriveActionContainer from '../../../actions/SocialDriveAction/Socia
 
 const AlphaTemplate = props => {
   const { primaryCampaignId, userId } = props;
-
   let url = `${PHOENIX_URL}/us/join?user_id=${userId}`;
+
   if (primaryCampaignId) {
     url = `${url}&campaign_id=${primaryCampaignId}`;
   }


### PR DESCRIPTION
### What does this PR do?

This PR refactors the alpha template to render a `SocialActionDrive` component with the user's beta template URL, getting it a whole lot closer to the [design](https://projects.invisionapp.com/share/GYSBOGRSDUA#/screens/372969111):

* Adds optional `shareCardTitle` prop to `SocialActionDrive` for overriding the "Your Online Drive" Card header

* Adds optional `shareCardDescription` prop for intro text required by design

### Any background context you want to provide?

This seemed like a good spot to open for review. There are two biggies left, but shouldn't necessarily block merge as this isn't going live for a bit. 

1 - CSS. The `.social-drive-action` has a width set to 66.6666666666666%, so this looks terrible. Ideally we need to override this on the Referral Page to full width

~2 - Per design, the `Embed` should have title "Check Out Your Referral Page" and a custom description. I doubt we'd want the SEO title/description to read as this, so I've asked about this in our [product team Slack](https://dosomething.slack.com/archives/C09ANFQLA/p1565655219094400) to determine next steps on this item. I was thinking initially that we could pass optional `title` and `description` props to the `Embed`, which would entail another two extra additional props on a `SocialDriveActionContainer` in order to pass these along to the `Embed` within (feels kinda yucky and defeating of an `Embed`)~ Non-issue per https://github.com/DoSomething/phoenix-next/pull/1538#issuecomment-521033247

### What are the relevant tickets/cards?

* https://www.pivotaltracker.com/story/show/167602877
* https://www.pivotaltracker.com/story/show/167633963

### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.
* [ ] Added screenshot to PR description of related front-end updates on **small** screens.
* [ ] Added screenshot to PR description of related front-end updates on **medium** screens.
* [ ] Added screenshot to PR description of related front-end updates on **large** screens.
