### PR TITLE
Progress on updating flow to separate login from registration flow.

### DIFF
--- a/app/Http/Controllers/AuthController.php
+++ b/app/Http/Controllers/AuthController.php
@@ -23,6 +23,78 @@ class AuthController extends Controller
     protected $redirectAfterLogout;
 
     /**
+     * Get destination metadata for Northstar login.
+     * Defaults to "title" in $options or null.
+     *
+     * @param  array  $queryParams
+     * @param  array  $options
+     * @return string
+     */
+    protected function getDestination($queryParams, $options = []) {
+        return array_get($queryParams, 'destination', array_get($options, 'title'));
+    }
+
+    /**
+     * Get options containing metadata for Northstar login.
+     *
+     * @param  array $queryParams
+     * @return array
+     */
+    protected function getOptions($queryParams) {
+        $options = array_get($queryParams, 'options', []);
+
+        if (is_string($options)) {
+            $options = (array) json_decode($options);
+        }
+
+        return $options;
+    }
+
+    /**
+     * Get the destination URL to redirect to on a successful login.
+     *
+     * @return string
+     */
+    protected function getUrl() {
+        $url = session('login.intended', $this->redirectTo);
+
+        // If there is an actionId in the session, set it as a query param on to the intended URL.
+        if (session('actionId')) {
+            $actionIdParam = 'actionId='.urlencode(session('actionId'));
+
+            $url .= str_contains($url, '?') ? '&'.$actionIdParam : '?'.$actionIdParam;
+        }
+
+        return $url;
+    }
+
+    /**
+     * Set session data used post-login and once user returns, redirected back to intended page.
+     *
+     * @param array $queryParams
+     */
+    protected function setSessionData($queryParams = []) {
+        if (array_has($queryParams, 'code')) {
+            return;
+        }
+
+        // The default post-login redirect will be to the previous page (if the user clicked
+        // "Log In" in the top navigation), or to the path defined in the $redirectTo property.
+        $defaultIntended = is_same_domain(url()->previous()) ? url()->previous() : $this->redirectTo;
+
+        // The post-login redirect will be to the intended page (if logging in to view a page
+        // protected by the 'auth' middleware), or to the default path determined above.
+        $intended = session()->pull('url.intended', $defaultIntended);
+
+        session(['login.intended' => $intended]);
+
+        // If starting the login process, see if we have a "queued" action.
+        $actionId = array_get($queryParams, 'actionId');
+
+        session()->flash('actionId', $actionId);
+    }
+
+    /**
      * Make a new AuthController, inject dependencies,
      * and set middleware for this controller's methods.
      */
@@ -35,59 +107,23 @@ class AuthController extends Controller
      * Handle a login request to the application.
      *
      * @param ServerRequestInterface $request
-     * @param ResponseInterface $response
+     * @param ResponseInterface      $response
      * @return \Illuminate\Http\RedirectResponse
      */
     public function getLogin(ServerRequestInterface $request, ResponseInterface $response)
     {
         $queryParams = $request->getQueryParams();
 
-        // Save the post-login redirect for when the user completes the flow.
-        if (! array_has($queryParams, 'code')) {
-            // The default post-login redirect will be to the previous page (if the user clicked
-            // "Log In" in the top navigation), or to the path defined in the $redirectTo property.
-            $defaultIntended = is_same_domain(url()->previous()) ? url()->previous() : $this->redirectTo;
+        $this->setSessionData($queryParams);
 
-            // The post-login redirect will be to the intended page (if logging in to view a page
-            // protected by the 'auth' middleware), or to the default path determined above.
-            $intended = session()->pull('url.intended', $defaultIntended);
+        $url = $this->getUrl();
 
-            session(['login.intended' => $intended]);
+        $options = $this->getOptions($queryParams);
 
-            // If starting the login process, see if we have a "queued" action.
-            $actionId = array_get($queryParams, 'actionId');
+        $destination = $this->getDestination($queryParams, $options);
 
-            session()->flash('actionId', $actionId);
-        }
-
-
-        // Set options containing metadata for Northstar login.
-        $options = array_get($queryParams, 'options', []);
-
-        if (is_string($options)) {
-            $options = (array) json_decode($options);
-        }
-
-        // Set destination metadata for Northstar login; defaults to "title" in $options or null.
-        $destination = array_get($queryParams, 'destination', array_get($options, 'title'));
-
-        $url = session('login.intended', $this->redirectTo);
-
-        // If there is an actionId in the session, set it as a query param on to the intended URL.
-        if (session('actionId')) {
-            $actionIdParam = 'actionId='.urlencode(session('actionId'));
-
-            $url .= str_contains($url, '?') ? '&'.$actionIdParam : '?'.$actionIdParam;
-        }
-
-        dd([
-            $queryParams,
-            $request,
-            $response,
-            $url,
-            $destination,
-            $options,
-        ]);
+        // Override the default Northstar authorization /register page and view /login instead.
+        $options['mode'] = 'login';
 
         return gateway('northstar')->authorize($request, $response, $url, $destination, $options);
     }
@@ -103,15 +139,25 @@ class AuthController extends Controller
         return gateway('northstar')->logout($response, $this->redirectAfterLogout);
     }
 
-    public function getRegister(ServerRequestInterface $request, ResponseInterface $response)
+    /**
+     * Handle a registration request to the application.
+     *
+     * @param  ServerRequestInterface $request
+     * @param  ResponseInterface      $response
+     * @return \Illuminate\Http\RedirectResponse
+     */
+    public function getRegistration(ServerRequestInterface $request, ResponseInterface $response)
     {
-
         $queryParams = $request->getQueryParams();
 
-        dd([
-            $request,
-            $response,
-            $queryParams,
-        ]);
+        $this->setSessionData($queryParams);
+
+        $url = $this->getUrl();
+
+        $options = $this->getOptions($queryParams);
+
+        $destination = $this->getDestination($queryParams, $options);
+
+        return gateway('northstar')->authorize($request, $response, $url, $destination, $options);
     }
 }

--- a/app/Http/Controllers/AuthController.php
+++ b/app/Http/Controllers/AuthController.php
@@ -60,6 +60,7 @@ class AuthController extends Controller
             session()->flash('actionId', $actionId);
         }
 
+
         // Set options containing metadata for Northstar login.
         $options = array_get($queryParams, 'options', []);
 
@@ -79,6 +80,15 @@ class AuthController extends Controller
             $url .= str_contains($url, '?') ? '&'.$actionIdParam : '?'.$actionIdParam;
         }
 
+        dd([
+            $queryParams,
+            $request,
+            $response,
+            $url,
+            $destination,
+            $options,
+        ]);
+
         return gateway('northstar')->authorize($request, $response, $url, $destination, $options);
     }
 
@@ -91,5 +101,17 @@ class AuthController extends Controller
     public function getLogout(ResponseInterface $response)
     {
         return gateway('northstar')->logout($response, $this->redirectAfterLogout);
+    }
+
+    public function getRegister(ServerRequestInterface $request, ResponseInterface $response)
+    {
+
+        $queryParams = $request->getQueryParams();
+
+        dd([
+            $request,
+            $response,
+            $queryParams,
+        ]);
     }
 }

--- a/app/Http/Controllers/AuthController.php
+++ b/app/Http/Controllers/AuthController.php
@@ -30,7 +30,8 @@ class AuthController extends Controller
      * @param  array  $options
      * @return string
      */
-    protected function getDestination($queryParams, $options = []) {
+    protected function getDestination($queryParams, $options = [])
+    {
         return array_get($queryParams, 'destination', array_get($options, 'title'));
     }
 
@@ -40,7 +41,8 @@ class AuthController extends Controller
      * @param  array $queryParams
      * @return array
      */
-    protected function getOptions($queryParams) {
+    protected function getOptions($queryParams)
+    {
         $options = array_get($queryParams, 'options', []);
 
         if (is_string($options)) {
@@ -55,7 +57,8 @@ class AuthController extends Controller
      *
      * @return string
      */
-    protected function getUrl() {
+    protected function getUrl()
+    {
         $url = session('login.intended', $this->redirectTo);
 
         // If there is an actionId in the session, set it as a query param on to the intended URL.
@@ -73,7 +76,8 @@ class AuthController extends Controller
      *
      * @param array $queryParams
      */
-    protected function setSessionData($queryParams = []) {
+    protected function setSessionData($queryParams = [])
+    {
         if (array_has($queryParams, 'code')) {
             return;
         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -2222,7 +2222,7 @@
     "@types/zen-observable": {
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/@types/zen-observable/-/zen-observable-0.8.0.tgz",
-      "integrity": "sha1-i2OrfxqlMhJIqtWsiQpIVlbc6k0="
+      "integrity": "sha512-te5lMAWii1uEJ4FwLjzdlbw3+n0FZNOvFXHxQDKeT0dilh7HOzdMzV2TrJVUzq8ep7J4Na8OUYPRLSQkJHAlrg=="
     },
     "@webassemblyjs/ast": {
       "version": "1.8.5",
@@ -2420,7 +2420,7 @@
     "@xtuc/ieee754": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
-      "integrity": "sha1-7vAUoxRa5Hehy8AM0eVSM23Ot5A=",
+      "integrity": "sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==",
       "dev": true
     },
     "@xtuc/long": {
@@ -2876,7 +2876,7 @@
     "apollo-link-persisted-queries": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/apollo-link-persisted-queries/-/apollo-link-persisted-queries-0.2.2.tgz",
-      "integrity": "sha1-FWWXyyWbe7Vs9Olnp74DEpVPRZE=",
+      "integrity": "sha512-YL7XBu/5QsSbbYaWUXgm87T2Hn/2AQZk5Wr8CLXGDr3Wl3E/TRhBhKgQQTly9xhaTi7jgBO+AeIyTH5wCBHA9w==",
       "requires": {
         "apollo-link": "^1.2.1",
         "hash.js": "^1.1.3"
@@ -3094,7 +3094,7 @@
     "asn1.js": {
       "version": "4.10.1",
       "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.10.1.tgz",
-      "integrity": "sha1-ucK/WAXx5kqt7tbfOiv6+1pz9aA=",
+      "integrity": "sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==",
       "dev": true,
       "requires": {
         "bn.js": "^4.0.0",
@@ -3514,7 +3514,7 @@
     "base64-js": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.0.tgz",
-      "integrity": "sha1-yrHmEY8FEJXli1KBrqjBzSK/wOM=",
+      "integrity": "sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw==",
       "dev": true
     },
     "bcrypt-pbkdf": {
@@ -3579,7 +3579,7 @@
     "bn.js": {
       "version": "4.11.8",
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
-      "integrity": "sha1-LN4J617jQfSEdGuwMJsyU7GxRC8=",
+      "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==",
       "dev": true
     },
     "body-parser": {
@@ -3695,7 +3695,7 @@
     "browserify-aes": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
-      "integrity": "sha1-Mmc0ZC9APavDADIJhTu3CtQo70g=",
+      "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
       "dev": true,
       "requires": {
         "buffer-xor": "^1.0.3",
@@ -3709,7 +3709,7 @@
     "browserify-cipher": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.1.tgz",
-      "integrity": "sha1-jWR0wbhwv9q807z8wZNKEOlPFfA=",
+      "integrity": "sha512-sPhkz0ARKbf4rRQt2hTpAHqn47X3llLkUGn+xEJzLjwY8LRs2p0v7ljvI5EyoRO/mexrNunNECisZs+gw2zz1w==",
       "dev": true,
       "requires": {
         "browserify-aes": "^1.0.4",
@@ -3720,7 +3720,7 @@
     "browserify-des": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.2.tgz",
-      "integrity": "sha1-OvTx9Zg5QDVy8cZiBDdfen9wPpw=",
+      "integrity": "sha512-BioO1xf3hFwz4kc6iBhI3ieDFompMhrMlnDFC4/0/vd5MokpuAc3R+LYbwTA9A5Yc9pq9UYPqffKpW2ObuwX5A==",
       "dev": true,
       "requires": {
         "cipher-base": "^1.0.1",
@@ -3757,7 +3757,7 @@
     "browserify-zlib": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.2.0.tgz",
-      "integrity": "sha1-KGlFnZqjviRf6P4sofRuLn9U1z8=",
+      "integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
       "dev": true,
       "requires": {
         "pako": "~1.0.5"
@@ -3885,7 +3885,7 @@
         "y18n": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
-          "integrity": "sha1-le+U+F7MgdAHwmThkKEg8KPIVms=",
+          "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
           "dev": true
         },
         "yallist": {
@@ -4147,7 +4147,7 @@
     "chownr": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.1.tgz",
-      "integrity": "sha1-VHJri4//TfBTxCGH6AH7RBLfFJQ=",
+      "integrity": "sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g==",
       "dev": true
     },
     "chrome-trace-event": {
@@ -4167,7 +4167,7 @@
     "cipher-base": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
-      "integrity": "sha1-h2Dk7MJy9MNjUy+SbYdKriwTl94=",
+      "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
       "dev": true,
       "requires": {
         "inherits": "^2.0.1",
@@ -4649,7 +4649,7 @@
     "copy-concurrently": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/copy-concurrently/-/copy-concurrently-1.0.5.tgz",
-      "integrity": "sha1-kilzmMrjSTf8r9bsgTnBgFHwteA=",
+      "integrity": "sha512-f2domd9fsVDFtaFcbaRZuYXwtdmnzqbADSwhSWYxYB/Q8zsdUUFMXVRwXGDMWmbEzAn1kdRrtI1T/KTFOL4X2A==",
       "dev": true,
       "requires": {
         "aproba": "^1.1.1",
@@ -4733,7 +4733,7 @@
     "create-ecdh": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.3.tgz",
-      "integrity": "sha1-yREbbzMEXEaX8UR4f5JUzcd8Rf8=",
+      "integrity": "sha512-GbEHQPMOswGpKXM9kCWVrremUcBmjteUaQ01T9rkKCPDXfUHX0IoP9LpHYo2NPFampa4e+/pFDc3jQdxrxQLaw==",
       "dev": true,
       "requires": {
         "bn.js": "^4.1.0",
@@ -4743,7 +4743,7 @@
     "create-hash": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
-      "integrity": "sha1-iJB4rxGmN1a8+1m9IhmWvjqe8ZY=",
+      "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
       "dev": true,
       "requires": {
         "cipher-base": "^1.0.1",
@@ -4756,7 +4756,7 @@
     "create-hmac": {
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
-      "integrity": "sha1-aRcMeLOrlXFHsriwRXLkfq0iQ/8=",
+      "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
       "dev": true,
       "requires": {
         "cipher-base": "^1.0.3",
@@ -4782,7 +4782,7 @@
     "crypto-browserify": {
       "version": "3.12.0",
       "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.12.0.tgz",
-      "integrity": "sha1-OWz58xN/A+S45TLFj2mCVOAPgOw=",
+      "integrity": "sha512-fz4spIh+znjO2VjL+IdhEpRJ3YN6sMzITSBijk6FK2UvTqruSQW+/cCZTSNsMiZNvUeq0CqurF+dAbyiGOY6Wg==",
       "dev": true,
       "requires": {
         "browserify-cipher": "^1.0.0",
@@ -5522,7 +5522,7 @@
     "diffie-hellman": {
       "version": "5.0.3",
       "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
-      "integrity": "sha1-QOjumPVaIUlgcUaSHGPhrl89KHU=",
+      "integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
       "dev": true,
       "requires": {
         "bn.js": "^4.1.0",
@@ -5561,7 +5561,7 @@
     "domain-browser": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.2.0.tgz",
-      "integrity": "sha1-PTH1AZGmdJ3RN1p/Ui6CPULlTto=",
+      "integrity": "sha512-jnjyiM6eRyZl2H+W8Q/zLMA481hzi0eszAaBUzIVnmYVDBbnLxVNnfu1HgEBvCbL+71FrxMl3E6lpKH7Ge3OXA==",
       "dev": true
     },
     "domelementtype": {
@@ -5668,7 +5668,7 @@
     "elliptic": {
       "version": "6.4.1",
       "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.4.1.tgz",
-      "integrity": "sha1-wtC3d2kRuGcixjLDwGxg8vgZk5o=",
+      "integrity": "sha512-BsXLz5sqX8OHcsh7CqBMztyXARmGQ3LWPtGjJi6DiJHq5C/qvi9P3OqgswKSDftbu8+IoI/QDTAm2fFnQ9SZSQ==",
       "dev": true,
       "requires": {
         "bn.js": "^4.4.0",
@@ -5718,7 +5718,7 @@
     "end-of-stream": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
-      "integrity": "sha1-7SljTRm6ukY7bOa4CjchPqtx7EM=",
+      "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
       "requires": {
         "once": "^1.4.0"
       }
@@ -6403,7 +6403,7 @@
     "evp_bytestokey": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
-      "integrity": "sha1-f8vbGY3HGVlDLv4ThCaE4FJaywI=",
+      "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
       "dev": true,
       "requires": {
         "md5.js": "^1.3.4",
@@ -6821,7 +6821,7 @@
     "figgy-pudding": {
       "version": "3.5.1",
       "resolved": "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-3.5.1.tgz",
-      "integrity": "sha1-hiRwESkBxyeg5JWoB0S9W6odZ5A=",
+      "integrity": "sha512-vNKxJHTEKNThjfrdJwHc7brvM6eVevuO5nTj6ez8ZQ1qbXTvGthucRF7S4vf2cr71QVnT70V34v0S1DyQsti0w==",
       "dev": true
     },
     "figures": {
@@ -10669,7 +10669,7 @@
     "md5.js": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
-      "integrity": "sha1-tdB7jjIW4+J81yjXL3DR5qNCAF8=",
+      "integrity": "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==",
       "dev": true,
       "requires": {
         "hash-base": "^3.0.0",
@@ -10873,7 +10873,7 @@
     "miller-rabin": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.1.tgz",
-      "integrity": "sha1-8IA1HIZbDcViqEYpZtqlNUPHik0=",
+      "integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
       "dev": true,
       "requires": {
         "bn.js": "^4.0.0",
@@ -10959,7 +10959,7 @@
     "mississippi": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/mississippi/-/mississippi-3.0.0.tgz",
-      "integrity": "sha1-6goykfl+C16HdrNj1fChLZTGcCI=",
+      "integrity": "sha512-x471SsVjUtBRtcvd4BzKE9kFC+/2TeWgKCgw0bZcw1b9l2X3QX5vCWgF+KaZaYm87Ss//rHnWryupDrgLvmSkA==",
       "dev": true,
       "requires": {
         "concat-stream": "^1.5.0",
@@ -12221,7 +12221,7 @@
     "pbkdf2": {
       "version": "3.0.17",
       "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.17.tgz",
-      "integrity": "sha1-l2wgZTBhexTrsyEUI597CTNuk6Y=",
+      "integrity": "sha512-U/il5MsrZp7mGg3mSQfn742na2T+1/vHDCG5/iTI3X9MKUuYUZVLQhyRsg06mCgDBTd57TxzgZt7P+fYfjRLtA==",
       "dev": true,
       "requires": {
         "create-hash": "^1.1.2",
@@ -12692,7 +12692,7 @@
     "public-encrypt": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.3.tgz",
-      "integrity": "sha1-T8ydd6B+SLp1J+fL4N4z0HATMeA=",
+      "integrity": "sha512-zVpa8oKZSz5bTMTFClc1fQOnyyEzpl5ozpi1B5YcvBrdohMjH2rfsBtyXcuNuwjsDIXmBYlF2N5FlJYhR29t8Q==",
       "dev": true,
       "requires": {
         "bn.js": "^4.1.0",
@@ -12706,7 +12706,7 @@
     "pump": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
-      "integrity": "sha1-tKIRaBW94vTh6mAjVOjHVWUQemQ=",
+      "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
       "requires": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
@@ -12715,7 +12715,7 @@
     "pumpify": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/pumpify/-/pumpify-1.5.1.tgz",
-      "integrity": "sha1-NlE74karJ1cLGjdKXOJ4v9dDcM4=",
+      "integrity": "sha512-oClZI37HvuUJJxSKKrC17bZ9Cu0ZYhEAGPsPUy9KlMUmv9dKX2o77RUmq7f3XjIxbwyGwYzbzQ1L2Ks8sIradQ==",
       "dev": true,
       "requires": {
         "duplexify": "^3.6.0",
@@ -12726,7 +12726,7 @@
         "pump": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
-          "integrity": "sha1-Ejma3W5M91Jtlzy8i1zi4pCLOQk=",
+          "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
           "dev": true,
           "requires": {
             "end-of-stream": "^1.1.0",
@@ -12813,7 +12813,7 @@
     "randomfill": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/randomfill/-/randomfill-1.0.4.tgz",
-      "integrity": "sha1-ySGW/IarQr6YPxvzF3giSTHWFFg=",
+      "integrity": "sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==",
       "dev": true,
       "requires": {
         "randombytes": "^2.0.5",
@@ -12953,7 +12953,7 @@
     "react-portal": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/react-portal/-/react-portal-4.2.0.tgz",
-      "integrity": "sha1-VACDHNsK5k3MuBKBIc8HYImrGv0=",
+      "integrity": "sha512-Zf+vGQ/VEAb5XAy+muKEn48yhdCNYPZaB1BWg1xc8sAZWD8pXTgPtQT4ihBdmWzsfCq8p8/kqf0GWydSBqc+Eg==",
       "requires": {
         "prop-types": "^15.5.8"
       }
@@ -13500,7 +13500,7 @@
     "ripemd160": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz",
-      "integrity": "sha1-ocGm9iR1FXe6XQeRTLyShQWFiQw=",
+      "integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
       "dev": true,
       "requires": {
         "hash-base": "^3.0.0",
@@ -13786,7 +13786,7 @@
     "sha.js": {
       "version": "2.4.11",
       "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
-      "integrity": "sha1-N6XPC4HsvGlD3hCbopYNGyZYSuc=",
+      "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
       "dev": true,
       "requires": {
         "inherits": "^2.0.1",
@@ -14217,7 +14217,7 @@
     "ssri": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.1.tgz",
-      "integrity": "sha1-KjxBso3UW2K2Nnbst0ABJlrp7dg=",
+      "integrity": "sha512-3Wge10hNcT1Kur4PDFwEieXSCMCJs/7WvSACcrMYrNp+b8kDL1/0wJch5Ni2WrtwEa2IO8OsVfeKIciKCDx/QA==",
       "dev": true,
       "requires": {
         "figgy-pudding": "^3.5.1"
@@ -14285,7 +14285,7 @@
     "stream-each": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/stream-each/-/stream-each-1.2.3.tgz",
-      "integrity": "sha1-6+J6DDibBPvMIzZClS4Qcxr6m64=",
+      "integrity": "sha512-vlMC2f8I2u/bZGqkdfLQW/13Zihpej/7PmSiMQsbYddxuTsJp8vRe2x2FvVExZg7FaOds43ROAuFJwPR4MTZLw==",
       "dev": true,
       "requires": {
         "end-of-stream": "^1.1.0",
@@ -14295,7 +14295,7 @@
     "stream-http": {
       "version": "2.8.3",
       "resolved": "https://registry.npmjs.org/stream-http/-/stream-http-2.8.3.tgz",
-      "integrity": "sha1-stJCRpKIpaJ+xP6JM6z2I95lFPw=",
+      "integrity": "sha512-+TSkfINHDo4J+ZobQLWiMouQYB+UVYFttRA94FpEzzJ7ZdqcL4uUUQ7WkdkI4DSozGmgBUE/a47L+38PenXhUw==",
       "dev": true,
       "requires": {
         "builtin-status-codes": "^3.0.0",
@@ -14614,7 +14614,7 @@
     "through2": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
-      "integrity": "sha1-AcHjnrMdB8t9A6lqcIIyYLIxMs0=",
+      "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
       "dev": true,
       "requires": {
         "readable-stream": "~2.3.6",
@@ -14630,7 +14630,7 @@
     "timers-browserify": {
       "version": "2.0.10",
       "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.10.tgz",
-      "integrity": "sha1-HSjj0qrfHVpZlsTp+VYBzQU0gK4=",
+      "integrity": "sha512-YvC1SV1XdOUaL6gx5CoGroT3Gu49pK9+TZ38ErPldOWW4j49GI1HKs9DV+KGq/w6y+LZ72W1c8cKz2vzY+qpzg==",
       "dev": true,
       "requires": {
         "setimmediate": "^1.0.4"
@@ -14983,7 +14983,7 @@
     "unique-filename": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-1.1.1.tgz",
-      "integrity": "sha1-HWl2k2mtoFgxA6HmrodoG1ZXMjA=",
+      "integrity": "sha512-Vmp0jIp2ln35UTXuryvjzkjGdRyf9b2lTXuSYUiPmzRcl3FDtYqAwOnTJkAngD9SWhnoJzDbTKwaOrZ+STtxNQ==",
       "dev": true,
       "requires": {
         "unique-slug": "^2.0.0"
@@ -15291,7 +15291,7 @@
     "watchpack": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.6.0.tgz",
-      "integrity": "sha1-S8EsLr6KonenHx0/FNaFx7RGzQA=",
+      "integrity": "sha512-i6dHe3EyLjMmDlU1/bGQpEw25XSjkJULPuAVKCbNRefQVq48yXKUpwg538F7AZTf9kyr57zj++pQFltUa5H7yA==",
       "dev": true,
       "requires": {
         "chokidar": "^2.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2222,7 +2222,7 @@
     "@types/zen-observable": {
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/@types/zen-observable/-/zen-observable-0.8.0.tgz",
-      "integrity": "sha512-te5lMAWii1uEJ4FwLjzdlbw3+n0FZNOvFXHxQDKeT0dilh7HOzdMzV2TrJVUzq8ep7J4Na8OUYPRLSQkJHAlrg=="
+      "integrity": "sha1-i2OrfxqlMhJIqtWsiQpIVlbc6k0="
     },
     "@webassemblyjs/ast": {
       "version": "1.8.5",
@@ -2420,7 +2420,7 @@
     "@xtuc/ieee754": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
-      "integrity": "sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==",
+      "integrity": "sha1-7vAUoxRa5Hehy8AM0eVSM23Ot5A=",
       "dev": true
     },
     "@xtuc/long": {
@@ -2876,7 +2876,7 @@
     "apollo-link-persisted-queries": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/apollo-link-persisted-queries/-/apollo-link-persisted-queries-0.2.2.tgz",
-      "integrity": "sha512-YL7XBu/5QsSbbYaWUXgm87T2Hn/2AQZk5Wr8CLXGDr3Wl3E/TRhBhKgQQTly9xhaTi7jgBO+AeIyTH5wCBHA9w==",
+      "integrity": "sha1-FWWXyyWbe7Vs9Olnp74DEpVPRZE=",
       "requires": {
         "apollo-link": "^1.2.1",
         "hash.js": "^1.1.3"
@@ -3094,7 +3094,7 @@
     "asn1.js": {
       "version": "4.10.1",
       "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.10.1.tgz",
-      "integrity": "sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==",
+      "integrity": "sha1-ucK/WAXx5kqt7tbfOiv6+1pz9aA=",
       "dev": true,
       "requires": {
         "bn.js": "^4.0.0",
@@ -3514,7 +3514,7 @@
     "base64-js": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.0.tgz",
-      "integrity": "sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw==",
+      "integrity": "sha1-yrHmEY8FEJXli1KBrqjBzSK/wOM=",
       "dev": true
     },
     "bcrypt-pbkdf": {
@@ -3579,7 +3579,7 @@
     "bn.js": {
       "version": "4.11.8",
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
-      "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==",
+      "integrity": "sha1-LN4J617jQfSEdGuwMJsyU7GxRC8=",
       "dev": true
     },
     "body-parser": {
@@ -3695,7 +3695,7 @@
     "browserify-aes": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
-      "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
+      "integrity": "sha1-Mmc0ZC9APavDADIJhTu3CtQo70g=",
       "dev": true,
       "requires": {
         "buffer-xor": "^1.0.3",
@@ -3709,7 +3709,7 @@
     "browserify-cipher": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.1.tgz",
-      "integrity": "sha512-sPhkz0ARKbf4rRQt2hTpAHqn47X3llLkUGn+xEJzLjwY8LRs2p0v7ljvI5EyoRO/mexrNunNECisZs+gw2zz1w==",
+      "integrity": "sha1-jWR0wbhwv9q807z8wZNKEOlPFfA=",
       "dev": true,
       "requires": {
         "browserify-aes": "^1.0.4",
@@ -3720,7 +3720,7 @@
     "browserify-des": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.2.tgz",
-      "integrity": "sha512-BioO1xf3hFwz4kc6iBhI3ieDFompMhrMlnDFC4/0/vd5MokpuAc3R+LYbwTA9A5Yc9pq9UYPqffKpW2ObuwX5A==",
+      "integrity": "sha1-OvTx9Zg5QDVy8cZiBDdfen9wPpw=",
       "dev": true,
       "requires": {
         "cipher-base": "^1.0.1",
@@ -3757,7 +3757,7 @@
     "browserify-zlib": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.2.0.tgz",
-      "integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
+      "integrity": "sha1-KGlFnZqjviRf6P4sofRuLn9U1z8=",
       "dev": true,
       "requires": {
         "pako": "~1.0.5"
@@ -3885,7 +3885,7 @@
         "y18n": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
-          "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
+          "integrity": "sha1-le+U+F7MgdAHwmThkKEg8KPIVms=",
           "dev": true
         },
         "yallist": {
@@ -4147,7 +4147,7 @@
     "chownr": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.1.tgz",
-      "integrity": "sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g==",
+      "integrity": "sha1-VHJri4//TfBTxCGH6AH7RBLfFJQ=",
       "dev": true
     },
     "chrome-trace-event": {
@@ -4167,7 +4167,7 @@
     "cipher-base": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
-      "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
+      "integrity": "sha1-h2Dk7MJy9MNjUy+SbYdKriwTl94=",
       "dev": true,
       "requires": {
         "inherits": "^2.0.1",
@@ -4649,7 +4649,7 @@
     "copy-concurrently": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/copy-concurrently/-/copy-concurrently-1.0.5.tgz",
-      "integrity": "sha512-f2domd9fsVDFtaFcbaRZuYXwtdmnzqbADSwhSWYxYB/Q8zsdUUFMXVRwXGDMWmbEzAn1kdRrtI1T/KTFOL4X2A==",
+      "integrity": "sha1-kilzmMrjSTf8r9bsgTnBgFHwteA=",
       "dev": true,
       "requires": {
         "aproba": "^1.1.1",
@@ -4733,7 +4733,7 @@
     "create-ecdh": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.3.tgz",
-      "integrity": "sha512-GbEHQPMOswGpKXM9kCWVrremUcBmjteUaQ01T9rkKCPDXfUHX0IoP9LpHYo2NPFampa4e+/pFDc3jQdxrxQLaw==",
+      "integrity": "sha1-yREbbzMEXEaX8UR4f5JUzcd8Rf8=",
       "dev": true,
       "requires": {
         "bn.js": "^4.1.0",
@@ -4743,7 +4743,7 @@
     "create-hash": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
-      "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
+      "integrity": "sha1-iJB4rxGmN1a8+1m9IhmWvjqe8ZY=",
       "dev": true,
       "requires": {
         "cipher-base": "^1.0.1",
@@ -4756,7 +4756,7 @@
     "create-hmac": {
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
-      "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
+      "integrity": "sha1-aRcMeLOrlXFHsriwRXLkfq0iQ/8=",
       "dev": true,
       "requires": {
         "cipher-base": "^1.0.3",
@@ -4782,7 +4782,7 @@
     "crypto-browserify": {
       "version": "3.12.0",
       "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.12.0.tgz",
-      "integrity": "sha512-fz4spIh+znjO2VjL+IdhEpRJ3YN6sMzITSBijk6FK2UvTqruSQW+/cCZTSNsMiZNvUeq0CqurF+dAbyiGOY6Wg==",
+      "integrity": "sha1-OWz58xN/A+S45TLFj2mCVOAPgOw=",
       "dev": true,
       "requires": {
         "browserify-cipher": "^1.0.0",
@@ -5522,7 +5522,7 @@
     "diffie-hellman": {
       "version": "5.0.3",
       "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
-      "integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
+      "integrity": "sha1-QOjumPVaIUlgcUaSHGPhrl89KHU=",
       "dev": true,
       "requires": {
         "bn.js": "^4.1.0",
@@ -5561,7 +5561,7 @@
     "domain-browser": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.2.0.tgz",
-      "integrity": "sha512-jnjyiM6eRyZl2H+W8Q/zLMA481hzi0eszAaBUzIVnmYVDBbnLxVNnfu1HgEBvCbL+71FrxMl3E6lpKH7Ge3OXA==",
+      "integrity": "sha1-PTH1AZGmdJ3RN1p/Ui6CPULlTto=",
       "dev": true
     },
     "domelementtype": {
@@ -5668,7 +5668,7 @@
     "elliptic": {
       "version": "6.4.1",
       "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.4.1.tgz",
-      "integrity": "sha512-BsXLz5sqX8OHcsh7CqBMztyXARmGQ3LWPtGjJi6DiJHq5C/qvi9P3OqgswKSDftbu8+IoI/QDTAm2fFnQ9SZSQ==",
+      "integrity": "sha1-wtC3d2kRuGcixjLDwGxg8vgZk5o=",
       "dev": true,
       "requires": {
         "bn.js": "^4.4.0",
@@ -5718,7 +5718,7 @@
     "end-of-stream": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
-      "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
+      "integrity": "sha1-7SljTRm6ukY7bOa4CjchPqtx7EM=",
       "requires": {
         "once": "^1.4.0"
       }
@@ -6403,7 +6403,7 @@
     "evp_bytestokey": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
-      "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
+      "integrity": "sha1-f8vbGY3HGVlDLv4ThCaE4FJaywI=",
       "dev": true,
       "requires": {
         "md5.js": "^1.3.4",
@@ -6821,7 +6821,7 @@
     "figgy-pudding": {
       "version": "3.5.1",
       "resolved": "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-3.5.1.tgz",
-      "integrity": "sha512-vNKxJHTEKNThjfrdJwHc7brvM6eVevuO5nTj6ez8ZQ1qbXTvGthucRF7S4vf2cr71QVnT70V34v0S1DyQsti0w==",
+      "integrity": "sha1-hiRwESkBxyeg5JWoB0S9W6odZ5A=",
       "dev": true
     },
     "figures": {
@@ -10669,7 +10669,7 @@
     "md5.js": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
-      "integrity": "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==",
+      "integrity": "sha1-tdB7jjIW4+J81yjXL3DR5qNCAF8=",
       "dev": true,
       "requires": {
         "hash-base": "^3.0.0",
@@ -10873,7 +10873,7 @@
     "miller-rabin": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.1.tgz",
-      "integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
+      "integrity": "sha1-8IA1HIZbDcViqEYpZtqlNUPHik0=",
       "dev": true,
       "requires": {
         "bn.js": "^4.0.0",
@@ -10959,7 +10959,7 @@
     "mississippi": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/mississippi/-/mississippi-3.0.0.tgz",
-      "integrity": "sha512-x471SsVjUtBRtcvd4BzKE9kFC+/2TeWgKCgw0bZcw1b9l2X3QX5vCWgF+KaZaYm87Ss//rHnWryupDrgLvmSkA==",
+      "integrity": "sha1-6goykfl+C16HdrNj1fChLZTGcCI=",
       "dev": true,
       "requires": {
         "concat-stream": "^1.5.0",
@@ -12221,7 +12221,7 @@
     "pbkdf2": {
       "version": "3.0.17",
       "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.17.tgz",
-      "integrity": "sha512-U/il5MsrZp7mGg3mSQfn742na2T+1/vHDCG5/iTI3X9MKUuYUZVLQhyRsg06mCgDBTd57TxzgZt7P+fYfjRLtA==",
+      "integrity": "sha1-l2wgZTBhexTrsyEUI597CTNuk6Y=",
       "dev": true,
       "requires": {
         "create-hash": "^1.1.2",
@@ -12692,7 +12692,7 @@
     "public-encrypt": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.3.tgz",
-      "integrity": "sha512-zVpa8oKZSz5bTMTFClc1fQOnyyEzpl5ozpi1B5YcvBrdohMjH2rfsBtyXcuNuwjsDIXmBYlF2N5FlJYhR29t8Q==",
+      "integrity": "sha1-T8ydd6B+SLp1J+fL4N4z0HATMeA=",
       "dev": true,
       "requires": {
         "bn.js": "^4.1.0",
@@ -12706,7 +12706,7 @@
     "pump": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
-      "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+      "integrity": "sha1-tKIRaBW94vTh6mAjVOjHVWUQemQ=",
       "requires": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
@@ -12715,7 +12715,7 @@
     "pumpify": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/pumpify/-/pumpify-1.5.1.tgz",
-      "integrity": "sha512-oClZI37HvuUJJxSKKrC17bZ9Cu0ZYhEAGPsPUy9KlMUmv9dKX2o77RUmq7f3XjIxbwyGwYzbzQ1L2Ks8sIradQ==",
+      "integrity": "sha1-NlE74karJ1cLGjdKXOJ4v9dDcM4=",
       "dev": true,
       "requires": {
         "duplexify": "^3.6.0",
@@ -12726,7 +12726,7 @@
         "pump": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
-          "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
+          "integrity": "sha1-Ejma3W5M91Jtlzy8i1zi4pCLOQk=",
           "dev": true,
           "requires": {
             "end-of-stream": "^1.1.0",
@@ -12813,7 +12813,7 @@
     "randomfill": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/randomfill/-/randomfill-1.0.4.tgz",
-      "integrity": "sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==",
+      "integrity": "sha1-ySGW/IarQr6YPxvzF3giSTHWFFg=",
       "dev": true,
       "requires": {
         "randombytes": "^2.0.5",
@@ -12953,7 +12953,7 @@
     "react-portal": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/react-portal/-/react-portal-4.2.0.tgz",
-      "integrity": "sha512-Zf+vGQ/VEAb5XAy+muKEn48yhdCNYPZaB1BWg1xc8sAZWD8pXTgPtQT4ihBdmWzsfCq8p8/kqf0GWydSBqc+Eg==",
+      "integrity": "sha1-VACDHNsK5k3MuBKBIc8HYImrGv0=",
       "requires": {
         "prop-types": "^15.5.8"
       }
@@ -13500,7 +13500,7 @@
     "ripemd160": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz",
-      "integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
+      "integrity": "sha1-ocGm9iR1FXe6XQeRTLyShQWFiQw=",
       "dev": true,
       "requires": {
         "hash-base": "^3.0.0",
@@ -13786,7 +13786,7 @@
     "sha.js": {
       "version": "2.4.11",
       "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
-      "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
+      "integrity": "sha1-N6XPC4HsvGlD3hCbopYNGyZYSuc=",
       "dev": true,
       "requires": {
         "inherits": "^2.0.1",
@@ -14217,7 +14217,7 @@
     "ssri": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.1.tgz",
-      "integrity": "sha512-3Wge10hNcT1Kur4PDFwEieXSCMCJs/7WvSACcrMYrNp+b8kDL1/0wJch5Ni2WrtwEa2IO8OsVfeKIciKCDx/QA==",
+      "integrity": "sha1-KjxBso3UW2K2Nnbst0ABJlrp7dg=",
       "dev": true,
       "requires": {
         "figgy-pudding": "^3.5.1"
@@ -14285,7 +14285,7 @@
     "stream-each": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/stream-each/-/stream-each-1.2.3.tgz",
-      "integrity": "sha512-vlMC2f8I2u/bZGqkdfLQW/13Zihpej/7PmSiMQsbYddxuTsJp8vRe2x2FvVExZg7FaOds43ROAuFJwPR4MTZLw==",
+      "integrity": "sha1-6+J6DDibBPvMIzZClS4Qcxr6m64=",
       "dev": true,
       "requires": {
         "end-of-stream": "^1.1.0",
@@ -14295,7 +14295,7 @@
     "stream-http": {
       "version": "2.8.3",
       "resolved": "https://registry.npmjs.org/stream-http/-/stream-http-2.8.3.tgz",
-      "integrity": "sha512-+TSkfINHDo4J+ZobQLWiMouQYB+UVYFttRA94FpEzzJ7ZdqcL4uUUQ7WkdkI4DSozGmgBUE/a47L+38PenXhUw==",
+      "integrity": "sha1-stJCRpKIpaJ+xP6JM6z2I95lFPw=",
       "dev": true,
       "requires": {
         "builtin-status-codes": "^3.0.0",
@@ -14614,7 +14614,7 @@
     "through2": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
-      "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+      "integrity": "sha1-AcHjnrMdB8t9A6lqcIIyYLIxMs0=",
       "dev": true,
       "requires": {
         "readable-stream": "~2.3.6",
@@ -14630,7 +14630,7 @@
     "timers-browserify": {
       "version": "2.0.10",
       "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.10.tgz",
-      "integrity": "sha512-YvC1SV1XdOUaL6gx5CoGroT3Gu49pK9+TZ38ErPldOWW4j49GI1HKs9DV+KGq/w6y+LZ72W1c8cKz2vzY+qpzg==",
+      "integrity": "sha1-HSjj0qrfHVpZlsTp+VYBzQU0gK4=",
       "dev": true,
       "requires": {
         "setimmediate": "^1.0.4"
@@ -14983,7 +14983,7 @@
     "unique-filename": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-1.1.1.tgz",
-      "integrity": "sha512-Vmp0jIp2ln35UTXuryvjzkjGdRyf9b2lTXuSYUiPmzRcl3FDtYqAwOnTJkAngD9SWhnoJzDbTKwaOrZ+STtxNQ==",
+      "integrity": "sha1-HWl2k2mtoFgxA6HmrodoG1ZXMjA=",
       "dev": true,
       "requires": {
         "unique-slug": "^2.0.0"
@@ -15291,7 +15291,7 @@
     "watchpack": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.6.0.tgz",
-      "integrity": "sha512-i6dHe3EyLjMmDlU1/bGQpEw25XSjkJULPuAVKCbNRefQVq48yXKUpwg538F7AZTf9kyr57zj++pQFltUa5H7yA==",
+      "integrity": "sha1-S8EsLr6KonenHx0/FNaFx7RGzQA=",
       "dev": true,
       "requires": {
         "chokidar": "^2.0.2",

--- a/resources/views/partials/navigation.blade.php
+++ b/resources/views/partials/navigation.blade.php
@@ -33,9 +33,22 @@
                         <li><a href="{{ route('logout') }}" class="secondary-nav-item" id="link--logout">Log Out</a></li>
                     </ul>
                 @else
-                    <a href="{{ route('login', isset($campaign) ? get_login_query($campaign) : get_login_query()) }}">Log In</a>
+                    <a href="{{ route('login', array_merge(['mode' => 'login'], isset($campaign) ? get_login_query($campaign) : get_login_query())) }}">Log In</a>
+                    <a href="{{ route('register', isset($campaign) ? get_login_query($campaign) : get_login_query())}}">Join Now</a>
                 @endif
             </li>
         </ul>
     </div>
 </div>
+
+{{--
+http://phoenix.test/next/login?
+    destination=%5BTest%5D+Teens+for+Jeans
+    &options%5Btitle%5D=%5BTest%5D+Teens+for+Jeans
+    &options%5BcoverImage%5D=https%3A%2F%2Fimages.ctfassets.net%2F81iqaqpfd8fy%2F4k8rv5sN0kii0AoCawc6UQ%2Fc22c3c132d1bb43055b6bafc248fcea5%2Fvn7gpbosm9rx.jpg
+    &options%5BcallToAction%5D=Let%27s+collect+another+million+jeans+TOGETHER.
+
+http://phoenix.test/next/login?
+    actionId=auth%3A1565286536853
+    &options=%7B%22title%22%3A%22%5BTest%5D%20Teens%20for%20Jeans%22%2C%22callToAction%22%3A%22Let%27s%20collect%20another%20million%20jeans%20TOGETHER.%22%2C%22coverImage%22%3A%22https%3A%2F%2Fimages.ctfassets.net%2F81iqaqpfd8fy%2F4k8rv5sN0kii0AoCawc6UQ%2Fc22c3c132d1bb43055b6bafc248fcea5%2Fvn7gpbosm9rx.jpg%3Fw%3D800%26h%3D600%26fit%3Dfill%22%2C%22contentful_id%22%3A%226LQzMvDNQcYQYwso8qSkQ8%22%7D
+--}}

--- a/resources/views/partials/navigation.blade.php
+++ b/resources/views/partials/navigation.blade.php
@@ -33,8 +33,8 @@
                         <li><a href="{{ route('logout') }}" class="secondary-nav-item" id="link--logout">Log Out</a></li>
                     </ul>
                 @else
-                    <a href="{{ route('login', array_merge(['mode' => 'login'], isset($campaign) ? get_login_query($campaign) : get_login_query())) }}">Log In</a>
-                    <a href="{{ route('register', isset($campaign) ? get_login_query($campaign) : get_login_query())}}">Join Now</a>
+                    {{-- <a href="{{ route('login', isset($campaign) ? get_login_query($campaign) : null) }}">Log In</a> --}}
+                    <a href="{{ route('register', isset($campaign) ? get_login_query($campaign) : get_login_query() }}">Log In</a>
                 @endif
             </li>
         </ul>

--- a/resources/views/partials/navigation.blade.php
+++ b/resources/views/partials/navigation.blade.php
@@ -1,3 +1,9 @@
+@php
+    // @TODO: temporary until we can universalize campaign, pages, story-page entities into
+    // a single variable passed to the view.
+    $entity = isset($campaign) ? $campaign : null;
+@endphp
+
 <div class="navigation {{isset($legacyNavigation) ? '-white -floating' : 'bg-white'}}">
     <a class="navigation__logo" href="{{ url('/') }}"><span>DoSomething.org</span></a>
     <a  id="js-navigation-toggle" class="navigation__toggle"><span>Show Menu</span></a>
@@ -33,8 +39,8 @@
                         <li><a href="{{ route('logout') }}" class="secondary-nav-item" id="link--logout">Log Out</a></li>
                     </ul>
                 @else
-                    {{-- <a href="{{ route('login', isset($campaign) ? get_login_query($campaign) : null) }}">Log In</a> --}}
-                    <a href="{{ route('register', isset($campaign) ? get_login_query($campaign) : get_login_query() }}">Log In</a>
+                    {{-- <a href="{{ route('login', get_login_query($entity)) }}">Log In</a> --}}
+                    <a href="{{ route('register', get_login_query($entity)) }}">Log In</a>
                 @endif
             </li>
         </ul>

--- a/resources/views/partials/navigation.blade.php
+++ b/resources/views/partials/navigation.blade.php
@@ -40,15 +40,3 @@
         </ul>
     </div>
 </div>
-
-{{--
-http://phoenix.test/next/login?
-    destination=%5BTest%5D+Teens+for+Jeans
-    &options%5Btitle%5D=%5BTest%5D+Teens+for+Jeans
-    &options%5BcoverImage%5D=https%3A%2F%2Fimages.ctfassets.net%2F81iqaqpfd8fy%2F4k8rv5sN0kii0AoCawc6UQ%2Fc22c3c132d1bb43055b6bafc248fcea5%2Fvn7gpbosm9rx.jpg
-    &options%5BcallToAction%5D=Let%27s+collect+another+million+jeans+TOGETHER.
-
-http://phoenix.test/next/login?
-    actionId=auth%3A1565286536853
-    &options=%7B%22title%22%3A%22%5BTest%5D%20Teens%20for%20Jeans%22%2C%22callToAction%22%3A%22Let%27s%20collect%20another%20million%20jeans%20TOGETHER.%22%2C%22coverImage%22%3A%22https%3A%2F%2Fimages.ctfassets.net%2F81iqaqpfd8fy%2F4k8rv5sN0kii0AoCawc6UQ%2Fc22c3c132d1bb43055b6bafc248fcea5%2Fvn7gpbosm9rx.jpg%3Fw%3D800%26h%3D600%26fit%3Dfill%22%2C%22contentful_id%22%3A%226LQzMvDNQcYQYwso8qSkQ8%22%7D
---}}

--- a/routes/web.php
+++ b/routes/web.php
@@ -12,7 +12,7 @@ $router->redirect('/', '/us');
 $router->get('/us', 'HomePageController');
 
 // Authentication
-$router->get('/register', 'AuthController@getRegister')->name('register');
+$router->get('/register', 'AuthController@getRegistration')->name('register');
 $router->get('next/login', 'AuthController@getLogin')->name('login');
 
 $router->get('next/logout', 'AuthController@getLogout')->name('logout');

--- a/routes/web.php
+++ b/routes/web.php
@@ -12,7 +12,9 @@ $router->redirect('/', '/us');
 $router->get('/us', 'HomePageController');
 
 // Authentication
+$router->get('/register', 'AuthController@getRegister')->name('register');
 $router->get('next/login', 'AuthController@getLogin')->name('login');
+
 $router->get('next/logout', 'AuthController@getLogout')->name('logout');
 $router->redirect('auth/login', 'next/login'); // Fix for hard-coded redirect in Gateway! <goo.gl/2VPxDC>
 


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?
This PR updates the flow to separate out the login flow from the registration flow. It includes a new route for `/register` that will be specifically for users registering via Northstar and a separate one for the login flow.

I ended up breaking the `getLogin()` method in the `AuthController.php` file into smaller protected methods in the class that now get called by both the `getLogin()` and `getRegistration()` methods. By splitting up the logic into smaller methods it helps make it a little bit more understandable instead of having a large block of logic, and also allows using the logic in both flows. The `getLogin()` method is only really different in that it adds an additional item to the `$options` array to specify overriding the authorization page so it heads to the `/login` on Northstar rather than `/register`.

### Any background context you want to provide?

To refrain from the PR getting to big I'll be doing the styling updates and fixes along with showing the new navigation link in an upcoming PR. For now I just hid it by commenting it out in Blade.

### What are the relevant tickets/cards?

Refs [Pivotal ID #167527420](https://www.pivotaltracker.com/story/show/167527420)

### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.