### PR TITLE
Prefixing register endpoint to resolve issue with prior 301 redirect.

### DIFF
--- a/app/Http/Controllers/AuthController.php
+++ b/app/Http/Controllers/AuthController.php
@@ -78,6 +78,7 @@ class AuthController extends Controller
      */
     protected function setSessionData($queryParams = [])
     {
+        // @see Northstar Authorization Code Grant: https://git.io/fjd8N
         if (array_has($queryParams, 'code')) {
             return;
         }

--- a/routes/web.php
+++ b/routes/web.php
@@ -12,7 +12,7 @@ $router->redirect('/', '/us');
 $router->get('/us', 'HomePageController');
 
 // Authentication
-$router->get('/register', 'AuthController@getRegistration')->name('register');
+$router->get('us/register', 'AuthController@getRegistration')->name('register');
 $router->get('next/login', 'AuthController@getLogin')->name('login');
 
 $router->get('next/logout', 'AuthController@getLogout')->name('logout');


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR updates the new `/register` route endpoint to `/us/register` since a while back a vanity URL was set up as a `301` redirect from `/register` to `vote.dosomething.org`. Being a `301` this redirect is permanently cached in a user's browser unless we set up a redirect back or potentially try to bust the browser cache with some cache control headers 🤷‍♂ For now this should work fine an allow us to move forward.

### Any background context you want to provide?

Some context on `301` browser caching via [stack overflow](https://stackoverflow.com/questions/9130422/how-long-do-browsers-cache-http-301s/21396547#21396547)

### What are the relevant tickets/cards?

Refs [Pivotal ID #167527420](https://www.pivotaltracker.com/story/show/167527420)

### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.