### PR TITLE
Fix to ensure Signup button heads to /us/register.

### DIFF
--- a/resources/assets/helpers/index.js
+++ b/resources/assets/helpers/index.js
@@ -49,19 +49,19 @@ export function appendToQuery(
 }
 
 /**
- * Build login redirect URL with optional context data.
+ * Build authentication redirect URL with optional context data.
  *
  * @param  {Null|Object} options
  * @param  {Null|String} actionId
  * @return {String}
  */
-export function buildLoginRedirectUrl(options = null, actionId = null) {
+export function buildAuthRedirectUrl(options = null, actionId = null) {
   const params = queryString.stringify({
     actionId,
     options: JSON.stringify(options),
   });
 
-  return `${window.location.origin}/next/login?${params}`;
+  return `${window.location.origin}/us/register?${params}`;
 }
 
 /**

--- a/resources/assets/middleware/requiresAuthentication.js
+++ b/resources/assets/middleware/requiresAuthentication.js
@@ -3,7 +3,7 @@
 import { get } from 'lodash';
 import localforage from 'localforage';
 
-import { buildLoginRedirectUrl } from '../helpers';
+import { buildAuthRedirectUrl } from '../helpers';
 import { getDataForNorthstar } from '../selectors';
 import { isAuthenticated } from '../selectors/user';
 
@@ -18,7 +18,7 @@ const requiresAuthenticationMiddleware = ({ getState }) => next => action => {
     const actionId = `auth:${Date.now()}`;
 
     localforage.setItem(actionId, action).then(() => {
-      const redirect = buildLoginRedirectUrl(
+      const redirect = buildAuthRedirectUrl(
         getDataForNorthstar(state),
         actionId,
       );


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### Delete This Section

_If this issue is an API related PR, use the \_api template_ by appending `?template=api.md` to this pull request's URL before proceeding.\_

### What does this PR do?

Following up on #1539 and #1544, this PR updates the auth redirect path to head to `/us/register` instead of `/next/login`. Since the login path now goes directly to the Northstar login page, we shouldn't assume that users signing up for a campaign already have an account. So this reset the path to ensure clicking the signup button when not authenticated takes the user to the Northstar registration page.

Also renames the helper function since it's not just for logging in, but more for general user authentication 😄 

### What are the relevant tickets/cards?

Refs [Pivotal ID #167527420](https://www.pivotaltracker.com/story/show/167527420)

### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.