### PR TITLE
Override ENV variables for Cypress tests

### DIFF
--- a/cypress/support/index.js
+++ b/cypress/support/index.js
@@ -11,6 +11,14 @@ import './commands';
 Cypress.on('window:before:load', window => {
   const document = window.document;
 
+  // Custom ENV veriables for the testing environment.
+  window.ENV = {
+    NPS_SURVEY_ENABLED: false,
+    VOTER_REG_MODAL_ENABLED: false,
+    SIXPACK_ENABLED: false,
+    SIXPACK_BASE_URL: 'http://sixpack.test', // Our Sixpack service will throw an error if this isn't set.
+  };
+
   // Remove built-in 'fetch' support since it cannot yet be mocked by Cypress.
   delete window.fetch; // eslint-disable-line no-param-reassign
 

--- a/cypress/support/index.js
+++ b/cypress/support/index.js
@@ -11,7 +11,7 @@ import './commands';
 Cypress.on('window:before:load', window => {
   const document = window.document;
 
-  // Custom ENV veriables for the testing environment.
+  // Custom ENV variables for the testing environment.
   window.ENV = {
     NPS_SURVEY_ENABLED: false,
     VOTER_REG_MODAL_ENABLED: false,


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR overrides the `window.ENV` object for our Cypress tests so that it doesn't collide with any of the local environment variables.

### Any background context you want to provide?
I bumped into an issue while working on #1549 where the Cypress tests failed due to the [Survey modal](https://github.com/DoSomething/phoenix-next/blob/bf9d0170dfdee4da6fb8f12a87dd823405009915/resources/assets/components/Campaign/Campaign.js#L31-L46) launching and messing with the UI being tested, causing failures. This did only happen because I'd lowered the launch timer to 1 second but it illustrated the issue of potential collisions.

@DFurnes made the point that as a general rule we ought to have a custom ENV setup for the Cypress tests so that we don't rely on any local setup, and can customize and control our testing environment properly.

*Q*: Did I put this in the right place? I tried to follow some of the suggested approaches in the [Cypress docs](https://docs.cypress.io/guides/guides/environment-variables.html) for setting env variables for tests, with no success -- I think due to the way [we set the env variables](https://github.com/DoSomething/phoenix-next/blob/db0145d10919695bc0fa5b5e3079d3872cc77c85/resources/views/layouts/master.blade.php#L51) on the `window` from the backend. So I opted to directly override the `window.ENV` object from within the core config file.

These seemed to be the only settings necessary to add for the tests to pass, but we can of course update this at will.

### What are the relevant tickets/cards?

Refs [Pivotal ID #167881873](https://www.pivotaltracker.com/story/show/167881873)
