### PR TITLE
Fixing registration authorization issue and updating auth route.

### DIFF
--- a/app/Http/Controllers/AuthController.php
+++ b/app/Http/Controllers/AuthController.php
@@ -45,8 +45,14 @@ class AuthController extends Controller
     {
         $options = array_get($queryParams, 'options', []);
 
+        $mode = array_get($queryParams, 'mode', null);
+
         if (is_string($options)) {
             $options = (array) json_decode($options);
+        }
+
+        if ($mode) {
+            $options['mode'] = $mode;
         }
 
         return $options;
@@ -109,31 +115,6 @@ class AuthController extends Controller
     }
 
     /**
-     * Handle a login request to the application.
-     *
-     * @param ServerRequestInterface $request
-     * @param ResponseInterface      $response
-     * @return \Illuminate\Http\RedirectResponse
-     */
-    public function getLogin(ServerRequestInterface $request, ResponseInterface $response)
-    {
-        $queryParams = $request->getQueryParams();
-
-        $this->setSessionData($queryParams);
-
-        $url = $this->getUrl();
-
-        $options = $this->getOptions($queryParams);
-
-        $destination = $this->getDestination($queryParams, $options);
-
-        // Override the default Northstar authorization /register page and view /login instead.
-        $options['mode'] = 'login';
-
-        return gateway('northstar')->authorize($request, $response, $url, $destination, $options);
-    }
-
-    /**
      * Handle a logout request to the application.
      *
      * @param ResponseInterface $response
@@ -145,13 +126,13 @@ class AuthController extends Controller
     }
 
     /**
-     * Handle a registration request to the application.
+     * Handle an auth request to the application.
      *
      * @param  ServerRequestInterface $request
      * @param  ResponseInterface      $response
      * @return \Illuminate\Http\RedirectResponse
      */
-    public function getRegistration(ServerRequestInterface $request, ResponseInterface $response)
+    public function getAuthorization(ServerRequestInterface $request, ResponseInterface $response)
     {
         $queryParams = $request->getQueryParams();
 

--- a/app/Http/Controllers/AuthController.php
+++ b/app/Http/Controllers/AuthController.php
@@ -23,6 +23,48 @@ class AuthController extends Controller
     protected $redirectAfterLogout;
 
     /**
+     * Make a new AuthController, inject dependencies,
+     * and set middleware for this controller's methods.
+     */
+    public function __construct()
+    {
+        $this->redirectAfterLogout = config('app.url');
+    }
+
+    /**
+     * Handle a logout request to the application.
+     *
+     * @param ResponseInterface $response
+     * @return ResponseInterface
+     */
+    public function getLogout(ResponseInterface $response)
+    {
+        return gateway('northstar')->logout($response, $this->redirectAfterLogout);
+    }
+
+    /**
+     * Handle an auth request to the application.
+     *
+     * @param  ServerRequestInterface $request
+     * @param  ResponseInterface      $response
+     * @return \Illuminate\Http\RedirectResponse
+     */
+    public function getAuthorization(ServerRequestInterface $request, ResponseInterface $response)
+    {
+        $queryParams = $request->getQueryParams();
+
+        $this->setSessionData($queryParams);
+
+        $url = $this->getUrl();
+
+        $options = $this->getOptions($queryParams);
+
+        $destination = $this->getDestination($queryParams, $options);
+
+        return gateway('northstar')->authorize($request, $response, $url, $destination, $options);
+    }
+
+    /**
      * Get destination metadata for Northstar login.
      * Defaults to "title" in $options or null.
      *
@@ -103,47 +145,5 @@ class AuthController extends Controller
         $actionId = array_get($queryParams, 'actionId');
 
         session()->flash('actionId', $actionId);
-    }
-
-    /**
-     * Make a new AuthController, inject dependencies,
-     * and set middleware for this controller's methods.
-     */
-    public function __construct()
-    {
-        $this->redirectAfterLogout = config('app.url');
-    }
-
-    /**
-     * Handle a logout request to the application.
-     *
-     * @param ResponseInterface $response
-     * @return ResponseInterface
-     */
-    public function getLogout(ResponseInterface $response)
-    {
-        return gateway('northstar')->logout($response, $this->redirectAfterLogout);
-    }
-
-    /**
-     * Handle an auth request to the application.
-     *
-     * @param  ServerRequestInterface $request
-     * @param  ResponseInterface      $response
-     * @return \Illuminate\Http\RedirectResponse
-     */
-    public function getAuthorization(ServerRequestInterface $request, ResponseInterface $response)
-    {
-        $queryParams = $request->getQueryParams();
-
-        $this->setSessionData($queryParams);
-
-        $url = $this->getUrl();
-
-        $options = $this->getOptions($queryParams);
-
-        $destination = $this->getDestination($queryParams, $options);
-
-        return gateway('northstar')->authorize($request, $response, $url, $destination, $options);
     }
 }

--- a/app/Http/Middleware/StartSession.php
+++ b/app/Http/Middleware/StartSession.php
@@ -12,7 +12,7 @@ class StartSession extends Middleware
      * @var array
      */
     protected $mustPersistSession = [
-        'next/login',
+        'authorize',
     ];
 
     /**
@@ -27,6 +27,7 @@ class StartSession extends Middleware
         // If we don't have a session cookie & aren't on a route that requires keeping a
         // persistent session between anonymous requests, use the 'array' driver.
         $isAnonymousSession = ! $request->cookies->has(config('session.cookie'));
+
         if ($isAnonymousSession && ! $request->is($this->mustPersistSession)) {
             config(['session.driver' => 'array']);
         }

--- a/app/Http/Middleware/StartSession.php
+++ b/app/Http/Middleware/StartSession.php
@@ -12,7 +12,7 @@ class StartSession extends Middleware
      * @var array
      */
     protected $mustPersistSession = [
-        'authorize',
+        '/authorize',
     ];
 
     /**

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -472,8 +472,9 @@ function get_campaign_social_fields($campaign, $uri)
  * @param  stdClass $campaign
  * @return array
  */
-function get_login_query($campaign = null)
+function get_authorization_query($entity = null, $mode = null)
 {
+    $query = [];
     $options = [];
     $params = [
         'referrer_user_id',
@@ -482,25 +483,33 @@ function get_login_query($campaign = null)
         'utm_source',
     ];
 
+    if ($mode) {
+        $query['mode'] = $mode;
+    }
+
     foreach ($params as $param) {
         if (request($param)) {
             $options[$param] = request($param);
         }
     }
 
-    if (! $campaign) {
-        return ['options' => $options];
+    if (! $entity) {
+        $query['options'] = $options;
+
+        return $query;
     }
 
-    return [
-        'destination' => $campaign->title,
-        'options' => array_merge($options, [
-            'contentful_id' => $campaign->id,
-            'title' => $campaign->title,
-            'coverImage' => $campaign->coverImage->url,
-            'callToAction' => $campaign->callToAction,
-        ]),
-    ];
+    // dd([$entity, $options, ! $entity]);
+
+    $query['destination'] = $entity->title;
+    $query['options'] = array_merge($options, [
+        'contentful_id' => $entity->id,
+        'title' => $entity->title,
+        'coverImage' => $entity->coverImage->url,
+        'callToAction' => $entity->callToAction,
+    ]);
+
+    return $query;
 }
 
 /**

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -499,9 +499,8 @@ function get_authorization_query($entity = null, $mode = null)
         return $query;
     }
 
-    // dd([$entity, $options, ! $entity]);
-
     $query['destination'] = $entity->title;
+
     $query['options'] = array_merge($options, [
         'contentful_id' => $entity->id,
         'title' => $entity->title,

--- a/config/services.php
+++ b/config/services.php
@@ -40,7 +40,7 @@ return [
             'client_id' => env('NORTHSTAR_AUTHORIZATION_ID'),
             'client_secret' => env('NORTHSTAR_AUTHORIZATION_SECRET'),
             'scope' => ['user', 'activity', 'write', 'openid', 'role:staff', 'role:admin'],
-            'redirect_uri' => 'next/login',
+            'redirect_uri' => 'authorize',
         ],
     ],
 

--- a/resources/assets/helpers/index.js
+++ b/resources/assets/helpers/index.js
@@ -61,7 +61,7 @@ export function buildAuthRedirectUrl(options = null, actionId = null) {
     options: JSON.stringify(options),
   });
 
-  return `${window.location.origin}/us/register?${params}`;
+  return `${window.location.origin}/authorize?${params}`;
 }
 
 /**

--- a/resources/views/partials/navigation.blade.php
+++ b/resources/views/partials/navigation.blade.php
@@ -39,8 +39,8 @@
                         <li><a href="{{ route('logout') }}" class="secondary-nav-item" id="link--logout">Log Out</a></li>
                     </ul>
                 @else
-                    {{-- <a href="{{ route('authorize', array_merge(['mode' => 'login'], get_login_query($entity))) }}">Log In</a> --}}
-                    <a href="{{ route('authorize', get_login_query($entity)) }}">Log In</a>
+                    {{-- <a href="{{ route('authorize', get_authorization_query($entity, 'login')) }}">Log In</a> --}}
+                    <a href="{{ route('authorize', get_authorization_query($entity)) }}">Log In</a>
                 @endif
             </li>
         </ul>

--- a/resources/views/partials/navigation.blade.php
+++ b/resources/views/partials/navigation.blade.php
@@ -39,8 +39,8 @@
                         <li><a href="{{ route('logout') }}" class="secondary-nav-item" id="link--logout">Log Out</a></li>
                     </ul>
                 @else
-                    {{-- <a href="{{ route('login', get_login_query($entity)) }}">Log In</a> --}}
-                    <a href="{{ route('register', get_login_query($entity)) }}">Log In</a>
+                    {{-- <a href="{{ route('authorize', array_merge(['mode' => 'login'], get_login_query($entity))) }}">Log In</a> --}}
+                    <a href="{{ route('authorize', get_login_query($entity)) }}">Log In</a>
                 @endif
             </li>
         </ul>

--- a/routes/api.php
+++ b/routes/api.php
@@ -40,9 +40,6 @@ $router->group(['prefix' => 'v2'], function () {
     $this->get('/posts', 'Api\PostsController@index');
     $this->post('/posts', 'Api\PostsController@store');
 
-    // Signups
-    $this->get('/signups', 'Api\SignupsController@index');
-
     // Unknown Route Fallback
     $this->fallback(function () {
         return response()->json(['message' => 'Not Found!'], 404);

--- a/routes/web.php
+++ b/routes/web.php
@@ -12,11 +12,11 @@ $router->redirect('/', '/us');
 $router->get('/us', 'HomePageController');
 
 // Authentication
-$router->get('us/register', 'AuthController@getRegistration')->name('register');
-$router->get('next/login', 'AuthController@getLogin')->name('login');
+$router->get('/authorize', 'AuthController@getAuthorization')->name('authorize');
+$router->redirect('/auth/login', '/next/login', 302); // Fix for hard-coded redirect in Gateway! <goo.gl/2VPxDC>
+$router->redirect('/next/login', '/authorize', 302);
 
 $router->get('next/logout', 'AuthController@getLogout')->name('logout');
-$router->redirect('auth/login', 'next/login'); // Fix for hard-coded redirect in Gateway! <goo.gl/2VPxDC>
 
 // Profile
 $router->redirect('/northstar/{id}', '/us/account/profile');


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR provides a fix for both the issue we were experiencing on QA when testing registration, where the server would throw a `500` error and indicating that `The OAuth state field did not match`. Turns out there's a custom middleware we use that I missed updating which controls which routes to persist session data on if the flow redirects outside the app. It was specified as `next/login` but the new route for authentication was `/register`. Thus on the return trip from Northstar during the OAuth flow, the session state data did not match because it did not exist!

However, this PR gave us an opportunity to rethink the routes as well, and within the OAuth flow established, it makes more sense to have a single route for both login and register, so we've renamed it to `/authorize` which overall just makes a bit more sense.

### Any background context you want to provide?

Additionally, during this process that was full of surprises, we also found out that the defined route redirects in Laravel prior to 5.7 would set redirects as `301` which are permanently cached in a user's browser and nigh impossible to clear. As of Laravel 5.7 this has been updated so redirects default to `302`.

Moving forward we're changing the defined redirects in the routes file to `302`, and being very prudent as to which should be `301` 😬 

### What are the relevant tickets/cards?

Refs [Pivotal ID #167527420](https://www.pivotaltracker.com/story/show/167527420)

### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.