### PR TITLE
Removing forwardslash on auth route.

### DIFF
--- a/app/Http/Middleware/StartSession.php
+++ b/app/Http/Middleware/StartSession.php
@@ -12,7 +12,7 @@ class StartSession extends Middleware
      * @var array
      */
     protected $mustPersistSession = [
-        '/authorize',
+        'authorize',
     ];
 
     /**


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR removes the forward slash from the route listed in the array for routes that must persist session data. Turns out adding it did cause problems. Initially it seemed like a fluke, but apparently it does affect it and curious to investigate later why.

### Any background context you want to provide?

My [hubris](https://github.com/DoSomething/phoenix-next/pull/1552#discussion_r316728869) 😬 

### What are the relevant tickets/cards?

Refs [Pivotal ID #167527420](https://www.pivotaltracker.com/story/show/167527420)

### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.