### PR TITLE
Remove Signup Button Copy Override Experiment

### DIFF
--- a/resources/assets/components/SignupButton/SignupButton.js
+++ b/resources/assets/components/SignupButton/SignupButton.js
@@ -4,7 +4,6 @@ import { get } from 'lodash';
 
 import Button from '../utilities/Button/Button';
 import { query, withoutNulls, isCampaignClosed } from '../../helpers';
-import SixpackExperiment from '../utilities/SixpackExperiment/SixpackExperiment';
 
 const SignupButton = props => {
   const {
@@ -16,7 +15,6 @@ const SignupButton = props => {
     disableSignup,
     endDate,
     pageId,
-    sixpackSourceActionText,
     sourceActionText,
     storeCampaignSignup,
     text,
@@ -60,38 +58,12 @@ const SignupButton = props => {
     return null;
   }
 
-  // In descending priority: button-specific text prop,
-  // campaign action text override, or standard "Take Action" copy.
-  const buttonCopy = text || campaignActionText;
+  // In descending priority: button copy override based on the user's traffic source,
+  // button-specific text prop, campaign action text override, or standard "Take Action" copy.
+  const buttonCopy =
+    get(sourceActionText, trafficSource) || text || campaignActionText;
 
-  // Button copy override based on the user's traffic source.
-  const sourceOverride = get(sourceActionText, trafficSource);
-  return sixpackSourceActionText && sourceOverride ? (
-    /* @SIXPACK Code Test: 2019-07-19 */
-    <SixpackExperiment
-      title={`Source Action Text Override ${campaignTitle}`}
-      convertableActions={['signup']}
-      control={
-        <Button
-          className={className}
-          onClick={handleSignup}
-          testName="Default Copy"
-        >
-          {isCampaignClosed(endDate) ? 'Notify Me' : buttonCopy}
-        </Button>
-      }
-      alternatives={[
-        <Button
-          className={className}
-          onClick={handleSignup}
-          testName="Source Action Text Override"
-        >
-          {isCampaignClosed(endDate) ? 'Notify Me' : sourceOverride}
-        </Button>,
-      ]}
-    />
-  ) : (
-    /* @SIXPACK Code Test: 2019-07-19 */
+  return (
     <Button className={className} onClick={handleSignup}>
       {isCampaignClosed(endDate) ? 'Notify Me' : buttonCopy}
     </Button>
@@ -107,7 +79,6 @@ SignupButton.propTypes = {
   disableSignup: PropTypes.bool,
   endDate: PropTypes.string,
   pageId: PropTypes.string.isRequired,
-  sixpackSourceActionText: PropTypes.bool,
   sourceActionText: PropTypes.objectOf(PropTypes.string),
   storeCampaignSignup: PropTypes.func.isRequired,
   text: PropTypes.string,
@@ -120,7 +91,6 @@ SignupButton.defaultProps = {
   className: null,
   disableSignup: false,
   endDate: null,
-  sixpackSourceActionText: false,
   sourceActionText: null,
   text: null,
   trafficSource: null,

--- a/resources/assets/components/SignupButton/SignupButtonContainer.js
+++ b/resources/assets/components/SignupButton/SignupButtonContainer.js
@@ -15,11 +15,6 @@ const mapStateToProps = state => ({
   endDate: state.campaign.endDate,
   pageId: state.campaign.id || state.page.id,
   disableSignup: get(state.campaign, 'additionalContent.disableSignup', false),
-  sixpackSourceActionText: get(
-    state.campaign,
-    'additionalContent.sixpackSourceActionText',
-    false,
-  ),
   sourceActionText: get(state.campaign, 'additionalContent.sourceActionText'),
   trafficSource: state.user.source,
 });


### PR DESCRIPTION
This override functionality will now just always work.

### What does this PR do?

This PR removes the Sixpack experiment added in #1512 to test the signup button copy override based on `utm_source` feature.

### Any background context you want to provide?
The results are in... and this feature's a keeper! Our next step is to formalize this functionality specifically for scholarship traffic, instead of the current more open-ended `additionalContent` settings. (See Pivotal ticket for more context.)

### What are the relevant tickets/cards?

Refs [Pivotal ID #167923056](https://www.pivotaltracker.com/story/show/167923056)

### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.
