### PR TITLE
Updates to sign up button logic for campaigns

### DIFF
--- a/resources/assets/components/LedeBanner/templates/MosaicTemplate.js
+++ b/resources/assets/components/LedeBanner/templates/MosaicTemplate.js
@@ -38,8 +38,6 @@ const MosaicTemplate = props => {
     )})`,
   };
 
-  const displayClosedCampaignCopy = isCampaignClosed(endDate);
-
   const signupButton = displaySignup ? (
     <div className="mosaic-lede-banner__signup">
       {affiliateOptInContent ? (
@@ -50,7 +48,6 @@ const MosaicTemplate = props => {
 
       <SignupButtonContainer
         className={classnames({ '-float': affiliateSponsors.length })}
-        displayClosedCampaignCopy={displayClosedCampaignCopy}
       />
       {signupArrowContent ? (
         <CampaignSignupArrow
@@ -67,7 +64,7 @@ const MosaicTemplate = props => {
         className={classnames('button', '-action')}
         to={affiliatedActionLink}
       >
-        {displayClosedCampaignCopy
+        {isCampaignClosed(endDate)
           ? 'Notify Me'
           : affiliatedActionText || 'Take Action'}
       </Link>

--- a/resources/assets/components/LedeBanner/templates/MosaicTemplate.js
+++ b/resources/assets/components/LedeBanner/templates/MosaicTemplate.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import { Link } from 'react-router-dom';
 
-import { contentfulImageUrl } from '../../../helpers';
+import { contentfulImageUrl, isCampaignClosed } from '../../../helpers';
 import CampaignSignupArrow from '../../CampaignSignupArrow';
 import TextContent from '../../utilities/TextContent/TextContent';
 import SignupButtonContainer from '../../SignupButton/SignupButtonContainer';
@@ -20,6 +20,7 @@ const MosaicTemplate = props => {
     affiliateOptInContent,
     affiliateSponsors,
     displaySignup,
+    endDate,
     title,
     subtitle,
     blurb,
@@ -37,6 +38,8 @@ const MosaicTemplate = props => {
     )})`,
   };
 
+  const displayClosedCampaignCopy = isCampaignClosed(endDate);
+
   const signupButton = displaySignup ? (
     <div className="mosaic-lede-banner__signup">
       {affiliateOptInContent ? (
@@ -47,6 +50,7 @@ const MosaicTemplate = props => {
 
       <SignupButtonContainer
         className={classnames({ '-float': affiliateSponsors.length })}
+        displayClosedCampaignCopy={displayClosedCampaignCopy}
       />
       {signupArrowContent ? (
         <CampaignSignupArrow
@@ -63,7 +67,9 @@ const MosaicTemplate = props => {
         className={classnames('button', '-action')}
         to={affiliatedActionLink}
       >
-        {affiliatedActionText || 'Take Action'}
+        {displayClosedCampaignCopy
+          ? 'Notify Me'
+          : affiliatedActionText || 'Take Action'}
       </Link>
     </div>
   ) : null;
@@ -121,6 +127,7 @@ MosaicTemplate.propTypes = {
     url: PropTypes.string,
   }).isRequired,
   displaySignup: PropTypes.bool,
+  endDate: PropTypes.string,
   isAffiliated: PropTypes.bool.isRequired,
   subtitle: PropTypes.string.isRequired,
   title: PropTypes.string.isRequired,
@@ -134,6 +141,7 @@ MosaicTemplate.defaultProps = {
   affiliateOptInContent: null,
   blurb: null,
   displaySignup: true,
+  endDate: null,
   signupArrowContent: null,
 };
 

--- a/resources/assets/components/LedeBanner/templates/MosaicTemplate.js
+++ b/resources/assets/components/LedeBanner/templates/MosaicTemplate.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import { Link } from 'react-router-dom';
 
-import { contentfulImageUrl, isCampaignClosed } from '../../../helpers';
+import { contentfulImageUrl } from '../../../helpers';
 import CampaignSignupArrow from '../../CampaignSignupArrow';
 import TextContent from '../../utilities/TextContent/TextContent';
 import SignupButtonContainer from '../../SignupButton/SignupButtonContainer';
@@ -20,7 +20,6 @@ const MosaicTemplate = props => {
     affiliateOptInContent,
     affiliateSponsors,
     displaySignup,
-    endDate,
     title,
     subtitle,
     blurb,
@@ -64,9 +63,7 @@ const MosaicTemplate = props => {
         className={classnames('button', '-action')}
         to={affiliatedActionLink}
       >
-        {isCampaignClosed(endDate)
-          ? 'Notify Me'
-          : affiliatedActionText || 'Take Action'}
+        {affiliatedActionText || 'Take Action'}
       </Link>
     </div>
   ) : null;
@@ -124,7 +121,6 @@ MosaicTemplate.propTypes = {
     url: PropTypes.string,
   }).isRequired,
   displaySignup: PropTypes.bool,
-  endDate: PropTypes.string,
   isAffiliated: PropTypes.bool.isRequired,
   subtitle: PropTypes.string.isRequired,
   title: PropTypes.string.isRequired,
@@ -138,7 +134,6 @@ MosaicTemplate.defaultProps = {
   affiliateOptInContent: null,
   blurb: null,
   displaySignup: true,
-  endDate: null,
   signupArrowContent: null,
 };
 

--- a/resources/assets/components/SignupButton/SignupButton.js
+++ b/resources/assets/components/SignupButton/SignupButton.js
@@ -14,6 +14,7 @@ const SignupButton = props => {
     campaignTitle,
     className,
     disableSignup,
+    displayClosedCampaignCopy,
     pageId,
     sixpackSourceActionText,
     sourceActionText,
@@ -65,7 +66,6 @@ const SignupButton = props => {
 
   // Button copy override based on the user's traffic source.
   const sourceOverride = get(sourceActionText, trafficSource);
-
   return sixpackSourceActionText && sourceOverride ? (
     /* @SIXPACK Code Test: 2019-07-19 */
     <SixpackExperiment
@@ -77,7 +77,7 @@ const SignupButton = props => {
           onClick={handleSignup}
           testName="Default Copy"
         >
-          {buttonCopy}
+          {displayClosedCampaignCopy ? 'Notify Me' : buttonCopy}
         </Button>
       }
       alternatives={[
@@ -86,14 +86,14 @@ const SignupButton = props => {
           onClick={handleSignup}
           testName="Source Action Text Override"
         >
-          {sourceOverride}
+          {displayClosedCampaignCopy ? 'Notify Me' : sourceOverride}
         </Button>,
       ]}
     />
   ) : (
     /* @SIXPACK Code Test: 2019-07-19 */
     <Button className={className} onClick={handleSignup}>
-      {buttonCopy}
+      {displayClosedCampaignCopy ? 'Notify Me' : buttonCopy}
     </Button>
   );
 };
@@ -105,6 +105,7 @@ SignupButton.propTypes = {
   campaignTitle: PropTypes.string,
   className: PropTypes.string,
   disableSignup: PropTypes.bool,
+  displayClosedCampaignCopy: PropTypes.bool,
   pageId: PropTypes.string.isRequired,
   sixpackSourceActionText: PropTypes.bool,
   sourceActionText: PropTypes.objectOf(PropTypes.string),
@@ -118,6 +119,7 @@ SignupButton.defaultProps = {
   campaignTitle: null,
   className: null,
   disableSignup: false,
+  displayClosedCampaignCopy: false,
   sixpackSourceActionText: false,
   sourceActionText: null,
   text: null,

--- a/resources/assets/components/SignupButton/SignupButton.js
+++ b/resources/assets/components/SignupButton/SignupButton.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { get } from 'lodash';
 
 import Button from '../utilities/Button/Button';
-import { query, withoutNulls } from '../../helpers';
+import { query, withoutNulls, isCampaignClosed } from '../../helpers';
 import SixpackExperiment from '../utilities/SixpackExperiment/SixpackExperiment';
 
 const SignupButton = props => {
@@ -14,7 +14,7 @@ const SignupButton = props => {
     campaignTitle,
     className,
     disableSignup,
-    displayClosedCampaignCopy,
+    endDate,
     pageId,
     sixpackSourceActionText,
     sourceActionText,
@@ -77,7 +77,7 @@ const SignupButton = props => {
           onClick={handleSignup}
           testName="Default Copy"
         >
-          {displayClosedCampaignCopy ? 'Notify Me' : buttonCopy}
+          {isCampaignClosed(endDate) ? 'Notify Me' : buttonCopy}
         </Button>
       }
       alternatives={[
@@ -86,14 +86,14 @@ const SignupButton = props => {
           onClick={handleSignup}
           testName="Source Action Text Override"
         >
-          {displayClosedCampaignCopy ? 'Notify Me' : sourceOverride}
+          {isCampaignClosed(endDate) ? 'Notify Me' : sourceOverride}
         </Button>,
       ]}
     />
   ) : (
     /* @SIXPACK Code Test: 2019-07-19 */
     <Button className={className} onClick={handleSignup}>
-      {displayClosedCampaignCopy ? 'Notify Me' : buttonCopy}
+      {isCampaignClosed(endDate) ? 'Notify Me' : buttonCopy}
     </Button>
   );
 };
@@ -105,7 +105,7 @@ SignupButton.propTypes = {
   campaignTitle: PropTypes.string,
   className: PropTypes.string,
   disableSignup: PropTypes.bool,
-  displayClosedCampaignCopy: PropTypes.bool,
+  endDate: PropTypes.string,
   pageId: PropTypes.string.isRequired,
   sixpackSourceActionText: PropTypes.bool,
   sourceActionText: PropTypes.objectOf(PropTypes.string),
@@ -119,7 +119,7 @@ SignupButton.defaultProps = {
   campaignTitle: null,
   className: null,
   disableSignup: false,
-  displayClosedCampaignCopy: false,
+  endDate: null,
   sixpackSourceActionText: false,
   sourceActionText: null,
   text: null,

--- a/resources/assets/components/SignupButton/SignupButtonContainer.js
+++ b/resources/assets/components/SignupButton/SignupButtonContainer.js
@@ -12,6 +12,7 @@ const mapStateToProps = state => ({
   campaignActionText: state.campaign.actionText,
   campaignId: state.campaign.campaignId,
   campaignTitle: state.campaign.title,
+  endDate: state.campaign.endDate,
   pageId: state.campaign.id || state.page.id,
   disableSignup: get(state.campaign, 'additionalContent.disableSignup', false),
   sixpackSourceActionText: get(

--- a/resources/assets/components/pages/CampaignPage/CampaignClosedPage.js
+++ b/resources/assets/components/pages/CampaignPage/CampaignClosedPage.js
@@ -11,7 +11,7 @@ const CampaignClosedPage = props => {
 
   return (
     <div>
-      <LedeBannerContainer displaySignup />
+      <LedeBannerContainer />
 
       <div className="main clearfix">
         <Enclosure className="default-container margin-top-lg margin-bottom-lg">

--- a/resources/assets/components/pages/CampaignPage/CampaignClosedPage.js
+++ b/resources/assets/components/pages/CampaignPage/CampaignClosedPage.js
@@ -11,7 +11,7 @@ const CampaignClosedPage = props => {
 
   return (
     <div>
-      <LedeBannerContainer displaySignup={false} />
+      <LedeBannerContainer displaySignup />
 
       <div className="main clearfix">
         <Enclosure className="default-container margin-top-lg margin-bottom-lg">


### PR DESCRIPTION

## _PULL REQUEST OVERVIEW_


### What does this PR do?

This PR adds logic to check the campaign end date before displaying the button copy. It should display 'Notify Me' on closed campaigns and the chosen campaign action text for open campaigns. This should allow for the campaigns team to continue to collect contact information of everyone interested in a campaign in the case that it is re opened.

### Any background context you want to provide?

This is a change from the previous ticket that hid the display of the button when the campaign was closed.

### What are the relevant tickets/cards?

Refs [Pivotal ID #167980313](https://www.pivotaltracker.com/story/show/167980313)

### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.
* [ ] Added screenshot to PR description of related front-end updates on **small** screens.
* [ ] Added screenshot to PR description of related front-end updates on **medium** screens.
* [ ] Added screenshot to PR description of related front-end updates on **large** screens.
