### PR TITLE
Rendering CTA's on Articles & Facts pages (Feature Flagged)

### DIFF
--- a/resources/assets/components/PageDispatcher/PageDispatcher.js
+++ b/resources/assets/components/PageDispatcher/PageDispatcher.js
@@ -25,10 +25,14 @@ const PageDispatcher = props => {
 };
 
 PageDispatcher.propTypes = {
-  authUrl: PropTypes.string.isRequired,
+  authUrl: PropTypes.string,
   isAuthenticated: PropTypes.bool.isRequired,
   type: PropTypes.string.isRequired,
   fields: PropTypes.object.isRequired,
+};
+
+PageDispatcher.defaultProps = {
+  authUrl: null,
 };
 
 export default PageDispatcher;

--- a/resources/assets/components/PageDispatcher/PageDispatcher.js
+++ b/resources/assets/components/PageDispatcher/PageDispatcher.js
@@ -14,11 +14,19 @@ const PageDispatcher = props => {
       return <StoryPage {...props.fields} />;
 
     default:
-      return <GeneralPage {...props.fields} />;
+      return (
+        <GeneralPage
+          {...props.fields}
+          authUrl={props.authUrl}
+          isAuthenticated={props.isAuthenticated}
+        />
+      );
   }
 };
 
 PageDispatcher.propTypes = {
+  authUrl: PropTypes.string.isRequired,
+  isAuthenticated: PropTypes.bool.isRequired,
   type: PropTypes.string.isRequired,
   fields: PropTypes.object.isRequired,
 };

--- a/resources/assets/components/PageDispatcher/PageDispatcherContainer.js
+++ b/resources/assets/components/PageDispatcher/PageDispatcherContainer.js
@@ -1,11 +1,18 @@
 import { connect } from 'react-redux';
 
 import PageDispatcher from './PageDispatcher';
+import { buildAuthRedirectUrl } from '../../helpers';
+import { getDataForNorthstar } from '../../selectors';
+import { isAuthenticated } from '../../selectors/user';
 
 /**
  * Provide state from the Redux store as props for this component.
  */
-const mapStateToProps = state => state.page;
+const mapStateToProps = state => ({
+  ...state.page,
+  isAuthenticated: isAuthenticated(state),
+  authUrl: buildAuthRedirectUrl(getDataForNorthstar(state)),
+});
 
 // Export the container component.
 export default connect(mapStateToProps)(PageDispatcher);

--- a/resources/assets/components/pages/GeneralPage/GeneralPage.js
+++ b/resources/assets/components/pages/GeneralPage/GeneralPage.js
@@ -8,12 +8,21 @@ import Enclosure from '../../Enclosure';
 import LazyImage from '../../utilities/LazyImage';
 import Byline from '../../utilities/Byline/Byline';
 import ContentfulEntry from '../../ContentfulEntry';
+import { REGISTER_CTA_COPY } from '../../../constants';
 import AuthorBio from '../../utilities/Author/AuthorBio';
+import CtaBanner from '../../utilities/CtaBanner/CtaBanner';
+import CtaPopover from '../../utilities/CtaPopover/CtaPopover';
 import TextContent from '../../utilities/TextContent/TextContent';
-import { contentfulImageUrl, withoutNulls } from '../../../helpers';
+import DelayedElement from '../../utilities/DelayedElement/DelayedElement';
+import { contentfulImageUrl, withoutNulls, query } from '../../../helpers';
 import SocialShareTray from '../../utilities/SocialShareTray/SocialShareTray';
+import DismissableElement from '../../utilities/DismissableElement/DismissableElement';
 
 import './general-page.scss';
+
+// Grab the CTA copy based on the current page category.
+const pageCategory = window.location.pathname.split('/')[2];
+const ctaCopy = REGISTER_CTA_COPY[pageCategory];
 
 /**
  * Render a general page
@@ -30,6 +39,8 @@ const GeneralPage = props => {
     sidebar,
     blocks,
     displaySocialShare,
+    isAuthenticated,
+    authUrl,
   } = props;
 
   return (
@@ -125,6 +136,32 @@ const GeneralPage = props => {
           ) : null}
         </Enclosure>
       </div>
+
+      {ctaCopy && !isAuthenticated && query('show_register_cta') ? (
+        <>
+          <DismissableElement
+            testName="CTA Popover"
+            name="cta_register_popover"
+            render={handleClose => (
+              <DelayedElement delay={3}>
+                <CtaPopover
+                  title={ctaCopy.title}
+                  content={ctaCopy.content}
+                  link={authUrl}
+                  buttonText={ctaCopy.buttonText}
+                  handleClose={handleClose}
+                />
+              </DelayedElement>
+            )}
+          />
+          <CtaBanner
+            title={ctaCopy.title}
+            content={ctaCopy.content}
+            link={authUrl}
+            buttonText={ctaCopy.buttonText}
+          />
+        </>
+      ) : null}
     </div>
   );
 };
@@ -141,6 +178,8 @@ GeneralPage.propTypes = {
   sidebar: PropTypes.arrayOf(PropTypes.object),
   blocks: PropTypes.arrayOf(PropTypes.object).isRequired,
   displaySocialShare: PropTypes.bool,
+  isAuthenticated: PropTypes.bool.isRequired,
+  authUrl: PropTypes.string.isRequired,
 };
 
 GeneralPage.defaultProps = {

--- a/resources/assets/components/pages/GeneralPage/GeneralPage.js
+++ b/resources/assets/components/pages/GeneralPage/GeneralPage.js
@@ -147,7 +147,7 @@ const GeneralPage = props => {
               testName="CTA Popover"
               name="cta_register_popover"
               render={handleClose => (
-                <DelayedElement delay={0}>
+                <DelayedElement delay={3}>
                   <CtaPopover
                     title={ctaCopy.title}
                     content={ctaCopy.content}

--- a/resources/assets/components/pages/GeneralPage/GeneralPage.js
+++ b/resources/assets/components/pages/GeneralPage/GeneralPage.js
@@ -16,6 +16,7 @@ import TextContent from '../../utilities/TextContent/TextContent';
 import DelayedElement from '../../utilities/DelayedElement/DelayedElement';
 import { contentfulImageUrl, withoutNulls, query } from '../../../helpers';
 import SocialShareTray from '../../utilities/SocialShareTray/SocialShareTray';
+import SixpackExperiment from '../../utilities/SixpackExperiment/SixpackExperiment';
 import DismissableElement from '../../utilities/DismissableElement/DismissableElement';
 
 import './general-page.scss';
@@ -137,29 +138,37 @@ const GeneralPage = props => {
         </Enclosure>
       </div>
 
-      {ctaCopy && !isAuthenticated && query('show_register_cta') ? (
-        <>
-          <DismissableElement
-            name="cta_register_popover"
-            render={handleClose => (
-              <DelayedElement delay={3}>
-                <CtaPopover
-                  title={ctaCopy.title}
-                  content={ctaCopy.content}
-                  link={authUrl}
-                  buttonText={ctaCopy.buttonText}
-                  handleClose={handleClose}
-                />
-              </DelayedElement>
-            )}
-          />
-          <CtaBanner
-            title={ctaCopy.title}
-            content={ctaCopy.content}
-            link={authUrl}
-            buttonText={ctaCopy.buttonText}
-          />
-        </>
+      {ctaCopy && !isAuthenticated ? (
+        <SixpackExperiment
+          title={`Registration Call To Actions: ${pageCategory}`}
+          convertableActions={['ctaButtonClick']}
+          control={
+            <DismissableElement
+              testName="CTA Popover"
+              name="cta_register_popover"
+              render={handleClose => (
+                <DelayedElement delay={0}>
+                  <CtaPopover
+                    title={ctaCopy.title}
+                    content={ctaCopy.content}
+                    link={authUrl}
+                    buttonText={ctaCopy.buttonText}
+                    handleClose={handleClose}
+                  />
+                </DelayedElement>
+              )}
+            />
+          }
+          alternatives={[
+            <CtaBanner
+              testName="CTA Banner"
+              title={ctaCopy.title}
+              content={ctaCopy.content}
+              link={authUrl}
+              buttonText={ctaCopy.buttonText}
+            />,
+          ]}
+        ></SixpackExperiment>
       ) : null}
     </div>
   );

--- a/resources/assets/components/pages/GeneralPage/GeneralPage.js
+++ b/resources/assets/components/pages/GeneralPage/GeneralPage.js
@@ -140,7 +140,6 @@ const GeneralPage = props => {
       {ctaCopy && !isAuthenticated && query('show_register_cta') ? (
         <>
           <DismissableElement
-            testName="CTA Popover"
             name="cta_register_popover"
             render={handleClose => (
               <DelayedElement delay={3}>

--- a/resources/assets/components/pages/GeneralPage/GeneralPage.js
+++ b/resources/assets/components/pages/GeneralPage/GeneralPage.js
@@ -140,7 +140,9 @@ const GeneralPage = props => {
 
       {ctaCopy && !isAuthenticated ? (
         <SixpackExperiment
-          title={`Registration Call To Actions: ${pageCategory}`}
+          title={`Registration CTA: ${pageCategory} - ${
+            window.innerWidth <= 759 ? 'Small' : 'Large'
+          }`}
           convertableActions={['ctaButtonClick']}
           control={
             <DismissableElement

--- a/resources/assets/components/pages/GeneralPage/GeneralPage.js
+++ b/resources/assets/components/pages/GeneralPage/GeneralPage.js
@@ -13,8 +13,8 @@ import AuthorBio from '../../utilities/Author/AuthorBio';
 import CtaBanner from '../../utilities/CtaBanner/CtaBanner';
 import CtaPopover from '../../utilities/CtaPopover/CtaPopover';
 import TextContent from '../../utilities/TextContent/TextContent';
+import { contentfulImageUrl, withoutNulls } from '../../../helpers';
 import DelayedElement from '../../utilities/DelayedElement/DelayedElement';
-import { contentfulImageUrl, withoutNulls, query } from '../../../helpers';
 import SocialShareTray from '../../utilities/SocialShareTray/SocialShareTray';
 import SixpackExperiment from '../../utilities/SixpackExperiment/SixpackExperiment';
 import DismissableElement from '../../utilities/DismissableElement/DismissableElement';
@@ -168,7 +168,7 @@ const GeneralPage = props => {
               buttonText={ctaCopy.buttonText}
             />,
           ]}
-        ></SixpackExperiment>
+        />
       ) : null}
     </div>
   );

--- a/resources/assets/components/pages/GeneralPage/GeneralPage.js
+++ b/resources/assets/components/pages/GeneralPage/GeneralPage.js
@@ -21,10 +21,6 @@ import DismissableElement from '../../utilities/DismissableElement/DismissableEl
 
 import './general-page.scss';
 
-// Grab the CTA copy based on the current page category.
-const pageCategory = window.location.pathname.split('/')[2];
-const ctaCopy = REGISTER_CTA_COPY[pageCategory];
-
 /**
  * Render a general page
  *
@@ -32,6 +28,7 @@ const ctaCopy = REGISTER_CTA_COPY[pageCategory];
  */
 const GeneralPage = props => {
   const {
+    slug,
     authors,
     title,
     subTitle,
@@ -43,6 +40,10 @@ const GeneralPage = props => {
     isAuthenticated,
     authUrl,
   } = props;
+
+  // Grab the CTA copy based on the current page category.
+  const pageCategory = slug.split('/')[0];
+  const ctaCopy = REGISTER_CTA_COPY[pageCategory];
 
   return (
     <div>
@@ -177,6 +178,7 @@ const GeneralPage = props => {
 };
 
 GeneralPage.propTypes = {
+  slug: PropTypes.string.isRequired,
   authors: PropTypes.arrayOf(PropTypes.object),
   title: PropTypes.string.isRequired,
   subTitle: PropTypes.string,

--- a/resources/assets/components/utilities/CtaBanner/CtaBanner.js
+++ b/resources/assets/components/utilities/CtaBanner/CtaBanner.js
@@ -1,6 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
+import { sixpack } from '../../../helpers';
+
 import './cta-banner.scss';
 
 const CtaBanner = ({ buttonText, content, link, title }) => (
@@ -8,7 +10,11 @@ const CtaBanner = ({ buttonText, content, link, title }) => (
     <div className="grid-narrow m-4">
       <h3 className="text-m text-yellow font-bold uppercase">{title}</h3>
       <p className="text-white mt-4">{content}</p>
-      <a className="cta-banner__button button p-4 mt-4" href={link}>
+      <a
+        className="cta-banner__button button p-4 mt-4"
+        href={link}
+        onClick={() => sixpack().convertOnAction('ctaButtonClick')}
+      >
         {buttonText}
       </a>
     </div>

--- a/resources/assets/components/utilities/CtaPopover/CtaPopover.js
+++ b/resources/assets/components/utilities/CtaPopover/CtaPopover.js
@@ -1,6 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
+import { sixpack } from '../../../helpers';
+
 import './cta-popover.scss';
 
 const CtaPopover = ({ buttonText, content, handleClose, link, title }) => (
@@ -14,7 +16,11 @@ const CtaPopover = ({ buttonText, content, handleClose, link, title }) => (
     </button>
     <h3 className="text-m text-yellow font-bold uppercase">{title}</h3>
     <p className="text-white mt-4">{content}</p>
-    <a className="cta-popover__button button p-4 mt-4" href={link}>
+    <a
+      className="cta-popover__button button p-4 mt-4"
+      href={link}
+      onClick={() => sixpack().convertOnAction('ctaButtonClick')}
+    >
       {buttonText}
     </a>
   </div>

--- a/resources/assets/components/utilities/CtaPopover/CtaPopover.js
+++ b/resources/assets/components/utilities/CtaPopover/CtaPopover.js
@@ -3,8 +3,15 @@ import PropTypes from 'prop-types';
 
 import './cta-popover.scss';
 
-const CtaPopover = ({ buttonText, content, link, title }) => (
+const CtaPopover = ({ buttonText, content, handleClose, link, title }) => (
   <div className="cta-popover p-4 bordered rounded">
+    <button
+      type="button"
+      className="modal__close -white -small"
+      onClick={handleClose}
+    >
+      &times;
+    </button>
     <h3 className="text-m text-yellow font-bold uppercase">{title}</h3>
     <p className="text-white mt-4">{content}</p>
     <a className="cta-popover__button button p-4 mt-4" href={link}>
@@ -16,6 +23,7 @@ const CtaPopover = ({ buttonText, content, link, title }) => (
 CtaPopover.propTypes = {
   buttonText: PropTypes.string.isRequired,
   content: PropTypes.string.isRequired,
+  handleClose: PropTypes.func.isRequired,
   link: PropTypes.string.isRequired,
   title: PropTypes.string.isRequired,
 };

--- a/resources/assets/components/utilities/CtaPopover/CtaPopover.js
+++ b/resources/assets/components/utilities/CtaPopover/CtaPopover.js
@@ -7,11 +7,7 @@ import './cta-popover.scss';
 
 const CtaPopover = ({ buttonText, content, handleClose, link, title }) => (
   <div className="cta-popover p-4 bordered rounded">
-    <button
-      type="button"
-      className="modal__close -white -small"
-      onClick={handleClose}
-    >
+    <button type="button" className="modal__close -white" onClick={handleClose}>
       &times;
     </button>
     <h3 className="text-m text-yellow font-bold uppercase">{title}</h3>

--- a/resources/assets/components/utilities/CtaPopover/cta-popover.scss
+++ b/resources/assets/components/utilities/CtaPopover/cta-popover.scss
@@ -7,9 +7,9 @@
 
   position: fixed;
   bottom: $half-spacing;
-  right: $half-spacing;
+  right: 0;
+  margin: 0 $half-spacing;
   max-width: 500px;
-  margin-left: $half-spacing;
   z-index: $sticky-cta-zindex;
 
   @include media($medium) {

--- a/resources/assets/components/utilities/CtaPopover/cta-popover.scss
+++ b/resources/assets/components/utilities/CtaPopover/cta-popover.scss
@@ -18,9 +18,9 @@
     max-width: 400px;
   }
 
-  // Snap back to the left once the wrapper width maxes out so the
-  // popover isn't drawn past the edge of the chrome.
-  @media (min-width: 1440px) {
+  // @HACK: Snap back to the left a bit after the wrapper width maxes out
+  // so the popover isn't drawn too far past the edge of the chrome.
+  @media (min-width: 1500px) {
     right: inherit;
   }
 

--- a/resources/assets/components/utilities/CtaPopover/cta-popover.scss
+++ b/resources/assets/components/utilities/CtaPopover/cta-popover.scss
@@ -18,10 +18,10 @@
     max-width: 400px;
   }
 
-  // @HACK: Snap back to the left a bit after the wrapper width maxes out
-  // so the popover isn't drawn too far past the edge of the chrome.
-  @media (min-width: 1500px) {
-    right: inherit;
+  // Ensure the popover isn't drawn past the edge of the chrome
+  // once the wrapper maxes out at 1440px.
+  @media (min-width: 1440px) {
+    right: calc((100vw - 1440px) / 2);
   }
 
   .cta-popover__button {

--- a/resources/assets/components/utilities/CtaPopover/cta-popover.scss
+++ b/resources/assets/components/utilities/CtaPopover/cta-popover.scss
@@ -18,9 +18,11 @@
     max-width: 400px;
   }
 
-  // Ensure the popover isn't drawn past the edge of the chrome
+  // Ensure the popover isn't drawn past the edge of the chrome into the 'gray space'
   // once the wrapper maxes out at 1440px.
   @media (min-width: 1440px) {
+    // Calculates the current 'grey space' on the right of the viewport by subtracting the space occupied by
+    // the chrome, and dividing the remainder in two to subtract the space on the left of the chrome.
     right: calc((100vw - 1440px) / 2);
   }
 

--- a/resources/assets/components/utilities/Modal/ModalContent.js
+++ b/resources/assets/components/utilities/Modal/ModalContent.js
@@ -4,6 +4,7 @@ import classnames from 'classnames';
 
 const ModalContent = ({ children, onClose, className }) => (
   <div className={classnames('modal', className)}>
+    {/* @TODO: Extract this 'ex button' into a utility component. */}
     <button type="button" className="modal__close" onClick={onClose}>
       &times;
     </button>

--- a/resources/assets/components/utilities/Modal/modal.scss
+++ b/resources/assets/components/utilities/Modal/modal.scss
@@ -64,10 +64,6 @@
   &.-white {
     color: $white;
   }
-
-  &.-small {
-    font-size: $font-regular;
-  }
 }
 
 .modal.badge {

--- a/resources/assets/components/utilities/Modal/modal.scss
+++ b/resources/assets/components/utilities/Modal/modal.scss
@@ -60,6 +60,14 @@
   &:focus {
     outline: thin dotted;
   }
+
+  &.-white {
+    color: $white;
+  }
+
+  &.-small {
+    font-size: $font-regular;
+  }
 }
 
 .modal.badge {

--- a/resources/assets/constants/index.js
+++ b/resources/assets/constants/index.js
@@ -20,3 +20,19 @@ export const NetworkStatus = {
   READY: 7,
   ERROR: 8,
 };
+
+// Register CTA copy for specific page categories:
+export const REGISTER_CTA_COPY = {
+  facts: {
+    title: 'Learn Something...Then Do Something!',
+    content:
+      'Sign up for DoSomething.org. You’ll can make an impact with millions of young people and earn easy scholarships for volunteering!',
+    buttonText: 'Join us',
+  },
+  articles: {
+    title: 'Join DoSomething Today!',
+    content:
+      'Make an impact with millions of young people, and earn easy scholarships for volunteering.',
+    buttonText: 'Join us',
+  },
+};


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR renders the `CtaBanner` and `CtaPopover` on the `GeneralPage`, with copy based on the page category in the URL for unauthenticated users.

It also adds a 'close' or 'ex' button to the `CtaPopover` to handle user dismissal. I ended up utilizing the pre-existing styling from the [Modal component](https://github.com/DoSomething/phoenix-next/blob/fc5cdfcf5d6edea99ab07966d2ec5b0568b16941/resources/assets/components/utilities/Modal/modal.scss#L46-L62) and duplicating its rendering of the button, but it does feel like we can extract that into a utility component to DRY this up a bit? (I needed to add some modifier classes to get the right color and sizing https://github.com/DoSomething/phoenix-next/commit/f32d4a042b2512595d0ce86dc4ad3471885c5f8d). I added a TODO for the above - but lemme know if you disagree! https://github.com/DoSomething/phoenix-next/commit/475d237b5993cde41fa28b786c77388326c2b327

https://github.com/DoSomething/phoenix-next/commit/dac0d806a3d1aa4ed0eb9429d3cdb6aaf01dbf4c I also updated the HACK to snap the popover to the left of the page to prevent chrome overflow to be more generous about when it does so, since it should optimally be on the right, and it was snapping a pixel too early to begin with. 

~Finally, I feature flagged the CTA's under the `show_register_cta` query param.~ 🎩 💁‍♂ @aaronschachter

UPDATE: I added the sixpack experiment conversion for any `ctaButtonClick` tests to the CTA components in https://github.com/DoSomething/phoenix-next/pull/1585/commits/7c6d0ea6f66234e464ae67fe717fb942f8716fc1 and rendered the CTA's in a Sixpack Experiment on the `GeneralPage` in https://github.com/DoSomething/phoenix-next/pull/1585/commits/a559de459c0046c198e866d864474376db984cb2 which means this should be launch-ready once approved!

### What are the relevant tickets/cards?

Refs [Pivotal ID #167527419](https://www.pivotaltracker.com/story/show/167527419), [Pivotal ID #167878581](https://www.pivotaltracker.com/story/show/167878581)


### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.
* [ ] Added screenshot to PR description of related front-end updates on **small** screens.
* [ ] Added screenshot to PR description of related front-end updates on **medium** screens.
* [x] Added screenshot to PR description of related front-end updates on **large** screens.

![image](https://user-images.githubusercontent.com/12417657/64199827-32ba6b80-ce59-11e9-92c1-0b3a2d088ec8.png)

![image](https://user-images.githubusercontent.com/12417657/64199860-42d24b00-ce59-11e9-9539-26156c4984d0.png)
