### PR TITLE
Fix nav link analytics and add analytics for DS logo link.

### DIFF
--- a/resources/assets/helpers/navigation.js
+++ b/resources/assets/helpers/navigation.js
@@ -18,6 +18,7 @@ export function linkAnalyticsHandler(link) {
   link.addEventListener(
     'mousedown',
     event => {
+      // If element is not an anchor tag, find the parent which should be an anchor tag!
       const element =
         event.target.tagName !== 'A'
           ? event.target.parentElement

--- a/resources/assets/helpers/navigation.js
+++ b/resources/assets/helpers/navigation.js
@@ -18,6 +18,11 @@ export function linkAnalyticsHandler(link) {
   link.addEventListener(
     'mousedown',
     event => {
+      const element =
+        event.target.tagName !== 'A'
+          ? event.target.parentElement
+          : event.target;
+
       trackAnalyticsEvent({
         context: {
           ...getUtmContext(),
@@ -25,9 +30,9 @@ export function linkAnalyticsHandler(link) {
           referrer: document.referrer,
         },
         metadata: {
-          adjective: snakeCase(event.target.textContent),
+          adjective: snakeCase(element.dataset.label),
           category: 'navigation',
-          label: snakeCase(event.target.textContent),
+          label: snakeCase(element.dataset.label),
           noun: 'nav_link',
           target: 'link',
           verb: 'clicked',
@@ -107,6 +112,10 @@ export function bindNavigationEvents() {
   navLinks.forEach(link => {
     linkAnalyticsHandler(link);
   });
+
+  // Navigation Logo link analytics.
+  const navLogo = document.querySelector('.navigation__logo');
+  linkAnalyticsHandler(navLogo);
 
   // Search form analytics.
   const searchForm = document.querySelector('.navigation__menu .form-search');

--- a/resources/views/partials/navigation.blade.php
+++ b/resources/views/partials/navigation.blade.php
@@ -5,18 +5,18 @@
 @endphp
 
 <div class="navigation {{isset($legacyNavigation) ? '-white -floating' : 'bg-white'}}">
-    <a class="navigation__logo" href="{{ url('/') }}"><span>DoSomething.org</span></a>
+    <a class="navigation__logo" href="{{ url('/') }}" data-label="homepage"><span>DoSomething.org</span></a>
     <a  id="js-navigation-toggle" class="navigation__toggle"><span>Show Menu</span></a>
     <div class="navigation__menu">
         <ul class="navigation__primary">
             <li>
-                <a href="{{ config('app.url') }}/us/campaigns">
+                <a href="{{ config('app.url') }}/us/campaigns" data-label="explore-campaigns">
                     <strong class="navigation__title">Explore Campaigns</strong>
                     <span class="navigation__subtitle">Find ways to take action both online and off.</span>
                 </a>
             </li>
             <li>
-                <a href="{{ config('app.url') }}/us/about/who-we-are">
+                <a href="{{ config('app.url') }}/us/about/who-we-are" data-label="what-is-dosomething">
                     <strong class="navigation__title">What is DoSomething.org?</strong>
                     <span class="navigation__subtitle">A global movement for good.</span>
                 </a>
@@ -33,15 +33,15 @@
 
             @if (Auth::user())
                 <li class="navigation__dropdown">
-                    <a id="js-account-toggle" class="navigation__dropdown-toggle">My Profile</a>
+                    <a id="js-account-toggle" class="navigation__dropdown-toggle" data-label="account-toggle">My Profile</a>
                     <ul>
-                        <li><a href="{{ url('us/account/profile') }}">Profile</a></li>
-                        <li><a href="{{ route('logout') }}" class="secondary-nav-item" id="link--logout">Log Out</a></li>
+                        <li><a href="{{ url('us/account/profile') }}" data-label="profle">Profile</a></li>
+                        <li><a href="{{ route('logout') }}" class="secondary-nav-item" id="link--logout" data-label="log-out">Log Out</a></li>
                     </ul>
                 </li>
             @else
-                <li><a href="{{ route('authorize', get_authorization_query($entity, 'login')) }}">Log In</a></li>
-                <li class="navigation__join"><a href="{{ route('authorize', get_authorization_query($entity)) }}">Join Now</a></li>
+                <li><a href="{{ route('authorize', get_authorization_query($entity, 'login')) }}" data-label="log-in">Log In</a></li>
+                <li class="navigation__join"><a href="{{ route('authorize', get_authorization_query($entity)) }}" data-label="join-now">Join Now</a></li>
             @endif
         </ul>
     </div>

--- a/resources/views/partials/navigation.blade.php
+++ b/resources/views/partials/navigation.blade.php
@@ -35,7 +35,7 @@
                 <li class="navigation__dropdown">
                     <a id="js-account-toggle" class="navigation__dropdown-toggle" data-label="account-toggle">My Profile</a>
                     <ul>
-                        <li><a href="{{ url('us/account/profile') }}" data-label="profle">Profile</a></li>
+                        <li><a href="{{ url('us/account/profile') }}" data-label="profile">Profile</a></li>
                         <li><a href="{{ route('logout') }}" class="secondary-nav-item" id="link--logout" data-label="log-out">Log Out</a></li>
                     </ul>
                 </li>


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR fixes an issue with the analytics events in the Navigation added in #1580.

Turns out that since the nav items for "Explore Campaigns" and "What is DoSomething.org?" have subtext that shows on large size screens, sometimes what is clicked is the subtext in a `<span />` and thus the text obtained for the analytics `adjective` and `label` via `event.target.textContent` would vary (which we don't want to happen and prefer analytics consistency in event naming).

To simplify this, it seemed like a better approach to attach a `data-label` on all anchor links in the navigation and use the value assigned as the `adjective` and `label`, which makes it way more consistent and also much cleaner in naming that pulling from the elements text content.

### Any background context you want to provide?

This also adds a missing binding to the DS Logo link to trigger an analytics event as well!

Example:
![image](https://user-images.githubusercontent.com/105849/64288599-85b32200-cf30-11e9-8734-226feacf1b83.png)

### What are the relevant tickets/cards?

Refs [Pivotal ID #168175576](https://www.pivotaltracker.com/story/show/168175576)

### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.