### PR TITLE
Footer link to close Affirmation modal

### DIFF
--- a/resources/assets/components/Campaign/CampaignRoute/CampaignRoute.js
+++ b/resources/assets/components/Campaign/CampaignRoute/CampaignRoute.js
@@ -38,7 +38,10 @@ const CampaignRoute = props => {
   return (
     <React.Fragment>
       {shouldShowAffirmation ? (
-        <Modal onClose={clickedHideAffirmation}>
+        <Modal
+          onClose={clickedHideAffirmation}
+          closeFooterText="Continue to Campaign"
+        >
           <PostSignupModal affirmation={affirmation || undefined} />
         </Modal>
       ) : null}

--- a/resources/assets/components/utilities/Modal/Modal.js
+++ b/resources/assets/components/utilities/Modal/Modal.js
@@ -78,6 +78,7 @@ class Modal extends React.Component {
       <ModalContent
         onClose={this.props.onClose}
         className={this.props.className}
+        closeFooterText={this.props.closeFooterText}
       >
         {this.props.children}
       </ModalContent>
@@ -93,12 +94,14 @@ Modal.propTypes = {
   trackingId: PropTypes.string,
   onClose: PropTypes.func.isRequired,
   className: PropTypes.string,
+  closeFooterText: PropTypes.string,
 };
 
 Modal.defaultProps = {
   context: {},
   trackingId: null,
   className: null,
+  closeFooterText: null,
 };
 
 export default Modal;

--- a/resources/assets/components/utilities/Modal/ModalContent.js
+++ b/resources/assets/components/utilities/Modal/ModalContent.js
@@ -11,7 +11,11 @@ const ModalContent = ({ children, onClose, className, closeFooterText }) => (
     {children}
 
     {closeFooterText ? (
-      <button type="button" className="text-white" onClick={onClose}>
+      <button
+        type="button"
+        className="modal__footer text-white"
+        onClick={onClose}
+      >
         {closeFooterText}
       </button>
     ) : null}

--- a/resources/assets/components/utilities/Modal/ModalContent.js
+++ b/resources/assets/components/utilities/Modal/ModalContent.js
@@ -2,17 +2,24 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 
-const ModalContent = ({ children, onClose, className }) => (
+const ModalContent = ({ children, onClose, className, closeFooterText }) => (
   <div className={classnames('modal', className)}>
     <button type="button" className="modal__close" onClick={onClose}>
       &times;
     </button>
 
     {children}
+
+    {closeFooterText ? (
+      <button type="button" className="text-white" onClick={onClose}>
+        {closeFooterText}
+      </button>
+    ) : null}
   </div>
 );
 
 ModalContent.propTypes = {
+  closeFooterText: PropTypes.string,
   className: PropTypes.string,
   children: PropTypes.element.isRequired,
   onClose: PropTypes.func.isRequired,
@@ -20,6 +27,7 @@ ModalContent.propTypes = {
 
 ModalContent.defaultProps = {
   className: null,
+  closeFooterText: null,
 };
 
 export default ModalContent;

--- a/resources/assets/components/utilities/Modal/modal.scss
+++ b/resources/assets/components/utilities/Modal/modal.scss
@@ -69,3 +69,7 @@
     min-width: 600px;
   }
 }
+
+.modal__footer {
+  font-size: $font-regular;
+}


### PR DESCRIPTION
### What does this PR do?

In today's episode of "Hey let's try it", this PR adds a "Continue to campaign" footer link to Affirmation modals that close the modal. This feature has been requested per the Refer A Friend [designs](https://projects.invisionapp.com/share/GYSBOGRSDUA#/screens/372969109), however this really doesn't look anything like said designs. I'll be reviewing it with Leah shortly, as well as updating the `phoenix` dev client with the review app to make this testable.

<img src="https://user-images.githubusercontent.com/1236811/64370936-4f2ee300-cfd4-11e9-971d-af91932c4a66.png">


### Any background context you want to provide?


I am feeling like it'd be a much bigger lift to style the footer link to look like the design (within the modal content). Refs https://github.com/DoSomething/phoenix-next/pull/1551#issuecomment-523628327

### What are the relevant tickets/cards?

* https://www.pivotaltracker.com/story/show/167501569
* https://www.pivotaltracker.com/story/show/167633963

### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.
* [ ] Added screenshot to PR description of related front-end updates on **small** screens.
* [ ] Added screenshot to PR description of related front-end updates on **medium** screens.
* [ ] Added screenshot to PR description of related front-end updates on **large** screens.
