### PR TITLE
Affirmation close button

### DIFF
--- a/resources/assets/components/Affirmation/Affirmation.js
+++ b/resources/assets/components/Affirmation/Affirmation.js
@@ -96,9 +96,11 @@ const Affirmation = ({
 
     {query('refer-friends') ? <CtaReferralPageBannerContainer /> : null}
 
-    <button type="button" onClick={onClose}>
-      Continue to Campaign
-    </button>
+    <div className="p-4">
+      <button type="button" className="close-button" onClick={onClose}>
+        Continue to Campaign
+      </button>
+    </div>
   </Card>
 );
 

--- a/resources/assets/components/Affirmation/Affirmation.js
+++ b/resources/assets/components/Affirmation/Affirmation.js
@@ -38,6 +38,7 @@ const Affirmation = ({
   callToActionDescription,
   callToActionHeader,
   header,
+  onClose,
   quote,
   userId,
 }) => (
@@ -94,6 +95,10 @@ const Affirmation = ({
     ) : null}
 
     {query('refer-friends') ? <CtaReferralPageBannerContainer /> : null}
+
+    <button type="button" onClick={onClose}>
+      Continue to Campaign
+    </button>
   </Card>
 );
 
@@ -102,6 +107,7 @@ Affirmation.propTypes = {
   callToActionDescription: PropTypes.string,
   callToActionHeader: PropTypes.string,
   header: PropTypes.string,
+  onClose: PropTypes.func.isRequired,
   quote: PropTypes.string,
   userId: PropTypes.string.isRequired,
 };

--- a/resources/assets/components/Affirmation/Affirmation.js
+++ b/resources/assets/components/Affirmation/Affirmation.js
@@ -97,7 +97,11 @@ const Affirmation = ({
     {query('refer-friends') ? <CtaReferralPageBannerContainer /> : null}
 
     <div className="p-4">
-      <button type="button" className="close-button" onClick={onClose}>
+      <button
+        type="button"
+        className="close-button font-bold text-base"
+        onClick={onClose}
+      >
         Continue to Campaign
       </button>
     </div>

--- a/resources/assets/components/Affirmation/affirmation.scss
+++ b/resources/assets/components/Affirmation/affirmation.scss
@@ -10,4 +10,11 @@
       font-weight: 800;
     }
   }
+
+  .close-button {
+    color: $blue;
+    cursor: pointer;
+    font-size: $font-regular;
+    font-weight: 800;
+  }
 }

--- a/resources/assets/components/Affirmation/affirmation.scss
+++ b/resources/assets/components/Affirmation/affirmation.scss
@@ -14,7 +14,5 @@
   .close-button {
     color: $blue;
     cursor: pointer;
-    font-size: $font-regular;
-    font-weight: 800;
   }
 }

--- a/resources/assets/components/Campaign/CampaignRoute/CampaignRoute.js
+++ b/resources/assets/components/Campaign/CampaignRoute/CampaignRoute.js
@@ -39,7 +39,10 @@ const CampaignRoute = props => {
     <React.Fragment>
       {shouldShowAffirmation ? (
         <Modal onClose={clickedHideAffirmation}>
-          <PostSignupModal affirmation={affirmation || undefined} />
+          <PostSignupModal
+            affirmation={affirmation || undefined}
+            onClose={clickedHideAffirmation}
+          />
         </Modal>
       ) : null}
 

--- a/resources/assets/components/ContentfulEntry/ContentfulEntry.js
+++ b/resources/assets/components/ContentfulEntry/ContentfulEntry.js
@@ -64,7 +64,12 @@ class ContentfulEntry extends React.Component<Props, State> {
 
     switch (type) {
       case 'affirmation':
-        return <AffirmationContainer {...withoutNulls(json.fields)} />;
+        return (
+          <AffirmationContainer
+            {...withoutNulls(json.fields)}
+            onClose={json.onClose}
+          />
+        );
 
       case 'callToAction':
         return (

--- a/resources/assets/components/ContentfulEntry/ContentfulEntry.js
+++ b/resources/assets/components/ContentfulEntry/ContentfulEntry.js
@@ -64,6 +64,12 @@ class ContentfulEntry extends React.Component<Props, State> {
 
     switch (type) {
       case 'affirmation':
+        /**
+         * Note: For Affirmations, the json object includes an onClose function property,
+         * used to close the Affirmation modal. This is a little bit of a hack, as our json
+         * object is not truly json when it includes a function.
+         * @see components/pages/PostSignupModal.js
+         */
         return (
           <AffirmationContainer
             {...withoutNulls(json.fields)}

--- a/resources/assets/components/pages/PostSignupModal/PostSignupModal.js
+++ b/resources/assets/components/pages/PostSignupModal/PostSignupModal.js
@@ -4,16 +4,17 @@ import PropTypes from 'prop-types';
 import SlideshowContainer from '../../Slideshow';
 import ContentfulEntry from '../../ContentfulEntry';
 
-const PostSignupModal = ({ affirmation }) => (
+const PostSignupModal = ({ affirmation, onClose }) => (
   <div className="modal__slide">
     <SlideshowContainer slideshowId="post-signup-modal" hideCloseButton>
-      <ContentfulEntry json={affirmation} />
+      <ContentfulEntry json={{ ...affirmation, onClose }} />
     </SlideshowContainer>
   </div>
 );
 
 PostSignupModal.propTypes = {
   affirmation: PropTypes.object, // eslint-disable-line
+  onClose: PropTypes.func.isRequired,
 };
 
 PostSignupModal.defaultProps = {


### PR DESCRIPTION
### What does this PR do?

This PR adds a close footer link in Affirmation per [Refer A Friend designs](https://projects.invisionapp.com/share/GYSBOGRSDUA#/screens/372969109) and per  https://github.com/DoSomething/phoenix-next/pull/1590#discussion_r321747054.

<img src="https://user-images.githubusercontent.com/1236811/64453067-8ff22f00-d09c-11e9-99ab-95cff320eb5c.png">

### Any background context you want to provide?

As @mendelB mentioned in https://github.com/DoSomething/phoenix-next/pull/1590#discussion_r321747054, this might be a bit too hacky -- but I think appending an `onClose` property into the `json` of the Affirmation component beats passing an optional `onClose` prop to the `ContentfulEntry` component, since it's only used by the Affirmation.

### Screenshots

* [mobile](https://user-images.githubusercontent.com/1236811/64453348-363e3480-d09d-11e9-8363-8ebd7bf67a9d.png)
* [tablet](https://user-images.githubusercontent.com/1236811/64453371-3dfdd900-d09d-11e9-94a4-2eb9329c3e6e.png)
* [desktop](https://user-images.githubusercontent.com/1236811/64453067-8ff22f00-d09c-11e9-99ab-95cff320eb5c.png)

