### PR TITLE
CTA Popover UI Bug Fix for Title

### DIFF
--- a/resources/assets/components/utilities/CtaPopover/CtaPopover.js
+++ b/resources/assets/components/utilities/CtaPopover/CtaPopover.js
@@ -10,7 +10,9 @@ const CtaPopover = ({ buttonText, content, handleClose, link, title }) => (
     <button type="button" className="modal__close -white" onClick={handleClose}>
       &times;
     </button>
-    <h3 className="text-m text-yellow font-bold uppercase">{title}</h3>
+    <h3 className="cta-popover__title text-m text-yellow font-bold uppercase">
+      {title}
+    </h3>
     <p className="text-white mt-4">{content}</p>
     <a
       className="cta-popover__button button p-4 mt-4"

--- a/resources/assets/components/utilities/CtaPopover/cta-popover.scss
+++ b/resources/assets/components/utilities/CtaPopover/cta-popover.scss
@@ -26,6 +26,11 @@
     right: calc((100vw - 1440px) / 2);
   }
 
+  .cta-popover__title {
+    // Ensure the title doesn't overlap the close button.
+    max-width: 90%;
+  }
+
   .cta-popover__button {
     width: 100%;
 


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR adds a quick `max-width` rule to the CTA Popover's Title to prevent it from overlapping the X button

The title on this is a bit unfortunate in the sense that it has a very long chained second word so it flows a bit awkwardly on mobile, but I'm not sure what we can do about that.

![image](https://user-images.githubusercontent.com/12417657/64456967-6d254200-d0bf-11e9-857a-471dae1fbd66.png)


![image](https://user-images.githubusercontent.com/12417657/64456996-7f9f7b80-d0bf-11e9-800f-441576bcb8a0.png)

