### PR TITLE
Track analytics event for an Embed click

### DIFF
--- a/resources/assets/components/utilities/Embed/Embed.js
+++ b/resources/assets/components/utilities/Embed/Embed.js
@@ -38,8 +38,9 @@ const Embed = props => {
         url,
       },
       metadata: {
-        category: 'campaign_action',
-        noun: 'embed',
+        category: 'site_action',
+        adjective: 'embed',
+        noun: 'link',
         verb: 'clicked',
       },
     });

--- a/resources/assets/components/utilities/Embed/Embed.js
+++ b/resources/assets/components/utilities/Embed/Embed.js
@@ -12,6 +12,7 @@ import linkIcon from './linkIcon.svg';
 import { isExternal } from '../../../helpers';
 import ErrorBlock from '../../blocks/ErrorBlock/ErrorBlock';
 import PlaceholderText from '../PlaceholderText/PlaceholderText';
+import { trackAnalyticsEvent } from '../../../helpers/analytics';
 
 import './embed.scss';
 
@@ -30,6 +31,19 @@ const EMBED_QUERY = gql`
 
 const Embed = props => {
   const { url, badged, className } = props;
+
+  const onClick = () => {
+    trackAnalyticsEvent({
+      context: {
+        url,
+      },
+      metadata: {
+        category: 'campaign_action',
+        noun: 'embed',
+        verb: 'clicked',
+      },
+    });
+  };
 
   return (
     <div className={classnames('bordered', 'rounded', 'bg-white', className)}>
@@ -55,6 +69,7 @@ const Embed = props => {
               className="embed__linker"
               target={isExternal(url) ? '_blank' : '_self'}
               rel="noopener noreferrer"
+              onClick={onClick}
             >
               <div className="embed">
                 <LazyImage

--- a/resources/assets/components/utilities/Embed/Embed.js
+++ b/resources/assets/components/utilities/Embed/Embed.js
@@ -41,6 +41,7 @@ const Embed = props => {
         category: 'site_action',
         adjective: 'embed',
         noun: 'link',
+        target: 'link_embed',
         verb: 'clicked',
       },
     });

--- a/resources/assets/components/utilities/Embed/Embed.js
+++ b/resources/assets/components/utilities/Embed/Embed.js
@@ -41,7 +41,7 @@ const Embed = props => {
         category: 'site_action',
         adjective: 'embed',
         noun: 'link',
-        target: 'link_embed',
+        target: 'link',
         verb: 'clicked',
       },
     });


### PR DESCRIPTION
### What does this PR do?

This PR tracks a new analytics event for when a user clicks on the link in an `Embed` component. This can potentially resolve tracking the two [Refer A Friend events we wish to track](https://docs.google.com/spreadsheets/d/1hNZdkcS7orp7xU0mOHSRKPodNoif0EP5UC2YwOnDmPI/edit#gid=1098747526):

* Track clicks on the Beta page links to campaigns.
* Track clicks on alpha page link to view their beta page

### Any background context you want to provide?

I started a discussion in the [Pivotal story](https://www.pivotaltracker.com/n/projects/2019429/stories/168201845) but it may be easier to hash things out in this PR, where we can comment per line. Here are some outstanding questions:

* What category should this fall into? In Dev RT, the idea of a new category was discussed - but we need a name for said category if so. I picked `campaign_action` thinking that these are mainly used in campaign pages (although questionable if Refer A Friend clicks should toward that). Also we might use `Embed` components elsewhere, which may warrant refactoring this PR to send the track event payload as a prop to an `Embed` component...  

* Will using the `context.url` and the page the event was fired from give us enough information to track the desired clicks on the Alpha / Beta Referral Pages?

* `adjective` - I wonder whether it'd be useful to save something here like `internal` / `external` based on `isExternal(url)`

### What are the relevant tickets/cards?

Refs https://www.pivotaltracker.com/n/projects/2019429/stories/168201845

### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.
* ~[ ] Added screenshot to PR description of related front-end updates on **small** screens.~
* ~[ ] Added screenshot to PR description of related front-end updates on **medium** screens.~
* ~[ ] Added screenshot to PR description of related front-end updates on **large** screens.~
