### PR TITLE
Number Of Participants field on PhotoSubmissionAction

### DIFF
--- a/app/Entities/PhotoSubmissionAction.php
+++ b/app/Entities/PhotoSubmissionAction.php
@@ -19,6 +19,7 @@ class PhotoSubmissionAction extends Entity implements JsonSerializable
                 'showQuantityField' => $this->showQuantityField,
                 'quantityFieldLabel' => $this->quantityFieldLabel,
                 'quantityFieldPlaceholder' => $this->quantityFieldPlaceholder,
+                'numberOfParticipantsFieldLabel' => $this->numberOfParticipantsFieldLabel,
                 'whyParticipatedFieldLabel' => $this->whyParticipatedFieldLabel,
                 'whyParticipatedFieldPlaceholder' => $this->whyParticipatedFieldPlaceholder,
                 'buttonText' => $this->buttonText,

--- a/app/Http/Requests/PostRequest.php
+++ b/app/Http/Requests/PostRequest.php
@@ -33,7 +33,7 @@ class PostRequest extends FormRequest
                     'text.max' => 'The caption field may not be greater than :max characters.',
                     'text.min' => 'The caption field may not be less than :min characters.',
                     'text.required' => 'The caption field for your photo is required.',
-                    'number_of_participants.integer' => 'The number of participants must be an integer.',
+                    'number_of_participants.integer' => 'The number of participants must be a number.',
                 ];
 
             case 'text':

--- a/app/Http/Requests/PostRequest.php
+++ b/app/Http/Requests/PostRequest.php
@@ -63,7 +63,7 @@ class PostRequest extends FormRequest
                     'show_quantity' => 'required|boolean',
                     'text' => 'required|min:4|max:60',
                     'why_participated' => 'required',
-                    'number_of_participants' => 'integer',
+                    'number_of_participants' => 'integer|nullable',
                 ];
 
             case 'text':

--- a/app/Http/Requests/PostRequest.php
+++ b/app/Http/Requests/PostRequest.php
@@ -33,6 +33,7 @@ class PostRequest extends FormRequest
                     'text.max' => 'The caption field may not be greater than :max characters.',
                     'text.min' => 'The caption field may not be less than :min characters.',
                     'text.required' => 'The caption field for your photo is required.',
+                    'number_of_participants.integer' => 'The number of participants must be an integer.'
                 ];
 
             case 'text':
@@ -62,6 +63,7 @@ class PostRequest extends FormRequest
                     'show_quantity' => 'required|boolean',
                     'text' => 'required|min:4|max:60',
                     'why_participated' => 'required',
+                    'number_of_participants' => 'integer',
                 ];
 
             case 'text':

--- a/app/Http/Requests/PostRequest.php
+++ b/app/Http/Requests/PostRequest.php
@@ -33,7 +33,7 @@ class PostRequest extends FormRequest
                     'text.max' => 'The caption field may not be greater than :max characters.',
                     'text.min' => 'The caption field may not be less than :min characters.',
                     'text.required' => 'The caption field for your photo is required.',
-                    'number_of_participants.integer' => 'The number of participants must be an integer.'
+                    'number_of_participants.integer' => 'The number of participants must be an integer.',
                 ];
 
             case 'text':

--- a/app/Repositories/PostRepository.php
+++ b/app/Repositories/PostRepository.php
@@ -44,11 +44,14 @@ class PostRepository
             unset($payload['media']);
 
             // Guzzle expects specific file object for multipart form.
-            // @TODO: upadte Gateway to handle multipart form data.
+            // @TODO: update Gateway to handle multipart form data.
             $payload['file'] = fopen($payload['file']->getPathname(), 'r');
         }
 
         $multipartData = collect($payload)->map(function ($value, $key) {
+            if ($key === 'number_of_participants') {
+                return ['name' => 'details', 'contents' => json_encode(['number_of_participants' => $value])];
+            }
             return ['name' => $key, 'contents' => $value];
         })->values()->toArray();
 

--- a/app/Repositories/PostRepository.php
+++ b/app/Repositories/PostRepository.php
@@ -49,7 +49,7 @@ class PostRepository
         }
 
         $multipartData = collect($payload)->map(function ($value, $key) {
-            if ($key === 'number_of_participants') {
+            if ($key === 'number_of_participants' && ! is_null($value)) {
                 return ['name' => 'details', 'contents' => json_encode(['number_of_participants' => $value])];
             }
 

--- a/app/Repositories/PostRepository.php
+++ b/app/Repositories/PostRepository.php
@@ -52,6 +52,7 @@ class PostRepository
             if ($key === 'number_of_participants') {
                 return ['name' => 'details', 'contents' => json_encode(['number_of_participants' => $value])];
             }
+
             return ['name' => $key, 'contents' => $value];
         })->values()->toArray();
 

--- a/resources/assets/components/actions/PhotoSubmissionAction/PhotoSubmissionAction.js
+++ b/resources/assets/components/actions/PhotoSubmissionAction/PhotoSubmissionAction.js
@@ -375,6 +375,33 @@ class PhotoSubmissionAction extends React.Component {
                         </div>
                       ) : null}
 
+                      {this.props.numberOfParticipantsFieldLabel ? (
+                        <div className="form-item">
+                          <label
+                            className={classnames('field-label', {
+                              'has-error': has(errors, 'numberOfParticipants'),
+                            })}
+                            htmlFor="numberOfParticipants"
+                          >
+                            {this.props.numberOfParticipantsFieldLabel}
+                          </label>
+                          <input
+                            className={classnames('text-field', {
+                              'has-error shake': has(
+                                errors,
+                                'numberOfParticipants',
+                              ),
+                            })}
+                            type="text"
+                            id="numberOfParticipants"
+                            name="numberOfParticipants"
+                            placeholder="1"
+                            value={this.state.numberOfParticipantsValue}
+                            onChange={this.handleChange}
+                          />
+                        </div>
+                      ) : null}
+
                       <div className="form-item stretched">
                         <label
                           className={classnames('field-label', {
@@ -539,6 +566,7 @@ PhotoSubmissionAction.propTypes = {
   id: PropTypes.string.isRequired, // @TODO: rename property to blockId
   informationContent: PropTypes.string,
   informationTitle: PropTypes.string,
+  numberOfParticipantsFieldLabel: PropTypes.string,
   pageId: PropTypes.string.isRequired,
   quantityFieldLabel: PropTypes.string,
   quantityFieldPlaceholder: PropTypes.string,
@@ -567,6 +595,7 @@ PhotoSubmissionAction.defaultProps = {
   informationContent:
     'A DoSomething staffer will review and approve your photo.',
   informationTitle: 'More Info',
+  numberOfParticipantsFieldLabel: null,
   quantityFieldLabel: 'How many items are in this photo?',
   quantityFieldPlaceholder: 'Quantity # (e.g. 300)',
   showQuantityField: true,

--- a/resources/assets/components/actions/PhotoSubmissionAction/PhotoSubmissionAction.js
+++ b/resources/assets/components/actions/PhotoSubmissionAction/PhotoSubmissionAction.js
@@ -105,6 +105,7 @@ class PhotoSubmissionAction extends React.Component {
       signup: null,
       showModal: false,
       whyParticipatedValue: '',
+      numberOfParticipantsValue: '',
     };
   }
 
@@ -150,6 +151,10 @@ class PhotoSubmissionAction extends React.Component {
 
     if (this.props.showQuantityField) {
       items.quantity = 'quantity';
+    }
+
+    if (this.props.numberOfParticipantsFieldLabel) {
+      items.number_of_participants = 'numberOfParticipants';
     }
 
     return items;
@@ -261,6 +266,7 @@ class PhotoSubmissionAction extends React.Component {
       shouldResetForm: false,
       signup,
       whyParticipatedValue: '',
+      numberOfParticipantsValue: '',
     });
   };
 


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR utilizes the new Contentful field "Number Of Participants Field Label". If that field has been filled out in Contentful, it shows up on the PhotoSubmissionAction like this:
![image](https://user-images.githubusercontent.com/4240292/64466213-83360100-d0c5-11e9-93f4-d8d108a42cb6.png)

We validate to make sure the input is an integer:
![image (8)](https://user-images.githubusercontent.com/4240292/64466221-9052f000-d0c5-11e9-86ad-f5c6843d4e1a.png)

And pass the result along to Rogue in the `details` on the Post. It gets stored in Rogue like this:
![image](https://user-images.githubusercontent.com/4240292/64466230-a19bfc80-d0c5-11e9-8d4d-2928795f6c29.png)


### Any background context you want to provide?

(link to Contentful PR to go here!)

### What are the relevant tickets/cards?

Refs [Pivotal ID #167659459](https://www.pivotaltracker.com/story/show/167659459)

### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.
* [ ] Added screenshot to PR description of related front-end updates on **small** screens.
* [ ] Added screenshot to PR description of related front-end updates on **medium** screens.
* [ ] Added screenshot to PR description of related front-end updates on **large** screens.
