### PR TITLE
Signup Button Updates (scholarship affiliate override)

### DIFF
--- a/resources/assets/components/CallToAction/CallToAction.js
+++ b/resources/assets/components/CallToAction/CallToAction.js
@@ -3,6 +3,8 @@ import PropTypes from 'prop-types';
 import classnames from 'classnames';
 
 import Card from '../utilities/Card/Card';
+import { isScholarshipAffiliateReferral } from '../../helpers';
+import { SCHOLARSHIP_SIGNUP_BUTTON_TEXT } from '../../constants';
 import SignupButtonContainer from '../SignupButton/SignupButtonContainer';
 
 import './cta.scss';
@@ -60,7 +62,15 @@ const CallToAction = ({
         <div className="cta__message margin-bottom-lg">{content}</div>
       ) : null}
 
-      {isSignedUp ? null : <SignupButtonContainer />}
+      {isSignedUp ? null : (
+        <SignupButtonContainer
+          text={
+            isScholarshipAffiliateReferral()
+              ? SCHOLARSHIP_SIGNUP_BUTTON_TEXT
+              : undefined
+          }
+        />
+      )}
     </Card>
   );
 };

--- a/resources/assets/components/LedeBanner/templates/MosaicTemplate.js
+++ b/resources/assets/components/LedeBanner/templates/MosaicTemplate.js
@@ -7,12 +7,12 @@ import CampaignSignupArrow from '../../CampaignSignupArrow';
 import TextContent from '../../utilities/TextContent/TextContent';
 import { SCHOLARSHIP_SIGNUP_BUTTON_TEXT } from '../../../constants';
 import SignupButtonContainer from '../../SignupButton/SignupButtonContainer';
+import AffiliatePromotion from '../../utilities/AffiliatePromotion/AffiliatePromotion';
+import AffiliateOptInToggleContainer from '../../AffiliateOptInToggle/AffiliateOptInToggleContainer';
 import {
   contentfulImageUrl,
   isScholarshipAffiliateReferral,
 } from '../../../helpers';
-import AffiliatePromotion from '../../utilities/AffiliatePromotion/AffiliatePromotion';
-import AffiliateOptInToggleContainer from '../../AffiliateOptInToggle/AffiliateOptInToggleContainer';
 
 import './mosaic-lede-banner.scss';
 

--- a/resources/assets/components/LedeBanner/templates/MosaicTemplate.js
+++ b/resources/assets/components/LedeBanner/templates/MosaicTemplate.js
@@ -3,10 +3,14 @@ import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import { Link } from 'react-router-dom';
 
-import { contentfulImageUrl } from '../../../helpers';
 import CampaignSignupArrow from '../../CampaignSignupArrow';
 import TextContent from '../../utilities/TextContent/TextContent';
+import { SCHOLARSHIP_SIGNUP_BUTTON_TEXT } from '../../../constants';
 import SignupButtonContainer from '../../SignupButton/SignupButtonContainer';
+import {
+  contentfulImageUrl,
+  isScholarshipAffiliateReferral,
+} from '../../../helpers';
 import AffiliatePromotion from '../../utilities/AffiliatePromotion/AffiliatePromotion';
 import AffiliateOptInToggleContainer from '../../AffiliateOptInToggle/AffiliateOptInToggleContainer';
 
@@ -47,6 +51,11 @@ const MosaicTemplate = props => {
 
       <SignupButtonContainer
         className={classnames({ '-float': affiliateSponsors.length })}
+        text={
+          isScholarshipAffiliateReferral()
+            ? SCHOLARSHIP_SIGNUP_BUTTON_TEXT
+            : undefined
+        }
       />
       {signupArrowContent ? (
         <CampaignSignupArrow

--- a/resources/assets/components/SignupButton/SignupButton.js
+++ b/resources/assets/components/SignupButton/SignupButton.js
@@ -67,7 +67,7 @@ const SignupButton = props => {
 };
 
 SignupButton.propTypes = {
-  affiliateMessagingOptIn: PropTypes.bool.isRequired,
+  affiliateMessagingOptIn: PropTypes.bool,
   campaignActionText: PropTypes.string,
   campaignId: PropTypes.string.isRequired,
   campaignTitle: PropTypes.string,
@@ -80,6 +80,7 @@ SignupButton.propTypes = {
 };
 
 SignupButton.defaultProps = {
+  affiliateMessagingOptIn: false,
   campaignActionText: 'Take Action',
   campaignTitle: null,
   className: null,

--- a/resources/assets/components/SignupButton/SignupButton.js
+++ b/resources/assets/components/SignupButton/SignupButton.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { get } from 'lodash';
 
 import Button from '../utilities/Button/Button';
 import { query, withoutNulls, isCampaignClosed } from '../../helpers';
@@ -15,10 +14,8 @@ const SignupButton = props => {
     disableSignup,
     endDate,
     pageId,
-    sourceActionText,
     storeCampaignSignup,
     text,
-    trafficSource,
   } = props;
 
   // Decorate click handler for A/B tests & analytics.
@@ -58,10 +55,9 @@ const SignupButton = props => {
     return null;
   }
 
-  // In descending priority: button copy override based on the user's traffic source,
-  // button-specific text prop, campaign action text override, or standard "Take Action" copy.
-  const buttonCopy =
-    get(sourceActionText, trafficSource) || text || campaignActionText;
+  // In descending priority: button-specific text prop,
+  // campaign action text override, or standard "Take Action" copy.
+  const buttonCopy = text || campaignActionText;
 
   return (
     <Button className={className} onClick={handleSignup}>
@@ -79,10 +75,8 @@ SignupButton.propTypes = {
   disableSignup: PropTypes.bool,
   endDate: PropTypes.string,
   pageId: PropTypes.string.isRequired,
-  sourceActionText: PropTypes.objectOf(PropTypes.string),
   storeCampaignSignup: PropTypes.func.isRequired,
   text: PropTypes.string,
-  trafficSource: PropTypes.string,
 };
 
 SignupButton.defaultProps = {
@@ -91,9 +85,7 @@ SignupButton.defaultProps = {
   className: null,
   disableSignup: false,
   endDate: null,
-  sourceActionText: null,
   text: null,
-  trafficSource: null,
 };
 
 export default SignupButton;

--- a/resources/assets/components/SignupButton/SignupButton.test.js
+++ b/resources/assets/components/SignupButton/SignupButton.test.js
@@ -32,7 +32,7 @@ describe('The SignupButton component', () => {
     expect(storeCampaignSignup).toHaveBeenCalled();
   });
 
-  describe('the signup button text', () => {
+  describe('The signup button text', () => {
     it('defaults to the campaignActiontext', () => {
       const wrapper = mount(<SignupButton {...props} />);
 

--- a/resources/assets/components/SignupButton/SignupButton.test.js
+++ b/resources/assets/components/SignupButton/SignupButton.test.js
@@ -1,0 +1,55 @@
+import React from 'react';
+import { mount } from 'enzyme';
+
+import SignupButton from './SignupButton';
+
+const storeCampaignSignup = jest.fn();
+
+const props = {
+  campaignId: '123',
+  pageId: '456',
+  storeCampaignSignup,
+};
+
+describe('The SignupButton component', () => {
+  it('displays a Button', () => {
+    const wrapper = mount(<SignupButton {...props} />);
+
+    expect(wrapper.find('Button')).toHaveLength(1);
+  });
+
+  it("doesn't render the Button if the signup is disabled", () => {
+    const wrapper = mount(<SignupButton {...props} disableSignup={true} />);
+
+    expect(wrapper.find('Button')).toHaveLength(0);
+  });
+
+  it('invokes the storeCampaignSignup function when the button is clicked', () => {
+    const wrapper = mount(<SignupButton {...props} />);
+
+    wrapper.find('Button').simulate('click');
+
+    expect(storeCampaignSignup).toHaveBeenCalled();
+  });
+
+  describe('the signup button text', () => {
+    it('defaults to the campaignActiontext', () => {
+      const wrapper = mount(<SignupButton {...props} />);
+
+      expect(wrapper.find('Button').text()).toEqual('Take Action');
+    });
+
+    it('is overriden by the "text" prop', () => {
+      const text = 'Text Override!';
+      const wrapper = mount(<SignupButton {...props} text={text} />);
+
+      expect(wrapper.find('Button').text()).toEqual(text);
+    });
+
+    it('is overriden by the closed state text if the campaign is closed', () => {
+      const wrapper = mount(<SignupButton {...props} endDate="2019-09-08" />);
+
+      expect(wrapper.find('Button').text()).toEqual('Notify Me');
+    });
+  });
+});

--- a/resources/assets/components/SignupButton/SignupButton.test.js
+++ b/resources/assets/components/SignupButton/SignupButton.test.js
@@ -19,7 +19,7 @@ describe('The SignupButton component', () => {
   });
 
   it("doesn't render the Button if the signup is disabled", () => {
-    const wrapper = mount(<SignupButton {...props} disableSignup={true} />);
+    const wrapper = mount(<SignupButton {...props} disableSignup />);
 
     expect(wrapper.find('Button')).toHaveLength(0);
   });

--- a/resources/assets/components/SignupButton/SignupButtonContainer.js
+++ b/resources/assets/components/SignupButton/SignupButtonContainer.js
@@ -15,8 +15,6 @@ const mapStateToProps = state => ({
   endDate: state.campaign.endDate,
   pageId: state.campaign.id || state.page.id,
   disableSignup: get(state.campaign, 'additionalContent.disableSignup', false),
-  sourceActionText: get(state.campaign, 'additionalContent.sourceActionText'),
-  trafficSource: state.user.source,
 });
 
 /**

--- a/resources/assets/components/pages/LandingPage/templates/MarqueeTemplate.js
+++ b/resources/assets/components/pages/LandingPage/templates/MarqueeTemplate.js
@@ -5,9 +5,13 @@ import PropTypes from 'prop-types';
 
 import Enclosure from '../../../Enclosure';
 import Card from '../../../utilities/Card/Card';
-import { contentfulImageUrl } from '../../../../helpers';
 import TextContent from '../../../utilities/TextContent/TextContent';
+import { SCHOLARSHIP_SIGNUP_BUTTON_TEXT } from '../../../../constants';
 import SignupButtonContainer from '../../../SignupButton/SignupButtonContainer';
+import {
+  contentfulImageUrl,
+  isScholarshipAffiliateReferral,
+} from '../../../../helpers';
 import AffiliatePromotion from '../../../utilities/AffiliatePromotion/AffiliatePromotion';
 
 const MarqueeTemplate = ({
@@ -59,7 +63,14 @@ const MarqueeTemplate = ({
 
             <div className="grid-wide-3/10 secondary">
               <div className="marquee-signup-button">
-                <SignupButtonContainer className="w-full" />
+                <SignupButtonContainer
+                  className="w-full"
+                  text={
+                    isScholarshipAffiliateReferral()
+                      ? SCHOLARSHIP_SIGNUP_BUTTON_TEXT
+                      : undefined
+                  }
+                />
               </div>
 
               <Card className="bordered padded rounded campaign-info">

--- a/resources/assets/components/pages/LandingPage/templates/MarqueeTemplate.js
+++ b/resources/assets/components/pages/LandingPage/templates/MarqueeTemplate.js
@@ -8,11 +8,11 @@ import Card from '../../../utilities/Card/Card';
 import TextContent from '../../../utilities/TextContent/TextContent';
 import { SCHOLARSHIP_SIGNUP_BUTTON_TEXT } from '../../../../constants';
 import SignupButtonContainer from '../../../SignupButton/SignupButtonContainer';
+import AffiliatePromotion from '../../../utilities/AffiliatePromotion/AffiliatePromotion';
 import {
   contentfulImageUrl,
   isScholarshipAffiliateReferral,
 } from '../../../../helpers';
-import AffiliatePromotion from '../../../utilities/AffiliatePromotion/AffiliatePromotion';
 
 const MarqueeTemplate = ({
   additionalContent,

--- a/resources/assets/constants/index.js
+++ b/resources/assets/constants/index.js
@@ -36,3 +36,6 @@ export const REGISTER_CTA_COPY = {
     buttonText: 'Join us',
   },
 };
+
+// Signup Button text for scholarship referrals:
+export const SCHOLARSHIP_SIGNUP_BUTTON_TEXT = 'Apply Now!';

--- a/resources/assets/helpers/index.js
+++ b/resources/assets/helpers/index.js
@@ -893,12 +893,22 @@ export function isActionPage(page) {
 }
 
 /**
+ * Determine if the user is a scholarship affiliate referral.
+ *
+ * @return {Boolean}
+ */
+export function isScholarshipAffiliateReferral() {
+  const utmSource = query('utm_source');
+
+  return utmSource && utmSource.includes('scholarship');
+}
+
+/**
  * Get the Scholarship Affiliate Referrer's UTM Label.
  *
  * @return {String|Null}
  */
 export function getScholarshipAffiliateLabel() {
-  const utmSource = query('utm_source') || '';
   const utmCampaign = query('utm_campaign') || '';
 
   // The affiliate's UTM Label is expected to be the first value of a snake cased string.
@@ -906,7 +916,7 @@ export function getScholarshipAffiliateLabel() {
 
   // If the utm_source contains 'scholarship', we assume this visit to be a referral from a
   // scholarship affiliate and return the affiliate's UTM label.
-  return utmSource.includes('scholarship') ? utmLabel : null;
+  return isScholarshipAffiliateReferral() ? utmLabel : null;
 }
 
 /**


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR removes the experimental implementation of overriding the Signup button text based on traffic source via the `additionalContent` field, in favor of a formalized text override for traffic deemed a scholarship affiliate referral.

Feel free to commit-by-commit this, for a seamless review experience ☺️ 

### Any background context you want to provide?
We intend to formalize this functionality for any incoming traffic deemed a 'scholarship affiliate referral' to override the Signup Button with messaging aligned with the user's intent. ("Apply Now!").

We previously had this as a more open-ended feature where any `utm_source` value could be overridden with any custom button text value. This is going to be formalized and limited for the scholarship use case.

You'll notice that we've removed this feature from the `SignupButton` component itself, and lifted it into the parent components, utilizing the `text` prop for this override instead of burdening the `SignupButton` component with this feature specific logic. (See the discussion on the [Pivotal Ticket](https://www.pivotaltracker.com/story/show/167923056/comments/206484116))

❓I feel like it'd be nice to have this documented, but I wasn't sure where to fit this in! Any suggestions?

### What are the relevant tickets/cards?

Refs [Pivotal ID #167923056](https://www.pivotaltracker.com/story/show/167923056)

### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [x] Added appropriate feature/unit tests.
