### PR TITLE
Campaign Content Type Migration Script Update

### DIFF
--- a/contentful/content-types/campaign.js
+++ b/contentful/content-types/campaign.js
@@ -508,8 +508,10 @@ module.exports = function(migration) {
   });
 
   campaign.changeEditorInterface('scholarshipDeadline', 'datePicker', {
-    format: 'dateonly',
-    helpText: 'Deadline to take action and qualify for the scholarship.',
+    ampm: '12',
+    format: 'timeZ',
+    helpText:
+      "Deadline to take action and qualify for the scholarship. (Confirm that you've set the UTC-04:00 or UTC-05:00 timezones for EST/EDT (https://time.is/compare/UTC)).",
   });
 
   campaign.changeEditorInterface('affiliateOptInContent', 'richTextEditor', {

--- a/contentful/content-types/campaign.js
+++ b/contentful/content-types/campaign.js
@@ -36,7 +36,6 @@ module.exports = function(migration) {
       {
         regexp: {
           pattern: '^[a-zA-Z0-9-]+$',
-          flags: null,
         },
 
         message:
@@ -67,11 +66,7 @@ module.exports = function(migration) {
     .type('Symbol')
     .localized(false)
     .required(true)
-    .validations([
-      {
-        unique: true,
-      },
-    ])
+    .validations([])
     .disabled(false)
     .omitted(false);
 
@@ -290,7 +285,7 @@ module.exports = function(migration) {
     .required(false)
     .validations([
       {
-        linkContentType: ['campaignDashboard'],
+        linkContentType: ['campaignDashboard', 'sixpackExperiment'],
       },
     ])
     .disabled(false)
@@ -374,7 +369,6 @@ module.exports = function(migration) {
     .validations([])
     .disabled(false)
     .omitted(false);
-
   campaign
     .createField('scholarshipDeadline')
     .name('Scholarship Deadline')
@@ -437,11 +431,11 @@ module.exports = function(migration) {
   });
 
   campaign.changeEditorInterface('metadata', 'entryLinkEditor', {});
-
-  campaign.changeEditorInterface('legacyCampaignId', 'singleLine', {
-    helpText:
-      'The campaign should first be created in Rogue, then copy the ID and include it here.',
-  });
+  campaign.changeEditorInterface(
+    'legacyCampaignId',
+    'contentful-campaign-extension',
+    {},
+  );
 
   campaign.changeEditorInterface('campaignSettings', 'entryLinkEditor', {
     helpText:

--- a/contentful/content-types/campaign.js
+++ b/contentful/content-types/campaign.js
@@ -447,6 +447,8 @@ module.exports = function(migration) {
   campaign.changeEditorInterface('endDate', 'datePicker', {
     ampm: '12',
     format: 'timeZ',
+    helpText:
+      "The date the campaign will close. (Confirm that you've set the UTC-04:00 or UTC-05:00 timezones for EST/EDT (https://time.is/compare/UTC)).",
   });
 
   campaign.changeEditorInterface('callToAction', 'singleLine', {});


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR updates the Contentful migration script for the Campaign content-type:

- https://github.com/DoSomething/phoenix-next/commit/9e53c727978d8819ed53e8847fe885867004283a gets it up to speed with the `master` environment.

- https://github.com/DoSomething/phoenix-next/commit/80ad2635a2f4e8f781361522c869c9ee3e5d8785 updates the help text for the `endDate` field with some info regarding the UTC time zone differential.

- https://github.com/DoSomething/phoenix-next/commit/b42097394b5a76011de8ffabc42e2038b47352c1 updates the `scholarshipDeadline` field to include timezone information due to a (reasonably expectable) bug we encountered with converting UTC to EST/EDT on the browser side. (See attached Pivotal ticket)

### Any background context you want to provide?
We had some conversation in [Slack](https://dosomething.slack.com/archives/C2BPA7M8F/p1568064044054400) about the whole UTC/EST source of truth situation as it pertains to deadlines and dates in Contentful. We should be satisfied with our current setup, but it feels like it could be helpful to have some clarifying helper text on the fields as well! 


### What are the relevant tickets/cards?

Refs [Pivotal ID #168178947](https://www.pivotaltracker.com/story/show/168178947)
