### PR TITLE
Enable more flexibility with grid classes in RichText rendered components.

### DIFF
--- a/resources/assets/components/ContentfulEntry/ContentfulEntry.js
+++ b/resources/assets/components/ContentfulEntry/ContentfulEntry.js
@@ -39,6 +39,7 @@ const DEFAULT_BLOCK: ContentfulEntryJson = { fields: { type: null } };
 type Props = {
   json: ContentfulEntryJson,
   className: String,
+  classNameByEntry: Object,
 };
 type State = { hasError: boolean };
 
@@ -59,7 +60,11 @@ class ContentfulEntry extends React.Component<Props, State> {
     }
 
     // Otherwise, find the corresponding component & render it!
-    const { json = DEFAULT_BLOCK, className = null } = this.props;
+    const {
+      json = DEFAULT_BLOCK,
+      className = null,
+      classNameByEntry = {},
+    } = this.props;
     const type = parseContentfulType(json);
 
     switch (type) {
@@ -248,7 +253,7 @@ class ContentfulEntry extends React.Component<Props, State> {
         return (
           <SectionBlock
             className={className}
-            classNameByEntry={this.props.classNameByEntry}
+            classNameByEntry={classNameByEntry}
             id={json.id}
             {...withoutNulls(json.fields)}
           />

--- a/resources/assets/components/ContentfulEntry/ContentfulEntry.js
+++ b/resources/assets/components/ContentfulEntry/ContentfulEntry.js
@@ -248,6 +248,7 @@ class ContentfulEntry extends React.Component<Props, State> {
         return (
           <SectionBlock
             className={className}
+            classNameByEntry={this.props.classNameByEntry}
             id={json.id}
             {...withoutNulls(json.fields)}
           />

--- a/resources/assets/components/ContentfulEntry/ContentfulEntry.js
+++ b/resources/assets/components/ContentfulEntry/ContentfulEntry.js
@@ -40,6 +40,7 @@ type Props = {
   json: ContentfulEntryJson,
   className: String,
   classNameByEntry: Object,
+  classNameByEntryDefault: String,
 };
 type State = { hasError: boolean };
 
@@ -64,6 +65,7 @@ class ContentfulEntry extends React.Component<Props, State> {
       json = DEFAULT_BLOCK,
       className = null,
       classNameByEntry = {},
+      classNameByEntryDefault = null,
     } = this.props;
     const type = parseContentfulType(json);
 
@@ -254,6 +256,7 @@ class ContentfulEntry extends React.Component<Props, State> {
           <SectionBlock
             className={className}
             classNameByEntry={classNameByEntry}
+            classNameByEntryDefault={classNameByEntryDefault}
             id={json.id}
             {...withoutNulls(json.fields)}
           />

--- a/resources/assets/components/blocks/CampaignUpdate/__snapshots__/CampaignUpdate.test.js.snap
+++ b/resources/assets/components/blocks/CampaignUpdate/__snapshots__/CampaignUpdate.test.js.snap
@@ -10,11 +10,8 @@ exports[`it generates a campaign update in affiliate mode snapshot 1`] = `
 >
   <TextContent
     className="padded"
-    classNameByEntry={
-      Object {
-        "default": "grid-main",
-      }
-    }
+    classNameByEntry={Object {}}
+    classNameByEntryDefault={null}
     styles={Object {}}
   >
     Duis mollis, est non commodo luctus, nisi erat porttitor ligula, eget lacinia odio sem nec elit. Morbi leo risus, porta ac consectetur ac, vestibulum at eros. Sed posuere consectetur est at lobortis. Sed posuere consectetur est at lobortis. Nullam quis risus eget urna mollis ornare vel eu leo. Etiam porta sem malesuada magna mollis euismod. Cras mattis consectetur purus sit amet fermentum.
@@ -43,11 +40,8 @@ exports[`it generates a campaign update snapshot 1`] = `
 >
   <TextContent
     className="padded"
-    classNameByEntry={
-      Object {
-        "default": "grid-main",
-      }
-    }
+    classNameByEntry={Object {}}
+    classNameByEntryDefault={null}
     styles={Object {}}
   >
     Duis mollis, est non commodo luctus, nisi erat porttitor ligula, eget lacinia odio sem nec elit. Morbi leo risus, porta ac consectetur ac, vestibulum at eros. Sed posuere consectetur est at lobortis. Sed posuere consectetur est at lobortis. Nullam quis risus eget urna mollis ornare vel eu leo. Etiam porta sem malesuada magna mollis euismod. Cras mattis consectetur purus sit amet fermentum.

--- a/resources/assets/components/blocks/CampaignUpdate/__snapshots__/CampaignUpdate.test.js.snap
+++ b/resources/assets/components/blocks/CampaignUpdate/__snapshots__/CampaignUpdate.test.js.snap
@@ -10,6 +10,11 @@ exports[`it generates a campaign update in affiliate mode snapshot 1`] = `
 >
   <TextContent
     className="padded"
+    classNameByEntry={
+      Object {
+        "default": "grid-main",
+      }
+    }
     styles={Object {}}
   >
     Duis mollis, est non commodo luctus, nisi erat porttitor ligula, eget lacinia odio sem nec elit. Morbi leo risus, porta ac consectetur ac, vestibulum at eros. Sed posuere consectetur est at lobortis. Sed posuere consectetur est at lobortis. Nullam quis risus eget urna mollis ornare vel eu leo. Etiam porta sem malesuada magna mollis euismod. Cras mattis consectetur purus sit amet fermentum.
@@ -38,6 +43,11 @@ exports[`it generates a campaign update snapshot 1`] = `
 >
   <TextContent
     className="padded"
+    classNameByEntry={
+      Object {
+        "default": "grid-main",
+      }
+    }
     styles={Object {}}
   >
     Duis mollis, est non commodo luctus, nisi erat porttitor ligula, eget lacinia odio sem nec elit. Morbi leo risus, porta ac consectetur ac, vestibulum at eros. Sed posuere consectetur est at lobortis. Sed posuere consectetur est at lobortis. Nullam quis risus eget urna mollis ornare vel eu leo. Etiam porta sem malesuada magna mollis euismod. Cras mattis consectetur purus sit amet fermentum.

--- a/resources/assets/components/blocks/ContentBlock/__snapshots__/ContentBlock.test.js.snap
+++ b/resources/assets/components/blocks/ContentBlock/__snapshots__/ContentBlock.test.js.snap
@@ -13,11 +13,8 @@ exports[`ContentBlock component does not include SectionHeader when there's no t
   >
     <TextContent
       className={null}
-      classNameByEntry={
-        Object {
-          "default": "grid-main",
-        }
-      }
+      classNameByEntry={Object {}}
+      classNameByEntryDefault={null}
       styles={Object {}}
     >
       Test Content
@@ -43,11 +40,8 @@ exports[`ContentBlock component is rendered with the proper child components whe
   >
     <TextContent
       className={null}
-      classNameByEntry={
-        Object {
-          "default": "grid-main",
-        }
-      }
+      classNameByEntry={Object {}}
+      classNameByEntryDefault={null}
       styles={Object {}}
     >
       Test Content
@@ -62,11 +56,8 @@ exports[`ContentBlock component it works beautifully with content and an empty i
 >
   <TextContent
     className={null}
-    classNameByEntry={
-      Object {
-        "default": "grid-main",
-      }
-    }
+    classNameByEntry={Object {}}
+    classNameByEntryDefault={null}
     styles={Object {}}
   >
     hi there

--- a/resources/assets/components/blocks/ContentBlock/__snapshots__/ContentBlock.test.js.snap
+++ b/resources/assets/components/blocks/ContentBlock/__snapshots__/ContentBlock.test.js.snap
@@ -13,6 +13,11 @@ exports[`ContentBlock component does not include SectionHeader when there's no t
   >
     <TextContent
       className={null}
+      classNameByEntry={
+        Object {
+          "default": "grid-main",
+        }
+      }
       styles={Object {}}
     >
       Test Content
@@ -38,6 +43,11 @@ exports[`ContentBlock component is rendered with the proper child components whe
   >
     <TextContent
       className={null}
+      classNameByEntry={
+        Object {
+          "default": "grid-main",
+        }
+      }
       styles={Object {}}
     >
       Test Content
@@ -52,6 +62,11 @@ exports[`ContentBlock component it works beautifully with content and an empty i
 >
   <TextContent
     className={null}
+    classNameByEntry={
+      Object {
+        "default": "grid-main",
+      }
+    }
     styles={Object {}}
   >
     hi there

--- a/resources/assets/components/blocks/SectionBlock/SectionBlock.js
+++ b/resources/assets/components/blocks/SectionBlock/SectionBlock.js
@@ -11,7 +11,9 @@ const SectionBlock = props => {
   const {
     backgroundColor,
     className,
+    classNameByEntry,
     content,
+    gridType,
     hyperlinkColor,
     id,
     textColor,
@@ -35,6 +37,7 @@ const SectionBlock = props => {
 
       <TextContent
         className="section-block__content base-12-grid"
+        classNameByEntry={classNameByEntry}
         styles={styles}
       >
         {content}

--- a/resources/assets/components/blocks/SectionBlock/SectionBlock.js
+++ b/resources/assets/components/blocks/SectionBlock/SectionBlock.js
@@ -13,7 +13,6 @@ const SectionBlock = props => {
     className,
     classNameByEntry,
     content,
-    gridType,
     hyperlinkColor,
     id,
     textColor,
@@ -54,6 +53,7 @@ const SectionBlock = props => {
 SectionBlock.propTypes = {
   backgroundColor: PropTypes.string,
   className: PropTypes.string,
+  classNameByEntry: PropTypes.object,
   content: PropTypes.object.isRequired,
   hyperlinkColor: PropTypes.string,
   id: PropTypes.string.isRequired,
@@ -63,6 +63,9 @@ SectionBlock.propTypes = {
 SectionBlock.defaultProps = {
   backgroundColor: null,
   className: null,
+  classNameByEntry: {
+    default: 'grid-main',
+  },
   hyperlinkColor: null,
   textColor: null,
 };

--- a/resources/assets/components/blocks/SectionBlock/SectionBlock.js
+++ b/resources/assets/components/blocks/SectionBlock/SectionBlock.js
@@ -12,6 +12,7 @@ const SectionBlock = props => {
     backgroundColor,
     className,
     classNameByEntry,
+    classNameByEntryDefault,
     content,
     hyperlinkColor,
     id,
@@ -37,6 +38,7 @@ const SectionBlock = props => {
       <TextContent
         className="section-block__content base-12-grid"
         classNameByEntry={classNameByEntry}
+        classNameByEntryDefault={classNameByEntryDefault}
         styles={styles}
       >
         {content}
@@ -54,6 +56,7 @@ SectionBlock.propTypes = {
   backgroundColor: PropTypes.string,
   className: PropTypes.string,
   classNameByEntry: PropTypes.object,
+  classNameByEntryDefault: PropTypes.string,
   content: PropTypes.object.isRequired,
   hyperlinkColor: PropTypes.string,
   id: PropTypes.string.isRequired,
@@ -63,9 +66,8 @@ SectionBlock.propTypes = {
 SectionBlock.defaultProps = {
   backgroundColor: null,
   className: null,
-  classNameByEntry: {
-    default: 'grid-main',
-  },
+  classNameByEntry: {},
+  classNameByEntryDefault: null,
   hyperlinkColor: null,
   textColor: null,
 };

--- a/resources/assets/components/pages/StoryPage/StoryPage.js
+++ b/resources/assets/components/pages/StoryPage/StoryPage.js
@@ -51,10 +51,10 @@ const StoryPage = props => {
           <ContentfulEntry
             className="story-section"
             classNameByEntry={{
-              default: 'grid-narrow',
               EmbedBlock: 'grid-main',
               PostGalleryBlock: 'grid-main',
             }}
+            classNameByEntryDefault="grid-narrow"
             key={block.id}
             json={block}
           />

--- a/resources/assets/components/pages/StoryPage/StoryPage.js
+++ b/resources/assets/components/pages/StoryPage/StoryPage.js
@@ -51,7 +51,7 @@ const StoryPage = props => {
           <ContentfulEntry
             className="story-section"
             classNameByEntry={{
-              defaults: 'grid-narrow',
+              default: 'grid-narrow',
               EmbedBlock: 'grid-main',
               PostGalleryBlock: 'grid-main',
             }}

--- a/resources/assets/components/pages/StoryPage/StoryPage.js
+++ b/resources/assets/components/pages/StoryPage/StoryPage.js
@@ -50,6 +50,11 @@ const StoryPage = props => {
         {blocks.map(block => (
           <ContentfulEntry
             className="story-section"
+            classNameByEntry={{
+              defaults: 'grid-narrow',
+              EmbedBlock: 'grid-main',
+              PostGalleryBlock: 'grid-main',
+            }}
             key={block.id}
             json={block}
           />

--- a/resources/assets/components/utilities/ContentfulEntryLoader/ContentfulEntryLoader.js
+++ b/resources/assets/components/utilities/ContentfulEntryLoader/ContentfulEntryLoader.js
@@ -45,7 +45,7 @@ const CONTENTFUL_BLOCK_QUERY = gql`
   ${PetitionSubmissionBlockFragment}
 `;
 
-const ContentfulEntryLoader = ({ id, className }) => (
+const ContentfulEntryLoader = ({ id, className, classNameByEntry }) => (
   <Query
     query={CONTENTFUL_BLOCK_QUERY}
     variables={{ id, preview: env('CONTENTFUL_USE_PREVIEW_API') }}
@@ -65,16 +65,16 @@ const ContentfulEntryLoader = ({ id, className }) => (
         );
       }
 
-      const entryGridMapping = {
-        EmbedBlock: 'grid-main', // @TODO: may need to reassess, since maybe not all embeds should align to main?
-        PostGalleryBlock: 'grid-main',
-      };
-
       const blockType = data.block.__typename;
-      const gridClass = get(entryGridMapping, blockType, 'grid-narrow');
+
+      const entryClassNames = get(
+        classNameByEntry,
+        blockType,
+        classNameByEntry.defaults,
+      );
 
       return (
-        <div className={classnames(className, gridClass)}>
+        <div className={classnames(className, entryClassNames)}>
           <ContentfulEntry json={data.block} />
         </div>
       );
@@ -83,8 +83,8 @@ const ContentfulEntryLoader = ({ id, className }) => (
 );
 
 ContentfulEntryLoader.propTypes = {
-  id: PropTypes.string.isRequired,
   className: PropTypes.string,
+  id: PropTypes.string.isRequired,
 };
 
 ContentfulEntryLoader.defaultProps = {

--- a/resources/assets/components/utilities/ContentfulEntryLoader/ContentfulEntryLoader.js
+++ b/resources/assets/components/utilities/ContentfulEntryLoader/ContentfulEntryLoader.js
@@ -45,7 +45,12 @@ const CONTENTFUL_BLOCK_QUERY = gql`
   ${PetitionSubmissionBlockFragment}
 `;
 
-const ContentfulEntryLoader = ({ id, className, classNameByEntry }) => (
+const ContentfulEntryLoader = ({
+  id,
+  className,
+  classNameByEntry,
+  classNameByEntryDefault,
+}) => (
   <Query
     query={CONTENTFUL_BLOCK_QUERY}
     variables={{ id, preview: env('CONTENTFUL_USE_PREVIEW_API') }}
@@ -70,7 +75,7 @@ const ContentfulEntryLoader = ({ id, className, classNameByEntry }) => (
       const entryClassNames = get(
         classNameByEntry,
         blockType,
-        classNameByEntry.default,
+        classNameByEntryDefault || 'grid-main',
       );
 
       return (
@@ -85,14 +90,14 @@ const ContentfulEntryLoader = ({ id, className, classNameByEntry }) => (
 ContentfulEntryLoader.propTypes = {
   className: PropTypes.string,
   classNameByEntry: PropTypes.object,
+  classNameByEntryDefault: PropTypes.string,
   id: PropTypes.string.isRequired,
 };
 
 ContentfulEntryLoader.defaultProps = {
   className: null,
-  classNameByEntry: {
-    default: 'grid-main',
-  },
+  classNameByEntry: {},
+  classNameByEntryDefault: null,
 };
 
 export default ContentfulEntryLoader;

--- a/resources/assets/components/utilities/ContentfulEntryLoader/ContentfulEntryLoader.js
+++ b/resources/assets/components/utilities/ContentfulEntryLoader/ContentfulEntryLoader.js
@@ -84,11 +84,15 @@ const ContentfulEntryLoader = ({ id, className, classNameByEntry }) => (
 
 ContentfulEntryLoader.propTypes = {
   className: PropTypes.string,
+  classNameByEntry: PropTypes.object,
   id: PropTypes.string.isRequired,
 };
 
 ContentfulEntryLoader.defaultProps = {
   className: null,
+  classNameByEntry: {
+    default: 'grid-main',
+  },
 };
 
 export default ContentfulEntryLoader;

--- a/resources/assets/components/utilities/ContentfulEntryLoader/ContentfulEntryLoader.js
+++ b/resources/assets/components/utilities/ContentfulEntryLoader/ContentfulEntryLoader.js
@@ -70,7 +70,7 @@ const ContentfulEntryLoader = ({ id, className, classNameByEntry }) => (
       const entryClassNames = get(
         classNameByEntry,
         blockType,
-        classNameByEntry.defaults,
+        classNameByEntry.default,
       );
 
       return (

--- a/resources/assets/components/utilities/TextContent/RichTextDocument.js
+++ b/resources/assets/components/utilities/TextContent/RichTextDocument.js
@@ -17,10 +17,16 @@ const RichTextDocument = ({
   children,
   className = null,
   classNameByEntry,
+  classNameByEntryDefault,
   styles,
 }) => (
   <div className={classnames('richtext', className)}>
-    {parseRichTextDocument(children, classNameByEntry, styles)}
+    {parseRichTextDocument(
+      children,
+      classNameByEntry,
+      classNameByEntryDefault,
+      styles,
+    )}
   </div>
 );
 
@@ -28,6 +34,7 @@ RichTextDocument.propTypes = {
   children: PropTypes.object.isRequired,
   className: PropTypes.string,
   classNameByEntry: PropTypes.object,
+  classNameByEntryDefault: PropTypes.string,
   styles: PropTypes.shape({
     textColor: PropTypes.string,
     hyperlinkColor: PropTypes.string,
@@ -36,9 +43,8 @@ RichTextDocument.propTypes = {
 
 RichTextDocument.defaultProps = {
   className: null,
-  classNameByEntry: {
-    default: 'grid-main',
-  },
+  classNameByEntry: {},
+  classNameByEntryDefault: null,
   styles: {},
 };
 

--- a/resources/assets/components/utilities/TextContent/RichTextDocument.js
+++ b/resources/assets/components/utilities/TextContent/RichTextDocument.js
@@ -13,9 +13,14 @@ import { parseRichTextDocument } from '../../../helpers/text';
  * @param  {Object} options.styles
  * @return {Object}
  */
-const RichTextDocument = ({ className = null, children, styles }) => (
+const RichTextDocument = ({
+  children,
+  className = null,
+  classNameByEntry,
+  styles,
+}) => (
   <div className={classnames('richtext', className)}>
-    {parseRichTextDocument(children, styles)}
+    {parseRichTextDocument(children, classNameByEntry, styles)}
   </div>
 );
 

--- a/resources/assets/components/utilities/TextContent/RichTextDocument.js
+++ b/resources/assets/components/utilities/TextContent/RichTextDocument.js
@@ -27,6 +27,7 @@ const RichTextDocument = ({
 RichTextDocument.propTypes = {
   children: PropTypes.object.isRequired,
   className: PropTypes.string,
+  classNameByEntry: PropTypes.object,
   styles: PropTypes.shape({
     textColor: PropTypes.string,
     hyperlinkColor: PropTypes.string,
@@ -35,6 +36,9 @@ RichTextDocument.propTypes = {
 
 RichTextDocument.defaultProps = {
   className: null,
+  classNameByEntry: {
+    default: 'grid-main',
+  },
   styles: {},
 };
 

--- a/resources/assets/components/utilities/TextContent/TextContent.js
+++ b/resources/assets/components/utilities/TextContent/TextContent.js
@@ -17,10 +17,16 @@ import './markdown.scss'; // @deprecate
  * @param  {Object} options.styles
  * @return {Object}
  */
-const TextContent = ({ className = null, children, styles }) =>
+const TextContent = ({
+  children,
+  className = null,
+  classNameByEntry,
+  styles,
+}) =>
   has(children, 'nodeType') ? (
     <RichTextDocument
       className={classnames('text-content', className)}
+      classNameByEntry={classNameByEntry}
       styles={styles}
     >
       {children}

--- a/resources/assets/components/utilities/TextContent/TextContent.js
+++ b/resources/assets/components/utilities/TextContent/TextContent.js
@@ -44,6 +44,7 @@ TextContent.propTypes = {
     PropTypes.object,
   ]).isRequired,
   className: PropTypes.string,
+  classNameByEntry: PropTypes.object,
   styles: PropTypes.shape({
     textColor: PropTypes.string,
     hyperlinkColor: PropTypes.string,
@@ -52,6 +53,9 @@ TextContent.propTypes = {
 
 TextContent.defaultProps = {
   className: null,
+  classNameByEntry: {
+    default: 'grid-main',
+  },
   styles: {},
 };
 

--- a/resources/assets/components/utilities/TextContent/TextContent.js
+++ b/resources/assets/components/utilities/TextContent/TextContent.js
@@ -21,12 +21,14 @@ const TextContent = ({
   children,
   className = null,
   classNameByEntry,
+  classNameByEntryDefault,
   styles,
 }) =>
   has(children, 'nodeType') ? (
     <RichTextDocument
       className={classnames('text-content', className)}
       classNameByEntry={classNameByEntry}
+      classNameByEntryDefault={classNameByEntryDefault}
       styles={styles}
     >
       {children}
@@ -45,6 +47,7 @@ TextContent.propTypes = {
   ]).isRequired,
   className: PropTypes.string,
   classNameByEntry: PropTypes.object,
+  classNameByEntryDefault: PropTypes.string,
   styles: PropTypes.shape({
     textColor: PropTypes.string,
     hyperlinkColor: PropTypes.string,
@@ -53,9 +56,8 @@ TextContent.propTypes = {
 
 TextContent.defaultProps = {
   className: null,
-  classNameByEntry: {
-    default: 'grid-main',
-  },
+  classNameByEntry: {},
+  classNameByEntryDefault: null,
   styles: {},
 };
 

--- a/resources/assets/helpers/text.js
+++ b/resources/assets/helpers/text.js
@@ -77,7 +77,7 @@ export function parseRichTextDocument(document, classNameByEntry, styles) {
     renderNode: {
       [BLOCKS.HEADING_1]: (node, children) => (
         <h1
-          className={classnames(classNameByEntry.defaults)}
+          className={classnames(classNameByEntry.default)}
           style={{ color: textColor }}
         >
           <span>{children}</span>
@@ -85,7 +85,7 @@ export function parseRichTextDocument(document, classNameByEntry, styles) {
       ),
       [BLOCKS.HEADING_2]: (node, children) => (
         <h2
-          className={classnames(classNameByEntry.defaults)}
+          className={classnames(classNameByEntry.default)}
           style={{ color: textColor }}
         >
           {children}
@@ -93,7 +93,7 @@ export function parseRichTextDocument(document, classNameByEntry, styles) {
       ),
       [BLOCKS.HEADING_3]: (node, children) => (
         <h3
-          className={classnames(classNameByEntry.defaults)}
+          className={classnames(classNameByEntry.default)}
           style={{ color: textColor }}
         >
           {children}
@@ -101,7 +101,7 @@ export function parseRichTextDocument(document, classNameByEntry, styles) {
       ),
       [BLOCKS.HEADING_4]: (node, children) => (
         <h4
-          className={classnames(classNameByEntry.defaults)}
+          className={classnames(classNameByEntry.default)}
           style={{ color: textColor }}
         >
           {children}
@@ -109,7 +109,7 @@ export function parseRichTextDocument(document, classNameByEntry, styles) {
       ),
       [BLOCKS.HEADING_5]: (node, children) => (
         <h5
-          className={classnames(classNameByEntry.defaults)}
+          className={classnames(classNameByEntry.default)}
           style={{ color: textColor }}
         >
           {children}
@@ -117,7 +117,7 @@ export function parseRichTextDocument(document, classNameByEntry, styles) {
       ),
       [BLOCKS.HEADING_6]: (node, children) => (
         <h6
-          className={classnames(classNameByEntry.defaults)}
+          className={classnames(classNameByEntry.default)}
           style={{ color: textColor }}
         >
           {children}
@@ -126,7 +126,7 @@ export function parseRichTextDocument(document, classNameByEntry, styles) {
       [BLOCKS.PARAGRAPH]: (node, children) =>
         children[0] ? (
           <p
-            className={classnames(classNameByEntry.defaults)}
+            className={classnames(classNameByEntry.default)}
             style={{ color: textColor }}
           >
             {children}
@@ -134,7 +134,7 @@ export function parseRichTextDocument(document, classNameByEntry, styles) {
         ) : null,
       [BLOCKS.UL_LIST]: (node, children) => (
         <ul
-          className={classnames(classNameByEntry.defaults, 'text-left', 'list')}
+          className={classnames(classNameByEntry.default, 'text-left', 'list')}
           style={{ color: textColor }}
         >
           {children}
@@ -142,7 +142,7 @@ export function parseRichTextDocument(document, classNameByEntry, styles) {
       ),
       [BLOCKS.OL_LIST]: (node, children) => (
         <ol
-          className={classnames(classNameByEntry.defaults, 'text-left', 'list')}
+          className={classnames(classNameByEntry.default, 'text-left', 'list')}
           style={{ color: textColor }}
         >
           {children}
@@ -150,7 +150,7 @@ export function parseRichTextDocument(document, classNameByEntry, styles) {
       ),
       [BLOCKS.QUOTE]: (node, children) => (
         <blockquote
-          className={classnames(classNameByEntry.defaults, 'list')}
+          className={classnames(classNameByEntry.default, 'list')}
           style={{ color: textColor }}
         >
           {children}
@@ -166,7 +166,7 @@ export function parseRichTextDocument(document, classNameByEntry, styles) {
       [BLOCKS.EMBEDDED_ASSET]: node => (
         <p
           className={classnames(
-            classNameByEntry.defaults,
+            classNameByEntry.default,
             'component-entry',
             'text-center',
           )}

--- a/resources/assets/helpers/text.js
+++ b/resources/assets/helpers/text.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { get } from 'lodash';
+import classnames from 'classnames';
 import MarkdownIt from 'markdown-it';
 import iterator from 'markdown-it-for-inline';
 import { BLOCKS, INLINES } from '@contentful/rich-text-types';
@@ -68,71 +69,108 @@ function getMarkdownItInstance() {
  * @param  {Object} styles
  * @return {String}
  */
-export function parseRichTextDocument(document, styles) {
+export function parseRichTextDocument(document, classNameByEntry, styles) {
   const hyperlinkColor = get(styles, 'hyperlinkColor', null);
   const textColor = get(styles, 'textColor', null);
 
   const options = {
     renderNode: {
       [BLOCKS.HEADING_1]: (node, children) => (
-        <h1 className="grid-narrow" style={{ color: textColor }}>
+        <h1
+          className={classnames(classNameByEntry.defaults)}
+          style={{ color: textColor }}
+        >
           <span>{children}</span>
         </h1>
       ),
       [BLOCKS.HEADING_2]: (node, children) => (
-        <h2 className="grid-narrow" style={{ color: textColor }}>
+        <h2
+          className={classnames(classNameByEntry.defaults)}
+          style={{ color: textColor }}
+        >
           {children}
         </h2>
       ),
       [BLOCKS.HEADING_3]: (node, children) => (
-        <h3 className="grid-narrow" style={{ color: textColor }}>
+        <h3
+          className={classnames(classNameByEntry.defaults)}
+          style={{ color: textColor }}
+        >
           {children}
         </h3>
       ),
       [BLOCKS.HEADING_4]: (node, children) => (
-        <h4 className="grid-narrow" style={{ color: textColor }}>
+        <h4
+          className={classnames(classNameByEntry.defaults)}
+          style={{ color: textColor }}
+        >
           {children}
         </h4>
       ),
       [BLOCKS.HEADING_5]: (node, children) => (
-        <h5 className="grid-narrow" style={{ color: textColor }}>
+        <h5
+          className={classnames(classNameByEntry.defaults)}
+          style={{ color: textColor }}
+        >
           {children}
         </h5>
       ),
       [BLOCKS.HEADING_6]: (node, children) => (
-        <h6 className="grid-narrow" style={{ color: textColor }}>
+        <h6
+          className={classnames(classNameByEntry.defaults)}
+          style={{ color: textColor }}
+        >
           {children}
         </h6>
       ),
       [BLOCKS.PARAGRAPH]: (node, children) =>
         children[0] ? (
-          <p className="grid-narrow" style={{ color: textColor }}>
+          <p
+            className={classnames(classNameByEntry.defaults)}
+            style={{ color: textColor }}
+          >
             {children}
           </p>
         ) : null,
       [BLOCKS.UL_LIST]: (node, children) => (
-        <ul className="grid-narrow text-left list" style={{ color: textColor }}>
+        <ul
+          className={classnames(classNameByEntry.defaults, 'text-left', 'list')}
+          style={{ color: textColor }}
+        >
           {children}
         </ul>
       ),
       [BLOCKS.OL_LIST]: (node, children) => (
-        <ol className="grid-narrow text-left list" style={{ color: textColor }}>
+        <ol
+          className={classnames(classNameByEntry.defaults, 'text-left', 'list')}
+          style={{ color: textColor }}
+        >
           {children}
         </ol>
       ),
       [BLOCKS.QUOTE]: (node, children) => (
-        <blockquote className="grid-narrow list" style={{ color: textColor }}>
+        <blockquote
+          className={classnames(classNameByEntry.defaults, 'list')}
+          style={{ color: textColor }}
+        >
           {children}
         </blockquote>
       ),
       [BLOCKS.EMBEDDED_ENTRY]: node => (
         <ContentfulEntryLoader
-          className="component-entry margin-bottom-lg"
+          className={classnames('component-entry', 'margin-bottom-lg')}
+          classNameByEntry={classNameByEntry}
           id={node.data.target.sys.id}
         />
       ),
       [BLOCKS.EMBEDDED_ASSET]: node => (
-        <p className="grid-narrow component-entry text-center">
+        <p
+          className={classnames(
+            classNameByEntry.defaults,
+            'component-entry',
+            'text-center',
+          )}
+        >
           <ContentfulAsset id={node.data.target.sys.id} />
         </p>
       ),

--- a/resources/assets/helpers/text.js
+++ b/resources/assets/helpers/text.js
@@ -69,7 +69,12 @@ function getMarkdownItInstance() {
  * @param  {Object} styles
  * @return {String}
  */
-export function parseRichTextDocument(document, classNameByEntry, styles) {
+export function parseRichTextDocument(
+  document,
+  classNameByEntry,
+  classNameByEntryDefault,
+  styles,
+) {
   const hyperlinkColor = get(styles, 'hyperlinkColor', null);
   const textColor = get(styles, 'textColor', null);
 
@@ -77,7 +82,7 @@ export function parseRichTextDocument(document, classNameByEntry, styles) {
     renderNode: {
       [BLOCKS.HEADING_1]: (node, children) => (
         <h1
-          className={classnames(classNameByEntry.default)}
+          className={classnames(classNameByEntryDefault)}
           style={{ color: textColor }}
         >
           <span>{children}</span>
@@ -85,7 +90,7 @@ export function parseRichTextDocument(document, classNameByEntry, styles) {
       ),
       [BLOCKS.HEADING_2]: (node, children) => (
         <h2
-          className={classnames(classNameByEntry.default)}
+          className={classnames(classNameByEntryDefault)}
           style={{ color: textColor }}
         >
           {children}
@@ -93,7 +98,7 @@ export function parseRichTextDocument(document, classNameByEntry, styles) {
       ),
       [BLOCKS.HEADING_3]: (node, children) => (
         <h3
-          className={classnames(classNameByEntry.default)}
+          className={classnames(classNameByEntryDefault)}
           style={{ color: textColor }}
         >
           {children}
@@ -101,7 +106,7 @@ export function parseRichTextDocument(document, classNameByEntry, styles) {
       ),
       [BLOCKS.HEADING_4]: (node, children) => (
         <h4
-          className={classnames(classNameByEntry.default)}
+          className={classnames(classNameByEntryDefault)}
           style={{ color: textColor }}
         >
           {children}
@@ -109,7 +114,7 @@ export function parseRichTextDocument(document, classNameByEntry, styles) {
       ),
       [BLOCKS.HEADING_5]: (node, children) => (
         <h5
-          className={classnames(classNameByEntry.default)}
+          className={classnames(classNameByEntryDefault)}
           style={{ color: textColor }}
         >
           {children}
@@ -117,7 +122,7 @@ export function parseRichTextDocument(document, classNameByEntry, styles) {
       ),
       [BLOCKS.HEADING_6]: (node, children) => (
         <h6
-          className={classnames(classNameByEntry.default)}
+          className={classnames(classNameByEntryDefault)}
           style={{ color: textColor }}
         >
           {children}
@@ -126,7 +131,7 @@ export function parseRichTextDocument(document, classNameByEntry, styles) {
       [BLOCKS.PARAGRAPH]: (node, children) =>
         children[0] ? (
           <p
-            className={classnames(classNameByEntry.default)}
+            className={classnames(classNameByEntryDefault)}
             style={{ color: textColor }}
           >
             {children}
@@ -134,7 +139,7 @@ export function parseRichTextDocument(document, classNameByEntry, styles) {
         ) : null,
       [BLOCKS.UL_LIST]: (node, children) => (
         <ul
-          className={classnames(classNameByEntry.default, 'text-left', 'list')}
+          className={classnames(classNameByEntryDefault, 'text-left', 'list')}
           style={{ color: textColor }}
         >
           {children}
@@ -142,7 +147,7 @@ export function parseRichTextDocument(document, classNameByEntry, styles) {
       ),
       [BLOCKS.OL_LIST]: (node, children) => (
         <ol
-          className={classnames(classNameByEntry.default, 'text-left', 'list')}
+          className={classnames(classNameByEntryDefault, 'text-left', 'list')}
           style={{ color: textColor }}
         >
           {children}
@@ -150,7 +155,7 @@ export function parseRichTextDocument(document, classNameByEntry, styles) {
       ),
       [BLOCKS.QUOTE]: (node, children) => (
         <blockquote
-          className={classnames(classNameByEntry.default, 'list')}
+          className={classnames(classNameByEntryDefault, 'list')}
           style={{ color: textColor }}
         >
           {children}
@@ -160,13 +165,14 @@ export function parseRichTextDocument(document, classNameByEntry, styles) {
         <ContentfulEntryLoader
           className={classnames('component-entry', 'margin-bottom-lg')}
           classNameByEntry={classNameByEntry}
+          classNameByEntryDefault={classNameByEntryDefault}
           id={node.data.target.sys.id}
         />
       ),
       [BLOCKS.EMBEDDED_ASSET]: node => (
         <p
           className={classnames(
-            classNameByEntry.default,
+            classNameByEntryDefault,
             'component-entry',
             'text-center',
           )}


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR updates an issue we've had since the original `StoryPage` was completed. At the time we had hard-coded the `grid-narrow` class for any elements rendered using RichText. It worked great at the time when the `StoryPage` was the only component using RichText, and most of the components rendered on that page adhered to the `grid-narrow` layout.

However, now that we're expanding use and looking to implement the CSS Grid across more components, not all of them need to layout within the `grid-narrow`. So this PR provides an alternative approach when rendering components, which allows passing a `classNameByEntry` object that defines `defaults` for classes to always add to each component and the option to supply specific classes for dedicated components that get rendered in a particular context.

### Any background context you want to provide?

As an example, the `StoryPage` passes the following `classNameByEntry` object prop:

```js
classNameByEntry={{
  default: 'grid-narrow',
  EmbedBlock: 'grid-main',
  PostGalleryBlock: 'grid-main',
}}
```
Which indicates that by default, all components rendered in the `StoryPage` get a `grid-narrow` class, and the `EmbedBlock` and `PostGalleryBlock` get the `grid-main` class.

### What are the relevant tickets/cards?

Refs [Pivotal ID #167297536](https://www.pivotaltracker.com/story/show/167297536)

### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.