### PR TITLE
🐛Fix to ensure IE support of forEach method on NodeList

### DIFF
--- a/resources/assets/helpers/navigation.js
+++ b/resources/assets/helpers/navigation.js
@@ -110,7 +110,8 @@ export function bindNavigationEvents() {
   // Navigation link analytics.
   const navLinks = document.querySelectorAll('.navigation__menu a');
 
-  navLinks.forEach(link => {
+  // Convert NodeList to Array for IE support of forEach method on NodeList.
+  Array.from(navLinks).forEach(link => {
     linkAnalyticsHandler(link);
   });
 


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR fixes a bug where the much-beloved Internet Explorer [does not support](https://developer.mozilla.org/en-US/docs/Web/API/NodeList/forEach#Browser_Compatibility) invoking `forEach` on a `NodeList`, which we were attempting to do in our analytics toggling for some nav links causing IE browsers to cry.

The fix was to simply convert the NodeList to an `Array` with `Array.from`. ([Hat tip](https://github.com/babel/babel/issues/6511#issuecomment-338076009).)

### Any background context you want to provide?
We were seeing requests to site from IE browsers failing with this error:
`Object doesn't support property or method 'forEach'`

A quick Google search yielded [this issue](https://github.com/babel/babel/issues/6511#issuecomment-338051067), which thankfully was on the money for our issue here!

### What are the relevant tickets/cards?
[Slack](https://dosomething.slack.com/archives/C3ASB4204/p1568208534168300)

