### PR TITLE
Adds Design Updates to Badge Modal Close Button

### DIFF
--- a/resources/assets/components/pages/AccountPage/BadgeModal.js
+++ b/resources/assets/components/pages/AccountPage/BadgeModal.js
@@ -8,7 +8,7 @@ const BadgeModal = props => {
   const { name, earned, children, onClose } = props;
 
   return (
-    <Modal className="badge" onClose={onClose}>
+    <Modal className="badge -inverted" onClose={onClose}>
       <div>
         <div className="badge-pattern p-4">
           <Badge

--- a/resources/assets/components/pages/AccountPage/badges-tab.scss
+++ b/resources/assets/components/pages/AccountPage/badges-tab.scss
@@ -1,5 +1,6 @@
 .badge-pattern {
   background-image: url('badge-background.svg');
+  margin-top: 30px;
 }
 
 .clickable-badge {

--- a/resources/assets/components/utilities/Modal/modal.scss
+++ b/resources/assets/components/utilities/Modal/modal.scss
@@ -49,13 +49,13 @@
   cursor: pointer;
   display: block;
   font-size: 34px;
-  height: 30px;
+  height: 50px;
   line-height: 34px;
   position: absolute;
   right: 0;
   text-align: center;
   top: 0;
-  width: 30px;
+  width: 50px;
   z-index: 9999; // Ensure "x" is above all other elements, like iframes.
 
   &:focus {

--- a/resources/assets/components/utilities/Modal/modal.scss
+++ b/resources/assets/components/utilities/Modal/modal.scss
@@ -76,6 +76,6 @@
 
 .modal.-inverted {
   .modal__close {
-    color: white;
+    color: $white;
   }
 }

--- a/resources/assets/components/utilities/Modal/modal.scss
+++ b/resources/assets/components/utilities/Modal/modal.scss
@@ -44,7 +44,7 @@
 }
 
 .modal__close {
-  color: $white;
+  color: $black;
   cursor: pointer;
   display: block;
   font-size: 34px;

--- a/resources/assets/components/utilities/Modal/modal.scss
+++ b/resources/assets/components/utilities/Modal/modal.scss
@@ -44,17 +44,18 @@
 }
 
 .modal__close {
-  color: $black;
+  color: $white;
+  background-color: #731daa;
   cursor: pointer;
   display: block;
   font-size: 34px;
-  height: 50px;
+  height: 30px;
   line-height: 34px;
   position: absolute;
   right: 0;
   text-align: center;
   top: 0;
-  width: 50px;
+  width: 30px;
   z-index: 9999; // Ensure "x" is above all other elements, like iframes.
 
   &:focus {

--- a/resources/assets/components/utilities/Modal/modal.scss
+++ b/resources/assets/components/utilities/Modal/modal.scss
@@ -74,3 +74,9 @@
     min-width: 600px;
   }
 }
+
+.modal.-inverted {
+  .modal__close {
+    color: white;
+  }
+}

--- a/resources/assets/components/utilities/Modal/modal.scss
+++ b/resources/assets/components/utilities/Modal/modal.scss
@@ -45,7 +45,6 @@
 
 .modal__close {
   color: $white;
-  background-color: #731daa;
   cursor: pointer;
   display: block;
   font-size: 34px;


### PR DESCRIPTION
This PR changes the 'x' on the badge modals to white

### Any background context you want to provide?
An `-inverted` class was added to the .modal selector and added to the `Modal` container. This will only change the badge modal's 'x' button to white
Screen Sizes
**Small** 
<img width="494" alt="Screen Shot 2019-09-19 at 10 40 14 AM" src="https://user-images.githubusercontent.com/18747117/65254677-a64fb000-daca-11e9-828d-43deff0548da.png">

**Medium**
<img width="1107" alt="Screen Shot 2019-09-19 at 10 40 00 AM" src="https://user-images.githubusercontent.com/18747117/65254693-aea7eb00-daca-11e9-9ad3-f3c369640eeb.png">

**Large**
<img width="722" alt="Screen Shot 2019-09-19 at 10 39 39 AM" src="https://user-images.githubusercontent.com/18747117/65254737-c4b5ab80-daca-11e9-83ed-0d32aa8b9c97.png">


### What are the relevant tickets/cards?

Refs [Pivotal ID #168273935](https://www.pivotaltracker.com/story/show/168273935)

### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.
* [x] Added screenshot to PR description of related front-end updates on **small** screens.
* [x] Added screenshot to PR description of related front-end updates on **medium** screens.
* [x] Added screenshot to PR description of related front-end updates on **large** screens.
