### PR TITLE
Removes Embed tracking event

### DIFF
--- a/resources/assets/components/utilities/Embed/Embed.js
+++ b/resources/assets/components/utilities/Embed/Embed.js
@@ -12,7 +12,6 @@ import linkIcon from './linkIcon.svg';
 import { isExternal } from '../../../helpers';
 import ErrorBlock from '../../blocks/ErrorBlock/ErrorBlock';
 import PlaceholderText from '../PlaceholderText/PlaceholderText';
-import { trackAnalyticsEvent } from '../../../helpers/analytics';
 
 import './embed.scss';
 
@@ -32,6 +31,9 @@ const EMBED_QUERY = gql`
 const Embed = props => {
   const { url, badged, className } = props;
 
+  // @TODO: Add onClick once LinkAction no longer calls Embed (causes duplicate events)
+  // @see https://github.com/DoSomething/phoenix-next/pull/1598#issuecomment-532744108
+  /*
   const onClick = () => {
     trackAnalyticsEvent({
       context: {
@@ -46,6 +48,7 @@ const Embed = props => {
       },
     });
   };
+  */
 
   return (
     <div className={classnames('bordered', 'rounded', 'bg-white', className)}>
@@ -71,7 +74,6 @@ const Embed = props => {
               className="embed__linker"
               target={isExternal(url) ? '_blank' : '_self'}
               rel="noopener noreferrer"
-              onClick={onClick}
             >
               <div className="embed">
                 <LazyImage


### PR DESCRIPTION
### What does this PR do?

This PR comments out the analytics event tracking added in #1598, because as @mendelB [pointed out](https://github.com/DoSomething/phoenix-next/pull/1598#issuecomment-532744108), it creates duplicate events in a `LinkAction`.

### Any background context you want to provide?

We're hoping to go live with a Refer A Friend this week, and the analytics were a nice-to-have vs requirement. In the interest of keeping things simple via less changes and easier testing, we think it'd be cleaner to remove this for now vs having more components to test (e.g. we attempted any of the workarounds suggested in https://github.com/DoSomething/phoenix-next/pull/1598#issuecomment-532774793

### What are the relevant tickets/cards?

Refs https://www.pivotaltracker.com/story/show/168201845

### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.
* [ ] Added screenshot to PR description of related front-end updates on **small** screens.
* [ ] Added screenshot to PR description of related front-end updates on **medium** screens.
* [ ] Added screenshot to PR description of related front-end updates on **large** screens.
