### PR TITLE
Display Referral Page Banner per feature flags

### DIFF
--- a/resources/assets/components/Affirmation/Affirmation.js
+++ b/resources/assets/components/Affirmation/Affirmation.js
@@ -15,18 +15,13 @@ import CtaReferralPageBannerContainer from '../utilities/CtaReferralPageBanner/C
 
 import './affirmation.scss';
 
-const SIGNUP_COUNT_BADGE = gql`
-  query SignupsCountQuery($userId: String!) {
-    signupsCount(userId: $userId, limit: 2)
-  }
-`;
-
 const USER_QUERY = gql`
-  query AccountQuery($userId: String!) {
+  query UserAccountAndSignupsCountQuery($userId: String!) {
     user(id: $userId) {
       hasBadgesFlag: hasFeatureFlag(feature: "badges")
       hasReferFriendsFlag: hasFeatureFlag(feature: "refer-friends")
     }
+    signupsCount(userId: $userId, limit: 2)
   }
 `;
 
@@ -51,32 +46,22 @@ const Affirmation = ({
     ) : null}
 
     <Query query={USER_QUERY} variables={{ userId }}>
-      {userData => (
+      {res => (
         <React.Fragment>
-          {get(userData, 'user.hasBadgesFlag', false) ? (
-            <Query
-              query={SIGNUP_COUNT_BADGE}
-              variables={{ userId }}
-              hideSpinner
+          {get(res, 'user.hasBadgesFlag', false) && res.signupsCount === 1 ? (
+            <Badge
+              earned
+              className="badge padded"
+              size="medium"
+              name="signupBadge"
             >
-              {signupData =>
-                signupData.signupsCount === 1 ? (
-                  <Badge
-                    earned
-                    className="badge padded"
-                    size="medium"
-                    name="signupBadge"
-                  >
-                    <h4>1 Sign-Up</h4>
-                    <p>
-                      Congratulations! You signed up for your first
-                      campaign...and earned your first badge. NICE. Ready to
-                      earn *another* badge? Complete this campaign!
-                    </p>
-                  </Badge>
-                ) : null
-              }
-            </Query>
+              <h4>1 Sign-Up</h4>
+              <p>
+                Congratulations! You signed up for your first campaign...and
+                earned your first badge. NICE. Ready to earn *another* badge?
+                Complete this campaign!
+              </p>
+            </Badge>
           ) : null}
 
           <Flex className="flex-align-center">
@@ -98,7 +83,7 @@ const Affirmation = ({
             />
           ) : null}
 
-          {get(userData, 'user.hasReferFriendsFlag', false) ? (
+          {get(res, 'user.hasReferFriendsFlag', false) ? (
             <CtaReferralPageBannerContainer />
           ) : null}
 


### PR DESCRIPTION
### What does this PR do?

This PR modifies the `Affirmation` logic to display the Referral Page Banner if the user has a `refer-friends` value of `true` set in the `feature_flags` field (introduced in https://github.com/DoSomething/northstar/pull/915). There are no design changes, so screenshots not necessary.

### Any background context you want to provide?

Because we need to wait for the GraphQL response to render the top Badges component and newly added bottom Referral Page banner component, it felt like it made sense to move the `Flex` and `Byline` components inside the Query, to avoid elements shifting around as the request loads. It also felt like it made sense to add the spinner to the Query, to better indicate we're waiting for a request to complete when the modal appears.

I'll update the dev `phoenix` client so this app can be tested via review app. I've turned on `DS_REFER_FLAGS_TEST` in Northstar dev, so the easiest way to test this will be to create a new account and then sign up for a campaign to see the Affirmation -- your new user will have the `refer-friends` feature flag set and should see the banner. Will open a PR in Aurora eventually to make the `refer-flags` feature flag editable to admins (so it's a lot easier to test).

Next up: restrict the campaigns the Referral Page Banner appears on to a specific list of campaign ID's: https://www.pivotaltracker.com/n/projects/2019429/stories/168489148/comments/206819678

### What are the relevant tickets/cards?

https://www.pivotaltracker.com/story/show/168489148

### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.
* [ ] Added screenshot to PR description of related front-end updates on **small** screens.
* [ ] Added screenshot to PR description of related front-end updates on **medium** screens.
* [ ] Added screenshot to PR description of related front-end updates on **large** screens.
