### PR TITLE
Only display Referral Page Banner for certain campaigns

### DIFF
--- a/resources/assets/components/Query.js
+++ b/resources/assets/components/Query.js
@@ -13,7 +13,7 @@ const Query = ({ query, variables, children, hideSpinner }) => (
     {result => {
       // On initial load, just display a loading spinner.
       if (result.networkStatus === NetworkStatus.LOADING) {
-        return hideSpinner ? null : <div className="spinner -centered" />;
+        return hideSpinner ? null : <div className="spinner -centered p-8" />;
       }
 
       if (result.error) {

--- a/resources/assets/components/utilities/CtaReferralPageBanner/CtaReferralPageBanner.js
+++ b/resources/assets/components/utilities/CtaReferralPageBanner/CtaReferralPageBanner.js
@@ -3,24 +3,45 @@ import PropTypes from 'prop-types';
 
 import './cta-referral-page-banner.scss';
 
-const CtaReferralPageBanner = props => (
-  <div className="p-4">
-    <div className="cta-register-banner p-4 clearfix">
+// For now, only display Referral Pages for certain campaigns.
+// @see https://www.pivotaltracker.com/n/projects/2019429/stories/168489148/comments/206819678
+const REFERRAL_CAMPAIGN_IDS = [
+  '7',
+  '2932',
+  '3271',
+  '3302',
+  '3590',
+  '7951',
+  '9026',
+  '9027',
+  '9030',
+  '9031',
+  '9032',
+];
+
+const CtaReferralPageBanner = ({ campaignId }) => (
+  <React.Fragment>
+    {REFERRAL_CAMPAIGN_IDS.includes(campaignId) ? (
       <div className="p-4">
-        <h3 className="text-white">Benefits With Friends</h3>
-        <p className="text-white padding-bottom-md">
-          Refer a friend to this campaign, and you’ll *both* earn a $5 gift
-          card!
-        </p>
-        <a
-          href={`/us/refer-friends?campaign_id=${props.campaignId}`}
-          className="button padded -attached"
-        >
-          Refer A Friend
-        </a>
+        <div className="cta-register-banner p-4 clearfix">
+          <div className="p-4">
+            <h3 className="text-white">Benefits With Friends</h3>
+            <p className="text-white padding-bottom-md">
+              Refer a friend to this campaign, and you’ll *both* earn a $5 gift
+              card!
+            </p>
+            <a
+              href={`/us/refer-friends?campaign_id=${campaignId}`}
+              className="button padded -attached"
+            >
+              Refer A Friend
+            </a>
+          </div>
+        </div>
       </div>
-    </div>
-  </div>
+    ) : null}
+    ;
+  </React.Fragment>
 );
 
 CtaReferralPageBanner.propTypes = {


### PR DESCRIPTION
### What does this PR do?

This PR hardcodes a list of campaigns that we should display the Referral Page Banner for in an Affirmation. A future iteration of this could save the list of campaigns to a config variable, but for the sake of going live with this hopefully tomorrow -- hardcoding to keep it super simple.

### Any background context you want to provide?

Some of the complexity in using a Heroku config variable as a list of id's bring up question of sending over to React app. This could potentially be handled by adding a new property into the campaigns repository, but that can be for vLater. We may end up wanting to run this for all campaigns and removing the check completely.

### What are the relevant tickets/cards?

https://www.pivotaltracker.com/story/show/168489148

### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.
* [ ] Added screenshot to PR description of related front-end updates on **small** screens.
* [ ] Added screenshot to PR description of related front-end updates on **medium** screens.
* [ ] Added screenshot to PR description of related front-end updates on **large** screens.
