### PR TITLE
Register CTA Conversion Test - CTA Popover

### DIFF
--- a/resources/assets/components/pages/GeneralPage/GeneralPage.js
+++ b/resources/assets/components/pages/GeneralPage/GeneralPage.js
@@ -10,13 +10,11 @@ import Byline from '../../utilities/Byline/Byline';
 import ContentfulEntry from '../../ContentfulEntry';
 import { REGISTER_CTA_COPY } from '../../../constants';
 import AuthorBio from '../../utilities/Author/AuthorBio';
-import CtaBanner from '../../utilities/CtaBanner/CtaBanner';
 import CtaPopover from '../../utilities/CtaPopover/CtaPopover';
 import TextContent from '../../utilities/TextContent/TextContent';
 import { contentfulImageUrl, withoutNulls } from '../../../helpers';
 import DelayedElement from '../../utilities/DelayedElement/DelayedElement';
 import SocialShareTray from '../../utilities/SocialShareTray/SocialShareTray';
-import SixpackExperiment from '../../utilities/SixpackExperiment/SixpackExperiment';
 import DismissableElement from '../../utilities/DismissableElement/DismissableElement';
 
 import './general-page.scss';
@@ -139,38 +137,20 @@ const GeneralPage = props => {
         </Enclosure>
       </div>
 
-      {ctaCopy && !isAuthenticated ? (
-        <SixpackExperiment
-          title={`Registration CTA: ${pageCategory} - ${
-            window.innerWidth <= 759 ? 'Small' : 'Large'
-          }`}
-          convertableActions={['ctaButtonClick']}
-          control={
-            <DismissableElement
-              testName="CTA Popover"
-              name="cta_register_popover"
-              render={handleClose => (
-                <DelayedElement delay={3}>
-                  <CtaPopover
-                    title={ctaCopy.title}
-                    content={ctaCopy.content}
-                    link={authUrl}
-                    buttonText={ctaCopy.buttonText}
-                    handleClose={handleClose}
-                  />
-                </DelayedElement>
-              )}
-            />
-          }
-          alternatives={[
-            <CtaBanner
-              testName="CTA Banner"
-              title={ctaCopy.title}
-              content={ctaCopy.content}
-              link={authUrl}
-              buttonText={ctaCopy.buttonText}
-            />,
-          ]}
+      {!isAuthenticated ? (
+        <DismissableElement
+          name="cta_register_popover"
+          render={handleClose => (
+            <DelayedElement delay={3}>
+              <CtaPopover
+                title={ctaCopy.title}
+                content={ctaCopy.content}
+                link={authUrl}
+                buttonText={ctaCopy.buttonText}
+                handleClose={handleClose}
+              />
+            </DelayedElement>
+          )}
         />
       ) : null}
     </div>

--- a/resources/assets/components/utilities/CtaBanner/CtaBanner.js
+++ b/resources/assets/components/utilities/CtaBanner/CtaBanner.js
@@ -1,15 +1,12 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import { sixpack } from '../../../helpers';
 import { trackAnalyticsEvent } from '../../../helpers/analytics';
 
 import './cta-banner.scss';
 
 const CtaBanner = ({ buttonText, content, link, title }) => {
-  const handleClick = () => {
-    sixpack().convertOnAction('ctaButtonClick');
-
+  const handleClick = () =>
     trackAnalyticsEvent({
       metadata: {
         category: 'site_action',
@@ -23,7 +20,6 @@ const CtaBanner = ({ buttonText, content, link, title }) => {
         url: link,
       },
     });
-  };
 
   return (
     <div className="cta-banner base-12-grid">

--- a/resources/assets/components/utilities/CtaPopover/CtaPopover.js
+++ b/resources/assets/components/utilities/CtaPopover/CtaPopover.js
@@ -1,15 +1,12 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import { sixpack } from '../../../helpers';
 import { trackAnalyticsEvent } from '../../../helpers/analytics';
 
 import './cta-popover.scss';
 
 const CtaPopover = ({ buttonText, content, handleClose, link, title }) => {
-  const handleClick = () => {
-    sixpack().convertOnAction('ctaButtonClick');
-
+  const handleClick = () =>
     trackAnalyticsEvent({
       metadata: {
         category: 'site_action',
@@ -23,7 +20,6 @@ const CtaPopover = ({ buttonText, content, handleClose, link, title }) => {
         url: link,
       },
     });
-  };
 
   return (
     <div className="cta-popover p-4 bordered rounded">


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR branches off of #1622 (pending review) to remove the CTA Popover & Banner Sixpack experiment, in favor of rendering the CTA Popover. 

### Any background context you want to provide?
This is phase one of testing to determine actual registration conversion rates for users clicking on these two CTA's.

### What are the relevant tickets/cards?

Refs [Pivotal ID #168654795](https://www.pivotaltracker.com/story/show/168654795)
