### PR TITLE
Fix Affirmation Query Bug - Apollo caching issue

### DIFF
--- a/resources/assets/components/Affirmation/Affirmation.js
+++ b/resources/assets/components/Affirmation/Affirmation.js
@@ -18,6 +18,7 @@ import './affirmation.scss';
 const USER_QUERY = gql`
   query UserAccountAndSignupsCountQuery($userId: String!) {
     user(id: $userId) {
+      id
       hasBadgesFlag: hasFeatureFlag(feature: "badges")
       hasReferFriendsFlag: hasFeatureFlag(feature: "refer-friends")
     }


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_


### What does this PR do?

This PR adds an `id` field to the `UserAccountAndSignupsCountQuery` query in the `Affirmation`.

### Any background context you want to provide?
@ngjo [highlighted](https://dosomething.slack.com/archives/C3ASB4204/p1569260082012100) that the Affirmation was erroring out in some cases.

I was able to surface an Apollo `Network error` in the query:
```
Store error: the application attempted to write an object with no provided id but the store already contains an id of...
```
Google results yielded [a few](https://github.com/apollographql/react-apollo/issues/1656#issuecomment-497872112) [Github issues](https://github.com/apollographql/apollo-client/issues/2510#issuecomment-497869566) with the same error, and it seems to be due to a caching issue with nested queries, where the ID field is used multiple times for the queries, but the `id`  isn't requested as a field. (It also [seems](https://github.com/apollographql/react-apollo/issues/1003#issuecomment-359423424) that you can use any unique field for this.)

In any case, one commenter [linked](https://github.com/apollographql/apollo-client/issues/2510#issuecomment-497869566) to an update to the docs they made with [this warning](https://www.apollographql.com/docs/react/advanced/caching/#%EF%B8%8F-warning):
```
If you use queries for object types that omit id and also queries for the same object type that include the id field, the Apollo InMemoryCache will throw an error when attempting to write query results to the cache. To avoid this, it helps to be consistent when querying object types. The error that is thrown looks like this.
```

I'm still not completely certain I've wrapped my head around this properly, but this should do the trick for now, and we can continue to investigate!

### What are the relevant tickets/cards?
https://dosomething.slack.com/archives/C3ASB4204/p1569260082012100
