### PR TITLE
CTA on General Page Bug Fix 

### DIFF
--- a/resources/assets/components/pages/GeneralPage/GeneralPage.js
+++ b/resources/assets/components/pages/GeneralPage/GeneralPage.js
@@ -137,7 +137,7 @@ const GeneralPage = props => {
         </Enclosure>
       </div>
 
-      {!isAuthenticated ? (
+      {ctaCopy && !isAuthenticated ? (
         <DismissableElement
           name="cta_register_popover"
           render={handleClose => (


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR fixes a bug introduced in #1623 where we accidentally stopped ensuring that there was `ctaCopy` available before rending the CTA Popover.