### PR TITLE
Typeform Embed Styling

### DIFF
--- a/resources/assets/components/Campaign/Campaign.js
+++ b/resources/assets/components/Campaign/Campaign.js
@@ -38,6 +38,7 @@ const Campaign = props => (
             <DelayedElement delay={60}>
               <Modal onClose={handleClose} trackingId="SURVEY_MODAL">
                 <TypeFormEmbed
+                  displayType="modal"
                   typeformUrl="https://dosomething.typeform.com/to/Bvcwvm"
                   queryParameters={{
                     campaign_id: props.campaignId,

--- a/resources/assets/components/blocks/EmbedBlock/templates/TypeFormTemplate.js
+++ b/resources/assets/components/blocks/EmbedBlock/templates/TypeFormTemplate.js
@@ -6,6 +6,7 @@ import TypeFormEmbed from '../../../utilities/TypeFormEmbed/TypeFormEmbed';
 const TypeFormTemplate = props => {
   return (
     <TypeFormEmbed
+      displayType="block"
       typeformUrl={props.url}
       queryParameters={{
         northstar_id: props.userId,

--- a/resources/assets/components/pages/HomePage/HomePage.js
+++ b/resources/assets/components/pages/HomePage/HomePage.js
@@ -108,6 +108,7 @@ class HomePage extends React.Component {
                 <DelayedElement delay={30}>
                   <Modal onClose={handleClose} trackingId="SURVEY_MODAL">
                     <TypeFormEmbed
+                      displayType="modal"
                       typeformUrl="https://dosomething.typeform.com/to/iEdy7C"
                       queryParameters={{
                         northstar_id: get(window.AUTH, 'id', null),

--- a/resources/assets/components/utilities/TypeFormEmbed/TypeFormEmbed.js
+++ b/resources/assets/components/utilities/TypeFormEmbed/TypeFormEmbed.js
@@ -5,13 +5,30 @@ import PropTypes from 'prop-types';
 
 import { appendToQuery, makeUrl, withoutNulls } from '../../../helpers';
 
+const DISPLAY_STYLES = {
+  block: {
+    height: '815px',
+    border: '1px #dcdcdc solid',
+    borderRadius: '4px',
+    overflow: 'hidden',
+  },
+  modal: {
+    height: '500px',
+  },
+};
+
 class TypeFormEmbed extends React.Component {
   componentDidMount() {
     window.typeformInit();
   }
 
   render() {
-    const { queryParameters, redirectParameters, typeformUrl } = this.props;
+    const {
+      queryParameters,
+      redirectParameters,
+      typeformUrl,
+      displayType,
+    } = this.props;
 
     const redirectUrl = appendToQuery(redirectParameters, window.location.href);
 
@@ -28,10 +45,7 @@ class TypeFormEmbed extends React.Component {
         data-url={url.href}
         style={{
           width: '100%',
-          height: '815px',
-          border: '1px #dcdcdc solid',
-          borderRadius: '4px',
-          overflow: 'hidden',
+          ...DISPLAY_STYLES[displayType],
         }}
       />
     );
@@ -42,11 +56,13 @@ TypeFormEmbed.propTypes = {
   queryParameters: PropTypes.object,
   redirectParameters: PropTypes.object,
   typeformUrl: PropTypes.string.isRequired,
+  displayType: PropTypes.oneOf(['block', 'modal']),
 };
 
 TypeFormEmbed.defaultProps = {
   queryParameters: {},
   redirectParameters: {},
+  displayType: 'block',
 };
 
 export default TypeFormEmbed;


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR adds a `displayType` prop to the `TypeformEmbed` component to allow customizing the styles based on the display type (block vs modal etc.)

### Any background context you want to provide?
We've started displaying embedded typeform surveys in both modals _and_ blocks on the page which necessitates some distinct styling rules between the two.

### What are the relevant tickets/cards?
See [this Slack thread](https://dosomething.slack.com/archives/C3ASB4204/p1570115426014600)

**MODAL**
![image](https://user-images.githubusercontent.com/12417657/66143428-2569db80-e5d5-11e9-8109-6b321657e8ac.png)

**BLOCK**
![image](https://user-images.githubusercontent.com/12417657/66143507-429eaa00-e5d5-11e9-907b-1c240dcb4e46.png)



### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [x] Added screenshot to PR description of related front-end updates on **large** screens.
