### PR TITLE
Register CTA Conversion Test - CTA Banner

### DIFF
--- a/resources/assets/components/pages/GeneralPage/GeneralPage.js
+++ b/resources/assets/components/pages/GeneralPage/GeneralPage.js
@@ -10,12 +10,10 @@ import Byline from '../../utilities/Byline/Byline';
 import ContentfulEntry from '../../ContentfulEntry';
 import { REGISTER_CTA_COPY } from '../../../constants';
 import AuthorBio from '../../utilities/Author/AuthorBio';
-import CtaPopover from '../../utilities/CtaPopover/CtaPopover';
+import CtaBanner from '../../utilities/CtaBanner/CtaBanner';
 import TextContent from '../../utilities/TextContent/TextContent';
 import { contentfulImageUrl, withoutNulls } from '../../../helpers';
-import DelayedElement from '../../utilities/DelayedElement/DelayedElement';
 import SocialShareTray from '../../utilities/SocialShareTray/SocialShareTray';
-import DismissableElement from '../../utilities/DismissableElement/DismissableElement';
 
 import './general-page.scss';
 
@@ -138,19 +136,11 @@ const GeneralPage = props => {
       </div>
 
       {ctaCopy && !isAuthenticated ? (
-        <DismissableElement
-          name="cta_register_popover"
-          render={handleClose => (
-            <DelayedElement delay={3}>
-              <CtaPopover
-                title={ctaCopy.title}
-                content={ctaCopy.content}
-                link={authUrl}
-                buttonText={ctaCopy.buttonText}
-                handleClose={handleClose}
-              />
-            </DelayedElement>
-          )}
+        <CtaBanner
+          title={ctaCopy.title}
+          content={ctaCopy.content}
+          link={authUrl}
+          buttonText={ctaCopy.buttonText}
         />
       ) : null}
     </div>


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR replaces the rendering of the `CtaPopover` with the `CtaBanner` on /articles & /facts  pages for phase 2 of our account creation conversion test as per #1623 

### What are the relevant tickets/cards?

Refs [Pivotal ID #168731551](https://www.pivotaltracker.com/story/show/168731551)
