### PR TITLE
Update Typeform Embed Submission Handling

### DIFF
--- a/resources/assets/components/Campaign/Campaign.js
+++ b/resources/assets/components/Campaign/Campaign.js
@@ -34,7 +34,7 @@ const Campaign = props => (
       <TrafficDistribution percentage={5} feature="nps_survey">
         <DismissableElement
           name="nps_survey"
-          render={handleClose => (
+          render={(handleClose, handleComplete) => (
             <DelayedElement delay={60}>
               <Modal onClose={handleClose} trackingId="SURVEY_MODAL">
                 <TypeFormEmbed
@@ -44,9 +44,7 @@ const Campaign = props => (
                     campaign_id: props.campaignId,
                     northstar_id: props.userId,
                   }}
-                  redirectParameters={{
-                    hide_nps_survey: 1,
-                  }}
+                  onSubmit={handleComplete}
                 />
               </Modal>
             </DelayedElement>

--- a/resources/assets/components/pages/HomePage/HomePage.js
+++ b/resources/assets/components/pages/HomePage/HomePage.js
@@ -104,7 +104,7 @@ class HomePage extends React.Component {
           <TrafficDistribution percentage={5} feature="nps_survey">
             <DismissableElement
               name="nps_survey"
-              render={handleClose => (
+              render={(handleClose, handleComplete) => (
                 <DelayedElement delay={30}>
                   <Modal onClose={handleClose} trackingId="SURVEY_MODAL">
                     <TypeFormEmbed
@@ -113,9 +113,7 @@ class HomePage extends React.Component {
                       queryParameters={{
                         northstar_id: get(window.AUTH, 'id', null),
                       }}
-                      redirectParameters={{
-                        hide_nps_survey: 1,
-                      }}
+                      onSubmit={handleComplete}
                     />
                   </Modal>
                 </DelayedElement>

--- a/resources/assets/components/utilities/DismissableElement/DismissableElement.js
+++ b/resources/assets/components/utilities/DismissableElement/DismissableElement.js
@@ -7,11 +7,21 @@ import { get as getStorage, set as setStorage } from '../../../helpers/storage';
 const DismissableElement = ({ name, render }) => {
   const [showElement, setShowElement] = useState(true);
 
+  const handleCompletion = () => {
+    // Mark the element as "hidden" in local storage.
+    setStorage(`hide_${name}`, 'boolean', true);
+    setShowElement(false);
+  };
+
+  const handleDismissal = () => {
+    // Mark the element as "dismissed" in local storage & hide it.
+    setStorage(`dismissed_${name}`, 'timestamp', Date.now());
+    setShowElement(false);
+  };
+
   useEffect(() => {
-    // Mark the element as "hidden" in local storage if indicated by query param.
     if (query(`hide_${name}`) === '1') {
-      setStorage(`hide_${name}`, 'boolean', true);
-      setShowElement(false);
+      handleCompletion();
     }
   }, []);
 
@@ -26,13 +36,7 @@ const DismissableElement = ({ name, render }) => {
     return !shouldNotSee && !isDismissed && showElement;
   };
 
-  const handleDismissal = () => {
-    // Mark the element as "dismissed" in local storage & hide it.
-    setStorage(`dismissed_${name}`, 'timestamp', Date.now());
-    setShowElement(false);
-  };
-
-  return shouldSeeElement() ? render(handleDismissal) : null;
+  return shouldSeeElement() ? render(handleDismissal, handleCompletion) : null;
 };
 
 DismissableElement.propTypes = {

--- a/resources/assets/components/utilities/TypeFormEmbed/TypeFormEmbed.js
+++ b/resources/assets/components/utilities/TypeFormEmbed/TypeFormEmbed.js
@@ -1,10 +1,8 @@
-/* global window */
-
 import PropTypes from 'prop-types';
 import * as typeformEmbed from '@typeform/embed';
 import React, { useRef, useEffect } from 'react';
 
-import { appendToQuery, makeUrl, withoutNulls } from '../../../helpers';
+import { makeUrl, withoutNulls } from '../../../helpers';
 
 const DISPLAY_STYLES = {
   block: {

--- a/resources/assets/components/utilities/TypeFormEmbed/TypeFormEmbed.js
+++ b/resources/assets/components/utilities/TypeFormEmbed/TypeFormEmbed.js
@@ -21,22 +21,25 @@ const DISPLAY_STYLES = {
 const TypeFormEmbed = ({
   displayType,
   queryParameters,
-  redirectParameters,
   typeformUrl,
+  onSubmit,
 }) => {
   const typeformElement = useRef(null);
 
-  const redirectUrl = appendToQuery(redirectParameters, window.location.href);
-
   const typeformQuery = {
-    redirect_url: redirectUrl.href,
     ...queryParameters,
   };
 
   const url = makeUrl(typeformUrl, withoutNulls(typeformQuery));
 
   useEffect(() => {
-    typeformEmbed.makeWidget(typeformElement.current, url.href, {});
+    typeformEmbed.makeWidget(
+      typeformElement.current,
+      url.href,
+      withoutNulls({
+        onSubmit,
+      }),
+    );
   }, []);
 
   return (
@@ -52,15 +55,15 @@ const TypeFormEmbed = ({
 
 TypeFormEmbed.propTypes = {
   queryParameters: PropTypes.object,
-  redirectParameters: PropTypes.object,
   typeformUrl: PropTypes.string.isRequired,
   displayType: PropTypes.oneOf(['block', 'modal']),
+  onSubmit: PropTypes.func,
 };
 
 TypeFormEmbed.defaultProps = {
   queryParameters: {},
-  redirectParameters: {},
   displayType: 'block',
+  onSubmit: null,
 };
 
 export default TypeFormEmbed;


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR updates the `TypeformEmbed` component to use an optional `onSubmit` prop to pass through to the widget as a [callback post submission](https://developer.typeform.com/embed/onsubmit-callback/). https://github.com/DoSomething/phoenix-next/commit/3a0bab984d7ae77db4518e3a772d17532d92c726

It then updates the `DismissableElement` utility to yield a new `handleCompletion` method to its children https://github.com/DoSomething/phoenix-next/commit/4bf2f5afce37600e4e3be13b7cac23662691ae6e, which we pass through to the two NPS Surveys https://github.com/DoSomething/phoenix-next/commit/45c8a4bee332783d49eea21585d8c29a01a70740.

This allows us to more efficiently and safely handle submission logic to hide the NPS survey feature in the future upon submission, without relying on the [redirect setting](https://www.typeform.com/help/redirect-after-submitting/) in Typeform which was causing us some grief.

It's consistent with the established pattern in `DismissableElement` with the [`handleDismissal`](https://github.com/DoSomething/phoenix-next/blob/170b0f505bb79a8b6a2b1d6d3f0aec3fdbb0b973/resources/assets/components/utilities/DismissableElement/DismissableElement.js#L29-#L36) callback! It also affords us more control post submission (e.g. we could even start tracking an analytics event or whatnot), and is overall a more pleasant experience sans an extra page reload!

### What are the relevant tickets/cards?
We discovered/discussed the issue on slack https://dosomething.slack.com/archives/C3ASB4204/p1570217006043000?thread_ts=1570199430.032800&cid=C3ASB4204
