### PR TITLE
Don't Merge - Testing pull panda with new non data team

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,3 +1,4 @@
+TESTING Pull Panda
 # 🔥 Phoenix 🔥
 
 Welcome! This is **Phoenix**, the new campaign experience for [DoSomething.org](https://www.dosomething.org)! Phoenix is built using [Laravel](https://laravel.com/docs), [Contentful](https://www.contentful.com), [React](https://reactjs.com/), and [Redux](http://redux.js.org) and plays nicely with the rest of our team \([Northstar](https://github.com/DoSomething/northstar), [Rogue](https://github.com/DoSomething/rogue), and co.\)


### PR DESCRIPTION
The non-data team is not setup as a code owner yet, so just seeing if pull assigner will select a review from the defined team.

## _PULL REQUEST OVERVIEW_
Trying something different with the pull assigner setup. 

Steps taken so far:
1. I uninstalled the other pull reviewer app that was configured in case that was causing a conflict
2. I created a new team: Non-data devs and added devs outside of data engineering + me
3. I created a proxy team (see: https://docs.pullpanda.com/products/assigner/avoiding-team-notifications): Non-Data-PullAssigner
4.  Gave both of these new teams write access to phoenix-next
5. Ensured that everyone in the non-data dev team was invited as a user to pull panda (juuuust to make sure)
6. Configured pull assigner with this team and enabled it (the only thing I really configured was selecting the team and proxy team). I kept all the defaults the same.
7. Disabled the Team Rocket pull assigner setup.

* Setup done on this page: https://pullreminders.com/installs/731685/assigner/teams/3553

Hope this does something 🤞 