### PR TITLE
Update CODEOWNERS to use proxy team for PR assignment

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,4 +3,4 @@
 # This will automatically request the following users to review
 # pull requests made on this repository.
 
-*       @dosomething/team-rocket
+*       @DoSomething/non-data-pullassigner


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR swaps out the team in `CODEOWNERS` to be `DoSomething/non-data-pullassigner` which is a proxy team that will be assigned to PRs before someone from `DoSomething/non-data-devs` is assigned. That way not everyone on the team will be sent notifications and see themselves as a "reviewer" on the PR.

### Any background context you want to provide?

Further discussion in https://github.com/DoSomething/phoenix-next/pull/1640.
