### PR TITLE
Adding ability to logout.

### DIFF
--- a/app/Http/Controllers/AuthController.php
+++ b/app/Http/Controllers/AuthController.php
@@ -37,7 +37,7 @@ class AuthController extends Controller
      * @param ResponseInterface $response
      * @return ResponseInterface
      */
-    public function getLogout(ResponseInterface $response)
+    public function getDeauthorization(ResponseInterface $response)
     {
         return gateway('northstar')->logout($response, $this->redirectAfterLogout);
     }

--- a/resources/assets/components/pages/AccountPage/AccountNavigation.js
+++ b/resources/assets/components/pages/AccountPage/AccountNavigation.js
@@ -36,6 +36,9 @@ const AccountNavigation = props => (
       >
         Subscriptions
       </NavLink>
+      <a className="nav-link" href="/deauthorize">
+        Log Out
+      </a>
     </div>
   </div>
 );

--- a/routes/web.php
+++ b/routes/web.php
@@ -16,7 +16,9 @@ $router->get('/authorize', 'AuthController@getAuthorization')->name('authorize')
 $router->redirect('/auth/login', '/next/login', 302); // Fix for hard-coded redirect in Gateway! <goo.gl/2VPxDC>
 $router->redirect('/next/login', '/authorize', 302);
 
-$router->get('next/logout', 'AuthController@getLogout')->name('logout');
+
+$router->get('/deauthorize', 'AuthController@getDeauthorization')->name('deauthorize');
+$router->redirect('/next/logout', '/deauthorize', 302);
 
 // Profile
 $router->redirect('/northstar/{id}', '/us/account/profile');

--- a/routes/web.php
+++ b/routes/web.php
@@ -16,7 +16,6 @@ $router->get('/authorize', 'AuthController@getAuthorization')->name('authorize')
 $router->redirect('/auth/login', '/next/login', 302); // Fix for hard-coded redirect in Gateway! <goo.gl/2VPxDC>
 $router->redirect('/next/login', '/authorize', 302);
 
-
 $router->get('/deauthorize', 'AuthController@getDeauthorization')->name('deauthorize');
 $router->redirect('/next/logout', '/deauthorize', 302);
 


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR updates the Profile navigation to add a "Log Out" link, so that members can log out once the new Meganav is implemented.

### Any background context you want to provide?

It also removes the old `/next/logout` URL to continue the efforts to remove all vestiges of `/next` in favor of `/deauthorize` which matches as the counterpart to `/authorize` for logging in and authenticating a user.

### What are the relevant tickets/cards?

Refs [Pivotal ID #168552873](https://www.pivotaltracker.com/story/show/168552873)

### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.
* [ ] Added screenshot to PR description of related front-end updates on **small** screens.
* [ ] Added screenshot to PR description of related front-end updates on **medium** screens.
* [ ] Added screenshot to PR description of related front-end updates on **large** screens.
