### PR TITLE
Meganav moar updates

### DIFF
--- a/app/Http/Controllers/AuthController.php
+++ b/app/Http/Controllers/AuthController.php
@@ -37,7 +37,7 @@ class AuthController extends Controller
      * @param ResponseInterface $response
      * @return ResponseInterface
      */
-    public function getLogout(ResponseInterface $response)
+    public function getDeauthorization(ResponseInterface $response)
     {
         return gateway('northstar')->logout($response, $this->redirectAfterLogout);
     }

--- a/resources/assets/components/NavApp.js
+++ b/resources/assets/components/NavApp.js
@@ -1,0 +1,33 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Provider } from 'react-redux';
+import { ApolloProvider } from 'react-apollo';
+import { Router, Route, Switch } from 'react-router-dom';
+
+import { env } from '../helpers';
+import graphqlClient from '../graphql';
+import { initializeStore } from '../store/store';
+import SiteNavigationContainer from './SiteNavigation/SiteNavigationContainer';
+
+const App = ({ store, history }) => {
+  initializeStore(store);
+
+  return (
+    <Provider store={store}>
+      <ApolloProvider client={graphqlClient(env('GRAPHQL_URL'))}>
+        <Router history={history}>
+          <Switch>
+            <Route path="/" component={SiteNavigationContainer} />
+          </Switch>
+        </Router>
+      </ApolloProvider>
+    </Provider>
+  );
+};
+
+App.propTypes = {
+  store: PropTypes.object.isRequired,
+  history: PropTypes.object.isRequired,
+};
+
+export default App;

--- a/resources/assets/components/pages/AccountPage/AccountNavigation.js
+++ b/resources/assets/components/pages/AccountPage/AccountNavigation.js
@@ -36,6 +36,9 @@ const AccountNavigation = props => (
       >
         Subscriptions
       </NavLink>
+      <a className="nav-link" href="/deauthorize">
+        Log Out
+      </a>
     </div>
   </div>
 );

--- a/resources/assets/init.js
+++ b/resources/assets/init.js
@@ -33,8 +33,9 @@ import './scss/placeholder.scss';
 import './scss/fonts.scss';
 import './scss/gallery-grid.scss';
 
-// React Application
+// React Application(s)
 import App from './components/App';
+import NavApp from './components/NavApp';
 
 // DOM Helpers
 import { ready, debug } from './helpers';
@@ -87,5 +88,11 @@ ready(() => {
   const appElement = document.getElementById('app');
   if (appElement) {
     ReactDom.render(<App store={store} history={history} />, appElement);
+  }
+
+  // Render the nav on PHP rendered pages!
+  const navAppElement = document.getElementById('nav-container');
+  if (navAppElement) {
+    ReactDom.render(<NavApp store={store} history={history} />, navAppElement);
   }
 });

--- a/resources/views/campaigns/index.blade.php
+++ b/resources/views/campaigns/index.blade.php
@@ -1,6 +1,7 @@
 @extends('layouts.master')
 
 @section('content')
+    <div id="nav-container"></div>
     <div class="container -padded">
         <div class="wrapper">
             <div class="container__block">

--- a/resources/views/errors/404.blade.php
+++ b/resources/views/errors/404.blade.php
@@ -1,6 +1,7 @@
 @extends('layouts.master')
 
 @section('content')
+    <div id="nav-container"></div>
     <div class="chrome -plain">
         <div class="wrapper">
             <section class="container -framed">

--- a/resources/views/errors/500.blade.php
+++ b/resources/views/errors/500.blade.php
@@ -1,6 +1,7 @@
 @extends('layouts.master')
 
 @section('content')
+    <div id="nav-container"></div>
     <div class="chrome -plain">
         <div class="wrapper">
             <a class="construction__logo" href="http://dosomething.org"></a>

--- a/resources/views/search/results.blade.php
+++ b/resources/views/search/results.blade.php
@@ -1,6 +1,7 @@
 @extends('layouts.master')
 
 @section('content')
+    <div id="nav-container"></div>
     <div class="container -padded">
         <div class="wrapper">
             <div class="container__block">

--- a/routes/web.php
+++ b/routes/web.php
@@ -16,7 +16,9 @@ $router->get('/authorize', 'AuthController@getAuthorization')->name('authorize')
 $router->redirect('/auth/login', '/next/login', 302); // Fix for hard-coded redirect in Gateway! <goo.gl/2VPxDC>
 $router->redirect('/next/login', '/authorize', 302);
 
-$router->get('next/logout', 'AuthController@getLogout')->name('logout');
+
+$router->get('/deauthorize', 'AuthController@getDeauthorization')->name('deauthorize');
+$router->redirect('/next/logout', '/deauthorize', 302);
 
 // Profile
 $router->redirect('/northstar/{id}', '/us/account/profile');

--- a/routes/web.php
+++ b/routes/web.php
@@ -16,7 +16,6 @@ $router->get('/authorize', 'AuthController@getAuthorization')->name('authorize')
 $router->redirect('/auth/login', '/next/login', 302); // Fix for hard-coded redirect in Gateway! <goo.gl/2VPxDC>
 $router->redirect('/next/login', '/authorize', 302);
 
-
 $router->get('/deauthorize', 'AuthController@getDeauthorization')->name('deauthorize');
 $router->redirect('/next/logout', '/deauthorize', 302);
 


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR adds some updates to allow members to log out via a link in their profile (now that Meganav does not contain a log out link), and also updates PHP rendered pages to enable displaying the new `SiteNavigation` React component.

The new route to log out is now `/deauthorize` which is a nice counterpart to the `/authorize` route when logging in and authenticating. I added a redirect from `/next/logout` to go to `/deauthorize` in case there are straggling links that still refer to `/next/logout`, etc.

### Any background context you want to provide?

I ended up having to create a new "app" that gets added solely to a new `nav-container` ID'd element on PHP rendered pages (explore campaigns, search, 404, 503, and potentially others?). Not the most ideal approach, but I'm going to create a ticket on the Platforms team board to address switching over the PHP rendered pages to use the main `App` component and unify them.

### What are the relevant tickets/cards?

Refs [Pivotal ID #168552873](https://www.pivotaltracker.com/story/show/168552873)

### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.
* [ ] Added screenshot to PR description of related front-end updates on **small** screens.
* [ ] Added screenshot to PR description of related front-end updates on **medium** screens.
* [ ] Added screenshot to PR description of related front-end updates on **large** screens.
