### PR TITLE
Removing default Safari styling for search inputs.

### DIFF
--- a/resources/assets/components/SiteNavigation/site-navigation.scss
+++ b/resources/assets/components/SiteNavigation/site-navigation.scss
@@ -287,6 +287,7 @@ $extraSmall: '(min-width: 360px)';
     margin-left: 3px;
     padding: 5px;
     width: 100%;
+    -webkit-appearance: none;
 
     &:focus {
       outline: none;

--- a/resources/assets/components/pages/HomePage/home-page.scss
+++ b/resources/assets/components/pages/HomePage/home-page.scss
@@ -15,6 +15,7 @@
   }
 
   .header {
+    padding-top: 72px;
     padding-bottom: 50px;
   }
 


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR adds a quick fix to remove the default styling Safari adds to Search inputs. It also adds an additional quick fix to shorten the Homepage banner top padding now that the navigation is no longer positioned absolutely on that page.

### Any background context you want to provide?

🌵 

### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.
* [ ] Added screenshot to PR description of related front-end updates on **small** screens.
* [ ] Added screenshot to PR description of related front-end updates on **medium** screens.
* [ ] Added screenshot to PR description of related front-end updates on **large** screens.
