### PR TITLE
Allowing label to be used if adjective not provided.

### DIFF
--- a/resources/assets/components/SiteNavigation/SiteNavigation.js
+++ b/resources/assets/components/SiteNavigation/SiteNavigation.js
@@ -41,6 +41,8 @@ class SiteNavigation extends React.Component {
 
     const context = get(analytics, 'context', {});
 
+    const label = get(analytics, 'label', null);
+
     trackAnalyticsEvent({
       context: {
         ...getPageContext(),
@@ -49,9 +51,9 @@ class SiteNavigation extends React.Component {
         ...context,
       },
       metadata: {
-        adjective: get(analytics, 'adjective', null),
+        adjective: get(analytics, 'adjective', label),
         category: get(analytics, 'category', 'navigation'),
-        label: get(analytics, 'label', null),
+        label,
         noun: get(analytics, 'noun', 'nav_link'),
         target,
         verb: get(analytics, 'verb', 'clicked'),


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR fixes a slight bug introduced in #1654. We're allowing the option to provide an override for the analytics `adjective`... but need to make sure it defaults to the `label` if no adjective is provided.

### What are the relevant tickets/cards?

🌵 

### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.