### PR TITLE
Adds hideIfSignedUp prop to Campaign Pages footer CTA

### DIFF
--- a/resources/assets/components/pages/CampaignPage/CampaignPageContent.js
+++ b/resources/assets/components/pages/CampaignPage/CampaignPageContent.js
@@ -95,7 +95,11 @@ const CampaignPageContent = props => {
       </div>
 
       {isClosed ? null : (
-        <CallToActionContainer useCampaignTagline visualStyle="transparent" />
+        <CallToActionContainer
+          useCampaignTagline
+          visualStyle="transparent"
+          hideIfSignedUp
+        />
       )}
     </div>
   );


### PR DESCRIPTION
### What does this PR do?

This PR removes the CTA that would appear at the bottom of campaign pages after a user would sign up. All we've added is a`hideIfSignedUp` prop being passed to the CTA container.

### Any background context you want to provide?

GitLens tells me it was probably Diego's fault, a year ago or something.

### What are the relevant tickets/cards?

Refs [Pivotal ID #169045802](https://www.pivotaltracker.com/story/show/169045802)

### Checklist
![Screen Shot 2019-10-24 at 4 14 34 PM](https://user-images.githubusercontent.com/1865372/67521734-6ce60380-f679-11e9-8a59-3da4444b3965.png)
