### PR TITLE
Do Not Merge - Cypress test for subscription center

### DIFF
--- a/cypress/fixtures/graphql.js
+++ b/cypress/fixtures/graphql.js
@@ -39,6 +39,10 @@ export const mocks = {
   // Custom scalars:
   AbsoluteUrl: () => 'https://www.example.com/',
   DateTime: () => new Date().toISOString(),
+  Date: () => {
+    const date = new Date().toISOString();
+    return date.substring(0, 10);
+  },
 
   // Types:
   User: () => ({

--- a/cypress/integration/subscription-center.js
+++ b/cypress/integration/subscription-center.js
@@ -1,0 +1,46 @@
+/// <reference types="Cypress" />
+
+import { userFactory } from '../fixtures/user';
+
+describe('Subscription Center', () => {
+  // Configure a new "mock" server before each test:
+  beforeEach(() => cy.configureMocks());
+
+  it('View existing subscriptions', () => {
+    const user = userFactory();
+
+    // Log in & visit the subscription center:
+    cy.login(user).visit('/us/account/profile/subscriptions');
+
+    // have graphQL return 2 subscriptions in particular
+    // make sure those are the boxes that are checked
+    // cy.mock()
+    // look at campaign-gallery.js for GraphQL mocks
+
+    cy.contains('Example Campaign');
+    cy.contains('This is an example campaign for automated testing.');
+
+    // We shouldn't see the "Join Now" button or affiramation modal,
+    // since the user is already signed up for this campaign:
+    cy.get('mosaic-lede-banner__signup').should('not.exist');
+    cy.get('.card.affirmation').should('not.exist');
+  });
+
+  it('Update subscriptions', () => {
+    const user = userFactory();
+
+    // Log in & visit the campaign action page:
+    cy.login(user)
+      .withState(exampleCampaign)
+      .withSignup(exampleCampaign.campaign.campaignId)
+      .visit('/us/campaigns/test-example-campaign');
+
+    cy.contains('Example Campaign');
+    cy.contains('This is an example campaign for automated testing.');
+
+    // We shouldn't see the "Join Now" button or affiramation modal,
+    // since the user is already signed up for this campaign:
+    cy.get('mosaic-lede-banner__signup').should('not.exist');
+    cy.get('.card.affirmation').should('not.exist');
+  });
+});

--- a/cypress/integration/subscription-center.js
+++ b/cypress/integration/subscription-center.js
@@ -7,40 +7,25 @@ describe('Subscription Center', () => {
   beforeEach(() => cy.configureMocks());
 
   it('View existing subscriptions', () => {
+    // This user is just for auth purposes
     const user = userFactory();
+
+    cy.mockGraphqlOp('AccountQuery', {
+      // Get back a particular user and subscription topics
+      user: root => ({
+        firstName: 'Delilah',
+        emailSubscriptionTopics: ['COMMUNITY', 'NEWS', 'LIFESTYLE'],
+      }),
+    });
 
     // Log in & visit the subscription center:
     cy.login(user).visit('/us/account/profile/subscriptions');
 
-    // have graphQL return 2 subscriptions in particular
-    // make sure those are the boxes that are checked
-    // cy.mock()
-    // look at campaign-gallery.js for GraphQL mocks
-
-    cy.contains('Example Campaign');
-    cy.contains('This is an example campaign for automated testing.');
-
-    // We shouldn't see the "Join Now" button or affiramation modal,
-    // since the user is already signed up for this campaign:
-    cy.get('mosaic-lede-banner__signup').should('not.exist');
-    cy.get('.card.affirmation').should('not.exist');
-  });
-
-  it('Update subscriptions', () => {
-    const user = userFactory();
-
-    // Log in & visit the campaign action page:
-    cy.login(user)
-      .withState(exampleCampaign)
-      .withSignup(exampleCampaign.campaign.campaignId)
-      .visit('/us/campaigns/test-example-campaign');
-
-    cy.contains('Example Campaign');
-    cy.contains('This is an example campaign for automated testing.');
-
-    // We shouldn't see the "Join Now" button or affiramation modal,
-    // since the user is already signed up for this campaign:
-    cy.get('mosaic-lede-banner__signup').should('not.exist');
-    cy.get('.card.affirmation').should('not.exist');
+    // We should see the user's name and the correct subscription topics checked
+    cy.contains('Welcome, Delilah!');
+    cy.get('input[name=COMMUNITY]').should('be.checked');
+    cy.get('input[name=NEWS]').should('be.checked');
+    cy.get('input[name=LIFESTYLE]').should('be.checked');
+    cy.get('input[name=SCHOLARSHIPS]').should('not.be.checked');
   });
 });

--- a/routes/web.php
+++ b/routes/web.php
@@ -21,8 +21,7 @@ $router->get('next/logout', 'AuthController@getLogout')->name('logout');
 // Profile
 $router->redirect('/northstar/{id}', '/us/account/profile');
 $router->view('/us/account/{clientRoute?}', 'app')
-    ->where('clientRoute', '.*')
-    ->middleware('auth');
+    ->where('clientRoute', '.*');
 
 // Campaigns index
 $router->get('us/campaigns', 'CampaignController@index');


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

Hi everyone! We wrote this together! This test tests the following flow:
- As an authenticated user, going to `/us/account/profile/subscriptions`
- From GraphQL, mock receiving a `firstName` and `emailSubscriptionTopics`
- Making sure the name and subscription topics on the page match what we got back from GraphQL

### Any background context you want to provide?

Hell yeah, we had to remove the `auth` middleware from this route in order to be able to test it, but we don't really want to do that, so this can't be merged yet.



### Checklist

* [X] Added appropriate feature/unit tests.

