### PR TITLE
Add an in-house analytics waypoint to Link Actions

### DIFF
--- a/resources/assets/components/actions/LinkAction/LinkAction.js
+++ b/resources/assets/components/actions/LinkAction/LinkAction.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { get } from 'lodash';
-import PropTypes from 'prop-types';
 import gql from 'graphql-tag';
+import PropTypes from 'prop-types';
 
 import CtaTemplate from './templates/CtaTemplate';
 import DefaultTemplate from './templates/DefaultTemplate';

--- a/resources/assets/components/actions/LinkAction/LinkAction.js
+++ b/resources/assets/components/actions/LinkAction/LinkAction.js
@@ -2,7 +2,6 @@ import React from 'react';
 import { get } from 'lodash';
 import PropTypes from 'prop-types';
 import gql from 'graphql-tag';
-import { PuckWaypoint } from '@dosomething/puck-client';
 
 import CtaTemplate from './templates/CtaTemplate';
 import DefaultTemplate from './templates/DefaultTemplate';
@@ -36,10 +35,8 @@ const LinkAction = props => {
   return (
     <React.Fragment>
       <AnalyticsWaypoint name="link_action-top" context={{ blockId: id }} />
-      <PuckWaypoint name="link_action-top" waypointData={{ blockId: id }} />
       <LinkActionTemplate {...props} />
       <AnalyticsWaypoint name="link_action-bottom" context={{ blockId: id }} />
-      <PuckWaypoint name="link_action-bottom" waypointData={{ blockId: id }} />
     </React.Fragment>
   );
 };

--- a/resources/assets/components/actions/LinkAction/LinkAction.js
+++ b/resources/assets/components/actions/LinkAction/LinkAction.js
@@ -6,6 +6,7 @@ import { PuckWaypoint } from '@dosomething/puck-client';
 
 import CtaTemplate from './templates/CtaTemplate';
 import DefaultTemplate from './templates/DefaultTemplate';
+import AnalyticsWaypoint from '../../utilities/AnalyticsWaypoint/AnalyticsWaypoint';
 
 export const LinkBlockFragment = gql`
   fragment LinkBlockFragment on LinkBlock {
@@ -34,8 +35,10 @@ const LinkAction = props => {
 
   return (
     <React.Fragment>
+      <AnalyticsWaypoint name="link_action-top" context={{ blockId: id }} />
       <PuckWaypoint name="link_action-top" waypointData={{ blockId: id }} />
       <LinkActionTemplate {...props} />
+      <AnalyticsWaypoint name="link_action-bottom" context={{ blockId: id }} />
       <PuckWaypoint name="link_action-bottom" waypointData={{ blockId: id }} />
     </React.Fragment>
   );


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR is a sort of proof of concept/beginning of our implementation of replacing Puck waypoints within Phoenix with our in house `AnalyticsWaypoint` to track to GTM/Snowplow, etc.

### Any background context you want to provide?
We're starting with this, once we establish that this is working and reaching GA and Quasar, ~we can retire the Puck waypoint in this component~ (done!), and continue to replace the other scattered components within the app.

This can be tested by visiting any page with a Link Action via the PR review app deployment, e.g. https://dosomething-phoenix-de-pr-1661.herokuapp.com/us/articles/ally-guide has one in the middle of the page, toggling DS debugging in the dev console e.g. `window.DS.Debug.enableLogs(['snowplow'])`, and ensuring you see the two events being logged!

### What are the relevant tickets/cards?

Refs [Pivotal ID #167630633](https://www.pivotaltracker.com/story/show/167630633)
