### PR TITLE
adds the google auth tracking info to docs for analytics

### DIFF
--- a/docs/development/data-and-performance/analytics.md
+++ b/docs/development/data-and-performance/analytics.md
@@ -100,6 +100,7 @@ The event's `data.waypointData` field will contain the `contentfulId` (ID of the
 | `northstar_clicked_register`                   | clicked the 'Create a DoSomething.org account' link                                         | Puck, GA, Snowplow |
 | `northstar_clicked_forgot_password`            | clicked the 'Forgot your password?' link                                                    | Puck, GA, Snowplow |
 | `northstar_clicked_login_facebook`             | clicked the Facebook auth button                                                            | Puck, GA, Snowplow |
+| `northstar_clicked_login_google`               | clicked the Google auth button                                                              | Puck, GA, Snowplow |
 | `northstar_failed_validation`                  | Form was submitted but returned with validation errors (from the backend)                   | Puck, GA, Snowplow |
 | `northstar_focused_field_[field_name]`         | focused on a text field in the form.                                                        | Puck, GA, Snowplow |
 | `northstar_submitted_edit_profile`             | submitted the edit profile form                                                             | Puck, GA, Snowplow |


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR adds the google login tracking to our analytics documentation.

### Any background context you want to provide?

This addition is very similar to the tracking we've implemented for facebook logins.

### What are the relevant tickets/cards?

Refs [169344603](https://www.pivotaltracker.com/story/show/169344603)

### Checklist

* [ ] Documentation added for new features/changed endpoints.
