### PR TITLE
Meganav dropdown styles

### DIFF
--- a/resources/assets/components/SiteNavigation/SiteNavigation.js
+++ b/resources/assets/components/SiteNavigation/SiteNavigation.js
@@ -7,6 +7,7 @@ import classnames from 'classnames';
 import PropTypes from 'prop-types';
 
 import SearchIcon from '../artifacts/SearchIcon/SearchIcon';
+import SiteNavigationFeature from './SiteNavigationFeature';
 import CloseButton from '../artifacts/CloseButton/CloseButton';
 import ProfileIcon from '../artifacts/ProfileIcon/ProfileIcon';
 import DoSomethingLogo from '../utilities/DoSomethingLogo/DoSomethingLogo';
@@ -247,24 +248,23 @@ class SiteNavigation extends React.Component {
                     </section>
 
                     <section className="main-subnav__featured menu-subnav__content menu-subnav__section">
-                      <a href="/" className="main-subnav__feature">
-                        <img
-                          className="mb-4"
-                          src="http://placekitten.com/g/550/250"
-                          alt="temporary place kitten"
-                        />
-                        <h1 className="main-subnav__feature-title">
-                          Take Back the Kittens
-                        </h1>
-                        <div className="main-subnav__feature-content">
-                          <p>
-                            Donec ullamcorper nulla non metus auctor fringilla.
-                          </p>
-                          <p className="main-subnav__feature-link">
-                            Learn More
-                          </p>
-                        </div>
-                      </a>
+                      <SiteNavigationFeature
+                        imageSrc="https://placedog.net/1100/500?id=2"
+                        imageAlt="temporary place puppers"
+                        url="/"
+                        title="Take Back the Puppers"
+                        text="Donec ullamcorper nulla non metus auctor fringilla."
+                        callback={e =>
+                          this.analyzeEvent(e, {
+                            context: {
+                              campaignId: '12asasd23sdasd3',
+                            },
+                            label: 'subnav_feature',
+                            target: 'link',
+                            verb: 'clicked',
+                          })
+                        }
+                      />
                     </section>
 
                     {this.state.isSubNavFixed ? (

--- a/resources/assets/components/SiteNavigation/SiteNavigation.js
+++ b/resources/assets/components/SiteNavigation/SiteNavigation.js
@@ -7,7 +7,6 @@ import classnames from 'classnames';
 import PropTypes from 'prop-types';
 
 import SearchIcon from '../artifacts/SearchIcon/SearchIcon';
-import SiteNavigationFeature from './SiteNavigationFeature';
 import CloseButton from '../artifacts/CloseButton/CloseButton';
 import ProfileIcon from '../artifacts/ProfileIcon/ProfileIcon';
 import DoSomethingLogo from '../utilities/DoSomethingLogo/DoSomethingLogo';
@@ -161,124 +160,13 @@ class SiteNavigation extends React.Component {
           </div>
 
           <ul className="main-nav menu-nav">
-            <li
-              className={classnames('menu-nav__item', {
-                'is-active': this.state.activeSubNav === 'CausesSubNav',
-              })}
-              onMouseEnter={() => this.handleMouseEnter('CausesSubNav')}
-              onMouseLeave={() => this.handleMouseLeave('CausesSubNav')}
-            >
+            <li className="menu-nav__item">
               <a
                 href="/us/campaigns"
-                onClick={e =>
-                  this.handleOnClickToggle(e, 'CausesSubNav', {
-                    label: 'campaigns',
-                  })
-                }
+                onClick={e => this.handleOnClickLink(e, { label: 'campaigns' })}
               >
                 Campaigns
-                <span className="main-nav__arrow" />
               </a>
-
-              {this.state.activeSubNav === 'CausesSubNav' ? (
-                <div className="main-subnav menu-subnav">
-                  <div className="wrapper base-12-grid">
-                    <section className="main-subnav__links-causes menu-subnav__links menu-subnav__section">
-                      <h1>
-                        <a href="/">All Causes</a>
-                      </h1>
-                      <ul>
-                        <li>
-                          <a href="/">Education</a>
-                        </li>
-                        <li>
-                          <a href="/">Mental Health</a>
-                        </li>
-                        <li>
-                          <a href="/">Homelessness & Poverty</a>
-                        </li>
-                        <li>
-                          <a href="/">Environment</a>
-                        </li>
-                        <li>
-                          <a href="/">Animal Welfare</a>
-                        </li>
-                        <li>
-                          <a href="/">Sexual Harassment</a>
-                        </li>
-                        <li>
-                          <a href="/">Bullying</a>
-                        </li>
-                        <li>
-                          <a href="/">Gender Rights</a>
-                        </li>
-                        <li>
-                          <a href="/">Racial Justice</a>
-                        </li>
-                        <li>
-                          <a href="/">Immigration & Refugees</a>
-                        </li>
-                        <li>
-                          <a href="/">LGBT+ Rights</a>
-                        </li>
-                        <li>
-                          <a href="/">Get Out the Vote!</a>
-                        </li>
-                      </ul>
-                    </section>
-
-                    <section className="main-subnav__links-campaigns menu-subnav__links menu-subnav__section">
-                      <h1>
-                        <a href="/">All Campaigns</a>
-                      </h1>
-                      <ul>
-                        <li>
-                          <a href="/">Online</a>
-                        </li>
-                        <li>
-                          <a href="/">In-person</a>
-                        </li>
-                        <li>
-                          <a href="/">Petitions</a>
-                        </li>
-                        <li>
-                          <a href="/">Collections</a>
-                        </li>
-                      </ul>
-                    </section>
-
-                    <section className="main-subnav__featured menu-subnav__content menu-subnav__section">
-                      <SiteNavigationFeature
-                        imageSrc="https://placedog.net/1100/500?id=2"
-                        imageAlt="temporary place puppers"
-                        url="/"
-                        title="Take Back the Puppers"
-                        text="Donec ullamcorper nulla non metus auctor fringilla."
-                        callback={e =>
-                          this.analyzeEvent(e, {
-                            context: {
-                              campaignId: '12asasd23sdasd3',
-                            },
-                            label: 'subnav_feature',
-                            target: 'link',
-                            verb: 'clicked',
-                          })
-                        }
-                      />
-                    </section>
-
-                    {this.state.isSubNavFixed ? (
-                      <CloseButton
-                        callback={this.handleOnClickClose}
-                        className="btn__close--subnav btn__close--main-subnav block"
-                        dataLabel="close_subnav"
-                        dataNoun="nav_button"
-                        size="22px"
-                      />
-                    ) : null}
-                  </div>
-                </div>
-              ) : null}
             </li>
 
             <li className="menu-nav__item">

--- a/resources/assets/components/SiteNavigation/SiteNavigation.js
+++ b/resources/assets/components/SiteNavigation/SiteNavigation.js
@@ -247,14 +247,24 @@ class SiteNavigation extends React.Component {
                     </section>
 
                     <section className="main-subnav__featured menu-subnav__content menu-subnav__section">
-                      <img
-                        className="mb-4"
-                        src="http://placekitten.com/g/550/250"
-                        alt="temporary place kitten"
-                      />
-                      <h1>Take Back the Kittens</h1>
-                      <p>Donec ullamcorper nulla non metus auctor fringilla.</p>
-                      <a href="/">Learn More</a>
+                      <a href="/" className="main-subnav__feature">
+                        <img
+                          className="mb-4"
+                          src="http://placekitten.com/g/550/250"
+                          alt="temporary place kitten"
+                        />
+                        <h1 className="main-subnav__feature-title">
+                          Take Back the Kittens
+                        </h1>
+                        <div className="main-subnav__feature-content">
+                          <p>
+                            Donec ullamcorper nulla non metus auctor fringilla.
+                          </p>
+                          <p className="main-subnav__feature-link">
+                            Learn More
+                          </p>
+                        </div>
+                      </a>
                     </section>
 
                     {this.state.isSubNavFixed ? (

--- a/resources/assets/components/SiteNavigation/SiteNavigation.js
+++ b/resources/assets/components/SiteNavigation/SiteNavigation.js
@@ -160,13 +160,115 @@ class SiteNavigation extends React.Component {
           </div>
 
           <ul className="main-nav menu-nav">
-            <li className="menu-nav__item">
+            <li
+              className={classnames('menu-nav__item', {
+                'is-active': this.state.activeSubNav === 'CausesSubNav',
+              })}
+              onMouseEnter={() => this.handleMouseEnter('CausesSubNav')}
+              onMouseLeave={() => this.handleMouseLeave('CausesSubNav')}
+            >
               <a
                 href="/us/campaigns"
-                onClick={e => this.handleOnClickLink(e, { label: 'campaigns' })}
+                onClick={e =>
+                  this.handleOnClickToggle(e, 'CausesSubNav', {
+                    label: 'campaigns',
+                  })
+                }
               >
                 Campaigns
+                <span className="main-nav__arrow" />
               </a>
+
+              {this.state.activeSubNav === 'CausesSubNav' ? (
+                <div className="main-subnav menu-subnav">
+                  <div className="wrapper base-12-grid">
+                    <section className="main-subnav__links-causes menu-subnav__links menu-subnav__section">
+                      <h1>
+                        <a href="/">All Causes</a>
+                      </h1>
+                      <ul>
+                        <li>
+                          <a href="/">Education</a>
+                        </li>
+                        <li>
+                          <a href="/">Mental Health</a>
+                        </li>
+                        <li>
+                          <a href="/">Homelessness & Poverty</a>
+                        </li>
+                        <li>
+                          <a href="/">Environment</a>
+                        </li>
+                        <li>
+                          <a href="/">Animal Welfare</a>
+                        </li>
+                        <li>
+                          <a href="/">Sexual Harassment</a>
+                        </li>
+                        <li>
+                          <a href="/">Bullying</a>
+                        </li>
+                        <li>
+                          <a href="/">Gender Rights</a>
+                        </li>
+                        <li>
+                          <a href="/">Racial Justice</a>
+                        </li>
+                        <li>
+                          <a href="/">Immigration & Refugees</a>
+                        </li>
+                        <li>
+                          <a href="/">LGBT+ Rights</a>
+                        </li>
+                        <li>
+                          <a href="/">Get Out the Vote!</a>
+                        </li>
+                      </ul>
+                    </section>
+
+                    <section className="main-subnav__links-campaigns menu-subnav__links menu-subnav__section">
+                      <h1>
+                        <a href="/">All Campaigns</a>
+                      </h1>
+                      <ul>
+                        <li>
+                          <a href="/">Online</a>
+                        </li>
+                        <li>
+                          <a href="/">In-person</a>
+                        </li>
+                        <li>
+                          <a href="/">Petitions</a>
+                        </li>
+                        <li>
+                          <a href="/">Collections</a>
+                        </li>
+                      </ul>
+                    </section>
+
+                    <section className="main-subnav__featured menu-subnav__content menu-subnav__section">
+                      <img
+                        className="mb-4"
+                        src="http://placekitten.com/g/550/250"
+                        alt="temporary place kitten"
+                      />
+                      <h1>Take Back the Kittens</h1>
+                      <p>Donec ullamcorper nulla non metus auctor fringilla.</p>
+                      <a href="/">Learn More</a>
+                    </section>
+
+                    {this.state.isSubNavFixed ? (
+                      <CloseButton
+                        callback={this.handleOnClickClose}
+                        className="btn__close--subnav btn__close--main-subnav block"
+                        dataLabel="close_subnav"
+                        dataNoun="nav_button"
+                        size="22px"
+                      />
+                    ) : null}
+                  </div>
+                </div>
+              ) : null}
             </li>
 
             <li className="menu-nav__item">

--- a/resources/assets/components/SiteNavigation/SiteNavigationFeature.js
+++ b/resources/assets/components/SiteNavigation/SiteNavigationFeature.js
@@ -1,0 +1,41 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const SiteNavigationFeature = ({
+  callback,
+  imageSrc,
+  imageAlt,
+  moreLinkText,
+  text,
+  title,
+  url,
+}) => (
+  <a href={url} className="main-subnav__feature" onClick={callback}>
+    <img className="mb-4" src={imageSrc} alt={imageAlt} />
+
+    <h1 className="main-subnav__feature-title">{title}</h1>
+
+    <div className="main-subnav__feature-content">
+      <p>{text}</p>
+
+      <p className="main-subnav__feature-link">{moreLinkText}</p>
+    </div>
+  </a>
+);
+
+SiteNavigationFeature.propTypes = {
+  callback: PropTypes.func,
+  imageSrc: PropTypes.string.isRequired,
+  imageAlt: PropTypes.string.isRequired,
+  title: PropTypes.string.isRequired,
+  text: PropTypes.string.isRequired,
+  moreLinkText: PropTypes.string,
+  url: PropTypes.string.isRequired,
+};
+
+SiteNavigationFeature.defaultProps = {
+  callback: () => {},
+  moreLinkText: 'Learn More',
+};
+
+export default SiteNavigationFeature;

--- a/resources/assets/components/SiteNavigation/site-navigation.scss
+++ b/resources/assets/components/SiteNavigation/site-navigation.scss
@@ -63,11 +63,15 @@ $extraSmall: '(min-width: 360px)';
   position: relative;
 
   &:first-of-type {
-    padding-top: 0;
+    padding-top: 12px;
+
+    @include media($large) {
+      padding-top: 0;
+    }
   }
 
-  &:last-of-type {
-    padding-bottom: $spacing_2x;
+  @include media($large) {
+    padding-top: 0;
   }
 }
 
@@ -101,10 +105,21 @@ $extraSmall: '(min-width: 360px)';
   }
 
   > h1 {
+    margin-bottom: 0;
+
     a {
       color: black;
       font-size: 22px;
       font-weight: bold;
+      padding: 0 0 12px;
+
+      @include media($large) {
+        font-size: 18px;
+      }
+
+      @include media($larger) {
+        font-size: 22px;
+      }
     }
   }
 }
@@ -205,6 +220,38 @@ $extraSmall: '(min-width: 360px)';
 
   @include media($large) {
     grid-column: 7 / wide-end;
+  }
+}
+
+.main-subnav__feature {
+  display: block;
+  font-weight: $weight-normal;
+
+  &:active,
+  &:hover {
+    text-decoration: none;
+
+    .main-subnav__feature-link {
+      text-decoration: underline;
+    }
+  }
+}
+
+.main-subnav__feature-title {
+  font-size: 22px;
+}
+
+.main-subnav__feature-content {
+}
+
+.main-subnav__feature-link {
+  color: $blue;
+  font-weight: $weight-bold;
+  margin-top: 0;
+
+  &:active,
+  &:hover {
+    text-decoration: underline;
   }
 }
 

--- a/resources/assets/components/SiteNavigation/site-navigation.scss
+++ b/resources/assets/components/SiteNavigation/site-navigation.scss
@@ -102,6 +102,10 @@ $extraSmall: '(min-width: 360px)';
     display: block;
     font-weight: $weight-normal;
     padding: 8px 0;
+
+    @include media($large) {
+      padding: 6px 0;
+    }
   }
 
   > h1 {

--- a/resources/assets/components/SiteNavigation/site-navigation.scss
+++ b/resources/assets/components/SiteNavigation/site-navigation.scss
@@ -58,7 +58,48 @@ $extraSmall: '(min-width: 360px)';
   }
 }
 
+.menu-subnav__section {
+  padding: $spacing_1_5x 0;
+  position: relative;
+
+  &:first-of-type {
+    padding-top: 0;
+  }
+
+  &:last-of-type {
+    padding-bottom: $spacing_2x;
+  }
+}
+
+.menu-subnav__section + .menu-subnav__section {
+  &::before {
+    background-color: $gray-200;
+    content: '';
+    display: block;
+    height: 1px;
+    left: -12px;
+    position: absolute;
+    top: 0;
+    width: 100vw;
+
+    @include media($medium) {
+      left: -48px;
+    }
+
+    @include media($large) {
+      display: none;
+    }
+  }
+}
+
 .menu-subnav__links {
+  a {
+    color: black;
+    display: block;
+    font-weight: $weight-normal;
+    padding: 8px 0;
+  }
+
   > h1 {
     a {
       color: black;


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR wraps up most of the styling for the Causes dropdown so it'll be ready when the cause pages launch! It also adds a new `SiteNavigationFeature` component that handles the featured item in the dropdown. It's a basic component for now and we can chat about maybe having some solid default content to show/link to if added with no props, but it's not in use yet, so we can hold off for now.

![Responsive Styled Causes Dropdown](https://user-images.githubusercontent.com/105849/67706753-b42d0680-f98f-11e9-86a6-03e3ff967ac9.gif)


### Any background context you want to provide?

🌵 


### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.
* [x] Added screen-grab to PR description of related front-end updates on **small** screens.
* [x] Added screen-grab to PR description of related front-end updates on **medium** screens.
* [x] Added screen-grab to PR description of related front-end updates on **large** screens.
