### PR TITLE
Update Cause Page content type - rich text validations

### DIFF
--- a/contentful/content-types/cause-page.js
+++ b/contentful/content-types/cause-page.js
@@ -119,10 +119,11 @@ module.exports = function(migration) {
           'unordered-list',
           'hr',
           'blockquote',
+          'hyperlink',
         ],
 
         message:
-          'Only heading 1, heading 2, heading 3, heading 4, heading 5, heading 6, ordered list, unordered list, horizontal rule, and quote nodes are allowed',
+          'Only heading 1, heading 2, heading 3, heading 4, heading 5, heading 6, ordered list, unordered list, horizontal rule, quote, and link to Url nodes are allowed',
       },
     ])
     .disabled(false)
@@ -139,10 +140,30 @@ module.exports = function(migration) {
         nodes: {
           'embedded-entry-block': [
             {
-              linkContentType: ['galleryBlock'],
+              linkContentType: ['contentBlock', 'galleryBlock'],
             },
           ],
         },
+      },
+      {
+        enabledNodeTypes: [
+          'heading-1',
+          'heading-2',
+          'heading-3',
+          'heading-4',
+          'heading-5',
+          'heading-6',
+          'ordered-list',
+          'unordered-list',
+          'hr',
+          'blockquote',
+          'embedded-entry-block',
+          'embedded-asset-block',
+          'hyperlink',
+        ],
+
+        message:
+          'Only heading 1, heading 2, heading 3, heading 4, heading 5, heading 6, ordered list, unordered list, horizontal rule, quote, block entry, asset, and link to Url nodes are allowed',
       },
     ])
     .disabled(false)


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR updates the validations for the Rich text fields in the Cause Page Contentful content-type script:
- Allow links in the `description`
- Enforce the standard validations for Rich text in the `content` field and whitelist `ContentBlock`s as an embedded entry

### Any background context you want to provide?
We're going to want Content Blocks in the `content` field in addition to galleries!

### What are the relevant tickets/cards?

Refs [Pivotal ID #169097150](https://www.pivotaltracker.com/story/show/169097150)

