### PR TITLE
Revert to the OG DS logo

### DIFF
--- a/.styleci.yml
+++ b/.styleci.yml
@@ -1,13 +1,17 @@
 preset: laravel
 
 disabled:
- - concat_without_spaces
- - no_useless_return
- - simplified_null_return
- - phpdoc_no_package
- - phpdoc_summary
- - phpdoc_var_without_name
+  - concat_without_spaces
+  - no_useless_return
+  - simplified_null_return
+  - phpdoc_no_package
+  - phpdoc_summary
+  - phpdoc_var_without_name
+  - alpha_ordered_imports
+
+enabled:
+  - length_ordered_imports
 
 finder:
   exclude:
-    - "tests"
+    - 'tests'

--- a/resources/assets/components/SiteNavigation/SiteNavigation.js
+++ b/resources/assets/components/SiteNavigation/SiteNavigation.js
@@ -9,9 +9,7 @@ import PropTypes from 'prop-types';
 import SearchIcon from '../artifacts/SearchIcon/SearchIcon';
 import CloseButton from '../artifacts/CloseButton/CloseButton';
 import ProfileIcon from '../artifacts/ProfileIcon/ProfileIcon';
-// @TODO: After Halloween 2019, uncomment the next line and delete this line
-// import DoSomethingLogo from '../utilities/DoSomethingLogo/DoSomethingLogo';
-import BooSomethingLogo from '../utilities/DoSomethingLogo/BooSomethingLogo';
+import DoSomethingLogo from '../utilities/DoSomethingLogo/DoSomethingLogo';
 import {
   trackAnalyticsEvent,
   getUtmContext,
@@ -157,8 +155,7 @@ class SiteNavigation extends React.Component {
               href="/"
               onClick={e => this.handleOnClickLink(e, { label: 'homepage' })}
             >
-              {/* @TODO: After Halloween 2019, change this back to DoSomethingLogo */}
-              <BooSomethingLogo />
+              <DoSomethingLogo />
             </a>
           </div>
 


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR reverts #1667 (while maintaining the new BooSomething logo component for next time!) to get back to the original DS logo on the nav bar.

Also overriding the [freshly launched](https://twitter.com/TeamStyleCI/status/1188186758925684736) StyleCI Laravel preset for [`alpha_ordered_imports`](https://docs.styleci.io/fixers#alpha_ordered_imports) with our preferred [`length_ordered_imports`](https://docs.styleci.io/fixers#length_ordered_imports) rule

### Any background context you want to provide?
Alsa, 'tis no longer Halloween and the youths don't want to be spooked 😭 

### What are the relevant tickets/cards?

Refs [Pivotal ID #169346474](https://www.pivotaltracker.com/story/show/169346474)

