### PR TITLE
Cause Page - Routing & Rendering

### DIFF
--- a/contentful/content-types/cause-page.js
+++ b/contentful/content-types/cause-page.js
@@ -39,7 +39,7 @@ module.exports = function(migration) {
         },
 
         message:
-          'Slug should match the cause type e.g. "environment". Only alphanumeric and hyphen characters are allowed in slugs! The URL for the Cause Page will be prefixed with "causes/" e.g. "https://dosomething.org/us/causes/environment".',
+          'Only alphanumeric and hyphen characters are allowed in slugs!',
       },
     ])
     .disabled(false)
@@ -176,7 +176,7 @@ module.exports = function(migration) {
 
   causePage.changeEditorInterface('slug', 'slugEditor', {
     helpText:
-      'Must begin with the "causes/" category prefix for the slug, e.g. "causes/environment".',
+      'Slug should match the cause type e.g. "environment". The URL for the Cause Page will be prefixed with "causes/" e.g. "https://dosomething.org/us/causes/environment".',
   });
 
   causePage.changeEditorInterface('coverImage', 'assetLinkEditor', {

--- a/resources/assets/components/App.js
+++ b/resources/assets/components/App.js
@@ -11,6 +11,7 @@ import { initializeStore } from '../store/store';
 import HomePage from './pages/HomePage/HomePage';
 import BlockPage from './pages/BlockPage/BlockPage';
 import CampaignContainer from './Campaign/CampaignContainer';
+import CausePageQuery from './pages/CausePage/CausePageQuery';
 import { getUserId, isAuthenticated } from '../selectors/user';
 import BetaReferralPage from './pages/ReferralPage/Beta/BetaPage';
 import AccountContainer from './pages/AccountPage/AccountContainer';
@@ -38,6 +39,12 @@ const App = ({ store, history }) => {
               <Route path="/us/account" component={AccountContainer} />
               <Route path="/us/blocks/:id" component={BlockPage} />
               <Route path="/us/campaigns/:slug" component={CampaignContainer} />
+              <Route
+                path="/us/causes/:slug"
+                render={routeProps => (
+                  <CausePageQuery slug={routeProps.match.params.slug} />
+                )}
+              />
               <Route path="/us/join" component={BetaReferralPage} />
               <Route
                 path="/us/refer-friends"

--- a/resources/assets/components/NotFound.js
+++ b/resources/assets/components/NotFound.js
@@ -10,9 +10,10 @@ const NotFound = () => (
   <Card title="Not Found" className="rounded bordered">
     <TextContent className="padded">
       __We searched our site, but couldn&apos;t find what you were looking
-      for.__ Try [Grab the Mic](/us/campaigns/grab-mic?utm_source=404) and join
-      our movement to create the most civically active generation ever. You can
-      also try [our homepage](/) or [reach out]({zendeskUrl}) to us.
+      for.__ Find ways you can [Take Action](/us/campaigns?utm_source=404) and
+      join a movement of 5 million young people making an impact in their
+      communities. You can also try [our homepage](/) or [reach out](
+      {zendeskUrl}) to us.
     </TextContent>
   </Card>
 );

--- a/resources/assets/components/pages/CausePage/CausePage.js
+++ b/resources/assets/components/pages/CausePage/CausePage.js
@@ -1,0 +1,28 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import TextContent from '../../utilities/TextContent/TextContent';
+
+const CausePage = ({ coverImage, superTitle, title, description, content }) => (
+  <div>
+    <img src={coverImage.url} alt={coverImage.description} />
+    <p>{superTitle}</p>
+    <h1>{title}</h1>
+    <TextContent>{description}</TextContent>
+
+    <TextContent>{content}</TextContent>
+  </div>
+);
+
+CausePage.propTypes = {
+  coverImage: PropTypes.shape({
+    url: PropTypes.string.isRequired,
+    description: PropTypes.string,
+  }).isRequired,
+  superTitle: PropTypes.string.isRequired,
+  title: PropTypes.string.isRequired,
+  description: PropTypes.object.isRequired,
+  content: PropTypes.object.isRequired,
+};
+
+export default CausePage;

--- a/resources/assets/components/pages/CausePage/CausePageQuery.js
+++ b/resources/assets/components/pages/CausePage/CausePageQuery.js
@@ -1,0 +1,40 @@
+import React from 'react';
+import gql from 'graphql-tag';
+import PropTypes from 'prop-types';
+
+import Query from '../../Query';
+import CausePage from './CausePage';
+import { env } from '../../../helpers';
+import NotFoundPage from '../NotFoundPage';
+
+const CAUSE_PAGE_QUERY = gql`
+  query CausePageQuery($slug: String!, $preview: Boolean!) {
+    causePageBySlug(slug: $slug, preview: $preview) {
+      coverImage {
+        url
+        description
+      }
+      superTitle
+      title
+      description
+      content
+    }
+  }
+`;
+
+const CausePageQuery = ({ slug }) => (
+  <Query
+    query={CAUSE_PAGE_QUERY}
+    variables={{ slug, preview: env('CONTENTFUL_USE_PREVIEW_API') }}
+  >
+    {({ causePageBySlug }) =>
+      causePageBySlug ? <CausePage {...causePageBySlug} /> : <NotFoundPage />
+    }
+  </Query>
+);
+
+CausePageQuery.propTypes = {
+  slug: PropTypes.string.isRequired,
+};
+
+export default CausePageQuery;

--- a/resources/assets/components/pages/NotFoundPage.js
+++ b/resources/assets/components/pages/NotFoundPage.js
@@ -6,7 +6,7 @@ import SiteNavigationContainer from '../SiteNavigation/SiteNavigationContainer';
 const NotFoundPage = () => (
   <>
     <SiteNavigationContainer />
-    <section className="container -framed">
+    <section className="container -framed mx-2">
       <NotFound />
     </section>
   </>

--- a/resources/assets/components/pages/NotFoundPage.js
+++ b/resources/assets/components/pages/NotFoundPage.js
@@ -1,0 +1,15 @@
+import React from 'react';
+
+import NotFound from '../NotFound';
+import SiteNavigationContainer from '../SiteNavigation/SiteNavigationContainer';
+
+const NotFoundPage = () => (
+  <>
+    <SiteNavigationContainer />
+    <section className="container -framed">
+      <NotFound />
+    </section>
+  </>
+);
+
+export default NotFoundPage;

--- a/resources/assets/scss/base.scss
+++ b/resources/assets/scss/base.scss
@@ -592,6 +592,11 @@ p {
   margin-bottom: $half-spacing;
 }
 
+.mx-2 {
+  margin-left: $half-spacing / 2;
+  margin-right: $half-spacing / 2;
+}
+
 .p-0 {
   padding: 0;
 }

--- a/routes/web.php
+++ b/routes/web.php
@@ -68,6 +68,9 @@ $router->get('{slug}', function ($slug) {
     return redirect('us/'.$slug);
 });
 
+// Causes
+$router->view('us/causes/{cause}', 'app');
+
 // Cache
 $router->get('cache/{cacheId}', 'CacheController');
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -69,7 +69,7 @@ $router->get('{slug}', function ($slug) {
 });
 
 // Causes
-$router->view('us/causes/{cause}', 'app');
+$router->view('us/causes/{slug}', 'app');
 
 // Cache
 $router->get('cache/{cacheId}', 'CacheController');


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR sets up a new `/causes/:slug` route and adds rendering support via our React app on the front end.

### Any background context you want to provide?
The `CausePage` component is just a skeletal barebones version for now. Design implementation forthcoming in later work!

This is our first Contentful entity being rendered entirely via the front end & GraphQL so this required a touch of updating to ensure we had a working 404 page for the frontend as well. I went with adding a new `NotFoundPage` component which renders the [`NotFound`](https://github.com/DoSomething/phoenix-next/blob/bfeb98ddb0cbcf1e2b7e0b3a7f829f9809e1bc97/resources/assets/components/NotFound.js) component in page format, using similar styling as our backend rendered [`404.blade.php`](https://git.io/Je20d)

I also snuck in a super simple update for the `causePage` content type (fixing validation messaging for the `slug` field).

### What are the relevant tickets/cards?

Refs [Pivotal ID #169323671](https://www.pivotaltracker.com/story/show/169323671)

### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.
* [x] Added screenshot to PR description of related front-end updates on **small** screens.
* [x] Added screenshot to PR description of related front-end updates on **medium** screens.
* [x] Added screenshot to PR description of related front-end updates on **large** screens.

📸 front end 404 page:
- [Large](https://user-images.githubusercontent.com/12417657/68131103-74fc3980-feea-11e9-8169-3979c08cf8ae.png)
- [Medium](https://user-images.githubusercontent.com/12417657/68131105-7594d000-feea-11e9-801f-235433d0835a.png)
- [Small](https://user-images.githubusercontent.com/12417657/68131104-74fc3980-feea-11e9-88da-111592adc8a2.png)

