### PR TITLE
Update Person 'photo' field

### DIFF
--- a/app/Entities/Person.php
+++ b/app/Entities/Person.php
@@ -22,8 +22,14 @@ class Person extends Entity implements JsonSerializable
                 'active' => $this->active,
                 'jobTitle' => $this->jobTitle,
                 'email' => $this->email,
-                'photo' => get_image_url($this->photo),
-                'alternatePhoto' => get_image_url($this->alternatePhoto),
+                'photo' => [
+                    'url' => get_image_url($this->photo),
+                    'description' => $this->photo ? $this->photo->getDescription() : null,
+                ],
+                'alternatePhoto' => [
+                    'url' => get_image_url($this->alternatePhoto),
+                    'description' => $this->alternatePhoto ? $this->alternatePhoto->getDescription() : null,
+                ],
                 'description' => $this->description,
                 'twitterId' => $this->twitterId,
             ],

--- a/resources/assets/components/Affirmation/Affirmation.js
+++ b/resources/assets/components/Affirmation/Affirmation.js
@@ -79,7 +79,12 @@ const Affirmation = ({
             <Byline
               author={author.fields.name}
               {...withoutNulls(author.fields)}
-              photo={contentfulImageUrl(author.fields.photo, 175, 175, 'fill')}
+              photo={contentfulImageUrl(
+                author.fields.photo.url,
+                175,
+                175,
+                'fill',
+              )}
               className="padding-bottom-md padding-horizontal-md"
             />
           ) : null}

--- a/resources/assets/components/blocks/CampaignUpdate/CampaignUpdate.js
+++ b/resources/assets/components/blocks/CampaignUpdate/CampaignUpdate.js
@@ -27,7 +27,7 @@ const CampaignUpdate = props => {
   } = props;
 
   const authorFields = get(author, 'fields', {});
-  const authorPhoto = authorFields.photo || undefined;
+  const authorPhoto = get(authorFields, 'photo.url') || undefined;
 
   const isTweet = content && content.length < 144;
 

--- a/resources/assets/components/pages/GeneralPage/GeneralPage.js
+++ b/resources/assets/components/pages/GeneralPage/GeneralPage.js
@@ -61,7 +61,7 @@ const GeneralPage = props => {
                     author={author.fields.name}
                     {...withoutNulls(author.fields)}
                     photo={contentfulImageUrl(
-                      author.fields.photo,
+                      author.fields.photo.url,
                       175,
                       175,
                       'fill',
@@ -124,7 +124,7 @@ const GeneralPage = props => {
                   <AuthorBio
                     {...withoutNulls(author.fields)}
                     photo={contentfulImageUrl(
-                      author.fields.photo,
+                      author.fields.photo.url,
                       175,
                       175,
                       'fill',

--- a/resources/assets/components/utilities/Person/templates/AdvisoryBoardMemberTemplate/AdvisoryBoardMemberTemplate.js
+++ b/resources/assets/components/utilities/Person/templates/AdvisoryBoardMemberTemplate/AdvisoryBoardMemberTemplate.js
@@ -11,7 +11,7 @@ const AdvisoryBoardMemberTemplate = props => {
   return (
     <Figure
       alt={`${name}-photo`}
-      image={contentfulImageUrl(photo, '100', '100', 'fill')}
+      image={contentfulImageUrl(photo.url, '100', '100', 'fill')}
       alignment="left"
     >
       <h4>{name}</h4>
@@ -23,7 +23,9 @@ const AdvisoryBoardMemberTemplate = props => {
 
 AdvisoryBoardMemberTemplate.propTypes = {
   name: PropTypes.string.isRequired,
-  photo: PropTypes.string.isRequired,
+  photo: PropTypes.shape({
+    url: PropTypes.string.isRequired,
+  }).isRequired,
   description: PropTypes.string.isRequired,
 };
 

--- a/resources/assets/components/utilities/Person/templates/BoardMemberTemplate/BoardMemberTemplate.js
+++ b/resources/assets/components/utilities/Person/templates/BoardMemberTemplate/BoardMemberTemplate.js
@@ -11,7 +11,7 @@ const BoardMemberTemplate = props => {
   return (
     <Figure
       alt={`${name}-photo`}
-      image={contentfulImageUrl(alternatePhoto, '400', '400', 'fill')}
+      image={contentfulImageUrl(alternatePhoto.url, '400', '400', 'fill')}
     >
       <h4>{name}</h4>
 
@@ -22,7 +22,9 @@ const BoardMemberTemplate = props => {
 
 BoardMemberTemplate.propTypes = {
   name: PropTypes.string.isRequired,
-  alternatePhoto: PropTypes.string.isRequired,
+  alternatePhoto: PropTypes.shape({
+    url: PropTypes.string.isRequired,
+  }).isRequired,
   description: PropTypes.string.isRequired,
 };
 

--- a/resources/assets/components/utilities/Person/templates/StaffTemplate/StaffTemplate.js
+++ b/resources/assets/components/utilities/Person/templates/StaffTemplate/StaffTemplate.js
@@ -10,7 +10,7 @@ const StaffTemplate = props => {
   return (
     <Figure
       alt={`${name}-photo`}
-      image={contentfulImageUrl(alternatePhoto, '400', '400', 'fill')}
+      image={contentfulImageUrl(alternatePhoto.url, '400', '400', 'fill')}
     >
       <h4>
         {twitterId ? (
@@ -33,7 +33,9 @@ const StaffTemplate = props => {
 StaffTemplate.propTypes = {
   name: PropTypes.string.isRequired,
   jobTitle: PropTypes.string.isRequired,
-  alternatePhoto: PropTypes.string.isRequired,
+  alternatePhoto: PropTypes.shape({
+    url: PropTypes.string.isRequired,
+  }).isRequired,
   twitterId: PropTypes.string,
 };
 


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR updates the `Person` Entity's `photo` and `alternatePhoto` fields to be formatted as an object with `url` and `description` attributes. 

It also updates the various components using this field to be up to par.

### Any background context you want to provide?
This is nice since it follows our general convention, but will ultimately also allow us to query more things via GraphQL since that's the schema it follows (an [`Asset`](https://github.com/DoSomething/graphql/blob/dcfa1bcc437a4925acb84bad4a3f95a5ace24805/src/schema/contentful/phoenix.js#L60-L71) type, including these two fields, on the [`Person#photo`](https://github.com/DoSomething/graphql/blob/dcfa1bcc437a4925acb84bad4a3f95a5ace24805/src/schema/contentful/phoenix.js#L149-L153)).

And more relevant -- it'll help set us up to start querying the `GalleryBlock` (and it's respective supported nodes) via GraphQL, which we'll need supported for the [Cause Page initiative](https://www.pivotaltracker.com/story/show/169325037).

### What are the relevant tickets/cards?

Refs [Pivotal ID #168177643](https://www.pivotaltracker.com/story/show/168177643)

