### PR TITLE
contentfulImageUrl helper update

### DIFF
--- a/resources/assets/components/blocks/ContentBlock/ContentBlock.test.js
+++ b/resources/assets/components/blocks/ContentBlock/ContentBlock.test.js
@@ -11,8 +11,8 @@ const props = {
   title: 'Test Title',
   content: 'Test Content',
   image: {
-    url: 'image.com',
-    description: 'cool image of image.com',
+    url: 'http://image.com',
+    description: 'cool image of http://image.com',
   },
   imageAlignment: 'right',
 };

--- a/resources/assets/components/blocks/ContentBlock/__snapshots__/ContentBlock.test.js.snap
+++ b/resources/assets/components/blocks/ContentBlock/__snapshots__/ContentBlock.test.js.snap
@@ -6,8 +6,8 @@ exports[`ContentBlock component does not include SectionHeader when there's no t
 >
   <Figure
     alignment="right-collapse"
-    alt="cool image of image.com"
-    image="image.com?w=600&h=600&fit=fill"
+    alt="cool image of http://image.com"
+    image="http://image.com/?fit=fill&h=600&w=600"
     imageClassName={null}
     size="one-third"
   >
@@ -33,8 +33,8 @@ exports[`ContentBlock component is rendered with the proper child components whe
   />
   <Figure
     alignment="right-collapse"
-    alt="cool image of image.com"
-    image="image.com?w=600&h=600&fit=fill"
+    alt="cool image of http://image.com"
+    image="http://image.com/?fit=fill&h=600&w=600"
     imageClassName={null}
     size="one-third"
   >

--- a/resources/assets/helpers/index.js
+++ b/resources/assets/helpers/index.js
@@ -86,6 +86,37 @@ export function isEmptyArray(data) {
 }
 
 /**
+ * Remove items with null properties.
+ * Helps with React defaultProps.
+ *
+ * @param  {Object} data
+ * @return {Object}
+ */
+export function withoutNulls(data) {
+  return omitBy(data, isNull);
+}
+
+/**
+ * Remove items with undefined properties.
+ *
+ * @param  {Object} data
+ * @return {Object}
+ */
+export function withoutUndefined(data) {
+  return omitBy(data, isUndefined);
+}
+
+/**
+ * Remove items from object with null, undefined, or empty string values.
+ *
+ * @param  {Object} data
+ * @return {Object}
+ */
+export function withoutValueless(data) {
+  return omitBy(omitBy(omitBy(data, isNil), isEmptyArray), isEmptyString);
+}
+
+/**
  * Generate a Contentful Image URL with added url parameters.
  *
  * @param  {String} url
@@ -834,37 +865,6 @@ export function stringifyNestedObjects(data) {
 
     return value;
   });
-}
-
-/**
- * Remove items with null properties.
- * Helps with React defaultProps.
- *
- * @param  {Object} data
- * @return {Object}
- */
-export function withoutNulls(data) {
-  return omitBy(data, isNull);
-}
-
-/**
- * Remove items with undefined properties.
- *
- * @param  {Object} data
- * @return {Object}
- */
-export function withoutUndefined(data) {
-  return omitBy(data, isUndefined);
-}
-
-/**
- * Remove items from object with null, undefined, or empty string values.
- *
- * @param  {Object} data
- * @return {Object}
- */
-export function withoutValueless(data) {
-  return omitBy(omitBy(omitBy(data, isNil), isEmptyArray), isEmptyString);
 }
 
 /**

--- a/resources/assets/helpers/index.js
+++ b/resources/assets/helpers/index.js
@@ -135,21 +135,13 @@ export function contentfulImageUrl(
     return undefined;
   }
 
-  const params = [];
+  const params = withoutNulls({
+    w: width, // eslint-disable-line id-length
+    h: height, // eslint-disable-line id-length
+    fit,
+  });
 
-  if (width) {
-    params.push(`w=${width}`);
-  }
-
-  if (height) {
-    params.push(`h=${height}`);
-  }
-
-  if (fit) {
-    params.push(`fit=${fit}`);
-  }
-
-  return params.length ? `${url}?${params.join('&')}` : url;
+  return Object.keys(params).length ? appendToQuery(params, url).href : url;
 }
 
 /**

--- a/resources/assets/helpers/test.js
+++ b/resources/assets/helpers/test.js
@@ -12,35 +12,37 @@ import {
  */
 test('generate contentful image url with defaults', () => {
   const contentfulImage = contentfulImageUrl(
-    '//images.contentful.com/somecrazystring.jpg',
+    'http://images.contentful.com/somecrazystring.jpg',
   );
 
-  expect(contentfulImage).toBe('//images.contentful.com/somecrazystring.jpg');
+  expect(contentfulImage).toBe(
+    'http://images.contentful.com/somecrazystring.jpg',
+  );
 });
 
 test('generate contentful image url with specified fit', () => {
   const contentfulImage = contentfulImageUrl(
-    '//images.contentful.com/somecrazystring.jpg',
+    'http://images.contentful.com/somecrazystring.jpg',
     undefined,
     undefined,
     'fill',
   );
 
   expect(contentfulImage).toBe(
-    '//images.contentful.com/somecrazystring.jpg?fit=fill',
+    'http://images.contentful.com/somecrazystring.jpg?fit=fill',
   );
 });
 
 test('generate contentful image url with all specified parameters', () => {
   const contentfulImage = contentfulImageUrl(
-    '//images.contentful.com/somecrazystring.jpg',
+    'http://images.contentful.com/somecrazystring.jpg',
     800,
     600,
     'fill',
   );
 
   expect(contentfulImage).toBe(
-    '//images.contentful.com/somecrazystring.jpg?w=800&h=600&fit=fill',
+    'http://images.contentful.com/somecrazystring.jpg?fit=fill&h=600&w=800',
   );
 });
 


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR updates the `contentfulImageUrl` helper method to support URL's with pre-existing query parameters. (It ends up being slightly cleaner too, with the help of `withoutNulls`!)

### Any background context you want to provide?
This will make it easy for us to support image fields queried via GraphQL, since those are auto assigned certain formatting parameters [by default](https://github.com/DoSomething/graphql/blob/dcfa1bcc437a4925acb84bad4a3f95a5ace24805/src/repositories/contentful/phoenix.js#L296-L303) which would cause this helper to malfunction with the current setup.

This is extracted from #1522 based on the work @jocoso did to help set up querying GalleryBlocks via GraphQL. This will be helpful towards implementing that initiative for the sake of the current [Hubs / Cause Page initiative](https://www.pivotaltracker.com/story/show/169325037)!

### What are the relevant tickets/cards?

Refs [Pivotal ID #168177916](https://www.pivotaltracker.com/story/show/168177916)