### PR TITLE
BUG FIX: Add default base for URL constructor in query param helper

### DIFF
--- a/resources/assets/helpers/index.js
+++ b/resources/assets/helpers/index.js
@@ -36,7 +36,7 @@ export function appendToQuery(
   additionalParameters,
   href = window.location.href,
 ) {
-  const urlObject = new URL(href);
+  const urlObject = new URL(href, window.location.origin);
 
   const mergedParameters = merge(
     queryString.parse(urlObject.search),

--- a/resources/assets/helpers/test.js
+++ b/resources/assets/helpers/test.js
@@ -12,7 +12,7 @@ import {
  */
 test('generate contentful image url with defaults', () => {
   const contentfulImage = contentfulImageUrl(
-    'http://images.contentful.com/somecrazystring.jpg',
+    '//images.contentful.com/somecrazystring.jpg',
   );
 
   expect(contentfulImage).toBe(
@@ -22,7 +22,7 @@ test('generate contentful image url with defaults', () => {
 
 test('generate contentful image url with specified fit', () => {
   const contentfulImage = contentfulImageUrl(
-    'http://images.contentful.com/somecrazystring.jpg',
+    '//images.contentful.com/somecrazystring.jpg',
     undefined,
     undefined,
     'fill',
@@ -35,7 +35,7 @@ test('generate contentful image url with specified fit', () => {
 
 test('generate contentful image url with all specified parameters', () => {
   const contentfulImage = contentfulImageUrl(
-    'http://images.contentful.com/somecrazystring.jpg',
+    '//images.contentful.com/somecrazystring.jpg',
     800,
     600,
     'fill',

--- a/resources/assets/helpers/test.js
+++ b/resources/assets/helpers/test.js
@@ -15,9 +15,7 @@ test('generate contentful image url with defaults', () => {
     '//images.contentful.com/somecrazystring.jpg',
   );
 
-  expect(contentfulImage).toBe(
-    'http://images.contentful.com/somecrazystring.jpg',
-  );
+  expect(contentfulImage).toBe('//images.contentful.com/somecrazystring.jpg');
 });
 
 test('generate contentful image url with specified fit', () => {


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR fixes a bug introduced in #1676 wherein any Contentful asset URL which often come formatted with two leading forward slashes (`//images.ctfassets.net` (presumably to default to the existing protocol)) would break the URL construction in the [`appendToQuery` helper](https://github.com/DoSomething/phoenix-next/blob/b52ba512b9f012313705ea71ef0d4d47ebf9a4df/resources/assets/helpers/index.js#L39) which we use to construct the formatted Contentful image URL.

I thought of a few options, but the fix that seemed simplest to me was to add a `base` parameter, which the `URL` constructor uses as a default for cases like this, instead of throwing an error. Our `window.location.origin` seemed like a good choice (we use it in our [`isExternal`](https://github.com/DoSomething/phoenix-next/blob/b52ba512b9f012313705ea71ef0d4d47ebf9a4df/resources/assets/helpers/index.js#L59) helper as well!).

I reverted some of the test updates as well so that we're testing against this formatting.
### Any background context you want to provide?
We have many of these asset URL's embedded in our Markdown content fields by editors, which get formatted [here](https://github.com/DoSomething/phoenix-next/blob/b52ba512b9f012313705ea71ef0d4d47ebf9a4df/resources/assets/helpers/text.js#L14-L25) to ensure we add sane formatting the images instead of rendering them wholesale on prod.

