### PR TITLE
Quick fix to allow toggling checkbox by clicking the label.

### DIFF
--- a/resources/assets/components/AffiliateOptInToggle/AffiliateOptInToggle.js
+++ b/resources/assets/components/AffiliateOptInToggle/AffiliateOptInToggle.js
@@ -13,7 +13,7 @@ const AffiliateOptInToggle = ({
   textColor,
 }) => (
   <div className="form-wrapper affiliate-opt-in">
-    <label className="option -checkbox" htmlFor="affiliate_opt_in">
+    <label className="option -checkbox" htmlFor="opt_in">
       <input
         type="checkbox"
         id="opt_in"


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR fixes a small bug with the affiliate opt-in toggle. Currently you can hover over the text label for the checkbox and the cursor changes to imply you can click on it, but it does not actually toggle the checkbox when clicked.

This is because the `for` attribute is incorrect and needs to match the `id` of the checkbox `<input>`.

### Any background context you want to provide?

🌵 

### What are the relevant tickets/cards?

Refs [Pivotal ID #](https://www.pivotaltracker.com/story/show/169577469)

### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.