### PR TITLE
Make the Gallery Block GraphQL Query-able!

### DIFF
--- a/resources/assets/components/Affirmation/Affirmation.js
+++ b/resources/assets/components/Affirmation/Affirmation.js
@@ -80,7 +80,7 @@ const Affirmation = ({
               author={author.fields.name}
               {...withoutNulls(author.fields)}
               photo={contentfulImageUrl(
-                author.fields.photo.url,
+                get(author, 'fields.photo.url'),
                 175,
                 175,
                 'fill',

--- a/resources/assets/components/ContentfulEntry/ContentfulEntry.js
+++ b/resources/assets/components/ContentfulEntry/ContentfulEntry.js
@@ -165,6 +165,9 @@ class ContentfulEntry extends React.Component<Props, State> {
       case 'galleryBlock':
         return <GalleryBlock {...json.fields} />;
 
+      case 'GalleryBlock':
+        return <GalleryBlock {...withoutNulls(json)} />;
+
       case 'imagesBlock':
         return (
           <ImagesBlock className={className} images={json.fields.images} />

--- a/resources/assets/components/blocks/GalleryBlock/GalleryBlock.js
+++ b/resources/assets/components/blocks/GalleryBlock/GalleryBlock.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
+import { withoutNulls } from '../../../helpers';
 import Person from '../../utilities/Person/Person';
 import Gallery from '../../utilities/Gallery/Gallery';
 import PageGalleryItem from '../../utilities/Gallery/templates/PageGalleryItem/PageGalleryItem';
@@ -8,23 +9,54 @@ import ContentBlockGalleryItem from '../../utilities/Gallery/templates/ContentBl
 import CampaignGalleryItem from '../../utilities/Gallery/templates/CampaignGalleryItem/CampaignGalleryItem';
 
 const renderBlock = (block, imageAlignment, imageFit) => {
-  switch (block.type) {
+  // We finesse the block type and fields to support both
+  // GraphQL ('Showcasable' interface) and Phoenix-backend (legacy) queried blocks.
+  const blockType = block.__typename || block.type;
+  const fields =
+    block.__typename || block.type === 'campaign'
+      ? withoutNulls(block)
+      : withoutNulls(block.fields);
+
+  switch (blockType) {
     case 'person':
-      return <Person key={block.id} {...block.fields} />;
+    case 'PersonBlock':
+      return <Person key={block.id} {...fields} />;
 
     case 'campaign':
-      return <CampaignGalleryItem key={block.id} {...block} />;
+    case 'CampaignWebsite':
+      return (
+        <CampaignGalleryItem
+          key={block.id}
+          showcaseTitle={fields.title}
+          showcaseDescription={fields.tagline}
+          showcaseImage={fields.coverImage}
+          {...fields}
+        />
+      );
 
     case 'page':
-      return <PageGalleryItem key={block.id} {...block.fields} />;
+    case 'Page':
+      return (
+        <PageGalleryItem
+          key={block.id}
+          showcaseTitle={fields.title}
+          showcaseDescription={fields.subTitle}
+          showcaseImage={fields.coverImage}
+          {...fields}
+        />
+      );
 
     case 'contentBlock':
+    case 'ContentBlock':
       return (
         <ContentBlockGalleryItem
           key={block.id}
-          {...block.fields}
+          showcaseTitle={fields.title}
+          showcaseDescription={fields.content}
+          showcaseImage={fields.image}
           imageAlignment={imageAlignment}
           imageFit={imageFit}
+          {...fields}
         />
       );
 

--- a/resources/assets/components/blocks/GalleryBlock/GalleryBlock.js
+++ b/resources/assets/components/blocks/GalleryBlock/GalleryBlock.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import gql from 'graphql-tag';
 import PropTypes from 'prop-types';
 
 import { withoutNulls } from '../../../helpers';
@@ -7,6 +8,36 @@ import Gallery from '../../utilities/Gallery/Gallery';
 import PageGalleryItem from '../../utilities/Gallery/templates/PageGalleryItem/PageGalleryItem';
 import ContentBlockGalleryItem from '../../utilities/Gallery/templates/ContentBlockGalleryItem';
 import CampaignGalleryItem from '../../utilities/Gallery/templates/CampaignGalleryItem/CampaignGalleryItem';
+
+export const GalleryBlockFragment = gql`
+  fragment GalleryBlockFragment on GalleryBlock {
+    title
+    imageAlignment
+    imageFit
+    itemsPerRow
+    blocks {
+      id
+      ... on Showcasable {
+        showcaseTitle
+        showcaseDescription
+        showcaseImage {
+          url
+          description
+        }
+      }
+      ... on PersonBlock {
+        type
+        twitterId
+      }
+      ... on CampaignWebsite {
+        slug
+      }
+      ... on Page {
+        slug
+      }
+    }
+  }
+`;
 
 const renderBlock = (block, imageAlignment, imageFit) => {
   // We finesse the block type and fields to support both

--- a/resources/assets/components/pages/GeneralPage/GeneralPage.js
+++ b/resources/assets/components/pages/GeneralPage/GeneralPage.js
@@ -1,6 +1,7 @@
 /* global window */
 
 import React from 'react';
+import get from 'lodash/get';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 
@@ -61,7 +62,7 @@ const GeneralPage = props => {
                     author={author.fields.name}
                     {...withoutNulls(author.fields)}
                     photo={contentfulImageUrl(
-                      author.fields.photo.url,
+                      get(author, 'fields.photo.url'),
                       175,
                       175,
                       'fill',
@@ -124,7 +125,7 @@ const GeneralPage = props => {
                   <AuthorBio
                     {...withoutNulls(author.fields)}
                     photo={contentfulImageUrl(
-                      author.fields.photo.url,
+                      get(author, 'fields.photo.url'),
                       175,
                       175,
                       'fill',

--- a/resources/assets/components/utilities/ContentfulEntryLoader/ContentfulEntryLoader.js
+++ b/resources/assets/components/utilities/ContentfulEntryLoader/ContentfulEntryLoader.js
@@ -12,6 +12,7 @@ import { EmbedBlockFragment } from '../../blocks/EmbedBlock/EmbedBlock';
 import { LinkBlockFragment } from '../../actions/LinkAction/LinkAction';
 import { ImagesBlockFragment } from '../../blocks/ImagesBlock/ImagesBlock';
 import { ShareBlockFragment } from '../../actions/ShareAction/ShareAction';
+import { GalleryBlockFragment } from '../../blocks/GalleryBlock/GalleryBlock';
 import { PostGalleryBlockFragment } from '../../blocks/PostGalleryBlock/PostGalleryBlockQuery';
 import { TextSubmissionBlockFragment } from '../../actions/TextSubmissionAction/TextSubmissionAction';
 import { PhotoSubmissionBlockFragment } from '../../actions/PhotoSubmissionAction/PhotoSubmissionAction';
@@ -26,6 +27,7 @@ const CONTENTFUL_BLOCK_QUERY = gql`
       ...ShareBlockFragment
       ...EmbedBlockFragment
       ...ImagesBlockFragment
+      ...GalleryBlockFragment
       ...PostGalleryBlockFragment
       ...TextSubmissionBlockFragment
       ...PhotoSubmissionBlockFragment
@@ -38,6 +40,7 @@ const CONTENTFUL_BLOCK_QUERY = gql`
   ${ShareBlockFragment}
   ${EmbedBlockFragment}
   ${ImagesBlockFragment}
+  ${GalleryBlockFragment}
   ${PostGalleryBlockFragment}
   ${TextSubmissionBlockFragment}
   ${PhotoSubmissionBlockFragment}

--- a/resources/assets/components/utilities/Gallery/templates/CampaignGalleryItem/CampaignGalleryItem.js
+++ b/resources/assets/components/utilities/Gallery/templates/CampaignGalleryItem/CampaignGalleryItem.js
@@ -4,22 +4,29 @@ import PropTypes from 'prop-types';
 import { Figure } from '../../../Figure/Figure';
 import { contentfulImageUrl } from '../../../../../helpers';
 
-const CampaignGalleryItem = ({ title, tagline, coverImage, slug }) => (
+const CampaignGalleryItem = ({
+  showcaseTitle,
+  showcaseDescription,
+  showcaseImage,
+  slug,
+}) => (
   <a className="campaign-gallery-item block" href={`/us/campaigns/${slug}`}>
     <Figure
-      alt={`${coverImage.description || title}-photo`}
-      image={contentfulImageUrl(coverImage.url, '400', '400', 'fill')}
+      alt={`${showcaseImage.description || showcaseTitle}-photo`}
+      image={contentfulImageUrl(showcaseImage.url, '400', '400', 'fill')}
     >
-      <h4>{title}</h4>
-      {tagline ? <p className="font-normal">{tagline}</p> : null}
+      <h4>{showcaseTitle}</h4>
+      {showcaseDescription ? (
+        <p className="font-normal">{showcaseDescription}</p>
+      ) : null}
     </Figure>
   </a>
 );
 
 CampaignGalleryItem.propTypes = {
-  title: PropTypes.string.isRequired,
-  tagline: PropTypes.string.isRequired,
-  coverImage: PropTypes.shape({
+  showcaseTitle: PropTypes.string.isRequired,
+  showcaseDescription: PropTypes.string.isRequired,
+  showcaseImage: PropTypes.shape({
     url: PropTypes.string,
     description: PropTypes.string,
   }).isRequired,

--- a/resources/assets/components/utilities/Gallery/templates/ContentBlockGalleryItem.js
+++ b/resources/assets/components/utilities/Gallery/templates/ContentBlockGalleryItem.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import get from 'lodash/get';
 import PropTypes from 'prop-types';
 
 import { Figure } from '../../Figure/Figure';
@@ -22,7 +23,7 @@ const ContentBlockGalleryItem = ({
     <Figure
       alt={showcaseImage.description || `${showcaseTitle}-photo`}
       image={contentfulImageUrl(
-        showcaseImage.url,
+        get(showcaseImage, 'url'),
         imageFormatting,
         imageFormatting,
         imageFit,

--- a/resources/assets/components/utilities/Gallery/templates/ContentBlockGalleryItem.js
+++ b/resources/assets/components/utilities/Gallery/templates/ContentBlockGalleryItem.js
@@ -6,9 +6,9 @@ import TextContent from '../../TextContent/TextContent';
 import { contentfulImageUrl } from '../../../../helpers';
 
 const ContentBlockGalleryItem = ({
-  title,
-  image,
-  content,
+  showcaseTitle,
+  showcaseImage,
+  showcaseDescription,
   imageAlignment,
   imageFit,
 }) => {
@@ -20,31 +20,37 @@ const ContentBlockGalleryItem = ({
 
   return (
     <Figure
-      alt={image.description || `${title}-photo`}
+      alt={showcaseImage.description || `${showcaseTitle}-photo`}
       image={contentfulImageUrl(
-        image.url,
+        showcaseImage.url,
         imageFormatting,
         imageFormatting,
         imageFit,
       )}
       alignment={alignment}
     >
-      <h4>{title}</h4>
+      <h4>{showcaseTitle}</h4>
 
-      {content ? <TextContent>{content}</TextContent> : null}
+      {showcaseDescription ? (
+        <TextContent>{showcaseDescription}</TextContent>
+      ) : null}
     </Figure>
   );
 };
 
 ContentBlockGalleryItem.propTypes = {
-  title: PropTypes.string.isRequired,
-  image: PropTypes.shape({
+  showcaseTitle: PropTypes.string.isRequired,
+  showcaseImage: PropTypes.shape({
     url: PropTypes.string,
     description: PropTypes.string,
-  }).isRequired,
-  content: PropTypes.string.isRequired,
+  }),
+  showcaseDescription: PropTypes.string.isRequired,
   imageAlignment: PropTypes.oneOf(['top', 'left']).isRequired,
   imageFit: PropTypes.oneOf(['fill', 'pad']).isRequired,
+};
+
+ContentBlockGalleryItem.defaultProps = {
+  showcaseImage: {},
 };
 
 export default ContentBlockGalleryItem;

--- a/resources/assets/components/utilities/Gallery/templates/PageGalleryItem/PageGalleryItem.js
+++ b/resources/assets/components/utilities/Gallery/templates/PageGalleryItem/PageGalleryItem.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import get from 'lodash/get';
 import PropTypes from 'prop-types';
 
 import { Figure } from '../../../Figure/Figure';
@@ -13,7 +14,12 @@ const PageGalleryItem = ({
   <a className="page-gallery-item block" href={`/us/${slug}`}>
     <Figure
       alt={`${showcaseImage.description || showcaseTitle}-photo`}
-      image={contentfulImageUrl(showcaseImage.url, '400', '400', 'fill')}
+      image={contentfulImageUrl(
+        get(showcaseImage, 'url'),
+        '400',
+        '400',
+        'fill',
+      )}
     >
       <h4>{showcaseTitle}</h4>
       {showcaseDescription ? (

--- a/resources/assets/components/utilities/Gallery/templates/PageGalleryItem/PageGalleryItem.js
+++ b/resources/assets/components/utilities/Gallery/templates/PageGalleryItem/PageGalleryItem.js
@@ -4,22 +4,29 @@ import PropTypes from 'prop-types';
 import { Figure } from '../../../Figure/Figure';
 import { contentfulImageUrl } from '../../../../../helpers';
 
-const PageGalleryItem = ({ title, subTitle, coverImage, slug }) => (
+const PageGalleryItem = ({
+  showcaseTitle,
+  showcaseDescription,
+  showcaseImage,
+  slug,
+}) => (
   <a className="page-gallery-item block" href={`/us/${slug}`}>
     <Figure
-      alt={`${coverImage.description || title}-photo`}
-      image={contentfulImageUrl(coverImage.url, '400', '400', 'fill')}
+      alt={`${showcaseImage.description || showcaseTitle}-photo`}
+      image={contentfulImageUrl(showcaseImage.url, '400', '400', 'fill')}
     >
-      <h4>{title}</h4>
-      {subTitle ? <p className="font-normal">{subTitle}</p> : null}
+      <h4>{showcaseTitle}</h4>
+      {showcaseDescription ? (
+        <p className="font-normal">{showcaseDescription}</p>
+      ) : null}
     </Figure>
   </a>
 );
 
 PageGalleryItem.propTypes = {
-  title: PropTypes.string.isRequired,
-  subTitle: PropTypes.string,
-  coverImage: PropTypes.shape({
+  showcaseTitle: PropTypes.string.isRequired,
+  showcaseDescription: PropTypes.string,
+  showcaseImage: PropTypes.shape({
     url: PropTypes.string,
     description: PropTypes.string,
   }),
@@ -27,8 +34,8 @@ PageGalleryItem.propTypes = {
 };
 
 PageGalleryItem.defaultProps = {
-  subTitle: null,
-  coverImage: {},
+  showcaseDescription: null,
+  showcaseImage: {},
 };
 
 export default PageGalleryItem;

--- a/resources/assets/components/utilities/Person/Person.js
+++ b/resources/assets/components/utilities/Person/Person.js
@@ -8,13 +8,34 @@ import AdvisoryBoardMemberTemplate from './templates/AdvisoryBoardMemberTemplate
 const Person = props => {
   switch (props.type) {
     case 'staff':
-      return <StaffTemplate {...props} />;
+      return (
+        <StaffTemplate
+          showcaseTitle={props.name}
+          showcaseDescription={props.jobTitle}
+          showcaseImage={props.alternatePhoto}
+          {...props}
+        />
+      );
 
     case 'board member':
-      return <BoardMemberTemplate {...props} />;
+      return (
+        <BoardMemberTemplate
+          showcaseTitle={props.name}
+          showcaseDescription={props.description}
+          showcaseImage={props.alternatePhoto}
+          {...props}
+        />
+      );
 
     case 'advisory board member':
-      return <AdvisoryBoardMemberTemplate {...props} />;
+      return (
+        <AdvisoryBoardMemberTemplate
+          showcaseTitle={props.name}
+          showcaseDescription={props.description}
+          showcaseImage={props.photo}
+          {...props}
+        />
+      );
 
     default:
       return null;
@@ -23,6 +44,25 @@ const Person = props => {
 
 Person.propTypes = {
   type: PropTypes.string.isRequired,
+  name: PropTypes.string,
+  description: PropTypes.string,
+  jobTitle: PropTypes.string,
+  photo: PropTypes.shape({
+    url: PropTypes.string,
+    description: PropTypes.string,
+  }),
+  alternatePhoto: PropTypes.shape({
+    url: PropTypes.string,
+    description: PropTypes.string,
+  }),
+};
+
+Person.defaultProps = {
+  name: null,
+  description: null,
+  jobTitle: null,
+  photo: {},
+  alternatePhoto: {},
 };
 
 export default Person;

--- a/resources/assets/components/utilities/Person/templates/AdvisoryBoardMemberTemplate/AdvisoryBoardMemberTemplate.js
+++ b/resources/assets/components/utilities/Person/templates/AdvisoryBoardMemberTemplate/AdvisoryBoardMemberTemplate.js
@@ -11,7 +11,7 @@ const AdvisoryBoardMemberTemplate = props => {
 
   return (
     <Figure
-      alt={`${showcaseTitle}-photo`}
+      alt={`picture of ${showcaseTitle}`}
       image={contentfulImageUrl(
         get(showcaseImage, 'url'),
         '100',

--- a/resources/assets/components/utilities/Person/templates/AdvisoryBoardMemberTemplate/AdvisoryBoardMemberTemplate.js
+++ b/resources/assets/components/utilities/Person/templates/AdvisoryBoardMemberTemplate/AdvisoryBoardMemberTemplate.js
@@ -6,27 +6,29 @@ import TextContent from '../../../TextContent/TextContent';
 import { contentfulImageUrl } from '../../../../../helpers';
 
 const AdvisoryBoardMemberTemplate = props => {
-  const { name, photo, description } = props;
+  const { showcaseTitle, showcaseImage, showcaseDescription } = props;
 
   return (
     <Figure
-      alt={`${name}-photo`}
-      image={contentfulImageUrl(photo.url, '100', '100', 'fill')}
+      alt={`${showcaseTitle}-photo`}
+      image={contentfulImageUrl(showcaseImage.url, '100', '100', 'fill')}
       alignment="left"
     >
-      <h4>{name}</h4>
+      <h4>{showcaseTitle}</h4>
 
-      {description ? <TextContent>{description}</TextContent> : null}
+      {showcaseDescription ? (
+        <TextContent>{showcaseDescription}</TextContent>
+      ) : null}
     </Figure>
   );
 };
 
 AdvisoryBoardMemberTemplate.propTypes = {
-  name: PropTypes.string.isRequired,
-  photo: PropTypes.shape({
+  showcaseTitle: PropTypes.string.isRequired,
+  showcaseImage: PropTypes.shape({
     url: PropTypes.string.isRequired,
   }).isRequired,
-  description: PropTypes.string.isRequired,
+  showcaseDescription: PropTypes.string.isRequired,
 };
 
 export default AdvisoryBoardMemberTemplate;

--- a/resources/assets/components/utilities/Person/templates/AdvisoryBoardMemberTemplate/AdvisoryBoardMemberTemplate.js
+++ b/resources/assets/components/utilities/Person/templates/AdvisoryBoardMemberTemplate/AdvisoryBoardMemberTemplate.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import get from 'lodash/get';
 import PropTypes from 'prop-types';
 
 import { Figure } from '../../../Figure/Figure';
@@ -11,7 +12,12 @@ const AdvisoryBoardMemberTemplate = props => {
   return (
     <Figure
       alt={`${showcaseTitle}-photo`}
-      image={contentfulImageUrl(showcaseImage.url, '100', '100', 'fill')}
+      image={contentfulImageUrl(
+        get(showcaseImage, 'url'),
+        '100',
+        '100',
+        'fill',
+      )}
       alignment="left"
     >
       <h4>{showcaseTitle}</h4>

--- a/resources/assets/components/utilities/Person/templates/BoardMemberTemplate/BoardMemberTemplate.js
+++ b/resources/assets/components/utilities/Person/templates/BoardMemberTemplate/BoardMemberTemplate.js
@@ -6,26 +6,28 @@ import TextContent from '../../../TextContent/TextContent';
 import { contentfulImageUrl } from '../../../../../helpers';
 
 const BoardMemberTemplate = props => {
-  const { name, alternatePhoto, description } = props;
+  const { showcaseTitle, showcaseImage, showcaseDescription } = props;
 
   return (
     <Figure
-      alt={`${name}-photo`}
-      image={contentfulImageUrl(alternatePhoto.url, '400', '400', 'fill')}
+      alt={`${showcaseTitle}-photo`}
+      image={contentfulImageUrl(showcaseImage.url, '400', '400', 'fill')}
     >
-      <h4>{name}</h4>
+      <h4>{showcaseTitle}</h4>
 
-      {description ? <TextContent>{description}</TextContent> : null}
+      {showcaseDescription ? (
+        <TextContent>{showcaseDescription}</TextContent>
+      ) : null}
     </Figure>
   );
 };
 
 BoardMemberTemplate.propTypes = {
-  name: PropTypes.string.isRequired,
-  alternatePhoto: PropTypes.shape({
+  showcaseTitle: PropTypes.string.isRequired,
+  showcaseImage: PropTypes.shape({
     url: PropTypes.string.isRequired,
   }).isRequired,
-  description: PropTypes.string.isRequired,
+  showcaseDescription: PropTypes.string.isRequired,
 };
 
 export default BoardMemberTemplate;

--- a/resources/assets/components/utilities/Person/templates/BoardMemberTemplate/BoardMemberTemplate.js
+++ b/resources/assets/components/utilities/Person/templates/BoardMemberTemplate/BoardMemberTemplate.js
@@ -11,7 +11,7 @@ const BoardMemberTemplate = props => {
 
   return (
     <Figure
-      alt={`${showcaseTitle}-photo`}
+      alt={`picture of ${showcaseTitle}`}
       image={contentfulImageUrl(
         get(showcaseImage, 'url'),
         '400',

--- a/resources/assets/components/utilities/Person/templates/BoardMemberTemplate/BoardMemberTemplate.js
+++ b/resources/assets/components/utilities/Person/templates/BoardMemberTemplate/BoardMemberTemplate.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import get from 'lodash/get';
 import PropTypes from 'prop-types';
 
 import { Figure } from '../../../Figure/Figure';
@@ -11,7 +12,12 @@ const BoardMemberTemplate = props => {
   return (
     <Figure
       alt={`${showcaseTitle}-photo`}
-      image={contentfulImageUrl(showcaseImage.url, '400', '400', 'fill')}
+      image={contentfulImageUrl(
+        get(showcaseImage, 'url'),
+        '400',
+        '400',
+        'fill',
+      )}
     >
       <h4>{showcaseTitle}</h4>
 

--- a/resources/assets/components/utilities/Person/templates/StaffTemplate/StaffTemplate.js
+++ b/resources/assets/components/utilities/Person/templates/StaffTemplate/StaffTemplate.js
@@ -15,7 +15,7 @@ const StaffTemplate = props => {
 
   return (
     <Figure
-      alt={`${showcaseTitle}-photo`}
+      alt={`picture of ${showcaseTitle}`}
       image={contentfulImageUrl(
         get(showcaseImage, 'url'),
         '400',

--- a/resources/assets/components/utilities/Person/templates/StaffTemplate/StaffTemplate.js
+++ b/resources/assets/components/utilities/Person/templates/StaffTemplate/StaffTemplate.js
@@ -5,12 +5,17 @@ import { Figure } from '../../../Figure/Figure';
 import { contentfulImageUrl } from '../../../../../helpers';
 
 const StaffTemplate = props => {
-  const { name, jobTitle, alternatePhoto, twitterId } = props;
+  const {
+    showcaseTitle,
+    showcaseDescription,
+    showcaseImage,
+    twitterId,
+  } = props;
 
   return (
     <Figure
-      alt={`${name}-photo`}
-      image={contentfulImageUrl(alternatePhoto.url, '400', '400', 'fill')}
+      alt={`${showcaseTitle}-photo`}
+      image={contentfulImageUrl(showcaseImage.url, '400', '400', 'fill')}
     >
       <h4>
         {twitterId ? (
@@ -19,21 +24,21 @@ const StaffTemplate = props => {
             rel="noopener noreferrer"
             target="_blank"
           >
-            {name}
+            {showcaseTitle}
           </a>
         ) : (
-          name
+          showcaseTitle
         )}
       </h4>
-      <p>{jobTitle}</p>
+      <p>{showcaseDescription}</p>
     </Figure>
   );
 };
 
 StaffTemplate.propTypes = {
-  name: PropTypes.string.isRequired,
-  jobTitle: PropTypes.string.isRequired,
-  alternatePhoto: PropTypes.shape({
+  showcaseTitle: PropTypes.string.isRequired,
+  showcaseDescription: PropTypes.string.isRequired,
+  showcaseImage: PropTypes.shape({
     url: PropTypes.string.isRequired,
   }).isRequired,
   twitterId: PropTypes.string,

--- a/resources/assets/components/utilities/Person/templates/StaffTemplate/StaffTemplate.js
+++ b/resources/assets/components/utilities/Person/templates/StaffTemplate/StaffTemplate.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import get from 'lodash/get';
 import PropTypes from 'prop-types';
 
 import { Figure } from '../../../Figure/Figure';
@@ -15,7 +16,12 @@ const StaffTemplate = props => {
   return (
     <Figure
       alt={`${showcaseTitle}-photo`}
-      image={contentfulImageUrl(showcaseImage.url, '400', '400', 'fill')}
+      image={contentfulImageUrl(
+        get(showcaseImage, 'url'),
+        '400',
+        '400',
+        'fill',
+      )}
     >
       <h4>
         {twitterId ? (


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR... looks scary but really is pretty straightforward!!

We're setting up the `GalleryBlock` component/entity to be query-able via GraphQL. In order to do that, we need to update the formatting of the fields, make some things 'Showcasable', and of course add the query. I'll explain:

- https://github.com/DoSomething/phoenix-next/commit/6fdb39bcd58f754b1dda1a779136dbe30ff45053 updates the various gallery template nodes to use the standardized 'Showcasable' fields. For more context, check out this PR in GraphQL https://github.com/DoSomething/graphql/pull/120 where we introduced this interface. TL;DR: This gives us a convenient way to think about showcasing contentful entries like Campaigns, Pages, and the like in a synchronized consistent manner.
- The issue is, we still need to support the ole field names, since when querying via the Phoenix backend for most Pages, we won't have these resolved showcasable fields! So https://github.com/DoSomething/phoenix-next/commit/75a891a20c4100b48acdbb9b730cf6d0f7c02d92 does the job of finessing support for both GraphQL formatted, and legacy formatted JSON.
 - Then of course, we need the actual GraphQL query! https://github.com/DoSomething/phoenix-next/commit/7f238f1c16dd488d74dd11bbe288f65cd610e5b8, https://github.com/DoSomething/phoenix-next/commit/a649f127371ca8805ff2a061d069977e5ae89f36, and https://github.com/DoSomething/phoenix-next/commit/938e472226f56106b9f4142e3ff3e1a4eaca73e7 do the job of defining and exporting a `GalleryBlockFragment` from the `GalleryBlock`, and adding it to the list in the `ContentfulEntryLoader`. You might notice some specifically queried fields for things like a PersonBlock within the galleries `blocks`. This is because our gallery template nodes expect some additional specific fields for certain types (`twitterId` for `PersonBlocks` of type `staff` for example).
 - Then, two quick misc improvements: https://github.com/DoSomething/phoenix-next/commit/d48a71eaf37516a6479e4e2e9af8a32236e670b1 to safely retrieve contentful image URLs when the image is not required on the Entity, so we don't see any annoying explosions (mostly an editor/developer convenience). And https://github.com/DoSomething/phoenix-next/commit/f5b516e4a4c6405d3a5b984c53ef73d325268e28 to add better `alt` descriptions for our person gallery node templates, inspired by the [`Byine`](https://github.com/DoSomething/phoenix-next/blob/f4e762488824085da695e74ee314001212f12d31/resources/assets/components/utilities/Byline/Byline.js#L21).

That's it! I told you, this is way less scary than it seems, it just is bloated mostly because of updated prop naming. and misc improvements.

### Any background context you want to provide?
This is towards the effort to implement Cause Pages in Phoenix, wherein we'll be querying RichText field embedded GalleryBlocks via GraphQL.

A major major hat tip to @jocoso, since he did most of the leg work for this in #1522 ...and oh goody! This actually closes #1522  Thank you Joshua!! Your work has been invaluable towards this initiative 🙌

Some of the queried fields (`itemsPerRow` for GalleryBlocks, `twitterId` for PersonBlocks) rely on an open PR in GraphQL land https://github.com/DoSomething/graphql/pull/151

### What are the relevant tickets/cards?

Refs [Pivotal ID #168182024](https://www.pivotaltracker.com/story/show/168182024) and [#168182083](https://www.pivotaltracker.com/story/show/168182083)

