### PR TITLE
Add GraphQL query support  for the Content Block

### DIFF
--- a/resources/assets/components/ContentfulEntry/ContentfulEntry.js
+++ b/resources/assets/components/ContentfulEntry/ContentfulEntry.js
@@ -123,6 +123,16 @@ class ContentfulEntry extends React.Component<Props, State> {
           />
         );
 
+      case 'ContentBlock':
+        return (
+          <ContentBlock
+            className={className}
+            // Resolves the alias used in the ContentBlockFragment.
+            content={json.contentBlockContent}
+            {...withoutNulls(json)}
+          />
+        );
+
       case 'embed':
         return (
           <EmbedBlockContainer

--- a/resources/assets/components/blocks/ContentBlock/ContentBlock.js
+++ b/resources/assets/components/blocks/ContentBlock/ContentBlock.js
@@ -2,7 +2,6 @@ import React from 'react';
 import gql from 'graphql-tag';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
-import requiredIf from 'react-required-if';
 
 import { contentfulImageUrl } from '../../../helpers';
 import { Figure } from '../../utilities/Figure/Figure';
@@ -65,14 +64,14 @@ ContentBlock.propTypes = {
     url: PropTypes.string,
     description: PropTypes.string,
   }).isRequired,
-  imageAlignment: requiredIf(PropTypes.string, props => props.image.url),
+  imageAlignment: PropTypes.oneOf(['right', 'left']),
   superTitle: PropTypes.string,
   title: PropTypes.string,
 };
 
 ContentBlock.defaultProps = {
   className: null,
-  imageAlignment: null,
+  imageAlignment: 'right',
   superTitle: null,
   title: null,
 };

--- a/resources/assets/components/blocks/ContentBlock/ContentBlock.js
+++ b/resources/assets/components/blocks/ContentBlock/ContentBlock.js
@@ -16,7 +16,8 @@ export const ContentBlockFragment = gql`
     superTitle
     title
     subTitle
-    content
+    # Aliasing to avoid conflicting with *non-required* content fields in other fragments.
+    contentBlockContent: content
     image {
       url
       description

--- a/resources/assets/components/blocks/ContentBlock/ContentBlock.js
+++ b/resources/assets/components/blocks/ContentBlock/ContentBlock.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import gql from 'graphql-tag';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import requiredIf from 'react-required-if';
@@ -9,6 +10,20 @@ import TextContent from '../../utilities/TextContent/TextContent';
 import SectionHeader from '../../utilities/SectionHeader/SectionHeader';
 
 import './content-block.scss';
+
+export const ContentBlockFragment = gql`
+  fragment ContentBlockFragment on ContentBlock {
+    superTitle
+    title
+    subTitle
+    content
+    image {
+      url
+      description
+    }
+    imageAlignment
+  }
+`;
 
 const ContentBlock = props => {
   const {

--- a/resources/assets/components/utilities/ContentfulEntryLoader/ContentfulEntryLoader.js
+++ b/resources/assets/components/utilities/ContentfulEntryLoader/ContentfulEntryLoader.js
@@ -13,6 +13,7 @@ import { LinkBlockFragment } from '../../actions/LinkAction/LinkAction';
 import { ImagesBlockFragment } from '../../blocks/ImagesBlock/ImagesBlock';
 import { ShareBlockFragment } from '../../actions/ShareAction/ShareAction';
 import { GalleryBlockFragment } from '../../blocks/GalleryBlock/GalleryBlock';
+import { ContentBlockFragment } from '../../blocks/ContentBlock/ContentBlock';
 import { PostGalleryBlockFragment } from '../../blocks/PostGalleryBlock/PostGalleryBlockQuery';
 import { TextSubmissionBlockFragment } from '../../actions/TextSubmissionAction/TextSubmissionAction';
 import { PhotoSubmissionBlockFragment } from '../../actions/PhotoSubmissionAction/PhotoSubmissionAction';
@@ -28,6 +29,7 @@ const CONTENTFUL_BLOCK_QUERY = gql`
       ...EmbedBlockFragment
       ...ImagesBlockFragment
       ...GalleryBlockFragment
+      ...ContentBlockFragment
       ...PostGalleryBlockFragment
       ...TextSubmissionBlockFragment
       ...PhotoSubmissionBlockFragment
@@ -41,6 +43,7 @@ const CONTENTFUL_BLOCK_QUERY = gql`
   ${EmbedBlockFragment}
   ${ImagesBlockFragment}
   ${GalleryBlockFragment}
+  ${ContentBlockFragment}
   ${PostGalleryBlockFragment}
   ${TextSubmissionBlockFragment}
   ${PhotoSubmissionBlockFragment}


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR adds GraphQL query support for ContentBlocks with a new `ContentBlockFragment` and rendering support in the `ContentfulEntry`.

https://github.com/DoSomething/phoenix-next/commit/b07ed78fa2d4b96979aaab8a0fc6f989ede2c6ca also updates the `ContentBlock` component to default the `imageAlignment` prop, since we no longer have the [resolved value](https://github.com/DoSomething/phoenix-next/blob/92155e4716a0da4e086214e93645568634d08e31/app/Entities/ContentBlock.php#L28) from the Phoenix Entity for GraphQL queries.

### Any background context you want to provide?
This will support the Cause Page initiative, with ContentBlocks being an embeddable entry type within the Cause Page `content` Rich Text field.

👽 
You may notice that we've used an [alias](https://www.apollographql.com/docs/resources/graphql-glossary/#alias) for the `content` field within the fragment.

The issue here is that we've got [other](https://github.com/DoSomething/phoenix-next/blob/92155e4716a0da4e086214e93645568634d08e31/resources/assets/components/actions/LinkAction/LinkAction.js#L13) [fragments](https://github.com/DoSomething/phoenix-next/blob/92155e4716a0da4e086214e93645568634d08e31/resources/assets/components/actions/VoterRegistrationAction/VoterRegistrationAction.js#L18) querying `content` fields, but unlike the ContentBlock - where this field is required in the [GraphQL schema](https://github.com/DoSomething/graphql/blob/25952a7621fdbeb7f5a825920242e303cd15d040/src/schema/contentful/phoenix.js#L237), these ones are not!

This resulted in the query breaking with the following error:
```
Fields "content" conflict because they return conflicting types String and String!. Use different aliases on the fields to fetch both if this was intentional.
```

In order to avoid this conflict, we need to add the alias and [resolve the field](https://github.com/DoSomething/phoenix-next/compare/content-blocks-from-graphql?expand=1#diff-35056872f13a368c9e668973f09a237aR131) back to the `content` prop in the `ContentfulEntry`.

(There's a really neat explanation as for why these fragment fields are merged in the first place leading to this conflict, in [this issue](https://github.com/graphql/graphql-spec/issues/399) (see [this response](https://github.com/graphql/graphql-spec/issues/399#issuecomment-370665347)))

Thanks, @DFurnes for talking this over, and ideating this solution here. We discussed the idea of potentially breaking the mega `block` query in `ContentfulEntryLoader` to more dynamically include only specific fragments, which would be one way to avoid needing to alias field - since that's probably not a great long term solution. We don't think that's a good idea since it'll cause out [persisted queries](https://github.com/DoSomething/phoenix-next/blob/92155e4716a0da4e086214e93645568634d08e31/resources/assets/graphql.js#L50) to not be as persistent (since they'd dynamically be generated and thus would be often individual!). This could also cause issues with dev tooling. 

We do think that this is something to mull over, and hopefully, come up with a neat clever long term solution to having our cake with persisted mega queries, and eating it too without the food poisoning of somewhat awkward aliases, and field collisions, especially as we move ever more blocks over to GraphQL, and develop more features in Phoenix! 

### What are the relevant tickets/cards?

Refs [Pivotal ID #169485759](https://www.pivotaltracker.com/story/show/169485759)

### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.
