### PR TITLE
Beta Referral Page tests

### DIFF
--- a/cypress/fixtures/constants.js
+++ b/cypress/fixtures/constants.js
@@ -1,0 +1,7 @@
+/**
+ * These constants correspond to real entities in our dev environment, used to avoid 404's.
+ */
+
+export const campaignId = '9002';
+
+export const userId = '5575e568a59dbf3b7a8b4572';

--- a/cypress/fixtures/constants.js
+++ b/cypress/fixtures/constants.js
@@ -1,5 +1,5 @@
 /**
- * These constants correspond to real entities in our dev environment, used to avoid 404's.
+ * These constants correspond to real ID's in our dev environment, used to avoid 404's.
  */
 
 export const campaignId = '9002';

--- a/cypress/fixtures/contentful.js
+++ b/cypress/fixtures/contentful.js
@@ -5,11 +5,12 @@
 //
 // https://dev.dosomething.org/us/campaigns/test-example-campaign/action
 //
+import { campaignId } from './constants';
 
 export const exampleCampaign = {
   campaign: {
     id: '4MtEG1BNi3d2AQPkoql8i4',
-    campaignId: '9002',
+    campaignId,
     type: 'campaign',
     template: 'mosaic',
     title: 'Example Campaign',

--- a/cypress/integration/beta-referral-page.js
+++ b/cypress/integration/beta-referral-page.js
@@ -15,8 +15,11 @@ describe('Beta Referral Page', () => {
     cy.contains('gift card');
     cy.contains('FAQ');
 
-    // @TODO: Verify that the referral page links contain correct referrer_user_id query.
     cy.get('.referral-page-campaign').should('have.length', 2);
+
+    cy.get('.referral-page-campaign > a')
+      .should('have.attr', 'href')
+      .and('include', `referrer_user_id=${userId}`);
   });
 
   it('Visit beta referral page, with valid user ID and no campaign ID', () => {
@@ -25,6 +28,10 @@ describe('Beta Referral Page', () => {
     cy.visit(`/us/join?user_id=${userId}`);
 
     cy.get('.referral-page-campaign').should('have.length', 1);
+
+    cy.get('.referral-page-campaign > a')
+      .should('have.attr', 'href')
+      .and('include', `referrer_user_id=${userId}`);
   });
 
   it('Visit beta referral page, with invalid user ID', () => {

--- a/cypress/integration/beta-referral-page.js
+++ b/cypress/integration/beta-referral-page.js
@@ -13,6 +13,10 @@ describe('Beta Referral Page', () => {
     cy.visit(`/us/join?user_id=${userId}&campaign_id=${campaignId}`);
 
     cy.contains('gift card');
+
+    cy.get('.referral-page-campaign').should('have.length', 2);
+
+    cy.contains('FAQ');
   });
 
   it('Visit beta referral page with invalid user ID query', () => {

--- a/cypress/integration/beta-referral-page.js
+++ b/cypress/integration/beta-referral-page.js
@@ -7,17 +7,19 @@ describe('Beta Referral Page', () => {
   // Configure a new "mock" server before each test:
   beforeEach(() => cy.configureMocks());
 
-  it('Visit beta referral page with valid user and campaign IDs', () => {
+  it('Visit beta referral page, with valid user and campaign IDs', () => {
     const user = userFactory();
 
     cy.visit(`/us/join?user_id=${userId}&campaign_id=${campaignId}`);
 
     cy.contains('gift card');
-    cy.get('.referral-page-campaign').should('have.length', 2);
     cy.contains('FAQ');
+
+    // @TODO: Verify that the referral page links contain correct referrer_user_id query.
+    cy.get('.referral-page-campaign').should('have.length', 2);
   });
 
-  it('Visit beta referral page with valid user ID and no campaign ID', () => {
+  it('Visit beta referral page, with valid user ID and no campaign ID', () => {
     const user = userFactory();
 
     cy.visit(`/us/join?user_id=${userId}`);
@@ -25,7 +27,7 @@ describe('Beta Referral Page', () => {
     cy.get('.referral-page-campaign').should('have.length', 1);
   });
 
-  it('Visit beta referral page with invalid user ID query', () => {
+  it('Visit beta referral page, with invalid user ID', () => {
     const user = userFactory();
 
     // Our mock user ID won't exist in dev, we can expect a 404.
@@ -34,7 +36,7 @@ describe('Beta Referral Page', () => {
     cy.contains('Not Found');
   });
 
-  it('Visit beta referral page with missing user query var', () => {
+  it('Visit beta referral page, with missing user ID', () => {
     cy.visit('/us/join', { failOnStatusCode: false });
 
     // Our mock user ID won't exist in dev, we can expect a 404.

--- a/cypress/integration/beta-referral-page.js
+++ b/cypress/integration/beta-referral-page.js
@@ -13,10 +13,16 @@ describe('Beta Referral Page', () => {
     cy.visit(`/us/join?user_id=${userId}&campaign_id=${campaignId}`);
 
     cy.contains('gift card');
-
     cy.get('.referral-page-campaign').should('have.length', 2);
-
     cy.contains('FAQ');
+  });
+
+  it('Visit beta referral page with valid user ID and no campaign ID', () => {
+    const user = userFactory();
+
+    cy.visit(`/us/join?user_id=${userId}`);
+
+    cy.get('.referral-page-campaign').should('have.length', 1);
   });
 
   it('Visit beta referral page with invalid user ID query', () => {

--- a/cypress/integration/beta-referral-page.js
+++ b/cypress/integration/beta-referral-page.js
@@ -7,12 +7,27 @@ describe('Beta Referral Page', () => {
   // Configure a new "mock" server before each test:
   beforeEach(() => cy.configureMocks());
 
-  it('Visit beta referral page, as an anonymous user', () => {
+  it('Visit beta referral page with valid user and campaign IDs', () => {
     const user = userFactory();
 
-    // Visit the campaign pitch page:
     cy.visit(`/us/join?user_id=${userId}&campaign_id=${campaignId}`);
 
     cy.contains('gift card');
+  });
+
+  it('Visit beta referral page with invalid user ID query', () => {
+    const user = userFactory();
+
+    // Our mock user ID won't exist in dev, we can expect a 404.
+    cy.visit(`/us/join?user_id=${user.id}}`, { failOnStatusCode: false });
+
+    cy.contains('Not Found');
+  });
+
+  it('Visit beta referral page with missing user query var', () => {
+    cy.visit('/us/join', { failOnStatusCode: false });
+
+    // Our mock user ID won't exist in dev, we can expect a 404.
+    cy.contains('Not Found');
   });
 });

--- a/cypress/integration/beta-referral-page.js
+++ b/cypress/integration/beta-referral-page.js
@@ -1,0 +1,18 @@
+/// <reference types="Cypress" />
+
+import { userFactory } from '../fixtures/user';
+import { campaignId, userId } from '../fixtures/constants';
+
+describe('Beta Referral Page', () => {
+  // Configure a new "mock" server before each test:
+  beforeEach(() => cy.configureMocks());
+
+  it('Visit beta referral page, as an anonymous user', () => {
+    const user = userFactory();
+
+    // Visit the campaign pitch page:
+    cy.visit(`/us/join?user_id=${userId}&campaign_id=${campaignId}`);
+
+    cy.contains('gift card');
+  });
+});

--- a/cypress/integration/campaign-post.js
+++ b/cypress/integration/campaign-post.js
@@ -1,12 +1,12 @@
 /// <reference types="Cypress" />
 
 import { userFactory } from '../fixtures/user';
+import { campaignId } from '../fixtures/constants';
 import { existingSignup } from '../fixtures/signups';
 import { exampleCampaign } from '../fixtures/contentful';
 import { newTextPost, newPhotoPost } from '../fixtures/posts';
 import { MockList } from 'graphql-tools';
 
-const campaignId = '9002';
 const SIGNUPS_API = `/api/v2/campaigns/${campaignId}/signups`;
 const CAMPAIGN_POSTS_API = `/api/v2/campaigns/${campaignId}/posts`;
 const POSTS_API = `/api/v2/posts`;

--- a/cypress/integration/campaign-signup.js
+++ b/cypress/integration/campaign-signup.js
@@ -1,10 +1,10 @@
 /// <reference types="Cypress" />
 
 import { userFactory } from '../fixtures/user';
+import { campaignId } from '../fixtures/constants';
 import { exampleCampaign } from '../fixtures/contentful';
 import { emptyResponse, newSignup } from '../fixtures/signups';
 
-const campaignId = '9002';
 const API = `/api/v2/campaigns/${campaignId}`;
 
 describe('Campaign Signup', () => {

--- a/resources/assets/components/pages/ReferralPage/Beta/BetaPageCampaignLink.js
+++ b/resources/assets/components/pages/ReferralPage/Beta/BetaPageCampaignLink.js
@@ -27,12 +27,11 @@ const ReferralPageCampaignLink = props => (
       }
 
       return (
-        <div className="referral-page-campaign">
-          <Embed
-            url={`${PHOENIX_URL}/us/campaigns/${data.slug}?referrer_user_id=${props.userId}`}
-            badged
-          />
-        </div>
+        <Embed
+          className="referral-page-campaign"
+          url={`${PHOENIX_URL}/us/campaigns/${data.slug}?referrer_user_id=${props.userId}`}
+          badged
+        />
       );
     }}
   </Query>

--- a/resources/assets/components/pages/ReferralPage/Beta/BetaPageCampaignLink.js
+++ b/resources/assets/components/pages/ReferralPage/Beta/BetaPageCampaignLink.js
@@ -27,10 +27,12 @@ const ReferralPageCampaignLink = props => (
       }
 
       return (
-        <Embed
-          url={`${PHOENIX_URL}/us/campaigns/${data.slug}?referrer_user_id=${props.userId}`}
-          badged
-        />
+        <div className="referral-page-campaign">
+          <Embed
+            url={`${PHOENIX_URL}/us/campaigns/${data.slug}?referrer_user_id=${props.userId}`}
+            badged
+          />
+        </div>
       );
     }}
   </Query>


### PR DESCRIPTION
###  What does this PR do?

This PR adds some minimal testing for the Beta Referral Page, checking for expected content per query string parameters. Also adds a `constants` fixture to DRY hardcoding real user and campaign ID's to avoid getting 404 responses back from our dev API's, per chat in today's dev round table.

### Any background context you want to provide?

Future PR to add mocks and tests for verifying referring user's first name, campaign information, etc

### What are the relevant tickets/cards?

https://www.pivotaltracker.com/n/projects/2401401/stories/169604403

### Checklist

* [x] Added appropriate feature/unit tests.
