### PR TITLE
Updates to realign Meganav to CSS grid on large sizes and up.

### DIFF
--- a/resources/assets/components/SiteNavigation/site-navigation.scss
+++ b/resources/assets/components/SiteNavigation/site-navigation.scss
@@ -3,6 +3,7 @@
 $spacing_1x: 16px;
 $spacing_1_5x: 24px;
 $spacing_2x: 32px;
+$spacing_3x: 48px;
 $extraSmall: '(min-width: 360px)';
 
 .nav {
@@ -15,7 +16,7 @@ $extraSmall: '(min-width: 360px)';
     padding: $spacing_1x 0 0;
 
     @include media($medium) {
-      padding: $spacing_1_5x $spacing_2x 0;
+      padding: $spacing_1_5x $spacing_3x 0;
     }
   }
 }
@@ -185,7 +186,12 @@ $extraSmall: '(min-width: 360px)';
       white-space: nowrap;
 
       @include media($medium) {
-        padding-bottom: 40px;
+        padding: $spacing_1x 10px 40px;
+      }
+
+      @include media($large) {
+        padding-left: $spacing_1x;
+        padding-right: $spacing_1x;
       }
     }
   }


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR does a small realignment of Meganav based on feedback from @lkpttn and @mendelB, which they noticed while working on some CSS Grid stuff.

I don't quite remember why I had set the padding different; may have been something related to how I interpreted something in the mocks, or because of the new base 16px sizing (that Tailwind uses and we are switching from base 12px). Anyhoo, it was a simple adjustment, but then also ended up adjusting the horizontal padding on the main nav items just to keep the main nav and the utility nav from encroaching on each other's area too much. The larger horizontal padding to align with our grid only really applies to the nav from sizes large and up; smaller than this the nav kinda rolls on it's own (yet similar) grid since it has a stacking effect and no padding inside the grid container.

Meganav's new alignment, now with more spacing on the sides:
![new meganav alignment](https://user-images.githubusercontent.com/105849/68333659-f00a4f00-00a6-11ea-945f-fbfa7de1c994.png)

The Search grid now lines up better too. It wasn't as noticeable before since it technically looked fine, but if showing the grid lines you'd be able to tell the main nav was misaligned:
![search subnav in meganav](https://user-images.githubusercontent.com/105849/68333482-999d1080-00a6-11ea-9f5a-f2c8d542439f.png)

Profile is not shifted to the left a bit more from the edge:
![profile meganav example](https://user-images.githubusercontent.com/105849/68333445-87bb6d80-00a6-11ea-906d-fd5ded2ecd80.png)


### What are the relevant tickets/cards?

🌵 

### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.
* [x] Added screenshot to PR description of related front-end updates on **large** screens.
