### PR TITLE
Bug Fix - Patch the Content Block Gallery Item to not overwrite the gallery image alignment

### DIFF
--- a/resources/assets/components/blocks/GalleryBlock/GalleryBlock.js
+++ b/resources/assets/components/blocks/GalleryBlock/GalleryBlock.js
@@ -85,9 +85,9 @@ const renderBlock = (block, imageAlignment, imageFit) => {
           showcaseTitle={fields.title}
           showcaseDescription={fields.content}
           showcaseImage={fields.image}
+          {...fields}
           imageAlignment={imageAlignment}
           imageFit={imageFit}
-          {...fields}
         />
       );
 


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR patches a bug I introduced in #1680 which accidentally allowed A GalleryBlock's `imageAlignment` to be overridden by the ContentBlock's native alignment field.


### Any background context you want to provide?
When we render a Content Block in a Gallery, we use the Gallery Blocks [`imageAlignment`](https://github.com/DoSomething/phoenix-next/blob/ee419120bbdb8d460c2457fa2b48068d96a4e754/contentful/content-types/galleryBlock.js#L57-L63) setting in favor of the local `ContentBlock`s setting for overall gallery parity and control. By setting the `...fields` prop _below_ the `imageAlignment` one, we were overriding the GalleryBlock's setting with the local field.

This is a true testament to the awkwardness of supporting Content Blocks as gallery nodes, and another strong argument for getting some Cypress page tests introduced! (Working on it!)

### What are the relevant tickets/cards?

Refs [Pivotal ID #168182083](https://www.pivotaltracker.com/story/show/168182083)
