### PR TITLE
Read, write User schoolId

### DIFF
--- a/resources/assets/components/utilities/SchoolFinder/CurrentSchool.js
+++ b/resources/assets/components/utilities/SchoolFinder/CurrentSchool.js
@@ -1,0 +1,21 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const CurrentSchool = ({ schoolId }) => (
+  <div className="padded">
+    <p>
+      Something something something school finder post verification copy. You
+      can email{' '}
+      <a href="mailto:Sahara@DoSomething.org">mailto:Sahara@DoSomething.org</a>{' '}
+      to change your school.
+    </p>
+    <h3>{schoolId}</h3>
+    <small className="uppercase">City, state</small>
+  </div>
+);
+
+CurrentSchool.propTypes = {
+  schoolId: PropTypes.string.isRequired,
+};
+
+export default CurrentSchool;

--- a/resources/assets/components/utilities/SchoolFinder/SchoolFinder.js
+++ b/resources/assets/components/utilities/SchoolFinder/SchoolFinder.js
@@ -4,9 +4,8 @@ import PropTypes from 'prop-types';
 
 import Card from '../Card/Card';
 import Query from '../../Query';
-import Button from '../Button/Button';
-import SchoolSelect from './SchoolSelect';
-import SchoolStateSelect from '../UsaStateSelect';
+import UpdateSchool from './UpdateSchool';
+import CurrentSchool from './CurrentSchool';
 
 const USER_SCHOOL_QUERY = gql`
   query UserSchoolQuery($userId: String!) {
@@ -22,79 +21,30 @@ const SchoolFinder = ({ campaignId, userId }) => {
   if (campaignId !== '9001') {
     return null;
   }
-
-  const [selectedSchool, setSelectedSchool] = useState(null);
-  const [selectedSchoolState, setSelectedSchoolState] = useState(null);
-  const [submittedForm, setSubmittedForm] = useState(false);
+  const [currentSchool, setCurrentSchool] = useState(null);
 
   return (
     <div className="school-finder margin-bottom-lg margin-horizontal-md clear-both primary">
       <Query query={USER_SCHOOL_QUERY} variables={{ userId }}>
-        {res =>
-          res.user.schoolId ? (
-            <div>School {res.user.schoolId}</div>
-          ) : (
-            <div>No school selected</div>
-          )
-        }
+        {res => {
+          if (res.user && res.user.schoolId) {
+            setCurrentSchool(res.user.schoolId);
+          }
+
+          return (
+            <Card
+              title={currentSchool ? 'Your School' : 'Find Your School'}
+              className="rounded bordered overflow-visible"
+            >
+              {currentSchool ? (
+                <CurrentSchool schoolId={currentSchool} />
+              ) : (
+                <UpdateSchool onSubmit={setCurrentSchool} />
+              )}
+            </Card>
+          );
+        }}
       </Query>
-    </div>
-  );
-
-  // @TODO: Also display this content when user already has a school_id on their profile.
-  if (submittedForm) {
-    return (
-      <Card title="Your School" className="rounded bordered overflow-visible">
-        <div className="padded">
-          <p>
-            Something something something school finder post verification copy.
-            You can email{' '}
-            <a href="mailto:Sahara@DoSomething.org">
-              mailto:Sahara@DoSomething.org
-            </a>{' '}
-            to change your school.
-          </p>
-          <h3>{selectedSchool.name}</h3>
-          <small className="uppercase">
-            {selectedSchool.city}, {selectedSchool.state}
-          </small>
-        </div>
-      </Card>
-    );
-  }
-
-  return (
-    <div className="school-finder margin-bottom-lg margin-horizontal-md clear-both primary">
-      <Card
-        title="Find Your School"
-        className="rounded bordered overflow-visible"
-      >
-        <p className="padded">
-          Pick your school and whatever. Invite your classmates to join this
-          campaign and donate their jeans to win prizes and some other stuff.
-        </p>
-        <div className="select-state padded">
-          <strong>State</strong>
-          <SchoolStateSelect
-            onChange={selected => setSelectedSchoolState(selected)}
-          />
-        </div>
-        {selectedSchoolState ? (
-          <div className="select-school padded">
-            <SchoolSelect
-              onChange={selected => setSelectedSchool(selected)}
-              filterByState={selectedSchoolState.abbreviation}
-            />
-          </div>
-        ) : null}
-        <Button
-          onClick={() => setSubmittedForm(true)}
-          disabled={selectedSchool === null}
-          attached
-        >
-          Submit
-        </Button>
-      </Card>
     </div>
   );
 };

--- a/resources/assets/components/utilities/SchoolFinder/SchoolFinder.js
+++ b/resources/assets/components/utilities/SchoolFinder/SchoolFinder.js
@@ -39,7 +39,7 @@ const SchoolFinder = ({ campaignId, userId }) => {
               {currentSchool ? (
                 <CurrentSchool schoolId={currentSchool} />
               ) : (
-                <UpdateSchool onSubmit={setCurrentSchool} />
+                <UpdateSchool userId={userId} onSubmit={setCurrentSchool} />
               )}
             </Card>
           );

--- a/resources/assets/components/utilities/SchoolFinder/SchoolFinder.js
+++ b/resources/assets/components/utilities/SchoolFinder/SchoolFinder.js
@@ -1,12 +1,22 @@
 import React, { useState } from 'react';
+import gql from 'graphql-tag';
 import PropTypes from 'prop-types';
 
 import Card from '../Card/Card';
+import Query from '../../Query';
 import Button from '../Button/Button';
 import SchoolSelect from './SchoolSelect';
 import SchoolStateSelect from '../UsaStateSelect';
 
-const SchoolFinder = ({ campaignId }) => {
+const USER_SCHOOL_QUERY = gql`
+  query UserSchoolQuery($userId: String!) {
+    user(id: $userId) {
+      schoolId
+    }
+  }
+`;
+
+const SchoolFinder = ({ campaignId, userId }) => {
   // Check for our development Teens For Jeans (TFJ) campaign ID.
   // @TODO: Add additional check for production TFJ campaign ID once it exists.
   if (campaignId !== '9001') {
@@ -17,27 +27,39 @@ const SchoolFinder = ({ campaignId }) => {
   const [selectedSchoolState, setSelectedSchoolState] = useState(null);
   const [submittedForm, setSubmittedForm] = useState(false);
 
+  return (
+    <div className="school-finder margin-bottom-lg margin-horizontal-md clear-both primary">
+      <Query query={USER_SCHOOL_QUERY} variables={{ userId }}>
+        {res =>
+          res.user.schoolId ? (
+            <div>School {res.user.schoolId}</div>
+          ) : (
+            <div>No school selected</div>
+          )
+        }
+      </Query>
+    </div>
+  );
+
   // @TODO: Also display this content when user already has a school_id on their profile.
   if (submittedForm) {
     return (
-      <div className="school-finder margin-bottom-lg margin-horizontal-md clear-both primary">
-        <Card title="Your School" className="rounded bordered overflow-visible">
-          <div className="padded">
-            <p>
-              Something something something school finder post verification
-              copy. You can email{' '}
-              <a href="mailto:Sahara@DoSomething.org">
-                mailto:Sahara@DoSomething.org
-              </a>{' '}
-              to change your school.
-            </p>
-            <h3>{selectedSchool.name}</h3>
-            <small className="uppercase">
-              {selectedSchool.city}, {selectedSchool.state}
-            </small>
-          </div>
-        </Card>
-      </div>
+      <Card title="Your School" className="rounded bordered overflow-visible">
+        <div className="padded">
+          <p>
+            Something something something school finder post verification copy.
+            You can email{' '}
+            <a href="mailto:Sahara@DoSomething.org">
+              mailto:Sahara@DoSomething.org
+            </a>{' '}
+            to change your school.
+          </p>
+          <h3>{selectedSchool.name}</h3>
+          <small className="uppercase">
+            {selectedSchool.city}, {selectedSchool.state}
+          </small>
+        </div>
+      </Card>
     );
   }
 

--- a/resources/assets/components/utilities/SchoolFinder/SchoolFinder.js
+++ b/resources/assets/components/utilities/SchoolFinder/SchoolFinder.js
@@ -101,7 +101,7 @@ const SchoolFinder = ({ campaignId, userId }) => {
 
 SchoolFinder.propTypes = {
   campaignId: PropTypes.string.isRequired,
-  // @TODO: Add userId once we're ready to start reading/writing user's school_id.
+  userId: PropTypes.string.isRequired,
 };
 
 export default SchoolFinder;

--- a/resources/assets/components/utilities/SchoolFinder/UpdateSchool.js
+++ b/resources/assets/components/utilities/SchoolFinder/UpdateSchool.js
@@ -16,7 +16,7 @@ const USER_SCHOOL_MUTATION = gql`
   }
 `;
 
-const UpdateSchool = ({ userId }) => {
+const UpdateSchool = ({ onSubmit, userId }) => {
   const [schoolId, setSchoolId] = useState(null);
   const [schoolState, setSchoolState] = useState(null);
 
@@ -41,6 +41,7 @@ const UpdateSchool = ({ userId }) => {
       <Mutation
         mutation={USER_SCHOOL_MUTATION}
         variables={{ schoolId, userId }}
+        update={() => onSubmit(schoolId)}
       >
         {userMutation => (
           <Button onClick={userMutation} disabled={schoolId === null} attached>
@@ -53,6 +54,7 @@ const UpdateSchool = ({ userId }) => {
 };
 
 UpdateSchool.propTypes = {
+  onSubmit: PropTypes.func.isRequired,
   userId: PropTypes.string.isRequired,
 };
 

--- a/resources/assets/components/utilities/SchoolFinder/UpdateSchool.js
+++ b/resources/assets/components/utilities/SchoolFinder/UpdateSchool.js
@@ -1,0 +1,47 @@
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
+
+import Button from '../Button/Button';
+import SchoolSelect from './SchoolSelect';
+import SchoolStateSelect from '../UsaStateSelect';
+
+const UpdateSchool = ({ onSubmit }) => {
+  const [selectedSchool, setSelectedSchool] = useState(null);
+  const [selectedSchoolState, setSelectedSchoolState] = useState(null);
+
+  return (
+    <React.Fragment>
+      <p className="padded">
+        Pick your school and whatever. Invite your classmates to join this
+        campaign and donate their jeans to win prizes and some other stuff.
+      </p>
+      <div className="select-state padded">
+        <strong>State</strong>
+        <SchoolStateSelect
+          onChange={selected => setSelectedSchoolState(selected)}
+        />
+      </div>
+      {selectedSchoolState ? (
+        <div className="select-school padded">
+          <SchoolSelect
+            onChange={selected => setSelectedSchool(selected)}
+            filterByState={selectedSchoolState.abbreviation}
+          />
+        </div>
+      ) : null}
+      <Button
+        onClick={() => onSubmit(selectedSchool.gsid)}
+        disabled={selectedSchool === null}
+        attached
+      >
+        Submit
+      </Button>
+    </React.Fragment>
+  );
+};
+
+UpdateSchool.propTypes = {
+  onSubmit: PropTypes.func.isRequired,
+};
+
+export default UpdateSchool;

--- a/resources/assets/components/utilities/SchoolFinder/UpdateSchool.js
+++ b/resources/assets/components/utilities/SchoolFinder/UpdateSchool.js
@@ -1,13 +1,24 @@
 import React, { useState } from 'react';
+import gql from 'graphql-tag';
 import PropTypes from 'prop-types';
+import { Mutation } from 'react-apollo';
 
 import Button from '../Button/Button';
 import SchoolSelect from './SchoolSelect';
 import SchoolStateSelect from '../UsaStateSelect';
 
-const UpdateSchool = ({ onSubmit }) => {
-  const [selectedSchool, setSelectedSchool] = useState(null);
-  const [selectedSchoolState, setSelectedSchoolState] = useState(null);
+const USER_SCHOOL_MUTATION = gql`
+  mutation UserSchoolMutation($userId: String!, $schoolId: String) {
+    updateSchoolId(id: $userId, schoolId: $schoolId) {
+      id
+      schoolId
+    }
+  }
+`;
+
+const UpdateSchool = ({ userId }) => {
+  const [schoolId, setSchoolId] = useState(null);
+  const [schoolState, setSchoolState] = useState(null);
 
   return (
     <React.Fragment>
@@ -17,31 +28,32 @@ const UpdateSchool = ({ onSubmit }) => {
       </p>
       <div className="select-state padded">
         <strong>State</strong>
-        <SchoolStateSelect
-          onChange={selected => setSelectedSchoolState(selected)}
-        />
+        <SchoolStateSelect onChange={selected => setSchoolState(selected)} />
       </div>
-      {selectedSchoolState ? (
+      {schoolState ? (
         <div className="select-school padded">
           <SchoolSelect
-            onChange={selected => setSelectedSchool(selected)}
-            filterByState={selectedSchoolState.abbreviation}
+            onChange={selected => setSchoolId(selected.gsid)}
+            filterByState={schoolState.abbreviation}
           />
         </div>
       ) : null}
-      <Button
-        onClick={() => onSubmit(selectedSchool.gsid)}
-        disabled={selectedSchool === null}
-        attached
+      <Mutation
+        mutation={USER_SCHOOL_MUTATION}
+        variables={{ schoolId, userId }}
       >
-        Submit
-      </Button>
+        {userMutation => (
+          <Button onClick={userMutation} disabled={schoolId === null} attached>
+            Submit
+          </Button>
+        )}
+      </Mutation>
     </React.Fragment>
   );
 };
 
 UpdateSchool.propTypes = {
-  onSubmit: PropTypes.func.isRequired,
+  userId: PropTypes.string.isRequired,
 };
 
 export default UpdateSchool;


### PR DESCRIPTION
### What does this PR do?

This PR starts on reading and writing the current user's school from the `SchoolFinder` component:

* Splits `SchoolFinder` component into separate `UpdateSchool` and `CurrentSchool` components.
* Displays `CurrentSchool` component on page load if user school is already selected
* Displays `UpdateSchool` component if user school is not set, displays `CurrentSchool` upon save

### Any background context you want to provide?

Not displaying school name/info yet, as the `SchoolSelect` component is still querying the lofischools app. Once we get the schools DB + GraphQL integration sorted out (hopefully in https://github.com/DoSomething/graphql/pull/155), I'll make the change to query schools from GraphQL in a future PR.


Won't be adding screenshots, as this feature is still under active development. There aren't any visual changes from #1668.

### What are the relevant tickets/cards?

* Update user school https://www.pivotaltracker.com/story/show/169549547
* Display saved user school https://www.pivotaltracker.com/n/projects/2401401/stories/169549488

### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.
