### PR TITLE
Bug Fix - Add alias for content block image alignment fragment field

### DIFF
--- a/resources/assets/components/ContentfulEntry/ContentfulEntry.js
+++ b/resources/assets/components/ContentfulEntry/ContentfulEntry.js
@@ -127,8 +127,9 @@ class ContentfulEntry extends React.Component<Props, State> {
         return (
           <ContentBlock
             className={className}
-            // Resolves the alias used in the ContentBlockFragment.
+            // Resolves the aliases used in the ContentBlockFragment.
             content={json.contentBlockContent}
+            imageAlignment={json.contentBlockImageAlignment}
             {...withoutNulls(json)}
           />
         );

--- a/resources/assets/components/blocks/ContentBlock/ContentBlock.js
+++ b/resources/assets/components/blocks/ContentBlock/ContentBlock.js
@@ -21,7 +21,8 @@ export const ContentBlockFragment = gql`
       url
       description
     }
-    imageAlignment
+    # Aliasing to avoid conflicting with *required* imageAlignment field in GalleryBlockFragment.
+    contentBlockimageAlignment: imageAlignment
   }
 `;
 


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR fixes a bug introduced in #1680 wherein gql block queries would fail because of conflicting `imageAlignment` fields in the `ContentBlockFragment` (non required in gql schema) and `GalleryBlockFragment` (required). Simply adding another field alias (for more context on that see the explanation in #1680 for the alias for `content`)