### PR TITLE
Update to GraphQL defined enums formatting for Gallery & Content Blocks

### DIFF
--- a/app/Entities/ContentBlock.php
+++ b/app/Entities/ContentBlock.php
@@ -25,7 +25,7 @@ class ContentBlock extends Entity implements JsonSerializable
                     'url' => get_image_url($this->image),
                     'description' => $this->image ? $this->image->getDescription() : null,
                 ],
-                'imageAlignment' => $this->imageAlignment ? strtolower($this->imageAlignment) : 'right',
+                'imageAlignment' => $this->imageAlignment ? strtoupper($this->imageAlignment) : null,
                 'additionalContent' => $this->additionalContent,
             ],
         ];

--- a/app/Entities/GalleryBlock.php
+++ b/app/Entities/GalleryBlock.php
@@ -20,8 +20,8 @@ class GalleryBlock extends Entity implements JsonSerializable
                 'title' => $this->title,
                 'blocks' => $this->parseBlocks($this->blocks),
                 'itemsPerRow' => $this->itemsPerRow,
-                'imageAlignment' => $this->imageAlignment,
-                'imageFit' => $this->imageFit ?: 'fill',
+                'imageAlignment' => $this->imageAlignment ? strtoupper($this->imageAlignment) : null,
+                'imageFit' => $this->imageFit ? strtoupper($this->imageFit) : null,
             ],
         ];
     }

--- a/resources/assets/components/ContentfulEntry/ContentfulEntry.js
+++ b/resources/assets/components/ContentfulEntry/ContentfulEntry.js
@@ -174,7 +174,7 @@ class ContentfulEntry extends React.Component<Props, State> {
         );
 
       case 'galleryBlock':
-        return <GalleryBlock {...json.fields} />;
+        return <GalleryBlock {...withoutNulls(json.fields)} />;
 
       case 'GalleryBlock':
         return <GalleryBlock {...withoutNulls(json)} />;

--- a/resources/assets/components/blocks/ContentBlock/ContentBlock.js
+++ b/resources/assets/components/blocks/ContentBlock/ContentBlock.js
@@ -46,7 +46,7 @@ const ContentBlock = props => {
         <Figure
           image={contentfulImageUrl(image.url, '600', '600', 'fill')}
           alt={image.description || 'content-block'}
-          alignment={`${imageAlignment}-collapse`}
+          alignment={`${imageAlignment.toLowerCase()}-collapse`}
           size="one-third"
         >
           {contentNode}
@@ -65,14 +65,14 @@ ContentBlock.propTypes = {
     url: PropTypes.string,
     description: PropTypes.string,
   }).isRequired,
-  imageAlignment: PropTypes.oneOf(['right', 'left']),
+  imageAlignment: PropTypes.oneOf(['RIGHT', 'LEFT']),
   superTitle: PropTypes.string,
   title: PropTypes.string,
 };
 
 ContentBlock.defaultProps = {
   className: null,
-  imageAlignment: 'right',
+  imageAlignment: 'RIGHT',
   superTitle: null,
   title: null,
 };

--- a/resources/assets/components/blocks/GalleryBlock/GalleryBlock.js
+++ b/resources/assets/components/blocks/GalleryBlock/GalleryBlock.js
@@ -108,7 +108,13 @@ const GalleryBlock = props => {
       {title ? <h1>{title}</h1> : null}
 
       <Gallery type={galleryType} className="expand-horizontal-md">
-        {blocks.map(block => renderBlock(block, imageAlignment, imageFit))}
+        {blocks.map(block =>
+          renderBlock(
+            block,
+            imageAlignment.toLowerCase(),
+            imageFit.toLowerCase(),
+          ),
+        )}
       </Gallery>
     </div>
   );
@@ -118,12 +124,13 @@ GalleryBlock.propTypes = {
   title: PropTypes.string,
   blocks: PropTypes.arrayOf(PropTypes.object).isRequired,
   itemsPerRow: PropTypes.oneOf([2, 3, 4]).isRequired,
-  imageAlignment: PropTypes.oneOf(['top', 'left']).isRequired,
-  imageFit: PropTypes.oneOf(['fill', 'pad']).isRequired,
+  imageAlignment: PropTypes.oneOf(['TOP', 'LEFT']).isRequired,
+  imageFit: PropTypes.oneOf(['FILL', 'PAD']),
 };
 
 GalleryBlock.defaultProps = {
   title: null,
+  imageFit: 'FILL',
 };
 
 export default GalleryBlock;


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR updates the `GalleryBlock` & `ContentBlock`s `imageAlignment` & `imageFit` fields to expect the formatting defined for the enums for these fields in GraphQL. It also updates the backend Entities to do the same resolving as in gql so this formatting is consistent until we're completely switched over to gql.

### Any background context you want to provide?
Check out the GraphQL PR https://github.com/DoSomething/graphql/pull/156 for more context!

### What are the relevant tickets/cards?
This wraps up the initiatives defined in
[Pivotal ID #169485759](https://www.pivotaltracker.com/story/show/169485759) & [Pivotal ID #168182083](https://www.pivotaltracker.com/story/show/168182083)
