### PR TITLE
School Finder + GraphQL schools

### DIFF
--- a/cypress/fixtures/graphql.js
+++ b/cypress/fixtures/graphql.js
@@ -28,8 +28,8 @@ export const operations = {
   },
   EmbedQuery: {
     embed: {
-      title: 'Example Campaign',
-      description: 'This is an example campaign for automated testing.',
+      title: faker.lorem.words(),
+      description: faker.lorem.sentence(),
     },
   },
   ReferralPageCampaignQuery: {

--- a/cypress/fixtures/graphql.js
+++ b/cypress/fixtures/graphql.js
@@ -26,6 +26,17 @@ export const operations = {
   ActionGalleryQuery: {
     posts: (root, { count }) => MockList(count),
   },
+  EmbedQuery: {
+    embed: {
+      title: 'Example Campaign',
+      description: 'This is an example campaign for automated testing.',
+    },
+  },
+  ReferralPageCampaignQuery: {
+    campaignWebsiteByCampaignId: {
+      slug: 'test-example-campaign',
+    },
+  },
 };
 
 /**

--- a/cypress/fixtures/graphql.js
+++ b/cypress/fixtures/graphql.js
@@ -28,13 +28,13 @@ export const operations = {
   },
   EmbedQuery: {
     embed: {
-      title: 'Example Campaign',
-      description: 'This is an example campaign for automated testing.',
+      title: faker.lorem.words(),
+      description: faker.lorem.sentence(),
     },
   },
   ReferralPageCampaignQuery: {
     campaignWebsiteByCampaignId: {
-      slug: 'test-example-campaign',
+      slug: faker.lorem.slug(),
     },
   },
 };

--- a/cypress/fixtures/graphql.js
+++ b/cypress/fixtures/graphql.js
@@ -28,15 +28,15 @@ export const operations = {
   },
   EmbedQuery: {
     embed: {
-      title: 'Example Campaign',
-      description: 'This is an example campaign for automated testing.',
-      providerName: 'DoSomething.org',
-      thumbnailUrl: 'http://placekitten.com/200/300',
+      title: faker.lorem.words(),
+      description: faker.lorem.sentence(),
+      providerName: faker.company.companyName(),
+      thumbnailUrl: faker.image.imageUrl(),
     },
   },
   ReferralPageCampaignQuery: {
     campaignWebsiteByCampaignId: {
-      slug: 'test-example-campaign',
+      slug: faker.lorem.slug(),
     },
   },
 };

--- a/cypress/fixtures/graphql.js
+++ b/cypress/fixtures/graphql.js
@@ -28,8 +28,8 @@ export const operations = {
   },
   EmbedQuery: {
     embed: {
-      title: faker.lorem.words(),
-      description: faker.lorem.sentence(),
+      title: 'Example Campaign',
+      description: 'This is an example campaign for automated testing.',
     },
   },
   ReferralPageCampaignQuery: {

--- a/cypress/fixtures/graphql.js
+++ b/cypress/fixtures/graphql.js
@@ -26,17 +26,6 @@ export const operations = {
   ActionGalleryQuery: {
     posts: (root, { count }) => MockList(count),
   },
-  EmbedQuery: {
-    embed: {
-      title: faker.lorem.words(),
-      description: faker.lorem.sentence(),
-    },
-  },
-  ReferralPageCampaignQuery: {
-    campaignWebsiteByCampaignId: {
-      slug: faker.lorem.slug(),
-    },
-  },
 };
 
 /**

--- a/cypress/fixtures/graphql.js
+++ b/cypress/fixtures/graphql.js
@@ -30,6 +30,8 @@ export const operations = {
     embed: {
       title: 'Example Campaign',
       description: 'This is an example campaign for automated testing.',
+      providerName: 'DoSomething.org',
+      thumbnailUrl: 'http://placekitten.com/200/300',
     },
   },
   ReferralPageCampaignQuery: {

--- a/cypress/integration/beta-referral-page.js
+++ b/cypress/integration/beta-referral-page.js
@@ -29,13 +29,15 @@ describe('Beta Referral Page', () => {
 
      cy.get('.referral-page-campaign').should('have.length', 1);
 
-      /**
-       * TODO: Fix this. This test fails on CircleCId, the embed displays "Hello world!".
-       *
-      cy.get('.referral-page-campaign > a')
-        .should('have.attr', 'href')
-        .and('include', `referrer_user_id=${userId}`);
-      */
+
+    /**
+     * TODO: Fix this. This test fails on CircleCI, the Embed displays "Hello world!",
+     * and never loads with the placeholder design -- so there is no href found on the <a>.
+     *
+    cy.get('.referral-page-campaign > a')
+      .should('have.attr', 'href')
+      .and('include', `referrer_user_id=${userId}`);
+    */
   });
 
   it('Visit beta referral page, with invalid user ID', () => {

--- a/cypress/integration/beta-referral-page.js
+++ b/cypress/integration/beta-referral-page.js
@@ -22,29 +22,6 @@ describe('Beta Referral Page', () => {
       .and('include', `referrer_user_id=${userId}`);
   });
 
-  it('Visit beta referral page, with valid user ID and no campaign ID', () => {
-     const user = userFactory();
-
-     cy.visit(`/us/join?user_id=${userId}`);
-
-     cy.get('.referral-page-campaign').should('have.length', 1);
-
-
-    /**
-     * TODO: Fix this. This test fails on CircleCI, the Embed displays "Hello world!",
-     * and never loads with the placeholder design -- so there is no href found on the <a>.
-     * @see https://dashboard.cypress.io/#/projects/ayzqmy/runs/876  
-     *
-     * We might not need this test anyway, since we check above that the referrer_user_id
-     * is set in the campaign URL... but this is still a mystery. This rarely happens on local
-     * although I did see it once. 
-     *
-    cy.get('.referral-page-campaign > a')
-      .should('have.attr', 'href')
-      .and('include', `referrer_user_id=${userId}`);
-    */
-  });
-
   it('Visit beta referral page, with invalid user ID', () => {
     const user = userFactory();
 
@@ -59,5 +36,22 @@ describe('Beta Referral Page', () => {
 
     // Our mock user ID won't exist in dev, we can expect a 404.
     cy.contains('Not Found');
+  });
+
+  /**
+   * When this test is executed after the 1st test, where we test with valid User + Campaign,
+   * the Embed request hangs with a mystery "Hello World", never rendering the Embed a tag.
+   * @see https://dashboard.cypress.io/#/projects/ayzqmy/runs/876
+   */
+  it('Visit beta referral page, with valid user ID and no campaign ID', () => {
+    const user = userFactory();
+
+    cy.visit(`/us/join?user_id=${userId}`);
+
+    cy.get('.referral-page-campaign').should('have.length', 1);
+
+    cy.get('.referral-page-campaign > a')
+      .should('have.attr', 'href')
+      .and('include', `referrer_user_id=${userId}`);
   });
 });

--- a/cypress/integration/beta-referral-page.js
+++ b/cypress/integration/beta-referral-page.js
@@ -22,17 +22,21 @@ describe('Beta Referral Page', () => {
       .and('include', `referrer_user_id=${userId}`);
   });
 
-  // it('Visit beta referral page, with valid user ID and no campaign ID', () => {
-  //   const user = userFactory();
+  it('Visit beta referral page, with valid user ID and no campaign ID', () => {
+     const user = userFactory();
 
-  //   cy.visit(`/us/join?user_id=${userId}`);
+     cy.visit(`/us/join?user_id=${userId}`);
 
-  //   cy.get('.referral-page-campaign').should('have.length', 1);
+     cy.get('.referral-page-campaign').should('have.length', 1);
 
-  //   cy.get('.referral-page-campaign > a')
-  //     .should('have.attr', 'href')
-  //     .and('include', `referrer_user_id=${userId}`);
-  // });
+      /**
+       * TODO: Fix this. This test fails on CircleCId, the embed displays "Hello world!".
+       *
+      cy.get('.referral-page-campaign > a')
+        .should('have.attr', 'href')
+        .and('include', `referrer_user_id=${userId}`);
+      */
+  });
 
   it('Visit beta referral page, with invalid user ID', () => {
     const user = userFactory();

--- a/cypress/integration/beta-referral-page.js
+++ b/cypress/integration/beta-referral-page.js
@@ -33,6 +33,11 @@ describe('Beta Referral Page', () => {
     /**
      * TODO: Fix this. This test fails on CircleCI, the Embed displays "Hello world!",
      * and never loads with the placeholder design -- so there is no href found on the <a>.
+     * @see https://dashboard.cypress.io/#/projects/ayzqmy/runs/876  
+     *
+     * We might not need this test anyway, since we check above that the referrer_user_id
+     * is set in the campaign URL... but this is still a mystery. This rarely happens on local
+     * although I did see it once. 
      *
     cy.get('.referral-page-campaign > a')
       .should('have.attr', 'href')

--- a/package-lock.json
+++ b/package-lock.json
@@ -5585,9 +5585,9 @@
       "dev": true
     },
     "cypress": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-3.6.0.tgz",
-      "integrity": "sha512-ODhbOrH1XZx0DUoYmJSvOSbEQjycNOpFYe7jOnHkT1+sdsn2+uqwAjZ1x982q3H4R/5iZjpSd50gd/iw2bofzg==",
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-3.6.1.tgz",
+      "integrity": "sha512-6n0oqENdz/oQ7EJ6IgESNb2M7Bo/70qX9jSJsAziJTC3kICfEMmJUlrAnP9bn+ut24MlXQST5nRXhUP5nRIx6A==",
       "dev": true,
       "requires": {
         "@cypress/listr-verbose-renderer": "0.4.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,70 @@
         "lodash.xorby": "^4.7.0"
       }
     },
+    "@apollo/react-common": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@apollo/react-common/-/react-common-3.1.3.tgz",
+      "integrity": "sha512-Q7ZjDOeqjJf/AOGxUMdGxKF+JVClRXrYBGVq+SuVFqANRpd68MxtVV2OjCWavsFAN0eqYnRqRUrl7vtUCiJqeg==",
+      "requires": {
+        "ts-invariant": "^0.4.4",
+        "tslib": "^1.10.0"
+      }
+    },
+    "@apollo/react-components": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@apollo/react-components/-/react-components-3.1.3.tgz",
+      "integrity": "sha512-H0l2JKDQMz+LkM93QK7j3ThbNXkWQCduN3s3eKxFN3Rdg7rXsrikJWvx2wQ868jmqy0VhwJbS1vYdRLdh114uQ==",
+      "requires": {
+        "@apollo/react-common": "^3.1.3",
+        "@apollo/react-hooks": "^3.1.3",
+        "prop-types": "^15.7.2",
+        "ts-invariant": "^0.4.4",
+        "tslib": "^1.10.0"
+      }
+    },
+    "@apollo/react-hoc": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@apollo/react-hoc/-/react-hoc-3.1.3.tgz",
+      "integrity": "sha512-oCPma0uBVPTcYTR5sOvtMbpaWll4xDBvYfKr6YkDorUcQVeNzFu1LK1kmQjJP64bKsaziKYji5ibFaeCnVptmA==",
+      "requires": {
+        "@apollo/react-common": "^3.1.3",
+        "@apollo/react-components": "^3.1.3",
+        "hoist-non-react-statics": "^3.3.0",
+        "ts-invariant": "^0.4.4",
+        "tslib": "^1.10.0"
+      }
+    },
+    "@apollo/react-hooks": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@apollo/react-hooks/-/react-hooks-3.1.3.tgz",
+      "integrity": "sha512-reIRO9xKdfi+B4gT/o/hnXuopUnm7WED/ru8VQydPw+C/KG/05Ssg1ZdxFKHa3oxwiTUIDnevtccIH35POanbA==",
+      "requires": {
+        "@apollo/react-common": "^3.1.3",
+        "@wry/equality": "^0.1.9",
+        "ts-invariant": "^0.4.4",
+        "tslib": "^1.10.0"
+      }
+    },
+    "@apollo/react-ssr": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@apollo/react-ssr/-/react-ssr-3.1.3.tgz",
+      "integrity": "sha512-fUTmEYHxSTX1GA43B8vICxXXplpcEBnDwn0IgdAc3eG0p2YK97ZrJDRFCJ5vD7fyDZsrYhMf+rAI3sd+H2SS+A==",
+      "requires": {
+        "@apollo/react-common": "^3.1.3",
+        "@apollo/react-hooks": "^3.1.3",
+        "tslib": "^1.10.0"
+      }
+    },
+    "@apollo/react-testing": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@apollo/react-testing/-/react-testing-3.1.3.tgz",
+      "integrity": "sha512-58R7gROl4TZMHm5kS76Nof9FfZhD703AU3SmJTA2f7naiMqC9Qd8pZ4oNCBafcab0SYN//UtWvLcluK5O7V/9g==",
+      "requires": {
+        "@apollo/react-common": "^3.1.3",
+        "fast-json-stable-stringify": "^2.0.0",
+        "tslib": "^1.10.0"
+      }
+    },
     "@apollographql/apollo-tools": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/@apollographql/apollo-tools/-/apollo-tools-0.4.0.tgz",
@@ -2749,7 +2813,7 @@
     "@xtuc/ieee754": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
-      "integrity": "sha1-7vAUoxRa5Hehy8AM0eVSM23Ot5A=",
+      "integrity": "sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==",
       "dev": true
     },
     "@xtuc/long": {
@@ -3398,7 +3462,7 @@
     "apollo-link-persisted-queries": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/apollo-link-persisted-queries/-/apollo-link-persisted-queries-0.2.2.tgz",
-      "integrity": "sha1-FWWXyyWbe7Vs9Olnp74DEpVPRZE=",
+      "integrity": "sha512-YL7XBu/5QsSbbYaWUXgm87T2Hn/2AQZk5Wr8CLXGDr3Wl3E/TRhBhKgQQTly9xhaTi7jgBO+AeIyTH5wCBHA9w==",
       "requires": {
         "apollo-link": "^1.2.1",
         "hash.js": "^1.1.3"
@@ -3622,7 +3686,7 @@
     "asn1.js": {
       "version": "4.10.1",
       "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.10.1.tgz",
-      "integrity": "sha1-ucK/WAXx5kqt7tbfOiv6+1pz9aA=",
+      "integrity": "sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==",
       "dev": true,
       "requires": {
         "bn.js": "^4.0.0",
@@ -4150,7 +4214,7 @@
     "base64-js": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.0.tgz",
-      "integrity": "sha1-yrHmEY8FEJXli1KBrqjBzSK/wOM=",
+      "integrity": "sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw==",
       "dev": true
     },
     "bcrypt-pbkdf": {
@@ -4215,7 +4279,7 @@
     "bn.js": {
       "version": "4.11.8",
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
-      "integrity": "sha1-LN4J617jQfSEdGuwMJsyU7GxRC8=",
+      "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==",
       "dev": true
     },
     "body-parser": {
@@ -4331,7 +4395,7 @@
     "browserify-aes": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
-      "integrity": "sha1-Mmc0ZC9APavDADIJhTu3CtQo70g=",
+      "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
       "dev": true,
       "requires": {
         "buffer-xor": "^1.0.3",
@@ -4345,7 +4409,7 @@
     "browserify-cipher": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.1.tgz",
-      "integrity": "sha1-jWR0wbhwv9q807z8wZNKEOlPFfA=",
+      "integrity": "sha512-sPhkz0ARKbf4rRQt2hTpAHqn47X3llLkUGn+xEJzLjwY8LRs2p0v7ljvI5EyoRO/mexrNunNECisZs+gw2zz1w==",
       "dev": true,
       "requires": {
         "browserify-aes": "^1.0.4",
@@ -4356,7 +4420,7 @@
     "browserify-des": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.2.tgz",
-      "integrity": "sha1-OvTx9Zg5QDVy8cZiBDdfen9wPpw=",
+      "integrity": "sha512-BioO1xf3hFwz4kc6iBhI3ieDFompMhrMlnDFC4/0/vd5MokpuAc3R+LYbwTA9A5Yc9pq9UYPqffKpW2ObuwX5A==",
       "dev": true,
       "requires": {
         "cipher-base": "^1.0.1",
@@ -4393,7 +4457,7 @@
     "browserify-zlib": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.2.0.tgz",
-      "integrity": "sha1-KGlFnZqjviRf6P4sofRuLn9U1z8=",
+      "integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
       "dev": true,
       "requires": {
         "pako": "~1.0.5"
@@ -4521,7 +4585,7 @@
         "y18n": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
-          "integrity": "sha1-le+U+F7MgdAHwmThkKEg8KPIVms=",
+          "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
           "dev": true
         },
         "yallist": {
@@ -4757,7 +4821,7 @@
     "chownr": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.1.tgz",
-      "integrity": "sha1-VHJri4//TfBTxCGH6AH7RBLfFJQ=",
+      "integrity": "sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g==",
       "dev": true
     },
     "chrome-trace-event": {
@@ -4777,7 +4841,7 @@
     "cipher-base": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
-      "integrity": "sha1-h2Dk7MJy9MNjUy+SbYdKriwTl94=",
+      "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
       "dev": true,
       "requires": {
         "inherits": "^2.0.1",
@@ -5249,7 +5313,7 @@
     "copy-concurrently": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/copy-concurrently/-/copy-concurrently-1.0.5.tgz",
-      "integrity": "sha1-kilzmMrjSTf8r9bsgTnBgFHwteA=",
+      "integrity": "sha512-f2domd9fsVDFtaFcbaRZuYXwtdmnzqbADSwhSWYxYB/Q8zsdUUFMXVRwXGDMWmbEzAn1kdRrtI1T/KTFOL4X2A==",
       "dev": true,
       "requires": {
         "aproba": "^1.1.1",
@@ -5330,7 +5394,7 @@
     "create-ecdh": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.3.tgz",
-      "integrity": "sha1-yREbbzMEXEaX8UR4f5JUzcd8Rf8=",
+      "integrity": "sha512-GbEHQPMOswGpKXM9kCWVrremUcBmjteUaQ01T9rkKCPDXfUHX0IoP9LpHYo2NPFampa4e+/pFDc3jQdxrxQLaw==",
       "dev": true,
       "requires": {
         "bn.js": "^4.1.0",
@@ -5362,7 +5426,7 @@
     "create-hash": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
-      "integrity": "sha1-iJB4rxGmN1a8+1m9IhmWvjqe8ZY=",
+      "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
       "dev": true,
       "requires": {
         "cipher-base": "^1.0.1",
@@ -5375,7 +5439,7 @@
     "create-hmac": {
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
-      "integrity": "sha1-aRcMeLOrlXFHsriwRXLkfq0iQ/8=",
+      "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
       "dev": true,
       "requires": {
         "cipher-base": "^1.0.3",
@@ -5401,7 +5465,7 @@
     "crypto-browserify": {
       "version": "3.12.0",
       "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.12.0.tgz",
-      "integrity": "sha1-OWz58xN/A+S45TLFj2mCVOAPgOw=",
+      "integrity": "sha512-fz4spIh+znjO2VjL+IdhEpRJ3YN6sMzITSBijk6FK2UvTqruSQW+/cCZTSNsMiZNvUeq0CqurF+dAbyiGOY6Wg==",
       "dev": true,
       "requires": {
         "browserify-cipher": "^1.0.0",
@@ -6114,7 +6178,7 @@
     "diffie-hellman": {
       "version": "5.0.3",
       "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
-      "integrity": "sha1-QOjumPVaIUlgcUaSHGPhrl89KHU=",
+      "integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
       "dev": true,
       "requires": {
         "bn.js": "^4.1.0",
@@ -6161,7 +6225,7 @@
     "domain-browser": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.2.0.tgz",
-      "integrity": "sha1-PTH1AZGmdJ3RN1p/Ui6CPULlTto=",
+      "integrity": "sha512-jnjyiM6eRyZl2H+W8Q/zLMA481hzi0eszAaBUzIVnmYVDBbnLxVNnfu1HgEBvCbL+71FrxMl3E6lpKH7Ge3OXA==",
       "dev": true
     },
     "domelementtype": {
@@ -6262,7 +6326,7 @@
     "elliptic": {
       "version": "6.4.1",
       "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.4.1.tgz",
-      "integrity": "sha1-wtC3d2kRuGcixjLDwGxg8vgZk5o=",
+      "integrity": "sha512-BsXLz5sqX8OHcsh7CqBMztyXARmGQ3LWPtGjJi6DiJHq5C/qvi9P3OqgswKSDftbu8+IoI/QDTAm2fFnQ9SZSQ==",
       "dev": true,
       "requires": {
         "bn.js": "^4.4.0",
@@ -6312,7 +6376,7 @@
     "end-of-stream": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
-      "integrity": "sha1-7SljTRm6ukY7bOa4CjchPqtx7EM=",
+      "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
       "requires": {
         "once": "^1.4.0"
       }
@@ -7058,7 +7122,7 @@
     "evp_bytestokey": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
-      "integrity": "sha1-f8vbGY3HGVlDLv4ThCaE4FJaywI=",
+      "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
       "dev": true,
       "requires": {
         "md5.js": "^1.3.4",
@@ -7481,7 +7545,7 @@
     "figgy-pudding": {
       "version": "3.5.1",
       "resolved": "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-3.5.1.tgz",
-      "integrity": "sha1-hiRwESkBxyeg5JWoB0S9W6odZ5A=",
+      "integrity": "sha512-vNKxJHTEKNThjfrdJwHc7brvM6eVevuO5nTj6ez8ZQ1qbXTvGthucRF7S4vf2cr71QVnT70V34v0S1DyQsti0w==",
       "dev": true
     },
     "figures": {
@@ -11289,7 +11353,7 @@
     "md5.js": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
-      "integrity": "sha1-tdB7jjIW4+J81yjXL3DR5qNCAF8=",
+      "integrity": "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==",
       "dev": true,
       "requires": {
         "hash-base": "^3.0.0",
@@ -11495,7 +11559,7 @@
     "miller-rabin": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.1.tgz",
-      "integrity": "sha1-8IA1HIZbDcViqEYpZtqlNUPHik0=",
+      "integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
       "dev": true,
       "requires": {
         "bn.js": "^4.0.0",
@@ -11575,7 +11639,7 @@
     "mississippi": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/mississippi/-/mississippi-3.0.0.tgz",
-      "integrity": "sha1-6goykfl+C16HdrNj1fChLZTGcCI=",
+      "integrity": "sha512-x471SsVjUtBRtcvd4BzKE9kFC+/2TeWgKCgw0bZcw1b9l2X3QX5vCWgF+KaZaYm87Ss//rHnWryupDrgLvmSkA==",
       "dev": true,
       "requires": {
         "concat-stream": "^1.5.0",
@@ -12758,7 +12822,7 @@
     "pbkdf2": {
       "version": "3.0.17",
       "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.17.tgz",
-      "integrity": "sha1-l2wgZTBhexTrsyEUI597CTNuk6Y=",
+      "integrity": "sha512-U/il5MsrZp7mGg3mSQfn742na2T+1/vHDCG5/iTI3X9MKUuYUZVLQhyRsg06mCgDBTd57TxzgZt7P+fYfjRLtA==",
       "dev": true,
       "requires": {
         "create-hash": "^1.1.2",
@@ -13359,7 +13423,7 @@
     "public-encrypt": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.3.tgz",
-      "integrity": "sha1-T8ydd6B+SLp1J+fL4N4z0HATMeA=",
+      "integrity": "sha512-zVpa8oKZSz5bTMTFClc1fQOnyyEzpl5ozpi1B5YcvBrdohMjH2rfsBtyXcuNuwjsDIXmBYlF2N5FlJYhR29t8Q==",
       "dev": true,
       "requires": {
         "bn.js": "^4.1.0",
@@ -13373,7 +13437,7 @@
     "pump": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
-      "integrity": "sha1-tKIRaBW94vTh6mAjVOjHVWUQemQ=",
+      "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
       "requires": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
@@ -13382,7 +13446,7 @@
     "pumpify": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/pumpify/-/pumpify-1.5.1.tgz",
-      "integrity": "sha1-NlE74karJ1cLGjdKXOJ4v9dDcM4=",
+      "integrity": "sha512-oClZI37HvuUJJxSKKrC17bZ9Cu0ZYhEAGPsPUy9KlMUmv9dKX2o77RUmq7f3XjIxbwyGwYzbzQ1L2Ks8sIradQ==",
       "dev": true,
       "requires": {
         "duplexify": "^3.6.0",
@@ -13393,7 +13457,7 @@
         "pump": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
-          "integrity": "sha1-Ejma3W5M91Jtlzy8i1zi4pCLOQk=",
+          "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
           "dev": true,
           "requires": {
             "end-of-stream": "^1.1.0",
@@ -13485,7 +13549,7 @@
     "randomfill": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/randomfill/-/randomfill-1.0.4.tgz",
-      "integrity": "sha1-ySGW/IarQr6YPxvzF3giSTHWFFg=",
+      "integrity": "sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==",
       "dev": true,
       "requires": {
         "randombytes": "^2.0.5",
@@ -13530,17 +13594,15 @@
       }
     },
     "react-apollo": {
-      "version": "2.5.8",
-      "resolved": "https://registry.npmjs.org/react-apollo/-/react-apollo-2.5.8.tgz",
-      "integrity": "sha512-60yOQrnNosxU/tRbOxGDaYNLFcOKmQqxHPhxyvKTlGIaF/rRCXQRKixUgWVffpEupSHHD7psY5k5ZOuZsdsSGQ==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/react-apollo/-/react-apollo-3.1.3.tgz",
+      "integrity": "sha512-orCZNoAkgveaK5b75y7fw1MSqSHOU/Wuu9rRFOGmRQBSQVZjvV4DI+hj604rHmuN9+WDABxb5W48wTa0F/xNZQ==",
       "requires": {
-        "apollo-utilities": "^1.3.0",
-        "fast-json-stable-stringify": "^2.0.0",
-        "hoist-non-react-statics": "^3.3.0",
-        "lodash.isequal": "^4.5.0",
-        "prop-types": "^15.7.2",
-        "ts-invariant": "^0.4.2",
-        "tslib": "^1.9.3"
+        "@apollo/react-common": "^3.1.3",
+        "@apollo/react-components": "^3.1.3",
+        "@apollo/react-hoc": "^3.1.3",
+        "@apollo/react-hooks": "^3.1.3",
+        "@apollo/react-ssr": "^3.1.3"
       }
     },
     "react-base16-styling": {
@@ -13646,7 +13708,7 @@
     "react-portal": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/react-portal/-/react-portal-4.2.0.tgz",
-      "integrity": "sha1-VACDHNsK5k3MuBKBIc8HYImrGv0=",
+      "integrity": "sha512-Zf+vGQ/VEAb5XAy+muKEn48yhdCNYPZaB1BWg1xc8sAZWD8pXTgPtQT4ihBdmWzsfCq8p8/kqf0GWydSBqc+Eg==",
       "requires": {
         "prop-types": "^15.5.8"
       }
@@ -14237,7 +14299,7 @@
     "ripemd160": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz",
-      "integrity": "sha1-ocGm9iR1FXe6XQeRTLyShQWFiQw=",
+      "integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
       "dev": true,
       "requires": {
         "hash-base": "^3.0.0",
@@ -14541,7 +14603,7 @@
     "sha.js": {
       "version": "2.4.11",
       "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
-      "integrity": "sha1-N6XPC4HsvGlD3hCbopYNGyZYSuc=",
+      "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
       "dev": true,
       "requires": {
         "inherits": "^2.0.1",
@@ -14967,7 +15029,7 @@
     "ssri": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.1.tgz",
-      "integrity": "sha1-KjxBso3UW2K2Nnbst0ABJlrp7dg=",
+      "integrity": "sha512-3Wge10hNcT1Kur4PDFwEieXSCMCJs/7WvSACcrMYrNp+b8kDL1/0wJch5Ni2WrtwEa2IO8OsVfeKIciKCDx/QA==",
       "dev": true,
       "requires": {
         "figgy-pudding": "^3.5.1"
@@ -15040,7 +15102,7 @@
     "stream-each": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/stream-each/-/stream-each-1.2.3.tgz",
-      "integrity": "sha1-6+J6DDibBPvMIzZClS4Qcxr6m64=",
+      "integrity": "sha512-vlMC2f8I2u/bZGqkdfLQW/13Zihpej/7PmSiMQsbYddxuTsJp8vRe2x2FvVExZg7FaOds43ROAuFJwPR4MTZLw==",
       "dev": true,
       "requires": {
         "end-of-stream": "^1.1.0",
@@ -15050,7 +15112,7 @@
     "stream-http": {
       "version": "2.8.3",
       "resolved": "https://registry.npmjs.org/stream-http/-/stream-http-2.8.3.tgz",
-      "integrity": "sha1-stJCRpKIpaJ+xP6JM6z2I95lFPw=",
+      "integrity": "sha512-+TSkfINHDo4J+ZobQLWiMouQYB+UVYFttRA94FpEzzJ7ZdqcL4uUUQ7WkdkI4DSozGmgBUE/a47L+38PenXhUw==",
       "dev": true,
       "requires": {
         "builtin-status-codes": "^3.0.0",
@@ -15438,7 +15500,7 @@
     "through2": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
-      "integrity": "sha1-AcHjnrMdB8t9A6lqcIIyYLIxMs0=",
+      "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
       "dev": true,
       "requires": {
         "readable-stream": "~2.3.6",
@@ -15448,7 +15510,7 @@
     "timers-browserify": {
       "version": "2.0.10",
       "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.10.tgz",
-      "integrity": "sha1-HSjj0qrfHVpZlsTp+VYBzQU0gK4=",
+      "integrity": "sha512-YvC1SV1XdOUaL6gx5CoGroT3Gu49pK9+TZ38ErPldOWW4j49GI1HKs9DV+KGq/w6y+LZ72W1c8cKz2vzY+qpzg==",
       "dev": true,
       "requires": {
         "setimmediate": "^1.0.4"
@@ -15812,7 +15874,7 @@
     "unique-filename": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-1.1.1.tgz",
-      "integrity": "sha1-HWl2k2mtoFgxA6HmrodoG1ZXMjA=",
+      "integrity": "sha512-Vmp0jIp2ln35UTXuryvjzkjGdRyf9b2lTXuSYUiPmzRcl3FDtYqAwOnTJkAngD9SWhnoJzDbTKwaOrZ+STtxNQ==",
       "dev": true,
       "requires": {
         "unique-slug": "^2.0.0"
@@ -16120,7 +16182,7 @@
     "watchpack": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.6.0.tgz",
-      "integrity": "sha1-S8EsLr6KonenHx0/FNaFx7RGzQA=",
+      "integrity": "sha512-i6dHe3EyLjMmDlU1/bGQpEw25XSjkJULPuAVKCbNRefQVq48yXKUpwg538F7AZTf9kyr57zj++pQFltUa5H7yA==",
       "dev": true,
       "requires": {
         "chokidar": "^2.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -72,6 +72,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/@apollo/react-testing/-/react-testing-3.1.3.tgz",
       "integrity": "sha512-58R7gROl4TZMHm5kS76Nof9FfZhD703AU3SmJTA2f7naiMqC9Qd8pZ4oNCBafcab0SYN//UtWvLcluK5O7V/9g==",
+      "dev": true,
       "requires": {
         "@apollo/react-common": "^3.1.3",
         "fast-json-stable-stringify": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "test": "jest --watch",
     "test:ci": "jest --max-Workers=2",
     "cypress": "cypress open",
-    "cypress:ci": "cypress run -c baseUrl=http://127.0.0.1:8000 --record",
+    "cypress:ci": "cypress run -c --browser baseUrl=http://127.0.0.1:8000 --record",
     "lint": "eslint --ext .js resources/assets",
     "flow": "flow",
     "start": "npm run schema:fragments && webpack --env=development --hide-modules --watch",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,6 @@
   "dependencies": {
     "@apollo/react-common": "^3.1.3",
     "@apollo/react-hooks": "^3.1.3",
-    "@apollo/react-testing": "^3.1.3",
     "@contentful/rich-text-react-renderer": "^13.4.0",
     "@contentful/rich-text-types": "^13.4.0",
     "@dosomething/forge": "^6.10.0",
@@ -124,6 +123,7 @@
     "usa-states": "0.0.5"
   },
   "devDependencies": {
+    "@apollo/react-testing": "^3.1.3",
     "@babel/core": "^7.7.2",
     "@babel/preset-flow": "^7.0.0",
     "@dosomething/babel-preset": "^3.2.0",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "test": "jest --watch",
     "test:ci": "jest --max-Workers=2",
     "cypress": "cypress open",
-    "cypress:ci": "cypress run -c --browser baseUrl=http://127.0.0.1:8000 --record",
+    "cypress:ci": "cypress run -c baseUrl=http://127.0.0.1:8000 --record",
     "lint": "eslint --ext .js resources/assets",
     "flow": "flow",
     "start": "npm run schema:fragments && webpack --env=development --hide-modules --watch",

--- a/package.json
+++ b/package.json
@@ -133,7 +133,7 @@
     "autoprefixer": "^9.7.1",
     "bson": "^4.0.2",
     "contentful-management": "^5.11.3",
-    "cypress": "^3.6.0",
+    "cypress": "^3.6.1",
     "cypress-file-upload": "^3.5.0",
     "cypress-graphql-mock": "github:DFurnes/cypress-graphql-mock#with-persisted-batch-support",
     "eslint-loader": "^2.2.1",

--- a/package.json
+++ b/package.json
@@ -59,6 +59,9 @@
     "testURL": "http://localhost"
   },
   "dependencies": {
+    "@apollo/react-common": "^3.1.3",
+    "@apollo/react-hooks": "^3.1.3",
+    "@apollo/react-testing": "^3.1.3",
     "@contentful/rich-text-react-renderer": "^13.4.0",
     "@contentful/rich-text-types": "^13.4.0",
     "@dosomething/forge": "^6.10.0",
@@ -101,7 +104,7 @@
     "query-string": "^5.1.1",
     "react": "^16.11.0",
     "react-addons-update": "^15.6.2",
-    "react-apollo": "^2.5.8",
+    "react-apollo": "^3.1.3",
     "react-dom": "^16.11.0",
     "react-intersection-observer": "^8.25.1",
     "react-loadable": "^5.4.0",

--- a/resources/assets/components/App.js
+++ b/resources/assets/components/App.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Provider } from 'react-redux';
-import { ApolloProvider } from 'react-apollo';
+import { ApolloProvider } from '@apollo/react-common';
 import { Router, Route, Switch } from 'react-router-dom';
 import { PuckProvider } from '@dosomething/puck-client';
 

--- a/resources/assets/components/actions/PetitionSubmissioncAction/PetitionSubmissionAction.test.js
+++ b/resources/assets/components/actions/PetitionSubmissioncAction/PetitionSubmissionAction.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { mount } from 'enzyme';
-import { MockedProvider } from 'react-apollo/test-utils';
+import { MockedProvider } from '@apollo/react-testing';
 
 import { USER_POSTS_QUERY } from './PetitionSubmissionAction'; // eslint-disable-line import/no-duplicates
 import PetitionSubmissionAction from './PetitionSubmissionAction'; // eslint-disable-line import/no-duplicates

--- a/resources/assets/components/utilities/Embed/Embed.js
+++ b/resources/assets/components/utilities/Embed/Embed.js
@@ -55,6 +55,9 @@ const Embed = props => {
       <Query query={EMBED_QUERY} variables={{ url }}>
         {({ loading, error, data }) => {
           const isLoaded = !loading;
+          if (!isLoaded) {
+            return null;
+          }
           const { embed } = data;
 
           if (error) {

--- a/resources/assets/components/utilities/Embed/Embed.js
+++ b/resources/assets/components/utilities/Embed/Embed.js
@@ -2,7 +2,7 @@
 
 import React from 'react';
 import gql from 'graphql-tag';
-import { truncate } from 'lodash';
+import { get, truncate } from 'lodash';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import { Query } from 'react-apollo';
@@ -55,10 +55,7 @@ const Embed = props => {
       <Query query={EMBED_QUERY} variables={{ url }}>
         {({ loading, error, data }) => {
           const isLoaded = !loading;
-          if (!isLoaded) {
-            return null;
-          }
-          const { embed } = data;
+          const embed = get(data, 'embed', {});
 
           if (error) {
             return <ErrorBlock />;

--- a/resources/assets/components/utilities/SchoolFinder/CurrentSchool.js
+++ b/resources/assets/components/utilities/SchoolFinder/CurrentSchool.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-const CurrentSchool = ({ schoolId }) => (
+const CurrentSchool = ({ name, city, state }) => (
   <div className="padded">
     <p>
       Something something something school finder post verification copy. You
@@ -9,13 +9,24 @@ const CurrentSchool = ({ schoolId }) => (
       <a href="mailto:Sahara@DoSomething.org">mailto:Sahara@DoSomething.org</a>{' '}
       to change your school.
     </p>
-    <h3>{schoolId}</h3>
-    <small className="uppercase">City, state</small>
+    <h3>{name}</h3>
+    {city ? (
+      <small className="uppercase">
+        {city}, {state}
+      </small>
+    ) : null}
   </div>
 );
 
 CurrentSchool.propTypes = {
-  schoolId: PropTypes.string.isRequired,
+  name: PropTypes.string.isRequired,
+  city: PropTypes.string,
+  state: PropTypes.string,
+};
+
+CurrentSchool.defaultProps = {
+  city: null,
+  state: null,
 };
 
 export default CurrentSchool;

--- a/resources/assets/components/utilities/SchoolFinder/CurrentSchool.js
+++ b/resources/assets/components/utilities/SchoolFinder/CurrentSchool.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-const CurrentSchool = ({ name, city, state }) => (
+const CurrentSchool = ({ school }) => (
   <div className="padded">
     <p>
       Something something something school finder post verification copy. You
@@ -9,24 +9,21 @@ const CurrentSchool = ({ name, city, state }) => (
       <a href="mailto:Sahara@DoSomething.org">mailto:Sahara@DoSomething.org</a>{' '}
       to change your school.
     </p>
-    <h3>{name}</h3>
-    {city ? (
+    <h3>{school.name}</h3>
+    {school.city ? (
       <small className="uppercase">
-        {city}, {state}
+        {school.city}, {school.state}
       </small>
     ) : null}
   </div>
 );
 
 CurrentSchool.propTypes = {
-  name: PropTypes.string.isRequired,
-  city: PropTypes.string,
-  state: PropTypes.string,
-};
-
-CurrentSchool.defaultProps = {
-  city: null,
-  state: null,
+  school: PropTypes.shape({
+    name: PropTypes.string.isRequired,
+    city: PropTypes.string,
+    state: PropTypes.string,
+  }).isRequired,
 };
 
 export default CurrentSchool;

--- a/resources/assets/components/utilities/SchoolFinder/SchoolFinder.js
+++ b/resources/assets/components/utilities/SchoolFinder/SchoolFinder.js
@@ -41,15 +41,13 @@ const SchoolFinder = ({ campaignId, userId }) => {
     <div className="school-finder margin-bottom-lg margin-horizontal-md clear-both primary">
       <Query query={USER_SCHOOL_QUERY} variables={{ userId }}>
         {res => {
-          const schoolId = res.user.schoolId;
-
-          if (schoolId) {
+          if (res.user && res.user.school) {
             setSchool(res.user.school);
           }
 
           return (
             <Card
-              title={schoolId ? 'Your School' : 'Find Your School'}
+              title={school.id ? 'Your School' : 'Find Your School'}
               className="rounded bordered overflow-visible"
             >
               {school.id ? (

--- a/resources/assets/components/utilities/SchoolFinder/SchoolFinder.js
+++ b/resources/assets/components/utilities/SchoolFinder/SchoolFinder.js
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { get } from 'lodash';
 import gql from 'graphql-tag';
 import PropTypes from 'prop-types';
 
@@ -11,6 +12,12 @@ const USER_SCHOOL_QUERY = gql`
   query UserSchoolQuery($userId: String!) {
     user(id: $userId) {
       schoolId
+      school {
+        id
+        name
+        city
+        state
+      }
     }
   }
 `;
@@ -21,25 +28,42 @@ const SchoolFinder = ({ campaignId, userId }) => {
   if (campaignId !== '9001') {
     return null;
   }
-  const [currentSchool, setCurrentSchool] = useState(null);
+
+  const [schoolName, setSchoolName] = useState(null);
+  const [schoolCity, setSchoolCity] = useState(null);
+  const [schoolState, setSchoolState] = useState(null);
 
   return (
     <div className="school-finder margin-bottom-lg margin-horizontal-md clear-both primary">
       <Query query={USER_SCHOOL_QUERY} variables={{ userId }}>
         {res => {
-          if (res.user && res.user.schoolId) {
-            setCurrentSchool(res.user.schoolId);
+          if (get(res, 'user.school.id')) {
+            const { name, city, state } = res.user.school;
+            setSchoolName(name);
+            setSchoolCity(city);
+            setSchoolState(state);
           }
 
           return (
             <Card
-              title={currentSchool ? 'Your School' : 'Find Your School'}
+              title={schoolName ? 'Your School' : 'Find Your School'}
               className="rounded bordered overflow-visible"
             >
-              {currentSchool ? (
-                <CurrentSchool schoolId={currentSchool} />
+              {schoolName ? (
+                <CurrentSchool
+                  name={schoolName}
+                  city={schoolCity}
+                  state={schoolState}
+                />
               ) : (
-                <UpdateSchool userId={userId} onSubmit={setCurrentSchool} />
+                <UpdateSchool
+                  userId={userId}
+                  onSubmit={(name, city, state) => {
+                    setSchoolName(name);
+                    setSchoolCity(city);
+                    setSchoolState(state);
+                  }}
+                />
               )}
             </Card>
           );

--- a/resources/assets/components/utilities/SchoolFinder/SchoolFinder.js
+++ b/resources/assets/components/utilities/SchoolFinder/SchoolFinder.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { get } from 'lodash';
 import gql from 'graphql-tag';
 import PropTypes from 'prop-types';
@@ -29,45 +29,25 @@ const SchoolFinder = ({ campaignId, userId }) => {
     return null;
   }
 
-  const [schoolName, setSchoolName] = useState(null);
-  const [schoolCity, setSchoolCity] = useState(null);
-  const [schoolState, setSchoolState] = useState(null);
-
   return (
     <div className="school-finder margin-bottom-lg margin-horizontal-md clear-both primary">
       <Query query={USER_SCHOOL_QUERY} variables={{ userId }}>
-        {res => {
-          if (get(res, 'user.school.id')) {
-            const { name, city, state } = res.user.school;
-            setSchoolName(name);
-            setSchoolCity(city);
-            setSchoolState(state);
-          }
-
-          return (
-            <Card
-              title={schoolName ? 'Your School' : 'Find Your School'}
-              className="rounded bordered overflow-visible"
-            >
-              {schoolName ? (
-                <CurrentSchool
-                  name={schoolName}
-                  city={schoolCity}
-                  state={schoolState}
-                />
-              ) : (
-                <UpdateSchool
-                  userId={userId}
-                  onSubmit={(name, city, state) => {
-                    setSchoolName(name);
-                    setSchoolCity(city);
-                    setSchoolState(state);
-                  }}
-                />
-              )}
-            </Card>
-          );
-        }}
+        {res => (
+          <Card
+            title={res.user.schoolId ? 'Your School' : 'Find Your School'}
+            className="rounded bordered overflow-visible"
+          >
+            {res.user.schoolId ? (
+              <CurrentSchool
+                name={get(res, 'user.school.name', null)}
+                city={get(res, 'user.school.city', null)}
+                state={get(res, 'user.school.state', null)}
+              />
+            ) : (
+              <UpdateSchool userId={userId} />
+            )}
+          </Card>
+        )}
       </Query>
     </div>
   );

--- a/resources/assets/components/utilities/SchoolFinder/SchoolSelect.js
+++ b/resources/assets/components/utilities/SchoolFinder/SchoolSelect.js
@@ -49,6 +49,7 @@ const SchoolSelect = ({ filterByState, onChange }) => {
         `${school.name} - ${school.city}, ${school.state}`
       }
       getOptionValue={school => school.id}
+      isClearable={true}
       loadOptions={(input, callback) => {
         // Avoid querying by empty school name on page load.
         // @see https://github.com/JedWatson/react-select/issues/614#issuecomment-380763225

--- a/resources/assets/components/utilities/SchoolFinder/SchoolSelect.js
+++ b/resources/assets/components/utilities/SchoolFinder/SchoolSelect.js
@@ -1,17 +1,44 @@
 import React from 'react';
 import { debounce } from 'lodash';
 import PropTypes from 'prop-types';
+import gql from 'graphql-tag';
 import AsyncSelect from 'react-select/async';
+
+import { env } from '../../../helpers';
+import graphqlClient from '../../../graphql';
+
+const SEARCH_SCHOOLS_QUERY = gql`
+  query SearchSchoolsQuery($state: String!, $name: String!) {
+    searchSchools(state: $state, name: $name) {
+      id
+      name
+      city
+      state
+    }
+  }
+`;
+
+/**
+ * Ideally would call useApolloClient() but it triggers an error Invariant Violation
+ * No Apollo Client instance.
+ *
+ * @see https://stackoverflow.com/a/57743861
+ */
+const client = graphqlClient(env('GRAPHQL_URL'));
 
 const SchoolSelect = ({ filterByState, onChange }) => {
   // Debounce school search to query for schools after 250 ms typing pause.
   // @see https://github.com/JedWatson/react-select/issues/614#issuecomment-244006496
   const debouncedFetch = debounce((searchString, callback) => {
-    fetch(
-      `https://lofischools.herokuapp.com/search?state=${filterByState}&query=${searchString}`,
-    )
-      .then(res => res.json())
-      .then(res => callback(res.results))
+    client
+      .query({
+        query: SEARCH_SCHOOLS_QUERY,
+        variables: {
+          state: filterByState,
+          name: searchString,
+        },
+      })
+      .then(res => callback(res.data.searchSchools))
       .catch(error => callback(error));
   }, 250);
 

--- a/resources/assets/components/utilities/SchoolFinder/SchoolSelect.js
+++ b/resources/assets/components/utilities/SchoolFinder/SchoolSelect.js
@@ -3,9 +3,7 @@ import { debounce } from 'lodash';
 import PropTypes from 'prop-types';
 import gql from 'graphql-tag';
 import AsyncSelect from 'react-select/async';
-
-import { env } from '../../../helpers';
-import graphqlClient from '../../../graphql';
+import { useApolloClient } from '@apollo/react-hooks';
 
 const SEARCH_SCHOOLS_QUERY = gql`
   query SearchSchoolsQuery($state: String!, $name: String!) {
@@ -19,13 +17,7 @@ const SEARCH_SCHOOLS_QUERY = gql`
 `;
 
 const SchoolSelect = ({ filterByState, onChange }) => {
-  /**
-   * Ideally would call useApolloClient() but it triggers an error Invariant Violation
-   * No Apollo Client instance.
-   *
-   * @see https://stackoverflow.com/a/57743861
-   */
-  const client = graphqlClient(env('GRAPHQL_URL'));
+  const client = useApolloClient();
   // Debounce school search to query for schools after 250 ms typing pause.
   // @see https://github.com/JedWatson/react-select/issues/614#issuecomment-244006496
   const debouncedFetch = debounce((searchString, callback) => {

--- a/resources/assets/components/utilities/SchoolFinder/SchoolSelect.js
+++ b/resources/assets/components/utilities/SchoolFinder/SchoolSelect.js
@@ -49,7 +49,7 @@ const SchoolSelect = ({ filterByState, onChange }) => {
         `${school.name} - ${school.city}, ${school.state}`
       }
       getOptionValue={school => school.id}
-      isClearable={true}
+      isClearable
       /**
        * Changing per filterByState will result in clearing any selected options.
        * If user selects a school, but then changes the school state to something else, they should

--- a/resources/assets/components/utilities/SchoolFinder/SchoolSelect.js
+++ b/resources/assets/components/utilities/SchoolFinder/SchoolSelect.js
@@ -18,17 +18,14 @@ const SEARCH_SCHOOLS_QUERY = gql`
   }
 `;
 
-/**
- * Ideally would call useApolloClient() but it triggers an error Invariant Violation
- * No Apollo Client instance.
- *
- * @see https://stackoverflow.com/a/57743861
- */
-const url = env('GRAPHQL_URL');
-console.log('debugging GraphQL URL:', url);
-const client = graphqlClient(url);
-
 const SchoolSelect = ({ filterByState, onChange }) => {
+  /**
+   * Ideally would call useApolloClient() but it triggers an error Invariant Violation
+   * No Apollo Client instance.
+   *
+   * @see https://stackoverflow.com/a/57743861
+   */
+  const client = graphqlClient(env('GRAPHQL_URL'));
   // Debounce school search to query for schools after 250 ms typing pause.
   // @see https://github.com/JedWatson/react-select/issues/614#issuecomment-244006496
   const debouncedFetch = debounce((searchString, callback) => {

--- a/resources/assets/components/utilities/SchoolFinder/SchoolSelect.js
+++ b/resources/assets/components/utilities/SchoolFinder/SchoolSelect.js
@@ -50,9 +50,18 @@ const SchoolSelect = ({ filterByState, onChange }) => {
       }
       getOptionValue={school => school.id}
       isClearable={true}
+      /**
+       * Changing per filterByState will result in clearing any selected options.
+       * If user selects a school, but then changes the school state to something else, they should
+       * be forced to find school in the selected state.
+       * @see https://stackoverflow.com/a/55142916
+       */
+      key={filterByState}
       loadOptions={(input, callback) => {
-        // Avoid querying by empty school name on page load.
-        // @see https://github.com/JedWatson/react-select/issues/614#issuecomment-380763225
+        /**
+         * Avoid querying by empty school name on page load.
+         * @see https://github.com/JedWatson/react-select/issues/614#issuecomment-380763225
+         */
         if (!input) {
           return Promise.resolve([]);
         }

--- a/resources/assets/components/utilities/SchoolFinder/SchoolSelect.js
+++ b/resources/assets/components/utilities/SchoolFinder/SchoolSelect.js
@@ -24,7 +24,9 @@ const SEARCH_SCHOOLS_QUERY = gql`
  *
  * @see https://stackoverflow.com/a/57743861
  */
-const client = graphqlClient(env('GRAPHQL_URL'));
+const url = env('GRAPHQL_URL');
+console.log('debugging GraphQL URL:', url);
+const client = graphqlClient(url);
 
 const SchoolSelect = ({ filterByState, onChange }) => {
   // Debounce school search to query for schools after 250 ms typing pause.

--- a/resources/assets/components/utilities/SchoolFinder/UpdateSchool.js
+++ b/resources/assets/components/utilities/SchoolFinder/UpdateSchool.js
@@ -17,7 +17,7 @@ const USER_SCHOOL_MUTATION = gql`
 `;
 
 const UpdateSchool = ({ onSubmit, userId }) => {
-  const [schoolId, setSchoolId] = useState(null);
+  const [school, setSchool] = useState(null);
   const [schoolState, setSchoolState] = useState(null);
 
   return (
@@ -33,18 +33,18 @@ const UpdateSchool = ({ onSubmit, userId }) => {
       {schoolState ? (
         <div className="select-school padded">
           <SchoolSelect
-            onChange={selected => setSchoolId(selected.gsid)}
+            onChange={selected => setSchool(selected)}
             filterByState={schoolState.abbreviation}
           />
         </div>
       ) : null}
       <Mutation
         mutation={USER_SCHOOL_MUTATION}
-        variables={{ schoolId, userId }}
-        update={() => onSubmit(schoolId)}
+        variables={{ schoolId: school ? school.id : null, userId }}
+        update={() => onSubmit(school.name, school.city, school.state)}
       >
         {userMutation => (
-          <Button onClick={userMutation} disabled={schoolId === null} attached>
+          <Button onClick={userMutation} disabled={!school} attached>
             Submit
           </Button>
         )}

--- a/resources/assets/components/utilities/SchoolFinder/UpdateSchool.js
+++ b/resources/assets/components/utilities/SchoolFinder/UpdateSchool.js
@@ -16,7 +16,7 @@ const USER_SCHOOL_MUTATION = gql`
   }
 `;
 
-const UpdateSchool = ({ onSubmit, userId }) => {
+const UpdateSchool = ({ userId }) => {
   const [school, setSchool] = useState(null);
   const [schoolState, setSchoolState] = useState(null);
 
@@ -38,13 +38,17 @@ const UpdateSchool = ({ onSubmit, userId }) => {
           />
         </div>
       ) : null}
-      <Mutation
-        mutation={USER_SCHOOL_MUTATION}
-        variables={{ schoolId: school ? school.id : null, userId }}
-        update={() => onSubmit(school.name, school.city, school.state)}
-      >
-        {userMutation => (
-          <Button onClick={userMutation} disabled={!school} attached>
+      <Mutation mutation={USER_SCHOOL_MUTATION}>
+        {userSchoolMutation => (
+          <Button
+            onClick={() =>
+              userSchoolMutation({
+                variables: { schoolId: school ? school.id : null, userId },
+              })
+            }
+            disabled={!school}
+            attached
+          >
             Submit
           </Button>
         )}
@@ -54,7 +58,6 @@ const UpdateSchool = ({ onSubmit, userId }) => {
 };
 
 UpdateSchool.propTypes = {
-  onSubmit: PropTypes.func.isRequired,
   userId: PropTypes.string.isRequired,
 };
 

--- a/resources/assets/components/utilities/SchoolFinder/UpdateSchool.js
+++ b/resources/assets/components/utilities/SchoolFinder/UpdateSchool.js
@@ -12,6 +12,11 @@ const USER_SCHOOL_MUTATION = gql`
     updateSchoolId(id: $userId, schoolId: $schoolId) {
       id
       schoolId
+      school {
+        name
+        city
+        state
+      }
     }
   }
 `;

--- a/resources/assets/components/utilities/SchoolFinder/UpdateSchool.js
+++ b/resources/assets/components/utilities/SchoolFinder/UpdateSchool.js
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import gql from 'graphql-tag';
 import PropTypes from 'prop-types';
-import { Mutation } from 'react-apollo';
+import { useMutation } from '@apollo/react-hooks';
 
 import Button from '../Button/Button';
 import SchoolSelect from './SchoolSelect';
@@ -13,6 +13,7 @@ const USER_SCHOOL_MUTATION = gql`
       id
       schoolId
       school {
+        id
         name
         city
         state
@@ -24,6 +25,7 @@ const USER_SCHOOL_MUTATION = gql`
 const UpdateSchool = ({ userId }) => {
   const [school, setSchool] = useState(null);
   const [schoolState, setSchoolState] = useState(null);
+  const [updateUserSchool] = useMutation(USER_SCHOOL_MUTATION);
 
   return (
     <React.Fragment>
@@ -43,21 +45,17 @@ const UpdateSchool = ({ userId }) => {
           />
         </div>
       ) : null}
-      <Mutation mutation={USER_SCHOOL_MUTATION}>
-        {userSchoolMutation => (
-          <Button
-            onClick={() =>
-              userSchoolMutation({
-                variables: { schoolId: school ? school.id : null, userId },
-              })
-            }
-            disabled={!school}
-            attached
-          >
-            Submit
-          </Button>
-        )}
-      </Mutation>
+      <Button
+        onClick={() =>
+          updateUserSchool({
+            variables: { schoolId: school ? school.id : null, userId },
+          })
+        }
+        disabled={!school}
+        attached
+      >
+        Submit
+      </Button>
     </React.Fragment>
   );
 };

--- a/resources/assets/components/utilities/SchoolFinder/UpdateSchool.js
+++ b/resources/assets/components/utilities/SchoolFinder/UpdateSchool.js
@@ -22,7 +22,7 @@ const USER_SCHOOL_MUTATION = gql`
   }
 `;
 
-const UpdateSchool = ({ userId }) => {
+const UpdateSchool = ({ onSubmit, userId }) => {
   const [school, setSchool] = useState(null);
   const [schoolState, setSchoolState] = useState(null);
   const [updateUserSchool] = useMutation(USER_SCHOOL_MUTATION);
@@ -46,11 +46,13 @@ const UpdateSchool = ({ userId }) => {
         </div>
       ) : null}
       <Button
-        onClick={() =>
+        onClick={() => {
           updateUserSchool({
             variables: { schoolId: school ? school.id : null, userId },
-          })
-        }
+          });
+          // TODO: We shouldn't need this onSubmit handler, should update via Mutation update.
+          onSubmit(school);
+        }}
         disabled={!school}
         attached
       >
@@ -61,6 +63,7 @@ const UpdateSchool = ({ userId }) => {
 };
 
 UpdateSchool.propTypes = {
+  onSubmit: PropTypes.func.isRequired,
   userId: PropTypes.string.isRequired,
 };
 


### PR DESCRIPTION
### What does this PR do?

This PR continues development on the School Finder by querying GraphQL for school information (per https://github.com/DoSomething/graphql/pull/152 and https://github.com/DoSomething/graphql/pull/154) instead of the legacy [lofi-schools](https://github.com/DoSomething/lofi-schools-flask) app.

### Any background context you want to provide?

Still a few features left to add before this is ready for screenshots/visual review:

* Adding  "My school isn't available" checkbox + saving `school-not-available` to user's `school_id` field 
* Modal for searching tips

Writing Cypress tests for school finder is a bit tricky. Our best bet could be to create a new user for each test, to avoid needing to hardcore user ID's (and continuously unset / set their `school_id` values)

### What are the relevant tickets/cards?

* https://www.pivotaltracker.com/story/show/169549547
* https://www.pivotaltracker.com/story/show/169549488

### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.
