### PR TITLE
Gallery Card Styling - Pages & Content Blocks

### DIFF
--- a/resources/assets/components/utilities/Gallery/templates/CampaignGalleryItem/CampaignGalleryItem.js
+++ b/resources/assets/components/utilities/Gallery/templates/CampaignGalleryItem/CampaignGalleryItem.js
@@ -12,10 +12,7 @@ const CampaignGalleryItem = ({
   slug,
 }) => (
   <Card className="rounded">
-    <a
-      className="campaign-gallery-item block card border"
-      href={`/us/campaigns/${slug}`}
-    >
+    <a className="campaign-gallery-item block" href={`/us/campaigns/${slug}`}>
       <Figure
         alt={`${showcaseImage.description || showcaseTitle}-photo`}
         image={contentfulImageUrl(showcaseImage.url, '800', '450', 'fill')}

--- a/resources/assets/components/utilities/Gallery/templates/ContentBlockGalleryItem.js
+++ b/resources/assets/components/utilities/Gallery/templates/ContentBlockGalleryItem.js
@@ -1,7 +1,9 @@
 import React from 'react';
 import get from 'lodash/get';
 import PropTypes from 'prop-types';
+import classNames from 'classnames';
 
+import Card from '../../Card/Card';
 import { Figure } from '../../Figure/Figure';
 import TextContent from '../../TextContent/TextContent';
 import { contentfulImageUrl } from '../../../../helpers';
@@ -13,29 +15,38 @@ const ContentBlockGalleryItem = ({
   imageAlignment,
   imageFit,
 }) => {
+  const leftAligned = imageAlignment === 'left';
   // Image formatting needs to be smaller if they are left-aligned.
-  const imageFormatting = imageAlignment === 'left' ? '100' : '400';
+  const imageFormatting = leftAligned ? ['100', '100'] : ['800', '450'];
+
   // Ensure we don't pass the unsupported 'top' as the alignment prop to Figure.
   // @TODO (11/01/2018) Update this logic once we refactor the Figure component!
-  const alignment = imageAlignment === 'top' ? null : imageAlignment;
+  const alignment = leftAligned ? imageAlignment : undefined;
 
-  return (
+  const galleryItem = (
     <Figure
       alt={showcaseImage.description || `${showcaseTitle}-photo`}
       image={contentfulImageUrl(
         get(showcaseImage, 'url'),
-        imageFormatting,
-        imageFormatting,
+        ...imageFormatting,
         imageFit,
       )}
       alignment={alignment}
     >
-      <h4>{showcaseTitle}</h4>
+      <div className={classNames({ 'm-4': !leftAligned })}>
+        <h4>{showcaseTitle}</h4>
 
-      {showcaseDescription ? (
-        <TextContent>{showcaseDescription}</TextContent>
-      ) : null}
+        {showcaseDescription ? (
+          <TextContent>{showcaseDescription}</TextContent>
+        ) : null}
+      </div>
     </Figure>
+  );
+
+  return leftAligned ? (
+    galleryItem
+  ) : (
+    <Card className="card">{galleryItem}</Card>
   );
 };
 

--- a/resources/assets/components/utilities/Gallery/templates/PageGalleryItem/PageGalleryItem.js
+++ b/resources/assets/components/utilities/Gallery/templates/PageGalleryItem/PageGalleryItem.js
@@ -2,6 +2,7 @@ import React from 'react';
 import get from 'lodash/get';
 import PropTypes from 'prop-types';
 
+import Card from '../../../Card/Card';
 import { Figure } from '../../../Figure/Figure';
 import { contentfulImageUrl } from '../../../../../helpers';
 
@@ -11,22 +12,26 @@ const PageGalleryItem = ({
   showcaseImage,
   slug,
 }) => (
-  <a className="page-gallery-item block" href={`/us/${slug}`}>
-    <Figure
-      alt={`${showcaseImage.description || showcaseTitle}-photo`}
-      image={contentfulImageUrl(
-        get(showcaseImage, 'url'),
-        '400',
-        '400',
-        'fill',
-      )}
-    >
-      <h4>{showcaseTitle}</h4>
-      {showcaseDescription ? (
-        <p className="font-normal">{showcaseDescription}</p>
-      ) : null}
-    </Figure>
-  </a>
+  <Card className="rounded">
+    <a className="page-gallery-item block" href={`/us/${slug}`}>
+      <Figure
+        alt={`${showcaseImage.description || showcaseTitle}-photo`}
+        image={contentfulImageUrl(
+          get(showcaseImage, 'url'),
+          '800',
+          '450',
+          'fill',
+        )}
+      >
+        <div className="m-4">
+          <h4 className="text-blue-500">{showcaseTitle}</h4>
+          {showcaseDescription ? (
+            <p className="font-normal">{showcaseDescription}</p>
+          ) : null}
+        </div>
+      </Figure>
+    </a>
+  </Card>
 );
 
 PageGalleryItem.propTypes = {


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR adds the Card styling introduced in #1691 for Page and (top-aligned) Content Block gallery nodes.

### Any background context you want to provide?
You'll notice the already tricky `ContentBlockGalleryItem` got a tad trickier. This is because we're supporting essentially two templates in one, though the markup is so similar it was hard to justify two separate templates, at least before. I _think_ we can save the refactoring to perhaps a more general refactoring of our gallery nodes, which can hopefully be consolidated into a more centralized component at some point. (which was our ultimate goal way back when https://github.com/DoSomething/phoenix-next/pull/1160#pullrequestreview-170737314 hashtag roadmaps).

### What are the relevant tickets/cards?

Refs [Pivotal ID #169325037](https://www.pivotaltracker.com/story/show/169325037)

### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.
* [ ] Added screenshot to PR description of related front-end updates on **small** screens.
* [ ] Added screenshot to PR description of related front-end updates on **medium** screens.
* [x] Added screenshot to PR description of related front-end updates on **large** screens.

📸 
- [Before](https://user-images.githubusercontent.com/12417657/68607366-75627a80-047e-11ea-91cc-9122c985bda3.png)
- [After](https://user-images.githubusercontent.com/12417657/68607411-8f03c200-047e-11ea-92dc-151e76fdfa9b.png)

(Same across breakpoints)