### PR TITLE
Rich Text Font Size

### DIFF
--- a/resources/assets/components/pages/CausePage/CausePage.js
+++ b/resources/assets/components/pages/CausePage/CausePage.js
@@ -32,7 +32,7 @@ const CausePage = ({ coverImage, superTitle, title, description, content }) => {
             <h1 className="lede-banner__headline-title my-4 font-normal font-secondary color-white caps-lock">
               {title}
             </h1>
-            <TextContent styles={{ textColor: '#FFF' }}>
+            <TextContent styles={{ textColor: '#FFF', fontSize: '21px' }}>
               {/* @TODO: update font size of discription */}
               {description}
             </TextContent>

--- a/resources/assets/components/pages/CausePage/CausePage.js
+++ b/resources/assets/components/pages/CausePage/CausePage.js
@@ -33,7 +33,6 @@ const CausePage = ({ coverImage, superTitle, title, description, content }) => {
               {title}
             </h1>
             <TextContent styles={{ textColor: '#FFF', fontSize: '21px' }}>
-              {/* @TODO: update font size of discription */}
               {description}
             </TextContent>
           </div>

--- a/resources/assets/components/utilities/TextContent/RichTextDocument.js
+++ b/resources/assets/components/utilities/TextContent/RichTextDocument.js
@@ -38,6 +38,7 @@ RichTextDocument.propTypes = {
   styles: PropTypes.shape({
     textColor: PropTypes.string,
     hyperlinkColor: PropTypes.string,
+    fontSize: PropTypes.string,
   }),
 };
 

--- a/resources/assets/components/utilities/TextContent/TextContent.js
+++ b/resources/assets/components/utilities/TextContent/TextContent.js
@@ -51,6 +51,7 @@ TextContent.propTypes = {
   styles: PropTypes.shape({
     textColor: PropTypes.string,
     hyperlinkColor: PropTypes.string,
+    fontSize: PropTypes.string,
   }),
 };
 

--- a/resources/assets/helpers/text.js
+++ b/resources/assets/helpers/text.js
@@ -77,6 +77,7 @@ export function parseRichTextDocument(
 ) {
   const hyperlinkColor = get(styles, 'hyperlinkColor', null);
   const textColor = get(styles, 'textColor', null);
+  const fontSize = get(styles, 'fontSize', null);
 
   const options = {
     renderNode: {
@@ -132,7 +133,7 @@ export function parseRichTextDocument(
         children[0] ? (
           <p
             className={classnames(classNameByEntryDefault)}
-            style={{ color: textColor }}
+            style={{ color: textColor, fontSize }}
           >
             {children}
           </p>


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR adds the option to customize `font-size` for rich text rendered content via a new `styles.fontSize` option.

### Any background context you want to provide?
This will specifically apply to `<p>` tags (and by extension, links, formatted text and lists which are rendered inside `<p>` tags)

We wanted to bump the font size for the Cause Page description field which is a Rich text field.

### What are the relevant tickets/cards?

Refs [Pivotal ID #169325037](https://www.pivotaltracker.com/story/show/169325037)

### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.
* [ ] Added screenshot to PR description of related front-end updates on **small** screens.
* [ ] Added screenshot to PR description of related front-end updates on **medium** screens.
* [x] Added screenshot to PR description of related front-end updates on **large** screens.

📸 
- [Before](https://user-images.githubusercontent.com/12417657/68612451-9335dc80-048a-11ea-912f-ff0a4fd12312.png)
- [After](https://user-images.githubusercontent.com/12417657/68612473-9d57db00-048a-11ea-9590-83fe13d0aed8.png)
