### PR TITLE
Cause Page - set grid columns for Content blocks

### DIFF
--- a/resources/assets/components/pages/CausePage/CausePage.js
+++ b/resources/assets/components/pages/CausePage/CausePage.js
@@ -42,6 +42,7 @@ const CausePage = ({ coverImage, superTitle, title, description, content }) => {
           className="base-12-grid"
           classNameByEntry={{
             GalleryBlock: 'grid-full',
+            ContentBlock: 'content-block-grid',
           }}
         >
           {content}

--- a/resources/assets/components/pages/CausePage/cause-page.scss
+++ b/resources/assets/components/pages/CausePage/cause-page.scss
@@ -27,4 +27,12 @@
       }
     }
   }
+
+  .content-block-grid {
+    grid-column: full-start / full-end;
+
+    @include media($large) {
+      grid-column: full-start / -5;
+    }
+  }
 }


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR sets the `grid-column` styling for Content Blocks in Cause Page content. 
I couldn't figure out where this custom grid styling fit in to our existing scheme, so I scoped it to the `.cause-page` styling. I also couldn't think of a better class name than `content-block-grid` because I'm a creative 😢

### What are the relevant tickets/cards?

Refs [Pivotal ID #169325037](https://www.pivotaltracker.com/story/show/169325037)
[Slack discussion](https://dosomething.slack.com/archives/C3ASB4204/p1573499042209300)
### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.
* [x] Added screenshot to PR description of related front-end updates on **small** screens.
* [x] Added screenshot to PR description of related front-end updates on **medium** screens.
* [x] Added screenshot to PR description of related front-end updates on **large** screens.

📸 
- [Large](https://user-images.githubusercontent.com/12417657/68619125-d139fd00-0498-11ea-928a-84ea49a7f2c5.png)
- [Medium](https://user-images.githubusercontent.com/12417657/68619160-e44ccd00-0498-11ea-97b5-b7ada45bb9d9.png)
- [Small](https://user-images.githubusercontent.com/12417657/68619177-eca50800-0498-11ea-863b-71d448dadfe3.png)
