### PR TITLE
Revert Card styling for Content Block gallery items

### DIFF
--- a/resources/assets/components/utilities/Gallery/templates/ContentBlockGalleryItem.js
+++ b/resources/assets/components/utilities/Gallery/templates/ContentBlockGalleryItem.js
@@ -1,9 +1,7 @@
 import React from 'react';
 import get from 'lodash/get';
 import PropTypes from 'prop-types';
-import classNames from 'classnames';
 
-import Card from '../../Card/Card';
 import { Figure } from '../../Figure/Figure';
 import TextContent from '../../TextContent/TextContent';
 import { contentfulImageUrl } from '../../../../helpers';
@@ -17,13 +15,13 @@ const ContentBlockGalleryItem = ({
 }) => {
   const leftAligned = imageAlignment === 'left';
   // Image formatting needs to be smaller if they are left-aligned.
-  const imageFormatting = leftAligned ? ['100', '100'] : ['800', '450'];
+  const imageFormatting = leftAligned ? ['100', '100'] : ['400', '400'];
 
   // Ensure we don't pass the unsupported 'top' as the alignment prop to Figure.
   // @TODO (11/01/2018) Update this logic once we refactor the Figure component!
   const alignment = leftAligned ? imageAlignment : undefined;
 
-  const galleryItem = (
+  return (
     <Figure
       alt={showcaseImage.description || `${showcaseTitle}-photo`}
       image={contentfulImageUrl(
@@ -33,20 +31,12 @@ const ContentBlockGalleryItem = ({
       )}
       alignment={alignment}
     >
-      <div className={classNames({ 'm-4': !leftAligned })}>
-        <h4>{showcaseTitle}</h4>
+      <h4>{showcaseTitle}</h4>
 
-        {showcaseDescription ? (
-          <TextContent>{showcaseDescription}</TextContent>
-        ) : null}
-      </div>
+      {showcaseDescription ? (
+        <TextContent>{showcaseDescription}</TextContent>
+      ) : null}
     </Figure>
-  );
-
-  return leftAligned ? (
-    galleryItem
-  ) : (
-    <Card className="card">{galleryItem}</Card>
   );
 };
 


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR reverts the change in 5ee04bc562da0d784a6633090e0cc2815ba677de to add card styling to Content Block Gallery Items with a `top` aligned image.

### Any background context you want to provide?
Due to the (unfortunately) multifaceted nature of the Content Block gallery items, we observed negative downstream styling effects from this change discussed [here in Slack](https://dosomething.slack.com/archives/C3ASB4204/p1573576498225800)

We're accepting the compromise of external links in a gallery (the content block use case we were after) to _not_ have the card styling.

### What are the relevant tickets/cards?
https://dosomething.slack.com/archives/C3ASB4204/p1573576498225800

### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.
* [ ] Added screenshot to PR description of related front-end updates on **small** screens.
* [ ] Added screenshot to PR description of related front-end updates on **medium** screens.
* [x] Added screenshot to PR description of related front-end updates on **large** screens.

📸 
- [Bad Before](https://user-images.githubusercontent.com/12417657/68703834-5be23100-0559-11ea-8996-9d538fda7892.png)

- [Good After](https://user-images.githubusercontent.com/12417657/68703792-4bca5180-0559-11ea-8a06-2a30a6d0acbe.png)

- [Good Before](https://user-images.githubusercontent.com/12417657/68703900-74eae200-0559-11ea-89be-b35a6a90d670.png)
- [Compromise After](https://user-images.githubusercontent.com/12417657/68703922-79af9600-0559-11ea-8797-45ea1208e443.png)
