### PR TITLE
Quick Content Block Configuration

### DIFF
--- a/resources/assets/components/blocks/ContentBlock/ContentBlock.js
+++ b/resources/assets/components/blocks/ContentBlock/ContentBlock.js
@@ -66,7 +66,7 @@ ContentBlock.propTypes = {
   image: PropTypes.shape({
     url: PropTypes.string,
     description: PropTypes.string,
-  }).isRequired,
+  }),
   imageAlignment: PropTypes.oneOf(['RIGHT', 'LEFT']),
   superTitle: PropTypes.string,
   title: PropTypes.string,
@@ -74,6 +74,7 @@ ContentBlock.propTypes = {
 
 ContentBlock.defaultProps = {
   className: null,
+  image: {},
   imageAlignment: 'RIGHT',
   superTitle: null,
   title: null,


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR updates the `ContentBlock` components `image` prop to be optional.

### Any background context you want to provide?
Previously, we were assuming a constantly present `image` object because of the [`ContentBlock` PHP entity](https://github.com/DoSomething/phoenix-next/blob/afcbddb98fc233d79fc8ce975ae9d6367014dfc8/app/Entities/ContentBlock.php#L24-L27) on the backend. 

But for content blocks queried via GraphQL, since this is an optional field, this could cause breakage. (It's a detail I missed in #1681 )