### PR TITLE
Add grid column assignment class to badges page

### DIFF
--- a/resources/assets/components/pages/AccountPage/BadgesTab.js
+++ b/resources/assets/components/pages/AccountPage/BadgesTab.js
@@ -154,6 +154,7 @@ class BadgesTab extends React.Component {
     const { userId } = this.props;
 
     return (
+      // @TODO: Update heading etc. to align with other Account pages per https://github.com/DoSomething/phoenix-next/pull/1686
       <div className="grid-wide-2/3 bg-gray padding-bottom-lg wrapper">
         <h2 className="caps-lock league-gothic -sm">Your Badges</h2>
         <div className="margin-top-lg float-left">

--- a/resources/assets/components/pages/AccountPage/BadgesTab.js
+++ b/resources/assets/components/pages/AccountPage/BadgesTab.js
@@ -154,7 +154,7 @@ class BadgesTab extends React.Component {
     const { userId } = this.props;
 
     return (
-      <div className="bg-gray padding-bottom-lg wrapper">
+      <div className="grid-wide-2/3 bg-gray padding-bottom-lg wrapper">
         <h2 className="caps-lock league-gothic -sm">Your Badges</h2>
         <div className="margin-top-lg float-left">
           <div className="margin-top-lg">


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR adds a grid column utility class to the Badges page.

### Any background context you want to provide?
We've swapped the Account pages to the grid in #1686 so just getting the badges page up to speed!

### What are the relevant tickets/cards?
https://dosomething.slack.com/archives/C3ASB4204/p1573599317240100

**Before**
![image](https://user-images.githubusercontent.com/12417657/68780852-dd42cd80-0604-11ea-8309-a93ae386ef69.png)

**After**
![image](https://user-images.githubusercontent.com/12417657/68780889-ef247080-0604-11ea-9b86-8d48d38c4a67.png)
