### PR TITLE
updates deadline functionality for campaign info card

### DIFF
--- a/resources/assets/components/blocks/CampaignInfoBlock/CampaignInfoBlock.js
+++ b/resources/assets/components/blocks/CampaignInfoBlock/CampaignInfoBlock.js
@@ -42,14 +42,16 @@ const CampaignInfoBlock = ({ campaignId, scholarshipAmount }) => (
 
           return (
             <>
-              <dt>Deadline</dt>
-              <dd>
-                {endDate
-                  ? format(String(endDate), 'MMMM do, yyyy', {
+              {endDate ? (
+                <>
+                  <dt>Deadline</dt>
+                  <dd>
+                    {format(String(endDate), 'MMMM do, yyyy', {
                       awareOfUnicodeTokens: true,
-                    })
-                  : 'Evergreen'}
-              </dd>
+                    })}
+                  </dd>
+                </>
+              ) : null}
               {action && action.timeCommitmentLabel ? (
                 <React.Fragment>
                   <dt>Time</dt>


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR updates functionality on the campaign info card for the hero template. When there is no end date for a campaign, we don't want to display anything. Currently, we are displaying 'evergreen' in place of the date.

### Any background context you want to provide?

Updating based on feedback from the design team!

### What are the relevant tickets/cards?

Refs [Pivotal ID #169740537](https://www.pivotaltracker.com/story/show/169740537)

Before:
![Screen Shot 2019-11-13 at 3 07 00 PM](https://user-images.githubusercontent.com/15236023/68800011-489d9700-0627-11ea-8735-8f0e6c6b196a.png)

After:
![Screen Shot 2019-11-13 at 3 05 42 PM](https://user-images.githubusercontent.com/15236023/68799934-1ab85280-0627-11ea-961a-d3462530f73f.png)

### Checklist

* [x] Added screenshot to PR description of related front-end updates on **small** screens.
* [x] Added screenshot to PR description of related front-end updates on **medium** screens.
* [x] Added screenshot to PR description of related front-end updates on **large** screens.
