### PR TITLE
Update Cause Page title font utility class

### DIFF
--- a/resources/assets/components/pages/CausePage/CausePage.js
+++ b/resources/assets/components/pages/CausePage/CausePage.js
@@ -29,7 +29,7 @@ const CausePage = ({ coverImage, superTitle, title, description, content }) => {
         >
           <div className="title-lockup my-8">
             <h2 className="my-4 uppercase color-white text-lg">{superTitle}</h2>
-            <h1 className="lede-banner__headline-title my-4 font-normal font-secondary color-white caps-lock">
+            <h1 className="lede-banner__headline-title my-4 font-normal font-league-gothic color-white caps-lock">
               {title}
             </h1>
             <TextContent styles={{ textColor: '#FFF', fontSize: '21px' }}>


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR updates the `CausePage` title to use the Tailwind supported `.font-league-gothic` class.

### Any background context you want to provide?
This was a lil 👾 from https://github.com/DoSomething/phoenix-next/pull/1695 where we retired the legacy temp Tailwind replacement classes

### What are the relevant tickets/cards?
https://dosomething.slack.com/archives/C3ASB4204/p1573684492263900