### PR TITLE
Quick fix for broken styles on Pitch Page.

### DIFF
--- a/resources/assets/components/pages/LandingPage/templates/PitchTemplate.js
+++ b/resources/assets/components/pages/LandingPage/templates/PitchTemplate.js
@@ -38,9 +38,9 @@ const PitchTemplate = ({
         showPartnerMsgOptIn={showPartnerMsgOptIn}
       />
 
-      <div className="clearfix bg-white">
-        <Enclosure className="md:w-3/4 mx-auto mt-6 px-3 pitch-landing-page">
-          <div className="campaign-page">
+      <div className="bg-white">
+        <Enclosure className="md:w-3/4 mx-auto py-6 px-3 pitch-landing-page">
+          <div className="campaign-page clearfix">
             <div className="primary">
               {displayAffiliateScholarshipBlock ? (
                 <AffiliateScholarshipBlockQuery


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR fixes a styling bug that appeared after the Tailwind activation and switching around of classes in #1695. Thanks for spotting it @mendelB 🙌 

### Any background context you want to provide?

Fixes the Pitch Page layout to add missing spacing at bottom of content before the call-to-action. It switches to also using padding instead of margins and adds appropriate clearfix, since the primary and secondary items are floated on larger sizes.

### What are the relevant tickets/cards?

Refs [Pivotal ID #169578779](https://www.pivotaltracker.com/story/show/169578779)