### PR TITLE
Cause Page - better error handling

### DIFF
--- a/resources/assets/components/pages/CausePage/CausePageQuery.js
+++ b/resources/assets/components/pages/CausePage/CausePageQuery.js
@@ -1,11 +1,14 @@
 import React from 'react';
 import gql from 'graphql-tag';
 import PropTypes from 'prop-types';
+import { Query as ApolloQuery } from 'react-apollo';
 
-import Query from '../../Query';
 import CausePage from './CausePage';
+import ErrorPage from '../ErrorPage';
 import { env } from '../../../helpers';
 import NotFoundPage from '../NotFoundPage';
+import { NetworkStatus } from '../../../constants';
+import Placeholder from '../../utilities/Placeholder';
 
 const CAUSE_PAGE_QUERY = gql`
   query CausePageQuery($slug: String!, $preview: Boolean!) {
@@ -23,14 +26,32 @@ const CAUSE_PAGE_QUERY = gql`
 `;
 
 const CausePageQuery = ({ slug }) => (
-  <Query
-    query={CAUSE_PAGE_QUERY}
-    variables={{ slug, preview: env('CONTENTFUL_USE_PREVIEW_API') }}
-  >
-    {({ causePageBySlug }) =>
-      causePageBySlug ? <CausePage {...causePageBySlug} /> : <NotFoundPage />
-    }
-  </Query>
+  <>
+    <ApolloQuery
+      query={CAUSE_PAGE_QUERY}
+      variables={{ slug, preview: env('CONTENTFUL_USE_PREVIEW_API') }}
+      notifyOnNetworkStatusChange
+    >
+      {result => {
+        // On initial load, just display a loading spinner.
+        if (result.networkStatus === NetworkStatus.LOADING) {
+          return <Placeholder />;
+        }
+
+        if (result.error) {
+          return <ErrorPage />;
+        }
+
+        const { causePageBySlug } = result.data;
+
+        return causePageBySlug ? (
+          <CausePage {...causePageBySlug} />
+        ) : (
+          <NotFoundPage />
+        );
+      }}
+    </ApolloQuery>
+  </>
 );
 
 CausePageQuery.propTypes = {

--- a/resources/assets/components/pages/ErrorPage.js
+++ b/resources/assets/components/pages/ErrorPage.js
@@ -1,0 +1,45 @@
+import React from 'react';
+
+import SiteNavigationContainer from '../SiteNavigation/SiteNavigationContainer';
+
+const ErrorPage = () => (
+  <>
+    <SiteNavigationContainer />
+
+    <main role="main" className="py-20">
+      <article className="max-w-xl mx-auto text-center px-4 leading-relaxed mb-8">
+        <header className="mb-8">
+          <h2 className="text-purple-900 text-xl md:text-2xl mb-2">
+            Something went wrong.
+          </h2>
+
+          <h3 className="text-lg">
+            We&apos;ve noted the problem & will get it fixed soon!
+          </h3>
+        </header>
+
+        <p className="mb-8">
+          Try doing the same thing again - it may work the second time! If not,
+          we&apos;ve already noted the problem and our tech team will get it
+          fixed as soon as possible! You can also find ways to{' '}
+          <a href="/us/campaigns?utm_source=500">Take Action</a> and join a
+          movement of 5 million young people making an impact in their
+          communities.
+        </p>
+
+        <p className="text-sm text-gray-800 m-0">
+          If you continue to run into problems, contact our{' '}
+          <a
+            href="https://help.dosomething.org"
+            className="font-semibold text-gray-800 hover:text-gray-400 underline"
+          >
+            support squad
+          </a>
+          !
+        </p>
+      </article>
+    </main>
+  </>
+);
+
+export default ErrorPage;

--- a/resources/views/app.blade.php
+++ b/resources/views/app.blade.php
@@ -2,12 +2,8 @@
 
 @section('content')
     <div id="app">
-        <div class="flex wrapper">
-            <div class="flex__cell">
-                <div class="placeholder">
-                    <div class="spinner"></div>
-                </div>
-            </div>
+        <div class="placeholder">
+            <div class="spinner"></div>
         </div>
     </div>
 @endsection

--- a/resources/views/errors/500.blade.php
+++ b/resources/views/errors/500.blade.php
@@ -17,8 +17,8 @@
                 Try doing the same thing again - it may work the second time! If not, we've already noted
                 the problem and our tech team will get it fixed as soon as possible!
 
-                You can also try <a href="{{ url('/us/campaigns/grab-mic?utm_source=500') }}">Grab the Mic</a>
-                and join our movement to create the most civically active generation ever.
+                You can also find ways to <a href="{{ url('/us/campaigns?utm_source=500') }}">Take Action</a>
+                and join a movement of 5 million young people making an impact in their communities.
             </p>
 
             {{-- @TODO:forge-removal Remove margin reset once Forge is removed. --}}


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR updates the `CausePageQuery` to better handle errors and loading time as a full-page by swapping our usage of the in house `Query` component (which is better served for block level querying, for the Apollo one, along with some updates) (https://github.com/DoSomething/phoenix-next/commit/025da192688b2d7d9ff0e050541ddce17481ee3e):

#### Previously
The `Query` component, while waiting for GraphQL to load the page, we'd be met with an awkwardly loading spinner:
![image](https://user-images.githubusercontent.com/12417657/68891291-887b8180-06ee-11ea-9ab8-e86a05b3faad.png)


Using the `Placeholder` component instead worked like a charm ☺️ 
![image](https://user-images.githubusercontent.com/12417657/68891449-d42e2b00-06ee-11ea-928f-31930ba958e4.png)


We also didn't handle errors all that well, since the `Query` outputs an `ErrorBlock` which doesn't look its best in a full page:
![image](https://user-images.githubusercontent.com/12417657/68891266-7e598300-06ee-11ea-914c-bfc474f765c1.png)

So we introduce an `ErrorPage` component in cf4fea5 a la the [`NotFoundPage`](https://github.com/DoSomething/phoenix-next/blob/4dcb30e6540253f406a21de45a0c531d53c43778/resources/assets/components/pages/NotFoundPage.js) we've already introduced to solve this issue for a not found cause page.
![image](https://user-images.githubusercontent.com/12417657/68891579-10618b80-06ef-11ea-83a8-61108fd17c6b.png)


And then there were a couple of minor updates like
- https://github.com/DoSomething/phoenix-next/commit/6bdd3a6f5c2c48e64ce73bf90177e61d127f9ada something I noticed while testing the placeholder spinner we use on the backend `app.blade` -- on mobile the loader would render to the side due to the `flex__cell` it was assigned (📸 [here](https://user-images.githubusercontent.com/12417657/68891869-bc0adb80-06ef-11ea-97fa-18a50ec6de04.png)). But we already get all the styling we need due to the [`.placeholder`](https://github.com/DoSomething/phoenix-next/blob/a24afa6b89306bb856ab34890654dfa61850cabe/resources/assets/scss/placeholder.scss#L3-L11) class, so I just removed some of the markup and [it's Gucci](https://user-images.githubusercontent.com/12417657/68892005-ff654a00-06ef-11ea-94b6-dbec449b0ec2.png)
- 953db146cc03a21c19153c5153dce12c6ed4163a The `500.blade` was still using legacy copy and link for the Grab the Mic campaign, so I swapped it to the new link & copy (https://github.com/DoSomething/phoenix-next/pull/1572)

I think this will be super helpful for the Collections Page as well! Hopefully we'll be able to abstract this query component into something generally useful for any graphql full page query!
### What are the relevant tickets/cards?

Refs [Pivotal ID #169325037](https://www.pivotaltracker.com/story/show/169325037)

### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.