### PR TITLE
Cleaning up and removing manually added Tailwind margin classes. 🧼

### DIFF
--- a/resources/assets/components/SiteNavigation/SiteNavigationFeature.js
+++ b/resources/assets/components/SiteNavigation/SiteNavigationFeature.js
@@ -11,7 +11,7 @@ const SiteNavigationFeature = ({
   url,
 }) => (
   <a href={url} className="main-subnav__feature" onClick={callback}>
-    <img className="mb-4" src={imageSrc} alt={imageAlt} />
+    <img className="mb-3" src={imageSrc} alt={imageAlt} />
 
     <h1 className="main-subnav__feature-title">{title}</h1>
 

--- a/resources/assets/components/blocks/CampaignInfoBlock/CampaignInfoBlock.js
+++ b/resources/assets/components/blocks/CampaignInfoBlock/CampaignInfoBlock.js
@@ -28,7 +28,8 @@ const CAMPAIGN_INFO_QUERY = gql`
 
 const CampaignInfoBlock = ({ campaignId, scholarshipAmount }) => (
   <Card className="bordered p-3 rounded campaign-info">
-    <h1 className="mb-4 text-lg uppercase">Campaign Info</h1>
+    <h1 className="mb-3 text-lg uppercase">Campaign Info</h1>
+
     <dl className="clearfix">
       <Query query={CAMPAIGN_INFO_QUERY} variables={{ campaignId }}>
         {res => {

--- a/resources/assets/components/blocks/GalleryBlock/GalleryBlock.js
+++ b/resources/assets/components/blocks/GalleryBlock/GalleryBlock.js
@@ -107,7 +107,7 @@ const GalleryBlock = props => {
   return (
     <div className="gallery-block">
       {title ? <SectionHeader underlined title={title} /> : null}
-      <Gallery type={galleryType} className="expand-horizontal-md mt-4">
+      <Gallery type={galleryType} className="expand-horizontal-md mt-3">
         {blocks.map(block =>
           renderBlock(
             block,

--- a/resources/assets/components/pages/AccountPage/BadgesTab.js
+++ b/resources/assets/components/pages/AccountPage/BadgesTab.js
@@ -155,7 +155,7 @@ class BadgesTab extends React.Component {
 
     return (
       <div className="grid-wide bg-gray pb-6 wrapper">
-        <h2 className="mb-4">Your Badges</h2>
+        <h2 className="mb-3">Your Badges</h2>
         <ul className="gallery-grid-sextet">
           <Query query={SIGNUP_COUNT_BADGE} variables={{ userId }}>
             {data => (

--- a/resources/assets/components/pages/AccountPage/FormItem.js
+++ b/resources/assets/components/pages/AccountPage/FormItem.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const FormItem = props => (
-  <div className="mt-8">
+  <div className="mt-6">
     <h5>{props.title}</h5>
     <p>{props.value}</p>
   </div>

--- a/resources/assets/components/pages/AccountPage/Profile.js
+++ b/resources/assets/components/pages/AccountPage/Profile.js
@@ -43,7 +43,7 @@ const Profile = props => (
     </div>
     <div className="grid-wide-1/3 pb-6">
       <h3>Data and Privacy</h3>
-      <ul className="mt-4">
+      <ul className="mt-3">
         <li>
           <a
             href="mailto:trust@dosomething.org?subject=Delete my account"
@@ -55,7 +55,7 @@ const Profile = props => (
       </ul>
 
       <h3>Administration</h3>
-      <ul className="mt-4">
+      <ul className="mt-3">
         <li>
           <a
             href="/deauthorize"

--- a/resources/assets/components/pages/AccountPage/UserPostsQuery.js
+++ b/resources/assets/components/pages/AccountPage/UserPostsQuery.js
@@ -22,7 +22,7 @@ const USER_POSTS_QUERY = gql`
 
 const UserPostsQuery = ({ userId }) => (
   <div className="grid-wide">
-    <h2 className="mb-4">Your Uploads</h2>
+    <h2 className="mb-3">Your Uploads</h2>
     <PaginatedQuery
       query={USER_POSTS_QUERY}
       queryName="postsByUserId"

--- a/resources/assets/components/pages/CausePage/CausePage.js
+++ b/resources/assets/components/pages/CausePage/CausePage.js
@@ -27,9 +27,9 @@ const CausePage = ({ coverImage, superTitle, title, description, content }) => {
           className="lede-banner base-12-grid"
           style={withoutNulls(styles)}
         >
-          <div className="title-lockup my-8">
-            <h2 className="my-4 uppercase color-white text-lg">{superTitle}</h2>
-            <h1 className="lede-banner__headline-title my-4 font-normal font-league-gothic color-white caps-lock">
+          <div className="title-lockup my-6">
+            <h2 className="my-3 uppercase color-white text-lg">{superTitle}</h2>
+            <h1 className="lede-banner__headline-title my-3 font-normal font-league-gothic color-white caps-lock">
               {title}
             </h1>
             <TextContent styles={{ textColor: '#FFF', fontSize: '21px' }}>

--- a/resources/assets/components/utilities/CtaBanner/CtaBanner.js
+++ b/resources/assets/components/utilities/CtaBanner/CtaBanner.js
@@ -23,11 +23,11 @@ const CtaBanner = ({ buttonText, content, link, title }) => {
 
   return (
     <div className="cta-banner base-12-grid">
-      <div className="grid-narrow m-4">
+      <div className="grid-narrow m-3">
         <h3 className="text-m text-yellow font-bold uppercase">{title}</h3>
-        <p className="text-white mt-4">{content}</p>
+        <p className="text-white mt-3">{content}</p>
         <a
-          className="cta-banner__button button p-3 mt-4"
+          className="cta-banner__button button p-3 mt-3"
           href={link}
           onClick={handleClick}
         >

--- a/resources/assets/components/utilities/CtaPopover/CtaPopover.js
+++ b/resources/assets/components/utilities/CtaPopover/CtaPopover.js
@@ -16,7 +16,7 @@ const CtaPopover = ({ content, handleClose, title }) => {
       <h3 className="cta-popover__title text-m text-yellow font-bold uppercase">
         {title}
       </h3>
-      <p className="text-white mt-4">{content}</p>
+      <p className="text-white mt-3">{content}</p>
     </div>
   );
 };

--- a/resources/assets/components/utilities/Gallery/templates/CampaignGalleryItem/CampaignGalleryItem.js
+++ b/resources/assets/components/utilities/Gallery/templates/CampaignGalleryItem/CampaignGalleryItem.js
@@ -17,7 +17,7 @@ const CampaignGalleryItem = ({
         alt={`${showcaseImage.description || showcaseTitle}-photo`}
         image={contentfulImageUrl(showcaseImage.url, '800', '450', 'fill')}
       >
-        <div className="m-4">
+        <div className="m-3">
           <h4 className="text-blue-500">{showcaseTitle}</h4>
           {showcaseDescription ? (
             <p className="font-normal">{showcaseDescription}</p>

--- a/resources/assets/components/utilities/Gallery/templates/PageGalleryItem/PageGalleryItem.js
+++ b/resources/assets/components/utilities/Gallery/templates/PageGalleryItem/PageGalleryItem.js
@@ -23,7 +23,7 @@ const PageGalleryItem = ({
           'fill',
         )}
       >
-        <div className="m-4">
+        <div className="m-3">
           <h4 className="text-blue-500">{showcaseTitle}</h4>
           {showcaseDescription ? (
             <p className="font-normal">{showcaseDescription}</p>

--- a/resources/assets/scss/base.scss
+++ b/resources/assets/scss/base.scss
@@ -434,42 +434,6 @@ p {
   height: 32px;
 }
 
-.m-4 {
-  margin: $half-spacing;
-}
-
-.mt-4 {
-  margin-top: $half-spacing;
-}
-
-.mt-8 {
-  margin-top: $base-spacing;
-}
-
-.mb-4 {
-  margin-bottom: $half-spacing;
-}
-
-.mx-2 {
-  margin-left: $half-spacing / 2;
-  margin-right: $half-spacing / 2;
-}
-
-.my-2 {
-  margin-top: $half-spacing / 2;
-  margin-bottom: $half-spacing / 2;
-}
-
-.my-4 {
-  margin-top: $half-spacing;
-  margin-bottom: $half-spacing;
-}
-
-.my-8 {
-  margin-top: $base-spacing;
-  margin-bottom: $base-spacing;
-}
-
 .overflow-visible {
   overflow: visible !important;
 }


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR removes the manually added Tailwind-style margi classes added to `base.scss` and updates components to use the same Tailwind-style classes but with the updated pixel value reference.

For example, in our `base.scss` we had `m-4` defined as margin on all sides of `12px`. In proper Tailwind classes generated by the framework, `12px` all around is `m-3`, so I changed all references to `m-4` to `m-3`. Similar changes for lots of the other class changes you'll see in this PR!

### What are the relevant tickets/cards?

Refs [Pivotal ID #169578779](https://www.pivotaltracker.com/story/show/169578779)
