### PR TITLE
Add ability to query CallToAction block via GraphQL.

### DIFF
--- a/resources/assets/components/CallToAction/CallToAction.js
+++ b/resources/assets/components/CallToAction/CallToAction.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import gql from 'graphql-tag';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 
@@ -8,6 +9,18 @@ import { SCHOLARSHIP_SIGNUP_BUTTON_TEXT } from '../../constants';
 import SignupButtonContainer from '../SignupButton/SignupButtonContainer';
 
 import './cta.scss';
+
+export const CallToActionBlockFragment = gql`
+  fragment CallToActionBlockFragment on CallToActionBlock {
+    visualStyle
+    useCampaignTagline
+    content
+    impactPrefix
+    impactValue
+    impactSuffix
+    actionText
+  }
+`;
 
 const renderImpactContent = (prefix, value, suffix) => {
   const valueElem = <span className="cta__impact_number">{value}</span>;

--- a/resources/assets/components/ContentfulEntry/ContentfulEntry.js
+++ b/resources/assets/components/ContentfulEntry/ContentfulEntry.js
@@ -7,6 +7,7 @@ import Loader from '../utilities/Loader';
 import StaticBlock from '../StaticBlock';
 import { ContentfulEntryJson } from '../../types';
 import PollLocator from '../PollLocator/PollLocator';
+import CallToAction from '../CallToAction/CallToAction';
 import ErrorBlock from '../blocks/ErrorBlock/ErrorBlock';
 import ImagesBlock from '../blocks/ImagesBlock/ImagesBlock';
 import ContentBlock from '../blocks/ContentBlock/ContentBlock';
@@ -81,6 +82,19 @@ class ContentfulEntry extends React.Component<Props, State> {
           <AffirmationContainer
             {...withoutNulls(json.fields)}
             onClose={json.onClose}
+          />
+        );
+
+      case 'CallToActionBlock':
+        return (
+          <CallToAction
+            actionText={json.actionText}
+            content={json.content}
+            impactPrefix={json.impactPrefix}
+            impactSuffix={json.impactSuffix}
+            impactValue={json.impactValue}
+            visualStyle={json.visualStyle.toLowerCase()}
+            useCampaignTagline={json.useCampaignTagline}
           />
         );
 

--- a/resources/assets/components/utilities/ContentfulEntryLoader/ContentfulEntryLoader.js
+++ b/resources/assets/components/utilities/ContentfulEntryLoader/ContentfulEntryLoader.js
@@ -12,6 +12,7 @@ import { EmbedBlockFragment } from '../../blocks/EmbedBlock/EmbedBlock';
 import { LinkBlockFragment } from '../../actions/LinkAction/LinkAction';
 import { ImagesBlockFragment } from '../../blocks/ImagesBlock/ImagesBlock';
 import { ShareBlockFragment } from '../../actions/ShareAction/ShareAction';
+import { CallToActionBlockFragment } from '../../CallToAction/CallToAction';
 import { GalleryBlockFragment } from '../../blocks/GalleryBlock/GalleryBlock';
 import { ContentBlockFragment } from '../../blocks/ContentBlock/ContentBlock';
 import { PostGalleryBlockFragment } from '../../blocks/PostGalleryBlock/PostGalleryBlockQuery';
@@ -31,6 +32,7 @@ const CONTENTFUL_BLOCK_QUERY = gql`
       ...GalleryBlockFragment
       ...ContentBlockFragment
       ...PostGalleryBlockFragment
+      ...CallToActionBlockFragment
       ...TextSubmissionBlockFragment
       ...PhotoSubmissionBlockFragment
       ...VoterRegistrationBlockFragment
@@ -45,6 +47,7 @@ const CONTENTFUL_BLOCK_QUERY = gql`
   ${GalleryBlockFragment}
   ${ContentBlockFragment}
   ${PostGalleryBlockFragment}
+  ${CallToActionBlockFragment}
   ${TextSubmissionBlockFragment}
   ${PhotoSubmissionBlockFragment}
   ${VoterRegistrationBlockFragment}


### PR DESCRIPTION
### What does this PR do?

This PR adds the ability to render "Call To Action" blocks via GraphQL:

<img width="1324" alt="Screen Shot 2019-11-15 at 5 35 34 PM" src="https://user-images.githubusercontent.com/583202/68980410-69542100-07ce-11ea-86f7-c5a05758e6ce.png">

### Any background context you want to provide?

To keep things simple, rendering this block via GraphQL does not support any of the features that require a Redux campaign page context. This PR relies on DoSomething/graphql#162.

### What are the relevant tickets/cards?

References [#169216379](https://www.pivotaltracker.com/story/show/169216379).

### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.
* [ ] Added screenshot to PR description of related front-end updates on **small** screens.
* [ ] Added screenshot to PR description of related front-end updates on **medium** screens.
* [ ] Added screenshot to PR description of related front-end updates on **large** screens.
