### PR TITLE
Moar updates and cleanup (part 2) 🧼

### DIFF
--- a/resources/assets/components/AdminDashboard/AdminDashboard.js
+++ b/resources/assets/components/AdminDashboard/AdminDashboard.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const AdminDashboard = ({ enabled, children }) =>
-  enabled ? <div className="bg-light-gray -white p-4">{children}</div> : null;
+  enabled ? <div className="bg-gray-200 p-4">{children}</div> : null;
 
 AdminDashboard.propTypes = {
   children: PropTypes.node.isRequired,

--- a/resources/assets/components/LegacyQuiz/Answer.js
+++ b/resources/assets/components/LegacyQuiz/Answer.js
@@ -18,7 +18,7 @@ const Answer = props => {
 
   const classes = classnames('bordered overflow-hidden rounded', {
     '-active': isActive,
-    faded: isFaded,
+    'opacity-50': isFaded,
   });
 
   return (

--- a/resources/assets/components/Quiz/QuizChoice.js
+++ b/resources/assets/components/Quiz/QuizChoice.js
@@ -18,7 +18,7 @@ const QuizChoice = props => {
 
   const cardClasses = classnames('bordered rounded', {
     '-active': isActive,
-    faded: isFaded,
+    'opacity-50': isFaded,
   });
 
   return (

--- a/resources/assets/components/SiteNavigation/site-navigation.scss
+++ b/resources/assets/components/SiteNavigation/site-navigation.scss
@@ -396,7 +396,7 @@ $extraSmall: '(min-width: 360px)';
     }
 
     &::placeholder {
-      color: theme('colors.gray.300');
+      color: theme('colors.gray.500');
     }
   }
 }

--- a/resources/assets/components/SiteNavigation/site-navigation.scss
+++ b/resources/assets/components/SiteNavigation/site-navigation.scss
@@ -8,7 +8,7 @@ $extraSmall: '(min-width: 360px)';
 
 .nav {
   background-color: white;
-  border-bottom: 1px solid $gray-300;
+  border-bottom: 1px solid theme('colors.gray.300');
   position: relative;
   z-index: $site-navigation-zindex;
 
@@ -42,7 +42,7 @@ $extraSmall: '(min-width: 360px)';
 
 .menu-subnav {
   background-color: white;
-  border-top: 1px solid $gray-300;
+  border-top: 1px solid theme('colors.gray.300');
   box-shadow: 0 15px 10px -8px rgba(0, 0, 0, 0.5);
   left: 0;
   min-height: 50vh;
@@ -78,7 +78,7 @@ $extraSmall: '(min-width: 360px)';
 
 .menu-subnav__section + .menu-subnav__section {
   &::before {
-    background-color: $gray-200;
+    background-color: theme('colors.gray.200');
     content: '';
     display: block;
     height: 1px;
@@ -158,7 +158,7 @@ $extraSmall: '(min-width: 360px)';
 // Main Nav
 .main-nav {
   align-items: center;
-  border-top: 1px solid $gray-300;
+  border-top: 1px solid theme('colors.gray.300');
   display: flex;
   grid-column: full-start / full-end;
   grid-row: 2 / 3;
@@ -202,7 +202,7 @@ $extraSmall: '(min-width: 360px)';
   display: inline-block;
   border-left: 5px solid transparent;
   border-right: 5px solid transparent;
-  border-top: 6px solid $gray-300;
+  border-top: 6px solid theme('colors.gray.300');
   height: 0;
   margin-left: 5px;
   position: relative;
@@ -311,13 +311,13 @@ $extraSmall: '(min-width: 360px)';
 
   &.is-active {
     .wrapper {
-      background-color: $gray-200;
+      background-color: theme('colors.gray.200');
     }
   }
 }
 
 .utility-nav__auth {
-  border-left: 1px solid $gray-300;
+  border-left: 1px solid theme('colors.gray.300');
 
   > a {
     padding: $spacing_1x;
@@ -336,7 +336,7 @@ $extraSmall: '(min-width: 360px)';
 }
 
 .utility-nav__account-profile {
-  border-left: 1px solid $gray-300;
+  border-left: 1px solid theme('colors.gray.300');
 }
 
 .utility-nav__account-profile-icon {
@@ -359,7 +359,7 @@ $extraSmall: '(min-width: 360px)';
 
 .utility-subnav .search {
   align-items: center;
-  background-color: $gray-200;
+  background-color: theme('colors.gray.200');
   border-radius: $lg-border-radius;
   display: flex;
   grid-column: full-start / full-end;
@@ -392,11 +392,11 @@ $extraSmall: '(min-width: 360px)';
     }
 
     &:focus::placeholder {
-      color: $gray-300;
+      color: theme('colors.gray.300');
     }
 
     &::placeholder {
-      color: $gray-500;
+      color: theme('colors.gray.300');
     }
   }
 }
@@ -406,7 +406,7 @@ $extraSmall: '(min-width: 360px)';
     grid-column: full-start / full-end;
 
     > h1 {
-      color: $gray-300;
+      color: theme('colors.gray.300');
       font-size: 18px;
       font-weight: $weight-normal;
       margin-bottom: $spacing_1x;

--- a/resources/assets/components/blocks/AffiliateScholarshipBlock/affiliate-scholarship-block.scss
+++ b/resources/assets/components/blocks/AffiliateScholarshipBlock/affiliate-scholarship-block.scss
@@ -55,7 +55,7 @@
 
   dt {
     clear: right;
-    color: $gray-500;
+    color: theme('colors.gray.500');
     font-weight: $weight-sbold;
     text-transform: uppercase;
 
@@ -72,7 +72,7 @@
   }
 
   dt.scholarship-beta {
-    border-top: 1px solid $gray-300;
+    border-top: 1px solid theme('colors.gray.300');
     float: none;
     padding-top: $half-spacing;
   }

--- a/resources/assets/components/blocks/CampaignInfoBlock/campaign-info-block.scss
+++ b/resources/assets/components/blocks/CampaignInfoBlock/campaign-info-block.scss
@@ -22,7 +22,7 @@
 
   dt {
     clear: right;
-    color: theme('colors.gray.300');
+    color: theme('colors.gray.500');
     font-weight: $weight-sbold;
     text-transform: uppercase;
 

--- a/resources/assets/components/blocks/CampaignInfoBlock/campaign-info-block.scss
+++ b/resources/assets/components/blocks/CampaignInfoBlock/campaign-info-block.scss
@@ -22,7 +22,7 @@
 
   dt {
     clear: right;
-    color: $gray-500;
+    color: theme('colors.gray.300');
     font-weight: $weight-sbold;
     text-transform: uppercase;
 
@@ -41,7 +41,7 @@
   }
 
   dt.campaign-info__scholarship {
-    border-top: 1px solid $gray-300;
+    border-top: 1px solid theme('colors.gray.300');
     float: none;
     padding-top: $half-spacing;
   }

--- a/resources/assets/components/blocks/CampaignUpdate/CampaignUpdate.js
+++ b/resources/assets/components/blocks/CampaignUpdate/CampaignUpdate.js
@@ -47,7 +47,7 @@ const CampaignUpdate = props => {
       title={title}
       onClose={closeModal}
     >
-      <TextContent className={classnames('p-3', { 'font-size-lg': isTweet })}>
+      <TextContent className={classnames('p-3', { 'text-xl': isTweet })}>
         {content || 'Placeholder'}
       </TextContent>
 

--- a/resources/assets/components/pages/AccountPage/Badge.js
+++ b/resources/assets/components/pages/AccountPage/Badge.js
@@ -13,7 +13,7 @@ const Badge = props => {
       <img src={badgeImages[badgeImageIndex]} alt={name} />
       {showLock && !earned ? (
         <img
-          className="position-center-x"
+          className="absolute left-0 right-0 m-auto"
           style={{ width: '48px', bottom: '-24px' }}
           src={badgeImages.lock}
           alt="lock"

--- a/resources/assets/components/pages/AccountPage/VoterRegStatusBlock.js
+++ b/resources/assets/components/pages/AccountPage/VoterRegStatusBlock.js
@@ -10,7 +10,7 @@ import './voter-reg.scss';
 const VoterRegStatusBlock = ({ status }) => {
   if (status === 'PENDING') {
     return (
-      <div className="voter-reg -yellow display-flex flex-align-center">
+      <div className="voter-reg -yellow flex flex-align-center">
         <img className="post-badge icon-clock" src={pendingIcon} alt="hello" />
         <div className="ml-3">Your voter reg status is pending!</div>
       </div>
@@ -23,7 +23,7 @@ const VoterRegStatusBlock = ({ status }) => {
     status === 'REGISTER_OVR'
   ) {
     return (
-      <div className="voter-reg -green display-flex flex-align-center">
+      <div className="voter-reg -green flex flex-align-center">
         <img className="post-badge icon-check" src={checkmark} alt="hello" />
         <div className="ml-3">Your voter reg status is confirmed! Woo!</div>
       </div>
@@ -31,7 +31,7 @@ const VoterRegStatusBlock = ({ status }) => {
   }
 
   return (
-    <div className="voter-reg -red display-flex flex-align-center">
+    <div className="voter-reg -red flex flex-align-center">
       <img className="post-badge icon-x" src={rejectedIcon} alt="hello" />
       <div className="ml-3">
         We don&#39;t have your voter registration. Register here!

--- a/resources/assets/components/pages/LandingPage/landing-page.scss
+++ b/resources/assets/components/pages/LandingPage/landing-page.scss
@@ -59,7 +59,7 @@
 
 .marquee-signup-button {
   background-color: $white;
-  border-top: 1px solid $gray-200;
+  border-top: 1px solid theme('colors.gray.200');
   bottom: 0;
   left: 0;
   padding: $half-spacing;

--- a/resources/assets/components/pages/LandingPage/templates/PitchTemplate.js
+++ b/resources/assets/components/pages/LandingPage/templates/PitchTemplate.js
@@ -93,7 +93,7 @@ const PitchTemplate = ({
       <PuckWaypoint name="landing_page_cta-top" />
 
       <CallToActionContainer
-        className="legacy border-top border-radius-none bg-off-white p-6 hide-on-mobile"
+        className="legacy border-top border-radius-none bg-gray-100 p-6 hidden md:block"
         content={tagline}
       />
 

--- a/resources/assets/components/utilities/CampaignDashboard/campaign-dashboard.scss
+++ b/resources/assets/components/utilities/CampaignDashboard/campaign-dashboard.scss
@@ -30,12 +30,12 @@ $small-to-medium: '(min-width: 600px)';
 
   .dashboard__segment + .dashboard__segment {
     @include media($large) {
-      border-left: 1px solid $gray-300;
+      border-left: 1px solid theme('colors.gray.300');
     }
   }
 
   .dashboard-share {
-    border-top: 1px solid $gray-200;
+    border-top: 1px solid theme('colors.gray.200');
     margin-top: $half-spacing;
     padding-top: $base-spacing;
     text-align: left;

--- a/resources/assets/components/utilities/CtaPopover/CtaPopoverEmailForm.js
+++ b/resources/assets/components/utilities/CtaPopover/CtaPopoverEmailForm.js
@@ -39,7 +39,7 @@ const CtaPopoverEmailForm = () => {
           Sign Up
         </Button>
       </form>
-      <p className="text-gray-200 font-italic text-sm">
+      <p className="text-gray-200 italic text-sm">
         You&apos;ll also get a{' '}
         <a
           href="/us/about/default-notifications"

--- a/resources/assets/components/utilities/Embed/Embed.js
+++ b/resources/assets/components/utilities/Embed/Embed.js
@@ -88,7 +88,7 @@ const Embed = props => {
                 />
                 <div className="embed__content p-3">
                   <div className="my-3 mr-3">
-                    <h3 className="line-break">
+                    <h3>
                       {isLoaded ? (
                         truncate(embed ? embed.title : url, { length: 60 })
                       ) : (

--- a/resources/assets/components/utilities/PostCard/PostCard.js
+++ b/resources/assets/components/utilities/PostCard/PostCard.js
@@ -57,8 +57,8 @@ const PostCard = ({ post, hideCaption, hideQuantity, hideReactions }) => {
   switch (post.type) {
     case 'text':
       media = (
-        <div className="chat-bubble -post-bubble mb-0 rounded-top">
-          <p className="font-italic word-break">{post.text}</p>
+        <div className="px-3 py-6">
+          <p className="italic text-black text-lg word-break">{post.text}</p>
         </div>
       );
       break;
@@ -102,7 +102,7 @@ const PostCard = ({ post, hideCaption, hideQuantity, hideReactions }) => {
           ) : null}
 
           {post.type !== 'text' && post.text && !hideCaption ? (
-            <p>{post.text}</p>
+            <p className="text-gray-600">{post.text}</p>
           ) : null}
         </BaseFigure>
       </div>

--- a/resources/assets/components/utilities/PostCard/post.scss
+++ b/resources/assets/components/utilities/PostCard/post.scss
@@ -15,10 +15,6 @@
     font-weight: $weight-bold;
   }
 
-  p {
-    color: $med-gray;
-  }
-
   .figure.-right > .figure__body {
     overflow: unset;
   }

--- a/resources/assets/scss/admin-dashboard.scss
+++ b/resources/assets/scss/admin-dashboard.scss
@@ -1,7 +1,7 @@
 @import './next-toolbox';
 
 .admin-dashboard {
-  background-color: $gray-500;
+  background-color: theme('colors.gray.500');
   position: fixed;
   transform: translateY(-100%);
   transition: all 0.3s ease-out;
@@ -15,17 +15,17 @@
   }
 
   a {
-    color: $gray-100;
+    color: theme('colors.gray.100');
 
     &:hover {
-      color: $gray-700;
+      color: theme('colors.gray.700');
       text-decoration: none;
     }
   }
 
   .icon-link {
     .icon {
-      fill: $gray-200;
+      fill: theme('colors.gray.200');
       height: 15px;
       position: relative;
       top: 1px;
@@ -34,7 +34,7 @@
 
     &:hover {
       .icon {
-        fill: $gray-600;
+        fill: theme('colors.gray.600');
       }
     }
   }
@@ -52,7 +52,7 @@
   }
 
   .toggle {
-    background-color: $gray-500;
+    background-color: theme('colors.gray.500');
     bottom: -16px;
     content: '';
     cursor: pointer;
@@ -101,7 +101,7 @@
     }
 
     > span {
-      background-color: $gray-500;
+      background-color: theme('colors.gray.500');
       padding-right: 10px;
       position: relative;
     }
@@ -124,10 +124,10 @@
   }
 
   .panel-title {
-    color: $gray-900;
+    color: theme('colors.gray.900');
 
     .icon {
-      fill: $gray-700;
+      fill: theme('colors.gray.700');
       height: 20px;
       position: relative;
       top: 1px;

--- a/resources/assets/scss/base.scss
+++ b/resources/assets/scss/base.scss
@@ -27,7 +27,7 @@ $forge-path: '../../../node_modules/@dosomething/forge/assets/';
 
 // @TODO:forge-removal Rename this class to "text-field".
 .text-input {
-  @apply bg-white p-3 border border-gray-200 border-solid rounded;
+  @apply bg-white p-3 border border-gray-200 border-solid font-source-sans rounded;
 }
 
 .text-input:focus {
@@ -96,14 +96,6 @@ p {
   }
 }
 
-// @TODO: Added for the Marquee template experiment, so the full footer
-// can be viewed when fixed signup button reaches the bottom of the page.
-.footer {
-  @include media($small) {
-    padding-bottom: 105px;
-  }
-}
-
 // @TODO: for cleanup. Adding to base for now since needed
 // for validation in all forms.
 .field-label {
@@ -118,19 +110,6 @@ p {
 }
 
 // Utility classes.
-// @TODO: Move over to Forge 7 soon!
-.background-image-centered {
-  background-position: center;
-  background-size: cover;
-}
-
-.position-center-x {
-  position: absolute;
-  left: 0;
-  right: 0;
-  margin: auto;
-}
-
 .color-white {
   color: $white !important;
 }
@@ -155,16 +134,9 @@ p {
   background-color: $black !important;
 }
 
-.bg-purple {
-  background-color: $purple !important;
-}
-
-.bg-light-gray {
-  background-color: $light-gray !important;
-}
-
-.bg-off-white {
-  background-color: $off-white !important;
+// @TODO:phoenix-css-heirarchy-issue; delete once remedied.
+.bg-gray-100 {
+  background-color: theme('colors.gray.100') !important;
 }
 
 .bg-transparent {
@@ -188,31 +160,6 @@ p {
   border-radius: 0 !important;
 }
 
-.clearfix {
-  @include clearfix;
-}
-
-.clear-both {
-  clear: both;
-}
-
-.clear-left {
-  clear: left;
-}
-
-.clear-right {
-  clear: right;
-}
-
-.clear-none {
-  clear: none;
-}
-
-// @TODO: Rename to match Tailwind's .flex.
-.display-flex {
-  display: flex;
-}
-
 .expand-horizontal-lg {
   margin-left: -$base-spacing;
   margin-right: -$base-spacing;
@@ -221,16 +168,6 @@ p {
 .expand-horizontal-md {
   margin-left: -$half-spacing;
   margin-right: -$half-spacing;
-}
-
-.line-break {
-  line-break: normal;
-}
-
-.flex-center-y {
-  display: flex;
-  justify-content: center;
-  flex-direction: column;
 }
 
 .flex-center-xy {
@@ -243,67 +180,8 @@ p {
   align-items: center;
 }
 
-.flex-grow {
-  flex-grow: 1;
-}
-
-.h-full {
-  height: 100%;
-}
-
-.font-italic {
-  font-style: italic;
-}
-
-.font-size-lg {
-  font-size: $font-large;
-
-  p {
-    font-size: $font-large;
-  }
-}
-
 .word-break {
-  word-break: break-word;
-}
-
-// @TODO:forge-removal Required to override Forge; delete once Forge is removed.
-.mb-0 {
-  margin-bottom: 0 !important;
-}
-
-// @TODO:forge-removal Required to override Forge; delete once Forge is removed.
-.mt-0 {
-  margin-bottom: 0 !important;
-}
-
-.rounded-top {
-  border-radius: $lg-border-radius $lg-border-radius 0 0;
-  overflow: hidden;
-}
-
-.rounded-bottom {
-  border-radius: 0 0 $lg-border-radius $lg-border-radius;
-  overflow: hidden;
-}
-
-.faded {
-  opacity: 0.5;
-}
-
-.hide-on-mobile {
-  @include media($small) {
-    display: none;
-  }
-}
-
-// Search page form
-.search-form {
-  .text-field {
-    @include media($medium) {
-      min-width: 400px;
-    }
-  }
+  word-break: break-word; // CSS deprecated; find alternative.
 }
 
 /*

--- a/resources/assets/scss/flash-message.scss
+++ b/resources/assets/scss/flash-message.scss
@@ -1,7 +1,7 @@
 @import './next-toolbox';
 
 .flash-message {
-  background-color: $gray-800;
+  background-color: theme('colors.gray.800');
   display: none;
   margin: 0 auto;
   max-width: 1440px;
@@ -12,7 +12,7 @@
   }
 
   .flash-content {
-    color: $gray-200;
+    color: theme('colors.gray.200');
     grid-column: full-start / -2;
   }
 
@@ -31,10 +31,10 @@
   }
 
   .icon-close {
-    fill: $gray-400;
+    fill: theme('colors.gray.400');
 
     &:hover {
-      fill: $gray-200;
+      fill: theme('colors.gray.200');
     }
   }
 }

--- a/resources/assets/scss/next-toolbox.scss
+++ b/resources/assets/scss/next-toolbox.scss
@@ -66,16 +66,6 @@ $site-navigation-zindex: 500;
 $largest: '(min-width: 1280px)';
 
 // Tailwind Colors
-$gray-100: #fafafa;
-$gray-200: #e3e3e3;
-$gray-300: #c7c7c7;
-$gray-400: #b4b4b4;
-$gray-500: #999;
-$gray-600: #7f7f7f;
-$gray-700: #636363;
-$gray-800: #4e4e4e;
-$gray-900: #373737;
-
 $purple-500: #141493;
 
 $blue-500: #0ab6fe;

--- a/resources/views/partials/footer.blade.php
+++ b/resources/views/partials/footer.blade.php
@@ -1,4 +1,4 @@
-<footer class="footer">
+<footer class="footer pb-32 md:pb-3">
   <div class="footer__columns">
     <div class="footer__column -social">
       <ul>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -128,5 +128,24 @@ module.exports = {
     },
   },
   variants: {},
-  plugins: [],
+  plugins: [
+    function({ addUtilities, addComponents, e, prefix, config }) {
+      const newUtilities = {
+        '.clear-both': {
+          clear: 'both',
+        },
+        '.clear-left': {
+          clear: 'left',
+        },
+        '.clear-right': {
+          clear: 'right',
+        },
+        '.clear-none': {
+          clear: 'none',
+        },
+      };
+
+      addUtilities(newUtilities);
+    },
+  ],
 };

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -129,7 +129,7 @@ module.exports = {
   },
   variants: {},
   plugins: [
-    function({ addUtilities, addComponents, e, prefix, config }) {
+    function({ addUtilities }) {
       const newUtilities = {
         '.clear-both': {
           clear: 'both',


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR continues doing more cleanup removing manually added utility classes in favor of their Tailwind counterparts generated by the library.

It also utilizes Tailwind's handy `theme()` method that can help as we transition to using utility classes. It allows us to refer to colors specified in the Tailwind configuration within CSS rules. This PR utilizes it to help remove the old SASS variables for the series of gray colors in favor of the ones defined in the tailwind config, like so `theme('colors.gray.300')`.

This PR also adds some additional utility classes for us related to `clear`-ing floats. It does not any responsive variants, since they didn't seem necessary at the moment and likely less needed once we move to the CSS Grid layout.

### Any background context you want to provide?

🧼

### What are the relevant tickets/cards?

Refs [Pivotal ID #169578779](https://www.pivotaltracker.com/story/show/169578779)
