### PR TITLE
Remove deprecated PhotoSubmissionAction.additionalContent

### DIFF
--- a/resources/assets/actions/post.js
+++ b/resources/assets/actions/post.js
@@ -70,7 +70,7 @@ export function resetPostSubmissionItem(id) {
  * @return {function}
  */
 export function storeCampaignPost(campaignId, data) {
-  const { action, actionId, blockId, body, pageId, type } = data;
+  const { actionId, blockId, body, pageId, type } = data;
 
   if (type === 'photo' && !(body instanceof FormData)) {
     throw Error(
@@ -105,7 +105,6 @@ export function storeCampaignPost(campaignId, data) {
         body,
         failure: POST_SUBMISSION_FAILED,
         meta: {
-          action,
           actionId,
           campaignId,
           id: blockId, // @TODO: rename property to blockId

--- a/resources/assets/components/actions/PhotoSubmissionAction/PhotoSubmissionAction.js
+++ b/resources/assets/components/actions/PhotoSubmissionAction/PhotoSubmissionAction.js
@@ -41,7 +41,6 @@ export const PhotoSubmissionBlockFragment = gql`
     informationTitle
     informationContent
     affirmationContent
-    additionalContent
   }
 `;
 
@@ -197,8 +196,6 @@ class PhotoSubmissionAction extends React.Component {
 
     const type = 'photo';
 
-    const action = get(this.props.additionalContent, 'action', 'default');
-
     const values = mapValues(
       this.fields(),
       value => this.state[`${value}Value`],
@@ -214,7 +211,6 @@ class PhotoSubmissionAction extends React.Component {
     }
 
     const formFields = withoutNulls({
-      action, // @TODO: deprecate
       type,
       id: this.props.id, // @TODO: rename property to blockId?
       action_id: this.props.actionId,
@@ -226,7 +222,6 @@ class PhotoSubmissionAction extends React.Component {
 
     // Send request to store the campaign photo submission post.
     this.props.storeCampaignPost(this.props.campaignId, {
-      action, // @TODO: deprecate
       actionId: this.props.actionId,
       blockId: this.props.id,
       body: formatPostPayload(formFields),
@@ -561,9 +556,6 @@ class PhotoSubmissionAction extends React.Component {
 PhotoSubmissionAction.propTypes = {
   actionId: PropTypes.number,
   affirmationContent: PropTypes.string,
-  additionalContent: PropTypes.shape({
-    action: PropTypes.string,
-  }),
   buttonText: PropTypes.string,
   campaignId: PropTypes.string.isRequired,
   captionFieldLabel: PropTypes.string,
@@ -591,7 +583,6 @@ PhotoSubmissionAction.propTypes = {
 
 PhotoSubmissionAction.defaultProps = {
   actionId: null,
-  additionalContent: null,
   affirmationContent:
     "Thanks for joining the movement, and submitting your photo! After we review your submission, we'll add it to the public gallery alongside submissions from all the other members taking action in this campaign.",
   buttonText: 'Submit a new photo',


### PR DESCRIPTION
### What does this PR do?

This PR fixes the TODO's of removing the `additionalContent.action` props. From what I can tell in Contentful, all recent `PhotoSubmissionAction` entries contain an `actionId` field value -- and this should be safe to remove.


### Any background context you want to provide?

It also seems safe to fix the [TODO of removing support of an `action` value in a Rogue `POST /v3/posts` request](https://github.com/DoSomething/rogue/blob/master/app/Http/Requests/PostRequest.php#L39), as both Phoenix and Gambit are sending over action ID's when creating posts (refs https://github.com/DoSomething/gambit/pull/480)

### What are the relevant tickets/cards?

Prep for https://www.pivotaltracker.com/story/show/169549761
### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.
* [ ] Added screenshot to PR description of related front-end updates on **small** screens.
* [ ] Added screenshot to PR description of related front-end updates on **medium** screens.
* [ ] Added screenshot to PR description of related front-end updates on **large** screens.
