### PR TITLE
Collection Page Routing & Rendering

### DIFF
--- a/resources/assets/components/App.js
+++ b/resources/assets/components/App.js
@@ -14,6 +14,7 @@ import CausePage from './pages/CausePage/CausePage';
 import CampaignContainer from './Campaign/CampaignContainer';
 import { getUserId, isAuthenticated } from '../selectors/user';
 import BetaReferralPage from './pages/ReferralPage/Beta/BetaPage';
+import CollectionPage from './pages/CollectionPage/CollectionPage';
 import AccountContainer from './pages/AccountPage/AccountContainer';
 import PageDispatcherContainer from './PageDispatcher/PageDispatcherContainer';
 import AlphaReferralPageContainer from './pages/ReferralPage/Alpha/AlphaPageContainer';
@@ -43,6 +44,12 @@ const App = ({ store, history }) => {
                 path="/us/causes/:slug"
                 render={routeProps => (
                   <CausePage slug={routeProps.match.params.slug} />
+                )}
+              />
+              <Route
+                path="/us/collections/:slug"
+                render={routeProps => (
+                  <CollectionPage slug={routeProps.match.params.slug} />
                 )}
               />
               <Route path="/us/join" component={BetaReferralPage} />

--- a/resources/assets/components/pages/CollectionPage/CollectionPage.js
+++ b/resources/assets/components/pages/CollectionPage/CollectionPage.js
@@ -1,0 +1,97 @@
+import React from 'react';
+import gql from 'graphql-tag';
+import PropTypes from 'prop-types';
+
+import PageQuery from '../PageQuery';
+import TextContent from '../../utilities/TextContent/TextContent';
+import { contentfulImageUrl, withoutNulls } from '../../../helpers';
+import SiteNavigationContainer from '../../SiteNavigation/SiteNavigationContainer';
+
+import './collection-page.scss';
+
+export const COLLECTION_PAGE_QUERY = gql`
+  query CollectionPageQuery($slug: String!, $preview: Boolean!) {
+    page: collectionPageBySlug(slug: $slug, preview: $preview) {
+      coverImage {
+        url
+        description
+      }
+      superTitle
+      title
+      description
+      content
+    }
+  }
+`;
+
+const CollectionPageTemplate = ({
+  coverImage,
+  superTitle,
+  title,
+  description,
+  content,
+}) => {
+  // @TODO: Update this with image dimension logic to serve properly sized files to different screen sizes
+  const backgroundImage = coverImage
+    ? `url(${contentfulImageUrl(coverImage.url, '1440', '610', 'fill')})`
+    : null;
+
+  const styles = {
+    backgroundImage,
+  };
+
+  return (
+    <>
+      <SiteNavigationContainer />
+
+      <article className="collection-page">
+        <header
+          role="banner"
+          className="lede-banner base-12-grid"
+          style={withoutNulls(styles)}
+        >
+          <div className="title-lockup my-6">
+            <h2 className="my-3 uppercase color-white text-lg">{superTitle}</h2>
+            <h1 className="lede-banner__headline-title my-3 font-normal font-league-gothic color-white uppercase">
+              {title}
+            </h1>
+            <TextContent styles={{ textColor: '#FFF', fontSize: '21px' }}>
+              {description}
+            </TextContent>
+          </div>
+        </header>
+        <TextContent
+          className="base-12-grid"
+          classNameByEntry={{
+            GalleryBlock: 'grid-full',
+            ContentBlock: 'grid-full-8/12',
+          }}
+        >
+          {content}
+        </TextContent>
+      </article>
+    </>
+  );
+};
+
+CollectionPageTemplate.propTypes = {
+  coverImage: PropTypes.shape({
+    url: PropTypes.string.isRequired,
+  }).isRequired,
+  superTitle: PropTypes.string.isRequired,
+  title: PropTypes.string.isRequired,
+  description: PropTypes.object.isRequired,
+  content: PropTypes.object.isRequired,
+};
+
+const CollectionPage = ({ slug }) => (
+  <PageQuery query={COLLECTION_PAGE_QUERY} variables={{ slug }}>
+    {page => <CollectionPageTemplate {...page} />}
+  </PageQuery>
+);
+
+CollectionPage.propTypes = {
+  slug: PropTypes.string.isRequired,
+};
+
+export default CollectionPage;

--- a/resources/assets/components/pages/CollectionPage/collection-page.scss
+++ b/resources/assets/components/pages/CollectionPage/collection-page.scss
@@ -1,0 +1,30 @@
+@import '../../../scss/next-toolbox';
+
+.collection-page {
+  .lede-banner {
+    background-position: center center;
+    background-repeat: no-repeat;
+    background-size: cover;
+
+    > .title-lockup {
+      grid-column: 1 / -1;
+
+      @include media($medium) {
+        grid-column: 2 / -2;
+      }
+
+      @include media($large) {
+        grid-column: 1 / -6;
+      }
+    }
+
+    .lede-banner__headline-title {
+      font-size: 97px;
+      line-height: 1;
+
+      @include media($medium) {
+        font-size: 106px;
+      }
+    }
+  }
+}

--- a/routes/web.php
+++ b/routes/web.php
@@ -71,6 +71,9 @@ $router->get('{slug}', function ($slug) {
 // Causes
 $router->view('us/causes/{slug}', 'app');
 
+// Collections
+$router->view('us/collections/{slug}', 'app');
+
 // Cache
 $router->get('cache/{cacheId}', 'CacheController');
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -68,10 +68,10 @@ $router->get('{slug}', function ($slug) {
     return redirect('us/'.$slug);
 });
 
-// Causes
+// Cause Pages
 $router->view('us/causes/{slug}', 'app');
 
-// Collections
+// Collection Pages
 $router->view('us/collections/{slug}', 'app');
 
 // Cache


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_


### What does this PR do?

This PR adds a `/collections/:slug` route, `CollectionPage` component, and renders it from the `App`.

### Any background context you want to provide?
Does this look awfully familiar? You're not dreaming! This is a carbon copy of the `CausePage` component. The [`CausePage`](https://github.com/DoSomething/phoenix-next/blob/53e1ccbb369cf5e01f1bc81de664b8083aeb6d5f/resources/assets/components/pages/CausePage/CausePage.js) will likely experience dramatic changes in v2, for now, it's actually a model off of the `CollectionPage` wireframe. ♻️ 

### What are the relevant tickets/cards?

Refs [Pivotal ID #169582403](https://www.pivotaltracker.com/story/show/169582403)

### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.
* [x] Added screenshot to PR description of related front-end updates on **small** screens.
* [x] Added screenshot to PR description of related front-end updates on **medium** screens.
* [x] Added screenshot to PR description of related front-end updates on **large** screens.


![image](https://user-images.githubusercontent.com/12417657/69195351-653f4080-0af9-11ea-88e4-390e51f5ea2d.png)
![Screen Shot 2019-11-19 at 18 24 13](https://user-images.githubusercontent.com/12417657/69195524-de3e9800-0af9-11ea-8034-55a92ccf731f.png)
![Screen Shot 2019-11-19 at 18 24 17](https://user-images.githubusercontent.com/12417657/69195525-de3e9800-0af9-11ea-8f90-88d587d11046.png)
