### PR TITLE
Re-add action default for Photo Submission Action 

### DIFF
--- a/resources/assets/actions/post.js
+++ b/resources/assets/actions/post.js
@@ -70,7 +70,7 @@ export function resetPostSubmissionItem(id) {
  * @return {function}
  */
 export function storeCampaignPost(campaignId, data) {
-  const { actionId, blockId, body, pageId, type } = data;
+  const { actionId, action, blockId, body, pageId, type } = data;
 
   if (type === 'photo' && !(body instanceof FormData)) {
     throw Error(
@@ -105,6 +105,7 @@ export function storeCampaignPost(campaignId, data) {
         body,
         failure: POST_SUBMISSION_FAILED,
         meta: {
+          action,
           actionId,
           campaignId,
           id: blockId, // @TODO: rename property to blockId

--- a/resources/assets/components/actions/PhotoSubmissionAction/PhotoSubmissionAction.js
+++ b/resources/assets/components/actions/PhotoSubmissionAction/PhotoSubmissionAction.js
@@ -180,6 +180,9 @@ class PhotoSubmissionAction extends React.Component {
 
     const type = 'photo';
 
+    // Support legacy Photo Submission Actions without a set actionId.
+    const action = 'default';
+
     const values = mapValues(
       this.fields(),
       value => this.state[`${value}Value`],
@@ -195,6 +198,7 @@ class PhotoSubmissionAction extends React.Component {
     }
 
     const formFields = withoutNulls({
+      action,
       type,
       id: this.props.id, // @TODO: rename property to blockId?
       action_id: this.props.actionId,
@@ -206,6 +210,7 @@ class PhotoSubmissionAction extends React.Component {
 
     // Send request to store the campaign photo submission post.
     this.props.storeCampaignPost(this.props.campaignId, {
+      action,
       actionId: this.props.actionId,
       blockId: this.props.id,
       body: formatPostPayload(formFields),


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR re-adds the `action` default removed in #1728 while maintaining the deprecation of the `additionalContent.action` editor override.

### Any background context you want to provide?
Rogue [still expects](https://github.com/DoSomething/rogue/blob/0a3224c541b08de2bc1962542f5e3bf8f066ad4f/app/Http/Requests/PostRequest.php#L39) an `action` in the post payload in the absence of an `actionId`. We still have a bunch of database campaigns with these Photo Submission Actions, so until that's all updated we need this to stay 😩 

### What are the relevant tickets/cards?
https://dosomething.slack.com/archives/C3ASB4204/p1574275326356300

