### PR TITLE
Collection Page Affiliate Promotion

### DIFF
--- a/resources/assets/components/pages/CollectionPage/CollectionPage.js
+++ b/resources/assets/components/pages/CollectionPage/CollectionPage.js
@@ -19,6 +19,14 @@ export const COLLECTION_PAGE_QUERY = gql`
       superTitle
       title
       description
+      affiliatePrefix
+      affiliates {
+        title
+        logo {
+          url(w: 100, h: 100)
+          description
+        }
+      }
       content
     }
   }
@@ -29,6 +37,8 @@ const CollectionPageTemplate = ({
   superTitle,
   title,
   description,
+  affiliatePrefix,
+  affiliates,
   content,
 }) => {
   // @TODO: Update this with image dimension logic to serve properly sized files to different screen sizes
@@ -39,6 +49,8 @@ const CollectionPageTemplate = ({
   const styles = {
     backgroundImage,
   };
+
+  const affiliate = affiliates[0];
 
   return (
     <>
@@ -58,6 +70,18 @@ const CollectionPageTemplate = ({
             <TextContent styles={{ textColor: '#FFF', fontSize: '21px' }}>
               {description}
             </TextContent>
+            {affiliate ? (
+              <div className="mt-6">
+                <p className="font-proxima-nova font-bold font-size-base text-gray-500 uppercase">
+                  {affiliatePrefix}
+                </p>
+                <img
+                  className="mt-2 affiliate-logo"
+                  src={affiliate.logo.url}
+                  alt={affiliate.logo.description || affiliate.title}
+                />
+              </div>
+            ) : null}
           </div>
         </header>
         <TextContent
@@ -81,7 +105,14 @@ CollectionPageTemplate.propTypes = {
   superTitle: PropTypes.string.isRequired,
   title: PropTypes.string.isRequired,
   description: PropTypes.object.isRequired,
+  affiliatePrefix: PropTypes.string,
+  affiliates: PropTypes.arrayOf(PropTypes.object),
   content: PropTypes.object.isRequired,
+};
+
+CollectionPageTemplate.defaultProps = {
+  affiliatePrefix: 'In partnership with',
+  affiliates: [],
 };
 
 const CollectionPage = ({ slug }) => (

--- a/resources/assets/components/pages/CollectionPage/CollectionPage.js
+++ b/resources/assets/components/pages/CollectionPage/CollectionPage.js
@@ -86,7 +86,7 @@ CollectionPageTemplate.propTypes = {
 
 const CollectionPage = ({ slug }) => (
   <PageQuery query={COLLECTION_PAGE_QUERY} variables={{ slug }}>
-    {page => <CollectionPageTemplate {...page} />}
+    {page => <CollectionPageTemplate {...withoutNulls(page)} />}
   </PageQuery>
 );
 

--- a/resources/assets/components/pages/CollectionPage/CollectionPage.js
+++ b/resources/assets/components/pages/CollectionPage/CollectionPage.js
@@ -73,7 +73,7 @@ const CollectionPageTemplate = ({
             </TextContent>
             {affiliate ? (
               <div className="mt-6">
-                <p className="font-proxima-nova font-bold font-size-base text-gray-500 uppercase">
+                <p className="font-bold font-size-base text-gray-500 uppercase">
                   {affiliatePrefix}
                 </p>
                 <img

--- a/resources/assets/components/pages/CollectionPage/CollectionPage.js
+++ b/resources/assets/components/pages/CollectionPage/CollectionPage.js
@@ -50,6 +50,7 @@ const CollectionPageTemplate = ({
     backgroundImage,
   };
 
+  // We currently only support a single affiliate.
   const affiliate = affiliates[0];
 
   return (

--- a/resources/assets/components/pages/CollectionPage/collection-page.scss
+++ b/resources/assets/components/pages/CollectionPage/collection-page.scss
@@ -26,5 +26,9 @@
         font-size: 106px;
       }
     }
+
+    .affiliate-logo {
+      max-height: 50px;
+    }
   }
 }

--- a/resources/assets/components/utilities/SocialShareTray/social-share-tray.scss
+++ b/resources/assets/components/utilities/SocialShareTray/social-share-tray.scss
@@ -21,7 +21,7 @@
     }
 
     // Hack to avoid ugly button layout with 3 / 1 per row.
-    @include media('(max-width: 1300px)') {
+    @include media('(max-width: 1350px)') {
       grid-template-columns: repeat(2, auto);
     }
 

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -106,13 +106,6 @@ module.exports = {
         '"Arial Black"',
         'sans-serif',
       ],
-      'proxima-nova': [
-        '"Proxima Nova"',
-        '"Helvetica Neue"',
-        'Helvetica',
-        'Arial',
-        'sans-serif',
-      ],
     },
     fontSize: {
       xs: '12px',

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -106,6 +106,13 @@ module.exports = {
         '"Arial Black"',
         'sans-serif',
       ],
+      'proxima-nova': [
+        '"Proxima Nova"',
+        '"Helvetica Neue"',
+        'Helvetica',
+        'Arial',
+        'sans-serif',
+      ],
     },
     fontSize: {
       xs: '12px',


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_


### What does this PR do?

This PR adds an affiliate promotion to the Collection Page using the `affiliates` & `affiliatePrefix` contentful data.

### Any background context you want to provide?
This is the one unique aspect (for now) of the Collection Page from the Cause Page. You'll notice that we hardcode to only collect the first affiliate from the list - we also have a [validation in place](https://github.com/DoSomething/phoenix-next/blob/5c865e345d5e577c8c7a3636e7a09f3cec59ff2e/contentful/content-types/collection-page.js#L143-L146) on Contentful to only accept one affiliate - we've opted to limit the scope of this work to support one affiliate for now (See the [Pivotal convo](https://www.pivotaltracker.com/story/show/169582409/comments/208722528))

I snuck in a lil tiny style update for the `SocialShareTray` in https://github.com/DoSomething/phoenix-next/pull/1739/commits/0662b19a5a5a427357b3249e0f3d5a60992a5323 since I noticed it'd break a little visually at a 1300 viewport on general pages (was testing the alpha-referral page see [here](https://user-images.githubusercontent.com/12417657/69274327-23b99e80-0ba8-11ea-928e-b2679634633d.png))


### What are the relevant tickets/cards?

Refs [Pivotal ID #169598061](https://www.pivotaltracker.com/story/show/169598061)

### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.
* [ ] Added screenshot to PR description of related front-end updates on **small** screens.
* [ ] Added screenshot to PR description of related front-end updates on **medium** screens.
* [ ] Added screenshot to PR description of related front-end updates on **large** screens.

📷 
![image](https://user-images.githubusercontent.com/12417657/69275406-4fd61f00-0baa-11ea-8df8-4e683cf2d97b.png)

- [Medium](https://user-images.githubusercontent.com/12417657/69273272-10a5cf00-0ba6-11ea-914a-349f8a02e565.png)
- [Small](https://user-images.githubusercontent.com/12417657/69273273-113e6580-0ba6-11ea-85be-9c520e5e6e5a.png)
