### PR TITLE
Adds Dismissable Element to Cta Popover Email Form on Scholarship Page

### DIFF
--- a/resources/assets/components/pages/GeneralPage/GeneralPage.js
+++ b/resources/assets/components/pages/GeneralPage/GeneralPage.js
@@ -12,14 +12,14 @@ import ContentfulEntry from '../../ContentfulEntry';
 import { REGISTER_CTA_COPY } from '../../../constants';
 import AuthorBio from '../../utilities/Author/AuthorBio';
 import CtaBanner from '../../utilities/CtaBanner/CtaBanner';
-import CtaPopover from '../../utilities/CtaPopover/CtaPopover';
-import CtaPopoverEmailForm from '../../utilities/CtaPopover/CtaPopoverEmailForm';
+// import CtaPopover from '../../utilities/CtaPopover/CtaPopover';
+// import CtaPopoverEmailForm from '../../utilities/CtaPopover/CtaPopoverEmailForm';
 import TextContent from '../../utilities/TextContent/TextContent';
 import { contentfulImageUrl, withoutNulls } from '../../../helpers';
 import SocialShareTray from '../../utilities/SocialShareTray/SocialShareTray';
 import SiteNavigationContainer from '../../SiteNavigation/SiteNavigationContainer';
-import DelayedElement from '../../utilities/DelayedElement/DelayedElement';
-import DismissableElement from '../../utilities/DismissableElement/DismissableElement';
+// import DelayedElement from '../../utilities/DelayedElement/DelayedElement';
+// import DismissableElement from '../../utilities/DismissableElement/DismissableElement';
 
 import './general-page.scss';
 
@@ -53,7 +53,7 @@ const GeneralPage = props => {
       <div className="main general-page base-12-grid">
         <Enclosure className="grid-narrow">
           <div className="general-page__heading text-center">
-            <h1 className="general-page__title caps-lock">{title}</h1>
+            <h1 className="general-page__title uppercase">{title}</h1>
             {subTitle ? (
               <p className="general-page__subtitle">{subTitle}</p>
             ) : null}
@@ -147,7 +147,7 @@ const GeneralPage = props => {
           buttonText={ctaCopy.buttonText}
         />
       ) : null}
-      {slug === 'about/easy-scholarships' ? (
+      {/* {slug === 'about/easy-scholarships' ? (
         <DismissableElement
           name="cta_popover_email"
           render={(handleClose, handleComplete) => (
@@ -163,7 +163,7 @@ const GeneralPage = props => {
             </DelayedElement>
           )}
         />
-      ) : null}
+      ) : null} */}
     </div>
   );
 };

--- a/resources/assets/components/pages/GeneralPage/GeneralPage.js
+++ b/resources/assets/components/pages/GeneralPage/GeneralPage.js
@@ -6,18 +6,21 @@ import PropTypes from 'prop-types';
 import classnames from 'classnames';
 
 import Enclosure from '../../Enclosure';
+import Modal from '../../utilities/Modal/Modal';
 import LazyImage from '../../utilities/LazyImage';
 import Byline from '../../utilities/Byline/Byline';
 import ContentfulEntry from '../../ContentfulEntry';
 import { REGISTER_CTA_COPY } from '../../../constants';
 import AuthorBio from '../../utilities/Author/AuthorBio';
 import CtaBanner from '../../utilities/CtaBanner/CtaBanner';
-// import CtaPopover from '../../utilities/CtaPopover/CtaPopover';
-// import CtaPopoverEmailForm from '../../utilities/CtaPopover/CtaPopoverEmailForm';
+import CtaPopover from '../../utilities/CtaPopover/CtaPopover';
+import CtaPopoverEmailForm from '../../utilities/CtaPopover/CtaPopoverEmailForm';
 import TextContent from '../../utilities/TextContent/TextContent';
 import { contentfulImageUrl, withoutNulls } from '../../../helpers';
 import SocialShareTray from '../../utilities/SocialShareTray/SocialShareTray';
 import SiteNavigationContainer from '../../SiteNavigation/SiteNavigationContainer';
+import DelayedElement from '../../utilities/DelayedElement/DelayedElement';
+import DismissableElement from '../../utilities/DismissableElement/DismissableElement';
 
 import './general-page.scss';
 
@@ -51,7 +54,7 @@ const GeneralPage = props => {
       <div className="main general-page base-12-grid">
         <Enclosure className="grid-narrow">
           <div className="general-page__heading text-center">
-            <h1 className="general-page__title uppercase">{title}</h1>
+            <h1 className="general-page__title caps-lock">{title}</h1>
             {subTitle ? (
               <p className="general-page__subtitle">{subTitle}</p>
             ) : null}
@@ -145,15 +148,25 @@ const GeneralPage = props => {
           buttonText={ctaCopy.buttonText}
         />
       ) : null}
-      {/* {slug === 'about/easy-scholarships' ? (
-        <CtaPopover
-          title="PAYS TO DO GOOD"
-          content="Want to earn easy scholarships for volunteering?
-          Subscribe to DoSomething's monthly scholarship email."
-        >
-          <CtaPopoverEmailForm />
-        </CtaPopover>
-      ) : null} */}
+      {slug === 'about/easy-scholarships' ? (
+        <DismissableElement
+          name="cta_popover_email"
+          render={(handleClose, handleComplete) => (
+            <DelayedElement delay={3}>
+              <Modal onClose={handleClose}>
+                <CtaPopover
+                  title="PAYS TO DO GOOD"
+                  content="Want to earn easy scholarships for volunteering?
+                  Subscribe to DoSomething's monthly scholarship email."
+                >
+                  <CtaPopoverEmailForm />
+                  <Modal onSubmit={handleComplete} />
+                </CtaPopover>
+              </Modal>
+            </DelayedElement>
+          )}
+        />
+      ) : null}
     </div>
   );
 };

--- a/resources/assets/components/pages/GeneralPage/GeneralPage.js
+++ b/resources/assets/components/pages/GeneralPage/GeneralPage.js
@@ -6,7 +6,6 @@ import PropTypes from 'prop-types';
 import classnames from 'classnames';
 
 import Enclosure from '../../Enclosure';
-import Modal from '../../utilities/Modal/Modal';
 import LazyImage from '../../utilities/LazyImage';
 import Byline from '../../utilities/Byline/Byline';
 import ContentfulEntry from '../../ContentfulEntry';
@@ -153,16 +152,14 @@ const GeneralPage = props => {
           name="cta_popover_email"
           render={(handleClose, handleComplete) => (
             <DelayedElement delay={3}>
-              <Modal onClose={handleClose}>
-                <CtaPopover
-                  title="PAYS TO DO GOOD"
-                  content="Want to earn easy scholarships for volunteering?
+              <CtaPopover
+                title="PAYS TO DO GOOD"
+                content="Want to earn easy scholarships for volunteering?
                   Subscribe to DoSomething's monthly scholarship email."
-                >
-                  <CtaPopoverEmailForm />
-                  <Modal onSubmit={handleComplete} />
-                </CtaPopover>
-              </Modal>
+                handleClose={handleClose}
+              >
+                <CtaPopoverEmailForm handleComplete={handleComplete} />
+              </CtaPopover>
             </DelayedElement>
           )}
         />

--- a/resources/assets/components/utilities/CtaPopover/CtaPopover.js
+++ b/resources/assets/components/utilities/CtaPopover/CtaPopover.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 
 import './cta-popover.scss';
 
-const CtaPopover = ({ content, handleClose, title }) => {
+const CtaPopover = ({ content, handleClose, title, children }) => {
   return (
     <div className="cta-popover p-3 bordered rounded">
       <button
@@ -17,6 +17,7 @@ const CtaPopover = ({ content, handleClose, title }) => {
         {title}
       </h3>
       <p className="text-white mt-3">{content}</p>
+      {children}
     </div>
   );
 };
@@ -25,6 +26,7 @@ CtaPopover.propTypes = {
   content: PropTypes.string.isRequired,
   handleClose: PropTypes.func.isRequired,
   title: PropTypes.string.isRequired,
+  children: PropTypes.object.isRequired,
 };
 
 export default CtaPopover;

--- a/resources/assets/components/utilities/CtaPopover/CtaPopover.js
+++ b/resources/assets/components/utilities/CtaPopover/CtaPopover.js
@@ -26,7 +26,7 @@ CtaPopover.propTypes = {
   content: PropTypes.string.isRequired,
   handleClose: PropTypes.func.isRequired,
   title: PropTypes.string.isRequired,
-  children: PropTypes.object.isRequired,
+  // children: PropTypes.object.isRequired,
 };
 
 export default CtaPopover;

--- a/resources/assets/components/utilities/CtaPopover/CtaPopover.js
+++ b/resources/assets/components/utilities/CtaPopover/CtaPopover.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 
 import './cta-popover.scss';
 
-const CtaPopover = ({ content, handleClose, title, children }) => {
+const CtaPopover = ({ content, handleClose, title }) => {
   return (
     <div className="cta-popover p-3 bordered rounded">
       <button
@@ -17,7 +17,7 @@ const CtaPopover = ({ content, handleClose, title, children }) => {
         {title}
       </h3>
       <p className="text-white mt-3">{content}</p>
-      {children}
+      {/* {children} */}
     </div>
   );
 };


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR adds delay functionality to `CtaPopoverEmailForm` so that the component mounts 3 seconds after a user visits the page 

### Any background context you want to provide?
Extension of [#1673](https://github.com/DoSomething/phoenix-next/pull/1673)

### What are the relevant tickets/cards?

Refs [Pivotal ID #168209412](https://www.pivotaltracker.com/story/show/168209412)

### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.
* [ ] Added screenshot to PR description of related front-end updates on **small** screens.
* [ ] Added screenshot to PR description of related front-end updates on **medium** screens.
* [ ] Added screenshot to PR description of related front-end updates on **large** screens.
