### PR TITLE
removes 'below' from copy on scholarship card

### DIFF
--- a/resources/assets/components/blocks/AffiliateScholarshipBlock/AffiliateScholarshipBlockBeta.js
+++ b/resources/assets/components/blocks/AffiliateScholarshipBlock/AffiliateScholarshipBlockBeta.js
@@ -34,7 +34,7 @@ const AffiliateScholarshipBlockBeta = ({
         {affiliateTitle ? ` via ${affiliateTitle.toUpperCase()}` : null}!
       </strong>{' '}
       Ready to earn scholarships for doing good? Just follow the simple
-      instructions below for the chance to win. Let’s Do This!
+      instructions for the chance to win. Let’s Do This!
     </p>
     <dl className="clearfix">
       {scholarshipAmount ? (


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR updates the generic copy on the scholarship card to remove the `below` since the placement of the card has changed with the hero template!

### Any background context you want to provide?

👀 

### What are the relevant tickets/cards?

Refs [Pivotal ID #169895232](https://www.pivotaltracker.com/story/show/169895232)

