### PR TITLE
Adds Scholarship Info to LedeBanner & Flips our feature flag back to false

### DIFF
--- a/resources/assets/components/LedeBanner/LedeBanner.js
+++ b/resources/assets/components/LedeBanner/LedeBanner.js
@@ -31,8 +31,7 @@ LedeBanner.propTypes = {
 };
 
 LedeBanner.defaultProps = {
-  // @TODO: This should default to false once we're ready to ship the Hero Template!
-  featureFlagUseLegacyTemplate: true,
+  featureFlagUseLegacyTemplate: false,
 };
 
 export default LedeBanner;

--- a/resources/assets/components/LedeBanner/LedeBannerContainer.js
+++ b/resources/assets/components/LedeBanner/LedeBannerContainer.js
@@ -35,6 +35,8 @@ const mapStateToProps = (state, props) => ({
     'campaign.additionalContent.featureFlagUseLegacyTemplate',
   ),
   isAffiliated: isSignedUp(state),
+  scholarshipAmount: state.campaign.scholarshipAmount,
+  scholarshipDeadline: state.campaign.scholarshipDeadline,
   subtitle: get(props, 'subtitle', state.campaign.callToAction),
   template: get(props, 'template', state.campaign.template),
   title: get(props, 'title', state.campaign.title),

--- a/resources/assets/components/pages/LandingPage/LandingPage.js
+++ b/resources/assets/components/pages/LandingPage/LandingPage.js
@@ -93,8 +93,7 @@ LandingPage.defaultProps = {
   affiliateSponsors: [],
   affiliateOptInContent: null,
   endDate: null,
-  // @TODO: This should default to false once we're ready to ship the Hero Template!
-  featureFlagUseLegacyTemplate: true,
+  featureFlagUseLegacyTemplate: false,
   scholarshipAmount: null,
   scholarshipDeadline: null,
   showPartnerMsgOptIn: false,

--- a/resources/assets/components/pages/LandingPage/LandingPageContainer.js
+++ b/resources/assets/components/pages/LandingPage/LandingPageContainer.js
@@ -26,11 +26,11 @@ const mapStateToProps = (state, ownProps) => {
     content: landingPage.content,
     coverImage: state.campaign.coverImage,
     endDate: state.campaign.endDate,
-    scholarshipAmount: state.campaign.scholarshipAmount,
     featureFlagUseLegacyTemplate: get(
       state,
       'campaign.additionalContent.featureFlagUseLegacyTemplate',
     ),
+    scholarshipAmount: state.campaign.scholarshipAmount,
     scholarshipDeadline: state.campaign.scholarshipDeadline,
     showPartnerMsgOptIn: get(
       state.campaign.additionalContent,


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR adds our scholarship props to the Lede Banner container so that it can display correctly after signup.

### Any background context you want to provide?

Flagged by Diego in QA

### What are the relevant tickets/cards?

Refs [Pivotal ID #169685104](https://www.pivotaltracker.com/story/show/169685104)
