### PR TITLE
Add support for CampaignUpdateBlock via GraphQL.

### DIFF
--- a/resources/assets/components/ContentfulEntry/ContentfulEntry.js
+++ b/resources/assets/components/ContentfulEntry/ContentfulEntry.js
@@ -116,6 +116,17 @@ class ContentfulEntry extends React.Component<Props, State> {
           <CampaignDashboard id={json.id} {...withoutNulls(json.fields)} />
         );
 
+      case 'CampaignUpdateBlock':
+        return (
+          <CampaignUpdateContainer
+            id={json.id}
+            affiliateLogo={json.affiliateLogo}
+            author={json.author}
+            content={json.content}
+            link={json.link}
+          />
+        );
+
       case 'campaignUpdate':
         return (
           <CampaignUpdateContainer

--- a/resources/assets/components/blocks/CampaignUpdate/CampaignUpdate.js
+++ b/resources/assets/components/blocks/CampaignUpdate/CampaignUpdate.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import gql from 'graphql-tag';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import { get } from 'lodash';
@@ -11,6 +12,24 @@ import Byline from '../../utilities/Byline/Byline';
 import { contentfulImageUrl } from '../../../helpers';
 import TextContent from '../../utilities/TextContent/TextContent';
 import AffiliatePromotion from '../../utilities/AffiliatePromotion/AffiliatePromotion';
+
+export const CampaignUpdateBlockFragment = gql`
+  fragment CampaignUpdateBlockFragment on CampaignUpdateBlock {
+    id
+    content
+    link
+    author {
+      name
+      jobTitle
+      photo {
+        url
+      }
+    }
+    affiliateLogo {
+      url
+    }
+  }
+`;
 
 const CampaignUpdate = props => {
   const {
@@ -26,7 +45,8 @@ const CampaignUpdate = props => {
     // titleLink,
   } = props;
 
-  const authorFields = get(author, 'fields', {});
+  // Support both GraphQL & PHP Content API formats:
+  const authorFields = author && author.fields ? author.fields : author;
   const authorPhoto = get(authorFields, 'photo.url') || undefined;
 
   const isTweet = content && content.length < 144;

--- a/resources/assets/components/utilities/ContentfulEntryLoader/ContentfulEntryLoader.js
+++ b/resources/assets/components/utilities/ContentfulEntryLoader/ContentfulEntryLoader.js
@@ -15,6 +15,7 @@ import { ShareBlockFragment } from '../../actions/ShareAction/ShareAction';
 import { CallToActionBlockFragment } from '../../CallToAction/CallToAction';
 import { GalleryBlockFragment } from '../../blocks/GalleryBlock/GalleryBlock';
 import { ContentBlockFragment } from '../../blocks/ContentBlock/ContentBlock';
+import { CampaignUpdateBlockFragment } from '../../blocks/CampaignUpdate/CampaignUpdate';
 import { PostGalleryBlockFragment } from '../../blocks/PostGalleryBlock/PostGalleryBlockQuery';
 import { TextSubmissionBlockFragment } from '../../actions/TextSubmissionAction/TextSubmissionAction';
 import { PhotoSubmissionBlockFragment } from '../../actions/PhotoSubmissionAction/PhotoSubmissionAction';
@@ -33,6 +34,7 @@ const CONTENTFUL_BLOCK_QUERY = gql`
       ...ContentBlockFragment
       ...PostGalleryBlockFragment
       ...CallToActionBlockFragment
+      ...CampaignUpdateBlockFragment
       ...TextSubmissionBlockFragment
       ...PhotoSubmissionBlockFragment
       ...VoterRegistrationBlockFragment
@@ -48,6 +50,7 @@ const CONTENTFUL_BLOCK_QUERY = gql`
   ${ContentBlockFragment}
   ${PostGalleryBlockFragment}
   ${CallToActionBlockFragment}
+  ${CampaignUpdateBlockFragment}
   ${TextSubmissionBlockFragment}
   ${PhotoSubmissionBlockFragment}
   ${VoterRegistrationBlockFragment}


### PR DESCRIPTION
### What does this PR do?

This PR adds support for querying `CampaignUpdateBlock` via GraphQL.

![Screen Shot 2019-11-21 at 3 55 51 PM](https://user-images.githubusercontent.com/583202/69375954-69916800-0c77-11ea-9361-632fce9a877f.png)

### Any background context you want to provide?
This will allow us to once-again link directly to campaign updates! 😌

### What are the relevant tickets/cards?

Refs [Pivotal ID #169216379](https://www.pivotaltracker.com/story/show/169216379)

### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.
* [ ] Added screenshot to PR description of related front-end updates on **small** screens.
* [ ] Added screenshot to PR description of related front-end updates on **medium** screens.
* [ ] Added screenshot to PR description of related front-end updates on **large** screens.
