### PR TITLE
Mock GraphQL for text post test

### DIFF
--- a/cypress/integration/campaign-post.js
+++ b/cypress/integration/campaign-post.js
@@ -18,6 +18,15 @@ describe('Campaign Post', () => {
   it('Create a text post', () => {
     const user = userFactory();
 
+    cy.mockGraphqlOp('ActionAndUserByIdQuery', {
+      action: {
+        collectSchoolId: false,
+      },
+      user: {
+        schoolId: null,
+      },
+    });
+
     // Log in & visit the campaign action page:
     cy.authVisitCampaignWithSignup(user, exampleCampaign);
 

--- a/resources/assets/helpers/api.js
+++ b/resources/assets/helpers/api.js
@@ -155,6 +155,5 @@ export async function getUserActionSchoolId(graphqlClient, userId, actionId) {
     variables: { userId, actionId },
   });
 
-  // @TODO: Don't return user school ID if set to unavailable.
   return result.data.action.collectSchoolId ? result.data.user.schoolId : null;
 }


### PR DESCRIPTION

### What does this PR do?

This PR mocks the GraphQL request we make in a `PostCreatedModal` to ensure the text post test runs correctly. Also removes a TODO that it turns out don't need to do - we decided we'll save `school-not-available` school ID's on Rogue posts(vs sending through a `null`)

### Any background context you want to provide?

[Slack thread](https://dosomething.slack.com/archives/CP2D7UGAU/p1574370975272600?thread_ts=1574277446.237500&cid=CP2D7UGAU) re: saving the `school-not-available` value on a post
### What are the relevant tickets/cards?

https://www.pivotaltracker.com/n/projects/2401401/stories/169549761

### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.
