### PR TITLE
Footer/nav join link updates

### DIFF
--- a/resources/assets/components/SiteNavigation/SiteNavigation.js
+++ b/resources/assets/components/SiteNavigation/SiteNavigation.js
@@ -191,7 +191,7 @@ class SiteNavigation extends React.Component {
 
             <li className="menu-nav__item">
               <a
-                href="/us/about/who-we-are"
+                href="https://join.dosomething.org/"
                 onClick={e => this.handleOnClickLink(e, { label: 'about' })}
               >
                 About

--- a/resources/views/partials/footer.blade.php
+++ b/resources/views/partials/footer.blade.php
@@ -28,7 +28,7 @@
     <div class="footer__column -links">
         <h4>Who We Are</h4>
         <ul>
-          <li><a href="{{ config('app.url') }}/us/about/who-we-are">What is DoSomething.org?</a></li>
+          <li><a href="https://join.dosomething.org/">What is DoSomething.org?</a></li>
           <li><a href="{{ config('app.url') }}/us/about/our-people">Our Team</a></li>
           <li><a href="{{ config('app.url') }}/us/about/our-financials">Our Financials</a></li>
           <li><a href="{{ config('app.url') }}/us/about/our-press">Press</a></li>

--- a/resources/views/partials/footer.blade.php
+++ b/resources/views/partials/footer.blade.php
@@ -34,7 +34,6 @@
           <li><a href="{{ config('app.url') }}/us/about/our-press">Press</a></li>
           <li><a href="https://lets.dosomething.org/">Web Magazine</a></li>
           <li><a href="{{ config('app.url') }}/us/about/contact-us">Contact Us</a></li>
-          <li><a href="https://join.dosomething.org/">Join Now</a></li>
          </ul>
     </div>
     <div class="footer__column -links">


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR changes some links around.

1. "Join Now" link has been removed from the footer.
2. The "What is DoSomething.org?" link in the footer now points to https://join.dosomething.org
3. The "About" link in the meganav now points to https://join.dosomething.org

### Any background context you want to provide?

Nope! I think this one is straightforward.

### What are the relevant tickets/cards?

Refs [Pivotal ID #169826250](https://www.pivotaltracker.com/story/show/169826250)
