### PR TITLE
🐛 Ensure we have an actionId before making the action schoolId query

### DIFF
--- a/resources/assets/components/actions/PhotoSubmissionAction/PhotoSubmissionAction.js
+++ b/resources/assets/components/actions/PhotoSubmissionAction/PhotoSubmissionAction.js
@@ -204,11 +204,13 @@ class PhotoSubmissionAction extends React.Component {
       );
     }
 
-    const schoolId = await getUserActionSchoolId(
-      this.gqlClient,
-      this.props.userId,
-      this.props.actionId,
-    );
+    const schoolId = this.props.actionId
+      ? await getUserActionSchoolId(
+          this.gqlClient,
+          this.props.userId,
+          this.props.actionId,
+        )
+      : null;
 
     const formFields = withoutNulls({
       action,


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR ensures that an `actionId` is present on the Photo Submission Action before running the Graphql query to optionally fetch a user's school information.

### Any background context you want to provide?
We saw this break for legacy Photo Submission Actions without a set `actionId` which relied on the `default` value

### What are the relevant tickets/cards?
https://dosomething.slack.com/archives/C3ASB4204/p1574439249415100