### PR TITLE
Removes info bar on closed campaigns

### DIFF
--- a/resources/assets/components/pages/CampaignPage/CampaignPage.js
+++ b/resources/assets/components/pages/CampaignPage/CampaignPage.js
@@ -21,7 +21,10 @@ const CampaignPage = props => {
 
   return (
     <React.Fragment>
-      <LedeBannerContainer displaySignupButton={Boolean(!entryContent)} />
+      <LedeBannerContainer
+        displaySignupButton={Boolean(!entryContent)}
+        isCampaignClosed={isCampaignClosed}
+      />
 
       <div className="main clearfix">
         {dashboard ? <ContentfulEntry json={dashboard} /> : null}

--- a/resources/assets/components/pages/LandingPage/templates/MarqueeTemplate.js
+++ b/resources/assets/components/pages/LandingPage/templates/MarqueeTemplate.js
@@ -26,6 +26,7 @@ const MarqueeTemplate = ({
   content,
   coverImage,
   displaySignupButton,
+  isCampaignClosed,
   isAffiliated,
   scholarshipAmount,
   scholarshipDeadline,
@@ -119,7 +120,7 @@ const MarqueeTemplate = ({
           </Enclosure>
         </div>
       </article>
-      {!isAffiliated ? <CampaignInfoBarContainer /> : null}
+      {!isAffiliated && isCampaignClosed ? <CampaignInfoBarContainer /> : null}
     </React.Fragment>
   );
 };
@@ -134,6 +135,7 @@ MarqueeTemplate.propTypes = {
   coverImage: PropTypes.object.isRequired,
   displaySignupButton: PropTypes.bool,
   isAffiliated: PropTypes.bool,
+  isCampaignClosed: PropTypes.bool,
   scholarshipAmount: PropTypes.number,
   scholarshipDeadline: PropTypes.string,
   subtitle: PropTypes.string.isRequired,
@@ -148,6 +150,7 @@ MarqueeTemplate.defaultProps = {
   campaignId: null,
   displaySignupButton: true,
   isAffiliated: false,
+  isCampaignClosed: false,
   scholarshipAmount: null,
   scholarshipDeadline: null,
 };


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR add a check whether a campaign is closed to hide a second info bar from being visible on the Marquee template. It is duplicated at the bottom of the campaign page.

### Any background context you want to provide?

Flagged by design and Ben!

### What are the relevant tickets/cards?

Refs [Pivotal ID #169923376](https://www.pivotaltracker.com/story/show/169923376)

**Before:**
![Before](https://user-images.githubusercontent.com/15236023/69451278-f77b5a80-0d2c-11ea-8acf-795ff704aad2.png)

**After:**
![After](https://user-images.githubusercontent.com/15236023/69451288-02ce8600-0d2d-11ea-8fd9-11c53ee631ed.png)



### Checklist
* [ ] Added screenshot to PR description of related front-end updates on **small** screens.
* [ ] Added screenshot to PR description of related front-end updates on **medium** screens.
* [ ] Added screenshot to PR description of related front-end updates on **large** screens.
