### PR TITLE
Add ability to load AffirmationBlock via GraphQL.

### DIFF
--- a/resources/assets/components/Affirmation/Affirmation.js
+++ b/resources/assets/components/Affirmation/Affirmation.js
@@ -10,10 +10,27 @@ import Share from '../utilities/Share/Share';
 import Badge from '../pages/AccountPage/Badge';
 import Byline from '../utilities/Byline/Byline';
 import TextContent from '../utilities/TextContent/TextContent';
-import { contentfulImageUrl, withoutNulls } from '../../helpers';
+import { contentfulImageUrl } from '../../helpers';
 import CtaReferralPageBannerContainer from '../utilities/CtaReferralPageBanner/CtaReferralPageBannerContainer';
 
 import './affirmation.scss';
+
+export const AffirmationBlockFragment = gql`
+  fragment AffirmationBlockFragment on AffirmationBlock {
+    id
+    header
+    quote
+    callToActionHeader
+    callToActionDescription
+    author {
+      name
+      jobTitle
+      photo {
+        url
+      }
+    }
+  }
+`;
 
 const USER_QUERY = gql`
   query UserAccountAndSignupsCountQuery($userId: String!) {
@@ -42,65 +59,67 @@ const Affirmation = ({
   <Card className="affirmation rounded" title={header}>
     {quote ? <TextContent className="pt-3 px-3">{quote}</TextContent> : null}
 
-    <Query query={USER_QUERY} variables={{ userId }}>
-      {res => (
-        <React.Fragment>
-          {get(res, 'user.hasBadgesFlag', false) && res.signupsCount === 1 ? (
-            <Badge
-              earned
-              className="badge p-3"
-              size="medium"
-              name="signupBadge"
-            >
-              <h4>1 Sign-Up</h4>
-              <p>
-                Congratulations! You signed up for your first campaign...and
-                earned your first badge. NICE. Ready to earn *another* badge?
-                Complete this campaign!
-              </p>
-            </Badge>
-          ) : null}
+    {userId ? (
+      <Query query={USER_QUERY} variables={{ userId }}>
+        {res => (
+          <React.Fragment>
+            {get(res, 'user.hasBadgesFlag', false) && res.signupsCount === 1 ? (
+              <Badge
+                earned
+                className="badge p-3"
+                size="medium"
+                name="signupBadge"
+              >
+                <h4>1 Sign-Up</h4>
+                <p>
+                  Congratulations! You signed up for your first campaign...and
+                  earned your first badge. NICE. Ready to earn *another* badge?
+                  Complete this campaign!
+                </p>
+              </Badge>
+            ) : null}
 
-          <Flex className="flex-align-center">
-            <FlexCell className="affirmation__cta p-3" width="half">
-              <h3>{callToActionHeader}</h3>
-              <p>{callToActionDescription}</p>
-            </FlexCell>
-            <FlexCell className="p-3" width="half">
-              <Share variant="blue" parentSource="affirmation" />
-            </FlexCell>
-          </Flex>
+            <Flex className="flex-align-center">
+              <FlexCell className="affirmation__cta p-3" width="half">
+                <h3>{callToActionHeader}</h3>
+                <p>{callToActionDescription}</p>
+              </FlexCell>
+              <FlexCell className="p-3" width="half">
+                <Share variant="blue" parentSource="affirmation" />
+              </FlexCell>
+            </Flex>
 
-          {author ? (
-            <Byline
-              author={author.fields.name}
-              {...withoutNulls(author.fields)}
-              photo={contentfulImageUrl(
-                get(author, 'fields.photo.url'),
-                175,
-                175,
-                'fill',
-              )}
-              className="pb-3 px-3"
-            />
-          ) : null}
+            {author ? (
+              <Byline
+                author={author.name}
+                jobTitle={author.jobTitle}
+                photo={contentfulImageUrl(
+                  get(author, 'photo.url'),
+                  175,
+                  175,
+                  'fill',
+                )}
+                className="pb-3 px-3"
+              />
+            ) : null}
 
-          {get(res, 'user.hasReferFriendsFlag', false) ? (
-            <CtaReferralPageBannerContainer />
-          ) : null}
+            {get(res, 'user.hasReferFriendsFlag', false) ? (
+              <CtaReferralPageBannerContainer />
+            ) : null}
 
-          <div className="p-3">
-            <button
-              type="button"
-              className="close-button font-bold text-base"
-              onClick={onClose}
-            >
-              Continue to Campaign
-            </button>
-          </div>
-        </React.Fragment>
-      )}
-    </Query>
+            <div className="p-3">
+              <button
+                type="button"
+                className="close-button font-bold text-base"
+                onClick={onClose}
+              >
+                Continue to Campaign
+              </button>
+            </div>
+          </React.Fragment>
+        )}
+      </Query>
+    ) : null}
   </Card>
 );
 

--- a/resources/assets/components/ContentfulEntry/ContentfulEntry.js
+++ b/resources/assets/components/ContentfulEntry/ContentfulEntry.js
@@ -81,7 +81,17 @@ class ContentfulEntry extends React.Component<Props, State> {
         return (
           <AffirmationContainer
             {...withoutNulls(json.fields)}
+            author={json.fields.author.fields}
             onClose={json.onClose}
+          />
+        );
+
+      // @TODO: Need to figure out 'onClose'...
+      case 'AffirmationBlock':
+        return (
+          <AffirmationContainer
+            userId={window.AUTH.id}
+            {...withoutNulls(json)}
           />
         );
 

--- a/resources/assets/components/ContentfulEntry/ContentfulEntry.js
+++ b/resources/assets/components/ContentfulEntry/ContentfulEntry.js
@@ -81,7 +81,11 @@ class ContentfulEntry extends React.Component<Props, State> {
         return (
           <AffirmationContainer
             {...withoutNulls(json.fields)}
-            author={json.fields.author.fields}
+            author={
+              json.fields && json.fields.author
+                ? json.fields.author.fields
+                : undefined
+            }
             onClose={json.onClose}
           />
         );

--- a/resources/assets/components/utilities/ContentfulEntryLoader/ContentfulEntryLoader.js
+++ b/resources/assets/components/utilities/ContentfulEntryLoader/ContentfulEntryLoader.js
@@ -10,6 +10,7 @@ import ContentfulEntry from '../../ContentfulEntry';
 import ErrorBlock from '../../blocks/ErrorBlock/ErrorBlock';
 import { EmbedBlockFragment } from '../../blocks/EmbedBlock/EmbedBlock';
 import { LinkBlockFragment } from '../../actions/LinkAction/LinkAction';
+import { AffirmationBlockFragment } from '../../Affirmation/Affirmation';
 import { ImagesBlockFragment } from '../../blocks/ImagesBlock/ImagesBlock';
 import { ShareBlockFragment } from '../../actions/ShareAction/ShareAction';
 import { CallToActionBlockFragment } from '../../CallToAction/CallToAction';
@@ -32,6 +33,7 @@ const CONTENTFUL_BLOCK_QUERY = gql`
       ...ImagesBlockFragment
       ...GalleryBlockFragment
       ...ContentBlockFragment
+      ...AffirmationBlockFragment
       ...PostGalleryBlockFragment
       ...CallToActionBlockFragment
       ...CampaignUpdateBlockFragment
@@ -48,6 +50,7 @@ const CONTENTFUL_BLOCK_QUERY = gql`
   ${ImagesBlockFragment}
   ${GalleryBlockFragment}
   ${ContentBlockFragment}
+  ${AffirmationBlockFragment}
   ${PostGalleryBlockFragment}
   ${CallToActionBlockFragment}
   ${CampaignUpdateBlockFragment}


### PR DESCRIPTION
### What does this PR do?

This pull request adds the ability to load `AffirmationBlock` via GraphQL. Here's the "normal" version, still provided by the PHP Content API, and the new version on `blocks/:id`:

<img width="1144" alt="Screen Shot 2019-11-22 at 1 56 44 PM" src="https://user-images.githubusercontent.com/583202/69452714-5a222580-0d30-11ea-9cc9-6dddb54ecbb8.png">

<img width="1144" alt="Screen Shot 2019-11-22 at 1 56 41 PM" src="https://user-images.githubusercontent.com/583202/69452719-5bebe900-0d30-11ea-9631-6956504e52aa.png">


### Any background context you want to provide?

I have not added the ability to specify an `onClose` yet, since I want to think if there's a better way we can do that without having to pass a "single-use" prop that doesn't apply to more components. Let me know if you have any ideas!

### What are the relevant tickets/cards?

Refs [Pivotal ID #169216379](https://www.pivotaltracker.com/story/show/169216379).

### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.
* [ ] Added screenshot to PR description of related front-end updates on **small** screens.
* [ ] Added screenshot to PR description of related front-end updates on **medium** screens.
* [ ] Added screenshot to PR description of related front-end updates on **large** screens.
