### PR TITLE
Post + School ID cleanup

### DIFF
--- a/resources/assets/components/actions/PetitionSubmissioncAction/PetitionSubmissionAction.js
+++ b/resources/assets/components/actions/PetitionSubmissioncAction/PetitionSubmissionAction.js
@@ -6,6 +6,7 @@ import classnames from 'classnames';
 import { Query as ApolloQuery } from 'react-apollo';
 import { PuckWaypoint } from '@dosomething/puck-client';
 
+import PostForm from '../PostForm';
 import Card from '../../utilities/Card/Card';
 import Button from '../../utilities/Button/Button';
 import PostCreatedModal from '../PostCreatedModal';
@@ -44,7 +45,7 @@ export const USER_POSTS_QUERY = gql`
 
 const CHARACTER_LIMIT = 500;
 
-class PetitionSubmissionAction extends React.Component {
+class PetitionSubmissionAction extends PostForm {
   constructor(props) {
     super(props);
 
@@ -74,7 +75,7 @@ class PetitionSubmissionAction extends React.Component {
 
   handleChange = event => this.setState({ textValue: event.target.value });
 
-  handleSubmit = event => {
+  handleSubmit = async event => {
     event.preventDefault();
 
     const { actionId, id, pageId, storePost } = this.props;
@@ -90,6 +91,7 @@ class PetitionSubmissionAction extends React.Component {
       blockId: id,
       body: formatPostPayload({
         action_id: actionId,
+        school_id: await this.getUserActionSchoolId(),
         text: this.state.textValue,
         type,
       }),

--- a/resources/assets/components/actions/PetitionSubmissioncAction/PetitionSubmissionAction.test.js
+++ b/resources/assets/components/actions/PetitionSubmissioncAction/PetitionSubmissionAction.test.js
@@ -2,10 +2,26 @@ import React from 'react';
 import { mount } from 'enzyme';
 import { MockedProvider } from '@apollo/react-testing';
 
+import { USER_ACTION_SCHOOL_ID_QUERY } from '../PostForm';
 import { USER_POSTS_QUERY } from './PetitionSubmissionAction'; // eslint-disable-line import/no-duplicates
 import PetitionSubmissionAction from './PetitionSubmissionAction'; // eslint-disable-line import/no-duplicates
 
 const mocks = [
+  {
+    request: {
+      query: USER_ACTION_SCHOOL_ID_QUERY,
+      variables: {
+        userId: '1',
+        actionIds: [1],
+      },
+    },
+    result: {
+      data: {
+        action: {},
+        user: {},
+      },
+    },
+  },
   {
     request: {
       query: USER_POSTS_QUERY,

--- a/resources/assets/components/actions/PetitionSubmissioncAction/PetitionSubmissionAction.test.js
+++ b/resources/assets/components/actions/PetitionSubmissioncAction/PetitionSubmissionAction.test.js
@@ -2,26 +2,10 @@ import React from 'react';
 import { mount } from 'enzyme';
 import { MockedProvider } from '@apollo/react-testing';
 
-import { USER_ACTION_SCHOOL_ID_QUERY } from '../PostForm';
 import { USER_POSTS_QUERY } from './PetitionSubmissionAction'; // eslint-disable-line import/no-duplicates
 import PetitionSubmissionAction from './PetitionSubmissionAction'; // eslint-disable-line import/no-duplicates
 
 const mocks = [
-  {
-    request: {
-      query: USER_ACTION_SCHOOL_ID_QUERY,
-      variables: {
-        userId: '1',
-        actionIds: [1],
-      },
-    },
-    result: {
-      data: {
-        action: {},
-        user: {},
-      },
-    },
-  },
   {
     request: {
       query: USER_POSTS_QUERY,
@@ -43,6 +27,7 @@ describe('PetitionSubmissionAction component', () => {
   const wrapper = mount(
     <MockedProvider mocks={mocks} addTypename={false}>
       <PetitionSubmissionAction
+        automatedTest={true}
         id="abcdefghi123456789"
         pageId="abcdefghi123456789"
         campaignContentfulId="1"

--- a/resources/assets/components/actions/PetitionSubmissioncAction/PetitionSubmissionAction.test.js
+++ b/resources/assets/components/actions/PetitionSubmissioncAction/PetitionSubmissionAction.test.js
@@ -27,7 +27,7 @@ describe('PetitionSubmissionAction component', () => {
   const wrapper = mount(
     <MockedProvider mocks={mocks} addTypename={false}>
       <PetitionSubmissionAction
-        automatedTest={true}
+        automatedTest
         id="abcdefghi123456789"
         pageId="abcdefghi123456789"
         campaignContentfulId="1"

--- a/resources/assets/components/actions/PhotoSubmissionAction/PhotoSubmissionAction.js
+++ b/resources/assets/components/actions/PhotoSubmissionAction/PhotoSubmissionAction.js
@@ -7,7 +7,7 @@ import classnames from 'classnames';
 import { get, has, invert, mapValues } from 'lodash';
 import { PuckWaypoint } from '@dosomething/puck-client';
 
-import graphqlClient from '../../../graphql';
+import PostForm from '../PostForm';
 import Card from '../../utilities/Card/Card';
 import Button from '../../utilities/Button/Button';
 import PostCreatedModal from '../PostCreatedModal';
@@ -18,7 +18,7 @@ import {
   getUserCampaignSignups,
 } from '../../../helpers/api';
 import FormValidation from '../../utilities/Form/FormValidation';
-import { env, withoutUndefined, withoutNulls } from '../../../helpers';
+import { withoutUndefined, withoutNulls } from '../../../helpers';
 import PrivacyLanguage from '../../utilities/PrivacyLanguage/PrivacyLanguage';
 import {
   calculateDifference,
@@ -46,7 +46,7 @@ export const PhotoSubmissionBlockFragment = gql`
   }
 `;
 
-class PhotoSubmissionAction extends React.Component {
+class PhotoSubmissionAction extends PostForm {
   /**
    * Lifecycle method invoked before every render.
    *
@@ -94,9 +94,6 @@ class PhotoSubmissionAction extends React.Component {
       signup: null,
       whyParticipatedValue: '',
     };
-
-    // Needed to fetch the user action school ID via GraphQL.
-    this.gqlClient = graphqlClient(env('GRAPHQL_URL'));
   }
 
   /**

--- a/resources/assets/components/actions/PhotoSubmissionAction/PhotoSubmissionAction.js
+++ b/resources/assets/components/actions/PhotoSubmissionAction/PhotoSubmissionAction.js
@@ -13,10 +13,7 @@ import Button from '../../utilities/Button/Button';
 import PostCreatedModal from '../PostCreatedModal';
 import ActionInformation from '../ActionInformation';
 import MediaUploader from '../../utilities/MediaUploader';
-import {
-  getUserActionSchoolId,
-  getUserCampaignSignups,
-} from '../../../helpers/api';
+import { getUserCampaignSignups } from '../../../helpers/api';
 import FormValidation from '../../utilities/Form/FormValidation';
 import { withoutUndefined, withoutNulls } from '../../../helpers';
 import PrivacyLanguage from '../../utilities/PrivacyLanguage/PrivacyLanguage';
@@ -201,14 +198,6 @@ class PhotoSubmissionAction extends PostForm {
       );
     }
 
-    const schoolId = this.props.actionId
-      ? await getUserActionSchoolId(
-          this.gqlClient,
-          this.props.userId,
-          this.props.actionId,
-        )
-      : null;
-
     const formFields = withoutNulls({
       action,
       type,
@@ -218,7 +207,7 @@ class PhotoSubmissionAction extends PostForm {
       ...values,
       file: this.state.mediaValue.file || '',
       show_quantity: this.props.showQuantityField ? 1 : 0,
-      school_id: schoolId,
+      school_id: await this.getUserActionSchoolId(),
     });
 
     // Send request to store the campaign photo submission post.

--- a/resources/assets/components/actions/PhotoSubmissionAction/PhotoSubmissionAction.test.js
+++ b/resources/assets/components/actions/PhotoSubmissionAction/PhotoSubmissionAction.test.js
@@ -10,6 +10,7 @@ describe('PhotoSubmissionAction component', () => {
 
   const wrapper = shallow(
     <PhotoSubmissionAction
+      automatedTest={true}
       campaignContentfulId="1"
       campaignId="1234"
       id={id}

--- a/resources/assets/components/actions/PhotoSubmissionAction/PhotoSubmissionAction.test.js
+++ b/resources/assets/components/actions/PhotoSubmissionAction/PhotoSubmissionAction.test.js
@@ -1,0 +1,33 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import PhotoSubmissionAction from './PhotoSubmissionAction';
+
+jest.mock('../../../helpers/api');
+
+describe('PhotoSubmissionAction component', () => {
+  const id = 'abcdefghi123456789';
+
+  const wrapper = shallow(
+    <PhotoSubmissionAction
+      campaignContentfulId="1"
+      campaignId="1234"
+      id={id}
+      pageId={id}
+      resetPostSubmissionItem={jest.fn()}
+      storeCampaignPost={jest.fn()}
+      submissions={{
+        isPending: false,
+        items: {},
+      }}
+      userId="666655554444333322221111"
+    />,
+  );
+
+  test('is rendered as a card component with a form, MediaUploader and a submit button', () => {
+    expect(wrapper.find('Card').length).toBeGreaterThanOrEqual(1);
+    expect(wrapper.find('form').length).toEqual(1);
+    expect(wrapper.find('MediaUploader').length).toEqual(1);
+    expect(wrapper.find('Button').length).toEqual(1);
+  });
+});

--- a/resources/assets/components/actions/PhotoSubmissionAction/PhotoSubmissionAction.test.js
+++ b/resources/assets/components/actions/PhotoSubmissionAction/PhotoSubmissionAction.test.js
@@ -10,7 +10,7 @@ describe('PhotoSubmissionAction component', () => {
 
   const wrapper = shallow(
     <PhotoSubmissionAction
-      automatedTest={true}
+      automatedTest
       campaignContentfulId="1"
       campaignId="1234"
       id={id}

--- a/resources/assets/components/actions/PostForm.js
+++ b/resources/assets/components/actions/PostForm.js
@@ -27,7 +27,8 @@ class PostForm extends React.Component {
 
     /**
      * Needed to query GraphQL on form submit events while our Submission components are
-     * defined as classes -- and can't use React Hooks until we refactor as functional components.
+     * defined as classes and can't use React Hooks until they are as functional components.
+
      *
      * Because we're querying outside of our App, our tests fail with an Invariant Violation,
      * because MockedProvider can't find fetch for this new Apollo Client we're creating on the fly.
@@ -39,14 +40,20 @@ class PostForm extends React.Component {
 
   /**
    * Query GraphQL to determine whether to save user's current school when creating a post.
+   *
+   * @return {Promise}
    */
   async getUserActionSchoolId() {
-    const { actionId, userId } = this.props;
+    const { actionId, automatedTest, userId } = this.props;
 
-    if (!actionId || this.props.automatedTest) {
+    if (!actionId || automatedTest) {
       return Promise.resolve(null);
     }
 
+    /**
+     * We use ApolloClient.query here because React hooks fail wuith Invalid Hook Call warning.
+     * @see https://reactjs.org/warnings/invalid-hook-call-warning.html
+     */
     const result = await this.gqlClient.query({
       query: USER_ACTION_SCHOOL_ID_QUERY,
       variables: { userId, actionId },

--- a/resources/assets/components/actions/PostForm.js
+++ b/resources/assets/components/actions/PostForm.js
@@ -1,7 +1,20 @@
 import React from 'react';
+import gql from 'graphql-tag';
+import PropTypes from 'prop-types';
 
 import { env } from '../../helpers';
 import graphqlClient from '../../graphql';
+
+export const USER_ACTION_SCHOOL_ID_QUERY = gql`
+  query ActionAndUserByIdQuery($actionId: Int!, $userId: String!) {
+    action(id: $actionId) {
+      collectSchoolId
+    }
+    user(id: $userId) {
+      schoolId
+    }
+  }
+`;
 
 class PostForm extends React.Component {
   /**
@@ -13,11 +26,40 @@ class PostForm extends React.Component {
     super(props);
 
     /**
-     * Needed to query GraphQL on form submit events while our ActonTypeSubmissionAction components
-     * are classes, and can't use React Hooks until we refactor as functional components.
+     * Needed to query GraphQL on form submit events while our Submission components are
+     * defined as classes -- and can't use React Hooks until we refactor as functional components.
      */
     this.gqlClient = graphqlClient(env('GRAPHQL_URL'));
   }
+
+  /**
+   * Query GraphQL to determine whether to save user's current school when creating a post.
+   */
+  async getUserActionSchoolId() {
+    const { actionId, userId } = this.props;
+
+    if (!actionId) {
+      return Promise.resolve(null);
+    }
+
+    const result = await this.gqlClient.query({
+      query: USER_ACTION_SCHOOL_ID_QUERY,
+      variables: { userId, actionId },
+    });
+
+    return result.data.action.collectSchoolId
+      ? result.data.user.schoolId
+      : null;
+  }
 }
+
+PostForm.propTypes = {
+  actionId: PropTypes.number,
+  userId: PropTypes.string.isRequired,
+};
+
+PostForm.defaultProps = {
+  actionId: null,
+};
 
 export default PostForm;

--- a/resources/assets/components/actions/PostForm.js
+++ b/resources/assets/components/actions/PostForm.js
@@ -28,8 +28,13 @@ class PostForm extends React.Component {
     /**
      * Needed to query GraphQL on form submit events while our Submission components are
      * defined as classes -- and can't use React Hooks until we refactor as functional components.
+     *
+     * Because we're querying outside of our App, our tests fail with an Invariant Violation,
+     * because MockedProvider can't find fetch for this new Apollo Client we're creating on the fly.
      */
-    this.gqlClient = graphqlClient(env('GRAPHQL_URL'));
+    this.gqlClient = this.props.automatedTest
+      ? null
+      : graphqlClient(env('GRAPHQL_URL'));
   }
 
   /**
@@ -38,7 +43,7 @@ class PostForm extends React.Component {
   async getUserActionSchoolId() {
     const { actionId, userId } = this.props;
 
-    if (!actionId) {
+    if (!actionId || this.props.automatedTest) {
       return Promise.resolve(null);
     }
 
@@ -55,10 +60,12 @@ class PostForm extends React.Component {
 
 PostForm.propTypes = {
   actionId: PropTypes.number,
+  automatedTest: PropTypes.bool,
   userId: PropTypes.string.isRequired,
 };
 
 PostForm.defaultProps = {
+  automatedTest: false,
   actionId: null,
 };
 

--- a/resources/assets/components/actions/PostForm.js
+++ b/resources/assets/components/actions/PostForm.js
@@ -51,9 +51,6 @@ class PostForm extends React.Component {
       return Promise.resolve(null);
     }
 
-    /**
-
-     */
     const result = await this.gqlClient.query({
       query: USER_ACTION_SCHOOL_ID_QUERY,
       variables: { userId, actionId },

--- a/resources/assets/components/actions/PostForm.js
+++ b/resources/assets/components/actions/PostForm.js
@@ -1,0 +1,23 @@
+import React from 'react';
+
+import { env } from '../../helpers';
+import graphqlClient from '../../graphql';
+
+class PostForm extends React.Component {
+  /**
+   * Create a new instance.
+   *
+   * @param  {Object} props
+   */
+  constructor(props) {
+    super(props);
+
+    /**
+     * Needed to query GraphQL on form submit events while our ActonTypeSubmissionAction components
+     * are classes, and can't use React Hooks until we refactor as functional components.
+     */
+    this.gqlClient = graphqlClient(env('GRAPHQL_URL'));
+  }
+}
+
+export default PostForm;

--- a/resources/assets/components/actions/PostForm.js
+++ b/resources/assets/components/actions/PostForm.js
@@ -26,12 +26,13 @@ class PostForm extends React.Component {
     super(props);
 
     /**
-     * Needed to query GraphQL on form submit events while our Submission components are
-     * defined as classes and can't use React Hooks until they are as functional components.
-
+     * We need to create an ApolloClient instance to call query to make GraphQL requests within the
+     * Submission Action components because they are defined as classes, and can't use React Hooks.
+     * @see https://reactjs.org/warnings/invalid-hook-call-warning.html
      *
      * Because we're querying outside of our App, our tests fail with an Invariant Violation,
      * because MockedProvider can't find fetch for this new Apollo Client we're creating on the fly.
+     * @see https://circleci.com/gh/DoSomething/phoenix-next/1398?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link
      */
     this.gqlClient = this.props.automatedTest
       ? null
@@ -51,8 +52,7 @@ class PostForm extends React.Component {
     }
 
     /**
-     * We use ApolloClient.query here because React hooks fail wuith Invalid Hook Call warning.
-     * @see https://reactjs.org/warnings/invalid-hook-call-warning.html
+
      */
     const result = await this.gqlClient.query({
       query: USER_ACTION_SCHOOL_ID_QUERY,

--- a/resources/assets/components/actions/TextSubmissionAction/TextSubmissionAction.js
+++ b/resources/assets/components/actions/TextSubmissionAction/TextSubmissionAction.js
@@ -5,6 +5,7 @@ import classnames from 'classnames';
 import { get, has, invert, mapValues } from 'lodash';
 import { PuckWaypoint } from '@dosomething/puck-client';
 
+import PostForm from '../PostForm';
 import Card from '../../utilities/Card/Card';
 import Button from '../../utilities/Button/Button';
 import PostCreatedModal from '../PostCreatedModal';
@@ -33,7 +34,7 @@ export const TextSubmissionBlockFragment = gql`
   }
 `;
 
-class TextSubmissionAction extends React.Component {
+class TextSubmissionAction extends PostForm {
   static getDerivedStateFromProps(nextProps) {
     const response = nextProps.submissions.items[nextProps.id] || null;
 
@@ -82,7 +83,7 @@ class TextSubmissionAction extends React.Component {
     });
   };
 
-  handleSubmit = event => {
+  handleSubmit = async event => {
     event.preventDefault();
 
     this.props.resetPostSubmissionItem(this.props.id);
@@ -96,6 +97,7 @@ class TextSubmissionAction extends React.Component {
       type,
       id: this.props.id, // @TODO: rename property to blockId?
       action_id: this.props.actionId,
+      school_id: await this.getUserActionSchoolId(),
       // Associate state values to fields.
       ...mapValues(this.fields, value => this.state[`${value}Value`]),
     });

--- a/resources/assets/components/actions/TextSubmissionAction/TextSubmissionAction.test.js
+++ b/resources/assets/components/actions/TextSubmissionAction/TextSubmissionAction.test.js
@@ -8,6 +8,7 @@ describe('TextSubmissionAction component', () => {
 
   const wrapper = shallow(
     <TextSubmissionAction
+      automatedTest={true}
       campaignId="1234"
       id={id}
       resetPostSubmissionItem={jest.fn()}

--- a/resources/assets/components/actions/TextSubmissionAction/TextSubmissionAction.test.js
+++ b/resources/assets/components/actions/TextSubmissionAction/TextSubmissionAction.test.js
@@ -8,7 +8,7 @@ describe('TextSubmissionAction component', () => {
 
   const wrapper = shallow(
     <TextSubmissionAction
-      automatedTest={true}
+      automatedTest
       campaignId="1234"
       id={id}
       resetPostSubmissionItem={jest.fn()}

--- a/resources/assets/helpers/api.js
+++ b/resources/assets/helpers/api.js
@@ -2,7 +2,6 @@
 
 import { join } from 'path';
 import { get } from 'lodash';
-import gql from 'graphql-tag';
 import { RestApiClient } from '@dosomething/gateway';
 
 import { PHOENIX_URL } from '../constants';
@@ -125,35 +124,4 @@ export function getBlock(id) {
   const path = join('api/v2/blocks', id);
 
   return getRequest(`${PHOENIX_URL}/${path}`);
-}
-
-/**
- * Returns given user school ID if the given action should collect school ID.
- *
- * NOTE: We need to pass an ApolloClient argument to avoid an Invariant Violation in our jest tests.
- * @see https://circleci.com/gh/DoSomething/phoenix-next/1348?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link
- *
- * @param {ApolloClient} graphqlClient
- * @param {String} userId
- * @param {Number} actionId
- * @return {Promise}
- */
-export async function getUserActionSchoolId(graphqlClient, userId, actionId) {
-  const query = gql`
-    query ActionAndUserByIdQuery($actionId: Int!, $userId: String!) {
-      action(id: $actionId) {
-        collectSchoolId
-      }
-      user(id: $userId) {
-        schoolId
-      }
-    }
-  `;
-
-  const result = await graphqlClient.query({
-    query,
-    variables: { userId, actionId },
-  });
-
-  return result.data.action.collectSchoolId ? result.data.user.schoolId : null;
 }


### PR DESCRIPTION
### What does this PR do?

This PR moves the `getUserActionSchoolId` helper introduced in #1741 over to  a new `PostForm` class component, which all of our class components that create posts (and need to check whether to include the user's school ID) can inherit from. I've refactored the `PhotoSubmissionAction` to inherit from it, as well as `TextSubmissionAction` and `PetitionSubmissionAction`. 

The `PostForm` class component also has an `automatedTest` boolean prop that fixes the Invariant Violation we get when trying to create a new instance of ApolloClient within our MockedProvider in jest tests (refs https://github.com/DoSomething/phoenix-next/pull/1752#issuecomment-557584791, #1741)

### Any background context you want to provide?

I've been adding new actions to dev, and manually testing over on the Example School Finder Campaign I've been working against.

Last components left to refactor for School ID check will be for a future PR: SelectionAction, ShareAction, SoftEdgeWidgetAction

### What are the relevant tickets/cards?

https://www.pivotaltracker.com/story/show/169549761

### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.
