### PR TITLE
🐛Social Drive Action width bug fix

### DIFF
--- a/resources/assets/components/actions/SocialDriveAction/SocialDriveAction.js
+++ b/resources/assets/components/actions/SocialDriveAction/SocialDriveAction.js
@@ -65,7 +65,9 @@ class SocialDriveAction extends React.Component {
     const shortenedLink = this.state.shortenedLink;
 
     return (
-      <div className="clearfix pb-6 lg:flex">
+      <div
+        className={classNames('clearfix pb-6', { 'lg:flex': !hidePageViews })}
+      >
         <div
           className={classNames('social-drive-action', {
             'lg:w-2/3 lg:pr-3': !hidePageViews,


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR fixes a small UI bug on the `SocialDriveAction` wherein we'd always set `display: flex` causing it to not span the full width when we _weren't_ showing a page views card.

### What are the relevant tickets/cards?

https://www.pivotaltracker.com/story/show/169926813/comments/209049135

### Checklist

* [x] Added screenshot to PR description of related front-end updates on **large** screens.

**Before**
![image](https://user-images.githubusercontent.com/12417657/69567175-c9915280-0f86-11ea-8920-5e169011aee1.png)


**After**
![image](https://user-images.githubusercontent.com/12417657/69567194-d44be780-0f86-11ea-9a81-8f12f8e29877.png)

