### PR TITLE
Update table styles to match new branding

### DIFF
--- a/resources/assets/components/utilities/TextContent/markdown.scss
+++ b/resources/assets/components/utilities/TextContent/markdown.scss
@@ -99,25 +99,35 @@
   }
 
   table {
-    background-color: $white;
-    margin: $base-spacing 0;
-    table-layout: fixed;
+    border-collapse: collapse;
+    border-spacing: 0;
+    background-color: theme('colors.white');
+    margin: 32px 0;
+    border: 1px solid theme('colors.gray.200');
+    width: auto;
   }
 
-  th {
-    font-weight: 700;
-    text-align: center;
+  table td:last-child {
+    width: 100%;
   }
 
   th,
   td {
-    border: 1px solid $light-gray;
-    padding: $half-spacing;
-    width: 50%;
+    padding: 16px;
+    padding-right: 32px;
+    white-space: nowrap;
   }
 
-  tbody tr:nth-child(even) {
-    background-color: #f2f2f2;
+  th {
+    font-weight: 700;
+    text-align: left;
+    background-color: #332baa;
+    color: theme('colors.white');
+    border: none;
+  }
+
+  tbody tr:nth-child(2n) {
+    background-color: #f4f9ff;
   }
 
   hr {

--- a/resources/assets/components/utilities/TextContent/markdown.scss
+++ b/resources/assets/components/utilities/TextContent/markdown.scss
@@ -122,7 +122,7 @@
     border: none;
   }
 
-  tbody tr:nth-child(2n) {
+  tbody tr:nth-child(even) {
     background-color: #f4f9ff;
   }
 

--- a/resources/assets/components/utilities/TextContent/markdown.scss
+++ b/resources/assets/components/utilities/TextContent/markdown.scss
@@ -104,18 +104,14 @@
     background-color: theme('colors.white');
     margin: 32px 0;
     border: 1px solid theme('colors.gray.200');
-    width: auto;
-  }
-
-  table td:last-child {
-    width: 100%;
+    max-width: 100%;
+    overflow: scroll;
   }
 
   th,
   td {
     padding: 16px;
     padding-right: 32px;
-    white-space: nowrap;
   }
 
   th {


### PR DESCRIPTION
### What does this PR do?
This PR restyles tables created with Markdown for campaign and content pages. 

### Any background context you want to provide?
We haven't changed anything functionally, just updated the colors and spacing of table elements

### What are the relevant tickets/cards?
Refs [Pivotal ID #169608401](https://www.pivotaltracker.com/story/show/169608401)

### Checklist
**Small**
![Screen Shot 2019-11-25 at 1 34 48 PM](https://user-images.githubusercontent.com/1865372/69568546-d2375800-0f89-11ea-8bd0-a0e597f5053e.png)

**Medium**
![Screen Shot 2019-11-25 at 1 19 49 PM](https://user-images.githubusercontent.com/1865372/69568562-da8f9300-0f89-11ea-9260-3c4eea54a987.png)

**Large**
![Screen Shot 2019-11-25 at 1 45 08 PM](https://user-images.githubusercontent.com/1865372/69568571-dd8a8380-0f89-11ea-86d1-dffa62b18693.png)


