### PR TITLE
Add GraphQL support for SoftEdgeBlock, SocialDriveBlock, and SelectionSubmissionBlock.

### DIFF
--- a/app/Entities/SelectionSubmissionAction.php
+++ b/app/Entities/SelectionSubmissionAction.php
@@ -14,7 +14,7 @@ class SelectionSubmissionAction extends Entity implements JsonSerializable
             'fields' => [
                 'actionId' => $this->actionId,
                 'title' => $this->title,
-                'content' => $this->content,
+                'richText' => $this->content,
                 'selectionFieldLabel' => $this->selectionFieldLabel,
                 'selectionOptions' => $this->selectionOptions,
                 'selectionPlaceholderOption' => $this->selectionPlaceholderOption,

--- a/resources/assets/components/ContentfulEntry/ContentfulEntry.js
+++ b/resources/assets/components/ContentfulEntry/ContentfulEntry.js
@@ -340,6 +340,9 @@ class ContentfulEntry extends React.Component<Props, State> {
       case 'socialDriveAction':
         return <SocialDriveActionContainer {...json.fields} />;
 
+      case 'SoftEdgeBlock':
+        return <SoftEdgeWidgetActionContainer {...json} />;
+
       case 'softEdgeWidgetAction':
         return <SoftEdgeWidgetActionContainer {...json.fields} />;
 

--- a/resources/assets/components/ContentfulEntry/ContentfulEntry.js
+++ b/resources/assets/components/ContentfulEntry/ContentfulEntry.js
@@ -337,6 +337,9 @@ class ContentfulEntry extends React.Component<Props, State> {
           <SixpackExperiment id={json.id} {...withoutNulls(json.fields)} />
         );
 
+      case 'SocialDriveBlock':
+        return <SocialDriveActionContainer {...json} />;
+
       case 'socialDriveAction':
         return <SocialDriveActionContainer {...json.fields} />;
 

--- a/resources/assets/components/ContentfulEntry/ContentfulEntry.js
+++ b/resources/assets/components/ContentfulEntry/ContentfulEntry.js
@@ -324,6 +324,9 @@ class ContentfulEntry extends React.Component<Props, State> {
           />
         );
 
+      case 'SelectionSubmissionBlock':
+        return <SelectionSubmissionActionContainer {...withoutNulls(json)} />;
+
       case 'shareAction':
         return (
           <ShareActionContainer id={json.id} {...withoutNulls(json.fields)} />

--- a/resources/assets/components/actions/SelectionSubmissionAction/SelectionSubmissionAction.js
+++ b/resources/assets/components/actions/SelectionSubmissionAction/SelectionSubmissionAction.js
@@ -13,6 +13,19 @@ import { formatPostPayload, getFieldErrors } from '../../../helpers/forms';
 
 import './selection-submission-action.scss';
 
+export const SelectionSubmissionBlockFragment = gql`
+  fragment SelectionSubmissionBlockFragment on SelectionSubmissionBlock {
+    actionId
+    title
+    richText
+    selectionFieldLabel
+    selectionOptions
+    selectionPlaceholderOption
+    buttonText
+    postSubmissionLabel
+  }
+`;
+
 const USER_POSTS_QUERY = gql`
   query UserPostsQuery($userId: String!, $actionIds: [Int]!) {
     posts(userId: $userId, actionIds: $actionIds) {
@@ -88,7 +101,7 @@ class SelectionSubmissionAction extends React.Component {
       buttonText,
       id,
       title,
-      content,
+      richText,
       postSubmissionLabel,
       selectionFieldLabel,
       selectionPlaceholderOption,
@@ -112,7 +125,7 @@ class SelectionSubmissionAction extends React.Component {
       >
         {formResponse ? <FormValidation response={formResponse} /> : null}
 
-        <TextContent className="p-3">{content}</TextContent>
+        <TextContent className="p-3">{richText}</TextContent>
 
         <Query
           query={USER_POSTS_QUERY}
@@ -193,7 +206,7 @@ SelectionSubmissionAction.propTypes = {
   actionId: PropTypes.number.isRequired,
   buttonText: PropTypes.string,
   campaignId: PropTypes.string.isRequired,
-  content: PropTypes.object.isRequired,
+  richText: PropTypes.object.isRequired,
   id: PropTypes.string.isRequired, // @TODO: rename property to blockId
   pageId: PropTypes.string.isRequired,
   postSubmissionLabel: PropTypes.string.isRequired,

--- a/resources/assets/components/actions/SocialDriveAction/SocialDriveAction.js
+++ b/resources/assets/components/actions/SocialDriveAction/SocialDriveAction.js
@@ -1,6 +1,7 @@
 /* global document */
 
 import React from 'react';
+import gql from 'graphql-tag';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
@@ -13,6 +14,13 @@ import { dynamicString, withoutTokens } from '../../../helpers';
 import SocialShareTray from '../../utilities/SocialShareTray/SocialShareTray';
 
 import './social-drive.scss';
+
+export const SocialDriveBlockFragment = gql`
+  fragment SocialDriveBlockFragment on SocialDriveBlock {
+    link
+    hidePageViews
+  }
+`;
 
 class SocialDriveAction extends React.Component {
   constructor(props) {

--- a/resources/assets/components/actions/SoftEdgeWidgetAction/SoftEdgeWidgetAction.js
+++ b/resources/assets/components/actions/SoftEdgeWidgetAction/SoftEdgeWidgetAction.js
@@ -1,9 +1,18 @@
 /* global window, document, $cweb */
 import React from 'react';
+import gql from 'graphql-tag';
 import PropTypes from 'prop-types';
 
 import Card from '../../utilities/Card/Card';
 import { withoutNulls } from '../../../helpers';
+
+export const SoftEdgeBlockFragment = gql`
+  fragment SoftEdgeBlockFragment on SoftEdgeBlock {
+    title
+    actionId
+    softEdgeId
+  }
+`;
 
 class SoftEdgeWidgetAction extends React.Component {
   componentDidMount() {
@@ -28,9 +37,7 @@ class SoftEdgeWidgetAction extends React.Component {
     const actionId = this.props.actionId;
     const user = this.props.user;
 
-    let url = `//www.congressweb.com/dosomething/${softEdgeId}?acceptAuthor=true&memberId=${
-      this.props.userId
-    }&externalActionId=${actionId}`;
+    let url = `//www.congressweb.com/dosomething/${softEdgeId}?acceptAuthor=true&memberId=${this.props.userId}&externalActionId=${actionId}`;
 
     const prepopulatedFields = withoutNulls({
       firstName: user.firstName,

--- a/resources/assets/components/utilities/ContentfulEntryLoader/ContentfulEntryLoader.js
+++ b/resources/assets/components/utilities/ContentfulEntryLoader/ContentfulEntryLoader.js
@@ -18,6 +18,7 @@ import { GalleryBlockFragment } from '../../blocks/GalleryBlock/GalleryBlock';
 import { ContentBlockFragment } from '../../blocks/ContentBlock/ContentBlock';
 import { CampaignUpdateBlockFragment } from '../../blocks/CampaignUpdate/CampaignUpdate';
 import { PostGalleryBlockFragment } from '../../blocks/PostGalleryBlock/PostGalleryBlockQuery';
+import { SoftEdgeBlockFragment } from '../../actions/SoftEdgeWidgetAction/SoftEdgeWidgetAction';
 import { TextSubmissionBlockFragment } from '../../actions/TextSubmissionAction/TextSubmissionAction';
 import { PhotoSubmissionBlockFragment } from '../../actions/PhotoSubmissionAction/PhotoSubmissionAction';
 import { VoterRegistrationBlockFragment } from '../../actions/VoterRegistrationAction/VoterRegistrationAction';
@@ -33,6 +34,7 @@ const CONTENTFUL_BLOCK_QUERY = gql`
       ...ImagesBlockFragment
       ...GalleryBlockFragment
       ...ContentBlockFragment
+      ...SoftEdgeBlockFragment
       ...AffirmationBlockFragment
       ...PostGalleryBlockFragment
       ...CallToActionBlockFragment
@@ -50,6 +52,7 @@ const CONTENTFUL_BLOCK_QUERY = gql`
   ${ImagesBlockFragment}
   ${GalleryBlockFragment}
   ${ContentBlockFragment}
+  ${SoftEdgeBlockFragment}
   ${AffirmationBlockFragment}
   ${PostGalleryBlockFragment}
   ${CallToActionBlockFragment}

--- a/resources/assets/components/utilities/ContentfulEntryLoader/ContentfulEntryLoader.js
+++ b/resources/assets/components/utilities/ContentfulEntryLoader/ContentfulEntryLoader.js
@@ -17,6 +17,7 @@ import { CallToActionBlockFragment } from '../../CallToAction/CallToAction';
 import { GalleryBlockFragment } from '../../blocks/GalleryBlock/GalleryBlock';
 import { ContentBlockFragment } from '../../blocks/ContentBlock/ContentBlock';
 import { CampaignUpdateBlockFragment } from '../../blocks/CampaignUpdate/CampaignUpdate';
+import { SocialDriveBlockFragment } from '../../actions/SocialDriveAction/SocialDriveAction';
 import { PostGalleryBlockFragment } from '../../blocks/PostGalleryBlock/PostGalleryBlockQuery';
 import { SoftEdgeBlockFragment } from '../../actions/SoftEdgeWidgetAction/SoftEdgeWidgetAction';
 import { TextSubmissionBlockFragment } from '../../actions/TextSubmissionAction/TextSubmissionAction';
@@ -36,6 +37,7 @@ const CONTENTFUL_BLOCK_QUERY = gql`
       ...ContentBlockFragment
       ...SoftEdgeBlockFragment
       ...AffirmationBlockFragment
+      ...SocialDriveBlockFragment
       ...PostGalleryBlockFragment
       ...CallToActionBlockFragment
       ...CampaignUpdateBlockFragment
@@ -54,6 +56,7 @@ const CONTENTFUL_BLOCK_QUERY = gql`
   ${ContentBlockFragment}
   ${SoftEdgeBlockFragment}
   ${AffirmationBlockFragment}
+  ${SocialDriveBlockFragment}
   ${PostGalleryBlockFragment}
   ${CallToActionBlockFragment}
   ${CampaignUpdateBlockFragment}

--- a/resources/assets/components/utilities/ContentfulEntryLoader/ContentfulEntryLoader.js
+++ b/resources/assets/components/utilities/ContentfulEntryLoader/ContentfulEntryLoader.js
@@ -24,6 +24,7 @@ import { TextSubmissionBlockFragment } from '../../actions/TextSubmissionAction/
 import { PhotoSubmissionBlockFragment } from '../../actions/PhotoSubmissionAction/PhotoSubmissionAction';
 import { VoterRegistrationBlockFragment } from '../../actions/VoterRegistrationAction/VoterRegistrationAction';
 import { PetitionSubmissionBlockFragment } from '../../actions/PetitionSubmissioncAction/PetitionSubmissionAction';
+import { SelectionSubmissionBlockFragment } from '../../actions/SelectionSubmissionAction/SelectionSubmissionAction';
 
 const CONTENTFUL_BLOCK_QUERY = gql`
   query ContentfulBlockQuery($id: String!, $preview: Boolean!) {
@@ -45,6 +46,7 @@ const CONTENTFUL_BLOCK_QUERY = gql`
       ...PhotoSubmissionBlockFragment
       ...VoterRegistrationBlockFragment
       ...PetitionSubmissionBlockFragment
+      ...SelectionSubmissionBlockFragment
     }
   }
 
@@ -64,6 +66,7 @@ const CONTENTFUL_BLOCK_QUERY = gql`
   ${PhotoSubmissionBlockFragment}
   ${VoterRegistrationBlockFragment}
   ${PetitionSubmissionBlockFragment}
+  ${SelectionSubmissionBlockFragment}
 `;
 
 const ContentfulEntryLoader = ({


### PR DESCRIPTION
# What does this PR do?

This adds support for loading `SoftEdgeBlock`, `SocialDriveBlock`, and `SelectionSubmissionBlock` via GraphQL (rather than our PHP Content API). This gets us closer to being able to load blocks via GraphQL across the board, and allows editors to preview these types via our `/us/blocks/:id` route immediately!

### Any background context you want to provide?

Here's some example blocks you can check out on the review app:

- **SocialDriveBlock:** [`/us/blocks/2T5ARr1AViKw2Kw0Q4S0so`](https://dosomething-phoenix-de-pr-1768.herokuapp.com/us/blocks/2T5ARr1AViKw2Kw0Q4S0so)
- **SelectionSubmissionBlock:** [`/us/blocks/jw6RaCInscML2rC7PorsT`](https://dosomething-phoenix-de-pr-1768.herokuapp.com/us/blocks/jw6RaCInscML2rC7PorsT)
- **SoftEdgeBlock:** [`/us/blocks/1MfeJxLR4b9CIvrzlYTNxB`](https://dosomething-phoenix-de-pr-1768.herokuapp.com/us/blocks/1MfeJxLR4b9CIvrzlYTNxB) (must be authenticated)

### What are the relevant tickets/cards?

Refs [Pivotal ID #169216379](https://www.pivotaltracker.com/story/show/169216379)

### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.
* [ ] Added screenshot to PR description of related front-end updates on **small** screens.
* [ ] Added screenshot to PR description of related front-end updates on **medium** screens.
* [ ] Added screenshot to PR description of related front-end updates on **large** screens.
