### PR TITLE
Check for userId before ActionAndUserByIdQuery

### DIFF
--- a/resources/assets/components/actions/PostForm.js
+++ b/resources/assets/components/actions/PostForm.js
@@ -46,8 +46,12 @@ class PostForm extends React.Component {
    */
   async getUserActionSchoolId() {
     const { actionId, automatedTest, userId } = this.props;
-
-    if (!actionId || automatedTest) {
+    /**
+     * Legacy campaign content needs action backfills to create actionId.
+     * Some PostForm children may appear for anonymous users, e.g. StoryPage blocks.
+     * If this is an automatedTest, skip this request completely to avoid Invariant Violation.
+     */
+    if (!actionId || !userId || automatedTest) {
       return Promise.resolve(null);
     }
 
@@ -65,12 +69,13 @@ class PostForm extends React.Component {
 PostForm.propTypes = {
   actionId: PropTypes.number,
   automatedTest: PropTypes.bool,
-  userId: PropTypes.string.isRequired,
+  userId: PropTypes.string,
 };
 
 PostForm.defaultProps = {
   automatedTest: false,
   actionId: null,
+  userId: null,
 };
 
 export default PostForm;


### PR DESCRIPTION
### What does this PR do?

This PR fixes a bug introduced the `PostForm` refactor in #1762, occurring when a `TextPostSubmission` or `PetitionPostSubmission` is embedded on a StoryPage.

### Any background context you want to provide?

A future PR will contain an example `StoryPage` entry I'll set up in our dev space, and export as a fixture so we can add a Cypress test in the short-term (until we can use GraphQL mocks) 

### What are the relevant tickets/cards?

Refs https://dosomething.slack.com/archives/C3ASB4204/p1574712055452400?thread_ts=1574711377.449900&cid=C3ASB4204

### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.
