### PR TITLE
Fix School Finder GraphQL error on auth redirect

### DIFF
--- a/resources/assets/components/Query.js
+++ b/resources/assets/components/Query.js
@@ -17,7 +17,7 @@ const Query = ({ query, variables, children, hideSpinner }) => (
       }
 
       if (result.error) {
-        return <ErrorBlock />;
+        return <ErrorBlock error={result.error} />;
       }
 
       return children(result.data);

--- a/resources/assets/components/Query.js
+++ b/resources/assets/components/Query.js
@@ -17,7 +17,8 @@ const Query = ({ query, variables, children, hideSpinner }) => (
       }
 
       if (result.error) {
-        return <ErrorBlock error={result.error} />;
+        // If debugging, pass result.error as an error prop below:
+        return <ErrorBlock />;
       }
 
       return children(result.data);

--- a/resources/assets/components/blocks/ErrorBlock/ErrorBlock.js
+++ b/resources/assets/components/blocks/ErrorBlock/ErrorBlock.js
@@ -1,19 +1,31 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
 import errorIcon from './errorIcon.svg';
 import Card from '../../utilities/Card/Card';
 import { Figure } from '../../utilities/Figure/Figure';
 import TextContent from '../../utilities/TextContent/TextContent';
 
-const ErrorBlock = () => (
-  <Card className="error-block rounded bordered p-3">
-    <Figure image={errorIcon}>
-      <TextContent>
-        __Something went wrong!__ Try refreshing the page or [reach
-        out](https://help.dosomething.org/hc/en-us/requests/new) to us.
-      </TextContent>
-    </Figure>
-  </Card>
-);
+const ErrorBlock = ({ error }) => {
+  return (
+    <Card className="error-block rounded bordered p-3">
+      <Figure image={errorIcon}>
+        <TextContent>
+          __Something went wrong!__ Try refreshing the page or [reach
+          out](https://help.dosomething.org/hc/en-us/requests/new) to us.
+        </TextContent>
+        {error ? <code>{JSON.stringify(error)}</code> : null}
+      </Figure>
+    </Card>
+  );
+};
+
+ErrorBlock.propTypes = {
+  error: PropTypes.object,
+};
+
+ErrorBlock.defaultProps = {
+  error: null,
+};
 
 export default ErrorBlock;

--- a/resources/assets/components/utilities/SchoolFinder/SchoolFinder.js
+++ b/resources/assets/components/utilities/SchoolFinder/SchoolFinder.js
@@ -9,6 +9,7 @@ import SchoolFinderForm from './SchoolFinderForm';
 const USER_SCHOOL_QUERY = gql`
   query UserSchoolQuery($userId: String!) {
     user(id: $userId) {
+      id
       schoolId
       school {
         id


### PR DESCRIPTION
### What does this PR do?

This PR adds an `id` to the School Finder's `UserSchoolQuery` GraphQL query, fixing an error that is thrown when visiting a ContentBlock with a SchoolFinder after user authentication redirect:

 ```
Store error: the application attempted to write an object with no provided id but the store already contains an id of User:[user id here] for this object.
```

Refs https://github.com/apollographql/apollo-client/issues/2510.

It also adds an optional `error` prop to the `ErrorBlock` that devs can manually alter while debugging. A TODO for a future PR is to set it via config.


### Any background context you want to provide?

This has got me wondering about the cleanest way to check that a `ContentBlock` only displays the `SchoolFinder` if we have a user ID.... or would need a view for "Login to update to your school" type of view if our ContentBlock that contains a SchoolFinder via the `additionalContent` config is used on an anonymous page.

### What are the relevant tickets/cards?

https://dosomething.slack.com/archives/C3ASB4204/p1574712707454600?thread_ts=1574711377.449900&cid=C3ASB4204

### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.
