### PR TITLE
Fix GraphQL Store error in PostCreatedModal

### DIFF
--- a/resources/assets/components/Query.js
+++ b/resources/assets/components/Query.js
@@ -18,7 +18,11 @@ const Query = ({ query, variables, children, hideSpinner }) => (
 
       if (result.error) {
         // If debugging, pass result.error as an error prop below:
-        return <ErrorBlock />;
+        return (
+          <ErrorBlock
+            error={process.env.NODE_ENV !== 'production' ? result.error : null}
+          />
+        );
       }
 
       return children(result.data);

--- a/resources/assets/components/actions/PostCreatedModal.js
+++ b/resources/assets/components/actions/PostCreatedModal.js
@@ -12,6 +12,7 @@ import TextContent from '../utilities/TextContent/TextContent';
 const BADGE_QUERY = gql`
   query AccountQuery($userId: String!) {
     user(id: $userId) {
+      id
       hasBadgesFlag: hasFeatureFlag(feature: "badges")
     }
   }


### PR DESCRIPTION
### What does this PR do?

This PR creates a fix for a bug that seems to be a side-effect of #1770 - submitting a photo post results in a similar `Store error: the application attempted to write an object with no provided id but the store already contains an id of User:[user id here] for this object.` for the `AccountQuery` GraphQL that gets executed to see if the user is in the badges feature flag. The fix is the same, adding an `id` for the query resource.

This PR also adds the check for the `NODE_ENV` Node.js variable to output errors if per suggestion in https://github.com/DoSomething/phoenix-next/pull/1770#discussion_r350457062



### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.
