### PR TITLE
Send school ID in ShareAction and SelectionSubmissionAction components

### DIFF
--- a/resources/assets/components/actions/SelectionSubmissionAction/SelectionSubmissionAction.js
+++ b/resources/assets/components/actions/SelectionSubmissionAction/SelectionSubmissionAction.js
@@ -5,6 +5,7 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { Query } from 'react-apollo';
 
+import PostForm from '../PostForm';
 import Card from '../../utilities/Card/Card';
 import Button from '../../utilities/Button/Button';
 import FormValidation from '../../utilities/Form/FormValidation';
@@ -34,7 +35,7 @@ const USER_POSTS_QUERY = gql`
   }
 `;
 
-class SelectionSubmissionAction extends React.Component {
+class SelectionSubmissionAction extends PostForm {
   constructor(props) {
     super(props);
 
@@ -65,7 +66,7 @@ class SelectionSubmissionAction extends React.Component {
 
   handleChange = event => this.setState({ selection: event.target.value });
 
-  handleSubmit = event => {
+  handleSubmit = async event => {
     event.preventDefault();
 
     // Run a validation as an edge case measure (e.g. to prevent submitting custom data via dom manipulation).
@@ -86,6 +87,7 @@ class SelectionSubmissionAction extends React.Component {
       blockId: id,
       body: formatPostPayload({
         action_id: actionId,
+        school_id: await this.getUserActionSchoolId(),
         text: this.state.selection,
         type,
       }),

--- a/resources/assets/components/actions/ShareAction/ShareAction.js
+++ b/resources/assets/components/actions/ShareAction/ShareAction.js
@@ -216,6 +216,7 @@ class ShareAction extends PostForm {
             {affirmationBlock ? (
               <ContentfulEntry json={affirmationBlock} />
             ) : (
+              // @TODO: Refactor this with PostCreatedModal.
               <Card
                 title="Thanks for sharing!"
                 className="modal__slide bordered rounded"

--- a/resources/assets/components/actions/ShareAction/ShareAction.js
+++ b/resources/assets/components/actions/ShareAction/ShareAction.js
@@ -4,6 +4,7 @@ import gql from 'graphql-tag';
 import PropTypes from 'prop-types';
 import { PuckWaypoint } from '@dosomething/puck-client';
 
+import PostForm from '../PostForm';
 import Card from '../../utilities/Card/Card';
 import Embed from '../../utilities/Embed/Embed';
 import Modal from '../../utilities/Modal/Modal';
@@ -53,7 +54,7 @@ const POST_COUNT_BADGE = gql`
   }
 `;
 
-class ShareAction extends React.Component {
+class ShareAction extends PostForm {
   state = { showModal: false };
 
   componentDidMount() {
@@ -63,7 +64,7 @@ class ShareAction extends React.Component {
     }
   }
 
-  storeSharePost = puckId => {
+  storeSharePost = async puckId => {
     const action = get(this.props.additionalContent, 'action', 'default');
 
     const { actionId, pageId, campaignId, link } = this.props;
@@ -73,6 +74,7 @@ class ShareAction extends React.Component {
       type: SOCIAL_SHARE_TYPE,
       id: pageId, // @TODO: rename property to pageId? Other actions use the blockId?
       action_id: actionId,
+      school_id: await this.getUserActionSchoolId(),
       details: {
         url: link,
         platform: 'facebook',
@@ -135,9 +137,11 @@ class ShareAction extends React.Component {
 
           trackingData = { ...trackingData, puck_id: puckId };
 
-          this.storeSharePost(puckId);
+          return this.storeSharePost(puckId);
         }
-
+        return Promise.resolve();
+      })
+      .then(() => {
         this.trackEvent('facebook', 'action', 'completed', trackingData);
 
         this.setState({ showModal: true });

--- a/resources/assets/components/actions/ShareAction/ShareAction.js
+++ b/resources/assets/components/actions/ShareAction/ShareAction.js
@@ -212,11 +212,11 @@ class ShareAction extends PostForm {
           />
         </div>
         {this.state.showModal ? (
+          // @TODO: Refactor this with PostCreatedModal.
           <Modal onClose={() => this.setState({ showModal: false })}>
             {affirmationBlock ? (
               <ContentfulEntry json={affirmationBlock} />
             ) : (
-              // @TODO: Refactor this with PostCreatedModal.
               <Card
                 title="Thanks for sharing!"
                 className="modal__slide bordered rounded"

--- a/resources/assets/components/actions/ShareAction/ShareAction.test.js
+++ b/resources/assets/components/actions/ShareAction/ShareAction.test.js
@@ -22,6 +22,7 @@ describe('ShareAction component', () => {
   const getShallow = socialPlatform =>
     shallow(
       <ShareAction
+        automatedTest
         title="Click on this link!"
         content="This is a great link"
         socialPlatform={socialPlatform}


### PR DESCRIPTION
### What does this PR do?

This PR refactors the `ShareAction` and  `SelectionSubmissionAction` components as child `PostForm` components to check whether their action should collect school ID, and sending along the user's school ID on the action if so. Continues the work in #1762. The only action form left to alter to send School ID is the SoftEdge email form - I've asked about this over in #1771.

### Any background context you want to provide?

Documentation PR to follow soon, but the following action components now support sending school ID with an action:

* `PhotoSubmissionAction` - #1762 
* `TextSubmissionAction` - #1762 
* `PetitionSubmissionAction` - #1762 
* `ShareAction` - this PR
* `SelectionSubmissionAction` - this PR
* `SoftEdgeBlock` - TBD, this likely isn't as straight forward per https://github.com/DoSomething/phoenix-next/pull/1771#discussion_r350503800

Can also follow up with an updated Contentful campaign fixture for Cypress tests...but ideally the time might be better spent adding tests once all Contentful content is queried via GraphQL (and is significantly easier to mock)

### What are the relevant tickets/cards?

https://www.pivotaltracker.com/n/projects/2401401/stories/169549621

### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.
