### PR TITLE
Re-enable the bugging out test expectations for RAF test

### DIFF
--- a/cypress/fixtures/graphql.js
+++ b/cypress/fixtures/graphql.js
@@ -28,10 +28,12 @@ export const operations = {
   },
   EmbedQuery: {
     embed: {
+      type: 'LINK',
       title: faker.lorem.words(),
       description: faker.lorem.sentence(),
       providerName: faker.company.companyName(),
       thumbnailUrl: faker.image.imageUrl(),
+      html: null,
     },
   },
   ReferralPageCampaignQuery: {

--- a/cypress/integration/beta-referral-page.js
+++ b/cypress/integration/beta-referral-page.js
@@ -17,11 +17,10 @@ describe('Beta Referral Page', () => {
 
     cy.get('.referral-page-campaign').should('have.length', 1);
 
-    // @TODO: Our mock GraphQL doesn't seem to get called, this times out like below.
-    // cy.get('.referral-page-campaign > a')
-    //   .should('have.attr', 'href')
-    //   .and('include', `referrer_user_id=${userId}`)
-    //   .and('include', campaignPath);
+    cy.get('.referral-page-campaign > a')
+      .should('have.attr', 'href')
+      .and('include', `referrer_user_id=${userId}`)
+      .and('include', campaignPath);
   });
 
   it('Visit beta referral page, with invalid user ID', () => {
@@ -40,10 +39,6 @@ describe('Beta Referral Page', () => {
     cy.contains('Not Found');
   });
 
-  /**
-   * This Embed request hangs with a mystery "Hello World", never rendering the Embed a tag.
-   * @see https://dashboard.cypress.io/#/projects/ayzqmy/runs/876
-   */
   it('Visit beta referral page, with valid user ID and no campaign ID', () => {
     const user = userFactory();
 
@@ -51,8 +46,8 @@ describe('Beta Referral Page', () => {
 
     cy.get('.referral-page-campaign').should('have.length', 1);
 
-    // cy.get('.referral-page-campaign > a')
-    //   .should('have.attr', 'href')
-    //   .and('include', `referrer_user_id=${userId}`);
+    cy.get('.referral-page-campaign > a')
+      .should('have.attr', 'href')
+      .and('include', `referrer_user_id=${userId}`);
   });
 });


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

❗️This PR re-enables the previously buggy beta-referral tests

### Any background context you want to provide?
Sooo I think I finally solved the mystery here (while I was poking around for some updates for #1774)

#### The setup
Our `Embed` component [will output](https://github.com/DoSomething/phoenix-next/blob/c1c62a6de625c87c5ea4acd7fa2a9d79280cb58b/resources/assets/components/utilities/Embed/Embed.js#L69-L76) a `<div>` with embedded HTML for any provider returning an `iframe` or some such code (which happens for e.g. Youtube videos).

Now, our stubbed graphql response, was _not_ defining the `type` or `html` fields,  resulting in a stubbed `html: 'Hello World'` response, which resulted in that phantom [Hello World](https://files.slack.com/files-pri/T024GV2BW-FPYM5KA3U/screen_shot_2019-11-08_at_9.48.43_am.png) embed we were seeing ...which would cause the tests to intermittently fail.

#### Two oddities tho
Two oddities though:
1. Interesting that we'd get a stubbed response for a field _not_ defined in the graphql fixture. (you've thunk that the response would be _only_ those defined stubbed fields.)
2. Why were the tests passing locally?

#### A solution?!
As for #2: the `Embed` component, while waiting for the embed graphql query to load, outputs a skeletal `<a>` tag with loading state, but _containing_ the [`url`](https://github.com/DoSomething/phoenix-next/blob/c1c62a6de625c87c5ea4acd7fa2a9d79280cb58b/resources/assets/components/utilities/Embed/Embed.js#L78). So if Cypress didn't wait for the response to resolve, and ran its assertions, it'd find the `href` attribute with the expected URL! 

[Here's](https://dashboard.cypress.io/projects/ayzqmy/runs/1226/specs) a failure from when I accidentally stubbed `html: 'null'`as a String!
 
#### A half baked thought:
So perhaps our local machines ran _slower_ then CircleCI? With the response on Circle resolving quicker, causing the faulty HTML to embed and _not_ the `<a>` tag thus failing the tests on occasion? I'm not positive but probably something along those lines.

#### Ok, wat?!
Now the best part is, that I was hoping for a nice ❌ when I pushed my first commit to re-enable the tests, but alas, 4 re-builds and it's all ✅ ! Maybe something to do with the new `--run-in-band` flag which could [cause the builds to be a smidge slower](https://github.com/DoSomething/phoenix-next/pull/1763/files#r350267155)? 🤷‍♂ 


🆗  In any case, essay over. This should continue being green, and if this introduces more failures, I'll swallow my battered pride and revert this.

🤔 Something to mull over: How do we cause assertions to run against the _fully loaded_ embed component / graphql queries in general? Shouldn't this happen by default? What are we doing wrong or right here?

### What are the relevant tickets/cards?
https://dosomething.slack.com/archives/C3ASB4204/p1573230848173700
#1708 

