### PR TITLE
Affirmation UI Updates

### DIFF
--- a/resources/assets/components/Affirmation/Affirmation.js
+++ b/resources/assets/components/Affirmation/Affirmation.js
@@ -137,11 +137,11 @@ Affirmation.propTypes = {
 
 Affirmation.defaultProps = {
   author: null,
-  callToActionDescription:
+  callToActionDescription: "Let's Do This.",
+  header: 'Thanks for joining us!',
+  quote:
     "By joining this campaign, you've teamed up with millions of other members who are making an impact on the causes affecting your world. As a DoSomething.org member, you're part of something bigger. You're part of a global movement for good.",
   callToActionHeader: "Woohoo! You're signed up.",
-  header: 'Thanks for joining us!',
-  quote: null,
 };
 
 export default Affirmation;

--- a/resources/assets/components/Flex/flex.scss
+++ b/resources/assets/components/Flex/flex.scss
@@ -1,11 +1,6 @@
 @import '../../scss/next-toolbox';
 
 @include media($medium) {
-  .flex {
-    display: flex;
-    flex-wrap: wrap;
-  }
-
   .flex__cell {
     flex: 1;
 

--- a/resources/assets/components/Flex/index.js
+++ b/resources/assets/components/Flex/index.js
@@ -6,7 +6,7 @@ import { modifiers } from '../../helpers';
 import './flex.scss';
 
 export const Flex = ({ id, className = null, children }) => (
-  <div id={id} className={classnames('flex', className)}>
+  <div id={id} className={classnames('md:flex md:flex-wrap', className)}>
     {children}
   </div>
 );


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR addresses two things flagged by @LeahAngle:
https://github.com/DoSomething/phoenix-next/commit/31bcc585c1d3da0d953f759dc59159116b562e26 Our Tailwind implementation was clashing with the custom `Flex` rules which were only previously enforced on Medium+ screens. This was causing the social share button to be a bit wonky on Affirmations on smaller screens since they were still flex-ing. Updated this component to use the appropriate Tailwind classes to fix that. (There's still more work to do with this component's flex cells, but not a currently breaking issue so I left that alone.)

 
https://github.com/DoSomething/phoenix-next/commit/9ba47b8ba6e51b1a2beedff6efbcf050ce4850b0 Our default affirmation text was a bit heavy on the `ctaDescription` which @leahAngle pointed out would better be served as the `quote` up top so it doesn't crowd the social share. I added a simple default `ctaDescription`.
^ The only gripe is that now, the `Woohoo! you're signed up!` seems a bit late? I'm not sure if that's a big deal or not (see the screenshots below).


### What are the relevant tickets/cards?

https://www.pivotaltracker.com/story/show/169987137/comments/209147494
https://www.pivotaltracker.com/story/show/169987137/comments/209147691

#### Affirmation Mobile Social Share Button
**Before**
![Screen Shot 2019-11-27 at 13 03 50](https://user-images.githubusercontent.com/12417657/69748448-62a2a380-1116-11ea-8718-fb62c55a9e6d.png)

**After**
![Screen Shot 2019-11-27 at 13 03 32](https://user-images.githubusercontent.com/12417657/69748447-62a2a380-1116-11ea-9934-784f6ff965fa.png)


#### Affirmation Text
**Before**
![Screen Shot 2019-11-27 at 13 01 04](https://user-images.githubusercontent.com/12417657/69748345-1f483500-1116-11ea-8746-ae13aedc24c5.png)

**After**
![Screen Shot 2019-11-27 at 13 01 47](https://user-images.githubusercontent.com/12417657/69748346-1f483500-1116-11ea-9894-b2da8a90c26d.png)


