### PR TITLE
Cause Pages in the Navigation Subnav

### DIFF
--- a/resources/assets/components/SiteNavigation/SiteNavigation.js
+++ b/resources/assets/components/SiteNavigation/SiteNavigation.js
@@ -215,9 +215,9 @@ class SiteNavigation extends React.Component {
                         text="Create and post encouraging notes in your school bathrooms to brighten your classmates' day!"
                         callback={e =>
                           this.analyzeEvent(e, {
-                            label: 'subnav_feature',
+                            noun: 'subnav_link',
                             target: 'link',
-                            verb: 'clicked',
+                            label: 'feature_mirror_messages',
                           })
                         }
                       />

--- a/resources/assets/components/SiteNavigation/SiteNavigation.js
+++ b/resources/assets/components/SiteNavigation/SiteNavigation.js
@@ -7,6 +7,7 @@ import classnames from 'classnames';
 import PropTypes from 'prop-types';
 
 import SearchIcon from '../artifacts/SearchIcon/SearchIcon';
+import SiteNavigationFeature from './SiteNavigationFeature';
 import CloseButton from '../artifacts/CloseButton/CloseButton';
 import ProfileIcon from '../artifacts/ProfileIcon/ProfileIcon';
 import DoSomethingLogo from '../utilities/DoSomethingLogo/DoSomethingLogo';
@@ -160,13 +161,124 @@ class SiteNavigation extends React.Component {
           </div>
 
           <ul className="main-nav menu-nav">
-            <li className="menu-nav__item">
+            <li
+              className={classnames('menu-nav__item', {
+                'is-active': this.state.activeSubNav === 'CausesSubNav',
+              })}
+              onMouseEnter={() => this.handleMouseEnter('CausesSubNav')}
+              onMouseLeave={() => this.handleMouseLeave('CausesSubNav')}
+            >
               <a
                 href="/us/campaigns"
-                onClick={e => this.handleOnClickLink(e, { label: 'campaigns' })}
+                onClick={e =>
+                  this.handleOnClickToggle(e, 'CausesSubNav', {
+                    label: 'campaigns',
+                  })
+                }
               >
                 Campaigns
+                <span className="main-nav__arrow" />
               </a>
+
+              {this.state.activeSubNav === 'CausesSubNav' ? (
+                <div className="main-subnav menu-subnav">
+                  <div className="wrapper base-12-grid">
+                    <section className="main-subnav__links-causes menu-subnav__links menu-subnav__section">
+                      <h1>
+                        <a href="/">All Causes</a>
+                      </h1>
+                      <ul>
+                        <li>
+                          <a href="/">Education</a>
+                        </li>
+                        <li>
+                          <a href="/">Mental Health</a>
+                        </li>
+                        <li>
+                          <a href="/">Homelessness & Poverty</a>
+                        </li>
+                        <li>
+                          <a href="/">Environment</a>
+                        </li>
+                        <li>
+                          <a href="/">Animal Welfare</a>
+                        </li>
+                        <li>
+                          <a href="/">Sexual Harassment</a>
+                        </li>
+                        <li>
+                          <a href="/">Bullying</a>
+                        </li>
+                        <li>
+                          <a href="/">Gender Rights</a>
+                        </li>
+                        <li>
+                          <a href="/">Racial Justice</a>
+                        </li>
+                        <li>
+                          <a href="/">Immigration & Refugees</a>
+                        </li>
+                        <li>
+                          <a href="/">LGBT+ Rights</a>
+                        </li>
+                        <li>
+                          <a href="/">Get Out the Vote!</a>
+                        </li>
+                      </ul>
+                    </section>
+
+                    <section className="main-subnav__links-campaigns menu-subnav__links menu-subnav__section">
+                      <h1>
+                        <a href="/">All Campaigns</a>
+                      </h1>
+                      <ul>
+                        <li>
+                          <a href="/">Online</a>
+                        </li>
+                        <li>
+                          <a href="/">In-person</a>
+                        </li>
+                        <li>
+                          <a href="/">Petitions</a>
+                        </li>
+                        <li>
+                          <a href="/">Collections</a>
+                        </li>
+                      </ul>
+                    </section>
+
+                    <section className="main-subnav__featured menu-subnav__content menu-subnav__section">
+                      <SiteNavigationFeature
+                        imageSrc="https://placedog.net/1100/500?id=2"
+                        imageAlt="temporary place puppers"
+                        url="/"
+                        title="Take Back the Puppers"
+                        text="Donec ullamcorper nulla non metus auctor fringilla."
+                        callback={e =>
+                          this.analyzeEvent(e, {
+                            context: {
+                              campaignId: '12asasd23sdasd3',
+                            },
+                            label: 'subnav_feature',
+                            target: 'link',
+                            verb: 'clicked',
+                          })
+                        }
+                      />
+                    </section>
+
+                    {this.state.isSubNavFixed ? (
+                      <CloseButton
+                        callback={this.handleOnClickClose}
+                        className="btn__close--subnav btn__close--main-subnav block"
+                        dataLabel="close_subnav"
+                        dataNoun="nav_button"
+                        size="22px"
+                      />
+                    ) : null}
+                  </div>
+                </div>
+              ) : null}
             </li>
 
             <li className="menu-nav__item">

--- a/resources/assets/components/SiteNavigation/SiteNavigation.js
+++ b/resources/assets/components/SiteNavigation/SiteNavigation.js
@@ -169,14 +169,14 @@ class SiteNavigation extends React.Component {
               onMouseLeave={() => this.handleMouseLeave('CausesSubNav')}
             >
               <a
-                href="/us/campaigns"
+                href="/"
                 onClick={e =>
                   this.handleOnClickToggle(e, 'CausesSubNav', {
-                    label: 'campaigns',
+                    label: 'causes',
                   })
                 }
               >
-                Campaigns
+                Causes
                 <span className="main-nav__arrow" />
               </a>
 

--- a/resources/assets/components/SiteNavigation/SiteNavigation.js
+++ b/resources/assets/components/SiteNavigation/SiteNavigation.js
@@ -208,15 +208,15 @@ class SiteNavigation extends React.Component {
 
                     <section className="main-subnav__featured menu-subnav__content menu-subnav__section">
                       <SiteNavigationFeature
-                        imageSrc="https://placedog.net/1100/500?id=2"
-                        imageAlt="temporary place puppers"
-                        url="/"
-                        title="Take Back the Puppers"
-                        text="Donec ullamcorper nulla non metus auctor fringilla."
+                        imageSrc="https://images.ctfassets.net/81iqaqpfd8fy/5md4atcQCcWCMomiO22iyU/02de733ce619eb881fe69a9793e9bee9/pasted_image_at_2017_04_26_04_12_pm.png?fit=fill&h=500&w=1100"
+                        imageAlt="Mirror adorned with positive post it notes"
+                        url="/us/campaigns/mirror-messages"
+                        title="Mirror Messages"
+                        text="Create and post encouraging notes in your school bathrooms to brighten your classmates' day!"
                         callback={e =>
                           this.analyzeEvent(e, {
                             context: {
-                              campaignId: '12asasd23sdasd3',
+                              campaignId: '7',
                             },
                             label: 'subnav_feature',
                             target: 'link',

--- a/resources/assets/components/SiteNavigation/SiteNavigation.js
+++ b/resources/assets/components/SiteNavigation/SiteNavigation.js
@@ -184,9 +184,7 @@ class SiteNavigation extends React.Component {
                 <div className="main-subnav menu-subnav">
                   <div className="wrapper base-12-grid">
                     <section className="main-subnav__links-causes menu-subnav__links menu-subnav__section">
-                      <h1>
-                        <a href="/">All Causes</a>
-                      </h1>
+                      <h1>Causes</h1>
                       <ul>
                         <li>
                           <a href="/">Education</a>

--- a/resources/assets/components/SiteNavigation/SiteNavigation.js
+++ b/resources/assets/components/SiteNavigation/SiteNavigation.js
@@ -187,21 +187,69 @@ class SiteNavigation extends React.Component {
                       <h1>Causes</h1>
                       <ul>
                         <li>
-                          <a href="/us/causes/education">Education</a>
+                          <a
+                            href="/us/causes/education"
+                            onClick={e => {
+                              this.handleOnClickLink(e, {
+                                noun: 'subnav_link',
+                                label: 'causes_education',
+                              });
+                            }}
+                          >
+                            Education
+                          </a>
                         </li>
                         <li>
-                          <a href="/us/causes/mental-health">Mental Health</a>
+                          <a
+                            href="/us/causes/mental-health"
+                            onClick={e => {
+                              this.handleOnClickLink(e, {
+                                noun: 'subnav_link',
+                                label: 'causes_mental_health',
+                              });
+                            }}
+                          >
+                            Mental Health
+                          </a>
                         </li>
                         <li>
-                          <a href="/us/causes/homelessness-and-poverty">
+                          <a
+                            href="/us/causes/homelessness-and-poverty"
+                            onClick={e => {
+                              this.handleOnClickLink(e, {
+                                noun: 'subnav_link',
+                                label: 'causes_homelessness_and_poverty',
+                              });
+                            }}
+                          >
                             Homelessness & Poverty
                           </a>
                         </li>
                         <li>
-                          <a href="/us/causes/environment">Environment</a>
+                          <a
+                            href="/us/causes/environment"
+                            onClick={e => {
+                              this.handleOnClickLink(e, {
+                                noun: 'subnav_link',
+                                label: 'causes_environment',
+                              });
+                            }}
+                          >
+                            Environment
+                          </a>
                         </li>
                         <li>
-                          <a href="/us/causes/bullying">Bullying</a>
+                          <a
+                            href="/us/causes/bullying"
+                            onClick={e => {
+                              this.handleOnClickLink(e, {
+                                noun: 'subnav_link',
+                                label: 'causes_bullying',
+                              });
+                            }}
+                          >
+                            Bullying
+                          </a>
                         </li>
                       </ul>
                     </section>

--- a/resources/assets/components/SiteNavigation/SiteNavigation.js
+++ b/resources/assets/components/SiteNavigation/SiteNavigation.js
@@ -215,9 +215,6 @@ class SiteNavigation extends React.Component {
                         text="Create and post encouraging notes in your school bathrooms to brighten your classmates' day!"
                         callback={e =>
                           this.analyzeEvent(e, {
-                            context: {
-                              campaignId: '7',
-                            },
                             label: 'subnav_feature',
                             target: 'link',
                             verb: 'clicked',

--- a/resources/assets/components/SiteNavigation/SiteNavigation.js
+++ b/resources/assets/components/SiteNavigation/SiteNavigation.js
@@ -187,40 +187,21 @@ class SiteNavigation extends React.Component {
                       <h1>Causes</h1>
                       <ul>
                         <li>
-                          <a href="/">Education</a>
+                          <a href="/us/causes/education">Education</a>
                         </li>
                         <li>
-                          <a href="/">Mental Health</a>
+                          <a href="/us/causes/mental-health">Mental Health</a>
                         </li>
                         <li>
-                          <a href="/">Homelessness & Poverty</a>
+                          <a href="/us/causes/homelessness-and-poverty">
+                            Homelessness & Poverty
+                          </a>
                         </li>
                         <li>
-                          <a href="/">Environment</a>
+                          <a href="/us/causes/environment">Environment</a>
                         </li>
                         <li>
-                          <a href="/">Animal Welfare</a>
-                        </li>
-                        <li>
-                          <a href="/">Sexual Harassment</a>
-                        </li>
-                        <li>
-                          <a href="/">Bullying</a>
-                        </li>
-                        <li>
-                          <a href="/">Gender Rights</a>
-                        </li>
-                        <li>
-                          <a href="/">Racial Justice</a>
-                        </li>
-                        <li>
-                          <a href="/">Immigration & Refugees</a>
-                        </li>
-                        <li>
-                          <a href="/">LGBT+ Rights</a>
-                        </li>
-                        <li>
-                          <a href="/">Get Out the Vote!</a>
+                          <a href="/us/causes/bullying">Bullying</a>
                         </li>
                       </ul>
                     </section>

--- a/resources/assets/components/SiteNavigation/SiteNavigation.js
+++ b/resources/assets/components/SiteNavigation/SiteNavigation.js
@@ -225,26 +225,6 @@ class SiteNavigation extends React.Component {
                       </ul>
                     </section>
 
-                    <section className="main-subnav__links-campaigns menu-subnav__links menu-subnav__section">
-                      <h1>
-                        <a href="/">All Campaigns</a>
-                      </h1>
-                      <ul>
-                        <li>
-                          <a href="/">Online</a>
-                        </li>
-                        <li>
-                          <a href="/">In-person</a>
-                        </li>
-                        <li>
-                          <a href="/">Petitions</a>
-                        </li>
-                        <li>
-                          <a href="/">Collections</a>
-                        </li>
-                      </ul>
-                    </section>
-
                     <section className="main-subnav__featured menu-subnav__content menu-subnav__section">
                       <SiteNavigationFeature
                         imageSrc="https://placedog.net/1100/500?id=2"

--- a/resources/assets/components/SiteNavigation/site-navigation.scss
+++ b/resources/assets/components/SiteNavigation/site-navigation.scss
@@ -126,6 +126,21 @@ $extraSmall: '(min-width: 360px)';
         font-size: 22px;
       }
     }
+
+    // For now, the <h1> doesn't contain an <a>, since we don't
+    // have an index page to link to. So defining the <a> rules on the <h1>:
+    color: black;
+    font-size: 22px;
+    font-weight: bold;
+    padding: 0 0 12px;
+
+    @include media($large) {
+      font-size: 18px;
+    }
+
+    @include media($larger) {
+      font-size: 22px;
+    }
   }
 }
 


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_


### What does this PR do?

This PR adds links to the 5 live cause pages to the `SiteNavigation`'s subnav, as well as a featured subnav item - the Mirror Messages campaign.

It also adds the relevant analytics events triggered by clicking on these respective links.

Feel free to commit-by-commit this one!

### Any background context you want to provide?
@weerd helpfully already had most of this setup in a gist (see attached Pivotal card), so I just had to paste the markup in and alter to reflect the desired feature and cause links.

The one catch here is that this was originally designed to have a top-level sub-nav link which [optionally] goes to the index page of the category (so the underlying 'Causes' header would itself be a link). But Causes don't yet have an index page! 
I opted to temporarily alter the styling to reflect this not being a link while commenting out the styling for when we _make_ this a link https://github.com/DoSomething/phoenix-next/pull/1783/commits/6e89f31a4191c5a03596589901e1bc2582c6da64. Alternatively we can just remove the commented CSS and styling this based on it _not_ being a link!

### What are the relevant tickets/cards?

Refs [Pivotal ID #169323699](https://www.pivotaltracker.com/story/show/169323699)

### Checklist

* [ ] Documentation added for new features/changed endpoints.
* [ ] Added appropriate feature/unit tests.
* [x] Added screenshot to PR description of related front-end updates on **small** screens.
* [ ] Added screenshot to PR description of related front-end updates on **medium** screens.
* [x] Added screenshot to PR description of related front-end updates on **large** screens.

![image](https://user-images.githubusercontent.com/12417657/70329601-ca897600-1809-11ea-8b33-e655311a5102.png)

![image](https://user-images.githubusercontent.com/12417657/70329642-df660980-1809-11ea-8f12-64fdfc90d737.png)

![image](https://user-images.githubusercontent.com/12417657/70329681-f3117000-1809-11ea-8993-9db92d6010c6.png)

![image](https://user-images.githubusercontent.com/12417657/70329714-03294f80-180a-11ea-9505-aba0fd446aa1.png)

