### PR TITLE
DRY building campaign URL's in Beta Referral Page

### DIFF
--- a/cypress/fixtures/graphql.js
+++ b/cypress/fixtures/graphql.js
@@ -38,7 +38,8 @@ export const operations = {
   },
   ReferralPageCampaignQuery: {
     campaignWebsiteByCampaignId: {
-      slug: faker.lorem.slug(),
+      id: faker.random.uuid(),
+      url: faker.internet.url(),
     },
   },
 };

--- a/cypress/integration/beta-referral-page.js
+++ b/cypress/integration/beta-referral-page.js
@@ -1,7 +1,7 @@
 /// <reference types="Cypress" />
 
 import { userFactory } from '../fixtures/user';
-import { campaignId, campaignPath, userId } from '../fixtures/constants';
+import { campaignId, userId } from '../fixtures/constants';
 
 describe('Beta Referral Page', () => {
   // Configure a new "mock" server before each test:
@@ -19,8 +19,7 @@ describe('Beta Referral Page', () => {
 
     cy.get('.referral-page-campaign > a')
       .should('have.attr', 'href')
-      .and('include', `referrer_user_id=${userId}`)
-      .and('include', campaignPath);
+      .and('include', `referrer_user_id=${userId}`);
   });
 
   it('Visit beta referral page, with invalid user ID', () => {

--- a/resources/assets/components/pages/ReferralPage/Beta/BetaPageCampaignLink.js
+++ b/resources/assets/components/pages/ReferralPage/Beta/BetaPageCampaignLink.js
@@ -4,24 +4,22 @@ import gql from 'graphql-tag';
 
 import Query from '../../../Query';
 import Embed from '../../../utilities/Embed/Embed';
-import { PHOENIX_URL } from '../../../../constants';
 import ErrorBlock from '../../../blocks/ErrorBlock/ErrorBlock';
 
 const REFERRAL_PAGE_CAMPAIGN = gql`
   query ReferralPageCampaignQuery($campaignId: String!) {
     campaignWebsiteByCampaignId(campaignId: $campaignId) {
-      slug
+      id
+      url
     }
   }
 `;
 
-const ReferralPageCampaignLink = props => (
-  <Query
-    query={REFERRAL_PAGE_CAMPAIGN}
-    variables={{ campaignId: props.campaignId }}
-  >
+const ReferralPageCampaignLink = ({ campaignId, userId }) => (
+  <Query query={REFERRAL_PAGE_CAMPAIGN} variables={{ campaignId }}>
     {res => {
       const data = res.campaignWebsiteByCampaignId;
+
       if (!data) {
         return <ErrorBlock />;
       }
@@ -29,7 +27,7 @@ const ReferralPageCampaignLink = props => (
       return (
         <Embed
           className="referral-page-campaign"
-          url={`${PHOENIX_URL}/us/campaigns/${data.slug}?referrer_user_id=${props.userId}`}
+          url={`${data.url}?referrer_user_id=${userId}`}
           badged
         />
       );

--- a/schema.json
+++ b/schema.json
@@ -4851,6 +4851,22 @@
             "deprecationReason": null
           },
           {
+            "name": "url",
+            "description": "The URL for this campaign.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "callToAction",
             "description": "The call to action tagline for this campaign.",
             "args": [],


### PR DESCRIPTION
### What's this PR do?

This pull request alters the `BetaPageCampaignLink` component to use the newly added `url` field on the `CampaignWebsite` type in GraphQL. The less places we're repeating logic, the better.

### How should this be reviewed?

👀 

### Any background context you want to provide?

I've manually added the `CampaignWebsite.url` field to our `schema.json` to avoid errors in the Cypress tests that query for it.

### Relevant tickets

References https://github.com/DoSomething/graphql/pull/177

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added screenshots of front-end changes on small, medium, and large screens.
- [ ] Added appropriate feature/unit tests.
