### PR TITLE
Add additional content field to cause page migration

### DIFF
--- a/contentful/content-types/cause-page.js
+++ b/contentful/content-types/cause-page.js
@@ -162,6 +162,16 @@ module.exports = function(migration) {
     .disabled(false)
     .omitted(false);
 
+  causePage
+    .createField('additionalContent')
+    .name('Additional Content')
+    .type('Object')
+    .localized(false)
+    .required(false)
+    .validations([])
+    .disabled(false)
+    .omitted(false);
+
   causePage.changeFieldControl('internalTitle', 'builtin', 'singleLine', {
     helpText:
       'This title is used internally to help find this content. It will not be displayed anywhere on the rendered web page.',
@@ -195,4 +205,11 @@ module.exports = function(migration) {
     helpText:
       'The core content for this cause page, sits below the banner, optimally a collection of galleries e.g. campaigns & articles related to this cause space',
   });
+
+  causePage.changeFieldControl(
+    'additionalContent',
+    'builtin',
+    'objectEditor',
+    {},
+  );
 };


### PR DESCRIPTION
### What's this PR do?

This pull request updates the Cause Page Contentful migration script to include a new Additional Content field to support adding 'stats' content as an MVP.

### How should this be reviewed?
👀
I've added the field to the [cause page](https://app.contentful.com/spaces/81iqaqpfd8fy/environments/dev/content_types/causePage/fields) in our Contentful `dev` space.


### Any background context you want to provide?
We've opted to use the Additional Content field for now for the stats feature as an MVP and to save time. This Cause page is still something of an MVP to begin with.

### Relevant tickets

References [Pivotal #169919280](https://www.pivotaltracker.com/story/show/169919280).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added screenshots of front-end changes on small, medium, and large screens.
- [ ] Added appropriate feature/unit tests.
