### PR TITLE
Cause Page Stats

### DIFF
--- a/resources/assets/components/pages/CausePage/CausePage.js
+++ b/resources/assets/components/pages/CausePage/CausePage.js
@@ -20,6 +20,7 @@ export const CAUSE_PAGE_QUERY = gql`
       title
       description
       content
+      additionalContent
     }
   }
 `;
@@ -30,6 +31,7 @@ const CausePageTemplate = ({
   title,
   description,
   content,
+  additionalContent,
 }) => {
   // @TODO: Update this with image dimension logic to serve properly sized files to different screen sizes
   const backgroundImage = coverImage
@@ -39,6 +41,8 @@ const CausePageTemplate = ({
   const styles = {
     backgroundImage,
   };
+
+  const { stats, statsBackgroundColor } = additionalContent || {};
 
   return (
     <>
@@ -59,6 +63,31 @@ const CausePageTemplate = ({
               {description}
             </TextContent>
           </div>
+
+          {stats && statsBackgroundColor ? (
+            <div className="grid-full md:flex">
+              {stats.map(stat => (
+                <div
+                  key={stat.title}
+                  className="stat rounded mt-3 p-3 md:w-1/3"
+                  style={{ backgroundColor: statsBackgroundColor }}
+                >
+                  <p className="text-white text-lg font-bold uppercase">
+                    {stat.title}
+                  </p>
+                  <p className="text-white text-5xl font-league-gothic -mt-3">
+                    {stat.number.toLocaleString()}
+                  </p>
+                  <a
+                    className="text-white hover:text-white font-normal underline cursor-pointer"
+                    href={stat.link.url}
+                  >
+                    {stat.link.text}
+                  </a>
+                </div>
+              ))}
+            </div>
+          ) : null}
         </header>
         <TextContent
           className="base-12-grid"
@@ -82,6 +111,11 @@ CausePageTemplate.propTypes = {
   title: PropTypes.string.isRequired,
   description: PropTypes.object.isRequired,
   content: PropTypes.object.isRequired,
+  additionalContent: PropTypes.object,
+};
+
+CausePageTemplate.defaultProps = {
+  additionalContent: {},
 };
 
 const CausePage = ({ slug }) => (

--- a/resources/assets/components/pages/CausePage/CausePage.js
+++ b/resources/assets/components/pages/CausePage/CausePage.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import gql from 'graphql-tag';
 import PropTypes from 'prop-types';
+import classnames from 'classnames';
 
 import PageQuery from '../PageQuery';
 import TextContent from '../../utilities/TextContent/TextContent';
@@ -66,10 +67,12 @@ const CausePageTemplate = ({
 
           {stats && statsBackgroundColor ? (
             <div className="grid-full md:flex">
-              {stats.map(stat => (
+              {stats.map((stat, index) => (
                 <div
                   key={stat.title}
-                  className="stat rounded mt-3 p-3 md:w-1/3"
+                  className={classnames('stat rounded mt-3 p-3 md:w-1/3', {
+                    'md:mr-5': index < stats.length - 1,
+                  })}
                   style={{ backgroundColor: statsBackgroundColor }}
                 >
                   <p className="text-white text-lg font-bold uppercase">

--- a/resources/assets/components/pages/CausePage/cause-page.scss
+++ b/resources/assets/components/pages/CausePage/cause-page.scss
@@ -14,6 +14,14 @@
       }
     }
 
+    .stat {
+      @include media($medium) {
+        &:not(:last-child) {
+          margin-right: $base-spacing;
+        }
+      }
+    }
+
     .lede-banner__headline-title {
       font-size: 97px;
       line-height: 1;

--- a/resources/assets/components/pages/CausePage/cause-page.scss
+++ b/resources/assets/components/pages/CausePage/cause-page.scss
@@ -9,10 +9,6 @@
     > .title-lockup {
       grid-column: 1 / -1;
 
-      @include media($medium) {
-        grid-column: 2 / -2;
-      }
-
       @include media($large) {
         grid-column: 1 / -6;
       }

--- a/resources/assets/components/pages/CausePage/cause-page.scss
+++ b/resources/assets/components/pages/CausePage/cause-page.scss
@@ -14,14 +14,6 @@
       }
     }
 
-    .stat {
-      @include media($medium) {
-        &:not(:last-child) {
-          margin-right: $base-spacing;
-        }
-      }
-    }
-
     .lede-banner__headline-title {
       font-size: 97px;
       line-height: 1;


### PR DESCRIPTION
### What's this PR do?

This pull request adds the 'stats' feature to Cause Pages, allowing three stat cards to be set via the Additional Content field. It supports an array of `stats` and a `statsBackgroundColor` controlling the `background-color` styling of the stat cards.

https://github.com/DoSomething/phoenix-next/commit/a665459412cc507ca40d977f8ee60a4438577f32 includes a Luke approved update of medium size title-lockups, to span the full grid.
- [Before](https://user-images.githubusercontent.com/12417657/70250457-e9293780-174b-11ea-9106-568a9703cfe9.png)
- [After](https://user-images.githubusercontent.com/12417657/70250456-e9293780-174b-11ea-9326-68882cc969c5.png)


### How should this be reviewed?
This should be pretty straightforward! I dabbled in adding new `Stat` &\|| `StatList` components, but it ended up feeling like overkill for this MVP. 

Two notable styling decisions:
1. I needed to overwrite some of our [Forge `<a>` styling](https://github.com/DoSomething/forge/blob/3828463212a96e97b154b0afa007da30b869c5ab/scss/_base/_elements.scss#L53-L75) on the links, hence those involved tailwind classes. 
2. I struggled a tad with the best way to assign margin properly and ended up feeling best about using old fashioned CSS to assign margin-right to all but the last of the stats. ([I highlighted](https://dosomething.slack.com/archives/C3ASB4204/p1575493707058700) a cool Tailwind pseudo-class that might be helpful here if we feel good about that route). If you have a better idea pray tell!

### Relevant tickets

References [Pivotal #169769114](https://www.pivotaltracker.com/story/show/169769114).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [x] Added screenshots of front-end changes on small, medium, and large screens.
- [ ] Added appropriate feature/unit tests.

📸 

([Design mockups](https://app.goabstract.com/projects/fadf0790-f1f9-11e6-9a30-b54ba7e8e705/branches/master/collections/a1590c04-a8c2-4fd8-b598-aaebc2a79e65))
- [Small](https://user-images.githubusercontent.com/12417657/70250148-77e98480-174b-11ea-9798-ca9d77b01399.png)
- [Medium](https://user-images.githubusercontent.com/12417657/70250149-77e98480-174b-11ea-8104-7d45fadbae71.png)

![Screen Shot 2019-12-05 at 10 31 37](https://user-images.githubusercontent.com/12417657/70250150-77e98480-174b-11ea-85ce-85aee605bfc6.png)
