### PR TITLE
Cause/Collection pages content UI fix

### DIFF
--- a/resources/assets/components/pages/CausePage/CausePage.js
+++ b/resources/assets/components/pages/CausePage/CausePage.js
@@ -66,6 +66,7 @@ const CausePageTemplate = ({
             GalleryBlock: 'grid-full',
             ContentBlock: 'grid-full-8/12',
           }}
+          classNameByEntryDefault="grid-full-8/12"
         >
           {content}
         </TextContent>

--- a/resources/assets/components/pages/CollectionPage/CollectionPage.js
+++ b/resources/assets/components/pages/CollectionPage/CollectionPage.js
@@ -91,6 +91,7 @@ const CollectionPageTemplate = ({
             GalleryBlock: 'grid-full',
             ContentBlock: 'grid-full-8/12',
           }}
+          classNameByEntryDefault="grid-full-8/12"
         >
           {content}
         </TextContent>


### PR DESCRIPTION
### What's this PR do?

This pull request adds a default class to the content on the Cause/Collection pages so that plain copy elements are assigned a grid column span, and won't just collapse to one column!

### How should this be reviewed?
👁 
Is the `8/12` column-span reasonable? That's the span for the Content Blocks so it seemed like a sensible choice.

### Any background context you want to provide?
We didn't account for regular markdown in the Rich Text field since the designs called for Content Blocks & Gallery Blocks ideally, but we are technically allowing this in the field, and I guess that is the beauty of the Rich Text field so it'd be a shame to just disable embedded markdown.

#### Before
![image](https://user-images.githubusercontent.com/12417657/70331743-16d6b500-180e-11ea-9df7-2535223a21f9.png)
#### After
![image](https://user-images.githubusercontent.com/12417657/70331794-3f5eaf00-180e-11ea-9888-06b6a958276f.png)
