### PR TITLE
Adds Affirmation Message on Form Submission

### DIFF
--- a/resources/assets/components/pages/GeneralPage/GeneralPage.js
+++ b/resources/assets/components/pages/GeneralPage/GeneralPage.js
@@ -12,14 +12,14 @@ import ContentfulEntry from '../../ContentfulEntry';
 import { REGISTER_CTA_COPY } from '../../../constants';
 import AuthorBio from '../../utilities/Author/AuthorBio';
 import CtaBanner from '../../utilities/CtaBanner/CtaBanner';
-import CtaPopover from '../../utilities/CtaPopover/CtaPopover';
-import CtaPopoverEmailForm from '../../utilities/CtaPopover/CtaPopoverEmailForm';
+// import CtaPopover from '../../utilities/CtaPopover/CtaPopover';
+// import CtaPopoverEmailForm from '../../utilities/CtaPopover/CtaPopoverEmailForm';
 import TextContent from '../../utilities/TextContent/TextContent';
 import { contentfulImageUrl, withoutNulls } from '../../../helpers';
 import SocialShareTray from '../../utilities/SocialShareTray/SocialShareTray';
 import SiteNavigationContainer from '../../SiteNavigation/SiteNavigationContainer';
-import DelayedElement from '../../utilities/DelayedElement/DelayedElement';
-import DismissableElement from '../../utilities/DismissableElement/DismissableElement';
+// import DelayedElement from '../../utilities/DelayedElement/DelayedElement';
+// import DismissableElement from '../../utilities/DismissableElement/DismissableElement';
 
 import './general-page.scss';
 
@@ -147,7 +147,7 @@ const GeneralPage = props => {
           buttonText={ctaCopy.buttonText}
         />
       ) : null}
-      {slug === 'about/easy-scholarships' ? (
+      {/* {slug === 'about/easy-scholarships' ? (
         <DismissableElement
           name="cta_popover_email"
           render={(handleClose, handleComplete) => (
@@ -163,7 +163,7 @@ const GeneralPage = props => {
             </DelayedElement>
           )}
         />
-      ) : null}
+      ) : null} */}
     </div>
   );
 };

--- a/resources/assets/components/pages/GeneralPage/GeneralPage.js
+++ b/resources/assets/components/pages/GeneralPage/GeneralPage.js
@@ -12,14 +12,14 @@ import ContentfulEntry from '../../ContentfulEntry';
 import { REGISTER_CTA_COPY } from '../../../constants';
 import AuthorBio from '../../utilities/Author/AuthorBio';
 import CtaBanner from '../../utilities/CtaBanner/CtaBanner';
-// import CtaPopover from '../../utilities/CtaPopover/CtaPopover';
-// import CtaPopoverEmailForm from '../../utilities/CtaPopover/CtaPopoverEmailForm';
+import CtaPopover from '../../utilities/CtaPopover/CtaPopover';
+import CtaPopoverEmailForm from '../../utilities/CtaPopover/CtaPopoverEmailForm';
 import TextContent from '../../utilities/TextContent/TextContent';
 import { contentfulImageUrl, withoutNulls } from '../../../helpers';
 import SocialShareTray from '../../utilities/SocialShareTray/SocialShareTray';
 import SiteNavigationContainer from '../../SiteNavigation/SiteNavigationContainer';
-// import DelayedElement from '../../utilities/DelayedElement/DelayedElement';
-// import DismissableElement from '../../utilities/DismissableElement/DismissableElement';
+import DelayedElement from '../../utilities/DelayedElement/DelayedElement';
+import DismissableElement from '../../utilities/DismissableElement/DismissableElement';
 
 import './general-page.scss';
 
@@ -147,11 +147,11 @@ const GeneralPage = props => {
           buttonText={ctaCopy.buttonText}
         />
       ) : null}
-      {/* {slug === 'about/easy-scholarships' ? (
+      {slug === 'about/easy-scholarships' ? (
         <DismissableElement
           name="cta_popover_email"
           render={(handleClose, handleComplete) => (
-            <DelayedElement delay={3}>
+            <DelayedElement delay={1}>
               <CtaPopover
                 title="PAYS TO DO GOOD"
                 content="Want to earn easy scholarships for volunteering?
@@ -163,7 +163,7 @@ const GeneralPage = props => {
             </DelayedElement>
           )}
         />
-      ) : null} */}
+      ) : null}
     </div>
   );
 };

--- a/resources/assets/components/pages/GeneralPage/GeneralPage.js
+++ b/resources/assets/components/pages/GeneralPage/GeneralPage.js
@@ -151,7 +151,7 @@ const GeneralPage = props => {
         <DismissableElement
           name="cta_popover_email"
           render={(handleClose, handleComplete) => (
-            <DelayedElement delay={1}>
+            <DelayedElement delay={3}>
               <CtaPopover
                 title="PAYS TO DO GOOD"
                 content="Want to earn easy scholarships for volunteering?

--- a/resources/assets/components/utilities/CtaPopover/CtaPopover.js
+++ b/resources/assets/components/utilities/CtaPopover/CtaPopover.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 
 import './cta-popover.scss';
 
-const CtaPopover = ({ content, handleClose, title, children }) => {
+const CtaPopover = ({ content, handleClose, title }) => {
   return (
     <div className="cta-popover p-3 bordered rounded">
       <button
@@ -17,7 +17,7 @@ const CtaPopover = ({ content, handleClose, title, children }) => {
         {title}
       </h3>
       <p className="text-white mt-3">{content}</p>
-      {children}
+      {/* {children} */}
     </div>
   );
 };
@@ -26,7 +26,7 @@ CtaPopover.propTypes = {
   content: PropTypes.string.isRequired,
   handleClose: PropTypes.func.isRequired,
   title: PropTypes.string.isRequired,
-  children: PropTypes.object.isRequired,
+  // children: PropTypes.object.isRequired,
 };
 
 export default CtaPopover;

--- a/resources/assets/components/utilities/CtaPopover/CtaPopover.js
+++ b/resources/assets/components/utilities/CtaPopover/CtaPopover.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 
 import './cta-popover.scss';
 
-const CtaPopover = ({ content, handleClose, title }) => {
+const CtaPopover = ({ content, handleClose, title, children }) => {
   return (
     <div className="cta-popover p-3 bordered rounded">
       <button
@@ -17,7 +17,7 @@ const CtaPopover = ({ content, handleClose, title }) => {
         {title}
       </h3>
       <p className="text-white mt-3">{content}</p>
-      {/* { children } */}
+      {children}
     </div>
   );
 };
@@ -26,7 +26,7 @@ CtaPopover.propTypes = {
   content: PropTypes.string.isRequired,
   handleClose: PropTypes.func.isRequired,
   title: PropTypes.string.isRequired,
-  // children: PropTypes.object.isRequired,
+  children: PropTypes.object.isRequired,
 };
 
 export default CtaPopover;

--- a/resources/assets/components/utilities/CtaPopover/CtaPopoverEmailForm.js
+++ b/resources/assets/components/utilities/CtaPopover/CtaPopoverEmailForm.js
@@ -1,4 +1,5 @@
 import get from 'lodash/get';
+import PropTypes from 'prop-types';
 import React, { useState } from 'react';
 import { RestApiClient } from '@dosomething/gateway';
 
@@ -8,9 +9,10 @@ import { tabularLog } from '../../../helpers/api';
 
 import './cta-popover-email-form.scss';
 
-const CtaPopoverEmailForm = () => {
+const CtaPopoverEmailForm = ({ handleComplete }) => {
   const [emailValue, setEmailValue] = useState('');
   const [errorResponse, setErrorResponse] = useState(null);
+  const [showAffirmation, setShowAffirmation] = useState(false);
   const handleChange = event => setEmailValue(event.target.value);
 
   const handleSubmit = event => {
@@ -40,7 +42,7 @@ const CtaPopoverEmailForm = () => {
       });
   };
 
-  return (
+  return !showAffirmation ? (
     <div className="cta-popover-email-form pt-4">
       {errorResponse && errorResponse.fields.email ? (
         <div className="text-red-500">{errorResponse.fields.email[0]}</div>
@@ -56,7 +58,7 @@ const CtaPopoverEmailForm = () => {
         <Button
           className="email-form__button"
           type="submit"
-          onClick={handleSubmit}
+          onClick={handleComplete}
         >
           Sign Up
         </Button>
@@ -74,7 +76,13 @@ const CtaPopoverEmailForm = () => {
         a year for important announcements.
       </p>
     </div>
+  ) : (
+    setShowAffirmation(<div>Thank You For Submitting Your Email</div>, true)
   );
+};
+
+CtaPopoverEmailForm.propTypes = {
+  handleComplete: PropTypes.func.isRequired,
 };
 
 export default CtaPopoverEmailForm;

--- a/resources/assets/components/utilities/CtaPopover/CtaPopoverEmailForm.js
+++ b/resources/assets/components/utilities/CtaPopover/CtaPopoverEmailForm.js
@@ -29,6 +29,7 @@ const CtaPopoverEmailForm = ({ handleComplete }) => {
       })
       .then(response => {
         setShowAffirmation(true);
+        handleComplete();
         tabularLog(get(response, 'data', null));
 
         return response;
@@ -48,7 +49,7 @@ const CtaPopoverEmailForm = ({ handleComplete }) => {
       {errorResponse && errorResponse.fields.email ? (
         <div className="text-red-500">{errorResponse.fields.email[0]}</div>
       ) : null}
-      <form className="email-form form pb-2" onSubmit={handleSubmit}>
+      <form className="email-form form pb-2">
         <input
           className="text-field email-form__input"
           type="email"
@@ -59,7 +60,7 @@ const CtaPopoverEmailForm = ({ handleComplete }) => {
         <Button
           className="email-form__button"
           type="submit"
-          onClick={handleComplete}
+          onClick={handleSubmit}
         >
           Sign Up
         </Button>
@@ -78,7 +79,7 @@ const CtaPopoverEmailForm = ({ handleComplete }) => {
       </p>
     </div>
   ) : (
-    <div>Thank You For Submitting Your Email</div>
+    <div className="color-success">Thank You For Submitting Your Email</div>
   );
 };
 

--- a/resources/assets/components/utilities/CtaPopover/CtaPopoverEmailForm.js
+++ b/resources/assets/components/utilities/CtaPopover/CtaPopoverEmailForm.js
@@ -49,7 +49,7 @@ const CtaPopoverEmailForm = ({ handleComplete }) => {
       {errorResponse && errorResponse.fields.email ? (
         <div className="text-red-500">{errorResponse.fields.email[0]}</div>
       ) : null}
-      <form className="email-form form pb-2">
+      <form className="email-form form pb-2" onSubmit={handleSubmit}>
         <input
           className="text-field email-form__input"
           type="email"
@@ -57,11 +57,7 @@ const CtaPopoverEmailForm = ({ handleComplete }) => {
           placeholder="Enter your email address"
           onChange={handleChange}
         />
-        <Button
-          className="email-form__button"
-          type="submit"
-          onClick={handleSubmit}
-        >
+        <Button className="email-form__button" type="submit">
           Sign Up
         </Button>
       </form>
@@ -79,7 +75,7 @@ const CtaPopoverEmailForm = ({ handleComplete }) => {
       </p>
     </div>
   ) : (
-    <div className="color-success">Thank You For Submitting Your Email</div>
+    <div className="text-green-700">Thank You For Submitting Your Email</div>
   );
 };
 

--- a/resources/assets/components/utilities/CtaPopover/CtaPopoverEmailForm.js
+++ b/resources/assets/components/utilities/CtaPopover/CtaPopoverEmailForm.js
@@ -28,6 +28,7 @@ const CtaPopoverEmailForm = ({ handleComplete }) => {
         source_detail: 'scholarship_newsletter-cta_scholarship-page',
       })
       .then(response => {
+        setShowAffirmation(true);
         tabularLog(get(response, 'data', null));
 
         return response;
@@ -77,7 +78,7 @@ const CtaPopoverEmailForm = ({ handleComplete }) => {
       </p>
     </div>
   ) : (
-    setShowAffirmation(<div>Thank You For Submitting Your Email</div>, true)
+    <div>Thank You For Submitting Your Email</div>
   );
 };
 

--- a/resources/assets/components/utilities/DismissableElement/DismissableElement.js
+++ b/resources/assets/components/utilities/DismissableElement/DismissableElement.js
@@ -16,6 +16,7 @@ const DismissableElement = ({ name, render }) => {
     if (!getStorage(`hide_${name}`, 'boolean')) {
       // Mark the element as "dismissed" in local storage & hide it.
       setStorage(`dismissed_${name}`, 'timestamp', Date.now());
+      setShowElement(false);
     }
   };
 

--- a/resources/assets/components/utilities/DismissableElement/DismissableElement.js
+++ b/resources/assets/components/utilities/DismissableElement/DismissableElement.js
@@ -13,9 +13,10 @@ const DismissableElement = ({ name, render }) => {
   };
 
   const handleDismissal = () => {
-    // Mark the element as "dismissed" in local storage & hide it.
-    setStorage(`dismissed_${name}`, 'timestamp', Date.now());
-    setShowElement(false);
+    if (!getStorage(`hide_${name}`, 'boolean')) {
+      // Mark the element as "dismissed" in local storage & hide it.
+      setStorage(`dismissed_${name}`, 'timestamp', Date.now());
+    }
   };
 
   useEffect(() => {

--- a/resources/assets/components/utilities/DismissableElement/DismissableElement.js
+++ b/resources/assets/components/utilities/DismissableElement/DismissableElement.js
@@ -10,7 +10,6 @@ const DismissableElement = ({ name, render }) => {
   const handleCompletion = () => {
     // Mark the element as "hidden" in local storage.
     setStorage(`hide_${name}`, 'boolean', true);
-    setShowElement(false);
   };
 
   const handleDismissal = () => {
@@ -22,6 +21,7 @@ const DismissableElement = ({ name, render }) => {
   useEffect(() => {
     if (query(`hide_${name}`) === '1') {
       handleCompletion();
+      setShowElement(false);
     }
   }, []);
 


### PR DESCRIPTION
### What's this PR do?

This pull request allows an affirmation text to be displayed on the modal once the user submits an email. 

### How should this be reviewed?
This one should be smooth, I would flag anything that looks out of place or redundant. For example, am I making good use of the affirmation hooks I added? Is adding the conditional before the form a good idea? Should handleComplete be added on the button or the form? Is it a good idea to make changes to the `DismissableElement` or is there another way?(more background below)

### Any background context you want to provide?

`setShowElement(false)` has been removed from the `handleCompletion()` method in the `DismissableElement` to prevent the modal from closing automatically once the email is submitted so that the affirmation text will display. Therefore, the modal will only be dismissed when the close button is clicked. We tested it with the survey and it works fine but if this may cause any issues with other modals, let me know. 

### Relevant tickets

References [Pivotal #169325168](https://www.pivotaltracker.com/story/show/169325168).

![image](https://user-images.githubusercontent.com/18747117/70467677-a8a32400-1a93-11ea-83c5-dd3cdb80c324.png)

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added screenshots of front-end changes on small, medium, and large screens.
- [ ] Added appropriate feature/unit tests.
