### PR TITLE
Utility class cleanup pt4

### DIFF
--- a/resources/assets/components/Block/block-wrapper.scss
+++ b/resources/assets/components/Block/block-wrapper.scss
@@ -1,8 +1,8 @@
 @import '../../scss/next-toolbox';
 
 .block-wrapper {
-  @extend %block;
-  overflow: hidden;
+  // @extend %block;
+  @apply bg-white border border-gray-200 border-solid overflow-hidden p-3 rounded;
 
   @include media($medium) {
     width: 100%;

--- a/resources/assets/components/Block/block-wrapper.scss
+++ b/resources/assets/components/Block/block-wrapper.scss
@@ -1,7 +1,6 @@
 @import '../../scss/next-toolbox';
 
 .block-wrapper {
-  // @extend %block;
   @apply bg-white border border-gray-200 border-solid overflow-hidden p-3 rounded;
 
   @include media($medium) {

--- a/resources/assets/components/LedeBanner/templates/mosaic-lede-banner.scss
+++ b/resources/assets/components/LedeBanner/templates/mosaic-lede-banner.scss
@@ -3,7 +3,7 @@
 
 .mosaic-lede-banner {
   background-color: $dark-background-color;
-  color: $dark-background-contrast-color;
+  color: theme('colors.white');
   width: 100%;
 
   @include media($medium) {
@@ -101,7 +101,7 @@
 }
 
 .mosaic-lede-banner__headline-subtitle {
-  color: $dark-background-contrast-color;
+  color: theme('colors.white');
   border-top: 8px solid $primary-color;
   border-bottom: 8px solid $primary-color;
   font-family: theme('fontFamily.league-gothic');

--- a/resources/assets/components/actions/PhotoSubmissionAction/photo-submission-action.scss
+++ b/resources/assets/components/actions/PhotoSubmissionAction/photo-submission-action.scss
@@ -27,7 +27,7 @@
 
       // Vertical divider between form sections.
       &::after {
-        background-color: $light-gray;
+        background-color: theme('colors.gray.200');
         content: '';
         display: block;
         height: calc(100% - 12px);
@@ -65,7 +65,7 @@
     }
 
     > .wrapper {
-      border-bottom: 1px solid $light-gray;
+      border-bottom: 1px solid theme('colors.gray.200');
       padding: $half-spacing 0;
 
       @include media($medium) {

--- a/resources/assets/components/actions/SocialDriveAction/social-drive.scss
+++ b/resources/assets/components/actions/SocialDriveAction/social-drive.scss
@@ -42,7 +42,7 @@
         cursor: pointer;
 
         &:hover {
-          background-color: $light-gray;
+          background-color: theme('colors.gray.200');
         }
 
         p {

--- a/resources/assets/components/blocks/AffiliateScholarshipBlock/affiliate-scholarship-block.scss
+++ b/resources/assets/components/blocks/AffiliateScholarshipBlock/affiliate-scholarship-block.scss
@@ -2,7 +2,7 @@
 
 .affiliate-scholarship-block {
   // The border styling used throughout this component.
-  $border-style: 1px solid $primary-border-color;
+  $border-style: 1px solid theme('colors.gray.200');
 
   .scholarship-information,
   // Only add border-top to first scholarship detail item *if* scholarship amount is present.
@@ -80,7 +80,7 @@
   dd.scholarship-beta {
     float: none;
     font-family: theme('fontFamily.league-gothic');
-    font-size: $text-2xl;
+    font-size: theme('fontSize.3xl');
     line-height: 1;
   }
 }

--- a/resources/assets/components/blocks/CampaignInfoBlock/campaign-info-block.scss
+++ b/resources/assets/components/blocks/CampaignInfoBlock/campaign-info-block.scss
@@ -49,7 +49,7 @@
   dd.campaign-info__scholarship {
     float: none;
     font-family: theme('fontFamily.league-gothic');
-    font-size: $text-2xl;
+    font-size: theme('fontSize.3xl');
     line-height: 1;
   }
 }

--- a/resources/assets/components/pages/HomePage/home-page.scss
+++ b/resources/assets/components/pages/HomePage/home-page.scss
@@ -35,7 +35,7 @@
     text-align: center;
 
     h4 {
-      color: $light-gray;
+      color: theme('colors.gray.200');
     }
 
     ul {

--- a/resources/assets/components/pages/LandingPage/landing-page.scss
+++ b/resources/assets/components/pages/LandingPage/landing-page.scss
@@ -32,12 +32,12 @@
 
   .marquee-banner__headline-subtitle {
     text-transform: uppercase;
-    font-size: $text-2xl;
+    font-size: theme('fontSize.3xl');
     font-family: theme('fontFamily.league-gothic');
     font-weight: $weight-normal;
 
     @include media($medium) {
-      font-size: $text-4xl;
+      font-size: theme('fontSize.4xl');
     }
   }
 

--- a/resources/assets/components/utilities/Card/card.scss
+++ b/resources/assets/components/utilities/Card/card.scss
@@ -29,7 +29,7 @@
 
 .affiliate-content {
   .card__title {
-    background-color: $sponsor-accent;
+    background-color: #8963ca; // sponsor accent color
 
     h1,
     a {

--- a/resources/assets/components/utilities/Embed/embed.scss
+++ b/resources/assets/components/utilities/Embed/embed.scss
@@ -17,7 +17,7 @@
 
 .embed__image {
   flex: 0 0 150px;
-  background-color: $light-gray;
+  background-color: theme('colors.gray.200');
   background-size: cover;
   background-position: center;
 }

--- a/resources/assets/components/utilities/Form/form-validation.scss
+++ b/resources/assets/components/utilities/Form/form-validation.scss
@@ -1,7 +1,7 @@
 @import '../../../scss/next-toolbox.scss';
 
 .form-validation {
-  border-bottom: 2px solid $light-gray;
+  border-bottom: 2px solid theme('colors.gray.200');
 
   &.-error {
     color: $error-color;

--- a/resources/assets/components/utilities/PageNavigation/page-navigation.scss
+++ b/resources/assets/components/utilities/PageNavigation/page-navigation.scss
@@ -40,7 +40,7 @@
 
   &.is-stuck {
     background-color: $white;
-    border-bottom: 1px solid $primary-border-color;
+    border-bottom: 1px solid theme('colors.gray.200');
   }
 
   > .wrapper {

--- a/resources/assets/components/utilities/PlaceholderText/placeholder-text.scss
+++ b/resources/assets/components/utilities/PlaceholderText/placeholder-text.scss
@@ -11,12 +11,12 @@
 
 .placeholder-shimmer {
   animation: shimmer 2s linear 0s infinite normal forwards;
-  background: $light-gray;
+  background: theme('colors.gray.200');
   background-image: linear-gradient(
     to right,
-    $light-gray 25%,
-    lighten($light-gray, 10%) 50%,
-    $light-gray 75%
+    theme('colors.gray.200') 25%,
+    theme('colors.gray.100') 50%,
+    theme('colors.gray.200') 75%
   );
   background-size: 400px 50px; // Consistent gradient for all elements.
 }

--- a/resources/assets/components/utilities/PostCard/post.scss
+++ b/resources/assets/components/utilities/PostCard/post.scss
@@ -31,7 +31,7 @@
 
 // HACK: Ensure text post cards look okay on "classic" campaign pages.
 .campaign-page .post-ornament-text {
-  border-left-color: $light-gray;
+  border-left-color: theme('colors.gray.200');
 }
 
 .chat-bubble.-post-bubble {

--- a/resources/assets/components/utilities/Share/share.scss
+++ b/resources/assets/components/utilities/Share/share.scss
@@ -59,7 +59,7 @@
   &.-icon {
     width: auto;
     display: inline-block;
-    color: $light-gray;
+    color: theme('colors.gray.200');
     margin-left: $half-spacing / 2;
     margin-right: $half-spacing / 2;
 

--- a/resources/assets/components/utilities/SocialShareTray/ShareButton.js
+++ b/resources/assets/components/utilities/SocialShareTray/ShareButton.js
@@ -5,7 +5,7 @@ import classnames from 'classnames';
 const ShareButton = ({ className, onClick, disabled, icon, text }) => (
   <button
     type="button"
-    className={classnames('button share-button m-2', className)}
+    className={classnames('btn share-button m-2', className)}
     onClick={onClick}
     disabled={disabled}
   >

--- a/resources/assets/components/utilities/SocialShareTray/SocialShareTray.js
+++ b/resources/assets/components/utilities/SocialShareTray/SocialShareTray.js
@@ -139,7 +139,7 @@ class SocialShareTray extends React.Component {
         <div className={classNames('share-buttons', { responsive })}>
           {platforms.includes('facebook') ? (
             <ShareButton
-              className="facebook"
+              className="facebook bg-facebook-500 hover:bg-facebook-400"
               onClick={() =>
                 this.handleFacebookShareClick(shareLink, trackLink)
               }
@@ -151,7 +151,7 @@ class SocialShareTray extends React.Component {
 
           {platforms.includes('twitter') ? (
             <ShareButton
-              className="twitter"
+              className="twitter bg-twitter-500 hover:bg-twitter-400"
               onClick={() =>
                 handleTwitterShareClick(shareLink, { url: trackLink })
               }
@@ -163,7 +163,7 @@ class SocialShareTray extends React.Component {
 
           {platforms.includes('messenger') ? (
             <ShareButton
-              className="messenger"
+              className="messenger bg-messenger-500 hover:bg-messenger-400"
               disabled={!shareLink}
               icon={messengerIcon}
               text="Send"
@@ -175,7 +175,7 @@ class SocialShareTray extends React.Component {
 
           {platforms.includes('email') ? (
             <ShareButton
-              className="email"
+              className="email bg-blue-500 hover:bg-blue-400"
               disabled={!shareLink}
               icon={emailIcon}
               text="Email"

--- a/resources/assets/components/utilities/SocialShareTray/social-share-tray.scss
+++ b/resources/assets/components/utilities/SocialShareTray/social-share-tray.scss
@@ -1,17 +1,5 @@
 @import '../../../scss/next-toolbox.scss';
 
-// Sets a background color for social share buttons without overriding
-// the inherited 'disabled' and 'hover' .button states
-@mixin button-background($color) {
-  &:not([disabled]) {
-    background-color: $color;
-
-    &:hover {
-      background-color: lighten($color, $color-tint);
-    }
-  }
-}
-
 .social-share-tray {
   .share-buttons {
     @include media($large) {
@@ -26,22 +14,6 @@
     }
 
     .share-button {
-      &.facebook {
-        @include button-background($facebook-background-color);
-      }
-
-      &.twitter {
-        @include button-background($twitter-background-color);
-      }
-
-      &.messenger {
-        @include button-background($messenger-background-color);
-      }
-
-      &.email {
-        @include button-background($email-background-color);
-      }
-
       height: 55px;
       padding-right: 20px;
       padding-left: 20px;

--- a/resources/assets/scss/base.scss
+++ b/resources/assets/scss/base.scss
@@ -25,6 +25,10 @@ $forge-path: '../../../node_modules/@dosomething/forge/assets/';
   box-shadow: 0 0 3px theme('colors.blue.500');
 }
 
+.btn:disabled {
+  @apply cursor-default bg-gray-200 text-gray-100;
+}
+
 // @TODO:forge-removal Rename this class to "text-field".
 .text-input {
   @apply bg-white p-3 border border-gray-200 border-solid font-source-sans rounded;

--- a/resources/assets/scss/gallery-grid.scss
+++ b/resources/assets/scss/gallery-grid.scss
@@ -99,7 +99,7 @@
   color: inherit;
   font-size: $font-regular;
   font-weight: $weight-bold;
-  margin-bottom: $increment-spacing;
+  margin-bottom: 4px;
 
   @include media('(min-width: 425px)') {
     font-size: $font-small;

--- a/resources/assets/scss/next-toolbox.scss
+++ b/resources/assets/scss/next-toolbox.scss
@@ -15,10 +15,6 @@ $light-gray: #dcdcdc;
 
 // semantic colors
 $primary-color: #ffec04;
-$sponsor-accent: #8963ca;
-
-$primary-text-color: $off-black;
-$secondary-text-color: #a3a3a3;
 
 $primary-border-color: $light-gray;
 
@@ -27,12 +23,6 @@ $light-background-contrast-color: $off-black;
 $dark-background-color: $off-black;
 $dark-background-color-transparent: rgba(34, 34, 34, 0.9);
 $dark-background-contrast-color: $white;
-
-// Social share button background colors
-$email-background-color: #0ab6fe;
-$twitter-background-color: #00aced;
-$facebook-background-color: #39579a;
-$messenger-background-color: #0084ff;
 
 // spacing
 $half-spacing: $base-spacing / 2;

--- a/resources/assets/scss/next-toolbox.scss
+++ b/resources/assets/scss/next-toolbox.scss
@@ -11,43 +11,20 @@ $only-medium: '(min-width: 760px) and (max-width: 960px)';
 
 // overridden colors
 $black: $off-black;
-$light-gray: #dcdcdc;
 
 // semantic colors
 $primary-color: #ffec04;
 
-$primary-border-color: $light-gray;
-
 $light-background-color: #f6f6f6;
-$light-background-contrast-color: $off-black;
 $dark-background-color: $off-black;
 $dark-background-color-transparent: rgba(34, 34, 34, 0.9);
 $dark-background-contrast-color: $white;
 
 // spacing
 $half-spacing: $base-spacing / 2;
-$increment-spacing: 4px;
-
-$gothic-letter-spacing: 4px;
-
-%block {
-  background-color: $white;
-  border: 1px solid $primary-border-color;
-  border-radius: $lg-border-radius;
-  padding: $base-spacing / 2;
-}
 
 // Z-Indexes used
 $tabbed-navigation-zindex: 100;
 $sticky-cta-zindex: 200;
 $notification-zindex: 300;
 $site-navigation-zindex: 500;
-
-// Layout
-$largest: '(min-width: 1280px)';
-
-// Tailwind Font Sizes
-// @TODO: add the rest!
-$text-lg: 28px;
-$text-2xl: 47px;
-$text-4xl: 60px;

--- a/resources/assets/scss/next-toolbox.scss
+++ b/resources/assets/scss/next-toolbox.scss
@@ -18,7 +18,6 @@ $primary-color: #ffec04;
 $light-background-color: #f6f6f6;
 $dark-background-color: $off-black;
 $dark-background-color-transparent: rgba(34, 34, 34, 0.9);
-$dark-background-contrast-color: $white;
 
 // spacing
 $half-spacing: $base-spacing / 2;

--- a/resources/assets/scss/placeholder.scss
+++ b/resources/assets/scss/placeholder.scss
@@ -4,7 +4,7 @@
   display: flex;
   justify-content: center;
   align-items: center;
-  color: $light-gray;
+  color: theme('colors.gray.200');
   width: 100%;
   min-height: 200px;
   min-height: 100vh;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -94,6 +94,18 @@ module.exports = {
         '800': '#b09120',
         '900': '#967c1b',
       },
+      facebook: {
+        '400': '#4a6dbc',
+        '500': '#39579a',
+      },
+      messenger: {
+        '400': '#339dff',
+        '500': '#0084ff',
+      },
+      twitter: {
+        '400': '#21c2ff',
+        '500': '#00aced',
+      },
     },
     fontFamily: {
       'source-sans': [


### PR DESCRIPTION
### What's this PR do?

This pull request continues the cleanup work for Tailwind implementation. It removes a bunch of SCSS related variables in `next-toolbox.scss`. Most of the changes are pretty straight-forward.

The biggest update is related to the `SocialShareTray` component. I was able to significantly simplify the associated SCSS file, and switch to using Tailwind utilities for the button background colors and hovers, etc. Also added an update to the Tailwind composed `.btn` class to allow the `:disabled` state. Works well and social tray button behave as expected! 

Example buttons with Tailwind:

![SocialShareTray](https://user-images.githubusercontent.com/105849/70352463-31725380-1839-11ea-87b5-4d58d2b70637.gif)

We also now have Tailwind defined background colors for `facebook`, `twitter` and `messenger`, which should be useful in future with other social related things and when the Tailwind config is moved to new Forge version and used in Northstar! Tailwind will end up generating more classes than we need from these three, but once we add Purge CSS it should clean out all the unused ones 🛀 


### How should this be reviewed?

👀 

### Relevant tickets

References [Pivotal #169578779](https://www.pivotaltracker.com/story/show/169578779).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [x] Added screenshots of front-end changes on small, medium, and large screens.

