### PR TITLE
Safely Retrieve GraphQL Affiliate Info

### DIFF
--- a/resources/assets/components/blocks/AffiliateScholarshipBlock/AffiliateScholarshipBlockQuery.js
+++ b/resources/assets/components/blocks/AffiliateScholarshipBlock/AffiliateScholarshipBlockQuery.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import get from 'lodash/get';
 import gql from 'graphql-tag';
 import PropTypes from 'prop-types';
 
@@ -33,8 +34,8 @@ const AffiliateScholarshipBlockQuery = props => (
     }}
   >
     {res => {
-      const title = res.affiliate.title;
-      const logo = res.affiliate.logo;
+      const title = get(res, 'affiliate.title');
+      const logo = get(res, 'affiliate.logo');
 
       return (
         <AffiliateScholarshipBlock

--- a/resources/assets/components/blocks/ScholarshipInfoBlock/ScholarshipInfoBlockQuery.js
+++ b/resources/assets/components/blocks/ScholarshipInfoBlock/ScholarshipInfoBlockQuery.js
@@ -40,7 +40,7 @@ const ScholarshipInfoBlockQuery = props => (
     }}
   >
     {res => {
-      const title = res.affiliate.title;
+      const title = get(res, 'affiliate.title');
       const actions = get(res, 'actions', []);
       const actionItem = actions.find(
         action => action.scholarshipEntry && action.reportback,


### PR DESCRIPTION
### What's this PR do?

This pull request uses Lodash `get` to safely retrieve affiliate info from GraphQL response data.

### How should this be reviewed?
👀 

### Any background context you want to provide?
We use UTM param info to generate this query, there's always a fair chance this will be a `null` response, so we need to query this safely, or else we'll kaboom!

### Relevant tickets
https://dosomething.slack.com/archives/CP2D7UGAU/p1575670873344100

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added screenshots of front-end changes on small, medium, and large screens.
- [ ] Added appropriate feature/unit tests.
