### PR TITLE
Causes in Site Nav Updates

### DIFF
--- a/resources/assets/components/SiteNavigation/SiteNavigation.js
+++ b/resources/assets/components/SiteNavigation/SiteNavigation.js
@@ -184,7 +184,19 @@ class SiteNavigation extends React.Component {
                 <div className="main-subnav menu-subnav">
                   <div className="wrapper base-12-grid">
                     <section className="main-subnav__links-causes menu-subnav__links menu-subnav__section">
-                      <h1>Causes</h1>
+                      <h1>
+                        <a
+                          href="/us/campaigns"
+                          onClick={e => {
+                            this.handleOnClickLink(e, {
+                              noun: 'subnav_link',
+                              label: 'causes',
+                            });
+                          }}
+                        >
+                          Causes
+                        </a>
+                      </h1>
                       <ul>
                         <li>
                           <a
@@ -249,6 +261,19 @@ class SiteNavigation extends React.Component {
                             }}
                           >
                             Bullying
+                          </a>
+                        </li>
+                        <li>
+                          <a
+                            href="/us/campaigns"
+                            onClick={e => {
+                              this.handleOnClickLink(e, {
+                                noun: 'subnav_link',
+                                label: 'causes_all_campaigns',
+                              });
+                            }}
+                          >
+                            All Campaigns
                           </a>
                         </li>
                       </ul>

--- a/resources/assets/components/SiteNavigation/site-navigation.scss
+++ b/resources/assets/components/SiteNavigation/site-navigation.scss
@@ -126,21 +126,6 @@ $extraSmall: '(min-width: 360px)';
         font-size: 22px;
       }
     }
-
-    // For now, the <h1> doesn't contain an <a>, since we don't
-    // have an index page to link to. So defining the <a> rules on the <h1>:
-    color: black;
-    font-size: 22px;
-    font-weight: bold;
-    padding: 0 0 12px;
-
-    @include media($large) {
-      font-size: 18px;
-    }
-
-    @include media($larger) {
-      font-size: 22px;
-    }
   }
 }
 

--- a/resources/assets/components/blocks/ErrorBlock/ErrorBlock.js
+++ b/resources/assets/components/blocks/ErrorBlock/ErrorBlock.js
@@ -32,7 +32,7 @@ const ErrorBlock = ({ error }) => {
 };
 
 ErrorBlock.propTypes = {
-  error: PropTypes.oneOf(PropTypes.object, PropTypes.string),
+  error: PropTypes.oneOf([PropTypes.object, PropTypes.string]),
 };
 
 ErrorBlock.defaultProps = {


### PR DESCRIPTION
### What's this PR do?

This pull request adds a few quick updates for the Causes in Site Navigation:
- Turns the top level dropdown **Causes** into a link to the campaigns index page
- Adds an 'All Campaigns' link to the list of causes linking to the campaigns index page
- Updates the title in the campaigns index page to "Campaigns For All Causes"

I also saw a console error re one of our `PropTypes.oneOf` not placing it's arguments in an array so fixed that in https://github.com/DoSomething/phoenix-next/commit/533d56614fd41980295242d611ccfaf48cff339b

### How should this be reviewed?
Are the new analytics events ok? They seem to easily follow the convention we set up for the causes.

### Any background context you want to provide?
https://www.pivotaltracker.com/story/show/169323699/comments/209487701

### Relevant tickets
#1783 
References [Pivotal #169323699](https://www.pivotaltracker.com/story/show/169323699).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added screenshots of front-end changes on small, medium, and large screens.
- [ ] Added appropriate feature/unit tests.


![image](https://user-images.githubusercontent.com/12417657/70447711-30c20300-1a6d-11ea-9f1e-26ce3948d9d9.png)
![image](https://user-images.githubusercontent.com/12417657/70447727-36b7e400-1a6d-11ea-840e-4bd1afbeab51.png)

