### PR TITLE
Photo Submission Uploader Validation Updates

### DIFF
--- a/resources/assets/components/actions/PhotoSubmissionAction/PhotoSubmissionAction.js
+++ b/resources/assets/components/actions/PhotoSubmissionAction/PhotoSubmissionAction.js
@@ -16,6 +16,7 @@ import MediaUploader from '../../utilities/MediaUploader';
 import { getUserCampaignSignups } from '../../../helpers/api';
 import FormValidation from '../../utilities/Form/FormValidation';
 import { withoutUndefined, withoutNulls } from '../../../helpers';
+import CharacterLimit from '../../utilities/CharacterLimit/CharacterLimit';
 import PrivacyLanguage from '../../utilities/PrivacyLanguage/PrivacyLanguage';
 import {
   calculateDifference,
@@ -42,6 +43,8 @@ export const PhotoSubmissionBlockFragment = gql`
     affirmationContent
   }
 `;
+
+const CAPTION_CHARACTER_LIMIT = '60';
 
 class PhotoSubmissionAction extends PostForm {
   /**
@@ -324,6 +327,11 @@ class PhotoSubmissionAction extends PostForm {
                           placeholder={this.props.captionFieldPlaceholder}
                           value={this.state.captionValue}
                           onChange={this.handleChange}
+                        />
+                        <CharacterLimit
+                          className="pt-1"
+                          limit={CAPTION_CHARACTER_LIMIT}
+                          text={this.state.captionValue}
                         />
                       </div>
                     </div>

--- a/resources/assets/components/actions/PhotoSubmissionAction/PhotoSubmissionAction.js
+++ b/resources/assets/components/actions/PhotoSubmissionAction/PhotoSubmissionAction.js
@@ -328,6 +328,7 @@ class PhotoSubmissionAction extends PostForm {
                           value={this.state.captionValue}
                           onChange={this.handleChange}
                           required
+                          maxlength={CAPTION_CHARACTER_LIMIT}
                         />
                         <CharacterLimit
                           className="pt-1"

--- a/resources/assets/components/actions/PhotoSubmissionAction/PhotoSubmissionAction.js
+++ b/resources/assets/components/actions/PhotoSubmissionAction/PhotoSubmissionAction.js
@@ -373,6 +373,7 @@ class PhotoSubmissionAction extends PostForm {
                             value={this.state.quantityValue}
                             onChange={this.handleChange}
                             required
+                            min={Number(quantity) + 1}
                           />
                         </div>
                       ) : null}

--- a/resources/assets/components/actions/PhotoSubmissionAction/PhotoSubmissionAction.js
+++ b/resources/assets/components/actions/PhotoSubmissionAction/PhotoSubmissionAction.js
@@ -328,7 +328,7 @@ class PhotoSubmissionAction extends PostForm {
                           value={this.state.captionValue}
                           onChange={this.handleChange}
                           required
-                          maxlength={CAPTION_CHARACTER_LIMIT}
+                          maxLength={CAPTION_CHARACTER_LIMIT}
                         />
                         <CharacterLimit
                           className="pt-1"

--- a/resources/assets/components/actions/PhotoSubmissionAction/PhotoSubmissionAction.js
+++ b/resources/assets/components/actions/PhotoSubmissionAction/PhotoSubmissionAction.js
@@ -366,7 +366,7 @@ class PhotoSubmissionAction extends PostForm {
                             className={classnames('text-field', {
                               'has-error shake': has(errors, 'quantity'),
                             })}
-                            type="text"
+                            type="number"
                             id="quantity"
                             name="quantity"
                             placeholder={this.props.quantityFieldPlaceholder}

--- a/resources/assets/components/actions/PhotoSubmissionAction/PhotoSubmissionAction.js
+++ b/resources/assets/components/actions/PhotoSubmissionAction/PhotoSubmissionAction.js
@@ -499,7 +499,7 @@ PhotoSubmissionAction.defaultProps = {
   affirmationContent:
     "Thanks for joining the movement, and submitting your photo! After we review your submission, we'll add it to the public gallery alongside submissions from all the other members taking action in this campaign.",
   buttonText: 'Submit a new photo',
-  captionFieldLabel: 'Add a caption to your photo.',
+  captionFieldLabel: 'Add a title to your photo.',
   captionFieldPlaceholder: '60 characters or less',
   className: null,
   informationContent:

--- a/resources/assets/components/actions/PhotoSubmissionAction/PhotoSubmissionAction.js
+++ b/resources/assets/components/actions/PhotoSubmissionAction/PhotoSubmissionAction.js
@@ -327,6 +327,7 @@ class PhotoSubmissionAction extends PostForm {
                           placeholder={this.props.captionFieldPlaceholder}
                           value={this.state.captionValue}
                           onChange={this.handleChange}
+                          required
                         />
                         <CharacterLimit
                           className="pt-1"
@@ -371,6 +372,7 @@ class PhotoSubmissionAction extends PostForm {
                             placeholder={this.props.quantityFieldPlaceholder}
                             value={this.state.quantityValue}
                             onChange={this.handleChange}
+                            required
                           />
                         </div>
                       ) : null}
@@ -422,6 +424,7 @@ class PhotoSubmissionAction extends PostForm {
                           }
                           value={this.state.whyParticipatedValue}
                           onChange={this.handleChange}
+                          required
                         />
                       </div>
                     </div>

--- a/resources/assets/components/utilities/CharacterLimit/CharacterLimit.js
+++ b/resources/assets/components/utilities/CharacterLimit/CharacterLimit.js
@@ -2,19 +2,28 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
-const CharacterLimit = ({ text, limit }) => {
+const CharacterLimit = ({ className, text, limit }) => {
   const remaining = limit - text.length;
 
   return (
-    <p className={classNames('footnote', { 'color-error': remaining <= 0 })}>
+    <p
+      className={classNames(className, 'footnote', {
+        'color-error': remaining <= 0,
+      })}
+    >
       {remaining} characters remaining
     </p>
   );
 };
 
 CharacterLimit.propTypes = {
+  className: PropTypes.string,
   limit: PropTypes.number.isRequired,
   text: PropTypes.string.isRequired,
+};
+
+CharacterLimit.defaultProps = {
+  className: null,
 };
 
 export default CharacterLimit;

--- a/resources/assets/components/utilities/MediaUploader/__snapshots__/test.js.snap
+++ b/resources/assets/components/utilities/MediaUploader/__snapshots__/test.js.snap
@@ -18,6 +18,7 @@ exports[`MediaUploader snapshot test 1`] = `
       id="media-uploader"
       name="media-uploader"
       onChange={[Function]}
+      required={true}
       type="file"
     />
   </label>

--- a/resources/assets/components/utilities/MediaUploader/index.js
+++ b/resources/assets/components/utilities/MediaUploader/index.js
@@ -75,6 +75,7 @@ class MediaUploader extends React.Component {
             id="media-uploader"
             name="media-uploader"
             onChange={this.handleChange}
+            required
           />
         </label>
       </div>


### PR DESCRIPTION
### What's this PR do?

This pull request adds a few simple updates to our Photo Submission Action to hopefully help prevent some common errors we've seen through our analytics.

- https://github.com/DoSomething/phoenix-next/commit/36184ce8a5da52cd6756e3fd196f6f0e4dcab824 the main one and the actual Pivotal carded feature request was to use the `CharacterLimit` utility component in the **Caption** field. A whopping 44% of our errors were from submissions over the 60 character limit, so this should really help. (https://github.com/DoSomething/phoenix-next/commit/357d9f34d998fd4628c64948a816c7456c78d2d8 the other request was to update the default label for the caption field.)

Looking at the [error sheet](https://docs.google.com/spreadsheets/d/1M71hhFgWME5G96PZQxStKKoOwlVe7uE1keREmP-Hdks/edit?ts=5d9cb047#gid=1833051252), and once I was poking around this component, there seemed to be a few more super easy wins to prevent a few of the other top errors, so I used some HTML <input> attributes to mark a few fields as 'required' https://github.com/DoSomething/phoenix-next/commit/d3b15b162e6d4dcbf8d6e05a66d446dcef630f3d (~20%), change the quantity type to `number` https://github.com/DoSomething/phoenix-next/commit/b070a39772bb5870402908a801a42f33183c93e7 (~6%) and add `minlength` https://github.com/DoSomething/phoenix-next/commit/3af3b9ebdec83f45ee15786361e86191cd9b6851 and `maxlength` attributes https://github.com/DoSomething/phoenix-next/commit/6655dc26c5fccf0fadc45471dd2e618966f6e431 (that same 44% + ~7%).

### How should this be reviewed?
These native HTML validations are admittedly not the most on-brand validation messages (see screenshots). Still, IMO they're pretty adequate for the meanwhile at least and can help reduce our error count drastically. That being said, we'd lose the error analytics on these fields. Still, my rationale was that the UX win of preventing those extra Rogue roundtrips and giving the user feedback on the spot and preventing their submission is more significant. 

I'd assume ultimately if we're committed to more client-side validation, we might want something similar to the client-side validation we have on Northstar where things are set to trigger on brand error messages and capture analytics.

All this being said, if folks feel strongly that we _shouldn't_ invest in these HTML validations (looking at you @weerd 😁, I know you have thoughts on client-side validation in general), I can roll the extra stuff back and keep this limited to the formal feature requests of caption char count and label updates! CC @LeahAngle @lkpttn 

### Relevant tickets

References [Pivotal #169028725](https://www.pivotaltracker.com/story/show/169028725).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [x] Added screenshots of front-end changes on small, medium, and large screens.
- [ ] Added appropriate feature/unit tests.


📸 
- [Character counter](https://user-images.githubusercontent.com/12417657/70452162-ac737e00-1a74-11ea-8a1b-0a892709786b.png)
- [Max reached](https://user-images.githubusercontent.com/12417657/70452184-b301f580-1a74-11ea-82f4-321861d3943a.png)
- [Required field](https://user-images.githubusercontent.com/12417657/70454002-bc409180-1a77-11ea-8ed8-67be3b3d9a05.png)
- [Required field](https://user-images.githubusercontent.com/12417657/70452240-c90fb600-1a74-11ea-8f0a-af8262978fbc.png)
- [Quantity minimum](https://user-images.githubusercontent.com/12417657/70452593-64089000-1a75-11ea-83c8-de538ad3bee1.png)