### PR TITLE
Tailwind replacing spacing variables 🧼

### DIFF
--- a/resources/assets/components/Block/BlockWrapper.js
+++ b/resources/assets/components/Block/BlockWrapper.js
@@ -32,7 +32,11 @@ const BlockTitle = ({ title, shareLink }: BlockTitleProps) => {
     title
   );
 
-  return <h4 className="block-wrapper__title">{titleElement}</h4>;
+  return (
+    <h4 className="block-wrapper__title -mt-3 -mx-3 mb-6 p-3">
+      {titleElement}
+    </h4>
+  );
 };
 
 type BlockWrapperProps = {

--- a/resources/assets/components/Block/block-wrapper.scss
+++ b/resources/assets/components/Block/block-wrapper.scss
@@ -18,8 +18,6 @@
   font-family: theme('fontFamily.source-sans');
   background-color: $primary-color;
   text-transform: uppercase;
-  margin: (-$half-spacing) (-$half-spacing) $base-spacing;
-  padding: $half-spacing;
 }
 
 .block-wrapper__title a {

--- a/resources/assets/components/CampaignSignupArrow/campaignSignupArrow.scss
+++ b/resources/assets/components/CampaignSignupArrow/campaignSignupArrow.scss
@@ -27,7 +27,7 @@
 
   .message-callout__copy {
     @include media($large) {
-      margin-top: -$half-spacing;
+      margin-top: -12px;
     }
 
     @include media($medium) {
@@ -35,7 +35,7 @@
     }
 
     @include media($small) {
-      margin-left: -$base-spacing * 2;
+      margin-left: -48px;
 
       p {
         font-size: 20px;
@@ -56,7 +56,7 @@
     }
 
     @include media($small) {
-      right: -$base-spacing;
+      right: -24px;
     }
   }
 }

--- a/resources/assets/components/CampaignSignupArrow/campaignSignupArrow.scss
+++ b/resources/assets/components/CampaignSignupArrow/campaignSignupArrow.scss
@@ -31,7 +31,7 @@
     }
 
     @include media($medium) {
-      padding-left: $base-spacing * 2;
+      padding-left: theme('spacing.12');
     }
 
     @include media($small) {

--- a/resources/assets/components/LedeBanner/templates/cover-lede-banner.scss
+++ b/resources/assets/components/LedeBanner/templates/cover-lede-banner.scss
@@ -13,7 +13,7 @@
 
   @include media($medium) {
     height: calc(100vh - 110px); // subtract .navigation height
-    padding: $base-spacing;
+    padding: theme('spacing.6');
   }
 
   // If narrow viewport less than 550px, do not stretch the lede banner and allow
@@ -51,7 +51,7 @@
   font-weight: normal;
   letter-spacing: 0.5px;
   line-height: 1.2;
-  margin-bottom: $base-spacing;
+  margin-bottom: theme('spacing.6');
   text-align: center;
   text-shadow: 0 0 5px rgba(0, 0, 0, 0.2);
   text-transform: uppercase;
@@ -63,7 +63,7 @@
 
 .cover-lede-banner__blurb {
   color: $white;
-  margin-bottom: $base-spacing;
+  margin-bottom: theme('spacing.6');
   text-align: center;
   text-shadow: 0 0 10px rgba(0, 0, 0, 0.8);
 

--- a/resources/assets/components/LedeBanner/templates/jumbo-lede-banner.scss
+++ b/resources/assets/components/LedeBanner/templates/jumbo-lede-banner.scss
@@ -46,7 +46,7 @@
   font-weight: normal;
   letter-spacing: 0.5px;
   line-height: 1.2;
-  margin-bottom: $base-spacing;
+  margin-bottom: theme('spacing.6');
   text-align: center;
   text-shadow: 0 0 5px rgba(0, 0, 0, 0.2);
   text-transform: uppercase;
@@ -58,7 +58,7 @@
 
 .jumbo-lede-banner__blurb {
   color: $white;
-  margin-bottom: $base-spacing;
+  margin-bottom: theme('spacing.6');
   text-align: center;
   text-shadow: 0 0 10px rgba(0, 0, 0, 0.8);
 
@@ -70,7 +70,7 @@
 }
 
 .jumbo-lede-banner__signup {
-  margin: 0 auto $base-spacing;
+  margin: 0 auto theme('spacing.6');
 
   .button {
     padding: 20px;

--- a/resources/assets/components/LedeBanner/templates/mosaic-lede-banner.scss
+++ b/resources/assets/components/LedeBanner/templates/mosaic-lede-banner.scss
@@ -91,7 +91,7 @@
 
   @include media($large) {
     font-size: 28px;
-    top: -$half-spacing;
+    top: -12px;
   }
 
   &.smaller-font {

--- a/resources/assets/components/LedeBanner/templates/mosaic-lede-banner.scss
+++ b/resources/assets/components/LedeBanner/templates/mosaic-lede-banner.scss
@@ -15,7 +15,7 @@
 
   .button {
     width: 100%;
-    padding: $base-spacing $half-spacing;
+    padding: theme('spacing.6') theme('spacing.3');
 
     @include media($large) {
       width: 50%;
@@ -39,7 +39,7 @@
   }
 
   .mosaic-lede-banner__signup {
-    padding-top: $base-spacing;
+    padding-top: theme('spacing.6');
 
     .button.-float {
       float: left;
@@ -55,10 +55,10 @@
   }
 
   & > .wrapper {
-    padding: $section-spacing $half-spacing;
+    padding: theme('spacing.12') theme('spacing.3');
 
     @include media($large) {
-      padding: $section-spacing $base-spacing;
+      padding: theme('spacing.12') theme('spacing.6');
     }
   }
 }
@@ -84,7 +84,7 @@
   color: $primary-color;
   font-family: theme('fontFamily.source-sans');
   font-size: 20px;
-  padding-right: $half-spacing;
+  padding-right: theme('spacing.3');
   position: absolute;
   top: -7px;
   text-transform: uppercase;
@@ -110,7 +110,7 @@
   letter-spacing: 4px;
   line-height: 1.1;
   margin-bottom: 0;
-  padding: $half-spacing 0;
+  padding: theme('spacing.3') 0;
   text-transform: uppercase;
 
   @include media($medium) {
@@ -120,7 +120,7 @@
 
 .mosaic-lede-banner__blurb {
   font-family: theme('fontFamily.source-sans');
-  padding-top: $base-spacing;
+  padding-top: theme('spacing.6');
 
   strong {
     color: $primary-color;
@@ -129,7 +129,7 @@
 
 .message-callout {
   clear: both;
-  margin-top: $half-spacing;
+  margin-top: theme('spacing.3');
 
   @include media($larger) {
     clear: none;

--- a/resources/assets/components/Notification/notification.scss
+++ b/resources/assets/components/Notification/notification.scss
@@ -12,7 +12,7 @@
 .notification {
   position: relative;
   width: 100%;
-  margin: $half-spacing;
+  margin: theme('spacing.3');
 
   &.-error {
     color: $white;
@@ -20,8 +20,8 @@
   }
 
   .notification__content {
-    padding: $half-spacing $base-spacing;
-    margin-right: $half-spacing;
+    padding: theme('spacing.3') theme('spacing.6');
+    margin-right: theme('spacing.3');
 
     p {
       color: inherit;
@@ -34,8 +34,8 @@
     color: inherit;
     font-size: 32px;
     position: absolute;
-    right: $half-spacing;
-    top: $half-spacing;
+    right: theme('spacing.3');
+    top: theme('spacing.3');
 
     &:focus {
       outline: transparent 0 none;

--- a/resources/assets/components/Quiz/quiz.scss
+++ b/resources/assets/components/Quiz/quiz.scss
@@ -1,7 +1,7 @@
 @import '../../scss/next-toolbox.scss';
 
 .quiz {
-  margin: 0 $half-spacing;
+  margin: 0 theme('spacing.3');
 
   .quiz__heading {
     color: $primary-color;
@@ -14,11 +14,11 @@
     font-family: theme('fontFamily.league-gothic');
     font-size: $font-hero;
     text-transform: uppercase;
-    margin-bottom: $base-spacing;
+    margin-bottom: theme('spacing.6');
   }
 
   .question {
-    margin: $base-spacing 0;
+    margin: theme('spacing.6') 0;
 
     .question__title {
       color: $white;
@@ -29,19 +29,19 @@
 
       @include media($medium) {
         font-size: $font-hero;
-        padding: $base-spacing;
+        padding: theme('spacing.6');
       }
     }
   }
 
   .question__choices {
-    margin-top: $base-spacing;
+    margin-top: theme('spacing.6');
     display: flex;
     flex-wrap: wrap;
   }
 
   .choice {
-    margin-bottom: $half-spacing;
+    margin-bottom: theme('spacing.3');
     font-weight: $weight-bold;
     text-decoration: none;
     width: 100%;
@@ -49,7 +49,7 @@
 
     &.background-image {
       flex: 0 0 33%;
-      padding: 0 $half-spacing $half-spacing 0;
+      padding: 0 theme('spacing.3') theme('spacing.3') 0;
 
       @include media($small) {
         flex: 0 0 50%;
@@ -67,7 +67,7 @@
   }
 
   .quiz-conclusion {
-    margin-bottom: $base-spacing;
+    margin-bottom: theme('spacing.6');
 
     .conclusion__item {
       display: inline-block;

--- a/resources/assets/components/Revealer/revealer.scss
+++ b/resources/assets/components/Revealer/revealer.scss
@@ -3,13 +3,13 @@
 .revealer {
   text-align: center;
   width: 100%;
-  margin-top: $base-spacing;
-  padding: $base-spacing $half-spacing 0;
+  margin-top: theme('spacing.6');
+  padding: theme('spacing.6') theme('spacing.3') 0;
   position: relative;
 
   @include media($medium) {
-    margin-bottom: $base-spacing;
-    padding-bottom: $base-spacing;
+    margin-bottom: theme('spacing.6');
+    padding-bottom: theme('spacing.6');
   }
 
   &::before {
@@ -31,7 +31,7 @@
   h1 {
     color: $black;
     font-size: type-scale(1);
-    margin-bottom: $base-spacing;
+    margin-bottom: theme('spacing.6');
   }
 
   .button.is-cta {

--- a/resources/assets/components/StaticBlock/static-block.scss
+++ b/resources/assets/components/StaticBlock/static-block.scss
@@ -1,7 +1,7 @@
 @import '~@dosomething/forge/scss/toolkit';
 
 .static-block__citation {
-  margin-top: $base-spacing;
+  margin-top: theme('spacing.6');
 
   &::before {
     content: '';
@@ -9,6 +9,6 @@
     width: 50%;
     height: 2px;
     background-color: $med-gray;
-    margin-bottom: $base-spacing / 2;
+    margin-bottom: theme('spacing.3');
   }
 }

--- a/resources/assets/components/actions/PhotoSubmissionAction/photo-submission-action.scss
+++ b/resources/assets/components/actions/PhotoSubmissionAction/photo-submission-action.scss
@@ -3,18 +3,18 @@
 .photo-submission-action {
   @include media($large) {
     float: left;
-    padding-right: $half-spacing;
+    padding-right: theme('spacing.3');
     width: 66.6666666666666%;
   }
 }
 
 .photo-submission-information {
-  margin-top: $base-spacing;
+  margin-top: theme('spacing.6');
 
   @include media($large) {
     float: right;
     margin-top: 0;
-    padding-left: $half-spacing;
+    padding-left: theme('spacing.3');
     width: 33.3333333333333%;
   }
 }
@@ -32,7 +32,7 @@
         display: block;
         height: calc(100% - 12px);
         position: absolute;
-        top: $half-spacing;
+        top: theme('spacing.3');
         left: 50%;
         width: 1px;
         z-index: 10;
@@ -58,7 +58,7 @@
 
   // Form Sections
   .form-section {
-    padding: 0 $half-spacing;
+    padding: 0 theme('spacing.3');
 
     @include media($medium) {
       flex: 1;
@@ -66,7 +66,7 @@
 
     > .wrapper {
       border-bottom: 1px solid theme('colors.gray.200');
-      padding: $half-spacing 0;
+      padding: theme('spacing.3') 0;
 
       @include media($medium) {
         border-bottom: 0 none;
@@ -92,7 +92,7 @@
   }
 
   .form-item + .form-item {
-    margin-top: $base-spacing;
+    margin-top: theme('spacing.6');
   }
 
   // Quantity Display
@@ -107,7 +107,7 @@
     font-size: $font-regular;
     font-weight: $weight-bold;
     line-height: 1;
-    margin-bottom: $half-spacing/2;
+    margin-bottom: theme('spacing.2');
     text-transform: uppercase;
   }
 

--- a/resources/assets/components/actions/SocialDriveAction/social-drive.scss
+++ b/resources/assets/components/actions/SocialDriveAction/social-drive.scss
@@ -4,18 +4,18 @@
   .link-area {
     @include media($large) {
       display: flex;
-
-      .share-text {
-        margin: auto;
-        white-space: nowrap;
-        padding-right: $half-spacing;
-        padding-bottom: 0;
-      }
     }
 
     .share-text {
       color: $off-black;
-      padding-bottom: $half-spacing / 2;
+      padding-bottom: theme('spacing.2');
+
+      @include media($large) {
+        margin: auto;
+        white-space: nowrap;
+        padding-right: theme('spacing.3');
+        padding-bottom: 0;
+      }
     }
 
     .link-bar {

--- a/resources/assets/components/actions/VoterRegistrationAction/voter-registration-action.scss
+++ b/resources/assets/components/actions/VoterRegistrationAction/voter-registration-action.scss
@@ -3,7 +3,7 @@
 
 .voter-registration {
   .button {
-    margin-top: $half-spacing;
+    margin-top: theme('spacing.3');
     max-width: 350px;
     text-transform: none;
     width: 100%;
@@ -12,7 +12,7 @@
   @include media($larger) {
     .markdown {
       float: left;
-      padding-right: $base-spacing;
+      padding-right: theme('spacing.6');
       width: 66.666666667%;
     }
 
@@ -21,7 +21,7 @@
       display: block;
       float: right;
       margin-top: 0;
-      padding-left: $half-spacing;
+      padding-left: theme('spacing.3');
       width: 33.333333333%;
     }
   }

--- a/resources/assets/components/blocks/AffiliateScholarshipBlock/affiliate-scholarship-block.scss
+++ b/resources/assets/components/blocks/AffiliateScholarshipBlock/affiliate-scholarship-block.scss
@@ -10,11 +10,11 @@
   // Any children following the first one should definitely have a border-top.
   .scholarship-information__details > :nth-child(n+2) {
     border-top: $border-style;
-    padding-top: $half-spacing;
+    padding-top: theme('spacing.3');
   }
 
   .scholarship-deadline {
-    padding-bottom: $half-spacing;
+    padding-bottom: theme('spacing.3');
   }
 
   @include media($medium) {
@@ -24,7 +24,7 @@
       .scholarship-information__amount {
         flex-basis: 50%;
         border-right: $border-style;
-        margin-right: $half-spacing;
+        margin-right: theme('spacing.3');
       }
 
       .scholarship-information__details {
@@ -68,13 +68,13 @@
     @include media('(min-width: 350px)') {
       float: none;
     }
-    padding-bottom: $half-spacing;
+    padding-bottom: theme('spacing.3');
   }
 
   dt.scholarship-beta {
     border-top: 1px solid theme('colors.gray.300');
     float: none;
-    padding-top: $half-spacing;
+    padding-top: theme('spacing.3');
   }
 
   dd.scholarship-beta {

--- a/resources/assets/components/blocks/CampaignInfoBlock/campaign-info-block.scss
+++ b/resources/assets/components/blocks/CampaignInfoBlock/campaign-info-block.scss
@@ -16,7 +16,7 @@
       @include media('(min-width: 350px)') {
         float: none;
       }
-      padding-bottom: $half-spacing;
+      padding-bottom: theme('spacing.3');
     }
   }
 
@@ -28,12 +28,12 @@
 
     @include media('(min-width: 350px)') {
       float: left;
-      padding-bottom: $half-spacing;
+      padding-bottom: theme('spacing.3');
     }
   }
 
   dd {
-    padding-bottom: $half-spacing;
+    padding-bottom: theme('spacing.3');
 
     @include media('(min-width: 350px)') {
       float: right;
@@ -43,7 +43,7 @@
   dt.campaign-info__scholarship {
     border-top: 1px solid theme('colors.gray.300');
     float: none;
-    padding-top: $half-spacing;
+    padding-top: theme('spacing.3');
   }
 
   dd.campaign-info__scholarship {

--- a/resources/assets/components/blocks/SectionBlock/section-block.scss
+++ b/resources/assets/components/blocks/SectionBlock/section-block.scss
@@ -12,7 +12,7 @@
   }
 
   > h1 {
-    margin-bottom: $base-spacing;
+    margin-bottom: theme('spacing.6');
 
     @include media($medium) {
       font-size: 60px;

--- a/resources/assets/components/pages/CampaignPage/campaign-page.scss
+++ b/resources/assets/components/pages/CampaignPage/campaign-page.scss
@@ -8,7 +8,7 @@
   .primary {
     @include media($large) {
       float: left;
-      padding-right: $half-spacing;
+      padding-right: theme('spacing.3');
       width: 66.6666666666666%;
     }
   }
@@ -19,8 +19,8 @@
     @include media($large) {
       display: block;
       float: right;
-      padding-left: $half-spacing;
-      margin: 0 0 $base-spacing;
+      padding-left: theme('spacing.3');
+      margin: 0 0 theme('spacing.6');
       width: 33.3333333333333%;
     }
   }

--- a/resources/assets/components/pages/GeneralPage/general-page.scss
+++ b/resources/assets/components/pages/GeneralPage/general-page.scss
@@ -52,7 +52,7 @@
 
   .general-page__authors {
     display: inline-block;
-    margin: $base-spacing auto 0;
+    margin: theme('spacing.6') auto 0;
     text-align: left;
 
     @include media($large) {

--- a/resources/assets/components/pages/GeneralPage/general-page.scss
+++ b/resources/assets/components/pages/GeneralPage/general-page.scss
@@ -22,7 +22,7 @@
     .general-page__subtitle {
       font-family: theme('fontFamily.source-sans');
       font-weight: $weight-bold;
-      margin-top: $half-spacing;
+      margin-top: theme('spacing.3');
 
       @include media($medium) {
         font-size: $font-large;
@@ -42,10 +42,10 @@
         $yellow 66.6%,
         $yellow 100%
       );
-      margin: $section-spacing 10px;
+      margin: theme('spacing.12') 10px;
 
       @include media($medium) {
-        margin: $section-spacing 0;
+        margin: theme('spacing.12') 0;
       }
     }
   }
@@ -62,17 +62,17 @@
 
   .general-page__author-bios {
     border-top: 2px solid #dcdcdc;
-    margin: $base-spacing $half-spacing 0;
-    padding: $half-spacing 0;
+    margin: theme('spacing.6') theme('spacing.3') 0;
+    padding: theme('spacing.3') 0;
   }
 
   .row {
     .primary {
-      margin: 0 0 $base-spacing;
+      margin: 0 0 theme('spacing.6');
 
       @include media($large) {
         float: left;
-        padding-right: $half-spacing;
+        padding-right: theme('spacing.3');
         width: 66.6666666666666%;
       }
     }
@@ -83,8 +83,8 @@
       @include media($large) {
         display: block;
         float: right;
-        padding-left: $half-spacing;
-        margin: 0 0 $base-spacing;
+        padding-left: theme('spacing.3');
+        margin: 0 0 theme('spacing.6');
         width: 33.3333333333333%;
       }
     }

--- a/resources/assets/components/pages/HomePage/home-page.scss
+++ b/resources/assets/components/pages/HomePage/home-page.scss
@@ -45,7 +45,7 @@
 
     li {
       display: inline-block;
-      margin: gutter() $base-spacing;
+      margin: theme('spacing.3') theme('spacing.6');
     }
 
     img {

--- a/resources/assets/components/pages/LandingPage/landing-page.scss
+++ b/resources/assets/components/pages/LandingPage/landing-page.scss
@@ -12,7 +12,7 @@
   }
 
   .marquee-banner {
-    margin-bottom: $half-spacing;
+    margin-bottom: theme('spacing.3');
     grid-column: full-start / full-end;
 
     @include media($large) {
@@ -42,11 +42,11 @@
   }
 
   .primary {
-    margin-bottom: $base-spacing;
+    margin-bottom: theme('spacing.6');
   }
 
   .secondary {
-    margin-bottom: $base-spacing;
+    margin-bottom: theme('spacing.6');
 
     @include media($largest) {
       // @TODO: if primary content is short and this only spans 2, then grid rows are spread
@@ -62,7 +62,7 @@
   border-top: 1px solid theme('colors.gray.200');
   bottom: 0;
   left: 0;
-  padding: $half-spacing;
+  padding: theme('spacing.3');
   position: fixed;
   width: 100%;
   z-index: 10;
@@ -81,10 +81,10 @@
     display: block;
     margin: 0 auto;
     max-width: 450px;
-    padding: $base-spacing;
+    padding: theme('spacing.6');
 
     @include media($medium) {
-      margin: 0 auto $half-spacing;
+      margin: 0 auto theme('spacing.3');
     }
   }
 }
@@ -101,7 +101,7 @@
     // blocks when they're stacked.
     & + .container__block {
       @include media($mobile) {
-        margin-top: $base-spacing;
+        margin-top: theme('spacing.6');
       }
     }
 

--- a/resources/assets/components/pages/StoryPage/story-page.scss
+++ b/resources/assets/components/pages/StoryPage/story-page.scss
@@ -10,7 +10,7 @@
 
     > .wrapper {
       grid-column: 1 / -1;
-      padding: 0 $half-spacing;
+      padding: 0 theme('spacing.3');
 
       @include media($medium) {
         grid-column: 2 / -2;
@@ -31,7 +31,7 @@
       font-size: 97px;
       font-weight: normal;
       line-height: 1;
-      margin: $half-spacing 0;
+      margin: theme('spacing.3') 0;
 
       @include media($medium) {
         font-size: 123px;
@@ -40,13 +40,13 @@
 
     .lede-banner__headline-subtitle {
       font-size: 30px;
-      margin: $half-spacing 0;
+      margin: theme('spacing.3') 0;
     }
   }
 }
 
 .story-section {
-  padding: $half-spacing 0;
+  padding: theme('spacing.3') 0;
 
   @include media($medium) {
     padding: $base-spacing 0;

--- a/resources/assets/components/pages/StoryPage/story-page.scss
+++ b/resources/assets/components/pages/StoryPage/story-page.scss
@@ -49,6 +49,6 @@
   padding: theme('spacing.3') 0;
 
   @include media($medium) {
-    padding: $base-spacing 0;
+    padding: theme('spacing.6') 0;
   }
 }

--- a/resources/assets/components/utilities/AffiliatePromotion/affiliate-promotion.scss
+++ b/resources/assets/components/utilities/AffiliatePromotion/affiliate-promotion.scss
@@ -20,7 +20,7 @@
     font-size: $font-small;
     font-weight: $weight-bold;
     line-height: 1;
-    padding-right: $half-spacing;
+    padding-right: theme('spacing.3');
     text-transform: uppercase;
     vertical-align: middle;
     white-space: nowrap;

--- a/resources/assets/components/utilities/Button/button.scss
+++ b/resources/assets/components/utilities/Button/button.scss
@@ -29,5 +29,5 @@
 }
 
 .button__attached-container {
-  padding: $half-spacing;
+  padding: theme('spacing.3');
 }

--- a/resources/assets/components/utilities/Byline/byline.scss
+++ b/resources/assets/components/utilities/Byline/byline.scss
@@ -13,10 +13,10 @@
 }
 
 .byline--page-author {
-  padding: $half-spacing/2 0;
+  padding: theme('spacing.2') 0;
 
   @include media($medium) {
     float: left;
-    padding: 0 $base-spacing;
+    padding: 0 theme('spacing.6');
   }
 }

--- a/resources/assets/components/utilities/CampaignDashboard/campaign-dashboard.scss
+++ b/resources/assets/components/utilities/CampaignDashboard/campaign-dashboard.scss
@@ -18,8 +18,8 @@ $small-to-medium: '(min-width: 600px)';
 
   .dashboard__segment {
     text-align: center;
-    padding-top: $half-spacing;
-    padding-bottom: $half-spacing;
+    padding-top: theme('spacing.3');
+    padding-bottom: theme('spacing.3');
 
     @include media($large) {
       text-align: left;
@@ -36,8 +36,8 @@ $small-to-medium: '(min-width: 600px)';
 
   .dashboard-share {
     border-top: 1px solid theme('colors.gray.200');
-    margin-top: $half-spacing;
-    padding-top: $base-spacing;
+    margin-top: theme('spacing.3');
+    padding-top: theme('spacing.6');
     text-align: left;
 
     @include media($small-to-medium) {
@@ -65,7 +65,7 @@ $small-to-medium: '(min-width: 600px)';
   }
 
   @include media($small-to-medium) {
-    padding-right: $half-spacing;
+    padding-right: theme('spacing.3');
   }
 
   @include media($large) {
@@ -81,7 +81,7 @@ $small-to-medium: '(min-width: 600px)';
 
 .dashboard-share__button {
   flex: 1 1;
-  margin-top: $half-spacing;
+  margin-top: theme('spacing.3');
 
   @include media($small-to-medium) {
     margin-top: 0;

--- a/resources/assets/components/utilities/Card/card.scss
+++ b/resources/assets/components/utilities/Card/card.scss
@@ -8,7 +8,7 @@
 .card__title {
   color: $black;
   background-color: $primary-color;
-  padding: $half-spacing;
+  padding: theme('spacing.3');
 
   h1 {
     font-family: theme('fontFamily.source-sans');
@@ -49,7 +49,7 @@
 
   &.-floating {
     position: absolute;
-    top: $half-spacing;
-    right: $half-spacing;
+    top: theme('spacing.3');
+    right: theme('spacing.3');
   }
 }

--- a/resources/assets/components/utilities/CtaPopover/cta-popover.scss
+++ b/resources/assets/components/utilities/CtaPopover/cta-popover.scss
@@ -6,9 +6,9 @@
   box-shadow: 0px 2px 5px 0px rgba(0, 0, 0, 0.25);
 
   position: fixed;
-  bottom: $half-spacing;
+  bottom: theme('spacing.3');
   right: 0;
-  margin: 0 $half-spacing;
+  margin: 0 theme('spacing.3');
   max-width: 500px;
   z-index: $sticky-cta-zindex;
 

--- a/resources/assets/components/utilities/Embed/embed.scss
+++ b/resources/assets/components/utilities/Embed/embed.scss
@@ -29,7 +29,7 @@
 .embed__badge {
   flex: 0 0 auto;
   border-radius: 0;
-  padding: $half-spacing;
+  padding: theme('spacing.3');
 }
 
 .embed__badge img {

--- a/resources/assets/components/utilities/Figure/figure.scss
+++ b/resources/assets/components/utilities/Figure/figure.scss
@@ -51,11 +51,11 @@
 .figure.-one-third {
   @include media($tablet) {
     &.figure.-right-collapse > .figure__media {
-      margin-left: $base-spacing;
+      margin-left: theme('spacing.6');
     }
 
     &.figure.-left-collapse > .figure__media {
-      margin-right: $base-spacing;
+      margin-right: theme('spacing.6');
     }
   }
 

--- a/resources/assets/components/utilities/MediaUploader/media-uploader.scss
+++ b/resources/assets/components/utilities/MediaUploader/media-uploader.scss
@@ -3,7 +3,7 @@
 .media-uploader {
   background-color: #eee;
   color: $med-gray;
-  margin-bottom: $half-spacing;
+  margin-bottom: theme('spacing.3');
   width: 100%;
 
   &:hover,

--- a/resources/assets/components/utilities/Modal/modal.scss
+++ b/resources/assets/components/utilities/Modal/modal.scss
@@ -22,12 +22,12 @@
     height: 100%;
     justify-content: center;
     overflow-y: scroll;
-    padding: $half-spacing;
+    padding: theme('spacing.3');
     position: relative;
     width: 100%;
 
     @include media($medium) {
-      padding: $base-spacing;
+      padding: theme('spacing.6');
     }
   }
 }

--- a/resources/assets/components/utilities/PageNavigation/PageNavigation.js
+++ b/resources/assets/components/utilities/PageNavigation/PageNavigation.js
@@ -63,7 +63,7 @@ class PageNavigation extends React.Component {
       <div
         ref={node => (this.node = node)}
         id="page-navigation"
-        className={classnames('page-navigation', {
+        className={classnames('page-navigation mt-3 -mb-3', {
           'is-stuck': this.state.isStuck,
         })}
       >

--- a/resources/assets/components/utilities/PageNavigation/page-navigation.scss
+++ b/resources/assets/components/utilities/PageNavigation/page-navigation.scss
@@ -3,7 +3,6 @@
 .page-navigation {
   @include clearfix;
 
-  margin: 12px 0 (-$half-spacing);
   position: relative;
 
   @include media($tablet) {
@@ -46,7 +45,7 @@
   > .wrapper {
     overflow-x: auto;
     overflow-y: hidden;
-    padding: $half-spacing;
+    padding: theme('spacing.3');
     position: relative;
     white-space: nowrap;
     -webkit-overflow-scrolling: touch;
@@ -64,7 +63,7 @@
   .nav-link {
     color: #9b9b9b;
     display: inline-block;
-    margin: 10px $half-spacing;
+    margin: 10px theme('spacing.3');
     text-transform: uppercase;
     border-bottom: 4px solid transparent;
 
@@ -83,8 +82,8 @@
   .nav-button {
     opacity: 0;
     position: absolute;
-    right: $half-spacing;
-    top: $half-spacing;
+    right: theme('spacing.3');
+    top: theme('spacing.3');
     transform: translateY(100%);
     transition: opacity 0.1s linear, transform 0.2s linear;
   }

--- a/resources/assets/components/utilities/PostCard/post.scss
+++ b/resources/assets/components/utilities/PostCard/post.scss
@@ -37,7 +37,7 @@
 .chat-bubble.-post-bubble {
   color: $black;
   background-color: $white;
-  padding: $base-spacing theme('spacing.3');
+  padding: theme('spacing.6') theme('spacing.3');
 
   p {
     color: $black;

--- a/resources/assets/components/utilities/PostCard/post.scss
+++ b/resources/assets/components/utilities/PostCard/post.scss
@@ -25,7 +25,7 @@
 }
 
 .post-ornament-text {
-  border-left: $half-spacing solid rgba(#fff, 0.3);
+  border-left: theme('spacing.3') solid rgba(#fff, 0.3);
   background-clip: padding-box; // Allow border to "see through" background.
 }
 
@@ -37,7 +37,7 @@
 .chat-bubble.-post-bubble {
   color: $black;
   background-color: $white;
-  padding: $base-spacing $half-spacing;
+  padding: $base-spacing theme('spacing.3');
 
   p {
     color: $black;

--- a/resources/assets/components/utilities/Share/share.scss
+++ b/resources/assets/components/utilities/Share/share.scss
@@ -1,7 +1,7 @@
 @import '../../../scss/next-toolbox.scss';
 
 .share-tray {
-  margin-top: $base-spacing * 3;
+  margin-top: 72px;
   text-align: center;
 
   @media (min-width: 425px) {

--- a/resources/assets/components/utilities/Share/share.scss
+++ b/resources/assets/components/utilities/Share/share.scss
@@ -5,7 +5,7 @@
   text-align: center;
 
   @media (min-width: 425px) {
-    margin-top: $half-spacing;
+    margin-top: theme('spacing.3');
   }
 
   .-icon {
@@ -60,12 +60,12 @@
     width: auto;
     display: inline-block;
     color: theme('colors.gray.200');
-    margin-left: $half-spacing / 2;
-    margin-right: $half-spacing / 2;
+    margin-left: 6px;
+    margin-right: 6px;
 
     @include media($medium) {
-      margin-left: $half-spacing;
-      margin-right: $half-spacing;
+      margin-left: theme('spacing.3');
+      margin-right: theme('spacing.3');
     }
 
     &:hover,

--- a/resources/assets/components/utilities/TextContent/markdown.scss
+++ b/resources/assets/components/utilities/TextContent/markdown.scss
@@ -21,7 +21,7 @@
   ol + p,
   ol + ol,
   ol + ul {
-    margin-top: $half-spacing;
+    margin-top: theme('spacing.3');
   }
 
   &.is-success {
@@ -42,12 +42,12 @@
   pre,
   blockquote {
     position: relative;
-    margin: $base-spacing 0;
+    margin: theme('spacing.6') 0;
 
     p,
     ul,
     code {
-      margin-left: $base-spacing;
+      margin-left: theme('spacing.6');
     }
 
     &:before {

--- a/resources/assets/components/utilities/TextContent/text-content.scss
+++ b/resources/assets/components/utilities/TextContent/text-content.scss
@@ -26,11 +26,11 @@
   > ol + p,
   > ol + ol,
   > ol + ul {
-    margin-top: $half-spacing;
+    margin-top: theme('spacing.3');
   }
 
   > p + .component-entry {
-    margin-top: $base-spacing;
+    margin-top: theme('spacing.6');
   }
 
   > h1 {
@@ -70,7 +70,7 @@
   > blockquote {
     position: relative;
     text-align: left;
-    margin: $base-spacing 0;
+    margin: theme('spacing.6') 0;
 
     &:before {
       content: '';
@@ -84,7 +84,7 @@
 
     p {
       font-size: $font-medium;
-      margin-left: $base-spacing;
+      margin-left: theme('spacing.6');
     }
   }
 }

--- a/resources/assets/scss/admin-dashboard.scss
+++ b/resources/assets/scss/admin-dashboard.scss
@@ -11,7 +11,7 @@
   > .wrapper {
     margin: 0 auto;
     max-width: 1440px;
-    padding: $base-spacing $base-spacing $section-spacing;
+    padding: theme('spacing.6') theme('spacing.6') theme('spacing.12');
   }
 
   a {
@@ -118,7 +118,7 @@
       }
 
       li + li {
-        margin-top: $half-spacing;
+        margin-top: theme('spacing.3');
       }
     }
   }

--- a/resources/assets/scss/base.scss
+++ b/resources/assets/scss/base.scss
@@ -172,14 +172,14 @@ p {
 
   // 4 columns
   grid-template-columns: [full-start] 1fr 1fr [midway] 1fr 1fr [full-end];
-  grid-column-gap: $half-spacing;
-  padding: $half-spacing;
+  grid-column-gap: theme('spacing.3');
+  padding: theme('spacing.3');
 
   @include media($medium) {
     // 8 columns
     grid-template-columns: [full-start] 1fr [main-start] 1fr 1fr 1fr [midway] 1fr 1fr 1fr [main-end] 1fr [full-end];
-    grid-column-gap: $base-spacing;
-    padding: $base-spacing $section-spacing;
+    grid-column-gap: theme('spacing.6');
+    padding: theme('spacing.6') theme('spacing.12');
   }
 
   @include media($large) {

--- a/resources/assets/scss/container.scss
+++ b/resources/assets/scss/container.scss
@@ -7,9 +7,9 @@ $soft-box-shadow: 0px 1px 4px 1px rgba(0, 0, 0, 0.2);
 
 .container {
   &.-framed {
-    margin-top: $base-spacing;
+    margin-top: theme('spacing.6');
     overflow: hidden;
-    padding: $section-spacing 0;
+    padding: theme('spacing.12') 0;
     position: relative;
 
     > .wrapper {
@@ -18,7 +18,7 @@ $soft-box-shadow: 0px 1px 4px 1px rgba(0, 0, 0, 0.2);
 
     @include media($tablet) {
       max-width: $container-max-width;
-      margin: $section-spacing auto;
+      margin: theme('spacing.12') auto;
 
       > .wrapper {
         margin-left: 0;
@@ -41,7 +41,7 @@ $soft-box-shadow: 0px 1px 4px 1px rgba(0, 0, 0, 0.2);
       @include media($tablet) {
         float: none;
         max-width: 600px;
-        margin: $base-spacing auto;
+        margin: theme('spacing.6') auto;
 
         // @TODO: Hacky!
         .field-label {

--- a/resources/assets/scss/gallery-grid.scss
+++ b/resources/assets/scss/gallery-grid.scss
@@ -6,14 +6,14 @@
 .gallery-grid-duo {
   display: grid;
   grid-template-columns: 1fr;
-  grid-row-gap: $half-spacing;
-  padding: 0 $half-spacing;
+  grid-row-gap: theme('spacing.3');
+  padding: 0 theme('spacing.3');
   overflow: hidden;
 
   @include media('(min-width: 425px)') {
     grid-template-columns: 1fr 1fr;
-    grid-column-gap: $half-spacing;
-    grid-row-gap: $half-spacing;
+    grid-column-gap: theme('spacing.3');
+    grid-row-gap: theme('spacing.3');
   }
 }
 
@@ -28,8 +28,8 @@
 
   @include media($larger) {
     grid-template-columns: repeat(4, 1fr);
-    grid-column-gap: $base-spacing;
-    grid-row-gap: $base-spacing;
+    grid-column-gap: theme('spacing.6');
+    grid-row-gap: theme('spacing.6');
   }
 }
 
@@ -44,8 +44,8 @@
 
   @include media($larger) {
     grid-template-columns: repeat(3, 1fr);
-    grid-column-gap: $base-spacing;
-    grid-row-gap: $base-spacing;
+    grid-column-gap: theme('spacing.6');
+    grid-row-gap: theme('spacing.6');
   }
 }
 
@@ -56,8 +56,8 @@
 
   @include media($larger) {
     grid-template-columns: repeat(2, 1fr);
-    grid-column-gap: $base-spacing;
-    grid-row-gap: $base-spacing;
+    grid-column-gap: theme('spacing.6');
+    grid-row-gap: theme('spacing.6');
   }
 }
 
@@ -76,8 +76,8 @@
 
   @include media($larger) {
     grid-template-columns: repeat(6, 1fr);
-    grid-column-gap: $base-spacing;
-    grid-row-gap: $base-spacing;
+    grid-column-gap: theme('spacing.6');
+    grid-row-gap: theme('spacing.6');
   }
 }
 
@@ -92,7 +92,7 @@
 }
 
 .gallery-item__meta {
-  margin-top: $half-spacing;
+  margin-top: theme('spacing.3');
 }
 
 .gallery-item__title {

--- a/resources/assets/scss/navigation.scss
+++ b/resources/assets/scss/navigation.scss
@@ -16,12 +16,12 @@
   margin-left: 0;
 
   @include media($larger) {
-    margin-right: $base-spacing;
+    margin-right: theme('spacing.6');
   }
 
   > li + li {
     @include media($largest) {
-      margin-left: $base-spacing;
+      margin-left: theme('spacing.6');
     }
   }
 
@@ -34,7 +34,7 @@
       display: inline-block;
       font-size: $font-regular;
       margin: 0 auto;
-      padding: $half-spacing $base-spacing;
+      padding: theme('spacing.3') theme('spacing.6');
 
       @include media($large) {
         border-color: $black;

--- a/resources/assets/scss/next-toolbox.scss
+++ b/resources/assets/scss/next-toolbox.scss
@@ -19,9 +19,6 @@ $light-background-color: #f6f6f6;
 $dark-background-color: $off-black;
 $dark-background-color-transparent: rgba(34, 34, 34, 0.9);
 
-// spacing
-$half-spacing: $base-spacing / 2;
-
 // Z-Indexes used
 $tabbed-navigation-zindex: 100;
 $sticky-cta-zindex: 200;


### PR DESCRIPTION
### What's this PR do?

This pull request removes the use of the `$section-spacing`, `$base-spacing` and `$half-spacing` SCSS variables from Phoenix, replacing them with the Tailwind `theme()` function and the appropriate value from Tailwind in the stylesheet:

- `$section-spacing` === `theme('spacing.12')` 
- `$base-spacing` === `theme('spacing.6')`
- `$half-spacing` === `theme('spacing.3')`

In a couple spots (where it's not entirely easy to use the `theme()` function and negative margin values) I opt for removing the styles from the stylesheet and popping them as Tailwind classes in the component. In a handful of scenarios I remove the variable and just use the pixel value since the styles were a little wonky (the signup arrow component which I think will likely be deprecated anyhoo) or so custom (the styles in shares.scss) they'd likely be component defined styles via Emotion in the future.

### How should this be reviewed?

👀 Lots of files but all pretty simple changes!! ✨ 

### Relevant tickets

References [Pivotal #169578779](https://www.pivotaltracker.com/story/show/169578779).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.

