### PR TITLE
School Finder cleanup + documentation

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -33,6 +33,7 @@
   - [Affiliate Opt In](development/features/affiliate-opt-in.md)
   - [Affiliate Scholarship Block](development/features/affiliate-scholarship-block.md)
   - [Analytics Waypoint](development/features/analytics-waypoint.md)
+  - [School Finder](development/features/school-finder.md)
 - [Contentful](development/contentful/README.md)
   - [Migration Scripts](development/contentful/migration-scripts.md)
   - [Content Management API Scripts](development/contentful/content-management-api-scripts.md)

--- a/docs/development/features/school-finder.md
+++ b/docs/development/features/school-finder.md
@@ -1,0 +1,50 @@
+# School Finder
+
+## Overview
+
+The `SchoolFinder` component provides an interface for an authenticated user to view or their current school, updating their Northstar profile's `school_id` field upon form submit. It also displays their school's impact for an action if an `action_id` property is set.
+
+The user is prompted to select their school's state, and then is presented with an autocomplete dropdown of schools in the selected state. This list of schools is sourced from [Great Schools](https://www.greatschools.org/).
+
+## Usage Instructions
+
+A `SchoolFinder` can be displayed within a `ContentBlock` entry, by setting the following properties in the `additionalContent` JSON field:
+
+- `showSchoolFinder` - If set to `true`, display a School Finder below the `ContentBlock`
+
+- `actionId` - The action to display the user school's aggregate quantity for
+
+- `schoolFinderFormDescription` - Description displayed above the school state/name select form. This property is optional, default value is `null`.
+
+- `schoolNotAvailableHeadline` - Headline displayed when user cannot find their school via dropdown. This property is optional, default value is "No School Selected".
+
+- `schoolNotAvailableDescription` - Description displayed when user cannot find their school via dropdown. This property is optional, default value is `null`.
+
+- `schoolSelectedConfirmation` - Description displayed when user has selected a school. This property is optional, default value is `null`.
+
+### Example
+
+```
+{
+    "showSchoolFinder": true,
+    "actionId": 21,
+    "schoolFinderFormDescription": "Pick your school and whatever. Invite your classmates to join this campaign and donate their jeans to win prizes and some other stuff.",
+    "schoolNotAvailableHeadline": "No School Selected",
+    "schoolNotAvailableDescription": "No school copy goes here, please email Sahara with information about your school.",
+    "schoolSelectedConfirmation": "Your school total will be updated anytime a submission from someone in your school has been reviewed."
+}
+```
+
+## Current Limitations
+
+- A user is currently unable to edit their school once it is set.
+
+- Colleges are currently not available to be selected via School Finder, only K-12 schools are listed.
+
+## Links
+
+- Editorial instructions
+
+- Product Brief
+
+- Technical Spec

--- a/docs/development/features/school-finder.md
+++ b/docs/development/features/school-finder.md
@@ -2,9 +2,11 @@
 
 ## Overview
 
-The `SchoolFinder` component provides an interface for an authenticated user to view or select their current school, updating their Northstar profile's `school_id` field upon submit. It also displays their school's impact for the [action](https://github.com/DoSomething/rogue/blob/master/docs/endpoints/actions.md) set via the `action_id` property of the `SchoolFinder`.
+The `SchoolFinder` component provides an interface for an authenticated user to view or select their current school, updating their Northstar profile's `school_id` field upon submit.
 
-The user is prompted to select their school's state, and then is presented with an autocomplete dropdown of schools in the selected state. This list of schools is sourced from [Great Schools](https://www.greatschools.org/).
+If they don't have a school set, the user is prompted to select their school's state, and then is presented with an autocomplete dropdown of schools in the selected state. This list of schools is sourced from [Great Schools](https://www.greatschools.org/).
+
+Upon selecting a school, if the `SchoolFinder` is configured with an `actionId`, the selected school's aggregate approved quantity for the action will display next to the school information.
 
 ## Usage Instructions
 
@@ -12,9 +14,9 @@ A `SchoolFinder` can be displayed within a `ContentBlock` entry, by setting the 
 
 - `showSchoolFinder` - If set to `true`, display a `SchoolFinder` below the `ContentBlock`
 
-- `actionId` - The action to display the user school's aggregate quantity for
+- `actionId` - If set, display the selected school's aggregate quantity for given [action](https://github.com/DoSomething/rogue/blob/master/docs/endpoints/actions.md). This property is optional, if not set - school impact is not displayed.
 
-- `schoolFinderFormDescription` - Description displayed above the school state/name select form. This property is optional, default value is `null`.
+- `schoolFinderFormDescription` - Optional. Description displayed above the school state/name select form. This property is optional, default value is `null`.
 
 - `schoolNotAvailableHeadline` - Headline displayed when user cannot find their school via dropdown. This property is optional, default value is "No School Selected".
 

--- a/docs/development/features/school-finder.md
+++ b/docs/development/features/school-finder.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-The `SchoolFinder` component provides an interface for an authenticated user to view or their current school, updating their Northstar profile's `school_id` field upon form submit. It also displays their school's impact for an action if an `action_id` property is set.
+The `SchoolFinder` component provides an interface for an authenticated user to view or select their current school, updating their Northstar profile's `school_id` field upon submit. It also displays their school's impact for the [action](https://github.com/DoSomething/rogue/blob/master/docs/endpoints/actions.md) set via the `action_id` property of the `SchoolFinder`.
 
 The user is prompted to select their school's state, and then is presented with an autocomplete dropdown of schools in the selected state. This list of schools is sourced from [Great Schools](https://www.greatschools.org/).
 
@@ -10,7 +10,7 @@ The user is prompted to select their school's state, and then is presented with 
 
 A `SchoolFinder` can be displayed within a `ContentBlock` entry, by setting the following properties in the `additionalContent` JSON field:
 
-- `showSchoolFinder` - If set to `true`, display a School Finder below the `ContentBlock`
+- `showSchoolFinder` - If set to `true`, display a `SchoolFinder` below the `ContentBlock`
 
 - `actionId` - The action to display the user school's aggregate quantity for
 

--- a/docs/development/features/school-finder.md
+++ b/docs/development/features/school-finder.md
@@ -43,8 +43,6 @@ A `SchoolFinder` can be displayed within a `ContentBlock` entry, by setting the 
 
 ## Links
 
-- Editorial instructions
+- [Editorial instructions](https://docs.google.com/document/d/1_sYkIseRBCUm3TmMvyB7iMAbMj4IOOTOz961rdl_2XY/edit#)
 
-- Product Brief
-
-- Technical Spec
+- [Technical Spec](https://docs.google.com/document/d/1c11vXT-nu5TGR4B8LyPPApQDYiTUcjgRMKaSP9nQ20M/edit?usp=sharing)

--- a/docs/development/features/school-finder.md
+++ b/docs/development/features/school-finder.md
@@ -37,9 +37,13 @@ A `SchoolFinder` can be displayed within a `ContentBlock` entry, by setting the 
 
 ## Current Limitations
 
+- Colleges are currently not available to be selected via School Finder, only K-12 schools are listed.
+
+  - Colleges are not included in our Great Schools data set. We may want to add colleges to our Schools database, and store our own internal ID for schools instead of the Great Schools`universal-id` we're currently saving to a user `school_id`.
+
 - A user is currently unable to edit their school once it is set.
 
-- Colleges are currently not available to be selected via School Finder, only K-12 schools are listed.
+  - This is mainly to avoid the complexity around whether we'd need to update any posts the user has submitted in association with their previous `school_id` value.
 
 ## Links
 

--- a/docs/development/features/school-finder.md
+++ b/docs/development/features/school-finder.md
@@ -22,6 +22,8 @@ A `SchoolFinder` can be displayed within a `ContentBlock` entry, by setting the 
 
 - `schoolSelectedConfirmation` - Description displayed when user has selected a school. This property is optional, default value is `null`.
 
+**Note** - This would be better implemented as a separate content type with fields instead hijacking the `additionalContent` JSON field of our `ContentBlock` content type. We may refactor if the feature will be used by multiple campaigns (was built for Teens For Jeans 2019).
+
 ### Example
 
 ```

--- a/resources/assets/components/blocks/ContentBlock/ContentBlock.js
+++ b/resources/assets/components/blocks/ContentBlock/ContentBlock.js
@@ -72,6 +72,9 @@ const ContentBlock = props => {
             schoolNotAvailableHeadline={
               additionalContent.schoolNotAvailableHeadline
             }
+            schoolSelectedConfirmation={
+              additionalContent.schoolSelectedConfirmation
+            }
           />
         </div>
       ) : null}

--- a/resources/assets/components/utilities/SchoolFinder/SchoolFinder.js
+++ b/resources/assets/components/utilities/SchoolFinder/SchoolFinder.js
@@ -70,7 +70,7 @@ const SchoolFinder = ({
 );
 
 SchoolFinder.propTypes = {
-  actionId: PropTypes.number,
+  actionId: PropTypes.number.isRequired,
   userId: PropTypes.string.isRequired,
   schoolFinderFormDescription: PropTypes.string,
   schoolNotAvailableHeadline: PropTypes.string,
@@ -79,7 +79,6 @@ SchoolFinder.propTypes = {
 };
 
 SchoolFinder.defaultProps = {
-  actionId: null,
   schoolFinderFormDescription: null,
   schoolNotAvailableHeadline: 'No School Selected',
   schoolNotAvailableDescription: null,

--- a/resources/assets/components/utilities/SchoolFinder/SchoolFinder.js
+++ b/resources/assets/components/utilities/SchoolFinder/SchoolFinder.js
@@ -70,7 +70,7 @@ const SchoolFinder = ({
 );
 
 SchoolFinder.propTypes = {
-  actionId: PropTypes.number.isRequired,
+  actionId: PropTypes.number,
   userId: PropTypes.string.isRequired,
   schoolFinderFormDescription: PropTypes.string,
   schoolNotAvailableHeadline: PropTypes.string,
@@ -79,6 +79,7 @@ SchoolFinder.propTypes = {
 };
 
 SchoolFinder.defaultProps = {
+  actionId: null,
   schoolFinderFormDescription: null,
   schoolNotAvailableHeadline: 'No School Selected',
   schoolNotAvailableDescription: null,

--- a/resources/assets/components/utilities/SchoolFinder/SchoolFinder.js
+++ b/resources/assets/components/utilities/SchoolFinder/SchoolFinder.js
@@ -27,6 +27,7 @@ const SchoolFinder = ({
   schoolFinderFormDescription,
   schoolNotAvailableDescription,
   schoolNotAvailableHeadline,
+  schoolSelectedConfirmation,
   userId,
 }) => (
   <div className="school-finder">
@@ -41,6 +42,9 @@ const SchoolFinder = ({
           >
             {schoolId ? (
               <div className="current-school p-3">
+                {schoolSelectedConfirmation ? (
+                  <p className="pb-3">{schoolSelectedConfirmation}</p>
+                ) : null}
                 <div className="border border-solid border-gray-200 rounded p-3">
                   {school.name ? (
                     <SchoolImpact school={school} actionId={actionId} />
@@ -71,6 +75,7 @@ SchoolFinder.propTypes = {
   schoolFinderFormDescription: PropTypes.string,
   schoolNotAvailableHeadline: PropTypes.string,
   schoolNotAvailableDescription: PropTypes.string,
+  schoolSelectedConfirmation: PropTypes.string,
 };
 
 SchoolFinder.defaultProps = {
@@ -78,6 +83,7 @@ SchoolFinder.defaultProps = {
   schoolFinderFormDescription: null,
   schoolNotAvailableHeadline: 'No School Selected',
   schoolNotAvailableDescription: null,
+  schoolSelectedConfirmation: null,
 };
 
 export default SchoolFinder;

--- a/resources/assets/components/utilities/SchoolFinder/SchoolImpact.js
+++ b/resources/assets/components/utilities/SchoolFinder/SchoolImpact.js
@@ -18,49 +18,61 @@ const SCHOOL_ACTION_QUERY = gql`
   }
 `;
 
-const SchoolImpact = ({ actionId, school }) => (
-  <div className="md:flex">
-    <div className="md:flex-auto mb-3 pb-3 md:pt-3 border-b border-solid border-gray-200 md:border-none">
-      <p className="school-name font-bold">{school.name}</p>
-      <span className="uppercase text-sm text-gray-400 font-bold">
-        {school.city}, {school.state}
-      </span>
-    </div>
-    <div className="quantity md:border-l md:pl-3 border-solid border-gray-200">
-      <Query
-        query={SCHOOL_ACTION_QUERY}
-        variables={{ actionId, schoolId: school.id }}
-      >
-        {result => {
-          const { noun, schoolActionStats, verb } = result.action;
-          const quantity = schoolActionStats.length
-            ? schoolActionStats[0].acceptedQuantity
-            : 0;
+const SchoolImpact = ({ actionId, school }) => {
+  const schoolClassName = actionId
+    ? 'mb-3 pb-3  md:pt-3 border-b border-solid border-gray-200 md:border-none'
+    : '';
 
-          return (
-            <React.Fragment>
-              <span className="quantity-value block font-league-gothic text-4xl leading-none">
-                {quantity}
-              </span>
-              <span className="quantity-label uppercase text-gray-400 font-bold">
-                {noun} {verb}
-              </span>
-            </React.Fragment>
-          );
-        }}
-      </Query>
+  return (
+    <div className="md:flex">
+      <div className={`md:flex-auto ${schoolClassName}`}>
+        <p className="school-name font-bold">{school.name}</p>
+        <span className="uppercase text-sm text-gray-400 font-bold">
+          {school.city}, {school.state}
+        </span>
+      </div>
+      {actionId ? (
+        <div className="quantity md:border-l md:pl-3 border-solid border-gray-200">
+          <Query
+            query={SCHOOL_ACTION_QUERY}
+            variables={{ actionId, schoolId: school.id }}
+          >
+            {result => {
+              const { noun, schoolActionStats, verb } = result.action;
+              const quantity = schoolActionStats.length
+                ? schoolActionStats[0].acceptedQuantity
+                : 0;
+
+              return (
+                <React.Fragment>
+                  <span className="quantity-value block font-league-gothic text-4xl leading-none">
+                    {quantity}
+                  </span>
+                  <span className="quantity-label uppercase text-gray-400 font-bold">
+                    {noun} {verb}
+                  </span>
+                </React.Fragment>
+              );
+            }}
+          </Query>
+        </div>
+      ) : null}
     </div>
-  </div>
-);
+  );
+};
 
 SchoolImpact.propTypes = {
-  actionId: PropTypes.number.isRequired,
+  actionId: PropTypes.number,
   school: PropTypes.shape({
     id: PropTypes.string,
     name: PropTypes.string,
     city: PropTypes.string,
     state: PropTypes.string,
   }).isRequired,
+};
+
+SchoolImpact.defaultProps = {
+  actionId: null,
 };
 
 export default SchoolImpact;


### PR DESCRIPTION
### What's this PR do?

This pull request adds documentation for the School Finder feature and makes the following tweaks:

* Makes the `actionId` prop optional, so that we only display School Impact when it exists (refs [Slack thread](https://dosomething.slack.com/archives/CP2D7UGAU/p1576170077377400?thread_ts=1576169841.377300&cid=CP2D7UGAU))

* Adds a `schoolSelectedConfirmation` optional prop to display text above the selected school per designs (refs [Slack thread](https://dosomething.slack.com/archives/C3ASB4204/p1576094682144200?thread_ts=1576094540.144100&cid=C3ASB4204))

### How should this be reviewed?

👀 

With Action ID:

<img width="242" alt="Screen Shot 2019-12-12 at 9 50 01 AM" src="https://user-images.githubusercontent.com/1236811/70736287-e044e280-1cc4-11ea-938c-f9fe124df38a.png">

Without Action ID:

<img width="245" alt="Screen Shot 2019-12-12 at 9 50 18 AM" src="https://user-images.githubusercontent.com/1236811/70736280-dcb15b80-1cc4-11ea-814b-812b6c2f0d59.png">


### Any background context you want to provide?

Will add Cypress tests in a following PR, it will require exporting a ContentBlock without an ActionID into fixtures - and looking to get this to prod sooner than later.

### Relevant tickets

References [Pivotal #169659230](https://www.pivotaltracker.com/n/projects/2401401/stories/169659230).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [x] Documentation added for new features/changed endpoints.
- [ ] Added screenshots of front-end changes on small, medium, and large screens.
- [ ] Added appropriate feature/unit tests.
