### PR TITLE
Allow SixpackExperiment to be queried via GraphQL.

### DIFF
--- a/app/Entities/SixpackExperiment.php
+++ b/app/Entities/SixpackExperiment.php
@@ -31,7 +31,7 @@ class SixpackExperiment extends Entity implements JsonSerializable
                 'control' => $this->control ? $this->parseBlock($this->control) : null,
                 'convertableActions' => $this->convertableActions,
                 'kpi' => $this->kpi,
-                'title' => $this->internalTitle,
+                'internalTitle' => $this->internalTitle,
                 'trafficFraction' => $this->parseTrafficFraction($this->trafficFraction),
             ],
         ];

--- a/resources/assets/components/ContentfulEntry/ContentfulEntry.js
+++ b/resources/assets/components/ContentfulEntry/ContentfulEntry.js
@@ -320,6 +320,9 @@ class ContentfulEntry extends React.Component {
       case 'ShareBlock':
         return <ShareActionContainer id={json.id} {...withoutNulls(json)} />;
 
+      case 'SixpackExperimentBlock':
+        return <SixpackExperiment id={json.id} {...withoutNulls(json)} />;
+
       case 'sixpackExperiment':
         return (
           <SixpackExperiment id={json.id} {...withoutNulls(json.fields)} />

--- a/resources/assets/components/utilities/ContentfulEntryLoader/ContentfulEntryLoader.js
+++ b/resources/assets/components/utilities/ContentfulEntryLoader/ContentfulEntryLoader.js
@@ -20,6 +20,7 @@ import { CallToActionBlockFragment } from '../../CallToAction/CallToAction';
 import { GalleryBlockFragment } from '../../blocks/GalleryBlock/GalleryBlock';
 import { ContentBlockFragment } from '../../blocks/ContentBlock/ContentBlock';
 import { CampaignDashboardFragment } from '../CampaignDashboard/CampaignDashboard';
+import { SixpackExperimentBlockFragment } from '../SixpackExperiment/SixpackExperiment';
 import { CampaignUpdateBlockFragment } from '../../blocks/CampaignUpdate/CampaignUpdate';
 import { SocialDriveBlockFragment } from '../../actions/SocialDriveAction/SocialDriveAction';
 import { PostGalleryBlockFragment } from '../../blocks/PostGalleryBlock/PostGalleryBlockQuery';
@@ -48,6 +49,7 @@ const CONTENTFUL_BLOCK_QUERY = gql`
       ...CampaignUpdateBlockFragment
       ...TextSubmissionBlockFragment
       ...PhotoSubmissionBlockFragment
+      ...SixpackExperimentBlockFragment
       ...VoterRegistrationBlockFragment
       ...PetitionSubmissionBlockFragment
       ...SelectionSubmissionBlockFragment
@@ -69,6 +71,7 @@ const CONTENTFUL_BLOCK_QUERY = gql`
   ${CampaignUpdateBlockFragment}
   ${TextSubmissionBlockFragment}
   ${PhotoSubmissionBlockFragment}
+  ${SixpackExperimentBlockFragment}
   ${VoterRegistrationBlockFragment}
   ${PetitionSubmissionBlockFragment}
   ${SelectionSubmissionBlockFragment}

--- a/resources/assets/components/utilities/SixpackExperiment/SixpackExperiment.js
+++ b/resources/assets/components/utilities/SixpackExperiment/SixpackExperiment.js
@@ -99,7 +99,12 @@ class SixpackExperiment extends React.Component {
     if (React.isValidElement(alternative)) {
       testAlternativeName = get(alternative.props, 'testName', null);
     } else {
-      testAlternativeName = alternative.internalTitle;
+      // The PHP Content API doesn't reliably return `internalTitle` for blocks.
+      // @TODO: We can remove this check after #169216496.
+      testAlternativeName =
+        alternative.internalTitle ||
+        get(alternative, 'fields.internalTitle') ||
+        get(alternative, 'fields.title');
     }
 
     return testAlternativeName;

--- a/resources/assets/components/utilities/SixpackExperiment/SixpackExperiment.js
+++ b/resources/assets/components/utilities/SixpackExperiment/SixpackExperiment.js
@@ -19,6 +19,8 @@ export const SixpackExperimentBlockFragment = gql`
       id
       internalTitle
     }
+    trafficFraction
+    kpi
   }
 `;
 

--- a/resources/assets/components/utilities/SixpackExperiment/SixpackExperiment.js
+++ b/resources/assets/components/utilities/SixpackExperiment/SixpackExperiment.js
@@ -1,11 +1,26 @@
 import React from 'react';
+import gql from 'graphql-tag';
 import PropTypes from 'prop-types';
 import { get, snakeCase } from 'lodash';
 
-import { sixpack } from '../../../helpers';
-import ContentfulEntry from '../../ContentfulEntry';
-import Placeholder from '../Placeholder';
 import Empty from '../Empty';
+import Placeholder from '../Placeholder';
+import { sixpack } from '../../../helpers';
+import ContentfulEntryLoader from '../ContentfulEntryLoader/ContentfulEntryLoader';
+
+export const SixpackExperimentBlockFragment = gql`
+  fragment SixpackExperimentBlockFragment on SixpackExperimentBlock {
+    internalTitle
+    convertableActions
+    control {
+      id
+    }
+    alternatives {
+      id
+      internalTitle
+    }
+  }
+`;
 
 class SixpackExperiment extends React.Component {
   constructor(props) {
@@ -82,12 +97,7 @@ class SixpackExperiment extends React.Component {
     if (React.isValidElement(alternative)) {
       testAlternativeName = get(alternative.props, 'testName', null);
     } else {
-      // @TODO: probably want to use internalTitle but not all entities expose that.
-      // Defaults to title field, but we should aim to start exposing internalTitle on entities!
-      testAlternativeName =
-        get(alternative, 'fields.internalTitle') ||
-        get(alternative, 'fields.title') ||
-        null;
+      testAlternativeName = alternative.internalTitle;
     }
 
     return testAlternativeName;
@@ -103,7 +113,7 @@ class SixpackExperiment extends React.Component {
     return React.isValidElement(selectedAlternative) ? (
       selectedAlternative
     ) : (
-      <ContentfulEntry json={selectedAlternative} />
+      <ContentfulEntryLoader id={selectedAlternative.id} />
     );
   }
 }

--- a/resources/assets/components/utilities/SixpackExperiment/SixpackExperiment.js
+++ b/resources/assets/components/utilities/SixpackExperiment/SixpackExperiment.js
@@ -15,7 +15,7 @@ class SixpackExperiment extends React.Component {
       selectedAlternative: null,
     };
 
-    this.experimentName = snakeCase(this.props.title);
+    this.experimentName = snakeCase(this.props.internalTitle);
   }
 
   componentDidMount() {
@@ -113,7 +113,7 @@ SixpackExperiment.propTypes = {
   control: PropTypes.object,
   convertableActions: PropTypes.arrayOf(PropTypes.string).isRequired,
   kpi: PropTypes.string,
-  title: PropTypes.string.isRequired,
+  internalTitle: PropTypes.string.isRequired,
   trafficFraction: PropTypes.number,
 };
 


### PR DESCRIPTION
### What's this PR do?

This pull request adds support for loading `SixpackExperiment` blocks via GraphQL.

### How should this be reviewed?

You can see [an example experiment](https://app.contentful.com/spaces/81iqaqpfd8fy/environments/dev/entries/59YXzX3L9tokeszMrzP1sC) in action at [`/us/blocks/59YXzX3L9tokeszMrzP1sC`](http://phoenix.test/us/blocks/59YXzX3L9tokeszMrzP1sC) (review app link pending). It'll randomly assign you to a campaign dashboard or empty "control" (once per session, so I'd check it in incognito if you want to get assigned a different alternative).

I'd recommend reviewing the code for this commit-by-commit for context! This also relies on DoSomething/graphql#183 so it might be worth peeking at that.

### Any background context you want to provide?

This is the second to last thing we need to make queryable via GraphQL before we can flip the switch! We're in the home stretch! ⚾️

### Relevant tickets

References [Pivotal #170053882](https://www.pivotaltracker.com/story/show/170053882).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added screenshots of front-end changes on small, medium, and large screens.
- [ ] Added appropriate feature/unit tests.
