### PR TITLE
Dashboard Position Updates

### DIFF
--- a/resources/assets/components/LedeBanner/LedeBannerContainer.js
+++ b/resources/assets/components/LedeBanner/LedeBannerContainer.js
@@ -29,6 +29,7 @@ const mapStateToProps = (state, props) => ({
   campaignId: state.campaign.campaignId,
   coverImage: get(props, 'coverImage', state.campaign.coverImage),
   content: get(state, 'campaign.landingPage.fields.content'),
+  dashboard: state.campaign.dashboard,
   endDate: state.campaign.endDate,
   featureFlagUseLegacyTemplate: get(
     state,

--- a/resources/assets/components/pages/CampaignPage/CampaignPage.js
+++ b/resources/assets/components/pages/CampaignPage/CampaignPage.js
@@ -17,7 +17,7 @@ import './campaign-page.scss';
  * @returns {XML}
  */
 const CampaignPage = props => {
-  const { dashboard, entryContent, isCampaignClosed } = props;
+  const { entryContent, isCampaignClosed } = props;
 
   return (
     <React.Fragment>
@@ -27,8 +27,6 @@ const CampaignPage = props => {
       />
 
       <div className="main clearfix">
-        {dashboard ? <ContentfulEntry json={dashboard} /> : null}
-
         {!isCampaignClosed && !entryContent ? (
           <CampaignPageNavigationContainer />
         ) : null}
@@ -52,11 +50,6 @@ const CampaignPage = props => {
 };
 
 CampaignPage.propTypes = {
-  dashboard: PropTypes.shape({
-    id: PropTypes.string,
-    type: PropTypes.string,
-    fields: PropTypes.object,
-  }),
   entryContent: PropTypes.object,
   isCampaignClosed: PropTypes.bool,
   landingPage: PropTypes.shape({
@@ -68,7 +61,6 @@ CampaignPage.propTypes = {
 };
 
 CampaignPage.defaultProps = {
-  dashboard: null,
   entryContent: null,
   isCampaignClosed: false,
   landingPage: null,

--- a/resources/assets/components/pages/CampaignPage/CampaignPageContainer.js
+++ b/resources/assets/components/pages/CampaignPage/CampaignPageContainer.js
@@ -23,7 +23,6 @@ const mapStateToProps = (state, ownProps) => {
 
   return {
     campaignEndDate: state.campaign.endDate,
-    dashboard: state.campaign.dashboard,
     entryContent,
     isCampaignClosed: isCampaignClosed(state.campaign.endDate),
     landingPage: get(state.campaign, 'landingPage', null),

--- a/resources/assets/components/pages/LandingPage/LandingPage.js
+++ b/resources/assets/components/pages/LandingPage/LandingPage.js
@@ -17,6 +17,7 @@ const LandingPage = props => {
     campaignId,
     content,
     coverImage,
+    dashboard,
     endDate,
     featureFlagUseLegacyTemplate,
     scholarshipAmount,
@@ -58,6 +59,7 @@ const LandingPage = props => {
           content={content}
           coverImage={coverImage}
           campaignId={campaignId}
+          dashboard={dashboard}
           endDate={endDate}
           scholarshipAmount={scholarshipAmount}
           scholarshipCallToAction={scholarshipCallToAction}
@@ -79,6 +81,7 @@ LandingPage.propTypes = {
   campaignId: PropTypes.string.isRequired,
   content: PropTypes.string.isRequired,
   coverImage: PropTypes.object.isRequired,
+  dashboard: PropTypes.object,
   endDate: PropTypes.string,
   featureFlagUseLegacyTemplate: PropTypes.bool,
   scholarshipAmount: PropTypes.number,
@@ -98,6 +101,7 @@ LandingPage.defaultProps = {
   affiliateCreditText: undefined,
   affiliateSponsors: [],
   affiliateOptInContent: null,
+  dashboard: null,
   endDate: null,
   featureFlagUseLegacyTemplate: false,
   scholarshipAmount: null,

--- a/resources/assets/components/pages/LandingPage/LandingPage.js
+++ b/resources/assets/components/pages/LandingPage/LandingPage.js
@@ -81,7 +81,11 @@ LandingPage.propTypes = {
   campaignId: PropTypes.string.isRequired,
   content: PropTypes.string.isRequired,
   coverImage: PropTypes.object.isRequired,
-  dashboard: PropTypes.object,
+  dashboard: PropTypes.shape({
+    id: PropTypes.string,
+    type: PropTypes.string,
+    fields: PropTypes.object,
+  }),
   endDate: PropTypes.string,
   featureFlagUseLegacyTemplate: PropTypes.bool,
   scholarshipAmount: PropTypes.number,

--- a/resources/assets/components/pages/LandingPage/LandingPageContainer.js
+++ b/resources/assets/components/pages/LandingPage/LandingPageContainer.js
@@ -25,6 +25,7 @@ const mapStateToProps = (state, ownProps) => {
     contentfulId: state.campaign.id,
     content: landingPage.content,
     coverImage: state.campaign.coverImage,
+    dashboard: state.campaign.dashboard,
     endDate: state.campaign.endDate,
     featureFlagUseLegacyTemplate: get(
       state,

--- a/resources/assets/components/pages/LandingPage/templates/MarqueeTemplate.js
+++ b/resources/assets/components/pages/LandingPage/templates/MarqueeTemplate.js
@@ -159,7 +159,11 @@ MarqueeTemplate.propTypes = {
   campaignId: PropTypes.string,
   content: PropTypes.string.isRequired,
   coverImage: PropTypes.object.isRequired,
-  dashboard: PropTypes.object,
+  dashboard: PropTypes.shape({
+    id: PropTypes.string,
+    type: PropTypes.string,
+    fields: PropTypes.object,
+  }),
   displaySignupButton: PropTypes.bool,
   isAffiliated: PropTypes.bool,
   isClosed: PropTypes.bool,

--- a/resources/assets/components/pages/LandingPage/templates/MarqueeTemplate.js
+++ b/resources/assets/components/pages/LandingPage/templates/MarqueeTemplate.js
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 
 import Enclosure from '../../../Enclosure';
 import Modal from '../../../utilities/Modal/Modal';
+import ContentfulEntry from '../../../ContentfulEntry';
 import TextContent from '../../../utilities/TextContent/TextContent';
 import { SCHOLARSHIP_SIGNUP_BUTTON_TEXT } from '../../../../constants';
 import SignupButtonContainer from '../../../SignupButton/SignupButtonContainer';
@@ -26,6 +27,7 @@ const MarqueeTemplate = ({
   campaignId,
   content,
   coverImage,
+  dashboard,
   displaySignupButton,
   isClosed,
   isAffiliated,
@@ -54,6 +56,7 @@ const MarqueeTemplate = ({
     medium: contentfulImageUrl(coverImage.url, '720', '350', 'fill'),
     small: contentfulImageUrl(coverImage.url, '360', '200', 'fill'),
   };
+  console.log('the dashboard', dashboard);
   return (
     <React.Fragment>
       <article className="marquee-landing-page">
@@ -142,6 +145,7 @@ const MarqueeTemplate = ({
           </Modal>
         ) : null}
       </article>
+      {dashboard ? <ContentfulEntry json={dashboard} /> : null}
       {!isAffiliated && !isClosed ? <CampaignInfoBarContainer /> : null}
     </React.Fragment>
   );
@@ -155,6 +159,7 @@ MarqueeTemplate.propTypes = {
   campaignId: PropTypes.string,
   content: PropTypes.string.isRequired,
   coverImage: PropTypes.object.isRequired,
+  dashboard: PropTypes.object,
   displaySignupButton: PropTypes.bool,
   isAffiliated: PropTypes.bool,
   isClosed: PropTypes.bool,
@@ -172,6 +177,7 @@ MarqueeTemplate.defaultProps = {
   affiliateSponsors: [],
   affiliateOptInContent: null,
   campaignId: null,
+  dashboard: null,
   displaySignupButton: true,
   isAffiliated: false,
   isClosed: false,

--- a/resources/assets/components/pages/LandingPage/templates/MarqueeTemplate.js
+++ b/resources/assets/components/pages/LandingPage/templates/MarqueeTemplate.js
@@ -56,7 +56,6 @@ const MarqueeTemplate = ({
     medium: contentfulImageUrl(coverImage.url, '720', '350', 'fill'),
     small: contentfulImageUrl(coverImage.url, '360', '200', 'fill'),
   };
-  console.log('the dashboard', dashboard);
   return (
     <React.Fragment>
       <article className="marquee-landing-page">


### PR DESCRIPTION
### What's this PR do?

This pull request adds the stats dashboard to the hero template pre sign-up. Per request from the campaigns team. A follow up PR will be coming with styling updates per some mocks from Luke.

### How should this be reviewed?

Let me know if it makes more sense from a technical perspective to leave it on the `CampaignPage` and only add it to the `LandingPageContainer` rather than adding it to the `LedeBannerContainer` and removing it altogether from the `CampaignPage`. I felt like it would be more consistent to follow the patterns of other props for the Hero Template, but if not I'm fine with changin.

### Any background context you want to provide?

https://dosomething.slack.com/archives/C09ANFQLA/p1576248746004000

### Relevant tickets

References [Pivotal #170286020](https://www.pivotaltracker.com/story/show/170286020).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added screenshots of front-end changes on small, medium, and large screens.
- [ ] Added appropriate feature/unit tests.
