### PR TITLE
Add Collection Page Cypress Test

### DIFF
--- a/cypress/fixtures/graphql.js
+++ b/cypress/fixtures/graphql.js
@@ -55,6 +55,7 @@ export const mocks = {
   // Custom scalars:
   AbsoluteUrl: () => 'https://www.example.com/',
   DateTime: () => new Date().toISOString(),
+  JSON: () => ({}),
 
   // Types:
   User: () => ({

--- a/cypress/integration/collection-page.js
+++ b/cypress/integration/collection-page.js
@@ -1,0 +1,33 @@
+/// <reference types="Cypress" />
+import { GraphQLError } from 'graphql';
+
+describe('Collection Page', () => {
+  // Configure a new "mock" server before each test:
+  beforeEach(() => cy.configureMocks());
+
+  it('Visit a non existent collection page', () => {
+    cy.mockGraphqlOp('CollectionPageQuery', {
+      collectionPageBySlug: null,
+    });
+
+    cy.visit('/us/collections/not-found');
+
+    cy.contains('Not Found');
+  });
+
+  it('Visit a collection page with a triggered GraphQL error', () => {
+    cy.mockGraphqlOp('CollectionPageQuery', {
+      collectionPageBySlug: new GraphQLError('Oops!... I Did It Again'),
+    });
+
+    cy.visit('/us/collections/error');
+
+    cy.contains('Something went wrong');
+  });
+
+  it('Visit a working collection page', () => {
+    cy.visit('/us/collections/collection');
+
+    cy.contains('h1', 'Hello World');
+  });
+});

--- a/cypress/support/index.js
+++ b/cypress/support/index.js
@@ -17,6 +17,7 @@ Cypress.on('window:before:load', window => {
     VOTER_REG_MODAL_ENABLED: false,
     SIXPACK_ENABLED: false,
     SIXPACK_BASE_URL: 'http://sixpack.test', // Our Sixpack service will throw an error if this isn't set.
+    CONTENTFUL_USE_PREVIEW_API: false,
   };
 
   // Remove built-in 'fetch' support since it cannot yet be mocked by Cypress.

--- a/resources/assets/components/blocks/AffiliateScholarshipBlock/AffiliateScholarshipBlockQuery.js
+++ b/resources/assets/components/blocks/AffiliateScholarshipBlock/AffiliateScholarshipBlockQuery.js
@@ -30,7 +30,7 @@ const AffiliateScholarshipBlockQuery = props => (
     query={AFFILIATE_QUERY}
     variables={{
       utmLabel: props.utmLabel,
-      preview: env('CONTENTFUL_USE_PREVIEW_API'),
+      preview: env('CONTENTFUL_USE_PREVIEW_API', false),
     }}
   >
     {res => {

--- a/resources/assets/components/blocks/ScholarshipInfoBlock/ScholarshipInfoBlockQuery.js
+++ b/resources/assets/components/blocks/ScholarshipInfoBlock/ScholarshipInfoBlockQuery.js
@@ -35,7 +35,7 @@ const ScholarshipInfoBlockQuery = props => (
     query={SCHOLARSHIP_AFFILIATE_QUERY}
     variables={{
       utmLabel: props.utmLabel,
-      preview: env('CONTENTFUL_USE_PREVIEW_API'),
+      preview: env('CONTENTFUL_USE_PREVIEW_API', false),
       campaignId: props.campaignId,
     }}
   >

--- a/resources/assets/components/pages/PageQuery.js
+++ b/resources/assets/components/pages/PageQuery.js
@@ -9,7 +9,10 @@ import Placeholder from '../utilities/Placeholder';
 
 const PageQuery = ({ query, variables, children }) => {
   const { loading, error, data } = useQuery(query, {
-    variables: { ...variables, preview: env('CONTENTFUL_USE_PREVIEW_API') },
+    variables: {
+      ...variables,
+      preview: env('CONTENTFUL_USE_PREVIEW_API', false),
+    },
   });
 
   if (loading) {

--- a/resources/assets/components/utilities/ContentfulAsset/ContentfulAsset.js
+++ b/resources/assets/components/utilities/ContentfulAsset/ContentfulAsset.js
@@ -30,7 +30,7 @@ const ContentfulAsset = ({ id, width, height }) => (
       id,
       width,
       height,
-      preview: env('CONTENTFUL_USE_PREVIEW_API'),
+      preview: env('CONTENTFUL_USE_PREVIEW_API', false),
     }}
   >
     {({ loading, error, data }) => {

--- a/resources/assets/components/utilities/ContentfulEntryLoader/ContentfulEntryLoader.js
+++ b/resources/assets/components/utilities/ContentfulEntryLoader/ContentfulEntryLoader.js
@@ -84,7 +84,7 @@ const ContentfulEntryLoader = ({
   classNameByEntryDefault,
 }) => {
   const { loading, error, data } = useQuery(CONTENTFUL_BLOCK_QUERY, {
-    variables: { id, preview: env('CONTENTFUL_USE_PREVIEW_API') },
+    variables: { id, preview: env('CONTENTFUL_USE_PREVIEW_API', false) },
   });
 
   if (loading) {

--- a/resources/assets/components/utilities/TextContent/TextContent.js
+++ b/resources/assets/components/utilities/TextContent/TextContent.js
@@ -1,7 +1,7 @@
 import React from 'react';
-import { has } from 'lodash';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
+import { has, isString, isArray } from 'lodash';
 
 import RichTextDocument from './RichTextDocument';
 import StandardMarkdown from './StandardMarkdown';
@@ -23,21 +23,30 @@ const TextContent = ({
   classNameByEntry,
   classNameByEntryDefault,
   styles,
-}) =>
-  has(children, 'nodeType') ? (
-    <RichTextDocument
-      className={classnames('text-content', className)}
-      classNameByEntry={classNameByEntry}
-      classNameByEntryDefault={classNameByEntryDefault}
-      styles={styles}
-    >
-      {children}
-    </RichTextDocument>
-  ) : (
-    <StandardMarkdown className={classnames('text-content', className)}>
-      {children}
-    </StandardMarkdown>
-  );
+}) => {
+  if (has(children, 'nodeType')) {
+    return (
+      <RichTextDocument
+        className={classnames('text-content', className)}
+        classNameByEntry={classNameByEntry}
+        classNameByEntryDefault={classNameByEntryDefault}
+        styles={styles}
+      >
+        {children}
+      </RichTextDocument>
+    );
+  }
+
+  if (isString(children) || isArray(children)) {
+    return (
+      <StandardMarkdown className={classnames('text-content', className)}>
+        {children}
+      </StandardMarkdown>
+    );
+  }
+
+  return null;
+};
 
 TextContent.propTypes = {
   children: PropTypes.oneOfType([

--- a/resources/assets/helpers/index.js
+++ b/resources/assets/helpers/index.js
@@ -520,8 +520,8 @@ export function findById(array, compareId) {
  * @param  {String} key
  * @return {String}
  */
-export function env(key) {
-  return (window.ENV || {})[key];
+export function env(key, defaultVal) {
+  return get(window.ENV, key, defaultVal);
 }
 
 /**


### PR DESCRIPTION
### What's this PR do?

This pull request adds a super basic Cypress test for Collection Pages, which serves more broadly to ensure that our `PageQuery` functionality (querying pages directly from GraphQL) is working properly.

### How should this be reviewed?
This ended up being slightly involved due to some configuration issues and some other unexpected issues, so please see below for more context and to ensure I've made the correct decisions here!

### Any background context you want to provide?
**_Apologies, this is a thesis level essay.... I wanted to give context, but ended up giving a WHOLE LOTTA context. Bless your heart if you actually make it through this. And hopefully this commit by commit walkthrough ends up being helpful! There was just a lot that came up!_**
- https://github.com/DoSomething/phoenix-next/pull/1826/commits/279cc89a2dbbf7d36228cef64d58715c56246e02 The first issue was that our Cypress tests run on their own dedicated ENV variable sandbox, so we needed to config the `CONTENTFUL_USE_PREVIEW_API` for it specifically. 
- ...though, the above really shouldn't have been an issue since this param defaults to `false`. The problem was that if this variable wasn't set, we'd be manually setting the param to `undefined` which is not a Boolean. https://github.com/DoSomething/phoenix-next/pull/1826/commits/9db1898acd4d532714d415bd847ca79278624f10 updates our `env` helper to allow a default value (akin to the [Laravel env helper](https://laravel.com/docs/5.5/helpers#method-env)), and https://github.com/DoSomething/phoenix-next/pull/1826/commits/6623f923ad812c7f8d5d227c1c894e6e2c180d27 adds the `false` default to various places we assign this param across Phoenix. ([See Slack convo](https://dosomething.slack.com/archives/C3ASB4204/p1577988210009500?thread_ts=1577986770.007800&cid=C3ASB4204))
- https://github.com/DoSomething/phoenix-next/pull/1826/commits/9516f7b8763827dba2eafeda83fa3c7b5623dcdb Since the collection page [makes use of](https://github.com/DoSomething/graphql/blob/2df05a996d26c578363e5ad69dd5643fac34d282/src/schema/contentful/phoenix.js#L236-#L237) Rich Text fields which are `JSON` scalars, we need to define a mock.
- Problem though, in the [`TextContent` component](https://git.io/Jepmu) which renders these values, this empty object was not getting passed through to the `RichTextDocument` component since it's missing the `nodeType` field. However, the `StandardMarkdown` component combusts due to this being an object and not a String. However, even if we do pass this through to the `RichTextDocument`, it'll combust due to invalid formatting / missing essential properties. This actually presents an interesting question: How do we handle mocking Rich Text fields? I was able to think of 3 options:
1. Manually add a mock of a valid Rich Text formatted object for these Rich text fields in the graphql fixture. Downside is that we'd need to do so for each query & field we're running in our tests which seems excessive.
2. Update the `TextContent` component to more specifically handle rendering so that in case it's presented a value that won't work with Rich Text or standard Markdown, it'll just return `null` and the tests will pass too! 
3. If we want to actually address mocking Rich text fields for our tests instead of relying on an empty JSON object or manually defining a mock for each query & field, we _could_ introduce a new `RichText` scalar to GraphQL and add a mock within the graphql fixture with the expected contentful Rich Text format. I just don't know if this is necessary, and this is def more involved...

I opted for the simpler option # 2 in https://github.com/DoSomething/phoenix-next/pull/1826/commits/bab39dc944ec618de7116ed1f2ed916e87844859

- Finally, https://github.com/DoSomething/phoenix-next/pull/1826/commits/c61a8fa08a02470ac1560066d8b1192f9259fab5 adds a basic Cypress test covering a non-existent collection page, an erroring one, & a valid one. 

### Relevant tickets

References [Pivotal #169781947](https://www.pivotaltracker.com/story/show/169781947).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added screenshots of front-end changes on small, medium, and large screens.
- [x] Added appropriate feature/unit tests.
