### PR TITLE
Link to Gitbook documentation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,25 +1,11 @@
-# 🔥 Phoenix 🔥
+# Phoenix
 
-Welcome! This is **Phoenix**, the new campaign experience for [DoSomething.org](https://www.dosomething.org)! Phoenix is built using [Laravel](https://laravel.com/docs), [Contentful](https://www.contentful.com), [React](https://reactjs.com/), and [Redux](http://redux.js.org) and plays nicely with the rest of our team \([Northstar](https://github.com/DoSomething/northstar), [Rogue](https://github.com/DoSomething/rogue), and co.\)
+This is **Phoenix**, the campaign experience for [DoSomething.org](https://www.dosomething.org)! Phoenix is built using [Laravel](https://laravel.com/docs), [Contentful](https://www.contentful.com), [React](https://reactjs.com/), and [Redux](http://redux.js.org).
 
-Phoenix is maintained by [Team Rocket](https://github.com/orgs/DoSomething/teams/team-rocket):
+### Documentation
 
-- 👨‍💻 [Diego](https://github.com/weerd) - Technical Lead
-- 👨‍💻 [Mendel](https://github.com/mendelB) - Engineer
-- 👨‍🎨 [Luke](https://github.com/lkpttn) - Product Designer
-- 👨‍🔬 [Dave](https://github.com/DFurnes) - Staff Engineer
-
-## Getting Started
-
-Please refer to the following sections for information on developing for the platform, or for further information on how everything works.
-
-### Development Information
-
-- [Development]()
-- [API Reference](api-reference/api-v2/README.md)
-
-If you would like to contribute to this documentation, please refer to the instructions on how to [edit this documentation](contributing-instructions/edit-this-documentation.md).
+https://dosomething.gitbook.io/phoenix-documentation/
 
 ## License
 
-©2019 DoSomething.org. Phoenix is free software, and may be redistributed under the terms specified in the [LICENSE](https://github.com/DoSomething/phoenix/blob/dev/LICENSE) file. The name and logo for DoSomething.org are trademarks of Do Something, Inc and may not be used without permission.
+©2020 DoSomething.org. Phoenix is free software, and may be redistributed under the terms specified in the [LICENSE](https://github.com/DoSomething/phoenix/blob/dev/LICENSE) file. The name and logo for DoSomething.org are trademarks of Do Something, Inc and may not be used without permission.

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,7 +2,7 @@
 
 This is **Phoenix**, the campaign experience for [DoSomething.org](https://www.dosomething.org)! Phoenix is built using [Laravel](https://laravel.com/docs), [Contentful](https://www.contentful.com), [React](https://reactjs.com/), and [Redux](http://redux.js.org).
 
-### Documentation
+## Documentation
 
 https://dosomething.gitbook.io/phoenix-documentation/
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
-# Phoenix
+# Phoenix [![StyleCI](https://styleci.io/repos/75642790/shield?style=flat-rounded)](https://styleci.io/repos/75642790)
 
-This is **Phoenix**, the campaign experience for [DoSomething.org](https://www.dosomething.org)! Phoenix is built using [Laravel](https://laravel.com/docs), [Contentful](https://www.contentful.com), [React](https://reactjs.com/), and [Redux](http://redux.js.org).
+This is **Phoenix**, the campaign experience for [DoSomething.org](https://www.dosomething.org). Phoenix is built using [Laravel](https://laravel.com/docs), [Contentful](https://www.contentful.com), [React](https://reactjs.com/), and [Redux](http://redux.js.org).
 
 ## Documentation
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # Phoenix [![StyleCI](https://styleci.io/repos/75642790/shield?style=flat-rounded)](https://styleci.io/repos/75642790)
 
-This is **Phoenix**, the campaign experience for [DoSomething.org](https://www.dosomething.org). Phoenix is built using [Laravel](https://laravel.com/docs), [Contentful](https://www.contentful.com), [React](https://reactjs.com/), and [Redux](http://redux.js.org).
+This is **Phoenix**, the web campaign experience for [DoSomething.org](https://www.dosomething.org). Phoenix is built using [Laravel](https://laravel.com/docs), [Contentful](https://www.contentful.com), [React](https://reactjs.com/), and [Redux](http://redux.js.org).
 
 ## Documentation
 

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -2,12 +2,6 @@
 
 - [🔥 Phoenix 🔥](README.md)
 
-## API Reference
-
-- [API v2](api-reference/api-v2/README.md)
-  - [Campaigns Resource](api-reference/api-v2/campaigns-resource.md)
-  - [Posts Resource](api-reference/api-v2/posts-resource.md)
-
 ## Installation + Usage
 
 - [Prerequisites](installation-and-usage/prerequisites.md)
@@ -38,6 +32,12 @@
 - [Contentful](development/contentful/README.md)
   - [Migration Scripts](development/contentful/migration-scripts.md)
   - [Content Management API Scripts](development/contentful/content-management-api-scripts.md)
+
+## Phoenix API
+
+- [v2](api-reference/api-v2/README.md)
+  - [Campaigns Resource](api-reference/api-v2/campaigns-resource.md)
+  - [Posts Resource](api-reference/api-v2/posts-resource.md)
 
 ## Data + Performance
 


### PR DESCRIPTION
### What's this PR do?

This pull request updates documentation:

* Updates content, license for 2020
* Adds the URL for the Gitbook documentation
* Adds the repo StyleCI badge

### How should this be reviewed?

👀 

### Any background context you want to provide?

I've moved the "API Reference" section lower in the summary, so that the Gitbook index page links to the "Preqrequisites" instead.

<img width="1045" alt="Screen Shot 2020-01-02 at 2 03 30 PM" src="https://user-images.githubusercontent.com/1236811/71696062-d3b62600-2d68-11ea-9b6c-0b63519ca519.png">

### Relevant tickets

Prepping for documentation updates over in https://www.pivotaltracker.com/story/show/170510799

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.

