### PR TITLE
Add ability to load Quiz blocks via GraphQL.

### DIFF
--- a/resources/assets/components/ContentfulEntry/ContentfulEntry.js
+++ b/resources/assets/components/ContentfulEntry/ContentfulEntry.js
@@ -289,6 +289,11 @@ class ContentfulEntry extends React.Component {
         return <QuizContainer {...json.fields} />;
       }
 
+      case 'QuizBlock': {
+        const QuizContainer = Loader(import('../Quiz/QuizContainer'));
+        return <QuizContainer {...json} />;
+      }
+
       case 'sectionBlock': {
         return (
           <SectionBlock

--- a/resources/assets/components/Quiz/Quiz.js
+++ b/resources/assets/components/Quiz/Quiz.js
@@ -2,6 +2,7 @@
 /* eslint-disable jsx-a11y/heading-has-content */
 
 import React from 'react';
+import gql from 'graphql-tag';
 import PropTypes from 'prop-types';
 import { find, every, get } from 'lodash';
 import ReactRouterPropTypes from 'react-router-prop-types';
@@ -17,6 +18,21 @@ import { trackAnalyticsEvent } from '../../helpers/analytics';
 import { calculateResult, resultParams, appendResultParams } from './helpers';
 
 import './quiz.scss';
+
+export const QuizBlockFragment = gql`
+  fragment QuizBlockFragment on QuizBlock {
+    title
+    slug
+    autoSubmit
+    hideQuestionNumber
+    results
+    defaultResultBlock {
+      id
+    }
+    questions
+    additionalContent
+  }
+`;
 
 class Quiz extends React.Component {
   constructor(props) {

--- a/resources/assets/components/Quiz/Quiz.js
+++ b/resources/assets/components/Quiz/Quiz.js
@@ -195,7 +195,7 @@ class Quiz extends React.Component {
     if (resultBlock.type === 'quiz' || resultBlock.__typename === 'QuizBlock') {
       const { location, history, slug } = this.props;
 
-      const resultBlockSlug = resultBlock.fields.slug;
+      const resultBlockSlug = resultBlock.slug || resultBlock.fields.slug;
 
       // Retain the current pathname while replacing the active quiz's slug with the resultBlocks slug
       const newPath = location.pathname.replace(

--- a/resources/assets/components/Quiz/Quiz.js
+++ b/resources/assets/components/Quiz/Quiz.js
@@ -274,13 +274,6 @@ class Quiz extends React.Component {
       );
     }
 
-    if (result) {
-      // Prepend the "quiz result" text to the specified block.
-      resultBlock.fields.content = `${result.content}\n\n${
-        resultBlock.fields.content
-      }`;
-    }
-
     return <ContentfulEntryLoader id={resultBlock.id} />;
   };
 

--- a/resources/assets/components/Quiz/Quiz.test.js
+++ b/resources/assets/components/Quiz/Quiz.test.js
@@ -119,7 +119,7 @@ test('clicking the button hides the quiz, shows the conclusion, and tracks the c
   expect(trackEventMock).toHaveBeenCalled();
   expect(history.push).toHaveBeenCalledTimes(0);
   expect(wrapper.find(QuizQuestion)).toHaveLength(0);
-  expect(wrapper.find('ContentfulEntry')).toHaveLength(1);
+  expect(wrapper.find('ContentfulEntryLoader')).toHaveLength(1);
 });
 
 test('a winning quiz resultBlock causes a redirect to the new quiz', () => {

--- a/resources/assets/components/utilities/ContentfulEntryLoader/ContentfulEntryLoader.js
+++ b/resources/assets/components/utilities/ContentfulEntryLoader/ContentfulEntryLoader.js
@@ -8,6 +8,7 @@ import { useQuery } from '@apollo/react-hooks';
 import NotFound from '../../NotFound';
 import { env } from '../../../helpers';
 import ContentfulEntry from '../../ContentfulEntry';
+import { QuizBlockFragment } from '../../Quiz/Quiz';
 import Spinner from '../../artifacts/Spinner/Spinner';
 import ErrorBlock from '../../blocks/ErrorBlock/ErrorBlock';
 import { SoftEdgeBlockFragment } from '../../actions/SoftEdgeBlock';
@@ -35,6 +36,7 @@ const CONTENTFUL_BLOCK_QUERY = gql`
     block(id: $id, preview: $preview) {
       id
       ...LinkBlockFragment
+      ...QuizBlockFragment
       ...ShareBlockFragment
       ...EmbedBlockFragment
       ...ImagesBlockFragment
@@ -57,6 +59,7 @@ const CONTENTFUL_BLOCK_QUERY = gql`
   }
 
   ${LinkBlockFragment}
+  ${QuizBlockFragment}
   ${ShareBlockFragment}
   ${EmbedBlockFragment}
   ${ImagesBlockFragment}


### PR DESCRIPTION
### What's this PR do?

This pull request adds support for loading Contentful Quizzes via GraphQL (started before the holidays in #1823). After this, we should be able to load any block on-demand!

### How should this be reviewed?

You can play around with this as a standalone block at [`/us/blocks/4S0grUEPHiiSQo8KWm20SM`](https://dosomething-phoenix-de-pr-1828.herokuapp.com/us/blocks/4S0grUEPHiiSQo8KWm20SM) or as a "campaign" quiz page at [`/us/campaigns/brake-it-down/quiz/best-friend`](https://dosomething-phoenix-de-pr-1828.herokuapp.com/us/campaigns/brake-it-down/quiz/best-friend).

### Any background context you want to provide?

I removed the ability for the quiz to "change" the `content` field on a linked block, since that would've been awkward to implement (since it'd require changes to `ContentfulEntryLoader`) and didn't seem to be used on any recent quizzes I could see on Contentful.

Since the `/us/blocks/:id` route doesn't have a "campaign context", we can't automatically create signups there when a user submits a quiz. I decided to add a conditional that'd skip that step if we're not on a campaign so that editors could still preview this block, but open to other ideas!

### Relevant tickets

References [Pivotal #170053835](https://www.pivotaltracker.com/story/show/170053835).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added screenshots of front-end changes on small, medium, and large screens.
- [ ] Added appropriate feature/unit tests.
