### PR TITLE
Adds Contentful workflow documentation, part 2

### DIFF
--- a/docs/development/contentful/workflow.md
+++ b/docs/development/contentful/workflow.md
@@ -6,11 +6,11 @@ We maintain an export file of each Contentful content type in code, in order to 
 
 Our Contentful space has three environments:
 
-- **Master**: Hosts our production content, and used for editorial workflows.
+- **`master`**: Hosts our production content, and used for editorial workflows.
 
-- **QA**: An exact copy of Master, refreshed weekly. Used for QA-ing any new migrations changes before deploying or running on production.
+- **`qa`**: An exact copy of `master`, refreshed weekly. Used to test any new migrations changes before deploying or running on production.
 
-- **Dev**: A sandbox environment consisting of test campaigns, beta content types, and dummy data. Developers can experiment here without breaking anything on the production end or adding clutter to the Master Environment. Migrations and new Content Types and fields can be fleshed out here, before moving forward to QA and Master.
+- **`dev`**: A sandbox environment consisting of test campaigns, beta content types, and dummy data. Developers can experiment here without breaking anything on the production end or adding clutter to the `master` environment. Migrations and new Content Types and fields can be fleshed out here, before moving forward to `qa` and `master`.
 
 ## Process
 
@@ -20,7 +20,7 @@ To create or edit a Contentful content type(s):
 
 We'll use this branch to open a pull request to add or update export file(s) per the content type changes we'll be making.
 
-### 2\) Make the changes on **Dev** via Contentful UI
+### 2\) Make the changes on **`dev`** via Contentful UI
 
 Use the web interface to create new content type, or add, update, or remove fields from existing content types.
 
@@ -47,9 +47,9 @@ Migration file created at contentful/content-types/currentSchoolBlock.js
 
 Once you've added all changes into the `contentful/content-types` files, open a pull request for review.
 
-### 5\) Upon merge, apply changes to Contentful QA and Master.
+### 5\) Upon merge, apply changes to Contentful `qa` and `master`.
 
-Once approved, the content type changes must manually be applied to the QA and Master environments.
+Once approved, the content type changes must manually be applied to the `qa` and `master` environments.
 
 #### Update content type
 
@@ -57,7 +57,7 @@ For updates to existing Content types, make the corresponding changes via the Co
 
 #### New content type
 
-For brand new Content types, it’s easiest to run the CLI [migration](https://github.com/contentful/contentful-cli/tree/master/docs/space/import) command to add new content types to qa and master:
+For brand new Content types, it’s easiest to run the CLI [migration](https://github.com/contentful/contentful-cli/tree/master/docs/space/import) command to add new content types to the `qa` and `master` environments:
 
 ```bash
 $ contentful space migration --s $SPACE_ID --e qa --content-file contentful/content-types/currentSchoolBlock.js

--- a/docs/development/contentful/workflow.md
+++ b/docs/development/contentful/workflow.md
@@ -29,7 +29,7 @@ Use the web interface to create new content type, or add, update, or remove fiel
 [Create a migration](https://github.com/contentful/contentful-cli/tree/master/docs/space/generate/migration) for each content type added or edited, saving the migration to the relevant `contentful/content-types` file, e.g. `contentful/content-types/currentSchoolBlock.js`
 
 ```bash
-$ contentful space generate migration -s $SPACE_ID -e dev -c galleryBlock -f contentful/content-types/galleryBlock.js
+$ contentful space generate migration -s $SPACE_ID -e dev -c currentSchoolBlock -f contentful/content-types/currentSchoolBlock.js
 ```
 
 Upon success, you'll see:

--- a/docs/development/contentful/workflow.md
+++ b/docs/development/contentful/workflow.md
@@ -26,7 +26,7 @@ Use the web interface to create new content type, or add, update, or remove fiel
 
 ### 3\) Export the changes as migrations
 
-[Create a migration](https://github.com/contentful/contentful-cli/tree/master/docs/space/generate/migration) for each content type added or edited, saving the migration to the relevant `contentful/content-types` file, e.g. `contentful/content-types/galleryBlock.js`
+[Create a migration](https://github.com/contentful/contentful-cli/tree/master/docs/space/generate/migration) for each content type added or edited, saving the migration to the relevant `contentful/content-types` file, e.g. `contentful/content-types/currentSchoolBlock.js`
 
 ```bash
 $ contentful space generate migration -s $SPACE_ID -e dev -c galleryBlock -f contentful/content-types/galleryBlock.js
@@ -35,12 +35,12 @@ $ contentful space generate migration -s $SPACE_ID -e dev -c galleryBlock -f con
 Upon success, you'll see:
 
 ```bash
-$ contentful space generate migration -s $SPACE_ID -e dev -c galleryBlock -f contentful/content-types/galleryBlock.js
+$ contentful space generate migration -s $SPACE_ID -e dev -c galleryBlock -f contentful/content-types/currentSchoolBlock.js
 
 Fetching content model
-Creating migration for content type: 'galleryBlock'
+Creating migration for content type: 'currentSchoolBlock'
 Fetching editor interface
-Migration file created at contentful/content-types/galleryBlock.js
+Migration file created at contentful/content-types/currentSchoolBlock.js
 ```
 
 ### 4\) Create a pull request
@@ -57,10 +57,41 @@ For updates to existing Content types, make the corresponding changes via the Co
 
 #### New content type
 
-For brand new Content types, it’s easiest to run the CLI [import](https://github.com/contentful/contentful-cli/tree/master/docs/space/import) command to add new content types to qa and master:
+For brand new Content types, it’s easiest to run the CLI [migration](https://github.com/contentful/contentful-cli/tree/master/docs/space/import) command to add new content types to qa and master:
 
 ```bash
-$ contentful space import  --space-id $SPACE_ID  --environment-id qa --content-file contentful/content-types/galleryBlock.js --content-model-only true
+$ contentful space migration --s $SPACE_ID --e qa --content-file contentful/content-types/currentSchoolBlock.js
+```
+
+Upon success, you'll see:
+
+```bash
+The following migration has been planned
+
+Environment: qa
+
+Create Content Type currentSchoolBlock
+  - name: "Current School Block"
+  - description: "Displays the user's current school, or allows them to select it if not set."
+  - displayField: "internalTitle"
+
+  Create field internalTitle
+    - name: "Internal Title"
+    - type: "Symbol"
+    - localized: false
+    - required: true
+    - validations: []
+    - disabled: false
+  ...
+```
+
+You'll be prompted whether to run the migration. Upon answering yes:
+
+```bash
+? Do you want to apply the migration Yes
+ ✔ Create Content Type currentSchoolBlock
+ ✔ Update field controls for Content Type currentSchoolBlock
+🎉  Migration successful
 ```
 
 ## Notes

--- a/docs/development/contentful/workflow.md
+++ b/docs/development/contentful/workflow.md
@@ -8,7 +8,7 @@ Our Contentful space has three environments:
 
 - **`master`**: Hosts our production content, and used for editorial workflows.
 
-- **`qa`**: An exact copy of `master`, refreshed weekly. Used to test any new migrations changes before deploying or running on production.
+- **`qa`**: An exact copy of `master`, refreshed weekly. Used to test any new changes before deploying or running on production.
 
 - **`dev`**: A sandbox environment consisting of test campaigns, beta content types, and dummy data. Developers can experiment here without breaking anything on the production end or adding clutter to the `master` environment. Migrations and new Content Types and fields can be fleshed out here, before moving forward to `qa` and `master`.
 

--- a/docs/development/contentful/workflow.md
+++ b/docs/development/contentful/workflow.md
@@ -26,7 +26,7 @@ Use the web interface to create new content type, or add, update, or remove fiel
 
 ### 3\) Export the changes as migrations
 
-[Create a migration](https://github.com/contentful/contentful-cli/tree/master/docs/space/generate/migration) for each content type added or edited, saving the migration to the relevant `contentful/content-types` file, e.g. `contentful/content-types/currentSchoolBlock.js`
+[Generate a migration](https://github.com/contentful/contentful-cli/tree/master/docs/space/generate/migration) for each content type added or edited, saving it to the relevant `contentful/content-types` file, e.g. `contentful/content-types/currentSchoolBlock.js`
 
 ```bash
 $ contentful space generate migration -s $SPACE_ID -e dev -c currentSchoolBlock -f contentful/content-types/currentSchoolBlock.js

--- a/docs/development/contentful/workflow.md
+++ b/docs/development/contentful/workflow.md
@@ -8,7 +8,7 @@ Our Contentful space has three environments:
 
 - **Dev**: A sandbox environment consisting of test campaigns, beta content types, and dummy data. Developers can experiment here without breaking anything on the production end or adding clutter to the Master Environment. Migrations and new Content Types and fields can be fleshed out here, before moving forward to QA and Master.
 
-We maintain an export file of each Contentful content type in code, in order to review changes to the Contentful content types changes by pull request.
+We maintain an export file of each Contentful content type in code, in order to review changes to the Contentful content types changes by pull request. The export files are created via the [Contentful CLI](https://github.com/contentful/contentful-cli).
 
 ## Process
 
@@ -18,7 +18,22 @@ To create or edit a content type(s):
 
 2. Make the changes on **Dev** via Contentful UI
 
-3. Export each content type added or edited, saving the migration to the relevant `contentful/content-types` file, e.g. `contentful/content-types/galleryBlock.js`
+3. [Create a migration](https://github.com/contentful/contentful-cli/tree/master/docs/space/generate/migration) for each content type added or edited, saving the migration to the relevant `contentful/content-types` file, e.g. `contentful/content-types/galleryBlock.js`
+
+```bash
+$ contentful space generate migration -s $SPACE_ID -e dev -c galleryBlock -f contentful/content-types/galleryBlock.js
+```
+
+Upon success, you'll see:
+
+```bash
+$ contentful space generate migration -s $SPACE_ID -e dev -c galleryBlock -f contentful/content-types/galleryBlock.js
+
+Fetching content model
+Creating migration for content type: 'galleryBlock'
+Fetching editor interface
+Migration file created at contentful/content-types/galleryBlock.js
+```
 
 4. Open a pull request for review.
 
@@ -30,12 +45,8 @@ For updates to existing Content types, make the corresponding changes via the Co
 
 ### New content type
 
-For brand new Content types, it’s easiest to run each new content type migration on qa and master directly from the [Contentful Migrations CLI](https://github.com/contentful/migration-cli). Run the migration from the project root using:
+For brand new Content types, it’s easiest to run the CLI [import](https://github.com/contentful/contentful-cli/tree/master/docs/space/import) command to add new content types to qa and master:
 
 ```bash
-$ contentful-migration --space-id $SPACE_ID --access-token $CONTENTFUL_MANAGEMENT_ACCESS_TOKEN contentful/content-types/galleryBlock.js
+$ contentful space import  --space-id $SPACE_ID --content-file contentful/content-types/galleryBlock.json
 ```
-
-If you have a `.contentfulrc.json` file setup in your home directory you can omit specifying the `--access-token`.
-
-You can obtain your user specific access token on Contentful within the Space Settings &gt; API Keys &gt; Personal Access Tokens.

--- a/docs/development/contentful/workflow.md
+++ b/docs/development/contentful/workflow.md
@@ -53,7 +53,7 @@ Once approved, the content type changes must manually be applied to the `qa` and
 
 #### Update content type
 
-For updates to existing Content types, make the corresponding changes via the Contentful UI on QA and Master.
+For updates to existing Content types, make the corresponding changes via the Contentful UI in the `qa` and `master` environments.
 
 #### New content type
 

--- a/docs/development/contentful/workflow.md
+++ b/docs/development/contentful/workflow.md
@@ -1,5 +1,9 @@
 # Workflow
 
+We maintain an export file of each Contentful content type in code, in order to use pull requests for reviewing changes to the Contentful content types. The export files are created via the [Contentful CLI](https://github.com/contentful/contentful-cli).
+
+## Environments
+
 Our Contentful space has three environments:
 
 - **Master**: Hosts our production content, and used for editorial workflows.
@@ -8,11 +12,9 @@ Our Contentful space has three environments:
 
 - **Dev**: A sandbox environment consisting of test campaigns, beta content types, and dummy data. Developers can experiment here without breaking anything on the production end or adding clutter to the Master Environment. Migrations and new Content Types and fields can be fleshed out here, before moving forward to QA and Master.
 
-We maintain an export file of each Contentful content type in code, in order to review changes to the Contentful content types changes by pull request. The export files are created via the [Contentful CLI](https://github.com/contentful/contentful-cli).
-
 ## Process
 
-To create or edit a content type(s):
+To create or edit a Contentful content type(s):
 
 ### 1\) Create a new branch
 

--- a/docs/development/contentful/workflow.md
+++ b/docs/development/contentful/workflow.md
@@ -60,3 +60,7 @@ For brand new Content types, it’s easiest to run the CLI [import](https://gith
 ```bash
 $ contentful space import  --space-id $SPACE_ID --content-file contentful/content-types/galleryBlock.json
 ```
+
+## Notes
+
+The migrations found in the `contentful/migrations` directory are from an earlier iteration of this workflow. We no longer add migrations here, but these files [do have value in the sense that they track migrations/content types which haven’t been ported over yet over to the `content-types` dir](https://dosomething.slack.com/archives/CP2D7UGAU/p1578081688027000?thread_ts=1577991900.006100&cid=CP2D7UGAU).

--- a/docs/development/contentful/workflow.md
+++ b/docs/development/contentful/workflow.md
@@ -18,7 +18,7 @@ To create or edit a Contentful content type(s):
 
 ### 1\) Create a new branch
 
-We'll use this branch to open a pull request with or new or updated export file(s) per the content type changes we'll be making.
+We'll use this branch to open a pull request to add or update export file(s) per the content type changes we'll be making.
 
 ### 2\) Make the changes on **Dev** via Contentful UI
 
@@ -60,7 +60,7 @@ For updates to existing Content types, make the corresponding changes via the Co
 For brand new Content types, it’s easiest to run the CLI [import](https://github.com/contentful/contentful-cli/tree/master/docs/space/import) command to add new content types to qa and master:
 
 ```bash
-$ contentful space import  --space-id $SPACE_ID --content-file contentful/content-types/galleryBlock.json
+$ contentful space import  --space-id $SPACE_ID  --environment-id qa --content-file contentful/content-types/galleryBlock.js --content-model-only true
 ```
 
 ## Notes

--- a/docs/development/contentful/workflow.md
+++ b/docs/development/contentful/workflow.md
@@ -14,11 +14,17 @@ We maintain an export file of each Contentful content type in code, in order to 
 
 To create or edit a content type(s):
 
-1. Create a new branch
+### 1\) Create a new branch
 
-2. Make the changes on **Dev** via Contentful UI
+We'll use this branch to open a pull request with or new or updated export file(s) per the content type changes we'll be making.
 
-3. [Create a migration](https://github.com/contentful/contentful-cli/tree/master/docs/space/generate/migration) for each content type added or edited, saving the migration to the relevant `contentful/content-types` file, e.g. `contentful/content-types/galleryBlock.js`
+### 2\) Make the changes on **Dev** via Contentful UI
+
+Use the web interface to create new content type, or add, update, or remove fields from existing content types.
+
+### 3\) Export the changes as migrations
+
+[Create a migration](https://github.com/contentful/contentful-cli/tree/master/docs/space/generate/migration) for each content type added or edited, saving the migration to the relevant `contentful/content-types` file, e.g. `contentful/content-types/galleryBlock.js`
 
 ```bash
 $ contentful space generate migration -s $SPACE_ID -e dev -c galleryBlock -f contentful/content-types/galleryBlock.js
@@ -35,15 +41,19 @@ Fetching editor interface
 Migration file created at contentful/content-types/galleryBlock.js
 ```
 
-4. Open a pull request for review.
+### 4\) Create a pull request
 
-5. Upon merge, make changes to Contentful QA and Master.
+Once you've added all changes into the `contentful/content-types` files, open a pull request for review.
 
-### Update content type
+### 5\) Upon merge, apply changes to Contentful QA and Master.
+
+Once approved, the content type changes must manually be applied to the QA and Master environments.
+
+#### Update content type
 
 For updates to existing Content types, make the corresponding changes via the Contentful UI on QA and Master.
 
-### New content type
+#### New content type
 
 For brand new Content types, it’s easiest to run the CLI [import](https://github.com/contentful/contentful-cli/tree/master/docs/space/import) command to add new content types to qa and master:
 


### PR DESCRIPTION
### What's this PR do?

This pull request adds specifics on how to use the CLI to generate the content type migration we'd expect to find in the `contentful/content-types` dir, as well as how to run the migration to create new content types.

### How should this be reviewed?

👀 

### Any background context you want to provide?

Also adds a Notes section to document the existence of the what-I-had-figured-was-and-still-kind-of-is-stale `contentful/migrations` dir.

### Relevant tickets

References [Pivotal #170510799](https://www.pivotaltracker.com/story/show/170510799).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.

