### PR TITLE
Add Quasi Pagination Support for Contentful Management API scripts

### DIFF
--- a/contentful/management-api-scripts/helpers.js
+++ b/contentful/management-api-scripts/helpers.js
@@ -63,6 +63,12 @@ async function processEntries(environment, args, entryType, process) {
     const entries = await attempt(() =>
       environment.getEntries({
         content_type: entryType,
+        // 1000 is the maximum amount the API will return (http://bit.ly/2uhYQsz).
+        // @TODO: Add pagination support to bulk process *all* entries.
+        limit: 1000,
+        // For now, if the content type exceeds 1000 entries, a hack is to increment this skip value by 1000
+        // and keep running the script until all entries are processed.
+        skip: 0,
       }),
     );
 
@@ -90,8 +96,8 @@ function linkReference(id) {
 
 // Configure and return a winston logger object (for easy logging to console and log file with specified title)
 function createLogger(title) {
-  const format = winston.format.printf(
-    info => (info.level === 'error' ? `error: ${info.message}` : info.message),
+  const format = winston.format.printf(info =>
+    info.level === 'error' ? `error: ${info.message}` : info.message,
   );
   const filename = `${__dirname}/logs/${title}_${new Date().getTime()}.txt`;
   winston.configure({

--- a/docs/development/contentful/content-management-api-scripts.md
+++ b/docs/development/contentful/content-management-api-scripts.md
@@ -86,3 +86,4 @@ If your script utilizes the `processEntries` helper method from `/helpers`, than
 
 - Since, unlike the migration CLI, there is no way to initially run the script to see if it's valid. You might want to first go about testing with a dummy \(staging / personal\) Contentful Space to ensure your script will behave as intended!
 - There is a suite of helper functions in `./helpers` containing some common logic we found ourselves running with these scripts.
+- If utilizing the `--all` flag to bulk process all entries of a content-type & if the content-type contains more then 1000 entries, a temporary workaround to the API's 1000 entry limit is to keep incrementing the `skip` parameter by 1000 in the `./helpers#processEntries` method to eventually process _all_ entries.


### PR DESCRIPTION
### What's this PR do?

This pull request starts the process of adding pagination support for Contentful management API scripts via the `processEntries` helper

### How should this be reviewed?
👁 

### Any background context you want to provide?
Since some of our Content Types have now accumulated over 100 entries (the [default minimum](https://www.contentful.com/developers/docs/references/content-delivery-api/#/reference/search-parameters/limit) returned by the API), we need to make use of the `skip` & `limit` parameters for pagination.

We ought to formulate a function to retrieve _all_ entries in bulk which shouldn't be too difficult, but I felt like this a quick win since it was super simple to set up. 

For now, we can keep incrementing the `skip` parameter by 1000 until all entries have been processed by the script.

### Relevant tickets
We're probably going to be utilizing this API for school finder work and company page work in the imminent future.

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [x] Documentation added for new features/changed endpoints.
- [ ] Added screenshots of front-end changes on small, medium, and large screens.
- [ ] Added appropriate feature/unit tests.
