### PR TITLE
Replace Puck Waypoints with In-House Analytics Waypoints

### DIFF
--- a/docs/development/data-and-performance/analytics.md
+++ b/docs/development/data-and-performance/analytics.md
@@ -69,18 +69,14 @@ We also track a Google Analytics [Pageview event](https://support.google.com/ana
 
 ### Events tracked internally by Puck
 
-| Event Name         | Event Description                               | Platforms |
-| ------------------ | ----------------------------------------------- | --------- |
-| `visit`            | tracked anytime another Puck event is triggered | Puck      |
-| `view`             | viewed a page                                   | Puck      |
-| `waypoint reached` | reached a waypoint embedded on page             | Puck      |
+| Event Name | Event Description                               | Platforms |
+| ---------- | ----------------------------------------------- | --------- |
+| `visit`    | tracked anytime another Puck event is triggered | Puck      |
+| `view`     | viewed a page                                   | Puck      |
 
-### List of Waypoint events being tracked in Phoenix by Puck
+### List of Waypoint events being tracked in Phoenix
 
-{% hint style="info" %}
-These events would be categorized under the `waypoint reached` event name.
-The event's `data.waypointData` field will contain the `contentfulId` (ID of the contentful entry) for the specific block on the page. The following list will contain the individual `data.waypointName` values paired by the events being tracked for the viewport reaching the top and bottom of the respective blocks.
-{% endhint %}
+Here's a list of active [waypoint events]('../features/analytics-waypoint.md') labeled by their respective `context.name`s:
 
 - `petition_submission_action-top`, `petition_submission_action-bottom`
 - `text_submission_action-top`, `text_submission_action-top`

--- a/docs/development/data-and-performance/analytics.md
+++ b/docs/development/data-and-performance/analytics.md
@@ -14,7 +14,7 @@ We use a few analytics services in Phoenix to track our events:
 
 ## Tracking an Event
 
-_@TODO: Update this with the new naming conventions based on the assorted `metadata` parameters, and the [naming conventions](https://github.com/orgs/DoSomething/teams/tech-leads/discussions/3)_
+_@TODO: Update this with the new naming conventions based on the assorted `metadata` parameters, and the [naming conventions](https://github.com/orgs/DoSomething/teams/deprecated-tech-leads/discussions/3)_
 
 To track a new event, simply import the `trackAnalyticsEvent` method from `/resources/assets/helpers/analytics.js` and pass it an object containing the following fields:
 

--- a/resources/assets/__mocks__/intersectionObserverMock.js
+++ b/resources/assets/__mocks__/intersectionObserverMock.js
@@ -1,0 +1,5 @@
+const IntersectionObserverMock = () => ({
+  observe: jest.fn(),
+});
+
+export default IntersectionObserverMock;

--- a/resources/assets/components/actions/PetitionSubmissioncAction/PetitionSubmissionAction.js
+++ b/resources/assets/components/actions/PetitionSubmissioncAction/PetitionSubmissionAction.js
@@ -4,7 +4,6 @@ import { get, has } from 'lodash';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import { Query as ApolloQuery } from 'react-apollo';
-import { PuckWaypoint } from '@dosomething/puck-client';
 
 import PostForm from '../PostForm';
 import Card from '../../utilities/Card/Card';
@@ -16,6 +15,7 @@ import TextContent from '../../utilities/TextContent/TextContent';
 import { formatPostPayload, getFieldErrors } from '../../../helpers/forms';
 import CharacterLimit from '../../utilities/CharacterLimit/CharacterLimit';
 import PrivacyLanguage from '../../utilities/PrivacyLanguage/PrivacyLanguage';
+import AnalyticsWaypoint from '../../utilities/AnalyticsWaypoint/AnalyticsWaypoint';
 
 import './petition-submission-action.scss';
 
@@ -129,9 +129,9 @@ class PetitionSubmissionAction extends PostForm {
           )}
           id={id}
         >
-          <PuckWaypoint
+          <AnalyticsWaypoint
             name="petition_submission_action-top"
-            waypointData={{ blockId: id }}
+            context={{ blockId: id }}
           />
           <ApolloQuery
             query={USER_POSTS_QUERY}
@@ -207,9 +207,9 @@ class PetitionSubmissionAction extends PostForm {
               );
             }}
           </ApolloQuery>
-          <PuckWaypoint
+          <AnalyticsWaypoint
             name="petition_submission_action-bottom"
-            waypointData={{ blockId: id }}
+            context={{ blockId: id }}
           />
         </div>
 

--- a/resources/assets/components/actions/PetitionSubmissioncAction/PetitionSubmissionAction.test.js
+++ b/resources/assets/components/actions/PetitionSubmissioncAction/PetitionSubmissionAction.test.js
@@ -4,6 +4,9 @@ import { MockedProvider } from '@apollo/react-testing';
 
 import { USER_POSTS_QUERY } from './PetitionSubmissionAction'; // eslint-disable-line import/no-duplicates
 import PetitionSubmissionAction from './PetitionSubmissionAction'; // eslint-disable-line import/no-duplicates
+import IntersectionObserverMock from '../../../__mocks__/intersectionObserverMock';
+
+global.IntersectionObserver = IntersectionObserverMock;
 
 const mocks = [
   {

--- a/resources/assets/components/actions/PhotoSubmissionAction/PhotoSubmissionAction.js
+++ b/resources/assets/components/actions/PhotoSubmissionAction/PhotoSubmissionAction.js
@@ -5,7 +5,6 @@ import gql from 'graphql-tag';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import { get, has, invert, mapValues } from 'lodash';
-import { PuckWaypoint } from '@dosomething/puck-client';
 
 import PostForm from '../PostForm';
 import Card from '../../utilities/Card/Card';
@@ -18,6 +17,7 @@ import FormValidation from '../../utilities/Form/FormValidation';
 import { withoutUndefined, withoutNulls } from '../../../helpers';
 import CharacterLimit from '../../utilities/CharacterLimit/CharacterLimit';
 import PrivacyLanguage from '../../utilities/PrivacyLanguage/PrivacyLanguage';
+import AnalyticsWaypoint from '../../utilities/AnalyticsWaypoint/AnalyticsWaypoint';
 import {
   calculateDifference,
   getFieldErrors,
@@ -284,9 +284,9 @@ class PhotoSubmissionAction extends PostForm {
       <React.Fragment>
         <div className="clearfix">
           <div className="photo-submission-action">
-            <PuckWaypoint
+            <AnalyticsWaypoint
               name="photo_submission_action-top"
-              waypointData={{ blockId: this.props.id }}
+              context={{ blockId: this.props.id }}
             />
             <Card
               className={classnames('bordered rounded', this.props.className)}
@@ -443,9 +443,9 @@ class PhotoSubmissionAction extends PostForm {
                 <PrivacyLanguage />
               </form>
             </Card>
-            <PuckWaypoint
+            <AnalyticsWaypoint
               name="photo_submission_action-bottom"
-              waypointData={{ blockId: this.props.id }}
+              context={{ blockId: this.props.id }}
             />
           </div>
 

--- a/resources/assets/components/actions/ShareAction/ShareAction.js
+++ b/resources/assets/components/actions/ShareAction/ShareAction.js
@@ -2,7 +2,6 @@ import React from 'react';
 import { get } from 'lodash';
 import gql from 'graphql-tag';
 import PropTypes from 'prop-types';
-import { PuckWaypoint } from '@dosomething/puck-client';
 
 import PostForm from '../PostForm';
 import Card from '../../utilities/Card/Card';
@@ -15,6 +14,7 @@ import { formatPostPayload } from '../../../helpers/forms';
 import { trackAnalyticsEvent } from '../../../helpers/analytics';
 import { SOCIAL_SHARE_TYPE } from '../../../constants/post-types';
 import TextContent from '../../utilities/TextContent/TextContent';
+import AnalyticsWaypoint from '../../utilities/AnalyticsWaypoint/AnalyticsWaypoint';
 import {
   dynamicString,
   loadFacebookSDK,
@@ -177,9 +177,9 @@ class ShareAction extends PostForm {
     return (
       <React.Fragment>
         <div className="share-action">
-          <PuckWaypoint
+          <AnalyticsWaypoint
             name="share_action-top"
-            waypointData={{ blockId: id }}
+            context={{ blockId: id }}
           />
           <Card title={title} className="rounded bordered">
             {content ? (
@@ -194,9 +194,9 @@ class ShareAction extends PostForm {
               Share on {isFacebook ? 'Facebook' : 'Twitter'}
             </Button>
           </Card>
-          <PuckWaypoint
+          <AnalyticsWaypoint
             name="share_action-bottom"
-            waypointData={{ blockId: id }}
+            context={{ blockId: id }}
           />
         </div>
         {this.state.showModal ? (

--- a/resources/assets/components/actions/TextSubmissionAction/TextSubmissionAction.js
+++ b/resources/assets/components/actions/TextSubmissionAction/TextSubmissionAction.js
@@ -3,7 +3,6 @@ import gql from 'graphql-tag';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import { get, has, invert, mapValues } from 'lodash';
-import { PuckWaypoint } from '@dosomething/puck-client';
 
 import PostForm from '../PostForm';
 import Card from '../../utilities/Card/Card';
@@ -16,6 +15,7 @@ import { withoutUndefined, withoutNulls } from '../../../helpers';
 import { getFieldErrors, formatPostPayload } from '../../../helpers/forms';
 import CharacterLimit from '../../utilities/CharacterLimit/CharacterLimit';
 import PrivacyLanguage from '../../utilities/PrivacyLanguage/PrivacyLanguage';
+import AnalyticsWaypoint from '../../utilities/AnalyticsWaypoint/AnalyticsWaypoint';
 
 import './text-submission-action.scss';
 
@@ -150,9 +150,9 @@ class TextSubmissionAction extends PostForm {
           )}
           id={this.props.id}
         >
-          <PuckWaypoint
+          <AnalyticsWaypoint
             name="text_submission_action-top"
-            waypointData={{ blockId: this.props.id }}
+            context={{ blockId: this.props.id }}
           />
           <Card className="bordered rounded" title={this.props.title}>
             {formResponse ? <FormValidation response={formResponse} /> : null}
@@ -197,9 +197,9 @@ class TextSubmissionAction extends PostForm {
               <PrivacyLanguage />
             </form>
           </Card>
-          <PuckWaypoint
+          <AnalyticsWaypoint
             name="text_submission_action-bottom"
-            waypointData={{ blockId: this.props.id }}
+            context={{ blockId: this.props.id }}
           />
         </div>
 

--- a/resources/assets/components/actions/VoterRegistrationAction/VoterRegistrationAction.js
+++ b/resources/assets/components/actions/VoterRegistrationAction/VoterRegistrationAction.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import gql from 'graphql-tag';
 import PropTypes from 'prop-types';
-import { PuckWaypoint } from '@dosomething/puck-client';
 
 import Card from '../../utilities/Card/Card';
 import { set } from '../../../helpers/storage';
@@ -9,6 +8,7 @@ import { dynamicString } from '../../../helpers';
 import ButtonLink from '../../utilities/ButtonLink/ButtonLink';
 import { trackAnalyticsEvent } from '../../../helpers/analytics';
 import TextContent from '../../utilities/TextContent/TextContent';
+import AnalyticsWaypoint from '../../utilities/AnalyticsWaypoint/AnalyticsWaypoint';
 
 import './voter-registration-action.scss';
 
@@ -58,7 +58,7 @@ const VoterRegistrationAction = props => {
       className="rounded bordered voter-registration"
       title="Register to vote"
     >
-      <PuckWaypoint name="voter_registration_action-top" />
+      <AnalyticsWaypoint name="voter_registration_action-top" />
       <div className="p-3 clearfix">
         <TextContent>{content}</TextContent>
 
@@ -66,7 +66,7 @@ const VoterRegistrationAction = props => {
           Start Registration
         </ButtonLink>
       </div>
-      <PuckWaypoint name="voter_registration_action-bottom" />
+      <AnalyticsWaypoint name="voter_registration_action-bottom" />
     </Card>
   );
 };

--- a/resources/assets/components/actions/VoterRegistrationAction/VoterRegistrationAction.test.js
+++ b/resources/assets/components/actions/VoterRegistrationAction/VoterRegistrationAction.test.js
@@ -5,10 +5,12 @@ import { get } from '../../../helpers/storage';
 import VoterRegistrationAction from './VoterRegistrationAction';
 import LocalStorageMock from '../../../__mocks__/localStorageMock';
 import { trackAnalyticsEvent as trackEventMock } from '../../../helpers/analytics';
+import IntersectionObserverMock from '../../../__mocks__/intersectionObserverMock';
 
 jest.mock('../../../helpers/analytics');
 
 global.localStorage = new LocalStorageMock();
+global.IntersectionObserver = IntersectionObserverMock;
 
 const renderVoterRegistration = () =>
   mount(

--- a/resources/assets/components/blocks/SectionBlock/SectionBlock.js
+++ b/resources/assets/components/blocks/SectionBlock/SectionBlock.js
@@ -1,9 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
-import { PuckWaypoint } from '@dosomething/puck-client';
 
 import TextContent from '../../utilities/TextContent/TextContent';
+import AnalyticsWaypoint from '../../utilities/AnalyticsWaypoint/AnalyticsWaypoint';
 
 import './section-block.scss';
 
@@ -30,10 +30,7 @@ const SectionBlock = props => {
       className={classnames('section-block', className)}
       style={{ backgroundColor }}
     >
-      <PuckWaypoint
-        name="section_block-top"
-        waypointData={{ contentfulId: id }}
-      />
+      <AnalyticsWaypoint name="section_block-top" context={{ blockId: id }} />
 
       <TextContent
         className="section-block__content base-12-grid"
@@ -44,9 +41,9 @@ const SectionBlock = props => {
         {content}
       </TextContent>
 
-      <PuckWaypoint
+      <AnalyticsWaypoint
         name="section_block-bottom"
-        waypointData={{ contentfulId: id }}
+        context={{ blockId: id }}
       />
     </section>
   );

--- a/resources/assets/components/utilities/IframeEmbed/IframeEmbed.js
+++ b/resources/assets/components/utilities/IframeEmbed/IframeEmbed.js
@@ -2,9 +2,9 @@ import React from 'react';
 import Media from 'react-media';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
-import { PuckWaypoint } from '@dosomething/puck-client';
 
 import LazyImage from '../LazyImage';
+import AnalyticsWaypoint from '../AnalyticsWaypoint/AnalyticsWaypoint';
 
 const IframeEmbed = ({ className, id, url, previewImage }) => {
   const iframeElement = () => (
@@ -13,7 +13,7 @@ const IframeEmbed = ({ className, id, url, previewImage }) => {
 
   return (
     <div id={id} className={classnames('embed', className)}>
-      <PuckWaypoint name="embed-top" waypointData={{ contentfulId: id }} />
+      <AnalyticsWaypoint name="embed-top" context={{ blockId: id }} />
 
       {previewImage ? (
         <Media query="(max-width: 759px)">
@@ -36,7 +36,7 @@ const IframeEmbed = ({ className, id, url, previewImage }) => {
         iframeElement()
       )}
 
-      <PuckWaypoint name="embed-bottom" waypointData={{ contentfulId: id }} />
+      <AnalyticsWaypoint name="embed-bottom" context={{ blockId: id }} />
     </div>
   );
 };

--- a/resources/assets/components/utilities/PostGallery/PostGallery.js
+++ b/resources/assets/components/utilities/PostGallery/PostGallery.js
@@ -2,11 +2,11 @@ import React from 'react';
 import { get } from 'lodash';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
-import { PuckWaypoint } from '@dosomething/puck-client';
 
 import Gallery from '../Gallery/Gallery';
 import LoadMore from '../LoadMore/LoadMore';
 import PostCard from '../PostCard/PostCard';
+import AnalyticsWaypoint from '../AnalyticsWaypoint/AnalyticsWaypoint';
 
 import './post-gallery.scss';
 
@@ -47,9 +47,9 @@ const PostGallery = props => {
   return posts.length ? (
     <div id={id} className={classnames('post-gallery', className)}>
       {waypointName ? (
-        <PuckWaypoint
+        <AnalyticsWaypoint
           name={`${waypointName}-top`}
-          waypointData={{ contentfulId: id }}
+          context={{ blockId: id }}
         />
       ) : null}
 
@@ -76,9 +76,9 @@ const PostGallery = props => {
       ) : null}
 
       {waypointName ? (
-        <PuckWaypoint
+        <AnalyticsWaypoint
           name={`${waypointName}-bottom`}
-          waypointData={{ contentfulId: id }}
+          context={{ blockId: id }}
         />
       ) : null}
     </div>


### PR DESCRIPTION
### What's this PR do?

This pull request replaces all usage of the `PuckWaypoint` analytics waypoint with our in-house `AnalyticsWaypoint` which tracks to Snowplow, GA, etc.

### How should this be reviewed?
👀 
I replaced a few straggling `contentfulId` context properties with `blockId` as per #1462 
### Any background context you want to provide?
This will allow us to remove Puck from Phoenix entirely in a follow-up PR!?!?!?!?!?!?!!!!*&*^%^%$%

### Relevant tickets

References [Pivotal #167630633](https://www.pivotaltracker.com/story/show/167630633).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [x] Documentation added for new features/changed endpoints.
- [ ] Added screenshots of front-end changes on small, medium, and large screens.
- [x] Added appropriate feature/unit tests.
