### PR TITLE
Initial cypress tests for site navigation

### DIFF
--- a/cypress/integration/site-navigation.js
+++ b/cypress/integration/site-navigation.js
@@ -22,40 +22,50 @@ describe('Site Navigation', () => {
 
   sizes.forEach(size => {
     it(`Search for not found content on ${size} viewport`, () => {
-      // Set the viewport
+      // Set the viewport:
       cy.viewport(size[0], size[1]);
 
+      // Go to an example site page:
       cy.withState(exampleFactPage).visit(
         '/us/facts/test-11-facts-about-testing',
       );
 
+      // Find the search icon in nav and click on it:
       cy.get('#nav .utility-nav__search-icon').click();
 
+      // Assert the search subnav is visible:
       cy.get('.utility-subnav').should('be.visible');
 
+      // Try searching for some content we know will not be found and submit the search form:
       cy.get('#utility-subnav__search input[type="search"]').type('clementine');
 
       cy.get('#utility-subnav__search').submit();
 
+      // Assert the new page url includes the search query:
       cy.url().should('include', '/search?query=clementine');
 
+      // Assert message received indicates query not found:
       cy.contains("couldn't find what you were looking for");
 
+      // Assert the subnav is not still rendered on search results page:
       cy.get('.utility-subnav').should('not.exist');
     });
 
     it(`Login and Join Now links are rendered with expected href on ${size} viewport`, () => {
-      // Set the viewport
+      // Set the viewport:
       cy.viewport(size[0], size[1]);
 
+      // Go to an example site page:
       cy.withState(exampleFactPage).visit(
         '/us/facts/test-11-facts-about-testing',
       );
 
+      // Assert the Login link is present and contains correct url in href:
       cy.get('#utility-nav__auth')
         .should('have.attr', 'href')
         .and('include', '/authorize');
 
+      // Assert the Join Now link is present and contains correct url in href:
       cy.get('#utility-nav__join')
         .should('have.attr', 'href')
         .and('include', '/authorize');

--- a/cypress/integration/site-navigation.js
+++ b/cypress/integration/site-navigation.js
@@ -10,7 +10,7 @@ const getViewportSizes = () => {
   return Object.keys(tailwindScreens).map(key => {
     const screenWidth = Number(tailwindScreens[key].replace('px', ''));
 
-    return [screenWidth, 900];
+    return { height: 900, width: screenWidth };
   });
 };
 
@@ -21,9 +21,9 @@ describe('Site Navigation', () => {
   beforeEach(() => cy.configureMocks());
 
   sizes.forEach(size => {
-    it(`Search for not found content on ${size} viewport`, () => {
+    it(`Search for not found content on ${size.width}px by ${size.height}px viewport`, () => {
       // Set the viewport:
-      cy.viewport(size[0], size[1]);
+      cy.viewport(size.width, size.height);
 
       // Go to an example site page:
       cy.withState(exampleFactPage).visit(
@@ -51,9 +51,9 @@ describe('Site Navigation', () => {
       cy.get('.utility-subnav').should('not.exist');
     });
 
-    it(`Login and Join Now links are rendered with expected href on ${size} viewport`, () => {
+    it(`Login and Join Now links are rendered with expected href on ${size.width}px by ${size.height}px viewport`, () => {
       // Set the viewport:
-      cy.viewport(size[0], size[1]);
+      cy.viewport(size.width, size.height);
 
       // Go to an example site page:
       cy.withState(exampleFactPage).visit(

--- a/cypress/integration/site-navigation.js
+++ b/cypress/integration/site-navigation.js
@@ -1,8 +1,20 @@
 /// <reference types="Cypress" />
 
+import tailwind from '../../tailwind.config';
 import exampleFactPage from '../fixtures/contentful/exampleFactPage';
 
-const sizes = ['iphone-6', 'iphone-x', 'ipad-2', [1024, 768]];
+// Return array of viewport sizes based on Tailwind configuration.
+const getViewportSizes = () => {
+  const tailwindScreens = tailwind.theme.screens;
+
+  return Object.keys(tailwindScreens).map(key => {
+    const screenWidth = Number(tailwindScreens[key].replace('px', ''));
+
+    return [screenWidth, 900];
+  });
+};
+
+const sizes = getViewportSizes();
 
 describe('Site Navigation', () => {
   // Configure a new "mock" server before each test:
@@ -11,11 +23,7 @@ describe('Site Navigation', () => {
   sizes.forEach(size => {
     it(`Search for not found content on ${size} viewport`, () => {
       // Set the viewport
-      if (Cypress._.isArray(size)) {
-        cy.viewport(size[0], size[1]);
-      } else {
-        cy.viewport(size);
-      }
+      cy.viewport(size[0], size[1]);
 
       cy.withState(exampleFactPage).visit(
         '/us/facts/test-11-facts-about-testing',
@@ -38,11 +46,7 @@ describe('Site Navigation', () => {
 
     it(`Login and Join Now links are rendered with expected href on ${size} viewport`, () => {
       // Set the viewport
-      if (Cypress._.isArray(size)) {
-        cy.viewport(size[0], size[1]);
-      } else {
-        cy.viewport(size);
-      }
+      cy.viewport(size[0], size[1]);
 
       cy.withState(exampleFactPage).visit(
         '/us/facts/test-11-facts-about-testing',

--- a/cypress/integration/site-navigation.js
+++ b/cypress/integration/site-navigation.js
@@ -1,0 +1,60 @@
+/// <reference types="Cypress" />
+
+import exampleFactPage from '../fixtures/contentful/exampleFactPage';
+
+const sizes = ['iphone-6', 'iphone-x', 'ipad-2', [1024, 768]];
+
+describe('Site Navigation', () => {
+  // Configure a new "mock" server before each test:
+  beforeEach(() => cy.configureMocks());
+
+  sizes.forEach(size => {
+    it(`Search for not found content on ${size} viewport`, () => {
+      // Set the viewport
+      if (Cypress._.isArray(size)) {
+        cy.viewport(size[0], size[1]);
+      } else {
+        cy.viewport(size);
+      }
+
+      cy.withState(exampleFactPage).visit(
+        '/us/facts/test-11-facts-about-testing',
+      );
+
+      cy.get('#nav .utility-nav__search-icon').click();
+
+      cy.get('.utility-subnav').should('be.visible');
+
+      cy.get('#utility-subnav__search input[type="search"]').type('clementine');
+
+      cy.get('#utility-subnav__search').submit();
+
+      cy.url().should('include', '/search?query=clementine');
+
+      cy.contains("couldn't find what you were looking for");
+
+      cy.get('.utility-subnav').should('not.exist');
+    });
+
+    it(`Login and Join Now links are rendered with expected href on ${size} viewport`, () => {
+      // Set the viewport
+      if (Cypress._.isArray(size)) {
+        cy.viewport(size[0], size[1]);
+      } else {
+        cy.viewport(size);
+      }
+
+      cy.withState(exampleFactPage).visit(
+        '/us/facts/test-11-facts-about-testing',
+      );
+
+      cy.get('#utility-nav__auth')
+        .should('have.attr', 'href')
+        .and('include', '/authorize');
+
+      cy.get('#utility-nav__join')
+        .should('have.attr', 'href')
+        .and('include', '/authorize');
+    });
+  });
+});

--- a/resources/assets/components/SiteNavigation/SiteNavigation.js
+++ b/resources/assets/components/SiteNavigation/SiteNavigation.js
@@ -492,6 +492,7 @@ class SiteNavigation extends React.Component {
               <>
                 <li className="utility-nav__account-profile menu-nav__item">
                   <a
+                    id="utility-nav__account-profile"
                     href="/us/account/profile"
                     className="utility-nav__account-profile-icon"
                     onClick={e => this.analyzeEvent(e, { label: 'profile' })}
@@ -504,6 +505,7 @@ class SiteNavigation extends React.Component {
               <>
                 <li className="utility-nav__auth menu-nav__item">
                   <a
+                    id="utility-nav__auth"
                     href={this.props.authLoginUrl}
                     onClick={e => this.analyzeEvent(e, { label: 'log_in' })}
                   >
@@ -513,6 +515,7 @@ class SiteNavigation extends React.Component {
 
                 <li className="utility-nav__join menu-nav__item">
                   <a
+                    id="utility-nav__join"
                     href={this.props.authRegisterUrl}
                     onClick={e => this.analyzeEvent(e, { label: 'join_now' })}
                   >


### PR DESCRIPTION
### What's this PR do?

This pull request adds some initial tests to the `SiteNavigation` component using Cypress. It is set up to test the navigation in multiple viewports to ensure that the site navigation renders and behaves as expected on a variety of devices. Additionally, I got it to pull the different screen sizes the tests run through from our [Tailwind configuration](https://github.com/DoSomething/phoenix-next/blob/181c934202a8aa7eb1c97a29c3f816e418185667/tailwind.config.js#L5-L12) 🎉 

Example test run:
![image](https://user-images.githubusercontent.com/105849/71845022-6f130800-3095-11ea-8a5c-9ef1e4e3ae76.png)

### How should this be reviewed?

🚥 

### Any background context you want to provide?

Based on some examples in the [Cypress docs](https://docs.cypress.io/api/commands/viewport.html#Dynamically-test-multiple-viewports) for dynamically testing multiple viewports.

### Relevant tickets

References [Pivotal #169580688](https://www.pivotaltracker.com/story/show/169580688).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [x] Added appropriate feature/unit tests.
