### PR TITLE
Adds migration for currentSchoolBlock content type

### DIFF
--- a/contentful/content-types/currentSchoolBlock.js
+++ b/contentful/content-types/currentSchoolBlock.js
@@ -1,0 +1,129 @@
+module.exports = function(migration) {
+  const currentSchoolBlock = migration
+    .createContentType('currentSchoolBlock')
+    .name('Current School Block')
+    .description(
+      "Displays the user's current school, or allows them to select it if not set.",
+    )
+    .displayField('internalTitle');
+
+  currentSchoolBlock
+    .createField('internalTitle')
+    .name('Internal Title')
+    .type('Symbol')
+    .localized(false)
+    .required(true)
+    .validations([])
+    .disabled(false)
+    .omitted(false);
+  currentSchoolBlock
+    .createField('actionId')
+    .name('Action ID')
+    .type('Integer')
+    .localized(false)
+    .required(false)
+    .validations([])
+    .disabled(false)
+    .omitted(false);
+  currentSchoolBlock
+    .createField('selectSchoolTitle')
+    .name('Select School Title')
+    .type('Symbol')
+    .localized(false)
+    .required(false)
+    .validations([])
+    .disabled(false)
+    .omitted(false);
+  currentSchoolBlock
+    .createField('selectSchoolDescription')
+    .name('Select School Description')
+    .type('Text')
+    .localized(false)
+    .required(false)
+    .validations([])
+    .disabled(false)
+    .omitted(false);
+  currentSchoolBlock
+    .createField('currentSchoolTitle')
+    .name('Current School Title')
+    .type('Symbol')
+    .localized(false)
+    .required(false)
+    .validations([])
+    .disabled(false)
+    .omitted(false);
+  currentSchoolBlock
+    .createField('currentSchoolDescription')
+    .name('Current School Description')
+    .type('Text')
+    .localized(false)
+    .required(false)
+    .validations([])
+    .disabled(false)
+    .omitted(false);
+  currentSchoolBlock
+    .createField('schoolNotAvailableDescription')
+    .name('School Not Available Description')
+    .type('Text')
+    .localized(false)
+    .required(false)
+    .validations([])
+    .disabled(false)
+    .omitted(false);
+
+  currentSchoolBlock.changeFieldControl(
+    'internalTitle',
+    'builtin',
+    'singleLine',
+    {
+      helpText:
+        'This title is used internally to help find this content. It will not be displayed anywhere on the rendered web page.',
+    },
+  );
+
+  currentSchoolBlock.changeFieldControl('actionId', 'builtin', 'numberEditor', {
+    helpText: "If set, displays the current school's aggregate impact",
+  });
+
+  currentSchoolBlock.changeFieldControl(
+    'selectSchoolTitle',
+    'builtin',
+    'singleLine',
+    {
+      helpText: 'Defaults to "Find Your School" if blank',
+    },
+  );
+
+  currentSchoolBlock.changeFieldControl(
+    'selectSchoolDescription',
+    'builtin',
+    'markdown',
+    {},
+  );
+
+  currentSchoolBlock.changeFieldControl(
+    'currentSchoolTitle',
+    'builtin',
+    'singleLine',
+    {
+      helpText: 'Defaults to "Your School" if blank',
+    },
+  );
+
+  currentSchoolBlock.changeFieldControl(
+    'currentSchoolDescription',
+    'builtin',
+    'markdown',
+    {},
+  );
+
+  currentSchoolBlock.changeFieldControl(
+    'schoolNotAvailableDescription',
+    'builtin',
+    'markdown',
+    {
+      helpText:
+        'Displayed when user has selected that they cannot find their school',
+    },
+  );
+};

--- a/contentful/content-types/page.js
+++ b/contentful/content-types/page.js
@@ -3,10 +3,9 @@ module.exports = function(migration) {
     .createContentType('page')
     .name('Page')
     .description(
-      'A custom page, for example a campaign FAQ or scholarship rules, or a standalone article or 11-facts page.',
+      'A custom page, for example a campaign FAQ or scholarship rules.',
     )
     .displayField('internalTitle');
-
   page
     .createField('internalTitle')
     .name('Internal Title')
@@ -115,11 +114,6 @@ module.exports = function(migration) {
       {
         linkMimetypeGroup: ['image'],
       },
-      {
-        assetFileSize: {
-          max: 20971520,
-        },
-      },
     ])
     .disabled(false)
     .omitted(false)
@@ -174,6 +168,7 @@ module.exports = function(migration) {
             'callToAction',
             'campaignUpdate',
             'contentBlock',
+            'currentSchoolBlock',
             'customBlock',
             'embed',
             'galleryBlock',
@@ -227,7 +222,7 @@ module.exports = function(migration) {
         linkContentType: ['socialOverride'],
       },
     ])
-    .disabled(true)
+    .disabled(false)
     .omitted(false)
     .linkType('Entry');
 
@@ -241,52 +236,64 @@ module.exports = function(migration) {
     .disabled(false)
     .omitted(false);
 
-  page.changeEditorInterface('internalTitle', 'singleLine', {
+  page
+    .createField('richMediaTest')
+    .name('Rich Media Test')
+    .type('RichText')
+    .localized(false)
+    .required(false)
+    .validations([
+      {
+        nodes: {},
+      },
+    ])
+    .disabled(false)
+    .omitted(false);
+
+  page.changeFieldControl('internalTitle', 'builtin', 'singleLine', {
     helpText:
       'This title is used internally to help find this content. It will not be displayed anywhere on the rendered web page.',
   });
 
-  page.changeEditorInterface('title', 'singleLine', {});
-  page.changeEditorInterface('subTitle', 'singleLine', {});
+  page.changeFieldControl('title', 'builtin', 'singleLine', {});
+  page.changeFieldControl('subTitle', 'builtin', 'singleLine', {});
 
-  page.changeEditorInterface('slug', 'slugEditor', {
+  page.changeFieldControl('slug', 'builtin', 'slugEditor', {
     helpText:
       'For an article page prefix with "articles/", a fact page prefix with "facts/" and for an about page prefix with "about/"',
   });
 
-  page.changeEditorInterface('metadata', 'entryLinkEditor', {});
+  page.changeFieldControl('metadata', 'builtin', 'entryLinkEditor', {});
+  page.changeFieldControl('authors', 'builtin', 'entryLinksEditor', {});
 
-  page.changeEditorInterface('authors', 'entryLinksEditor', {
-    bulkEditing: false,
+  page.changeFieldControl('coverImage', 'builtin', 'assetLinkEditor', {
+    helpText: 'The cover Image will display on the page before the content',
   });
 
-  page.changeEditorInterface('coverImage', 'assetLinkEditor', {
-    helpText: 'The cover image will display on the page before the content.',
-  });
+  page.changeFieldControl('content', 'builtin', 'markdown', {});
 
-  page.changeEditorInterface('content', 'markdown', {});
-
-  page.changeEditorInterface('sidebar', 'entryLinksEditor', {
+  page.changeFieldControl('sidebar', 'builtin', 'entryLinksEditor', {
     helpText: 'Add blocks to show up on alongside the main content.',
     bulkEditing: false,
   });
 
-  page.changeEditorInterface('blocks', 'entryLinksEditor', {
+  page.changeFieldControl('blocks', 'builtin', 'entryLinksEditor', {
     bulkEditing: false,
   });
 
-  page.changeEditorInterface('displaySocialShare', 'boolean', {
+  page.changeFieldControl('displaySocialShare', 'builtin', 'boolean', {
     helpText:
       "Select 'Yes' to display Social Sharing buttons on the bottom of the page. (Facebook & Twitter).",
     trueLabel: 'Yes',
     falseLabel: 'No',
   });
 
-  page.changeEditorInterface('hideFromNavigation', 'boolean', {
+  page.changeFieldControl('hideFromNavigation', 'builtin', 'boolean', {
     trueLabel: 'Yes',
     falseLabel: 'No',
   });
 
-  page.changeEditorInterface('socialOverride', 'entryLinkEditor', {});
-  page.changeEditorInterface('additionalContent', 'objectEditor', {});
+  page.changeFieldControl('socialOverride', 'builtin', 'entryLinkEditor', {});
+  page.changeFieldControl('additionalContent', 'builtin', 'objectEditor', {});
+  page.changeFieldControl('richMediaTest', 'builtin', 'richTextEditor', {});
 };

--- a/contentful/content-types/page.js
+++ b/contentful/content-types/page.js
@@ -3,9 +3,10 @@ module.exports = function(migration) {
     .createContentType('page')
     .name('Page')
     .description(
-      'A custom page, for example a campaign FAQ or scholarship rules.',
+      'A custom page, for example a campaign FAQ or scholarship rules, or a standalone article or 11-facts page.',
     )
     .displayField('internalTitle');
+
   page
     .createField('internalTitle')
     .name('Internal Title')
@@ -113,6 +114,11 @@ module.exports = function(migration) {
     .validations([
       {
         linkMimetypeGroup: ['image'],
+      },
+      {
+        assetFileSize: {
+          max: 20971520,
+        },
       },
     ])
     .disabled(false)
@@ -222,7 +228,7 @@ module.exports = function(migration) {
         linkContentType: ['socialOverride'],
       },
     ])
-    .disabled(false)
+    .disabled(true)
     .omitted(false)
     .linkType('Entry');
 
@@ -233,20 +239,6 @@ module.exports = function(migration) {
     .localized(false)
     .required(false)
     .validations([])
-    .disabled(false)
-    .omitted(false);
-
-  page
-    .createField('richMediaTest')
-    .name('Rich Media Test')
-    .type('RichText')
-    .localized(false)
-    .required(false)
-    .validations([
-      {
-        nodes: {},
-      },
-    ])
     .disabled(false)
     .omitted(false);
 
@@ -267,7 +259,7 @@ module.exports = function(migration) {
   page.changeFieldControl('authors', 'builtin', 'entryLinksEditor', {});
 
   page.changeFieldControl('coverImage', 'builtin', 'assetLinkEditor', {
-    helpText: 'The cover Image will display on the page before the content',
+    helpText: 'The cover image will display on the page before the content',
   });
 
   page.changeFieldControl('content', 'builtin', 'markdown', {});
@@ -295,5 +287,4 @@ module.exports = function(migration) {
 
   page.changeFieldControl('socialOverride', 'builtin', 'entryLinkEditor', {});
   page.changeFieldControl('additionalContent', 'builtin', 'objectEditor', {});
-  page.changeFieldControl('richMediaTest', 'builtin', 'richTextEditor', {});
 };


### PR DESCRIPTION
### What's this PR do?

This pull request adds a migration for a new `currentSchoolBlock` content type that I've created in `dev` (and mistakenly in `master` too - where I first created it). I ran the migration on `dev` to validate the content type was created as expected.

Following the steps in the Workflow documentation in #1832 -- this PR also updates the page migration to include the `currentSchoolBlock` type to the list of content types available in the multi-value `blocks` field. However, it seems to include quite a bit of other updates that I haven't made, that don't seem to have been manually updated when devs made these changes 😥 

### How should this be reviewed?

👀 

### Any background context you want to provide?

I considered whether to just manually add the `currentSchoolBlock` into the `content-types/page.js` vs migrate, but shouldn't this be the proper workflow? 

Upon merge and deploy, I'll manually take the following steps:

* [ ] `qa` - Run the migration to add the `currentSchoolBlock` content type 
* [ ]  `qa` - Alter the `page.blocks` field to to make the `currentSchoolBlock` content type available to select
* [x] `master` - run the migration to add `currentSchoolBlock` - don't need to do this because it already exists
* [ ]  `master` - Alter the `page.blocks` field to to make the `currentSchoolBlock` content type available to select

### Relevant tickets

References [Pivotal #170510799](https://www.pivotaltracker.com/story/show/170510799).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
