### PR TITLE
Adds analytics Tracking to Scholarship Modal Close

### DIFF
--- a/resources/assets/components/pages/LandingPage/templates/MarqueeTemplate.js
+++ b/resources/assets/components/pages/LandingPage/templates/MarqueeTemplate.js
@@ -124,6 +124,7 @@ const MarqueeTemplate = ({
           <Modal
             className="-inverted -scholarship__info"
             onClose={() => setShowScholarshipModal(false)}
+            trackingId="SCHOLARSHIP_MODAL"
           >
             <ScholarshipInfoBlockQuery
               affiliateSponsors={affiliateSponsors}


### PR DESCRIPTION
### What's this PR do?

This pull request adds the `trackingId` used in the modal component to track when the scholarship modal is closed!

### How should this be reviewed?

Let me know if there are other steps/variables I need to add. I think for this specific tracking I only needed to add the `SCHOLARSHIP_MODAL` ID.

### Any background context you want to provide?

Based on an overview of analytics from @mendelB !

### Relevant tickets

References [Pivotal # 170003912](https://www.pivotaltracker.com/story/show/170003912).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added screenshots of front-end changes on small, medium, and large screens.
- [ ] Added appropriate feature/unit tests.
