### PR TITLE
Adds Analytics Tracking to Scholarship CTA 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2325,7 +2325,7 @@
     "@types/zen-observable": {
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/@types/zen-observable/-/zen-observable-0.8.0.tgz",
-      "integrity": "sha512-te5lMAWii1uEJ4FwLjzdlbw3+n0FZNOvFXHxQDKeT0dilh7HOzdMzV2TrJVUzq8ep7J4Na8OUYPRLSQkJHAlrg=="
+      "integrity": "sha1-i2OrfxqlMhJIqtWsiQpIVlbc6k0="
     },
     "@webassemblyjs/ast": {
       "version": "1.8.5",

--- a/resources/assets/components/utilities/CtaPopover/CtaPopoverButton.js
+++ b/resources/assets/components/utilities/CtaPopover/CtaPopoverButton.js
@@ -12,9 +12,9 @@ const CtaPopoverButton = ({ buttonText, link }) => {
         category: 'site_action',
         target: 'button',
         verb: 'clicked',
-        noun: 'newsletter_cta',
+        noun: 'call_to_action',
         adjective: 'popover',
-        label: 'newsletter_cta__popover',
+        label: 'call_to_action_popover',
       },
       context: {
         url: link,

--- a/resources/assets/components/utilities/CtaPopover/CtaPopoverEmailForm.js
+++ b/resources/assets/components/utilities/CtaPopover/CtaPopoverEmailForm.js
@@ -18,7 +18,7 @@ const CtaPopoverEmailForm = ({ handleComplete }) => {
   const handleFocus = () => {
     trackAnalyticsEvent({
       metadata: {
-        label: 'call_to_action_popover_email',
+        label: 'call_to_action_popover',
         adjective: 'email',
         category: 'site_action',
         noun: 'call_to_action_popover',
@@ -71,10 +71,10 @@ const CtaPopoverEmailForm = ({ handleComplete }) => {
         }
 
         trackAnalyticsEvent({
-          context: { error, errorMessage },
+          context: { cta_type: newsletter_scholarships, error, errorMessage },
           metadata: {
-            label: 'call_to_action_popover_email',
-            adjective: 'call_to_action_popover_email',
+            label: 'call_to_action_popover',
+            adjective: 'call_to_action_popover',
             category: 'submission_failed',
             noun: 'form_submission',
             target: 'form',

--- a/resources/assets/components/utilities/CtaPopover/CtaPopoverEmailForm.js
+++ b/resources/assets/components/utilities/CtaPopover/CtaPopoverEmailForm.js
@@ -17,6 +17,7 @@ const CtaPopoverEmailForm = ({ handleComplete }) => {
 
   const handleFocus = () => {
     trackAnalyticsEvent({
+      context: { cta_type: 'newsletter_scholarships' },
       metadata: {
         adjective: 'email',
         category: 'site_action',

--- a/resources/assets/components/utilities/CtaPopover/CtaPopoverEmailForm.js
+++ b/resources/assets/components/utilities/CtaPopover/CtaPopoverEmailForm.js
@@ -71,14 +71,14 @@ const CtaPopoverEmailForm = ({ handleComplete }) => {
         }
 
         trackAnalyticsEvent({
-          context: { errorMessage },
+          context: { error, errorMessage },
           metadata: {
             label: 'call_to_action_popover_email',
-            adjective: 'email_error',
-            category: 'site-action',
-            noun: 'call_to_action_popover',
+            adjective: 'call_to_action_popover_email',
+            category: 'submission_failed',
+            noun: 'form_submission',
             target: 'form',
-            verb: 'error_triggered',
+            verb: 'failed',
           },
         });
       });

--- a/resources/assets/components/utilities/CtaPopover/CtaPopoverEmailForm.js
+++ b/resources/assets/components/utilities/CtaPopover/CtaPopoverEmailForm.js
@@ -6,14 +6,27 @@ import { RestApiClient } from '@dosomething/gateway';
 import Button from '../Button/Button';
 import { env, report } from '../../../helpers/index';
 import { tabularLog } from '../../../helpers/api';
-
 import './cta-popover-email-form.scss';
+import { trackAnalyticsEvent } from '../../../helpers/analytics';
 
 const CtaPopoverEmailForm = ({ handleComplete }) => {
   const [emailValue, setEmailValue] = useState('');
   const [errorResponse, setErrorResponse] = useState(null);
   const [showAffirmation, setShowAffirmation] = useState(false);
   const handleChange = event => setEmailValue(event.target.value);
+
+  const handleFocus = () => {
+    trackAnalyticsEvent({
+      metadata: {
+        label: 'call_to_action_popover_email',
+        adjective: 'email',
+        category: 'site_action',
+        noun: 'call_to_action_popover',
+        target: 'field',
+        verb: 'focused',
+      },
+    });
+  };
 
   const handleSubmit = event => {
     event.preventDefault();
@@ -32,6 +45,17 @@ const CtaPopoverEmailForm = ({ handleComplete }) => {
         handleComplete();
         tabularLog(get(response, 'data', null));
 
+        trackAnalyticsEvent({
+          metadata: {
+            label: 'call_to_action_popover_email',
+            adjective: 'email',
+            category: 'authentication',
+            noun: 'form_submited_popover',
+            target: 'button',
+            verb: 'clicked',
+          },
+        });
+
         return response;
       })
       .catch(error => {
@@ -45,6 +69,18 @@ const CtaPopoverEmailForm = ({ handleComplete }) => {
         if (window.ENV.APP_ENV !== 'production') {
           console.log('🚫 failed response? caught the error!', error);
         }
+
+        trackAnalyticsEvent({
+          context: { errorMessage },
+          metadata: {
+            label: 'submit_subscriptions_email_error',
+            adjective: 'email_error',
+            category: 'onboarding',
+            noun: 'form_submitted_popover_email_error',
+            target: 'button',
+            verb: 'error_triggered',
+          },
+        });
       });
   };
 
@@ -60,6 +96,7 @@ const CtaPopoverEmailForm = ({ handleComplete }) => {
           value={emailValue}
           placeholder="Enter your email address"
           onChange={handleChange}
+          onFocus={handleFocus}
         />
         <Button className="email-form__button" type="submit">
           Sign Up

--- a/resources/assets/components/utilities/CtaPopover/CtaPopoverEmailForm.js
+++ b/resources/assets/components/utilities/CtaPopover/CtaPopoverEmailForm.js
@@ -18,7 +18,6 @@ const CtaPopoverEmailForm = ({ handleComplete }) => {
   const handleFocus = () => {
     trackAnalyticsEvent({
       metadata: {
-        label: 'call_to_action_popover',
         adjective: 'email',
         category: 'site_action',
         noun: 'call_to_action_popover',
@@ -34,7 +33,6 @@ const CtaPopoverEmailForm = ({ handleComplete }) => {
     trackAnalyticsEvent({
       context: { cta_type: 'newsletter_scholarships' },
       metadata: {
-        label: 'call_to_action_popover',
         adjective: 'call_to_action_popover',
         category: 'site_action',
         noun: 'submission',

--- a/resources/assets/components/utilities/CtaPopover/CtaPopoverEmailForm.js
+++ b/resources/assets/components/utilities/CtaPopover/CtaPopoverEmailForm.js
@@ -31,6 +31,18 @@ const CtaPopoverEmailForm = ({ handleComplete }) => {
   const handleSubmit = event => {
     event.preventDefault();
 
+    trackAnalyticsEvent({
+      context: { cta_type: 'newsletter_scholarships' },
+      metadata: {
+        label: 'call_to_action_popover',
+        adjective: 'call_to_action_popover',
+        category: 'site_action',
+        noun: 'submission',
+        target: 'form',
+        verb: 'submitted',
+      },
+    });
+
     const client = new RestApiClient(`${env('NORTHSTAR_URL')}`);
 
     client
@@ -44,18 +56,6 @@ const CtaPopoverEmailForm = ({ handleComplete }) => {
         setShowAffirmation(true);
         handleComplete();
         tabularLog(get(response, 'data', null));
-
-        trackAnalyticsEvent({
-          context: { cta_type: 'newsletter_scholarships' },
-          metadata: {
-            label: 'call_to_action_popover',
-            adjective: 'call_to_action_popover',
-            category: 'site_action',
-            noun: 'submission',
-            target: 'form',
-            verb: 'submitted',
-          },
-        });
 
         return response;
       })

--- a/resources/assets/components/utilities/CtaPopover/CtaPopoverEmailForm.js
+++ b/resources/assets/components/utilities/CtaPopover/CtaPopoverEmailForm.js
@@ -71,7 +71,7 @@ const CtaPopoverEmailForm = ({ handleComplete }) => {
         }
 
         trackAnalyticsEvent({
-          context: { cta_type: newsletter_scholarships, error, errorMessage },
+          context: { cta_type: 'newsletter_scholarships', error, errorMessage },
           metadata: {
             label: 'call_to_action_popover',
             adjective: 'call_to_action_popover',

--- a/resources/assets/components/utilities/CtaPopover/CtaPopoverEmailForm.js
+++ b/resources/assets/components/utilities/CtaPopover/CtaPopoverEmailForm.js
@@ -46,11 +46,12 @@ const CtaPopoverEmailForm = ({ handleComplete }) => {
         tabularLog(get(response, 'data', null));
 
         trackAnalyticsEvent({
+          context: { cta_type: 'newsletter_scholarships' },
           metadata: {
-            label: 'call_to_action_popover_email',
-            adjective: 'email',
+            label: 'call_to_action_popover',
+            adjective: 'call_to_action_popover',
             category: 'site_action',
-            noun: 'call_to_action_popover',
+            noun: 'submission',
             target: 'form',
             verb: 'submitted',
           },
@@ -76,7 +77,7 @@ const CtaPopoverEmailForm = ({ handleComplete }) => {
             label: 'call_to_action_popover',
             adjective: 'call_to_action_popover',
             category: 'submission_failed',
-            noun: 'form_submission',
+            noun: 'submission',
             target: 'form',
             verb: 'failed',
           },

--- a/resources/assets/components/utilities/CtaPopover/CtaPopoverEmailForm.js
+++ b/resources/assets/components/utilities/CtaPopover/CtaPopoverEmailForm.js
@@ -33,9 +33,8 @@ const CtaPopoverEmailForm = ({ handleComplete }) => {
     trackAnalyticsEvent({
       context: { cta_type: 'newsletter_scholarships' },
       metadata: {
-        adjective: 'call_to_action_popover',
         category: 'site_action',
-        noun: 'submission',
+        noun: 'call_to_action_popover',
         target: 'form',
         verb: 'submitted',
       },
@@ -72,10 +71,8 @@ const CtaPopoverEmailForm = ({ handleComplete }) => {
         trackAnalyticsEvent({
           context: { cta_type: 'newsletter_scholarships', error, errorMessage },
           metadata: {
-            label: 'call_to_action_popover',
-            adjective: 'call_to_action_popover',
-            category: 'submission_failed',
-            noun: 'submission',
+            category: 'site_action',
+            noun: 'call_to_action_popover_submission',
             target: 'form',
             verb: 'failed',
           },

--- a/resources/assets/components/utilities/CtaPopover/CtaPopoverEmailForm.js
+++ b/resources/assets/components/utilities/CtaPopover/CtaPopoverEmailForm.js
@@ -49,10 +49,10 @@ const CtaPopoverEmailForm = ({ handleComplete }) => {
           metadata: {
             label: 'call_to_action_popover_email',
             adjective: 'email',
-            category: 'authentication',
-            noun: 'form_submited_popover',
-            target: 'button',
-            verb: 'clicked',
+            category: 'site_action',
+            noun: 'call_to_action_popover',
+            target: 'form',
+            verb: 'submitted',
           },
         });
 
@@ -73,11 +73,11 @@ const CtaPopoverEmailForm = ({ handleComplete }) => {
         trackAnalyticsEvent({
           context: { errorMessage },
           metadata: {
-            label: 'submit_subscriptions_email_error',
+            label: 'call_to_action_popover_email',
             adjective: 'email_error',
-            category: 'onboarding',
-            noun: 'form_submitted_popover_email_error',
-            target: 'button',
+            category: 'site-action',
+            noun: 'call_to_action_popover',
+            target: 'form',
             verb: 'error_triggered',
           },
         });


### PR DESCRIPTION
### What's this PR do?

This pull request adds analytics tracking to the `CtaPopoverEmailForm` so that GA/snowplow tracks the following on the newsletter cta: 

Who clicks on the form to fill it out
Who submits their email in the form
Form validation errors (if it makes sense)

### How should this be reviewed?
👀
### Any background context you want to provide?

[Newsletter CTA Tech Spec](https://docs.google.com/document/d/1ADzYNZegztHOD7xs3KPky0b06nxG6HZE3-iEfakSGHA/edit?ts=5e0f756d#)

### Relevant tickets

References [Pivotal #169330883](https://www.pivotaltracker.com/story/show/169330883).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added screenshots of front-end changes on small, medium, and large screens.
- [ ] Added appropriate feature/unit tests.
