### PR TITLE
Site navigation link behavior updates

### DIFF
--- a/cypress/integration/site-navigation.js
+++ b/cypress/integration/site-navigation.js
@@ -140,7 +140,7 @@ describe('Site Navigation', () => {
         '/us/facts/test-11-facts-about-testing',
       );
 
-      // Mouseover the Causes main nav item and assert it is visible:
+      // Mouseover the Causes main nav item and assert the subnav is visible:
       cy.get('#main-nav__causes')
         .trigger('mouseover')
         .should('be.visible');

--- a/cypress/integration/site-navigation.js
+++ b/cypress/integration/site-navigation.js
@@ -26,7 +26,7 @@ const allSizes = getViewportSizes();
 
 const smallAndMediumSizes = getViewportSizes(['xs', 'sm', 'md']);
 
-const largePlusSizes = getViewportSizes(['lg', 'xl', 'xxl']);
+const largeSizes = getViewportSizes(['lg', 'xl', 'xxl']);
 
 describe('Site Navigation', () => {
   // Configure a new "mock" server before each test:
@@ -130,7 +130,7 @@ describe('Site Navigation', () => {
     });
   });
 
-  largePlusSizes.forEach(size => {
+  largeSizes.forEach(size => {
     it(`Can click Causes main nav item on ${size.width}px by ${size.height}px viewport`, () => {
       // Set the viewport:
       cy.viewport(size.width, size.height);

--- a/cypress/integration/site-navigation.js
+++ b/cypress/integration/site-navigation.js
@@ -26,6 +26,8 @@ const allSizes = getViewportSizes();
 
 const smallAndMediumSizes = getViewportSizes(['xs', 'sm', 'md']);
 
+const largePlusSizes = getViewportSizes(['lg', 'xl', 'xxl']);
+
 describe('Site Navigation', () => {
   // Configure a new "mock" server before each test:
   beforeEach(() => cy.configureMocks());
@@ -105,7 +107,7 @@ describe('Site Navigation', () => {
   });
 
   smallAndMediumSizes.forEach(size => {
-    it(`Open and close the Causes subnav on ${size.width}px by ${size.height}px viewport`, () => {
+    it(`Can interact with toggleable Causes main nav item on ${size.width}px by ${size.height}px viewport`, () => {
       // Set the viewport:
       cy.viewport(size.width, size.height);
 
@@ -125,6 +127,28 @@ describe('Site Navigation', () => {
 
       // Assert the Causes subnav is not still rendered on page:
       cy.get('.main-subnav').should('not.exist');
+    });
+  });
+
+  largePlusSizes.forEach(size => {
+    it(`Can click Causes main nav item on ${size.width}px by ${size.height}px viewport`, () => {
+      // Set the viewport:
+      cy.viewport(size.width, size.height);
+
+      // Go to an example site page:
+      cy.withState(exampleFactPage).visit(
+        '/us/facts/test-11-facts-about-testing',
+      );
+
+      // Mouseover the Causes main nav item and assert it is visible:
+      cy.get('#main-nav__causes')
+        .trigger('mouseover')
+        .should('be.visible');
+
+      // Find the Causes main nav item and click on it:
+      cy.get('#main-nav__causes')
+        .should('have.attr', 'href')
+        .and('include', '/campaigns');
     });
   });
 });

--- a/resources/assets/components/SiteNavigation/SiteNavigation.js
+++ b/resources/assets/components/SiteNavigation/SiteNavigation.js
@@ -178,6 +178,7 @@ class SiteNavigation extends React.Component {
                   <>
                     {matches.large ? (
                       <a
+                        id="main-nav__causes"
                         href="/campaigns"
                         onClick={e =>
                           this.handleOnClickLink(e, {
@@ -190,6 +191,7 @@ class SiteNavigation extends React.Component {
                       </a>
                     ) : (
                       <a
+                        id="main-nav__causes"
                         href="/"
                         onClick={e =>
                           this.handleOnClickToggle(e, 'CausesSubNav', {

--- a/resources/assets/components/SiteNavigation/SiteNavigation.js
+++ b/resources/assets/components/SiteNavigation/SiteNavigation.js
@@ -3,8 +3,9 @@
 
 import React from 'react';
 import { get } from 'lodash';
-import classnames from 'classnames';
+import Media from 'react-media';
 import PropTypes from 'prop-types';
+import classnames from 'classnames';
 
 import SearchIcon from '../artifacts/SearchIcon/SearchIcon';
 import SiteNavigationFeature from './SiteNavigationFeature';
@@ -168,36 +169,47 @@ class SiteNavigation extends React.Component {
               onMouseEnter={() => this.handleMouseEnter('CausesSubNav')}
               onMouseLeave={() => this.handleMouseLeave('CausesSubNav')}
             >
-              <a
-                id="main-nav__causes"
-                href="/"
-                onClick={e =>
-                  this.handleOnClickToggle(e, 'CausesSubNav', {
-                    label: 'causes',
-                  })
-                }
+              <Media
+                queries={{
+                  large: '(min-width: 960px)',
+                }}
               >
-                Causes
-                <span className="main-nav__arrow" />
-              </a>
+                {matches => (
+                  <>
+                    {matches.large ? (
+                      <a
+                        href="/campaigns"
+                        onClick={e =>
+                          this.handleOnClickLink(e, {
+                            label: 'causes',
+                          })
+                        }
+                      >
+                        Causes
+                        <span className="main-nav__arrow" />
+                      </a>
+                    ) : (
+                      <a
+                        href="/"
+                        onClick={e =>
+                          this.handleOnClickToggle(e, 'CausesSubNav', {
+                            label: 'causes',
+                          })
+                        }
+                      >
+                        Causes
+                        <span className="main-nav__arrow" />
+                      </a>
+                    )}
+                  </>
+                )}
+              </Media>
 
               {this.state.activeSubNav === 'CausesSubNav' ? (
                 <div className="main-subnav menu-subnav">
                   <div className="wrapper base-12-grid">
                     <section className="main-subnav__links-causes menu-subnav__links menu-subnav__section">
-                      <h1>
-                        <a
-                          href="/us/campaigns"
-                          onClick={e => {
-                            this.handleOnClickLink(e, {
-                              noun: 'subnav_link',
-                              label: 'causes',
-                            });
-                          }}
-                        >
-                          Causes
-                        </a>
-                      </h1>
+                      <h1>Causes</h1>
                       <ul>
                         <li>
                           <a

--- a/resources/assets/components/SiteNavigation/site-navigation.scss
+++ b/resources/assets/components/SiteNavigation/site-navigation.scss
@@ -111,20 +111,17 @@ $extraSmall: '(min-width: 360px)';
 
   > h1 {
     margin-bottom: 0;
+    color: black;
+    font-size: 22px;
+    font-weight: bold;
+    padding: 0 0 12px;
 
-    a {
-      color: black;
+    @include media($large) {
+      font-size: 18px;
+    }
+
+    @include media($larger) {
       font-size: 22px;
-      font-weight: bold;
-      padding: 0 0 12px;
-
-      @include media($large) {
-        font-size: 18px;
-      }
-
-      @include media($larger) {
-        font-size: 22px;
-      }
     }
   }
 }


### PR DESCRIPTION
### What's this PR do?

This pull request updates the behavior of the main `SiteNavigation` component, so that the Causes subnav is toggleable on small and medium devices (most common touch device sizes), but clickable on device sizes large+ and heads over to `/explore` campaigns.

The behavior was accomplished by using the `react-media` package, which conveniently allows rendering a different `<a>` element that uses a different method depending on the media query context; easy-peasy 😄 

Example test run:
![image](https://user-images.githubusercontent.com/105849/71936198-c341e900-3176-11ea-8d9d-3332df7e0981.png)

### How should this be reviewed?

👀 

### Any background context you want to provide?

This also removes the link from the subnav "Causes" title since it would be redundant and ultimately was meant to be temporary until we got the correct functionality in. 

### Relevant tickets

References [Pivotal #170319248](https://www.pivotaltracker.com/story/show/170319248).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [x] Added appropriate feature/unit tests.
