### PR TITLE
Removes support for School Finder via ContentBlock.additionalContent

### DIFF
--- a/cypress/fixtures/contentful/exampleSchoolFinderCampaign.js
+++ b/cypress/fixtures/contentful/exampleSchoolFinderCampaign.js
@@ -65,28 +65,14 @@ export default {
           blocks: [
             {
               id: '6Kj1Av7MnvNcCXLYHLGee0',
-              type: 'contentBlock',
+              type: 'currentSchoolBlock',
               fields: {
-                superTitle: 'Step 1',
-                title: 'Find Your School',
-                subTitle:
-                  'Win great prizes for your school and climb the leaderboard',
-                content:
-                  'Donec mollis neque eros, vitae venenatis turpis ultricies non. Sed ut tincidunt nulla, et sagittis mauris. Mauris tempor mauris sit amet nisi semper, quis pellentesque nunc congue. Nullam pharetra lacinia leo eu viverra. Nulla pellentesque augue nisi, nec tristique libero efficitur at. Join a school or no prizes, sucker.',
-                image: {
-                  url: null,
-                  description: null,
-                },
-                imageAlignment: null,
-                additionalContent: {
-                  actionId: 21,
-                  showSchoolFinder: true,
-                  schoolNotAvailableHeadline: 'No School Selected',
-                  schoolFinderFormDescription:
-                    'Pick your school and whatever. Invite your classmates to join this campaign and donate their jeans to win prizes and some other stuff.',
-                  schoolNotAvailableDescription:
-                    'No school copy goes here, please email Sahara with information about your school.',
-                },
+                internalTitle: 'Generic Current School Block',
+                actionId: 21,
+                selectSchoolDescription:
+                  'Pick your school and whatever. Invite your classmates to join this campaign and donate their jeans to win prizes and some other stuff.',
+                schoolNotAvailableDescription:
+                  'No school copy goes here, please email Sahara with information about your school.',
               },
             },
           ],

--- a/cypress/integration/school-finder.js
+++ b/cypress/integration/school-finder.js
@@ -25,8 +25,7 @@ const exampleAction = {
 };
 
 const schoolFinderConfig =
-  exampleSchoolFinderCampaign.campaign.pages[0].fields.blocks[0].fields
-    .additionalContent;
+  exampleSchoolFinderCampaign.campaign.pages[0].fields.blocks[0].fields;
 
 describe('School Finder', () => {
   beforeEach(() => cy.configureMocks());
@@ -48,7 +47,7 @@ describe('School Finder', () => {
     cy.get('.school-finder h1').should('contain', 'Find Your School');
     cy.get('.school-finder').should(
       'contain',
-      schoolFinderConfig.schoolFinderFormDescription,
+      schoolFinderConfig.selectSchoolDescription,
     );
     cy.get('.school-finder').should(
       'not.contain',
@@ -86,7 +85,7 @@ describe('School Finder', () => {
     );
     cy.get('.school-finder').should(
       'not.contain',
-      schoolFinderConfig.schoolFinderFormDescription,
+      schoolFinderConfig.selectSchoolDescription,
     );
     cy.get('.school-finder').should(
       'not.contain',
@@ -143,7 +142,7 @@ describe('School Finder', () => {
     cy.get('.school-finder h1').should('contain', 'Your School');
     cy.get('.school-finder').should(
       'not.contain',
-      schoolFinderConfig.schoolFinderFormDescription,
+      schoolFinderConfig.selectSchoolDescription,
     );
     cy.get('.school-finder').should(
       'contain',

--- a/docs/development/content-types/content-block.md
+++ b/docs/development/content-types/content-block.md
@@ -10,15 +10,6 @@ Displays headline, subtitle, supertitle, copy, and image. Commonly used to list 
 
 - Available as a `ContentBlock` in GraphQL.
 
-- For now, the `additionalContent` field is used to display a Current School Block below a Section Block. This will be deprecated in the near future, but the expected values are:
-
 ```
-{
-    "showSchoolFinder": true,
-    "actionId": 21,
-    "schoolFinderFormDescription": "Pick your school and whatever. Invite your classmates to join this campaign and donate their jeans to win prizes and some other stuff.",
-    "schoolNotAvailableHeadline": "No School Selected",
-    "schoolNotAvailableDescription": "No school copy goes here, please email Sahara with information about your school.",
-    "schoolSelectedConfirmation": "Your school total will be updated anytime a submission from someone in your school has been reviewed."
-}
+
 ```

--- a/docs/development/content-types/content-block.md
+++ b/docs/development/content-types/content-block.md
@@ -9,7 +9,3 @@ Displays headline, subtitle, supertitle, copy, and image. Commonly used to list 
 ## Technical Notes
 
 - Available as a `ContentBlock` in GraphQL.
-
-```
-
-```

--- a/resources/assets/components/blocks/ContentBlock/ContentBlock.js
+++ b/resources/assets/components/blocks/ContentBlock/ContentBlock.js
@@ -7,7 +7,6 @@ import { contentfulImageUrl } from '../../../helpers';
 import { Figure } from '../../utilities/Figure/Figure';
 import TextContent from '../../utilities/TextContent/TextContent';
 import SectionHeader from '../../utilities/SectionHeader/SectionHeader';
-import CurrentSchoolBlockContainer from '../CurrentSchoolBlock/CurrentSchoolBlockContainer';
 
 import './content-block.scss';
 
@@ -24,13 +23,11 @@ export const ContentBlockFragment = gql`
     }
     # Aliasing to avoid conflicting with *required* imageAlignment field in GalleryBlockFragment.
     contentBlockimageAlignment: imageAlignment
-    additionalContent
   }
 `;
 
 const ContentBlock = props => {
   const {
-    additionalContent,
     className,
     content,
     image,
@@ -59,28 +56,11 @@ const ContentBlock = props => {
       ) : (
         contentNode
       )}
-      {additionalContent && additionalContent.showSchoolFinder ? (
-        <div className="pt-3">
-          <CurrentSchoolBlockContainer
-            actionId={additionalContent.actionId}
-            currentSchoolDescription={
-              additionalContent.schoolSelectedConfirmation
-            }
-            selectSchoolDescription={
-              additionalContent.schoolFinderFormDescription
-            }
-            schoolNotAvailableDescription={
-              additionalContent.schoolNotAvailableDescription
-            }
-          />
-        </div>
-      ) : null}
     </div>
   );
 };
 
 ContentBlock.propTypes = {
-  additionalContent: PropTypes.object,
   className: PropTypes.string,
   content: PropTypes.string.isRequired,
   image: PropTypes.shape({
@@ -93,7 +73,6 @@ ContentBlock.propTypes = {
 };
 
 ContentBlock.defaultProps = {
-  additionalContent: null,
   className: null,
   image: {},
   imageAlignment: 'RIGHT',


### PR DESCRIPTION
### What's this PR do?

This pull request removes the code that renders a `CurrentSchoolBlock` based on configuration in a `ContentBlock.additionalContent` field. This code is safe to remove because I've manually updated the TFJ and START action pages in `qa` and `master` to use new `CurrentSchoolBlock` entries instead of `ContentBlock` entries to display school finders.

Action page edit:

<img width="500" alt="Screen Shot 2020-01-08 at 12 44 05 PM" src="https://user-images.githubusercontent.com/1236811/72014983-c344f600-3215-11ea-86ce-8ee9c6948e0f.png">


Action page view:


<img width="500" alt="Screen Shot 2020-01-08 at 12 43 23 PM" src="https://user-images.githubusercontent.com/1236811/72014900-a14b7380-3215-11ea-8c6e-18e3d380d5a6.png">


### How should this be reviewed?

Verify that a School Finder is rendered on:

* https://www.dosomething.org/us/campaigns/start-teacher/action
* https://www.dosomething.org/us/campaigns/teens-jeans/action

### Any background context you want to provide?

Rendering the School Finder as a separate block adds a touch more of margin between the `ContentBlock` and the `CurrentSchoolBlock`, because of the bottom padding on the `ContentBlock` div. I'm hoping this is something we can live with.. alternatives I can think of: 

- Duplicate the supertitle, title, content fields and markup of a `ContentBlock` within a `CurrentSchoolBlock` to keep them in a single block div, which is extremely non DRY

- When rendering each block in a Page's `blocks` field, apply a `mb-3` instead of a `mb-6` if the next block in sequence will be a `CurrentSchoolBlock`

<img width="600" alt="Screen Shot 2020-01-08 at 12 49 20 PM" src="https://user-images.githubusercontent.com/1236811/72014749-5f223200-3215-11ea-8c63-78ce283e9773.png">


### Relevant tickets

References [Pivotal #170510799](https://www.pivotaltracker.com/story/show/170510799).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [x] Documentation added for new features/changed endpoints.
- [x] Added screenshots of front-end changes on small, medium, and large screens.
- [x] Added appropriate feature/unit tests.
