### PR TITLE
Properly determine 'refer a friend' default campaign ID

### DIFF
--- a/cypress/integration/beta-referral-page.js
+++ b/cypress/integration/beta-referral-page.js
@@ -1,16 +1,16 @@
 /// <reference types="Cypress" />
 
 import { userFactory } from '../fixtures/user';
-import { campaignId, userId } from '../fixtures/constants';
+import { userId } from '../fixtures/constants';
 
 describe('Beta Referral Page', () => {
   // Configure a new "mock" server before each test:
   beforeEach(() => cy.configureMocks());
 
-  it('Visit beta referral page, with valid user and campaign IDs', () => {
+  it('Visit beta referral page, with valid user', () => {
     const user = userFactory();
 
-    cy.visit(`/us/join?user_id=${userId}&campaign_id=${campaignId}`);
+    cy.visit(`/us/join?user_id=${userId}`);
 
     cy.contains('campaign scholarship');
     cy.contains('FAQ');
@@ -36,17 +36,5 @@ describe('Beta Referral Page', () => {
 
     // Our mock user ID won't exist in dev, we can expect a 404.
     cy.contains('Not Found');
-  });
-
-  it('Visit beta referral page, with valid user ID and no campaign ID', () => {
-    const user = userFactory();
-
-    cy.visit(`/us/join?user_id=${userId}`);
-
-    cy.get('.referral-page-campaign').should('have.length', 1);
-
-    cy.get('.referral-page-campaign > a')
-      .should('have.attr', 'href')
-      .and('include', `referrer_user_id=${userId}`);
   });
 });

--- a/resources/assets/components/pages/ReferralPage/Alpha/AlphaPage.js
+++ b/resources/assets/components/pages/ReferralPage/Alpha/AlphaPage.js
@@ -1,65 +1,55 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import { query } from '../../../../helpers';
 import { PHOENIX_URL } from '../../../../constants';
 import SiteNavigationContainer from '../../../SiteNavigation/SiteNavigationContainer';
 import SocialDriveActionContainer from '../../../actions/SocialDriveAction/SocialDriveActionContainer';
 
-const AlphaPage = props => {
-  const campaignId = query('campaign_id');
-  let url = `${PHOENIX_URL}/us/join?user_id=${props.userId}`;
-
-  if (campaignId) {
-    url = `${url}&campaign_id=${campaignId}`;
-  }
-
-  return (
-    <>
-      <SiteNavigationContainer />
-      <div className="main general-page base-12-grid">
-        <div className="grid-narrow">
-          <div className="my-6">
-            <div className="general-page__heading text-center">
-              <h1 className="general-page__title uppercase">
-                Want Free Money for School?
-              </h1>
-            </div>
-            <div className="my-6">
-              <SocialDriveActionContainer
-                shareCardDescription="Invite your friends to join DoSomething. When your friend completes this campaign, you'll both increase your chances of winning the campaign scholarship! Every friend you refer earns you an additional shot at winning the scholarship. (Psst...there's no limit on how many you can refer!)"
-                shareCardTitle="Refer A Friend"
-                link={url}
-                hidePageViews
-              />
-            </div>
-            <h3>FAQ</h3>
-            <h4>1. Who can I refer?</h4>
-            <p>
-              Earn your reward for referring NEW members to DoSomething!
-              Unfortunately, if you refer someone that already has a DoSomething
-              account, you won’t get the reward when they sign up for the shared
-              campaign.
-            </p>
-            <h4>2. How will I know if I won the scholarship?</h4>
-            <p>
-              We will email you using the same email address used to create your
-              DoSomething account. Scholarship winners are announced when the
-              campaign closes.
-            </p>
-            <h4>3. Where can I find the full rules?</h4>
-            <p>
-              This offer is for a limited time only. See the{' '}
-              <a href="/us/refer-a-friend-official-rules" target="_blank">
-                Refer A Friend Official Rules.
-              </a>
-            </p>
+const AlphaPage = ({ userId }) => (
+  <>
+    <SiteNavigationContainer />
+    <div className="main general-page base-12-grid">
+      <div className="grid-narrow">
+        <div className="my-6">
+          <div className="general-page__heading text-center">
+            <h1 className="general-page__title uppercase">
+              Want Free Money for School?
+            </h1>
           </div>
+          <div className="my-6">
+            <SocialDriveActionContainer
+              shareCardDescription="Invite your friends to join DoSomething. When your friend completes this campaign, you'll both increase your chances of winning the campaign scholarship! Every friend you refer earns you an additional shot at winning the scholarship. (Psst...there's no limit on how many you can refer!)"
+              shareCardTitle="Refer A Friend"
+              link={`${PHOENIX_URL}/us/join?user_id=${userId}`}
+              hidePageViews
+            />
+          </div>
+          <h3>FAQ</h3>
+          <h4>1. Who can I refer?</h4>
+          <p>
+            Earn your reward for referring NEW members to DoSomething!
+            Unfortunately, if you refer someone that already has a DoSomething
+            account, you won’t get the reward when they sign up for the shared
+            campaign.
+          </p>
+          <h4>2. How will I know if I won the scholarship?</h4>
+          <p>
+            We will email you using the same email address used to create your
+            DoSomething account. Scholarship winners are announced when the
+            campaign closes.
+          </p>
+          <h4>3. Where can I find the full rules?</h4>
+          <p>
+            This offer is for a limited time only. See the{' '}
+            <a href="/us/refer-a-friend-official-rules" target="_blank">
+              Refer A Friend Official Rules.
+            </a>
+          </p>
         </div>
       </div>
-    </>
-  );
-};
+    </div>
+  </>
+);
 
 AlphaPage.propTypes = {
   userId: PropTypes.string.isRequired,

--- a/resources/assets/components/pages/ReferralPage/Beta/BetaPage.js
+++ b/resources/assets/components/pages/ReferralPage/Beta/BetaPage.js
@@ -6,7 +6,6 @@ import ErrorPage from '../../ErrorPage';
 import MoneyHandImage from './money-hand.svg';
 import { query, env } from '../../../../helpers';
 import CampaignLink from './BetaPageCampaignLink';
-import { REFERRAL_CAMPAIGN_IDS } from '../../../../constants';
 
 const REFERRAL_PAGE_USER = gql`
   query ReferralPageUserQuery($id: String!) {
@@ -24,16 +23,11 @@ const BetaPage = () => {
     return <ErrorPage />;
   }
 
-  // The Referral Campaign ID defaults to the Teens for Jeans campaign,
-  // or a test campaign for development environments.
-  const useDevCampaign = ['local', 'development'].includes(env('APP_ENV'));
-  const DEFAULT_REFERRAL_CAMPAIGN_ID = useDevCampaign ? '9001' : '9037';
-
-  const queryCampaignId = query('campaign_id');
-
-  const campaignId = REFERRAL_CAMPAIGN_IDS.includes(queryCampaignId)
-    ? queryCampaignId
-    : DEFAULT_REFERRAL_CAMPAIGN_ID;
+  // The Refer a Friend feature is limited to the Teens for Jeans campaign,
+  // or a test campaign for development environments. (hardcoded by design https://git.io/JvJ4H).
+  const campaignId = ['local', 'development'].includes(env('APP_ENV'))
+    ? '9001'
+    : '9037';
 
   return (
     // We *do not* render a SiteNavigationContainer here to avoid losing the referral metadata (see https://git.io/JeX2A).

--- a/resources/assets/components/pages/ReferralPage/Beta/BetaPage.js
+++ b/resources/assets/components/pages/ReferralPage/Beta/BetaPage.js
@@ -3,13 +3,10 @@ import gql from 'graphql-tag';
 
 import Query from '../../../Query';
 import ErrorPage from '../../ErrorPage';
-import { query } from '../../../../helpers';
 import MoneyHandImage from './money-hand.svg';
+import { query, env } from '../../../../helpers';
 import CampaignLink from './BetaPageCampaignLink';
-import {
-  REFERRAL_CAMPAIGN_IDS,
-  DEFAULT_REFERRAL_CAMPAIGN_ID,
-} from '../../../../constants';
+import { REFERRAL_CAMPAIGN_IDS } from '../../../../constants';
 
 const REFERRAL_PAGE_USER = gql`
   query ReferralPageUserQuery($id: String!) {
@@ -26,6 +23,11 @@ const BetaPage = () => {
   if (!userId) {
     return <ErrorPage />;
   }
+
+  // The Referral Campaign ID defaults to the Teens for Jeans campaign,
+  // or a test campaign for development environments.
+  const useDevCampaign = ['local', 'development'].includes(env('APP_ENV'));
+  const DEFAULT_REFERRAL_CAMPAIGN_ID = useDevCampaign ? '9001' : '9037';
 
   const queryCampaignId = query('campaign_id');
 

--- a/resources/assets/components/utilities/CtaReferralPageBanner/CtaReferralPageBanner.js
+++ b/resources/assets/components/utilities/CtaReferralPageBanner/CtaReferralPageBanner.js
@@ -1,13 +1,13 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import { REFERRAL_CAMPAIGN_IDS } from '../../../constants';
-
 import './cta-referral-page-banner.scss';
 
 const CtaReferralPageBanner = ({ campaignId }) => (
   <React.Fragment>
-    {REFERRAL_CAMPAIGN_IDS.includes(campaignId) ? (
+    {/* The Refer a Friend feature is limited to the Teens for Jeans campaign, */}
+    {/* or a test campaign for development environments. (hardcoded by design https://git.io/JvJ4H). */}
+    {['9037', '9001'].includes(campaignId) ? (
       <div className="p-3">
         <div className="cta-register-banner md:px-6 pt-3 clearfix">
           <div className="cta-register-banner__content p-6 md:pr-0 text-center md:text-left">
@@ -16,10 +16,7 @@ const CtaReferralPageBanner = ({ campaignId }) => (
               Refer a friend to this campaign, and you’ll *both* increase your
               chances of winning the campaign scholarship!
             </p>
-            <a
-              href={`/us/refer-friends?campaign_id=${campaignId}`}
-              className="button p-3 -attached"
-            >
+            <a href="/us/refer-friends" className="button p-3 -attached">
               Refer A Friend
             </a>
           </div>

--- a/resources/assets/constants/index.js
+++ b/resources/assets/constants/index.js
@@ -42,11 +42,6 @@ export const REFERRAL_CAMPAIGN_IDS = [
   '9037',
 ];
 
-// The Referral Campaign ID defaults to the Teens for Jeans campaign,
-// or a test campaign for development environments.
-export const DEFAULT_REFERRAL_CAMPAIGN_ID =
-  process.env.NODE_ENV !== 'development' ? '9037' : '9001';
-
 // Signup Button text for scholarship referrals:
 export const SCHOLARSHIP_SIGNUP_BUTTON_TEXT = 'Apply Now!';
 

--- a/resources/assets/constants/index.js
+++ b/resources/assets/constants/index.js
@@ -34,14 +34,6 @@ export const REGISTER_CTA_COPY = {
   },
 };
 
-// Campaign IDs running within the Refer a Friend initiative.
-// For now, limited to the Teens For Jeans campaign.
-// @see https://www.pivotaltracker.com/story/show/169376190
-export const REFERRAL_CAMPAIGN_IDS = [
-  '9001', // Used to test on dev.
-  '9037',
-];
-
 // Signup Button text for scholarship referrals:
 export const SCHOLARSHIP_SIGNUP_BUTTON_TEXT = 'Apply Now!';
 


### PR DESCRIPTION
### What's this PR do?

This pull request actually fixes the bug attempted to be squashed here https://github.com/DoSomething/phoenix-next/pull/1559#issuecomment-572708917 to ensure we use a test campaign ID available on local & dev environments which should be using Rogue's dev environment, so that the referral link is valid, and doesn't break the embed.

### How should this be reviewed?
👁 

### Any background context you want to provide?
Unfortunately, this means we need to move this out of the `/constants` file so that we have the `window.ENV` in scope to determine the `APP_ENV` config variable.

### Relevant tickets
https://dosomething.slack.com/archives/C3ASB4204/p1578679794042200

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added screenshots of front-end changes on small, medium, and large screens.
- [ ] Added appropriate feature/unit tests.
