### PR TITLE
'View more' drawer scholarship - Part One

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2325,7 +2325,7 @@
     "@types/zen-observable": {
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/@types/zen-observable/-/zen-observable-0.8.0.tgz",
-      "integrity": "sha1-i2OrfxqlMhJIqtWsiQpIVlbc6k0="
+      "integrity": "sha512-te5lMAWii1uEJ4FwLjzdlbw3+n0FZNOvFXHxQDKeT0dilh7HOzdMzV2TrJVUzq8ep7J4Na8OUYPRLSQkJHAlrg=="
     },
     "@webassemblyjs/ast": {
       "version": "1.8.5",

--- a/resources/assets/components/blocks/ScholarshipInfoBlock/InfoHeader.js
+++ b/resources/assets/components/blocks/ScholarshipInfoBlock/InfoHeader.js
@@ -1,0 +1,18 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+// @TODO: Move to Helper Components?
+
+const Header = ({ content, textColor }) => (
+  <div className={`font-bold uppercase ${textColor}`}>{content}</div>
+);
+
+Header.propTypes = {
+  content: PropTypes.string.isRequired,
+  textColor: PropTypes.string,
+};
+
+Header.defaultProps = {
+  textColor: 'text-gray-600',
+};
+
+export default Header;

--- a/resources/assets/components/blocks/ScholarshipInfoBlock/ScholarshipActionType.js
+++ b/resources/assets/components/blocks/ScholarshipInfoBlock/ScholarshipActionType.js
@@ -1,0 +1,17 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import Header from './InfoHeader';
+
+const ScholarshipActionType = ({ actionLabel }) => (
+  <div>
+    <Header content="Action Type" />
+    <p className="pb-2">{actionLabel}</p>
+  </div>
+);
+
+export default ScholarshipActionType;
+
+ScholarshipActionType.propTypes = {
+  actionLabel: PropTypes.string.isRequired,
+};

--- a/resources/assets/components/blocks/ScholarshipInfoBlock/ScholarshipActionType.js
+++ b/resources/assets/components/blocks/ScholarshipInfoBlock/ScholarshipActionType.js
@@ -2,16 +2,24 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import Header from './InfoHeader';
+import PlaceholderText from '../../utilities/PlaceholderText/PlaceholderText';
 
-const ScholarshipActionType = ({ actionLabel }) => (
-  <div className="lg:w-1/2 lg:float-right">
-    <Header content="Action Type" />
-    <p className="pb-2">{actionLabel}</p>
-  </div>
+const ScholarshipActionType = ({ actionLabel, isLoaded }) => (
+  <>
+    {isLoaded && actionLabel ? (
+      <div className="lg:w-1/2 lg:float-right">
+        <Header content="Action Type" />
+        <p className="pb-2">{actionLabel}</p>
+      </div>
+    ) : (
+      <PlaceholderText size="medium" />
+    )}
+  </>
 );
 
 ScholarshipActionType.propTypes = {
   actionLabel: PropTypes.string.isRequired,
+  isLoaded: PropTypes.bool.isRequired,
 };
 
 export default ScholarshipActionType;

--- a/resources/assets/components/blocks/ScholarshipInfoBlock/ScholarshipActionType.js
+++ b/resources/assets/components/blocks/ScholarshipInfoBlock/ScholarshipActionType.js
@@ -4,14 +4,14 @@ import PropTypes from 'prop-types';
 import Header from './InfoHeader';
 
 const ScholarshipActionType = ({ actionLabel }) => (
-  <div>
+  <div className="lg:w-1/2 lg:float-right">
     <Header content="Action Type" />
     <p className="pb-2">{actionLabel}</p>
   </div>
 );
 
-export default ScholarshipActionType;
-
 ScholarshipActionType.propTypes = {
   actionLabel: PropTypes.string.isRequired,
 };
+
+export default ScholarshipActionType;

--- a/resources/assets/components/blocks/ScholarshipInfoBlock/ScholarshipInfoBlock.js
+++ b/resources/assets/components/blocks/ScholarshipInfoBlock/ScholarshipInfoBlock.js
@@ -86,6 +86,10 @@ const ScholarshipInfoBlock = ({
   const toggleHiddenInfo = () => {
     setDrawerOpen(!drawerOpen);
     setDetailsLabel('Less');
+
+    if (drawerOpen && detailsLabel === 'Less') {
+      setDetailsLabel('More');
+    }
   };
 
   const isLoaded = !loading;

--- a/resources/assets/components/blocks/ScholarshipInfoBlock/ScholarshipInfoBlock.js
+++ b/resources/assets/components/blocks/ScholarshipInfoBlock/ScholarshipInfoBlock.js
@@ -9,7 +9,10 @@ import PropTypes from 'prop-types';
 import { useQuery } from 'react-apollo';
 import { jsx, css } from '@emotion/core';
 
+import Header from './InfoHeader';
 import Card from '../../utilities/Card/Card';
+import ScholarshipActionType from './ScholarshipActionType';
+import ScholarshipRequirements from './ScholarshipRequirements';
 import TextContent from '../../utilities/TextContent/TextContent';
 import ScholarshipMoneyHand from '../../../images/scholarships.svg';
 import { env, getHumanFriendlyDate, report } from '../../../helpers';
@@ -39,20 +42,6 @@ const SCHOLARSHIP_AFFILIATE_QUERY = gql`
   }
 `;
 
-// @TODO: Move to Helper Components?
-const Header = ({ content, textColor }) => (
-  <div className={`font-bold uppercase ${textColor}`}>{content}</div>
-);
-
-Header.propTypes = {
-  content: PropTypes.string.isRequired,
-  textColor: PropTypes.string,
-};
-
-Header.defaultProps = {
-  textColor: 'text-gray-600',
-};
-
 const ScholarshipInfoBlock = ({
   affiliateSponsors,
   campaignId,
@@ -80,6 +69,7 @@ const ScholarshipInfoBlock = ({
     width: 1px;
     overflow: hidden;
     clip: rect(1px, 1px, 1px, 1px);
+    transition: all 0.3s ease-out;
     white-space: nowrap; /* added line */
   `;
 
@@ -202,10 +192,7 @@ const ScholarshipInfoBlock = ({
                         className="lg:w-1/2 lg:float-right"
                       >
                         {isLoaded && actionType ? (
-                          <>
-                            <Header content="Action Type" />
-                            <p className="pb-2">{actionType}</p>
-                          </>
+                          <ScholarshipActionType actionLabel={actionType} />
                         ) : (
                           <PlaceholderText size="medium" />
                         )}
@@ -213,10 +200,7 @@ const ScholarshipInfoBlock = ({
                     ) : (
                       <div className="lg:w-1/2 lg:float-right">
                         {isLoaded && actionType ? (
-                          <>
-                            <Header content="Action Type" />
-                            <p className="pb-2">{actionType}</p>
-                          </>
+                          <ScholarshipActionType actionLabel={actionType} />
                         ) : (
                           <PlaceholderText size="medium" />
                         )}
@@ -231,22 +215,10 @@ const ScholarshipInfoBlock = ({
                 <>
                   {matches.small ? (
                     <div css={!drawerOpen ? isVisible : null}>
-                      <Header content="Requirements" />
-                      <ul className="mt-2 pb-2 list-disc list-inside">
-                        <li>Under 26 years old</li>
-                        <li>No minimum GPA</li>
-                        <li>No essay</li>
-                      </ul>
+                      <ScholarshipRequirements />
                     </div>
                   ) : (
-                    <div>
-                      <Header content="Requirements" />
-                      <ul className="mt-2 pb-2 list-disc list-inside">
-                        <li>Under 26 years old</li>
-                        <li>No minimum GPA</li>
-                        <li>No essay</li>
-                      </ul>
-                    </div>
+                    <ScholarshipRequirements />
                   )}
                 </>
               )}

--- a/resources/assets/components/blocks/ScholarshipInfoBlock/ScholarshipInfoBlock.js
+++ b/resources/assets/components/blocks/ScholarshipInfoBlock/ScholarshipInfoBlock.js
@@ -3,6 +3,7 @@
 import React, { useState } from 'react';
 import { get } from 'lodash';
 import gql from 'graphql-tag';
+import Media from 'react-media';
 import PropTypes from 'prop-types';
 import { useQuery } from 'react-apollo';
 import { jsx, css } from '@emotion/core';
@@ -187,28 +188,64 @@ const ScholarshipInfoBlock = ({
                   </p>
                 </div>
               ) : null}
-              <div
-                css={!drawerOpen ? isVisible : null}
-                className="lg:w-1/2 lg:float-right"
-              >
-                {isLoaded && actionType ? (
+              <Media queries={{ small: '(max-width: 480px)' }}>
+                {matches => (
                   <>
-                    <Header content="Action Type" />
-                    <p className="pb-2">{actionType}</p>
+                    {matches.small ? (
+                      <div
+                        css={!drawerOpen ? isVisible : null}
+                        className="lg:w-1/2 lg:float-right"
+                      >
+                        {isLoaded && actionType ? (
+                          <>
+                            <Header content="Action Type" />
+                            <p className="pb-2">{actionType}</p>
+                          </>
+                        ) : (
+                          <PlaceholderText size="medium" />
+                        )}
+                      </div>
+                    ) : (
+                      <div className="lg:w-1/2 lg:float-right">
+                        {isLoaded && actionType ? (
+                          <>
+                            <Header content="Action Type" />
+                            <p className="pb-2">{actionType}</p>
+                          </>
+                        ) : (
+                          <PlaceholderText size="medium" />
+                        )}
+                      </div>
+                    )}
                   </>
-                ) : (
-                  <PlaceholderText size="medium" />
                 )}
-              </div>
+              </Media>
             </div>
-            <div css={!drawerOpen ? isVisible : null}>
-              <Header content="Requirements" />
-              <ul className="mt-2 pb-2 list-disc list-inside">
-                <li>Under 26 years old</li>
-                <li>No minimum GPA</li>
-                <li>No essay</li>
-              </ul>
-            </div>
+            <Media queries={{ small: '(max-width: 480px)' }}>
+              {matches => (
+                <>
+                  {matches.small ? (
+                    <div css={!drawerOpen ? isVisible : null}>
+                      <Header content="Requirements" />
+                      <ul className="mt-2 pb-2 list-disc list-inside">
+                        <li>Under 26 years old</li>
+                        <li>No minimum GPA</li>
+                        <li>No essay</li>
+                      </ul>
+                    </div>
+                  ) : (
+                    <div>
+                      <Header content="Requirements" />
+                      <ul className="mt-2 pb-2 list-disc list-inside">
+                        <li>Under 26 years old</li>
+                        <li>No minimum GPA</li>
+                        <li>No essay</li>
+                      </ul>
+                    </div>
+                  )}
+                </>
+              )}
+            </Media>
           </div>
           <div className="md:hidden text-center align-bottom">
             <button type="button" onClick={toggleHiddenInfo}>

--- a/resources/assets/components/blocks/ScholarshipInfoBlock/ScholarshipInfoBlock.js
+++ b/resources/assets/components/blocks/ScholarshipInfoBlock/ScholarshipInfoBlock.js
@@ -72,7 +72,7 @@ const ScholarshipInfoBlock = ({
   });
 
   const [drawerOpen, setDrawerOpen] = useState(false);
-  const [detailsLabel, setDetailsLabel] = useState('More');
+  const [detailsLabel, setDetailsLabel] = useState('Show');
 
   const isVisible = css`
     position: absolute !important;
@@ -85,10 +85,10 @@ const ScholarshipInfoBlock = ({
 
   const toggleHiddenInfo = () => {
     setDrawerOpen(!drawerOpen);
-    setDetailsLabel('Less');
+    setDetailsLabel('Hide');
 
-    if (drawerOpen && detailsLabel === 'Less') {
-      setDetailsLabel('More');
+    if (drawerOpen && detailsLabel === 'Hide') {
+      setDetailsLabel('Show');
     }
   };
 
@@ -254,7 +254,7 @@ const ScholarshipInfoBlock = ({
           </div>
           <div className="md:hidden text-center align-bottom">
             <button type="button" onClick={toggleHiddenInfo}>
-              <p className="text-sm font-bold">{`View ${detailsLabel}`}</p>
+              <p className="text-sm font-bold">{`${detailsLabel} Details`}</p>
             </button>
           </div>
         </div>

--- a/resources/assets/components/blocks/ScholarshipInfoBlock/ScholarshipInfoBlock.js
+++ b/resources/assets/components/blocks/ScholarshipInfoBlock/ScholarshipInfoBlock.js
@@ -190,20 +190,16 @@ const ScholarshipInfoBlock = ({
                   <>
                     {matches.small ? (
                       <div css={!drawerOpen ? isVisible : null}>
-                        {isLoaded && actionType ? (
-                          <ScholarshipActionType actionLabel={actionType} />
-                        ) : (
-                          <PlaceholderText size="medium" />
-                        )}
+                        <ScholarshipActionType
+                          isLoaded={isLoaded}
+                          actionLabel={actionType}
+                        />
                       </div>
                     ) : (
-                      <div className="lg:w-1/2 lg:float-right">
-                        {isLoaded && actionType ? (
-                          <ScholarshipActionType actionLabel={actionType} />
-                        ) : (
-                          <PlaceholderText size="medium" />
-                        )}
-                      </div>
+                      <ScholarshipActionType
+                        isLoaded={isLoaded}
+                        actionLabel={actionType}
+                      />
                     )}
                   </>
                 )}

--- a/resources/assets/components/blocks/ScholarshipInfoBlock/ScholarshipInfoBlock.js
+++ b/resources/assets/components/blocks/ScholarshipInfoBlock/ScholarshipInfoBlock.js
@@ -1,6 +1,7 @@
 /** @jsx jsx */
 
-import { useState } from 'react';
+// eslint-disable-next-line no-unused-vars
+import React, { useState } from 'react';
 import { get } from 'lodash';
 import gql from 'graphql-tag';
 import Media from 'react-media';

--- a/resources/assets/components/blocks/ScholarshipInfoBlock/ScholarshipInfoBlock.js
+++ b/resources/assets/components/blocks/ScholarshipInfoBlock/ScholarshipInfoBlock.js
@@ -63,13 +63,15 @@ const ScholarshipInfoBlock = ({
   const [drawerOpen, setDrawerOpen] = useState(false);
   const [detailsLabel, setDetailsLabel] = useState('Show');
 
+  const detail = css`
+    transition: all 0.3s ease-out;
+  `;
   const isVisible = css`
     position: absolute !important;
     height: 1px;
     width: 1px;
     overflow: hidden;
     clip: rect(1px, 1px, 1px, 1px);
-    transition: all 0.3s ease-out;
     white-space: nowrap; /* added line */
   `;
 

--- a/resources/assets/components/blocks/ScholarshipInfoBlock/ScholarshipInfoBlock.js
+++ b/resources/assets/components/blocks/ScholarshipInfoBlock/ScholarshipInfoBlock.js
@@ -1,13 +1,16 @@
+/** @jsx jsx */
+
 import React, { useState } from 'react';
 import { get } from 'lodash';
 import gql from 'graphql-tag';
 import PropTypes from 'prop-types';
 import { useQuery } from 'react-apollo';
+import { jsx, css } from '@emotion/core';
 
 import Card from '../../utilities/Card/Card';
-import { env, getHumanFriendlyDate, report } from '../../../helpers';
 import TextContent from '../../utilities/TextContent/TextContent';
 import ScholarshipMoneyHand from '../../../images/scholarships.svg';
+import { env, getHumanFriendlyDate, report } from '../../../helpers';
 import DoSomethingLogo from '../../utilities/DoSomethingLogo/DoSomethingLogo';
 import PlaceholderText from '../../utilities/PlaceholderText/PlaceholderText';
 
@@ -34,7 +37,7 @@ const SCHOLARSHIP_AFFILIATE_QUERY = gql`
   }
 `;
 
-// @TODO: Move to Helper Functions?
+// @TODO: Move to Helper Components?
 const Header = ({ content, textColor }) => (
   <div className={`font-bold uppercase ${textColor}`}>{content}</div>
 );
@@ -67,6 +70,16 @@ const ScholarshipInfoBlock = ({
   });
 
   const [drawerOpen, setDrawerOpen] = useState(false);
+  const [detailsLabel, setDetailsLabel] = useState('More');
+
+  const isVisible = css`
+    background-color: #f56565;
+  `;
+
+  const toggleHiddenInfo = () => {
+    setDrawerOpen(!drawerOpen);
+    setDetailsLabel('Less');
+  };
 
   const isLoaded = !loading;
   const affiliateTitle = get(data, 'affiliate.title');
@@ -169,7 +182,10 @@ const ScholarshipInfoBlock = ({
                   </p>
                 </div>
               ) : null}
-              <div className="lg:w-1/2 lg:float-right">
+              <div
+                css={drawerOpen ? isVisible : null}
+                className="lg:w-1/2 lg:float-right"
+              >
                 {isLoaded && actionType ? (
                   <>
                     <Header content="Action Type" />
@@ -180,7 +196,7 @@ const ScholarshipInfoBlock = ({
                 )}
               </div>
             </div>
-            <div>
+            <div css={drawerOpen ? isVisible : null}>
               <Header content="Requirements" />
               <ul className="mt-2 pb-2 list-disc list-inside">
                 <li>Under 26 years old</li>
@@ -190,8 +206,8 @@ const ScholarshipInfoBlock = ({
             </div>
           </div>
           <div className="md:hidden text-center align-bottom">
-            <button type="button" onClick={() => setDrawerOpen(!drawerOpen)}>
-              <p className="text-sm font-bold">View More</p>
+            <button type="button" onClick={toggleHiddenInfo}>
+              <p className="text-sm font-bold">{`View ${detailsLabel}`}</p>
             </button>
           </div>
         </div>

--- a/resources/assets/components/blocks/ScholarshipInfoBlock/ScholarshipInfoBlock.js
+++ b/resources/assets/components/blocks/ScholarshipInfoBlock/ScholarshipInfoBlock.js
@@ -73,7 +73,12 @@ const ScholarshipInfoBlock = ({
   const [detailsLabel, setDetailsLabel] = useState('More');
 
   const isVisible = css`
-    background-color: #f56565;
+    position: absolute !important;
+    height: 1px;
+    width: 1px;
+    overflow: hidden;
+    clip: rect(1px, 1px, 1px, 1px);
+    white-space: nowrap; /* added line */
   `;
 
   const toggleHiddenInfo = () => {
@@ -183,7 +188,7 @@ const ScholarshipInfoBlock = ({
                 </div>
               ) : null}
               <div
-                css={drawerOpen ? isVisible : null}
+                css={!drawerOpen ? isVisible : null}
                 className="lg:w-1/2 lg:float-right"
               >
                 {isLoaded && actionType ? (
@@ -196,7 +201,7 @@ const ScholarshipInfoBlock = ({
                 )}
               </div>
             </div>
-            <div css={drawerOpen ? isVisible : null}>
+            <div css={!drawerOpen ? isVisible : null}>
               <Header content="Requirements" />
               <ul className="mt-2 pb-2 list-disc list-inside">
                 <li>Under 26 years old</li>

--- a/resources/assets/components/blocks/ScholarshipInfoBlock/ScholarshipInfoBlock.js
+++ b/resources/assets/components/blocks/ScholarshipInfoBlock/ScholarshipInfoBlock.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { get } from 'lodash';
 import gql from 'graphql-tag';
 import PropTypes from 'prop-types';
@@ -34,6 +34,7 @@ const SCHOLARSHIP_AFFILIATE_QUERY = gql`
   }
 `;
 
+// @TODO: Move to Helper Functions?
 const Header = ({ content, textColor }) => (
   <div className={`font-bold uppercase ${textColor}`}>{content}</div>
 );
@@ -64,6 +65,8 @@ const ScholarshipInfoBlock = ({
       campaignId,
     },
   });
+
+  const [drawerOpen, setDrawerOpen] = useState(false);
 
   const isLoaded = !loading;
   const affiliateTitle = get(data, 'affiliate.title');
@@ -144,7 +147,7 @@ const ScholarshipInfoBlock = ({
         {children}
       </div>
       <div className="md:w-1/2 p-6 text-base scholarship-info-block">
-        <div className="bg-white mx-2 my-6 md:mx-6 md:my-10 p-6 rounded">
+        <div className="bg-white mx-2 my-6 md:mx-6 md:my-10 p-6 pb-2 rounded">
           {scholarshipAmount ? (
             <div>
               <Header
@@ -179,12 +182,17 @@ const ScholarshipInfoBlock = ({
             </div>
             <div>
               <Header content="Requirements" />
-              <ul className="mt-2 list-disc list-inside">
+              <ul className="mt-2 pb-2 list-disc list-inside">
                 <li>Under 26 years old</li>
                 <li>No minimum GPA</li>
                 <li>No essay</li>
               </ul>
             </div>
+          </div>
+          <div className="md:hidden text-center align-bottom">
+            <button type="button" onClick={() => setDrawerOpen(!drawerOpen)}>
+              <p className="text-sm font-bold">View More</p>
+            </button>
           </div>
         </div>
       </div>

--- a/resources/assets/components/blocks/ScholarshipInfoBlock/ScholarshipInfoBlock.js
+++ b/resources/assets/components/blocks/ScholarshipInfoBlock/ScholarshipInfoBlock.js
@@ -1,6 +1,6 @@
 /** @jsx jsx */
 
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { get } from 'lodash';
 import gql from 'graphql-tag';
 import Media from 'react-media';

--- a/resources/assets/components/blocks/ScholarshipInfoBlock/ScholarshipInfoBlock.js
+++ b/resources/assets/components/blocks/ScholarshipInfoBlock/ScholarshipInfoBlock.js
@@ -63,9 +63,9 @@ const ScholarshipInfoBlock = ({
   const [drawerOpen, setDrawerOpen] = useState(false);
   const [detailsLabel, setDetailsLabel] = useState('Show');
 
-  const detail = css`
-    transition: all 0.3s ease-out;
-  `;
+  // const detail = css`
+  //   transition: all 0.3s ease-out;
+  // `;
   const isVisible = css`
     position: absolute !important;
     height: 1px;
@@ -189,10 +189,7 @@ const ScholarshipInfoBlock = ({
                 {matches => (
                   <>
                     {matches.small ? (
-                      <div
-                        css={!drawerOpen ? isVisible : null}
-                        className="lg:w-1/2 lg:float-right"
-                      >
+                      <div css={!drawerOpen ? isVisible : null}>
                         {isLoaded && actionType ? (
                           <ScholarshipActionType actionLabel={actionType} />
                         ) : (

--- a/resources/assets/components/blocks/ScholarshipInfoBlock/ScholarshipRequirements.js
+++ b/resources/assets/components/blocks/ScholarshipInfoBlock/ScholarshipRequirements.js
@@ -1,0 +1,16 @@
+import React from 'react';
+
+import Header from './InfoHeader';
+
+const ScholarshipRequirements = () => (
+  <div>
+    <Header content="Requirements" />
+    <ul className="mt-2 pb-2 list-disc list-inside">
+      <li>Under 26 years old</li>
+      <li>No minimum GPA</li>
+      <li>No essay</li>
+    </ul>
+  </div>
+);
+
+export default ScholarshipRequirements;

--- a/resources/assets/images/Carat.svg
+++ b/resources/assets/images/Carat.svg
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="34px" height="17px" viewBox="0 0 34 17" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 59.1 (86144) - https://sketch.com -->
+    <title>Path 3</title>
+    <desc>Created with Sketch.</desc>
+    <g id="Components" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" stroke-linecap="round">
+        <g id="Icons" transform="translate(-172.000000, -97.000000)" stroke="#202020" stroke-width="4">
+            <g transform="translate(32.000000, 32.000000)" id="Carat">
+                <g transform="translate(132.000000, 48.000000)">
+                    <path d="M10,19 L23.5656332,31.4395059 C24.3519049,32.1605067 25.6247073,32.1631673 26.4150067,31.4395059 L40,19" id="Path-3"></path>
+                </g>
+            </g>
+        </g>
+    </g>
+</svg>

--- a/resources/assets/images/menu_carat.svg
+++ b/resources/assets/images/menu_carat.svg
@@ -1,0 +1,1 @@
+<svg width="34" height="17" viewBox="0 0 34 17" xmlns="http://www.w3.org/2000/svg"><path d="M2 2l13.566 12.44c.786.72 2.059.723 2.849 0L32 2" stroke="#202020" stroke-width="4" fill="none" fill-rule="evenodd" stroke-linecap="round"/></svg>


### PR DESCRIPTION
### What's this PR do?

This pull request is adding an improvement for the mobile experience of the users seeing scholarship modals. On mobile, the non-essential details of the scholarship card will be hidden under a 'view more' drawer, and when clicked the drawer will slide down to show the rest. 

### How should this be reviewed?

This should be one of two PRs on this feature add. As of right now, the 'Show Details' options should be visible only on mobile. If clicked, it should 'show' the `Action Type` and `Requirements` and update to say 'Hide Details'. If 'Hide Details' is clicked, they should be hidden again. 

The modal should look as it normally does on medium and large screens. 

Preview App: https://dosomething-phoenix-de-pr-1849.herokuapp.com/us/campaigns/test-teens-for-jeans?utm_source=scholarship&utm_campaign=fastweb

### Any background context you want to provide?

I went back and forth on a few different options for implementation here, so if there is a "cleaner" way you have encountered in the past let me know!

### Relevant tickets

References [Pivotal # 169929291](https://www.pivotaltracker.com/story/show/169929291).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added screenshots of front-end changes on small, medium, and large screens.
- [ ] Added appropriate feature/unit tests.
