### PR TITLE
Lede banner cleanup cleanup

### DIFF
--- a/resources/assets/components/pages/LandingPage/LandingPage.js
+++ b/resources/assets/components/pages/LandingPage/LandingPage.js
@@ -3,20 +3,104 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
+import Enclosure from '../../Enclosure';
+import Card from '../../utilities/Card/Card';
+import { getScholarshipAffiliateLabel } from '../../../helpers';
+import TextContent from '../../utilities/TextContent/TextContent';
 import LedeBannerContainer from '../../LedeBanner/LedeBannerContainer';
+import CallToActionContainer from '../../CallToAction/CallToActionContainer';
+import CampaignInfoBarContainer from '../../CampaignInfoBar/CampaignInfoBarContainer';
+import AffiliateScholarshipBlockQuery from '../../blocks/AffiliateScholarshipBlock/AffiliateScholarshipBlockQuery';
 
 const LandingPage = props => {
-  const { isCampaignClosed } = props;
+  const {
+    campaignId,
+    content,
+    isCampaignClosed,
+    featureFlagUseLegacyTemplate,
+    scholarshipAmount,
+    scholarshipDeadline,
+    sidebarCTA,
+    tagline,
+  } = props;
+  const scholarshipAffiliateLabel = getScholarshipAffiliateLabel();
+  const displayAffiliateScholarshipBlock =
+    scholarshipAffiliateLabel && scholarshipAmount && scholarshipDeadline;
 
-  return <LedeBannerContainer isClosed={isCampaignClosed} />;
+  return (
+    <React.Fragment>
+      <LedeBannerContainer isClosed={isCampaignClosed} />
+      {featureFlagUseLegacyTemplate ? (
+        <>
+          <div className="bg-white">
+            <Enclosure className="md:w-3/4 mx-auto py-6 px-3 pitch-landing-page">
+              <div className="campaign-page clearfix">
+                <div className="primary">
+                  {displayAffiliateScholarshipBlock ? (
+                    <AffiliateScholarshipBlockQuery
+                      campaignId={Number(campaignId)}
+                      utmLabel={scholarshipAffiliateLabel.toLowerCase()}
+                      scholarshipAmount={scholarshipAmount}
+                      scholarshipDeadline={scholarshipDeadline}
+                      className="mb-6"
+                    />
+                  ) : null}
+
+                  <TextContent>{content}</TextContent>
+                </div>
+                <div className="secondary">
+                  <Card title={sidebarCTA.title} className="rounded bordered">
+                    <TextContent className="p-3">
+                      {sidebarCTA.content}
+                    </TextContent>
+                  </Card>
+                </div>
+              </div>
+            </Enclosure>
+          </div>
+
+          <CallToActionContainer
+            className="bg-gray-100-important border-t border-solid border-gray-300 font-bold px-3 md:px-6 py-6 text-base md:text-lg"
+            content={tagline}
+          />
+
+          <CampaignInfoBarContainer />
+
+          <div className="info-bar bg-gray-700">
+            <div className="wrapper">
+              A DoSomething.org campaign. Join millions of young people
+              transforming their communities. Let&#39;s Do This!
+            </div>
+          </div>
+        </>
+      ) : null}
+    </React.Fragment>
+  );
 };
 
 LandingPage.propTypes = {
+  campaignId: PropTypes.string.isRequired,
+  content: PropTypes.string.isRequired,
+  featureFlagUseLegacyTemplate: PropTypes.bool,
   isCampaignClosed: PropTypes.bool,
+  scholarshipAmount: PropTypes.number,
+  scholarshipDeadline: PropTypes.string,
+  sidebarCTA: PropTypes.shape({
+    title: PropTypes.string,
+    content: PropTypes.string,
+  }),
+  tagline: PropTypes.string.isRequired,
 };
 
 LandingPage.defaultProps = {
+  featureFlagUseLegacyTemplate: false,
   isCampaignClosed: false,
+  scholarshipAmount: null,
+  scholarshipDeadline: null,
+  sidebarCTA: {
+    title: 'what you get',
+    content: '*You could win a $5,000 dollar scholarship!*',
+  },
 };
 
 export default LandingPage;

--- a/resources/assets/components/pages/LandingPage/LandingPage.js
+++ b/resources/assets/components/pages/LandingPage/LandingPage.js
@@ -21,6 +21,7 @@ const LandingPage = props => {
     scholarshipAmount,
     scholarshipDeadline,
     sidebarCTA,
+    signupArrowContent,
     tagline,
   } = props;
   const scholarshipAffiliateLabel = getScholarshipAffiliateLabel();
@@ -29,7 +30,10 @@ const LandingPage = props => {
 
   return (
     <React.Fragment>
-      <LedeBannerContainer isClosed={isCampaignClosed} />
+      <LedeBannerContainer
+        isClosed={isCampaignClosed}
+        signupArrowContent={signupArrowContent}
+      />
       {featureFlagUseLegacyTemplate ? (
         <>
           <div className="bg-white">
@@ -89,7 +93,8 @@ LandingPage.propTypes = {
     title: PropTypes.string,
     content: PropTypes.string,
   }),
-  tagline: PropTypes.string.isRequired,
+  signupArrowContent: PropTypes.string,
+  tagline: PropTypes.string,
 };
 
 LandingPage.defaultProps = {
@@ -101,6 +106,8 @@ LandingPage.defaultProps = {
     title: 'what you get',
     content: '*You could win a $5,000 dollar scholarship!*',
   },
+  signupArrowContent: null,
+  tagline: 'Ready to start?',
 };
 
 export default LandingPage;

--- a/resources/assets/components/pages/LandingPage/LandingPageContainer.js
+++ b/resources/assets/components/pages/LandingPage/LandingPageContainer.js
@@ -14,8 +14,22 @@ const mapStateToProps = (state, ownProps) => {
   const landingPage = get(ownProps, 'landingPage.fields', ownProps);
 
   return {
+    campaignId: state.campaign.campaignId,
+    content: landingPage.content,
+    featureFlagUseLegacyTemplate: get(
+      state,
+      'campaign.additionalContent.featureFlagUseLegacyTemplate',
+    ),
     isCampaignClosed: isCampaignClosed(state.campaign.endDate),
+    scholarshipAmount: state.campaign.scholarshipAmount,
+    scholarshipDeadline: state.campaign.scholarshipDeadline,
     sidebar: landingPage.sidebar,
+    signupArrowContent: get(
+      state.campaign.additionalContent,
+      'signupArrowContent',
+      null,
+    ),
+    tagline: get(state.campaign.additionalContent, 'tagline'),
   };
 };
 


### PR DESCRIPTION
### What's this PR do?

This resolves an issue with my lede banner cleanup where we weren't actually rendering content beneath the lede banner of legacy campaigns. The old PitchTemplate actually grabbed content beneath the lede banner and rendered that, we've brought that forward into the LandingPage component. 

This should only be relevant until the NFL and Taco Bell campaigns close, then we won't be supporting legacy campaigns anymore.

### How should this be reviewed?

Check out a legacy campaign for visual bugs

### Relevant tickets

References [Pivotal #170630923](https://www.pivotaltracker.com/story/show/170630923).
![Screenshot_2020-01-14 You've Got the Power](https://user-images.githubusercontent.com/1865372/72366648-aa7e8980-36c8-11ea-9dfc-e9e63e86b429.png)
