### PR TITLE
Scholarship Signup Button Tracking

### DIFF
--- a/resources/assets/components/LedeBanner/templates/HeroTemplate.js
+++ b/resources/assets/components/LedeBanner/templates/HeroTemplate.js
@@ -106,6 +106,7 @@ const HeroTemplate = ({
                         ? SCHOLARSHIP_SIGNUP_BUTTON_TEXT
                         : undefined
                     }
+                    contextSource="campaign_landing_page"
                   />
                   {affiliateOptInContent ? (
                     <AffiliateOptInToggleContainer
@@ -141,7 +142,7 @@ const HeroTemplate = ({
                 <SignupButtonContainer
                   className="w-full md:px-2"
                   text={SCHOLARSHIP_SIGNUP_BUTTON_TEXT}
-                  trackingId="scholarship_modal"
+                  contextSource="scholarship_modal"
                 />
               </div>
             </ScholarshipInfoBlock>

--- a/resources/assets/components/LedeBanner/templates/HeroTemplate.js
+++ b/resources/assets/components/LedeBanner/templates/HeroTemplate.js
@@ -141,7 +141,7 @@ const HeroTemplate = ({
                 <SignupButtonContainer
                   className="w-full md:px-2"
                   text={SCHOLARSHIP_SIGNUP_BUTTON_TEXT}
-                  modal_type="scholarship_modal"
+                  trackingId="scholarship_modal"
                 />
               </div>
             </ScholarshipInfoBlock>

--- a/resources/assets/components/LedeBanner/templates/HeroTemplate.js
+++ b/resources/assets/components/LedeBanner/templates/HeroTemplate.js
@@ -141,6 +141,7 @@ const HeroTemplate = ({
                 <SignupButtonContainer
                   className="w-full md:px-2"
                   text={SCHOLARSHIP_SIGNUP_BUTTON_TEXT}
+                  modal_type="scholarship_modal"
                 />
               </div>
             </ScholarshipInfoBlock>

--- a/resources/assets/components/SignupButton/SignupButton.js
+++ b/resources/assets/components/SignupButton/SignupButton.js
@@ -11,12 +11,12 @@ const SignupButton = props => {
     campaignId,
     campaignTitle,
     className,
+    contextSource,
     disableSignup,
     endDate,
     pageId,
     storeCampaignSignup,
     text,
-    trackingId,
   } = props;
 
   // Decorate click handler for A/B tests & analytics.
@@ -43,7 +43,7 @@ const SignupButton = props => {
       },
       analytics: {
         context: {
-          modalType: trackingId,
+          contextSource,
           pageId,
         },
         label: campaignTitle,
@@ -74,12 +74,12 @@ SignupButton.propTypes = {
   campaignId: PropTypes.string.isRequired,
   campaignTitle: PropTypes.string,
   className: PropTypes.string,
+  contextSource: PropTypes.string,
   disableSignup: PropTypes.bool,
   endDate: PropTypes.string,
   pageId: PropTypes.string.isRequired,
   storeCampaignSignup: PropTypes.func.isRequired,
   text: PropTypes.string,
-  trackingId: PropTypes.string,
 };
 
 SignupButton.defaultProps = {
@@ -87,10 +87,10 @@ SignupButton.defaultProps = {
   campaignActionText: 'Take Action',
   campaignTitle: null,
   className: null,
+  contextSource: null,
   disableSignup: false,
   endDate: null,
   text: null,
-  trackingId: null,
 };
 
 export default SignupButton;

--- a/resources/assets/components/SignupButton/SignupButton.js
+++ b/resources/assets/components/SignupButton/SignupButton.js
@@ -16,6 +16,7 @@ const SignupButton = props => {
     pageId,
     storeCampaignSignup,
     text,
+    trackingId,
   } = props;
 
   // Decorate click handler for A/B tests & analytics.
@@ -42,6 +43,7 @@ const SignupButton = props => {
       },
       analytics: {
         context: {
+          modalType: trackingId,
           pageId,
         },
         label: campaignTitle,
@@ -77,6 +79,7 @@ SignupButton.propTypes = {
   pageId: PropTypes.string.isRequired,
   storeCampaignSignup: PropTypes.func.isRequired,
   text: PropTypes.string,
+  trackingId: PropTypes.string,
 };
 
 SignupButton.defaultProps = {
@@ -87,6 +90,7 @@ SignupButton.defaultProps = {
   disableSignup: false,
   endDate: null,
   text: null,
+  trackingId: null,
 };
 
 export default SignupButton;

--- a/resources/assets/components/utilities/CtaPopover/CtaPopoverEmailForm.js
+++ b/resources/assets/components/utilities/CtaPopover/CtaPopoverEmailForm.js
@@ -17,7 +17,7 @@ const CtaPopoverEmailForm = ({ handleComplete }) => {
 
   const handleFocus = () => {
     trackAnalyticsEvent({
-      context: { cta_type: 'newsletter_scholarships' },
+      context: { contextSource: 'newsletter_scholarships' },
       metadata: {
         adjective: 'email',
         category: 'site_action',
@@ -32,7 +32,7 @@ const CtaPopoverEmailForm = ({ handleComplete }) => {
     event.preventDefault();
 
     trackAnalyticsEvent({
-      context: { cta_type: 'newsletter_scholarships' },
+      context: { contextSource: 'newsletter_scholarships' },
       metadata: {
         category: 'site_action',
         noun: 'call_to_action_popover',
@@ -70,7 +70,11 @@ const CtaPopoverEmailForm = ({ handleComplete }) => {
         }
 
         trackAnalyticsEvent({
-          context: { cta_type: 'newsletter_scholarships', error, errorMessage },
+          context: {
+            contextSource: 'newsletter_scholarships',
+            error,
+            errorMessage,
+          },
           metadata: {
             category: 'site_action',
             noun: 'call_to_action_popover_submission',


### PR DESCRIPTION
### What's this PR do?

This pull request adds a `modalType` flag to the signup button `context` section of `scholarship_modal` if a user signs up via the modal vs the campaign page. 

### How should this be reviewed?

Does the general logic of the implementation make sense? Also do you see any strong reasons for or against using the `modalType` naming vs something different? 

### Any background context you want to provide?

This is actually very similar to how we are doing tracking for all modals. see #1838 
Check in on the conversation in the pivotal ticket for the reasoning behind naming etc. @mendelB and I were thinking it would make more sense from the dev perspective to choose a name related to `source`, but I do also want to take consideration from the data team on this since they will be pulling this info in the end. 

### Relevant tickets

References [Pivotal # 170053904](https://www.pivotaltracker.com/story/show/170053904).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added screenshots of front-end changes on small, medium, and large screens.
- [ ] Added appropriate feature/unit tests.
