### PR TITLE
Zendesk Ticket Modal in Campaign Info Bar

### DIFF
--- a/cypress/fixtures/contentful/exampleCampaign.js
+++ b/cypress/fixtures/contentful/exampleCampaign.js
@@ -38,9 +38,15 @@ export default {
         active: true,
         jobTitle: 'Staff Engineer',
         email: 'dfurnes@dosomething.org',
-        photo: null,
-        alternatePhoto:
-          'https://images.ctfassets.net/81iqaqpfd8fy/3p0etbv0zYwYEso4AQysuS/4c571d69357c1fbc78bbd09d3e137c94/Dave_Furnes_Kid_Picture.png',
+        photo: {
+          url: null,
+          description: null,
+        },
+        alternatePhoto: {
+          url:
+            'https://images.ctfassets.net/81iqaqpfd8fy/3p0etbv0zYwYEso4AQysuS/4c571d69357c1fbc78bbd09d3e137c94/Dave_Furnes_Kid_Picture.png',
+          description: null,
+        },
         description: null,
         twitterId: 'dfurnes',
       },
@@ -76,7 +82,10 @@ export default {
           slug: 'test-example-campaign/action',
           metadata: null,
           authors: [],
-          coverImage: { description: '', url: null },
+          coverImage: {
+            description: '',
+            url: null,
+          },
           content: null,
           sidebar: [],
           blocks: [
@@ -89,8 +98,11 @@ export default {
                 subTitle: null,
                 content:
                   'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed venenatis eleifend diam, sit amet imperdiet mi porttitor luctus. Etiam luctus sem nec nunc aliquam, et interdum arcu pellentesque. Duis dictum nibh vel nibh dignissim condimentum. Phasellus vel varius ante. Vivamus finibus quam quis justo venenatis, eu porta dolor porta.',
-                image: { url: null, description: null },
-                imageAlignment: 'right',
+                image: {
+                  url: null,
+                  description: null,
+                },
+                imageAlignment: null,
                 additionalContent: null,
               },
             },
@@ -117,11 +129,14 @@ export default {
               fields: {
                 superTitle: 'Step 2',
                 title: 'Prove It',
-                subTitle: null,
+                subTitle: 'Just small change to know what this does',
                 content:
-                  'Vestibulum rhoncus tellus vitae sem tempor volutpat. Duis quam metus, dictum id mollis et, imperdiet a sapien. Pellentesque tincidunt vehicula ex vel sodales. Morbi elementum sem mauris, at euismod urna elementum vulputate. Nulla bibendum augue sit amet est lacinia feugiat in imperdiet lectus.',
-                image: { url: null, description: null },
-                imageAlignment: 'right',
+                  'Vestibulum rhoncus tellus vitae sem tempor volutpat. Duis quam metus, dictum id mollis et, imperdiet a sapien. Pellentesque tincidunt vehicula ex vel sodales. Morbi elementum sem mauris, at euismod urna elementum vulputate. Nulla bibendum augue sit amet est lacinia feugiat in imperdiet lectus.\n',
+                image: {
+                  url: null,
+                  description: null,
+                },
+                imageAlignment: null,
                 additionalContent: null,
               },
             },
@@ -136,6 +151,7 @@ export default {
                 showQuantityField: true,
                 quantityFieldLabel: null,
                 quantityFieldPlaceholder: null,
+                numberOfParticipantsFieldLabel: null,
                 whyParticipatedFieldLabel: null,
                 whyParticipatedFieldPlaceholder: null,
                 buttonText: null,
@@ -163,6 +179,29 @@ export default {
           socialOverride: null,
         },
       },
+      {
+        id: '2Ju2Efyg6WPlrDfGATSyEw',
+        type: 'page',
+        fields: {
+          internalTitle: "[Test] Example Campaign FAQ's Page",
+          title: "FAQ's",
+          subTitle: null,
+          slug: 'test-example-campaign/faqs',
+          metadata: null,
+          authors: [],
+          coverImage: {
+            description: '',
+            url: null,
+          },
+          content:
+            '# Here are some commonly asked questions:\n\n## Why?\nBecause.',
+          sidebar: [],
+          blocks: [],
+          displaySocialShare: null,
+          hideFromNavigation: null,
+          socialOverride: null,
+        },
+      },
     ],
     landingPage: {
       id: '1Y1b56hDTnpx1HOj6qebt',
@@ -185,7 +224,9 @@ export default {
     staffPick: true,
     cause: 'animals',
     scholarshipAmount: 5000,
+    scholarshipCallToAction: null,
     scholarshipDeadline: '2020-06-24T00:00:00Z',
+    scholarshipDescription: null,
     affiliateOptInContent: null,
   },
 };

--- a/cypress/integration/campaign-info-bar.js
+++ b/cypress/integration/campaign-info-bar.js
@@ -1,0 +1,44 @@
+/// <reference types="Cypress" />
+import { userFactory } from '../fixtures/user';
+import exampleCampaign from '../fixtures/contentful/exampleCampaign';
+
+describe('Campaign Info Bar', () => {
+  beforeEach(() => cy.configureMocks());
+
+  it('Displays the affiliate sponsors or partners', () => {
+    const affiliateTitle =
+      exampleCampaign.campaign.affiliateSponsors[0].fields.title;
+
+    cy.withState(exampleCampaign).visit('/us/campaigns/test-example-campaign');
+
+    cy.get('.info-bar').should('contain', affiliateTitle);
+  });
+
+  context('Unaffiliated users', () => {
+    it("Displays a mailto link to the campaign lead's email address", () => {
+      const campaignLeadEmail =
+        exampleCampaign.campaign.campaignLead.fields.email;
+
+      cy.withState(exampleCampaign).visit(
+        '/us/campaigns/test-example-campaign',
+      );
+
+      cy.get('.info-bar .info-bar__secondary a')
+        .should('have.attr', 'href')
+        .and('include', `mailto:${campaignLeadEmail}`);
+    });
+  });
+
+  context('Affiliated users', () => {
+    it('Displays a button triggering the Zendesk Form in a modal', () => {
+      const user = userFactory();
+      cy.authVisitCampaignWithSignup(user, exampleCampaign);
+
+      cy.get('.info-bar .info-bar__secondary button')
+        .contains('button', 'Contact Us')
+        .click();
+
+      cy.get('.modal .zendesk-form').contains('h1', 'Contact Us');
+    });
+  });
+});

--- a/cypress/integration/zendesk-form.js
+++ b/cypress/integration/zendesk-form.js
@@ -1,0 +1,44 @@
+/// <reference types="Cypress" />
+import { userFactory } from '../fixtures/user';
+import exampleCampaign from '../fixtures/contentful/exampleCampaign';
+
+const QUESTION = 'causeyhippo';
+
+describe('Zendesk Modal', () => {
+  beforeEach(() => {
+    cy.configureMocks();
+
+    const user = userFactory();
+    cy.authVisitCampaignWithSignup(user, exampleCampaign);
+
+    cy.get('.info-bar .info-bar__secondary button')
+      .contains('button', 'Contact Us')
+      .click();
+
+    cy.get('.modal .zendesk-form').contains('h1', 'Contact Us');
+    cy.get('a.zendesk-form__faqs-link')
+      .should('have.attr', 'href')
+      .and('include', `/us/campaigns/${exampleCampaign.campaign.slug}/faqs`);
+  });
+
+  it('Submits a question successfully and displays affirmation', () => {
+    cy.route('POST', '/api/v2/zendesk-tickets', []);
+
+    cy.get('.zendesk-form textarea').type(QUESTION);
+
+    cy.get('.zendesk-form button').click();
+
+    cy.get('.zendesk-form h1').contains('Thank You');
+  });
+
+  it('Submits a question unsuccessfully and displays error message', () => {
+    cy.route({ method: 'POST', url: '/api/v2/zendesk-tickets', status: 500 });
+
+    cy.get('.zendesk-form textarea').type(QUESTION);
+    cy.get('.zendesk-form button').click();
+
+    cy.get('.zendesk-form h1').contains('Contact Us');
+    cy.get('.zendesk-form').contains('Something went wrong!');
+    cy.get('.zendesk-form textarea').contains(QUESTION);
+  });
+});

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -30,6 +30,7 @@
   - [Affiliate Scholarship Block](development/features/affiliate-scholarship-block.md)
   - [Analytics Waypoint](development/features/analytics-waypoint.md)
   - [Refer A Friend](development/features/referral-pages.md)
+  - [Zendesk Form](development/features/zendesk-form.md)
 - [Contentful](development/contentful/README.md)
   - [Workflow](development/contentful/workflow.md)
   - [Content Management API Scripts](development/contentful/content-management-api-scripts.md)

--- a/docs/development/features/zendesk-form.md
+++ b/docs/development/features/zendesk-form.md
@@ -1,0 +1,13 @@
+# Zendesk Form
+
+The `ZendeskForm` component presents a form interface for campaign-affiliated users to submit questions to our Zendesk helpdesk.
+
+It'll also present a link to the Campaign's FAQs page if available, or our Help center otherwise.
+
+The form submits via the internal `api/v2/zendesk-tickets` API which creates a new Zendesk Ticket for the user.
+
+## Usage Instructions
+
+Render the `<ZendeskFormContainer/>` component from any page with a valid `campaign` in Redux state.
+
+Be sure to render the `ZendeskFormContainer` conditionally for affiliated users, since the zendesk tickets endpoint is gated and requires an authenticated user. Additionally, we prefer to only render the form for users signed up for the campaign.

--- a/docs/development/features/zendesk-form.md
+++ b/docs/development/features/zendesk-form.md
@@ -11,3 +11,7 @@ The form submits via the internal `api/v2/zendesk-tickets` API which creates a n
 Render the `<ZendeskFormContainer/>` component from any page with a valid `campaign` in Redux state.
 
 Be sure to render the `ZendeskFormContainer` conditionally for affiliated users, since the zendesk tickets endpoint is gated and requires an authenticated user. Additionally, we prefer to only render the form for users signed up for the campaign.
+
+{% hint style="info" %}
+If testing the Zendesk form, use 'causeyhippo' as the question text which will trigger an automatic resolve and categorization over in our Zendesk space.
+{% endhint %}

--- a/resources/assets/components/CampaignInfoBar/CampaignInfoBar.js
+++ b/resources/assets/components/CampaignInfoBar/CampaignInfoBar.js
@@ -1,34 +1,59 @@
-import React from 'react';
 import PropTypes from 'prop-types';
+import React, { useState } from 'react';
 
+import Modal from '../utilities/Modal/Modal';
 import AffiliateCredits from '../utilities/AffiliateCredits/AffiliateCredits';
+import ZendeskFormContainer from '../utilities/ZendeskForm/ZendeskFormContainer';
 
 const CampaignInfoBar = ({
   affiliateCreditText,
   affiliateSponsors,
   affiliatePartners,
   contactEmail,
-}) => (
-  <div className="info-bar bg-gray-700">
-    <div className="clearfix md:w-3/4 mx-auto px-3 py-6">
-      <AffiliateCredits
-        affiliateCreditText={affiliateCreditText}
-        affiliateSponsors={affiliateSponsors}
-        affiliatePartners={affiliatePartners}
-      />
+  isAffiliated,
+}) => {
+  const [showZendeskModal, updateShowZendeskModal] = useState(false);
 
-      <div className="info-bar__secondary">
-        Questions? <a href={`mailto:${contactEmail}`}>Contact {contactEmail}</a>
+  return (
+    <div className="info-bar bg-gray-700">
+      {showZendeskModal ? (
+        <Modal onClose={() => updateShowZendeskModal(false)}>
+          <ZendeskFormContainer />
+        </Modal>
+      ) : null}
+
+      <div className="clearfix md:w-3/4 mx-auto px-3 py-6">
+        <AffiliateCredits
+          affiliateCreditText={affiliateCreditText}
+          affiliateSponsors={affiliateSponsors}
+          affiliatePartners={affiliatePartners}
+        />
+
+        <div className="info-bar__secondary">
+          Questions?{' '}
+          {isAffiliated ? (
+            <button
+              type="button"
+              className="underline"
+              onClick={() => updateShowZendeskModal(true)}
+            >
+              Contact Us
+            </button>
+          ) : (
+            <a href={`mailto:${contactEmail}`}>Contact {contactEmail}</a>
+          )}
+        </div>
       </div>
     </div>
-  </div>
-);
+  );
+};
 
 CampaignInfoBar.propTypes = {
   affiliateCreditText: PropTypes.string,
   affiliateSponsors: PropTypes.arrayOf(PropTypes.object),
   affiliatePartners: PropTypes.arrayOf(PropTypes.object),
   contactEmail: PropTypes.string,
+  isAffiliated: PropTypes.bool,
 };
 
 CampaignInfoBar.defaultProps = {
@@ -36,6 +61,7 @@ CampaignInfoBar.defaultProps = {
   affiliateSponsors: [],
   affiliatePartners: [],
   contactEmail: 'help@dosomething.org',
+  isAffiliated: false,
 };
 
 export default CampaignInfoBar;

--- a/resources/assets/components/CampaignInfoBar/CampaignInfoBar.js
+++ b/resources/assets/components/CampaignInfoBar/CampaignInfoBar.js
@@ -12,12 +12,12 @@ const CampaignInfoBar = ({
   contactEmail,
   isAffiliated,
 }) => {
-  const [showZendeskModal, updateShowZendeskModal] = useState(false);
+  const [showZendeskModal, setShowZendeskModal] = useState(false);
 
   return (
     <div className="info-bar bg-gray-700">
       {showZendeskModal ? (
-        <Modal onClose={() => updateShowZendeskModal(false)}>
+        <Modal onClose={() => setShowZendeskModal(false)}>
           <ZendeskFormContainer />
         </Modal>
       ) : null}
@@ -35,7 +35,7 @@ const CampaignInfoBar = ({
             <button
               type="button"
               className="underline"
-              onClick={() => updateShowZendeskModal(true)}
+              onClick={() => setShowZendeskModal(true)}
             >
               Contact Us
             </button>

--- a/resources/assets/components/CampaignInfoBar/CampaignInfoBarContainer.js
+++ b/resources/assets/components/CampaignInfoBar/CampaignInfoBarContainer.js
@@ -2,6 +2,7 @@ import { get } from 'lodash';
 import { connect } from 'react-redux';
 
 import CampaignInfoBar from './CampaignInfoBar';
+import { isSignedUp } from '../../selectors/signup';
 
 const mapStateToProps = state => {
   return {
@@ -13,6 +14,7 @@ const mapStateToProps = state => {
     affiliateSponsors: state.campaign.affiliateSponsors,
     affiliatePartners: state.campaign.affiliatePartners,
     contactEmail: get(state, 'campaign.campaignLead.fields.email', undefined),
+    isAffiliated: isSignedUp(state),
   };
 };
 

--- a/resources/assets/components/blocks/ErrorBlock/ErrorBlock.js
+++ b/resources/assets/components/blocks/ErrorBlock/ErrorBlock.js
@@ -4,8 +4,8 @@ import PropTypes from 'prop-types';
 import errorIcon from './error_icon.svg';
 import { report } from '../../../helpers';
 import Card from '../../utilities/Card/Card';
+import { HELP_REQUEST_LINK } from '../../../constants';
 
-const HELP_LINK = 'https://help.dosomething.org/hc/en-us/requests/new';
 const DEBUGGING = process.env.NODE_ENV !== 'production';
 
 const ErrorBlock = ({ error }) => {
@@ -20,7 +20,7 @@ const ErrorBlock = ({ error }) => {
       <img src={errorIcon} alt="Error" className="mx-auto my-8" />
       <p className="text-center my-4">
         <strong>Something went wrong!</strong> Try refreshing the page or{' '}
-        <a href={HELP_LINK}>reach out</a> to us.
+        <a href={HELP_REQUEST_LINK}>reach out</a> to us.
       </p>
       {DEBUGGING && error ? (
         <p className="color-error text-center my-4">

--- a/resources/assets/components/utilities/ZendeskForm/ZendeskForm.js
+++ b/resources/assets/components/utilities/ZendeskForm/ZendeskForm.js
@@ -36,7 +36,7 @@ const ZendeskForm = ({ campaignName, faqsLink, token }) => {
 
   return (
     <Card title={title} className="rounded bordered zendesk-form">
-      {!status.success ? (
+      {status.success ? (
         <p className="p-3 pb-6">
           Thanks for reaching out! We&apos;ve received your submission and will
           be in touch in 1-2 business days.

--- a/resources/assets/components/utilities/ZendeskForm/ZendeskForm.js
+++ b/resources/assets/components/utilities/ZendeskForm/ZendeskForm.js
@@ -36,8 +36,8 @@ const ZendeskForm = ({ campaignName, faqsLink, token }) => {
 
   return (
     <Card title={title} className="rounded bordered zendesk-form">
-      {status.success ? (
-        <p className="p-3">
+      {!status.success ? (
+        <p className="p-3 pb-6">
           Thanks for reaching out! We&apos;ve received your submission and will
           be in touch in 1-2 business days.
         </p>

--- a/resources/assets/components/utilities/ZendeskForm/ZendeskFormContainer.js
+++ b/resources/assets/components/utilities/ZendeskForm/ZendeskFormContainer.js
@@ -1,0 +1,17 @@
+import { connect } from 'react-redux';
+
+import ZendeskForm from './ZendeskForm';
+import { getUserToken } from '../../../selectors/user';
+import { getCampaignFaqsPath } from '../../../selectors/campaign';
+
+/**
+ * Provide state from the Redux store as props for this component.
+ */
+const mapStateToProps = state => ({
+  token: getUserToken(state),
+  campaignName: state.campaign.title,
+  faqsLink: getCampaignFaqsPath(state),
+});
+
+// Export the container component.
+export default connect(mapStateToProps)(ZendeskForm);

--- a/resources/assets/constants/index.js
+++ b/resources/assets/constants/index.js
@@ -37,3 +37,8 @@ export const REGISTER_CTA_COPY = {
 // Signup Button text for scholarship referrals:
 export const SCHOLARSHIP_SIGNUP_BUTTON_TEXT = 'Apply Now!';
 
+// Help Center URL:
+export const HELP_LINK = 'https://help.dosomething.org/hc/en-us';
+
+// Help center - new ticket view URL:
+export const HELP_REQUEST_LINK = `${HELP_LINK}/requests/new`;

--- a/resources/assets/constants/index.js
+++ b/resources/assets/constants/index.js
@@ -37,6 +37,3 @@ export const REGISTER_CTA_COPY = {
 // Signup Button text for scholarship referrals:
 export const SCHOLARSHIP_SIGNUP_BUTTON_TEXT = 'Apply Now!';
 
-// Zendesk (sandbox) API endpoint:
-export const ZENDESK_API_ENDPOINT =
-  'https://dosomethingorg11412693296.zendesk.com/api/v2/requests.json';

--- a/resources/assets/selectors/campaign.js
+++ b/resources/assets/selectors/campaign.js
@@ -32,4 +32,23 @@ export function getCampaignDataForNorthstar(state) {
   };
 }
 
+/**
+ * Get path to Campaign FAQs page.
+ *
+ * @param  {Object} state
+ * @return {String|Undefined}
+ */
+export function getCampaignFaqsPath(state) {
+  // Find the FAQs page & grab its slug value.
+  const faqsSlug = get(
+    state.campaign.pages.find(page =>
+      get(page, 'fields.slug', '').endsWith('/faqs'),
+    ),
+    'fields.slug',
+  );
+
+  // If found, return fully formed path to the FAQs page.
+  return faqsSlug ? `/us/campaigns/${faqsSlug}` : undefined;
+}
+
 export default null;


### PR DESCRIPTION
### What's this PR do?

This pull request fleshes out the `ZendeskForm` component. Adds a link to the modal for affiliated users in the `CampaignInfoBar`.

One notable commit:
- https://github.com/DoSomething/phoenix-next/commit/8a9afab263bf6b8321fb07d88e183ea0b2993a4f adds a new campaign selector to help us fetch a link to the campaign's FAQ's page. This was a request from Hannah to preferably direct folks there instead of the help center if possible.
- https://github.com/DoSomething/phoenix-next/commit/0962bafc9a0e9e003e412ffb66b9f1be825a039d there's now proper error state in the Zendesk form
- https://github.com/DoSomething/phoenix-next/commit/7a5938c60ba2d2bce323e963e7155abc124b3a19 added an FAQs page to our `exampleCampaign` Cypress fixture so we can test that the proper help link shows up in the modal in our tests https://github.com/DoSomething/phoenix-next/commit/6c2f3b14d503bde041eef168a9270266feb14530


### How should this be reviewed?
Make sure the new `ZendeskForm` is sound. We're testing things properly. And ready to ship!

### Any background context you want to provide?
This relates to #1851 where we added an internal API endpoint for ticket creation. 

You may notice that for the error state, we maintain the current modal, instead of rendering an `ErrorBlock`. This is to ensure the user doesn't lose their question input which would be a frustrating UX! (@lkpttn approved.)

### Relevant tickets

References [Pivotal #167352209](https://www.pivotaltracker.com/story/show/167352209).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [x] Documentation added for new features/changed endpoints.
- [x] Added screenshots of front-end changes on small, medium, and large screens.
- [x] Added appropriate feature/unit tests.


📸 

![image](https://user-images.githubusercontent.com/12417657/72632481-57087780-3924-11ea-980a-8f49de4ea564.png)

- ~[Affirmation state](https://user-images.githubusercontent.com/12417657/72632500-64256680-3924-11ea-8309-ad57e7a46e3b.png)~
- [Affirmation state updated](https://user-images.githubusercontent.com/12417657/72831407-cc3fb980-3c50-11ea-9a22-9603473c5efd.png)


- [Error state](https://user-images.githubusercontent.com/12417657/72632542-7bfcea80-3924-11ea-8734-ea1540a6b2b4.png)
