### PR TITLE
🐛Landing Page Bug - Pass the sidebar CTA block

### DIFF
--- a/resources/assets/components/pages/LandingPage/LandingPageContainer.js
+++ b/resources/assets/components/pages/LandingPage/LandingPageContainer.js
@@ -1,4 +1,4 @@
-import { get } from 'lodash';
+import { first, get } from 'lodash';
 import { connect } from 'react-redux';
 
 import LandingPage from './LandingPage';
@@ -12,6 +12,8 @@ const mapStateToProps = (state, ownProps) => {
   // or a landingPage content type, the ownProps is structured a bit
   // differently. Revise once all landing pages use landingPage type.
   const landingPage = get(ownProps, 'landingPage.fields', ownProps);
+  // We use the first block in the landing page sidebar as the sidebar CTA.
+  const sidebarCTA = get(first(landingPage.sidebar), 'fields');
 
   return {
     campaignId: state.campaign.campaignId,
@@ -23,7 +25,7 @@ const mapStateToProps = (state, ownProps) => {
     isCampaignClosed: isCampaignClosed(state.campaign.endDate),
     scholarshipAmount: state.campaign.scholarshipAmount,
     scholarshipDeadline: state.campaign.scholarshipDeadline,
-    sidebar: landingPage.sidebar,
+    sidebarCTA,
     signupArrowContent: get(
       state.campaign.additionalContent,
       'signupArrowContent',


### PR DESCRIPTION
### What's this PR do?

This pull request fixes a bug that snuck past us in #1855 where we were no longer parsing out the `sidebarCTA` content from the Landing Page for legacy templates.

### How should this be reviewed?
👁 

### Any background context you want to provide?
This will all hopefully be cleaned up once we graduate support of these legacy templates!

### Relevant tickets
https://dosomething.slack.com/archives/CP2D7UGAU/p1579285434027600
