### PR TITLE
Closed Campaign Scholarship Display Updates

### DIFF
--- a/cypress/fixtures/graphql.js
+++ b/cypress/fixtures/graphql.js
@@ -1,5 +1,6 @@
 import faker from 'faker';
 import { ObjectID } from 'bson';
+import { addMonths } from 'date-fns';
 
 /**
  * Return a list of N items for a field, with an optional
@@ -79,5 +80,9 @@ export const mocks = {
     quantity: () => Math.ceil(Math.random() * 99),
     reactions: () => Math.floor(Math.random() * 30),
     impact: () => `${Math.ceil(Math.random() * 99)} things done`,
+  }),
+  Campaign: () => ({
+    endDate: () => addMonths(new Date(), 1).toISOString(),
+    isOpen: true,
   }),
 };

--- a/resources/assets/components/LedeBanner/templates/HeroTemplate.js
+++ b/resources/assets/components/LedeBanner/templates/HeroTemplate.js
@@ -119,7 +119,6 @@ const HeroTemplate = ({
               <CampaignInfoBlock
                 campaignId={numCampaignId}
                 scholarshipAmount={scholarshipAmount}
-                scholarshipDeadline={scholarshipDeadline}
               />
             </div>
           </Enclosure>

--- a/resources/assets/components/LedeBanner/templates/HeroTemplate.js
+++ b/resources/assets/components/LedeBanner/templates/HeroTemplate.js
@@ -119,6 +119,7 @@ const HeroTemplate = ({
               <CampaignInfoBlock
                 campaignId={numCampaignId}
                 scholarshipAmount={scholarshipAmount}
+                scholarshipDeadline={scholarshipDeadline}
               />
             </div>
           </Enclosure>

--- a/resources/assets/components/blocks/CampaignInfoBlock/CampaignInfoBlock.js
+++ b/resources/assets/components/blocks/CampaignInfoBlock/CampaignInfoBlock.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 
 import Query from '../../Query';
 import Card from '../../utilities/Card/Card';
-import { getHumanFriendlyDate, isCampaignClosed } from '../../../helpers';
+import { getHumanFriendlyDate } from '../../../helpers';
 
 import './campaign-info-block.scss';
 

--- a/resources/assets/components/blocks/CampaignInfoBlock/CampaignInfoBlock.js
+++ b/resources/assets/components/blocks/CampaignInfoBlock/CampaignInfoBlock.js
@@ -27,11 +27,7 @@ const CAMPAIGN_INFO_QUERY = gql`
   }
 `;
 
-const CampaignInfoBlock = ({
-  campaignId,
-  scholarshipAmount,
-  scholarshipDeadline,
-}) => (
+const CampaignInfoBlock = ({ campaignId, scholarshipAmount }) => (
   <Card className="bordered p-3 rounded campaign-info">
     <h1 className="mb-3 text-lg uppercase">Campaign Info</h1>
 
@@ -91,12 +87,10 @@ const CampaignInfoBlock = ({
 CampaignInfoBlock.propTypes = {
   campaignId: PropTypes.number.isRequired,
   scholarshipAmount: PropTypes.number,
-  scholarshipDeadline: PropTypes.string,
 };
 
 CampaignInfoBlock.defaultProps = {
   scholarshipAmount: null,
-  scholarshipDeadline: null,
 };
 
 export default CampaignInfoBlock;

--- a/resources/assets/components/blocks/CampaignInfoBlock/CampaignInfoBlock.js
+++ b/resources/assets/components/blocks/CampaignInfoBlock/CampaignInfoBlock.js
@@ -16,6 +16,7 @@ const CAMPAIGN_INFO_QUERY = gql`
     campaign(id: $campaignId) {
       id
       endDate
+      isOpen
       actions {
         actionLabel
         timeCommitmentLabel
@@ -26,7 +27,11 @@ const CAMPAIGN_INFO_QUERY = gql`
   }
 `;
 
-const CampaignInfoBlock = ({ campaignId, scholarshipAmount }) => (
+const CampaignInfoBlock = ({
+  campaignId,
+  scholarshipAmount,
+  scholarshipDeadline,
+}) => (
   <Card className="bordered p-3 rounded campaign-info">
     <h1 className="mb-3 text-lg uppercase">Campaign Info</h1>
 
@@ -35,6 +40,7 @@ const CampaignInfoBlock = ({ campaignId, scholarshipAmount }) => (
         {res => {
           const endDate = res.campaign.endDate;
           const actions = res.campaign.actions || [];
+          const isOpen = res.campaign.isOpen;
 
           let actionItem = actions.find(
             action => action.reportback && action.scholarshipEntry,
@@ -64,7 +70,7 @@ const CampaignInfoBlock = ({ campaignId, scholarshipAmount }) => (
                   <dd>{actionItem.actionLabel}</dd>
                 </React.Fragment>
               ) : null}
-              {scholarshipAmount && !isCampaignClosed(endDate) ? (
+              {scholarshipAmount && isOpen ? (
                 <React.Fragment>
                   <dt className="campaign-info__scholarship">
                     Win A Scholarship
@@ -85,10 +91,12 @@ const CampaignInfoBlock = ({ campaignId, scholarshipAmount }) => (
 CampaignInfoBlock.propTypes = {
   campaignId: PropTypes.number.isRequired,
   scholarshipAmount: PropTypes.number,
+  scholarshipDeadline: PropTypes.string,
 };
 
 CampaignInfoBlock.defaultProps = {
   scholarshipAmount: null,
+  scholarshipDeadline: null,
 };
 
 export default CampaignInfoBlock;

--- a/resources/assets/components/blocks/CampaignInfoBlock/CampaignInfoBlock.js
+++ b/resources/assets/components/blocks/CampaignInfoBlock/CampaignInfoBlock.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 
 import Query from '../../Query';
 import Card from '../../utilities/Card/Card';
-import { getHumanFriendlyDate } from '../../../helpers';
+import { getHumanFriendlyDate, isCampaignClosed } from '../../../helpers';
 
 import './campaign-info-block.scss';
 
@@ -64,7 +64,7 @@ const CampaignInfoBlock = ({ campaignId, scholarshipAmount }) => (
                   <dd>{actionItem.actionLabel}</dd>
                 </React.Fragment>
               ) : null}
-              {scholarshipAmount ? (
+              {scholarshipAmount && !isCampaignClosed(endDate) ? (
                 <React.Fragment>
                   <dt className="campaign-info__scholarship">
                     Win A Scholarship


### PR DESCRIPTION
### What's this PR do?

This pull request adds a check to the scholarship amount display to only display is the campaign is still open. 

### How should this be reviewed?

👀 

### Any background context you want to provide?

Want to have a clearer user experience for users looking at closed campaigns and what is available in that campaign.

### Relevant tickets

References [Pivotal #170001678](https://www.pivotaltracker.com/story/show/170001678).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added screenshots of front-end changes on small, medium, and large screens.
- [ ] Added appropriate feature/unit tests.
