### PR TITLE
Zendesk Ticket Endpoint Throttling

### DIFF
--- a/app/Http/Controllers/Api/ZendeskTicketsController.php
+++ b/app/Http/Controllers/Api/ZendeskTicketsController.php
@@ -15,6 +15,7 @@ class ZendeskTicketsController extends Controller
     public function __construct()
     {
         $this->middleware('auth:api');
+        $this->middleware('throttle:10,60');
     }
 
     public function store(Request $request)

--- a/app/Http/Controllers/Api/ZendeskTicketsController.php
+++ b/app/Http/Controllers/Api/ZendeskTicketsController.php
@@ -35,7 +35,7 @@ class ZendeskTicketsController extends Controller
 
         Log::debug('[Phoenix] ZendeskTicketsController@store: Creating Zendesk ticket:', [
             'northstar_id' => $northstarId,
-            'question' => $question,
+            'question' => str_limit($question, 5000, '(...)'),
         ]);
 
         $zendeskUser = Zendesk::users()->createOrUpdate([


### PR DESCRIPTION
### What's this PR do?

This pull request adds throttle middleware to the Zendesk ticket creation endpoint.

It also truncates the logged question text. We don't need a character max generally since Zendesk [has its own](https://support.zendesk.com/hc/en-us/articles/360000567348-Is-there-a-character-limit-on-ticket-comments-), but this felt like a good idea so that our logs don't become bombarded with essays.

### How should this be reviewed?
I used the same throttling params we used in the Northstar [subscriptions endpoint](https://github.com/DoSomething/northstar/blob/5ae12b19efe855449e99ce82a51fc180f66b74dc/app/Http/Controllers/SubscriptionController.php#L35) -- does that make sense?

Does the logged truncation make sense?

### Any background context you want to provide?
This felt like a safe idea! 👨‍🚒 

### Relevant tickets

References [Pivotal #167352209](https://www.pivotaltracker.com/story/show/167352209).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added screenshots of front-end changes on small, medium, and large screens.
- [ ] Added appropriate feature/unit tests.
