### PR TITLE
Contentful Migrations updates for Company Page & Gallery Block

### DIFF
--- a/contentful/content-types/companyPage.js
+++ b/contentful/content-types/companyPage.js
@@ -1,7 +1,7 @@
 module.exports = function(migration) {
   const companyPage = migration
     .createContentType('companyPage')
-    .name('CompanyPage')
+    .name('Company Page')
     .description(
       'A custom page for DoSomething static pages with company information.',
     )
@@ -12,24 +12,6 @@ module.exports = function(migration) {
     .type('Symbol')
     .localized(false)
     .required(true)
-    .validations([])
-    .disabled(false)
-    .omitted(false);
-  companyPage
-    .createField('title')
-    .name('Title')
-    .type('Symbol')
-    .localized(true)
-    .required(true)
-    .validations([])
-    .disabled(false)
-    .omitted(false);
-  companyPage
-    .createField('subTitle')
-    .name('Subtitle')
-    .type('Symbol')
-    .localized(true)
-    .required(false)
     .validations([])
     .disabled(false)
     .omitted(false);
@@ -51,11 +33,11 @@ module.exports = function(migration) {
       },
       {
         regexp: {
-          pattern: '^(?!/)[a-zA-Z0-9-/]+$',
+          pattern: '^[a-z\\-]+$',
         },
 
         message:
-          'Only alphanumeric, forward-slash, and hyphen characters are allowed in slugs! Entry cannot start with a forward-slash.',
+          'Only alphanumeric and hyphen characters are allowed in slugs!',
       },
     ])
     .disabled(false)
@@ -76,35 +58,105 @@ module.exports = function(migration) {
     .omitted(false)
     .linkType('Entry');
 
-  // @TODO: remove linkAction from accepted types.
+  companyPage
+    .createField('title')
+    .name('Title')
+    .type('Symbol')
+    .localized(true)
+    .required(true)
+    .validations([])
+    .disabled(false)
+    .omitted(false);
+  companyPage
+    .createField('subTitle')
+    .name('Subtitle')
+    .type('Symbol')
+    .localized(true)
+    .required(false)
+    .validations([])
+    .disabled(false)
+    .omitted(false);
+
+  companyPage
+    .createField('coverImage')
+    .name('Cover Image')
+    .type('Link')
+    .localized(false)
+    .required(false)
+    .validations([
+      {
+        linkMimetypeGroup: ['image'],
+      },
+      {
+        assetFileSize: {
+          max: 20971520,
+        },
+      },
+    ])
+    .disabled(false)
+    .omitted(false)
+    .linkType('Asset');
+
   companyPage
     .createField('content')
     .name('Content')
     .type('RichText')
     .localized(false)
-    .required(false)
+    .required(true)
     .validations([
       {
         nodes: {
           'embedded-entry-inline': [
             {
-              linkContentType: ['galleryBlock', 'imagesBlock', 'linkAction'],
+              linkContentType: [
+                'contentBlock',
+                'galleryBlock',
+                'imagesBlock',
+                'linkAction',
+              ],
             },
           ],
         },
+      },
+      {
+        enabledNodeTypes: [
+          'heading-1',
+          'heading-2',
+          'heading-3',
+          'heading-4',
+          'heading-5',
+          'heading-6',
+          'ordered-list',
+          'unordered-list',
+          'hr',
+          'blockquote',
+          'embedded-entry-block',
+          'embedded-asset-block',
+          'hyperlink',
+        ],
+
+        message:
+          'Only heading 1, heading 2, heading 3, heading 4, heading 5, heading 6, ordered list, unordered list, horizontal rule, quote, block entry, asset, and link to Url nodes are allowed',
       },
     ])
     .disabled(false)
     .omitted(false);
 
-  companyPage.changeEditorInterface('internalTitle', 'singleLine', {});
-  companyPage.changeEditorInterface('title', 'singleLine', {});
-  companyPage.changeEditorInterface('subTitle', 'singleLine', {});
+  companyPage.changeFieldControl('internalTitle', 'builtin', 'singleLine', {});
 
-  companyPage.changeEditorInterface('slug', 'slugEditor', {
-    helpText: 'For an about page prefix with "about/", etc.',
+  companyPage.changeFieldControl('slug', 'builtin', 'slugEditor', {
+    helpText:
+      'e.g. "our-team". The URL for the Company Page will be prefixed with "about/" e.g. "https://dosomething.org/us/about/our-team".',
   });
 
-  companyPage.changeEditorInterface('metadata', 'entryLinkEditor', {});
-  companyPage.changeEditorInterface('content', 'richTextEditor', {});
+  companyPage.changeFieldControl('metadata', 'builtin', 'entryLinkEditor', {});
+  companyPage.changeFieldControl('title', 'builtin', 'singleLine', {});
+  companyPage.changeFieldControl('subTitle', 'builtin', 'singleLine', {});
+  companyPage.changeFieldControl(
+    'coverImage',
+    'builtin',
+    'assetLinkEditor',
+    {},
+  );
+  companyPage.changeFieldControl('content', 'builtin', 'richTextEditor', {});
 };

--- a/contentful/content-types/galleryBlock.js
+++ b/contentful/content-types/galleryBlock.js
@@ -4,85 +4,107 @@ module.exports = function(migration) {
     .name('Gallery Block')
     .description('Displays a gallery of referenced entries')
     .displayField('internalTitle');
-
   galleryBlock
     .createField('internalTitle')
     .name('Internal Title')
     .type('Symbol')
+    .localized(false)
     .required(true)
-    .localized(false);
-
+    .validations([])
+    .disabled(false)
+    .omitted(false);
   galleryBlock
     .createField('title')
     .name('Title')
     .type('Symbol')
+    .localized(true)
     .required(false)
-    .localized(true);
+    .validations([])
+    .disabled(false)
+    .omitted(false);
 
   galleryBlock
     .createField('blocks')
     .name('Blocks')
     .type('Array')
-    .validations([
-      {
-        size: {
-          min: 2,
-        },
-      },
-    ])
+    .localized(false)
+    .required(true)
+    .validations([])
+    .disabled(false)
+    .omitted(false)
     .items({
       type: 'Link',
+
       validations: [
         {
-          linkContentType: ['person', 'campaign', 'page', 'contentBlock'],
+          linkContentType: ['campaign', 'contentBlock', 'page', 'person'],
         },
       ],
+
       linkType: 'Entry',
-    })
-    .required(true)
-    .localized(false);
+    });
 
   galleryBlock
     .createField('itemsPerRow')
     .name('Items Per Row')
     .type('Integer')
+    .localized(false)
+    .required(true)
     .validations([
       {
-        in: [2, 3, 4],
+        in: [2, 3, 4, 5],
       },
     ])
-    .required(true)
-    .localized(false);
+    .disabled(false)
+    .omitted(false);
 
   galleryBlock
     .createField('imageAlignment')
     .name('Image Alignment')
     .type('Symbol')
-    .validations([{ in: ['top', 'left'] }])
+    .localized(false)
     .required(true)
-    .localized(false);
+    .validations([
+      {
+        in: ['top', 'left'],
+      },
+    ])
+    .disabled(false)
+    .omitted(false);
 
   galleryBlock
     .createField('imageFit')
     .name('Image Fit')
     .type('Symbol')
-    .validations([{ in: ['fill', 'pad'] }])
+    .localized(false)
     .required(false)
-    .localized(false);
+    .validations([
+      {
+        in: ['fill', 'pad'],
+      },
+    ])
+    .disabled(false)
+    .omitted(false);
 
-  galleryBlock.changeEditorInterface('itemsPerRow', 'radio', {
+  galleryBlock.changeFieldControl('internalTitle', 'builtin', 'singleLine', {});
+  galleryBlock.changeFieldControl('title', 'builtin', 'singleLine', {});
+
+  galleryBlock.changeFieldControl('blocks', 'builtin', 'entryLinksEditor', {
+    bulkEditing: false,
+  });
+
+  galleryBlock.changeFieldControl('itemsPerRow', 'builtin', 'radio', {
     helpText:
       'The maximum number of items in a single row when viewing the gallery in a large display.',
   });
 
-  galleryBlock.changeEditorInterface('imageAlignment', 'radio', {
+  galleryBlock.changeFieldControl('imageAlignment', 'builtin', 'radio', {
     helpText:
       "Determines where the gallery item's images are aligned relative to their text.",
   });
 
-  galleryBlock.changeEditorInterface('imageFit', 'radio', {
-    helpText: `Controls the cropping method for the gallery images. 'Fill' will resize the images to ensure they
-      fit neatly into a square, cropping the image if needed. 'Pad' will do the same but will add padding
-      to the image instead of cropping it.`,
+  galleryBlock.changeFieldControl('imageFit', 'builtin', 'radio', {
+    helpText:
+      "Controls the cropping method for the gallery images. 'Fill' will resize the images to ensure they      fit neatly into a square, cropping the image if needed. 'Pad' will do the same but will add padding      to the image instead of cropping it.",
   });
 };

--- a/docs/development/contentful/workflow.md
+++ b/docs/development/contentful/workflow.md
@@ -46,6 +46,7 @@ Migration file created at contentful/content-types/currentSchoolBlock.js
 ### 4\) Create a pull request
 
 Once you've added all changes into the `contentful/content-types` files, open a pull request for review.
+_We find it helpful to update/create the documentation for the content type within this pull request to help clarify the changes in the migration_
 
 ### 5\) Upon merge, apply changes to Contentful `qa` and `master`.
 


### PR DESCRIPTION
### What's this PR do?

This pull request updates the Contentful migrations for Company Page & Gallery Block content types based on changes in https://github.com/DoSomething/phoenix-next/pull/1559

### How should this be reviewed?
👁 

### Any background context you want to provide?
I opted to remove the `/category` prefix as we did with [Collection pages](https://github.com/DoSomething/phoenix-next/blob/81e70c03e3128fd1c2cce5e0f2431ed41312f078/contentful/content-types/collection-page.js#L35-L43) since this will always be `/about/:slug`.

### Relevant tickets

References [Pivotal #167297536](https://www.pivotaltracker.com/story/show/167297536).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added screenshots of front-end changes on small, medium, and large screens.
- [ ] Added appropriate feature/unit tests.
