### PR TITLE
🐛 Landing Page sidebar CTA bug fix

### DIFF
--- a/resources/assets/components/pages/LandingPage/LandingPage.js
+++ b/resources/assets/components/pages/LandingPage/LandingPage.js
@@ -37,7 +37,7 @@ const LandingPage = props => {
         <>
           <div className="bg-white">
             <div className="md:w-3/4 mx-auto py-6 px-3 pitch-landing-page">
-              <div className="campaign-page clearfix">
+              <div className="campaign-page__content clearfix">
                 <div className="primary">
                   {displayAffiliateScholarshipBlock ? (
                     <AffiliateScholarshipBlockQuery


### PR DESCRIPTION
### What's this PR do?

This pull request updates the Landing page `campaign-page` classname to `campaign-page__content` so that it gets the legacy two-thirds / one-third visual styling following the updates in https://github.com/DoSomething/phoenix-next/pull/1850

### How should this be reviewed?
👁 


### Relevant tickets
https://github.com/DoSomething/phoenix-next/pull/1850


### Checklist

💔 
![image](https://user-images.githubusercontent.com/12417657/72909869-b17b4c80-3d05-11ea-8ee1-5c4914c41426.png)
❤️ 
![image](https://user-images.githubusercontent.com/12417657/72909889-b7712d80-3d05-11ea-9325-779e4acf57ba.png)

