### PR TITLE
Contentful migration for Campaign blurb field

### DIFF
--- a/contentful/content-types/campaign.js
+++ b/contentful/content-types/campaign.js
@@ -325,7 +325,7 @@ module.exports = function(migration) {
     .required(false)
     .validations([
       {
-        linkContentType: ['landingPage', 'sixpackExperiment'],
+        linkContentType: ['landingPage', 'page', 'sixpackExperiment'],
       },
     ])
     .disabled(false)
@@ -476,116 +476,157 @@ module.exports = function(migration) {
     .disabled(false)
     .omitted(false);
 
-  campaign.changeEditorInterface('internalTitle', 'singleLine', {
+  campaign.changeFieldControl('internalTitle', 'builtin', 'singleLine', {
     helpText:
       '(Example: "Teens for Jeans 2017") This title is used internally to help find this content in the CMS. It will not be displayed anywhere on the website.',
   });
 
-  campaign.changeEditorInterface('title', 'singleLine', {});
+  campaign.changeFieldControl('title', 'builtin', 'singleLine', {});
 
-  campaign.changeEditorInterface('slug', 'slugEditor', {
+  campaign.changeFieldControl('slug', 'builtin', 'slugEditor', {
     helpText:
       '(Example: example-campaign-title) Use hyphens to separate words.',
   });
 
-  campaign.changeEditorInterface('metadata', 'entryLinkEditor', {});
-  campaign.changeEditorInterface(
+  campaign.changeFieldControl('metadata', 'builtin', 'entryLinkEditor', {});
+  campaign.changeFieldControl(
     'legacyCampaignId',
+    'extension',
     'contentful-campaign-extension',
     {},
   );
 
-  campaign.changeEditorInterface('campaignSettings', 'entryLinkEditor', {
-    helpText:
-      'Configurable settings for a campaign, including Action Text overrides, enabling Sixpack, etc.',
-  });
+  campaign.changeFieldControl(
+    'campaignSettings',
+    'builtin',
+    'entryLinkEditor',
+    {
+      helpText:
+        'Configurable settings for a campaign, including Action Text overrides, enabling Sixpack, etc.',
+    },
+  );
 
-  campaign.changeEditorInterface('template', 'checkbox', {});
+  campaign.changeFieldControl('template', 'builtin', 'checkbox', {});
 
-  campaign.changeEditorInterface('endDate', 'datePicker', {
+  campaign.changeFieldControl('endDate', 'builtin', 'datePicker', {
     ampm: '12',
     format: 'timeZ',
     helpText:
       "The date the campaign will close. (Confirm that you've set the UTC-04:00 or UTC-05:00 timezones for EST/EDT (https://time.is/compare/UTC)).",
   });
 
-  campaign.changeEditorInterface('callToAction', 'singleLine', {});
+  campaign.changeFieldControl('callToAction', 'builtin', 'singleLine', {});
 
-  campaign.changeEditorInterface('blurb', 'markdown', {
+  campaign.changeFieldControl('blurb', 'builtin', 'markdown', {
     helpText:
       "Add a short blurb for the lede banner. Bolded items will use the campaign's primary color.",
   });
 
-  campaign.changeEditorInterface('coverImage', 'assetLinkEditor', {});
-  campaign.changeEditorInterface('campaignLead', 'entryLinkEditor', {});
+  campaign.changeFieldControl('coverImage', 'builtin', 'assetLinkEditor', {});
+  campaign.changeFieldControl('campaignLead', 'builtin', 'entryLinkEditor', {});
 
-  campaign.changeEditorInterface('affiliateSponsors', 'entryLinksEditor', {
-    helpText:
-      'Sponsors are Affiliates that pay for and promote a campaign. They recieve logo top billing at the top of the campaign page. There should usually be just one of these.',
-    bulkEditing: false,
-  });
+  campaign.changeFieldControl(
+    'affiliateSponsors',
+    'builtin',
+    'entryLinksEditor',
+    {
+      helpText:
+        'Sponsors are Affiliates that pay for and promote a campaign. They recieve logo top billing at the top of the campaign page. There should usually be just one of these.',
+      bulkEditing: false,
+    },
+  );
 
-  campaign.changeEditorInterface('affiliatePartners', 'entryLinksEditor', {
-    helpText:
-      "Partners are Affiliates that give us strategic help or resources. They don't require logos and show up at the bottom bar of the campaign page.",
-    bulkEditing: false,
-  });
+  campaign.changeFieldControl(
+    'affiliatePartners',
+    'builtin',
+    'entryLinksEditor',
+    {
+      helpText:
+        "Partners are Affiliates that give us strategic help or resources. They don't require logos and show up at the bottom bar of the campaign page.",
+      bulkEditing: false,
+    },
+  );
 
-  campaign.changeEditorInterface('affirmation', 'entryLinkEditor', {
+  campaign.changeFieldControl('affirmation', 'builtin', 'entryLinkEditor', {
     helpText:
       'If no affirmation added, the affirmation will use default content.',
   });
 
-  campaign.changeEditorInterface('pages', 'entryLinksEditor', {
+  campaign.changeFieldControl('pages', 'builtin', 'entryLinksEditor', {
     bulkEditing: false,
   });
 
-  campaign.changeEditorInterface('quizzes', 'entryLinksEditor', {
+  campaign.changeFieldControl('quizzes', 'builtin', 'entryLinksEditor', {
     bulkEditing: false,
   });
 
-  campaign.changeEditorInterface('dashboard', 'entryLinkEditor', {});
-  campaign.changeEditorInterface('socialOverride', 'entryLinkEditor', {});
+  campaign.changeFieldControl('dashboard', 'builtin', 'entryLinkEditor', {});
+  campaign.changeFieldControl(
+    'socialOverride',
+    'builtin',
+    'entryLinkEditor',
+    {},
+  );
 
-  campaign.changeEditorInterface('landingPage', 'entryLinkEditor', {
+  campaign.changeFieldControl('landingPage', 'builtin', 'entryLinkEditor', {
     helpText: '',
   });
 
-  campaign.changeEditorInterface('staffPick', 'boolean', {
+  campaign.changeFieldControl('staffPick', 'builtin', 'boolean', {
     helpText: 'Is this a Staff Pick campaign?',
     trueLabel: 'Yes',
     falseLabel: 'No',
   });
 
-  campaign.changeEditorInterface('cause', 'radio', {
+  campaign.changeFieldControl('cause', 'builtin', 'radio', {
     helpText: 'Primary cause for this campaign',
   });
 
-  campaign.changeEditorInterface('scholarshipAmount', 'numberEditor', {
+  campaign.changeFieldControl('scholarshipAmount', 'builtin', 'numberEditor', {
     helpText: 'e.g. 5000',
   });
 
-  campaign.changeEditorInterface('scholarshipDeadline', 'datePicker', {
+  campaign.changeFieldControl('scholarshipDeadline', 'builtin', 'datePicker', {
     ampm: '12',
     format: 'timeZ',
     helpText:
       "Deadline to take action and qualify for the scholarship. (Confirm that you've set the UTC-04:00 or UTC-05:00 timezones for EST/EDT (https://time.is/compare/UTC)).",
   });
 
-  campaign.changeEditorInterface('scholarshipCallToAction', 'singleLine', {
-    helpText:
-      "This should mirror the language used on the scholarship partner's site e.g. Win An Anti-Vaping Scholarship",
-  });
+  campaign.changeFieldControl(
+    'scholarshipCallToAction',
+    'builtin',
+    'singleLine',
+    {
+      helpText:
+        "This should mirror the language used on the scholarship partner's site e.g. Win An Anti-Vaping Scholarship",
+    },
+  );
 
-  campaign.changeEditorInterface('scholarshipDescription', 'richTextEditor', {
-    helpText:
-      'Add information about the scholarship & how it works with the campaign.',
-  });
+  campaign.changeFieldControl(
+    'scholarshipDescription',
+    'builtin',
+    'richTextEditor',
+    {
+      helpText:
+        'Add information about the scholarship & how it works with the campaign.',
+    },
+  );
 
-  campaign.changeEditorInterface('affiliateOptInContent', 'richTextEditor', {
-    helpText:
-      'If there is an affiliate opt in for this campaign, input the informational content to display alongside the opt in checkbox. The affiliate opt in checkbox will only appear if this field is populated.',
-  });
+  campaign.changeFieldControl(
+    'affiliateOptInContent',
+    'builtin',
+    'richTextEditor',
+    {
+      helpText:
+        'If there is an affiliate opt in for this campaign, input the informational content to display alongside the opt in checkbox. The affiliate opt in checkbox will only appear if this field is populated.',
+    },
+  );
 
-  campaign.changeEditorInterface('additionalContent', 'objectEditor', {});
+  campaign.changeFieldControl(
+    'additionalContent',
+    'builtin',
+    'objectEditor',
+    {},
+  );
 };

--- a/contentful/management-api-scripts/2020_01_17_import_campaign_blurb.js
+++ b/contentful/management-api-scripts/2020_01_17_import_campaign_blurb.js
@@ -23,22 +23,20 @@ async function importCampaignBlurbFromLandingPageContent(
     'additionalContent',
   );
 
+  logger.info(
+    `Processing Campaign ${campaignEntryId} - ${campaignInternalTitle}`,
+  );
+
   if (
     get(campaignAdditionalContent, 'featureFlagUseLegacyTemplate', false) ===
     true
   ) {
-    logger.info(
-      `Skipping legacy template Campaign ${campaignEntryId} - ${campaignInternalTitle}\n`,
-    );
+    logger.info('Skipping import for legacy template.');
     return;
   }
 
   const landingPageEntry = getField(campaignEntry, 'landingPage');
   const landingPageEntryId = landingPageEntry ? landingPageEntry.sys.id : null;
-
-  logger.info(
-    `Processing Campaign ${campaignEntryId} - ${campaignInternalTitle}`,
-  );
 
   if (!landingPageEntryId) {
     logger.info('Landing Page entry not found.');

--- a/contentful/management-api-scripts/2020_01_17_import_campaign_blurb.js
+++ b/contentful/management-api-scripts/2020_01_17_import_campaign_blurb.js
@@ -1,0 +1,34 @@
+const { get } = require('lodash');
+const { contentManagementClient } = require('./contentManagementClient');
+const {
+  attempt,
+  createLogger,
+  getField,
+  processEntries,
+  sleep,
+  withFields,
+  linkReference,
+  constants,
+} = require('./helpers');
+
+const { LOCALE } = constants;
+
+const logger = createLogger('import_campaign_blurb_from_landing_page_content');
+
+async function importCampaignBlurbFromLandingPageContent(
+  environment,
+  campaign,
+) {
+  logger.info(`Processing campaign ${campaignEntry.sys.id}\n`);
+
+  logger.info('--------------------------------------------\n');
+}
+
+contentManagementClient.init((environment, args) =>
+  processEntries(
+    environment,
+    args,
+    'campaign',
+    importCampaignBlurbFromLandingPageContent,
+  ),
+);

--- a/contentful/management-api-scripts/2020_01_17_import_campaign_blurb.js
+++ b/contentful/management-api-scripts/2020_01_17_import_campaign_blurb.js
@@ -18,11 +18,26 @@ async function importCampaignBlurbFromLandingPageContent(
 ) {
   const campaignEntryId = campaignEntry.sys.id;
   const campaignInternalTitle = getField(campaignEntry, 'internalTitle');
+  const campaignAdditionalContent = getField(
+    campaignEntry,
+    'additionalContent',
+  );
+
+  if (
+    get(campaignAdditionalContent, 'featureFlagUseLegacyTemplate', false) ===
+    true
+  ) {
+    logger.info(
+      `Skipping legacy template Campaign ${campaignEntryId} - ${campaignInternalTitle}\n`,
+    );
+    return;
+  }
+
   const landingPageEntry = getField(campaignEntry, 'landingPage');
   const landingPageEntryId = landingPageEntry ? landingPageEntry.sys.id : null;
 
   logger.info(
-    `Processing Campaign ${campaignEntryId} - ${campaignInternalTitle}\n`,
+    `Processing Campaign ${campaignEntryId} - ${campaignInternalTitle}`,
   );
 
   if (!landingPageEntryId) {
@@ -31,7 +46,7 @@ async function importCampaignBlurbFromLandingPageContent(
     return;
   }
 
-  logger.info(`\nFetching Landing Page ${landingPageEntryId}\n`);
+  logger.info(`Fetching Landing Page ${landingPageEntryId}`);
 
   const loadedLandingPageEntry = await environment.getEntry(landingPageEntryId);
   const landingPageContent = getField(loadedLandingPageEntry, 'content');

--- a/contentful/management-api-scripts/2020_01_17_import_campaign_blurb.js
+++ b/contentful/management-api-scripts/2020_01_17_import_campaign_blurb.js
@@ -17,11 +17,33 @@ const logger = createLogger('import_campaign_blurb_from_landing_page_content');
 
 async function importCampaignBlurbFromLandingPageContent(
   environment,
-  campaign,
+  campaignEntry,
 ) {
-  logger.info(`Processing campaign ${campaignEntry.sys.id}\n`);
+  const internalTitle = getField(campaignEntry, 'internalTitle');
+  const landingPageEntry = getField(campaignEntry, 'landingPage');
+  const landingPageEntryId = landingPageEntry ? landingPageEntry.sys.id : null;
 
-  logger.info('--------------------------------------------\n');
+  logger.info(
+    `Processing Campaign ${campaignEntry.sys.id} - ${internalTitle}\n`,
+  );
+
+  logger.info('Campaign Blurb:');
+  logger.info(getField(campaignEntry, 'blurb'));
+
+  if (landingPageEntryId) {
+    logger.info(`\nFetching Landing Page ${landingPageEntryId}\n`);
+
+    // @TODO: Shouldn't have to fetch here, should get loaded entry from processEntries.
+    const loadedLandingPageEntry = await environment.getEntry(
+      landingPageEntryId,
+    );
+    const landingPageContent = getField(loadedLandingPageEntry, 'content');
+
+    logger.info('Landing Page Content:');
+    logger.info(landingPageContent);
+  }
+
+  logger.info('----------------');
 }
 
 contentManagementClient.init((environment, args) =>

--- a/contentful/management-api-scripts/helpers.js
+++ b/contentful/management-api-scripts/helpers.js
@@ -69,8 +69,6 @@ async function processEntries(environment, args, entryType, process) {
         // For now, if the content type exceeds 1000 entries, a hack is to increment this skip value by 1000
         // and keep running the script until all entries are processed.
         skip: 0,
-        // @TODO: Why does this not work?
-        include: 3,
       }),
     );
 

--- a/contentful/management-api-scripts/helpers.js
+++ b/contentful/management-api-scripts/helpers.js
@@ -69,12 +69,19 @@ async function processEntries(environment, args, entryType, process) {
         // For now, if the content type exceeds 1000 entries, a hack is to increment this skip value by 1000
         // and keep running the script until all entries are processed.
         skip: 0,
+        // @TODO: Why does this not work?
+        include: 3,
       }),
     );
 
     if (!entries) {
       return;
     }
+
+    winston.info(
+      `Found ${entries.items.length} entries with type ${entryType} in environment.`,
+      environment,
+    );
 
     for (var i = 0; i < entries.items.length; i++) {
       const entry = entries.items[i];

--- a/contentful/management-api-scripts/helpers.js
+++ b/contentful/management-api-scripts/helpers.js
@@ -76,11 +76,6 @@ async function processEntries(environment, args, entryType, process) {
       return;
     }
 
-    winston.info(
-      `Found ${entries.items.length} entries with type ${entryType} in environment.`,
-      environment,
-    );
-
     for (var i = 0; i < entries.items.length; i++) {
       const entry = entries.items[i];
       await process(environment, entry);

--- a/docs/development/contentful/content-management-api-scripts.md
+++ b/docs/development/contentful/content-management-api-scripts.md
@@ -90,4 +90,6 @@ If your script utilizes the `processEntries` helper method from `/helpers`, than
 
 - If utilizing the `--all` flag to bulk process all entries of a content-type & if the content-type contains more then 1000 entries, a temporary workaround to the API's 1000 entry limit is to keep incrementing the `skip` parameter by 1000 in the `./helpers#processEntries` method to eventually process _all_ entries.
 
+## Notes
+
 - The Content Management API [does not support the `include` parameter to retrieve nested entries in a `getEntries` call](https://www.contentful.com/developers/docs/references/content-management-api/#/reference/search-parameters), so you'll need to make a `getEntry` request to access the fields of an entry reference field value.

--- a/docs/development/contentful/content-management-api-scripts.md
+++ b/docs/development/contentful/content-management-api-scripts.md
@@ -85,5 +85,9 @@ If your script utilizes the `processEntries` helper method from `/helpers`, than
 #### Pro Tips
 
 - Since, unlike the migration CLI, there is no way to initially run the script to see if it's valid. You might want to first go about testing with a dummy \(staging / personal\) Contentful Space to ensure your script will behave as intended!
+
 - There is a suite of helper functions in `./helpers` containing some common logic we found ourselves running with these scripts.
+
 - If utilizing the `--all` flag to bulk process all entries of a content-type & if the content-type contains more then 1000 entries, a temporary workaround to the API's 1000 entry limit is to keep incrementing the `skip` parameter by 1000 in the `./helpers#processEntries` method to eventually process _all_ entries.
+
+- The Content Management API [does not support the `include` parameter to retrieve nested entries in a `getEntries` call](https://www.contentful.com/developers/docs/references/content-management-api/#/reference/search-parameters), so you'll need to make a `getEntry` request to access the fields of an entry reference field value.

--- a/docs/development/contentful/content-management-api-scripts.md
+++ b/docs/development/contentful/content-management-api-scripts.md
@@ -77,7 +77,7 @@ Once your script is approved and merged you're ready to run it in any up to date
 You'll run the file as you would any regular `node.js` file, passing in the Contentful space ID and your access token:
 
 ```bash
-$ node contentful/content-management-scripts/20XX_XX_001_logs_all_entries.js --space-id $SPACE_ID --access-token $CONTENTFUL_MANAGEMENT_ACCESS_TOKEN
+$ node contentful/management-api-scripts/20XX_XX_001_logs_all_entries.js --space-id $SPACE_ID --access-token $CONTENTFUL_MANAGEMENT_ACCESS_TOKEN
 ```
 
 If your script utilizes the `processEntries` helper method from `/helpers`, than the script can either be applied to all entries of the provided type through the `--all` flag, or a single entry of the provided type through `--[contentType]-id [id]` \(e.g. `--campaign-id 12345`\).


### PR DESCRIPTION
### What's this PR do?

This pull request adds a migration that updates all `campaign` entries, setting the `blurb` field to its Landing Page's `content` field if it doesn't use the legacy template. 

It also modifies the `campaign` content type migration to temporarily allow `page` entries to be saved to the campaign's `landingPage` reference field.  This change will need to be manually made in each environment, and then changed back once the migration as ended. See background context.

### How should this be reviewed?

👀 

### Any background context you want to provide?

When this script attempts to update campaigns that have a `page` set for `landingPage`, we're unable to save our changes because of validation errors -- we can't save the `page` entry to the `landingPage` field. It's possible we could manually create `LandingPage` entries for the 10 campaign entries on production to avoid this, but we'd also need to copy/paste all the `content` fields for each. Let's create those entries manually once we no longer need their `content` field values anymore, because this migration will have run.


### Relevant tickets

References [Pivotal #170735335](https://www.pivotaltracker.com/story/show/170735335).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
