### PR TITLE
Remove page as accepted landingPage reference type

### DIFF
--- a/contentful/content-types/campaign.js
+++ b/contentful/content-types/campaign.js
@@ -325,7 +325,7 @@ module.exports = function(migration) {
     .required(false)
     .validations([
       {
-        linkContentType: ['landingPage', 'page', 'sixpackExperiment'],
+        linkContentType: ['landingPage', 'sixpackExperiment'],
       },
     ])
     .disabled(false)


### PR DESCRIPTION
### What's this PR do?

This pull request restores the `campaign` content type migration to only allow `landingPage` and `sixPackExperiment` types on its `landingPage` reference field, now that the migration in #1867 has been run on all environments, and we now want to restore the restriction that a `page` may not be saved as a valid `landingPage` (it once was, which is why a few campaigns have `page` entries set as their `landingPage`)

### How should this be reviewed?

👀 

### Any background context you want to provide?

I've already made these changes to the Campaign content type in each environment. Will start on the campaign content type documentation per this [suggestion](https://github.com/DoSomething/phoenix-next/pull/1865#issuecomment-577339787) in a future PR.

### Relevant tickets

References [Pivotal #170735335](https://www.pivotaltracker.com/story/show/170735335).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
