### PR TITLE
Display Campaign blurb as LedeBanner content

### DIFF
--- a/cypress/integration/campaign-signup.js
+++ b/cypress/integration/campaign-signup.js
@@ -6,6 +6,8 @@ import { emptyResponse, newSignup } from '../fixtures/signups';
 import exampleCampaign from '../fixtures/contentful/exampleCampaign';
 
 const API = `/api/v2/campaigns/${campaignId}`;
+// Text included in the campaign blurb.
+const exampleBlurb = `Did you know that the world's oldest cat`;
 
 describe('Campaign Signup', () => {
   // Configure a new "mock" server before each test:
@@ -19,6 +21,7 @@ describe('Campaign Signup', () => {
 
     cy.contains('Example Campaign');
     cy.contains('This is an example campaign for automated testing.');
+    cy.contains(exampleBlurb);
 
     // Mock the responses we'll be expecting once we hit "Join Now":
     cy.route(`${API}/signups?filter[northstar_id]=${user.id}`, emptyResponse);
@@ -40,6 +43,7 @@ describe('Campaign Signup', () => {
 
     cy.contains('Example Campaign');
     cy.contains('This is an example campaign for automated testing.');
+    cy.contains(exampleBlurb);
 
     // Mock the response we'll be expecting once we hit "Join Now":
     cy.route('POST', `${API}/signups`, newSignup(campaignId, user));
@@ -57,6 +61,7 @@ describe('Campaign Signup', () => {
 
     cy.contains('Example Campaign');
     cy.contains('This is an example campaign for automated testing.');
+    cy.contains(exampleBlurb);
 
     // We shouldn't see the "Join Now" button or affiramation modal,
     // since the user is already signed up for this campaign:

--- a/resources/assets/components/LedeBanner/LedeBannerContainer.js
+++ b/resources/assets/components/LedeBanner/LedeBannerContainer.js
@@ -29,7 +29,7 @@ const mapStateToProps = (state, props) => ({
   blurb: get(props, 'blurb', state.campaign.blurb),
   campaignId: state.campaign.campaignId,
   coverImage: get(props, 'coverImage', state.campaign.coverImage),
-  content: get(state, 'campaign.blurb'),
+  content: state.campaign.blurb,
   dashboard: state.campaign.dashboard,
   endDate: state.campaign.endDate,
   featureFlagUseLegacyTemplate: get(

--- a/resources/assets/components/LedeBanner/LedeBannerContainer.js
+++ b/resources/assets/components/LedeBanner/LedeBannerContainer.js
@@ -25,10 +25,11 @@ const mapStateToProps = (state, props) => ({
   ),
   affiliateOptInContent: state.campaign.affiliateOptInContent,
   affiliateSponsors: state.campaign.affiliateSponsors,
+  // @TODO: We won't need this blurb property once MosaicTemplate is retired.
   blurb: get(props, 'blurb', state.campaign.blurb),
   campaignId: state.campaign.campaignId,
   coverImage: get(props, 'coverImage', state.campaign.coverImage),
-  content: get(state, 'campaign.landingPage.fields.content'),
+  content: get(state, 'campaign.blurb'),
   dashboard: state.campaign.dashboard,
   endDate: state.campaign.endDate,
   featureFlagUseLegacyTemplate: get(


### PR DESCRIPTION
### What's this PR do?

This pull request modifies the LedeBanner container to set the `campaign.blurb` for the `content` component prop, and adds checks to the Campaign Signup tests to verify the blurb content appears on the campaign page for both not-signed-up and signed-up views.

### How should this be reviewed?

I've modified the blurb on Campaign entry for /us/campaigns/missing-history to test that the blurb field is displayed for both not-signed-up and signed-up views.


### Any background context you want to provide?

I was hoping that this change would allow us to delete the Landing Page `content` field -- but it's still used in the Mosaic Template. Next steps for that are [being discussed in Slack](https://dosomething.slack.com/archives/C3ASB4204/p1579731855016400).

### Relevant tickets

References [Pivotal #170735335](https://www.pivotaltracker.com/n/projects/2401401/stories/170735335) - this should be the last PR for that story.

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [x] Added appropriate feature/unit tests.
