### PR TITLE
Contentful Script to Create Company Pages

### DIFF
--- a/contentful/management-api-scripts/2020_01_22_create_company_pages_from_about_pages.js
+++ b/contentful/management-api-scripts/2020_01_22_create_company_pages_from_about_pages.js
@@ -1,0 +1,87 @@
+const { flatten } = require('lodash');
+const { contentManagementClient } = require('./contentManagementClient');
+const { richTextFromMarkdown } = require('@contentful/rich-text-from-markdown');
+const {
+  processEntries,
+  getField,
+  withFields,
+  createLogger,
+  attempt,
+} = require('./helpers');
+
+const logger = createLogger('create_company_pages_from_about_pages');
+
+const createCompanyPageFromAboutPage = async (environment, pageEntry) => {
+  const pageEntryId = pageEntry.sys.id;
+  const pageInternalTitle = getField(pageEntry, 'internalTitle');
+  const pageSlug = getField(pageEntry, 'slug', '');
+
+  // Skip over non 'about' pages.
+  if (!pageSlug.startsWith('about/')) {
+    return;
+  }
+
+  logger.info(`Processing Page ${pageEntryId} - ${pageInternalTitle}`);
+
+  const pageContent = getField(pageEntry, 'content');
+  // Convert Markdown 'Long Text' to Rich Text format.
+  const richTextFormattedContent = await richTextFromMarkdown(pageContent);
+
+  // Import linked references as valid Rich Text embedded entry blocks.
+  const blocks = getField(pageEntry, 'blocks', []);
+  const richTextFormattedBlocks = blocks.map(block => {
+    return {
+      nodeType: 'embedded-entry-block',
+      content: [],
+      data: {
+        target: {
+          sys: {
+            type: 'Link',
+            linkType: 'Entry',
+            id: block.sys.id,
+          },
+        },
+      },
+    };
+  });
+
+  // Format Rich Text value from converted markdown and embedded blocks.
+  const richTextContent = {
+    nodeType: 'document',
+    content: flatten([
+      richTextFormattedContent.content,
+      richTextFormattedBlocks,
+    ]),
+    data: {},
+  };
+
+  // Create the new Company Page draft derived from the About page.
+  const companyPage = await attempt(() =>
+    environment.createEntry(
+      'companyPage',
+      withFields({
+        internalTitle: getField(pageEntry, 'internalTitle'),
+        slug: pageSlug.replace('about/', ''),
+        metadata: getField(pageEntry, 'metadata'),
+        title: getField(pageEntry, 'title'),
+        subTitle: getField(pageEntry, 'subTitle'),
+        coverImage: getField(pageEntry, 'coverImage'),
+        content: richTextContent,
+      }),
+    ),
+  );
+
+  if (companyPage) {
+    logger.info(`-- Created Company Page! [ID: ${companyPage.sys.id}]\n`);
+    // Attempt to publish the Company Page.
+    const publishedCompanyPage = await attempt(() => companyPage.publish());
+
+    if (publishedCompanyPage) {
+      logger.info(`-- Published Company Page! [ID: ${companyPage.sys.id}]\n`);
+    }
+  }
+};
+
+contentManagementClient.init((environment, args) =>
+  processEntries(environment, args, 'page', createCompanyPageFromAboutPage),
+);


### PR DESCRIPTION
### What's this PR do?

This pull request adds a new Contentful management API script to derive new Company Page entries from any About Page entry (any Page entry with a `slug` field prefixed with `about/`).

### How should this be reviewed?
👁 

### Any background context you want to provide?
It's mostly par for the course. The trick is to convert the Long Text markdown `content` field and the Entry Reference `blocks` field into a singular Rich Text `content` field format.

For the above I followed along with the epic [Rich Text migration documentation](https://www.contentful.com/developers/docs/tutorials/general/migrate-to-rich-text/) from Contentful, utilizing the [@contentful/rich-text-from-markdown](https://www.npmjs.com/package/@contentful/rich-text-from-markdown) package to convert the markdown to Rich Text format, and employing their specified formatting for parsing the block references.

(We may be able to extract this functionality into a helper for future Markdown -> Rich Text migrations with the caveat being that embedded markdown image links pose a unique challenge and require a bunch more work (see [their step #9 here](https://www.contentful.com/developers/docs/tutorials/general/migrate-to-rich-text/#9-convert-the-markdown-text-with-images)). I was able to run a quick script to verify that none of the about pages contain embedded images (any `![...` content))

### Relevant tickets

References [Pivotal #167297536](https://www.pivotaltracker.com/story/show/167297536).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
