### PR TITLE
Migrate Landing Page content for legacy template campaigns

### DIFF
--- a/contentful/management-api-scripts/2020_01_23_import_landing_page_additional_content.js
+++ b/contentful/management-api-scripts/2020_01_23_import_landing_page_additional_content.js
@@ -1,0 +1,82 @@
+const { contentManagementClient } = require('./contentManagementClient');
+const { attempt, createLogger, getField, constants } = require('./helpers');
+
+const { LOCALE } = constants;
+
+const logger = createLogger('import_landing_page_additional_content');
+
+async function importLandingPageAdditionalContent(environment, id) {
+  logger.info(`Fetching Landing Page ${id}`);
+
+  const entry = await attempt(() => environment.getEntry(id));
+
+  logger.info(
+    `Retrieved Landing Page ${id} ${getField(entry, 'internalTitle')}`,
+  );
+
+  // Initalize an object to write save to the Additonal Content field.
+  const newAdditionalContentValue = {};
+
+  // Save the content field value as a legacyTemplateContent property.
+  newAdditionalContentValue[LOCALE] = {
+    legacyTemplateContent: getField(entry, 'content'),
+  };
+  entry.fields.additionalContent = newAdditionalContentValue;
+
+  // Attempt to update the entry.
+  const updatedEntry = await attempt(() => entry.update());
+
+  if (!updatedEntry) {
+    logger.info(`-- Could not update entry ${id}`);
+
+    return;
+  }
+
+  logger.info(`-- Updated entry ${id}`);
+
+  // Attempt to publish the entry.
+  const publishedEntry = await attempt(() => updatedEntry.publish());
+
+  logger.info(`-- Published entry ${id}`);
+}
+
+contentManagementClient.init(async (environment, args) => {
+  const id = args['id'];
+
+  if (id) {
+    return importLandingPageAdditionalContent(environment, args['id']);
+  }
+
+  if (!args['all']) {
+    return console.log('Missing --all or --id parameters.');
+  }
+
+  const result = await attempt(() =>
+    environment.getEntries({
+      content_type: 'campaign',
+      'fields.additionalContent[exists]': true,
+    }),
+  );
+
+  // If campaign uses the legacy template, save its Landing Page content field to additionalContent.
+  result.items.forEach(async campaignEntry => {
+    const additionalContent = getField(campaignEntry, 'additionalContent');
+
+    if (additionalContent.featureFlagUseLegacyTemplate !== true) {
+      return;
+    }
+
+    logger.info(`Updating legacy template Campaign ${campaignEntry.sys.id}`);
+
+    const landingPageEntry = getField(campaignEntry, 'landingPage');
+
+    if (!landingPageEntry) {
+      return;
+    }
+
+    return await importLandingPageAdditionalContent(
+      environment,
+      landingPageEntry.sys.id,
+    );
+  });
+});


### PR DESCRIPTION
### What's this PR do?

This pull request adds a migration to copy the `content` field value into `additionalContent` for all Landing Pages of campaigns that use the legacy template. 

Once this migration has been run on `qa` and `master` environments, we can modify the legacy template to source its content from `additionalContent` instead of `content` (see #1875), then delete the existing `content` long text field and recreate it as a Rich Text field (to close out the related Pivotal story).

### How should this be reviewed?

👀 

### Any background context you want to provide?

Eventually once we stop supporting the legacy template, it'd be nice to re-run this migration to delete all `additionalContent` for Landing Page entries, instead of saving the deprecated data.

### Relevant tickets

References [Pivotal #170606520](https://www.pivotaltracker.com/story/show/170606520).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added screenshots of front-end changes on small, medium, and large screens.
- [ ] Added appropriate feature/unit tests.
