### PR TITLE
Read additionalContent for legacy template content

### DIFF
--- a/resources/assets/components/pages/LandingPage/LandingPage.js
+++ b/resources/assets/components/pages/LandingPage/LandingPage.js
@@ -13,8 +13,8 @@ import AffiliateScholarshipBlockQuery from '../../blocks/AffiliateScholarshipBlo
 
 const LandingPage = props => {
   const {
+    additionalContent,
     campaignId,
-    content,
     isCampaignClosed,
     featureFlagUseLegacyTemplate,
     scholarshipAmount,
@@ -49,7 +49,11 @@ const LandingPage = props => {
                     />
                   ) : null}
 
-                  <TextContent>{content}</TextContent>
+                  {additionalContent.legacyTemplateContent ? (
+                    <TextContent>
+                      {additionalContent.legacyTemplateContent}
+                    </TextContent>
+                  ) : null}
                 </div>
                 <div className="secondary">
                   <Card title={sidebarCTA.title} className="rounded bordered">
@@ -82,8 +86,8 @@ const LandingPage = props => {
 };
 
 LandingPage.propTypes = {
+  additionalContent: PropTypes.object,
   campaignId: PropTypes.string.isRequired,
-  content: PropTypes.string.isRequired,
   featureFlagUseLegacyTemplate: PropTypes.bool,
   isCampaignClosed: PropTypes.bool,
   scholarshipAmount: PropTypes.number,
@@ -97,6 +101,7 @@ LandingPage.propTypes = {
 };
 
 LandingPage.defaultProps = {
+  additionalContent: null,
   featureFlagUseLegacyTemplate: false,
   isCampaignClosed: false,
   scholarshipAmount: null,

--- a/resources/assets/components/pages/LandingPage/LandingPageContainer.js
+++ b/resources/assets/components/pages/LandingPage/LandingPageContainer.js
@@ -16,8 +16,8 @@ const mapStateToProps = (state, ownProps) => {
   const sidebarCTA = get(first(landingPage.sidebar), 'fields');
 
   return {
+    additionalContent: landingPage.additionalContent,
     campaignId: state.campaign.campaignId,
-    content: landingPage.content,
     featureFlagUseLegacyTemplate: get(
       state,
       'campaign.additionalContent.featureFlagUseLegacyTemplate',


### PR DESCRIPTION
### What's this PR do?

This pull request makes the code changes to the legacy template now that the migration #1874 has been run, pulling the copy from `additionalContent` instead of the `content` field. Once this has been deployed, we'll be able to delete the existing `content` long text field from the Landing Page and recreate it as a Rich Text field.

### How should this be reviewed?

Spot check a legacy template campaign landing page once the migration in #1874 has been run. Example dev campaigns that use legacy campaign are:

* /us/campaigns/youve-got-power
* /us/campaigns/lukes-test-campaign

### Any background context you want to provide?

No

### Relevant tickets

References [Pivotal #170606520](https://www.pivotaltracker.com/n/projects/2401401/stories/170606520).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.

