### PR TITLE
Rich Text Landing Page content

### DIFF
--- a/app/Entities/LandingPage.php
+++ b/app/Entities/LandingPage.php
@@ -20,7 +20,7 @@ class LandingPage extends Entity implements JsonSerializable
                 'internalTitle' => $this->internalTitle,
                 'title' => $this->title,
                 'subTitle' => $this->subTitle,
-                'content' => $this->temporaryContent,
+                'content' => $this->content,
                 'sidebar' => $this->parseBlocks($this->sidebar),
                 'blocks' => $this->parseBlocks($this->blocks),
                 'additionalContent' => $this->additionalContent,

--- a/app/Entities/LandingPage.php
+++ b/app/Entities/LandingPage.php
@@ -20,7 +20,7 @@ class LandingPage extends Entity implements JsonSerializable
                 'internalTitle' => $this->internalTitle,
                 'title' => $this->title,
                 'subTitle' => $this->subTitle,
-                'content' => $this->content,
+                'content' => $this->temporaryContent,
                 'sidebar' => $this->parseBlocks($this->sidebar),
                 'blocks' => $this->parseBlocks($this->blocks),
                 'additionalContent' => $this->additionalContent,

--- a/contentful/content-types/landingPage.js
+++ b/contentful/content-types/landingPage.js
@@ -38,7 +38,7 @@ module.exports = function(migration) {
     .localized(true)
     .required(false)
     .validations([])
-    .disabled(true)
+    .disabled(false)
     .omitted(false);
 
   landingPage

--- a/contentful/content-types/landingPage.js
+++ b/contentful/content-types/landingPage.js
@@ -31,13 +31,24 @@ module.exports = function(migration) {
     .validations([])
     .disabled(false)
     .omitted(false);
+
   landingPage
     .createField('content')
     .name('Content')
-    .type('Text')
-    .localized(true)
+    .type('RichText')
+    .localized(false)
     .required(false)
-    .validations([])
+    .validations([
+      {
+        nodes: {
+          'entry-hyperlink': [
+            {
+              linkContentType: ['contentBlock', 'imagesBlock', 'linkAction'],
+            },
+          ],
+        },
+      },
+    ])
     .disabled(false)
     .omitted(false);
 
@@ -95,9 +106,10 @@ module.exports = function(migration) {
   landingPage.changeFieldControl('internalTitle', 'builtin', 'singleLine', {});
   landingPage.changeFieldControl('title', 'builtin', 'singleLine', {});
   landingPage.changeFieldControl('subTitle', 'builtin', 'singleLine', {});
-  landingPage.changeFieldControl('content', 'builtin', 'markdown', {});
+  landingPage.changeFieldControl('content', 'builtin', 'richTextEditor', {});
 
   landingPage.changeFieldControl('sidebar', 'builtin', 'entryLinksEditor', {
+    helpText: 'Deprecated -- only displayed on legacy template',
     bulkEditing: false,
   });
 

--- a/docs/development/content-types/landing-page.md
+++ b/docs/development/content-types/landing-page.md
@@ -10,6 +10,10 @@ The landing page displayed on a [campaign](development/content-types/campaign.md
 
 - **Content** : A Rich Text field, which can embed `contentBlock`, `imagesBlock`, and `linkAction` entries.
 
+- **Title** : This isn't used and should be deleted?
+
+- **Subtitle** : This too?
+
 - **Sidebar** : A multi-value reference field, only used on the legacy template.
 
 - **Additonal Content** : The legacy campaign template uses this field to display Landing Page content, expecting a `legacyTemplateContent` property.

--- a/docs/development/content-types/landing-page.md
+++ b/docs/development/content-types/landing-page.md
@@ -8,4 +8,8 @@ The landing page displayed on a [campaign](development/content-types/campaign.md
 
 - **Internal Title**: This is for our internal Contentful organization and will be how the entry shows up in search results, etc.
 
-- **Content** : This long text field is currently disabled. Its content has been migrated to the Campaign Blurb field.
+- **Content** : A Rich Text field, which can embed `contentBlock`, `imagesBlock`, and `linkAction` entries.
+
+- **Sidebar** : A multi-value reference field, only used on the legacy template.
+
+- **Additonal Content** : The legacy campaign template uses this field to display Landing Page content, expecting a `legacyTemplateContent` property.

--- a/docs/development/content-types/landing-page.md
+++ b/docs/development/content-types/landing-page.md
@@ -14,6 +14,6 @@ The landing page displayed on a [campaign](development/content-types/campaign.md
 
 - **Subtitle** : This too?
 
-- **Sidebar** : A multi-value reference field, only used on the legacy template.
+- **Sidebar** : A multi-value reference field, only displayed on the legacy campaign template.
 
 - **Additonal Content** : The legacy campaign template uses this field to display Landing Page content, expecting a `legacyTemplateContent` property.

--- a/resources/assets/components/LedeBanner/templates/HeroTemplate.js
+++ b/resources/assets/components/LedeBanner/templates/HeroTemplate.js
@@ -8,7 +8,6 @@ import TextContent from '../../utilities/TextContent/TextContent';
 import { SCHOLARSHIP_SIGNUP_BUTTON_TEXT } from '../../../constants';
 import SignupButtonContainer from '../../SignupButton/SignupButtonContainer';
 import CampaignInfoBlock from '../../blocks/CampaignInfoBlock/CampaignInfoBlock';
-import CampaignInfoBarContainer from '../../CampaignInfoBar/CampaignInfoBarContainer';
 import AffiliatePromotion from '../../utilities/AffiliatePromotion/AffiliatePromotion';
 import ScholarshipInfoBlock from '../../blocks/ScholarshipInfoBlock/ScholarshipInfoBlock';
 import AffiliateOptInToggleContainer from '../../AffiliateOptInToggle/AffiliateOptInToggleContainer';
@@ -30,7 +29,6 @@ const HeroTemplate = ({
   coverImage,
   dashboard,
   displaySignupButton,
-  isClosed,
   isAffiliated,
   scholarshipAmount,
   scholarshipCallToAction,
@@ -174,7 +172,6 @@ HeroTemplate.propTypes = {
   }),
   displaySignupButton: PropTypes.bool,
   isAffiliated: PropTypes.bool,
-  isClosed: PropTypes.bool,
   scholarshipAmount: PropTypes.number,
   scholarshipCallToAction: PropTypes.string,
   scholarshipDeadline: PropTypes.string,
@@ -192,7 +189,6 @@ HeroTemplate.defaultProps = {
   dashboard: null,
   displaySignupButton: true,
   isAffiliated: false,
-  isClosed: false,
   scholarshipAmount: null,
   scholarshipCallToAction: null,
   scholarshipDeadline: null,

--- a/resources/assets/components/LedeBanner/templates/HeroTemplate.js
+++ b/resources/assets/components/LedeBanner/templates/HeroTemplate.js
@@ -155,8 +155,6 @@ const HeroTemplate = ({
       </div>
 
       {dashboard ? <ContentfulEntry json={dashboard} /> : null}
-
-      {!isAffiliated && !isClosed ? <CampaignInfoBarContainer /> : null}
     </>
   );
 };

--- a/resources/assets/components/pages/LandingPage/LandingPage.js
+++ b/resources/assets/components/pages/LandingPage/LandingPage.js
@@ -15,6 +15,7 @@ const LandingPage = props => {
   const {
     additionalContent,
     campaignId,
+    content,
     isCampaignClosed,
     featureFlagUseLegacyTemplate,
     scholarshipAmount,
@@ -80,7 +81,9 @@ const LandingPage = props => {
             </div>
           </div>
         </>
-      ) : null}
+      ) : (
+        <TextContent>{content}</TextContent>
+      )}
     </React.Fragment>
   );
 };
@@ -88,6 +91,7 @@ const LandingPage = props => {
 LandingPage.propTypes = {
   additionalContent: PropTypes.object,
   campaignId: PropTypes.string.isRequired,
+  content: PropTypes.object,
   featureFlagUseLegacyTemplate: PropTypes.bool,
   isCampaignClosed: PropTypes.bool,
   scholarshipAmount: PropTypes.number,
@@ -102,6 +106,7 @@ LandingPage.propTypes = {
 
 LandingPage.defaultProps = {
   additionalContent: null,
+  content: null,
   featureFlagUseLegacyTemplate: false,
   isCampaignClosed: false,
   scholarshipAmount: null,

--- a/resources/assets/components/pages/LandingPage/LandingPage.js
+++ b/resources/assets/components/pages/LandingPage/LandingPage.js
@@ -82,7 +82,15 @@ const LandingPage = props => {
           </div>
         </>
       ) : (
-        <TextContent>{content}</TextContent>
+        <div className="bg-white">
+          <div className="md:w-3/4 mx-auto py-6 px-3 pitch-landing-page">
+            <div className="campaign-page__content clearfix">
+              <div className="primary">
+                <TextContent>{content}</TextContent>
+              </div>
+            </div>
+          </div>
+        </div>
       )}
     </React.Fragment>
   );

--- a/resources/assets/components/pages/LandingPage/LandingPage.js
+++ b/resources/assets/components/pages/LandingPage/LandingPage.js
@@ -82,15 +82,18 @@ const LandingPage = props => {
           </div>
         </>
       ) : (
-        <div className="bg-white">
-          <div className="md:w-3/4 mx-auto py-6 px-3 pitch-landing-page">
-            <div className="campaign-page__content clearfix">
-              <div className="primary">
-                <TextContent>{content}</TextContent>
+        <>
+          <div className="bg-white">
+            <div className="md:w-3/4 mx-auto py-6 px-3 pitch-landing-page">
+              <div className="campaign-page__content clearfix">
+                <div className="primary">
+                  <TextContent>{content}</TextContent>
+                </div>
               </div>
             </div>
           </div>
-        </div>
+          <CampaignInfoBarContainer />
+        </>
       )}
     </React.Fragment>
   );

--- a/resources/assets/components/pages/LandingPage/LandingPageContainer.js
+++ b/resources/assets/components/pages/LandingPage/LandingPageContainer.js
@@ -18,6 +18,7 @@ const mapStateToProps = (state, ownProps) => {
   return {
     additionalContent: landingPage.additionalContent,
     campaignId: state.campaign.campaignId,
+    content: landingPage.content,
     featureFlagUseLegacyTemplate: get(
       state,
       'campaign.additionalContent.featureFlagUseLegacyTemplate',


### PR DESCRIPTION
### What's this PR do?

Now that #1875 has been deployed, I've deleted the `content` long text field and recreated it as a Rich Text field. This PR adds the migration for that change, and displays the field in the Landing Page for non legacy template campaigns.

### How should this be reviewed?

I've created a test landing page with Rich Text content over on https://dosomething-phoenix-de-pr-1876.herokuapp.com/us/campaigns/aaron-test-campaign.

### Any background context you want to provide?

I've significantly edited this PR description now that all the things are working and it's no longer a WIP.

### Relevant tickets

References [Pivotal #170606520](https://www.pivotaltracker.com/n/projects/2401401/stories/170606520).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [x] Documentation added for new features/changed endpoints.
- [x] Added screenshots of front-end changes on small, medium, and large screens.
- [ ] Added appropriate feature/unit tests.
