### PR TITLE
Fix Company Page migration

### DIFF
--- a/contentful/content-types/companyPage.js
+++ b/contentful/content-types/companyPage.js
@@ -33,7 +33,7 @@ module.exports = function(migration) {
       },
       {
         regexp: {
-          pattern: '^[a-z\\-]+$',
+          pattern: '^[a-z[0-9]\\-]+$',
         },
 
         message:

--- a/contentful/content-types/companyPage.js
+++ b/contentful/content-types/companyPage.js
@@ -59,25 +59,6 @@ module.exports = function(migration) {
     .linkType('Entry');
 
   companyPage
-    .createField('title')
-    .name('Title')
-    .type('Symbol')
-    .localized(true)
-    .required(true)
-    .validations([])
-    .disabled(false)
-    .omitted(false);
-  companyPage
-    .createField('subTitle')
-    .name('Subtitle')
-    .type('Symbol')
-    .localized(true)
-    .required(false)
-    .validations([])
-    .disabled(false)
-    .omitted(false);
-
-  companyPage
     .createField('coverImage')
     .name('Cover Image')
     .type('Link')
@@ -98,6 +79,25 @@ module.exports = function(migration) {
     .linkType('Asset');
 
   companyPage
+    .createField('title')
+    .name('Title')
+    .type('Symbol')
+    .localized(true)
+    .required(true)
+    .validations([])
+    .disabled(false)
+    .omitted(false);
+  companyPage
+    .createField('subTitle')
+    .name('Subtitle')
+    .type('Symbol')
+    .localized(true)
+    .required(false)
+    .validations([])
+    .disabled(false)
+    .omitted(false);
+
+  companyPage
     .createField('content')
     .name('Content')
     .type('RichText')
@@ -106,7 +106,7 @@ module.exports = function(migration) {
     .validations([
       {
         nodes: {
-          'embedded-entry-inline': [
+          'embedded-entry-block': [
             {
               linkContentType: [
                 'contentBlock',
@@ -133,10 +133,11 @@ module.exports = function(migration) {
           'embedded-entry-block',
           'embedded-asset-block',
           'hyperlink',
+          'asset-hyperlink',
         ],
 
         message:
-          'Only heading 1, heading 2, heading 3, heading 4, heading 5, heading 6, ordered list, unordered list, horizontal rule, quote, block entry, asset, and link to Url nodes are allowed',
+          'Only heading 1, heading 2, heading 3, heading 4, heading 5, heading 6, ordered list, unordered list, horizontal rule, quote, block entry, asset, link to Url, and link to asset nodes are allowed',
       },
     ])
     .disabled(false)
@@ -150,13 +151,13 @@ module.exports = function(migration) {
   });
 
   companyPage.changeFieldControl('metadata', 'builtin', 'entryLinkEditor', {});
-  companyPage.changeFieldControl('title', 'builtin', 'singleLine', {});
-  companyPage.changeFieldControl('subTitle', 'builtin', 'singleLine', {});
   companyPage.changeFieldControl(
     'coverImage',
     'builtin',
     'assetLinkEditor',
     {},
   );
+  companyPage.changeFieldControl('title', 'builtin', 'singleLine', {});
+  companyPage.changeFieldControl('subTitle', 'builtin', 'singleLine', {});
   companyPage.changeFieldControl('content', 'builtin', 'richTextEditor', {});
 };

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -14,6 +14,7 @@
   - [Heroku](development/architecture/heroku.md)
 - [Content Types](development/content-types/README.md)
   - [Content Block](development/content-types/content-block.md)
+  - [Company Page](development/content-types/company-page.md)
   - [Current School Block](development/content-types/current-school-block.md)
   - [Embed](development/content-types/embed.md)
   - [Metadata](development/content-types/metadata.md)

--- a/docs/development/content-types/company-page.md
+++ b/docs/development/content-types/company-page.md
@@ -1,0 +1,29 @@
+# Company Page
+
+## Overview
+
+Displays static organizational 'about' information. Company Pages are accessed via an `/about/:slug` URL. Company Pages display in a wider grid template contrary to article/11-facts pages which have a narrower 'article friendly' layout.
+
+## Content Type Fields
+
+- **Internal Title**: This is for our internal Contentful organization and will be how the block shows up in search results, etc. (does _not_ display to the user on the company page).
+
+- **Slug**: The URL slug, which we prefix with `/about/`. e.g. `dosomething.org/about/our-team`.
+
+- **Cover Image** _(optional)_: Displays at the top of the page.
+
+- **Title**: The title of the page.
+
+- **Subtitle**: The subtitle of the page
+
+- **Content**: The Rich Text content of the page. This can be content in markdown format, embedded Assets, or embedded entry blocks ([Content Blocks](./content-block.md), Images Blocks, & Link Actions).
+
+## Technical Notes
+
+#### GraphQL
+
+The Company Page is available as a `CompanyPage` in GraphQL.
+
+#### Feature Flag
+
+Currently, `/about/:slug` pages pull from regular Page entries in Contentful, and _not_ from Company Pages. To toggle on the new Company Pages, `DS_ENABLE_COMPANY_PAGES=true` must be set in the `.env` file.

--- a/docs/development/content-types/company-page.md
+++ b/docs/development/content-types/company-page.md
@@ -16,7 +16,7 @@ Displays static organizational 'about' information. Company Pages are accessed v
 
 - **Subtitle**: The subtitle of the page
 
-- **Content**: The Rich Text content of the page. This can be content in markdown format, embedded Assets, or embedded entry blocks ([Content Blocks](./content-block.md), Images Blocks, & Link Actions).
+- **Content**: The Rich Text content of the page. This can be content in markdown format, embedded Assets, or valid embedded entry blocks.
 
 ## Technical Notes
 


### PR DESCRIPTION
### What's this PR do?

I'm a bit of a [Schlemiel](https://en.wikipedia.org/wiki/Schlemiel), and added the embedded entry block validation in the wrong way.

This fixes that, plus, updates the ordering of the Cover Image field to follow the way it's displayed on the page.

Also, while testing the #1870 script on QA, I bumped into validation errors because we weren't allowing numerical values in slugs, but some about pages have 'em! I think we do mean to support alphanumeric values (as per the validation message), so updated in https://github.com/DoSomething/phoenix-next/pull/1877/commits/c3c7a0cbddfc3dbe01f2f16b02dc714362a6d431 

While I was at it and re @aaronschachter's pro tip https://github.com/DoSomething/phoenix-next/pull/1865#pullrequestreview-346773991 I added some documentation for the company page. (@aaronschachter how do you link to the Gitbooks version from your PR's?)

### How should this be reviewed?
👀 

### Relevant tickets

References [Pivotal #167297536](https://www.pivotaltracker.com/story/show/167297536).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [x] Documentation added for new features/changed endpoints.
