### PR TITLE
Remove deprecated 'timed modals' env variables

### DIFF
--- a/config/services.php
+++ b/config/services.php
@@ -59,13 +59,4 @@ return [
         'url' => 'https://app.contentful.com',
         'cache' => env('CONTENTFUL_CACHE', true),
     ],
-
-    'timed_modals' => [
-        'nps_survey' => [
-            'enabled' => env('NPS_SURVEY_ENABLED', false),
-        ],
-        'voter_reg_modal' => [
-            'enabled' => env('VOTER_REG_MODAL_ENABLED', false),
-        ],
-    ],
 ];


### PR DESCRIPTION
### What's this PR do?

This PR removes the 'timed modal' env variables deprecated in #1871 

### How should this be reviewed?
👀 

### Relevant tickets

References [Pivotal #167297536](https://www.pivotaltracker.com/story/show/167297536).