### PR TITLE
Change Form Submission Type to Text

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2325,7 +2325,7 @@
     "@types/zen-observable": {
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/@types/zen-observable/-/zen-observable-0.8.0.tgz",
-      "integrity": "sha512-te5lMAWii1uEJ4FwLjzdlbw3+n0FZNOvFXHxQDKeT0dilh7HOzdMzV2TrJVUzq8ep7J4Na8OUYPRLSQkJHAlrg=="
+      "integrity": "sha1-i2OrfxqlMhJIqtWsiQpIVlbc6k0="
     },
     "@webassemblyjs/ast": {
       "version": "1.8.5",

--- a/resources/assets/components/pages/GeneralPage/GeneralPage.js
+++ b/resources/assets/components/pages/GeneralPage/GeneralPage.js
@@ -152,6 +152,7 @@ const GeneralPage = props => {
         {slug === 'about/easy-scholarships' ? (
           <DismissableElement
             name="cta_popover_scholarship_email"
+            context={{ ContextSource: 'newsletter_scholarships' }}
             render={(handleClose, handleComplete) => (
               <DelayedElement delay={3}>
                 <CtaPopover

--- a/resources/assets/components/pages/GeneralPage/GeneralPage.js
+++ b/resources/assets/components/pages/GeneralPage/GeneralPage.js
@@ -152,7 +152,7 @@ const GeneralPage = props => {
         {slug === 'about/easy-scholarships' ? (
           <DismissableElement
             name="cta_popover_scholarship_email"
-            context={{ ContextSource: 'newsletter_scholarships' }}
+            context={{ contextSource: 'newsletter_scholarships' }}
             render={(handleClose, handleComplete) => (
               <DelayedElement delay={3}>
                 <CtaPopover

--- a/resources/assets/components/utilities/CtaPopover/CtaPopoverEmailForm.js
+++ b/resources/assets/components/utilities/CtaPopover/CtaPopoverEmailForm.js
@@ -93,7 +93,7 @@ const CtaPopoverEmailForm = ({ handleComplete }) => {
       <form className="email-form form pb-2" onSubmit={handleSubmit}>
         <input
           className="text-field email-form__input"
-          type="email"
+          type="text"
           value={emailValue}
           placeholder="Enter your email address"
           onChange={handleChange}

--- a/resources/assets/components/utilities/DismissableElement/DismissableElement.js
+++ b/resources/assets/components/utilities/DismissableElement/DismissableElement.js
@@ -3,8 +3,9 @@ import { useState, useEffect } from 'react';
 
 import { isTimestampValid, query } from '../../../helpers';
 import { get as getStorage, set as setStorage } from '../../../helpers/storage';
+import { trackAnalyticsEvent } from '../../../helpers/analytics';
 
-const DismissableElement = ({ name, render }) => {
+const DismissableElement = ({ name, render, context }) => {
   const [showElement, setShowElement] = useState(true);
 
   const handleCompletion = () => {
@@ -16,6 +17,16 @@ const DismissableElement = ({ name, render }) => {
     if (!getStorage(`hide_${name}`, 'boolean')) {
       // Mark the element as "dismissed" in local storage & hide it.
       setStorage(`dismissed_${name}`, 'timestamp', Date.now());
+
+      trackAnalyticsEvent({
+        context,
+        metadata: {
+          category: 'site_action',
+          noun: name,
+          target: 'dismissable_element',
+          verb: 'dismissed',
+        },
+      });
     }
     setShowElement(false);
   };
@@ -42,8 +53,13 @@ const DismissableElement = ({ name, render }) => {
 };
 
 DismissableElement.propTypes = {
+  context: PropTypes.object,
   name: PropTypes.string.isRequired,
   render: PropTypes.func.isRequired,
+};
+
+DismissableElement.defaultProps = {
+  context: {},
 };
 
 export default DismissableElement;

--- a/resources/assets/components/utilities/DismissableElement/DismissableElement.test.js
+++ b/resources/assets/components/utilities/DismissableElement/DismissableElement.test.js
@@ -7,6 +7,8 @@ import { get, set } from '../../../helpers/storage';
 import DismissableElement from './DismissableElement';
 import LocalStorageMock from '../../../__mocks__/localStorageMock';
 
+jest.mock('../../../helpers/analytics');
+
 // Name for our dismissable element.
 const NAME = 'fun_survey';
 


### PR DESCRIPTION
### What's this PR do?

This pull request is in response to [this slack discussion](https://dosomething.slack.com/archives/C3ASB4204/p1579881161006700) and [pivotal discussion](https://www.pivotaltracker.com/n/projects/2401401/stories/169330883) allowing us to change the form submission type of the `CtaPopoverEmailForm` to `"text"` so that it captures all errors and not just email errors in the interim.

### How should this be reviewed?

👀
should be quick

### Any background context you want to provide?

Adds to PR [1853](https://github.com/DoSomething/phoenix-next/pull/1853)

### Relevant tickets

References [Pivotal #169330883](https://www.pivotaltracker.com/n/projects/2401401/stories/169330883).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added screenshots of front-end changes on small, medium, and large screens.
- [ ] Added appropriate feature/unit tests.
