### PR TITLE
Adding general utm getter

### DIFF
--- a/resources/assets/helpers/analytics.js
+++ b/resources/assets/helpers/analytics.js
@@ -191,6 +191,7 @@ export function getPageContext() {
 export function getUtmContext() {
   const utms = getUtmParameters();
 
+  // For analytics, we prefer camelCased keys:
   return mapKeys(utms, (value, key) => camelCase(key));
 }
 

--- a/resources/assets/helpers/analytics.js
+++ b/resources/assets/helpers/analytics.js
@@ -1,8 +1,9 @@
 /* global window */
 
-import { get, snakeCase, startCase } from 'lodash';
+import { camelCase, get, mapKeys, snakeCase, startCase } from 'lodash';
 
-import { debug, stringifyNestedObjects, withoutValueless, query } from '.';
+import { getUtmParameters } from './utm';
+import { debug, stringifyNestedObjects, withoutValueless } from '.';
 
 /**
  * App name prefix used for event naming.
@@ -188,11 +189,9 @@ export function getPageContext() {
  * @return {Object}
  */
 export function getUtmContext() {
-  return {
-    utmSource: query('utm_source'),
-    utmMedium: query('utm_medium'),
-    utmCampaign: query('utm_campaign'),
-  };
+  const utms = getUtmParameters();
+
+  return mapKeys(utms, (value, key) => camelCase(key));
 }
 
 /**

--- a/resources/assets/helpers/forms.js
+++ b/resources/assets/helpers/forms.js
@@ -2,7 +2,7 @@
 
 import { forEach, get, isInteger } from 'lodash';
 
-import { withoutNulls } from '.';
+import { withoutValueless } from '.';
 import { getUtmParameters } from './utm';
 
 /**
@@ -123,7 +123,7 @@ export function formatPostPayload(data = {}) {
 
   // Attach 'source_details' based on referring page/block & UTMs:
   formattedData.source_details = JSON.stringify(
-    withoutNulls({
+    withoutValueless({
       // @TODO: Pass in 'contentful_id' parameter here w/ the containing page ID.
       // contentful_id: contentfulId,
       ...getUtmParameters(),

--- a/resources/assets/helpers/forms.js
+++ b/resources/assets/helpers/forms.js
@@ -3,6 +3,7 @@
 import { forEach, get, isInteger } from 'lodash';
 
 import { query, withoutNulls } from '.';
+import { getUtmParameters } from './utm';
 
 /**
  * Calculate the difference between a total value and a submitted value.
@@ -125,9 +126,7 @@ export function formatPostPayload(data = {}) {
     withoutNulls({
       // @TODO: Pass in 'contentful_id' parameter here w/ the containing page ID.
       // contentful_id: contentfulId,
-      utm_source: query('utm_source'),
-      utm_medium: query('utm_medium'),
-      utm_campaign: query('utm_campaign'),
+      ...getUtmParameters(),
     }),
   );
 

--- a/resources/assets/helpers/forms.js
+++ b/resources/assets/helpers/forms.js
@@ -2,7 +2,7 @@
 
 import { forEach, get, isInteger } from 'lodash';
 
-import { query, withoutNulls } from '.';
+import { withoutNulls } from '.';
 import { getUtmParameters } from './utm';
 
 /**

--- a/resources/assets/helpers/utm.js
+++ b/resources/assets/helpers/utm.js
@@ -1,0 +1,16 @@
+/* eslint-disable import/prefer-default-export */
+
+import { query } from '.';
+
+/**
+ * Get UTM parameters.
+ *
+ * @return {Object}
+ */
+export function getUtmParameters() {
+  return {
+    utm_source: query('utm_source'),
+    utm_medium: query('utm_medium'),
+    utm_campaign: query('utm_campaign'),
+  };
+}

--- a/resources/assets/helpers/utm.js
+++ b/resources/assets/helpers/utm.js
@@ -1,5 +1,3 @@
-/* eslint-disable import/prefer-default-export */
-
 import { query } from '.';
 
 /**
@@ -14,3 +12,5 @@ export function getUtmParameters() {
     utm_campaign: query('utm_campaign'),
   };
 }
+
+export default null;

--- a/resources/assets/selectors/index.js
+++ b/resources/assets/selectors/index.js
@@ -1,3 +1,4 @@
+import { getUtmParameters } from '../helpers/utm';
 import { query, withoutValueless } from '../helpers';
 import { getCampaignDataForNorthstar } from './campaign';
 import { getStoryPageDataForNorthstar } from './storyPage';
@@ -11,9 +12,7 @@ export function getDataForNorthstar(state) {
     contentful_id: state.campaign.id || state.page.id,
     mode: query('mode') || null,
     referrer_user_id: query('referrer_user_id'),
-    utm_source: query('utm_source'),
-    utm_medium: query('utm_medium'),
-    utm_campaign: query('utm_campaign'),
+    ...getUtmParameters(),
   });
 }
 


### PR DESCRIPTION
### What's this PR do?

This pull request refactors a few of the locations that pull UTM query parameters, establishing a general helper function and updating the other locations to use the helper and thus DRYing the code up a bit.

There's one instance in the `helpers/analytics.js` file where we actually want the keys for the resulting UTM data object to be camelCase. We figured it'd be best to just address this in the same file using Lodash's [`mapKeys()` method](https://lodash.com/docs/4.17.15#mapKeys) instead of allowing passing a formatter to the `getUtmParameters()` function which seems a little useless and unnecessary.

### How should this be reviewed?

👀 

### Any background context you want to provide?

This is some pre-work to help with the ticket to allow UTMs to persist as a user clicks around the website.

### Relevant tickets

References [Pivotal #169960864](https://www.pivotaltracker.com/story/show/169960864).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Added appropriate feature/unit tests.
