### PR TITLE
Remove unused title and subtitle fields from Landing Page

### DIFF
--- a/app/Entities/LandingPage.php
+++ b/app/Entities/LandingPage.php
@@ -18,8 +18,6 @@ class LandingPage extends Entity implements JsonSerializable
             'type' => $this->getContentType(),
             'fields' => [
                 'internalTitle' => $this->internalTitle,
-                'title' => $this->title,
-                'subTitle' => $this->subTitle,
                 'content' => $this->content,
                 'sidebar' => $this->parseBlocks($this->sidebar),
                 'blocks' => $this->parseBlocks($this->blocks),

--- a/contentful/content-types/landingPage.js
+++ b/contentful/content-types/landingPage.js
@@ -13,24 +13,6 @@ module.exports = function(migration) {
     .validations([])
     .disabled(false)
     .omitted(false);
-  landingPage
-    .createField('title')
-    .name('Title')
-    .type('Symbol')
-    .localized(true)
-    .required(true)
-    .validations([])
-    .disabled(false)
-    .omitted(false);
-  landingPage
-    .createField('subTitle')
-    .name('Subtitle')
-    .type('Symbol')
-    .localized(true)
-    .required(false)
-    .validations([])
-    .disabled(false)
-    .omitted(false);
 
   landingPage
     .createField('content')
@@ -104,8 +86,6 @@ module.exports = function(migration) {
     .disabled(false)
     .omitted(false);
   landingPage.changeFieldControl('internalTitle', 'builtin', 'singleLine', {});
-  landingPage.changeFieldControl('title', 'builtin', 'singleLine', {});
-  landingPage.changeFieldControl('subTitle', 'builtin', 'singleLine', {});
   landingPage.changeFieldControl('content', 'builtin', 'richTextEditor', {});
 
   landingPage.changeFieldControl('sidebar', 'builtin', 'entryLinksEditor', {

--- a/cypress/integration/campaign-signup.js
+++ b/cypress/integration/campaign-signup.js
@@ -22,6 +22,7 @@ describe('Campaign Signup', () => {
     cy.contains('Example Campaign');
     cy.contains('This is an example campaign for automated testing.');
     cy.contains(exampleBlurb);
+    cy.get('.pitch-landing-page').should('have.length', 1);
 
     // Mock the responses we'll be expecting once we hit "Join Now":
     cy.route(`${API}/signups?filter[northstar_id]=${user.id}`, emptyResponse);
@@ -44,6 +45,7 @@ describe('Campaign Signup', () => {
     cy.contains('Example Campaign');
     cy.contains('This is an example campaign for automated testing.');
     cy.contains(exampleBlurb);
+    cy.get('.pitch-landing-page').should('have.length', 1);
 
     // Mock the response we'll be expecting once we hit "Join Now":
     cy.route('POST', `${API}/signups`, newSignup(campaignId, user));
@@ -62,6 +64,7 @@ describe('Campaign Signup', () => {
     cy.contains('Example Campaign');
     cy.contains('This is an example campaign for automated testing.');
     cy.contains(exampleBlurb);
+    cy.get('.pitch-landing-page').should('not.exist');
 
     // We shouldn't see the "Join Now" button or affiramation modal,
     // since the user is already signed up for this campaign:

--- a/docs/development/content-types/landing-page.md
+++ b/docs/development/content-types/landing-page.md
@@ -10,10 +10,6 @@ The landing page displayed on a [campaign](development/content-types/campaign.md
 
 - **Content** : A Rich Text field, which can embed `contentBlock`, `imagesBlock`, and `linkAction` entries.
 
-- **Title** : This isn't used and should be deleted?
-
-- **Subtitle** : This too?
-
 - **Sidebar** : A multi-value reference field, only displayed on the legacy campaign template.
 
 - **Additonal Content** : The legacy campaign template uses this field to display Landing Page content, expecting a `legacyTemplateContent` property.


### PR DESCRIPTION
### What's this PR do?

This pull request modifies the migration for the `landingPage` content type to remove the `title` and `subtitle` fields, which are [unused](https://github.com/DoSomething/phoenix-next/pull/1876#discussion_r370809474).

Also adds a test for #1876.

### How should this be reviewed?

👀 

### Any background context you want to provide?

Seems like we can safely delete the disabled `blocks` multi-value reference field from the `landingPage` content type as well? cc @mendelB 

### Relevant tickets

References [Pivotal #170606520](https://www.pivotaltracker.com/story/show/170606520).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [x] Documentation added for new features/changed endpoints.
- [x] Added appropriate feature/unit tests.
