### PR TITLE
🐛 🚨 patch the quiz loader

### DIFF
--- a/resources/assets/components/pages/CampaignPage/CampaignPage.js
+++ b/resources/assets/components/pages/CampaignPage/CampaignPage.js
@@ -36,7 +36,7 @@ const CampaignPage = props => {
             {!entryContent ? (
               <CampaignPageContent {...props} />
             ) : (
-              <ContentfulEntryLoader json={entryContent} />
+              <ContentfulEntryLoader id={entryContent.id} />
             )}
           </div>
 


### PR DESCRIPTION
### What's this PR do?

This pull request fixes the quiz loader via `ContentfulEntryLoader`.

It seems we may have accidentally reverted the `id` prop due to a git history mismatch https://github.com/DoSomething/phoenix-next/blame/1e656cc6fdf6c51add92c7571cb9f25a6df6de2b/resources/assets/components/pages/CampaignPage/CampaignPage.js#L39

https://dosomething.slack.com/archives/C09ANFQLA/p1579903379013300
