### PR TITLE
Persisting UTM parameters across user journey.

### DIFF
--- a/resources/assets/helpers/utm.js
+++ b/resources/assets/helpers/utm.js
@@ -52,8 +52,8 @@ export function persistUtms() {
   // Get any current query param utms:
   const utms = withoutValueless(getUtmParameters());
 
-  // If no current query param utms, check to see if there are any in session storage:
-  let sessionUtms = getSessionUtms(UTM_SESSION_KEY);
+  // Check to see if there are any in session storage:
+  const sessionUtms = getSessionUtms(UTM_SESSION_KEY);
 
   // If no current query param utms and no utms in session storage, return.
   if (isEmpty(utms) && isEmpty(sessionUtms)) {
@@ -62,7 +62,7 @@ export function persistUtms() {
 
   // If no session utms, then store the current query param utms:
   if (isEmpty(sessionUtms)) {
-    sessionUtms = setSessionUtms(UTM_SESSION_KEY, utms);
+    setSessionUtms(UTM_SESSION_KEY, utms);
 
     return;
   }
@@ -72,5 +72,7 @@ export function persistUtms() {
     const url = appendToQuery(sessionUtms);
 
     history.replaceState(null, '', url.href);
+
+    return;
   }
 }

--- a/resources/assets/helpers/utm.js
+++ b/resources/assets/helpers/utm.js
@@ -55,11 +55,6 @@ export function persistUtms() {
   // Check to see if there are any in session storage:
   const sessionUtms = getSessionUtms(UTM_SESSION_KEY);
 
-  // // If no current query param utms and no utms in session storage, return.
-  // if (isEmpty(utms) && isEmpty(sessionUtms)) {
-  //   return;
-  // }
-
   // If no session utms, then store the current query param utms:
   if (isEmpty(sessionUtms) && !isEmpty(utms)) {
     setSessionUtms(UTM_SESSION_KEY, utms);

--- a/resources/assets/helpers/utm.js
+++ b/resources/assets/helpers/utm.js
@@ -67,7 +67,5 @@ export function persistUtms() {
     const url = appendToQuery(sessionUtms);
 
     history.replaceState(null, '', url.href);
-
-    return;
   }
 }

--- a/resources/assets/helpers/utm.js
+++ b/resources/assets/helpers/utm.js
@@ -1,4 +1,34 @@
-import { query } from '.';
+/* global history */
+/* eslint-disable no-restricted-globals */
+
+import { isEmpty } from 'lodash';
+
+import { appendToQuery, query, withoutValueless } from '.';
+
+const UTM_SESSION_KEY = 'ds_utm_params';
+
+/**
+ * Get UTM parameters from session storage.
+ *
+ * @param  {String} key
+ * @return {Object}
+ */
+export function getSessionUtms(key) {
+  return JSON.parse(sessionStorage.getItem(key));
+}
+
+/**
+ * Store UTM parameters in session storage.
+ *
+ * @param  {String} key
+ * @param  {Object} utms
+ * @return {Object}
+ */
+export function setSessionUtms(key, utms) {
+  sessionStorage.setItem(key, JSON.stringify(utms));
+
+  return utms;
+}
 
 /**
  * Get UTM parameters.
@@ -13,4 +43,34 @@ export function getUtmParameters() {
   };
 }
 
-export default null;
+/**
+ * Persist UTM parameters in session storage.
+ *
+ * @return void
+ */
+export function persistUtms() {
+  // Get any current query param utms:
+  const utms = withoutValueless(getUtmParameters());
+
+  // If no current query param utms, check to see if there are any in session storage:
+  let sessionUtms = getSessionUtms(UTM_SESSION_KEY);
+
+  // If no current query param utms and no utms in session storage, return.
+  if (isEmpty(utms) && isEmpty(sessionUtms)) {
+    return;
+  }
+
+  // If no session utms, then store the current query param utms:
+  if (isEmpty(sessionUtms)) {
+    sessionUtms = setSessionUtms(UTM_SESSION_KEY, utms);
+
+    return;
+  }
+
+  // If no current query param utms, but found session utms, add them to the URL:
+  if (isEmpty(utms) && sessionUtms) {
+    const url = appendToQuery(sessionUtms);
+
+    history.replaceState(null, '', url.href);
+  }
+}

--- a/resources/assets/helpers/utm.js
+++ b/resources/assets/helpers/utm.js
@@ -55,20 +55,20 @@ export function persistUtms() {
   // Check to see if there are any in session storage:
   const sessionUtms = getSessionUtms(UTM_SESSION_KEY);
 
-  // If no current query param utms and no utms in session storage, return.
-  if (isEmpty(utms) && isEmpty(sessionUtms)) {
-    return;
-  }
+  // // If no current query param utms and no utms in session storage, return.
+  // if (isEmpty(utms) && isEmpty(sessionUtms)) {
+  //   return;
+  // }
 
   // If no session utms, then store the current query param utms:
-  if (isEmpty(sessionUtms)) {
+  if (isEmpty(sessionUtms) && !isEmpty(utms)) {
     setSessionUtms(UTM_SESSION_KEY, utms);
 
     return;
   }
 
   // If no current query param utms, but found session utms, add them to the URL:
-  if (isEmpty(utms) && sessionUtms) {
+  if (isEmpty(utms) && !isEmpty(sessionUtms)) {
     const url = appendToQuery(sessionUtms);
 
     history.replaceState(null, '', url.href);

--- a/resources/assets/init.js
+++ b/resources/assets/init.js
@@ -38,6 +38,7 @@ import NavApp from './components/NavApp';
 
 // DOM Helpers
 import { ready, debug } from './helpers';
+import { persistUtms } from './helpers/utm';
 import { init as historyInit } from './history';
 import { bindTokenRefreshEvent } from './helpers/auth';
 import { bindFlashMessageEvents } from './helpers/flash-message';
@@ -47,6 +48,9 @@ import { analyze, trackAnalyticsPageView } from './helpers/analytics';
 ready(() => {
   // Enable Debug tools.
   debug();
+
+  // Persist any query param UTMs across the user journey on site.
+  persistUtms();
 
   // Configure store & history.
   const history = historyInit();


### PR DESCRIPTION
### What's this PR do?

When a user comes to the DoSomething site from a partner's site, they typically have UTMs attached to the URL as query parameters that help with our analytics to let us know where the user was coming from. However, these UTMs only exist on the first DoSomething site page the user lands on. We would like the UTMs to persist throughout the user's journey so our analytics reflects the full context of that user's journey.

This pull request allows UTMs attached to the URL from a partner's site to persist throughout the users session on the web, even after logging in or signing up for a campaign. The UTMs are cleared after the user's session ends, so when they close the browser or tab they are using.

Example:
![Persisting UTM Parameters](https://user-images.githubusercontent.com/105849/73202632-6f894680-4109-11ea-9e2b-0f03e112e3de.gif)

### How should this be reviewed?

👀 

### Any background context you want to 

We're using [`sessionStorage`](https://developer.mozilla.org/en-US/docs/Web/API/Window/sessionStorage) to handle storing the UTMs for the session.

### Relevant tickets

References [Pivotal #](https://www.pivotaltracker.com/story/show/169960864).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [x] Added screenshots of front-end changes on small, medium, and large screens.
- [ ] Added appropriate feature/unit tests.
