### PR TITLE
Management API script processEntries pagination

### DIFF
--- a/docs/development/contentful/content-management-api-scripts.md
+++ b/docs/development/contentful/content-management-api-scripts.md
@@ -88,8 +88,6 @@ If your script utilizes the `processEntries` helper method from `/helpers`, than
 
 - There is a suite of helper functions in `./helpers` containing some common logic we found ourselves running with these scripts.
 
-- If utilizing the `--all` flag to bulk process all entries of a content-type & if the content-type contains more then 1000 entries, a temporary workaround to the API's 1000 entry limit is to keep incrementing the `skip` parameter by 1000 in the `./helpers#processEntries` method to eventually process _all_ entries.
-
 ## Notes
 
 - The Content Management API [does not support the `include` parameter to retrieve nested entries in a `getEntries` call](https://www.contentful.com/developers/docs/references/content-management-api/#/reference/search-parameters), so you'll need to make a `getEntry` request to access the fields of an entry reference field value.


### PR DESCRIPTION
### What's this PR do?

This pull request adds functionality to the `processEntries` helper we use in Contentful management API scripts to batch process *all* entries even above the 1000 API limit.

### How should this be reviewed?
👀 

### Any background context you want to provide?
I utterly humiliated myself trying to get to the bottom of what I thought was a thorny encoding issue causing #1870 to not process all about pages.

Turns out, I had completely forgotten about our lil pagination hack, and that we had more than 100 page entries! 🤦‍♂ 

This is an attempt to restore my dignity, and prevent this mistake or just make running these scripts easier as our content store keeps growing!

### Relevant tickets

References [Pivotal #167297536](https://www.pivotaltracker.com/story/show/167297536).
