### PR TITLE
Revising approach to persist UTMs for analytics.

### DIFF
--- a/resources/assets/helpers/utm.js
+++ b/resources/assets/helpers/utm.js
@@ -7,22 +7,20 @@ const UTM_SESSION_KEY = 'ds_utm_params';
 /**
  * Get UTM parameters from session storage.
  *
- * @param  {String} key
  * @return {Object}
  */
-export function getSessionUtms(key) {
-  return JSON.parse(sessionStorage.getItem(key));
+export function getSessionUtms() {
+  return JSON.parse(sessionStorage.getItem(UTM_SESSION_KEY));
 }
 
 /**
  * Store UTM parameters in session storage.
  *
- * @param  {String} key
  * @param  {Object} utms
  * @return {Object}
  */
-export function setSessionUtms(key, utms) {
-  sessionStorage.setItem(key, JSON.stringify(utms));
+export function setSessionUtms(utms) {
+  sessionStorage.setItem(UTM_SESSION_KEY, JSON.stringify(utms));
 
   return utms;
 }
@@ -33,7 +31,7 @@ export function setSessionUtms(key, utms) {
  * @return {Object}
  */
 export function getUtmParameters() {
-  const sessionUtms = getSessionUtms(UTM_SESSION_KEY);
+  const sessionUtms = getSessionUtms();
 
   return !isEmpty(sessionUtms)
     ? sessionUtms
@@ -51,7 +49,7 @@ export function getUtmParameters() {
  */
 export function persistUtms() {
   // Check to see if there are any utms in session storage:
-  const sessionUtms = getSessionUtms(UTM_SESSION_KEY);
+  const sessionUtms = getSessionUtms();
 
   // If utms in session storage, no need to store them again, so exit out.
   if (!isEmpty(sessionUtms)) {
@@ -63,6 +61,6 @@ export function persistUtms() {
 
   // If no session utms, then store the current query param utms:
   if (isEmpty(sessionUtms) && !isEmpty(utms)) {
-    setSessionUtms(UTM_SESSION_KEY, utms);
+    setSessionUtms(utms);
   }
 }


### PR DESCRIPTION
### What's this PR do?

After some discussion with the crew regarding the approach for persisting UTMs in #1884, we decided it best to revise the approach a bit. While we continue persisting the UTMs in session storage as planned, instead of using `history.pushState` to re-write the URL and append the UTM query params for every page in a user's journey, we would alternatively just pull the values from session storage (or URL query if no items in session) when an analytics event is triggered.

This should avoid any edge-case scenarios like when a page doesn't complete a full reload (going from campaign `/action` to `/faq` for example) and allow the URL to behave as expected w/ the UTMs disappearing after the initial arrival to a page from a third-party partner.

### How should this be reviewed?

👀 and maybe using ye ole `window.DS.Debug.enableLogs(['google', 'snowplow'])` to confirm context data includes UTMs when testing!

### Any background context you want to provide?

Apart from discussion in #1884 there's also some additional discussion in a [Slack thread](https://dosomething.slack.com/archives/CJ340DEEL/p1580235818005600).

### Relevant tickets

References [Pivotal #169960864](https://www.pivotaltracker.com/story/show/169960864).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Added appropriate feature/unit tests.
