### PR TITLE
Adds Newsletter CTA to Other Scholarship Article Pages

### DIFF
--- a/app/Entities/Page.php
+++ b/app/Entities/Page.php
@@ -45,6 +45,7 @@ class Page extends Entity implements JsonSerializable
                     'url' => get_image_url($this->coverImage),
                 ],
                 'content' => $this->content,
+                'additionalContent' => $this->additionalContent,
                 'sidebar' => $this->parseBlocks($this->sidebar),
                 'blocks' => $this->parseBlocks($this->blocks),
                 'displaySocialShare' => $this->displaySocialShare,

--- a/resources/assets/components/pages/GeneralPage/GeneralPage.js
+++ b/resources/assets/components/pages/GeneralPage/GeneralPage.js
@@ -155,9 +155,8 @@ const GeneralPage = props => {
           />
         ) : null}
         {!featureFlag('company_pages') &&
-        (slug === 'about/easy-scholarships' ||
-          additionalContent.display_scholarship_newsletter_cta_popover ===
-            true) ? (
+        additionalContent.display_scholarship_newsletter_cta_popover ===
+          true ? (
           <DismissableElement
             name="cta_popover_scholarship_email"
             context={{ contextSource: 'newsletter_scholarships' }}

--- a/resources/assets/components/pages/GeneralPage/GeneralPage.js
+++ b/resources/assets/components/pages/GeneralPage/GeneralPage.js
@@ -40,6 +40,7 @@ const GeneralPage = props => {
     subTitle,
     coverImage,
     content,
+    additionalContent,
     sidebar,
     blocks,
     displaySocialShare,
@@ -153,7 +154,10 @@ const GeneralPage = props => {
             buttonText={ctaCopy.buttonText}
           />
         ) : null}
-        {!featureFlag('company_pages') && slug === 'about/easy-scholarships' ? (
+        {!featureFlag('company_pages') &&
+        (slug === 'about/easy-scholarships' ||
+          additionalContent.display_scholarship_newsletter_cta_popover ===
+            true) ? (
           <DismissableElement
             name="cta_popover_scholarship_email"
             context={{ contextSource: 'newsletter_scholarships' }}
@@ -188,6 +192,7 @@ GeneralPage.propTypes = {
     description: PropTypes.string,
   }),
   content: PropTypes.string,
+  additionalContent: PropTypes.object,
   sidebar: PropTypes.arrayOf(PropTypes.object),
   blocks: PropTypes.arrayOf(PropTypes.object).isRequired,
   displaySocialShare: PropTypes.bool,
@@ -199,6 +204,7 @@ GeneralPage.defaultProps = {
   authors: [],
   coverImage: {},
   content: null,
+  additionalContent: {},
   sidebar: [],
   subTitle: null,
   displaySocialShare: false,

--- a/resources/assets/components/pages/GeneralPage/GeneralPage.js
+++ b/resources/assets/components/pages/GeneralPage/GeneralPage.js
@@ -19,11 +19,7 @@ import SocialShareTray from '../../utilities/SocialShareTray/SocialShareTray';
 import CtaPopoverEmailForm from '../../utilities/CtaPopover/CtaPopoverEmailForm';
 import SiteNavigationContainer from '../../SiteNavigation/SiteNavigationContainer';
 import DismissableElement from '../../utilities/DismissableElement/DismissableElement';
-import {
-  contentfulImageUrl,
-  featureFlag,
-  withoutNulls,
-} from '../../../helpers';
+import { contentfulImageUrl, withoutNulls } from '../../../helpers';
 
 import './general-page.scss';
 

--- a/resources/assets/components/pages/GeneralPage/GeneralPage.js
+++ b/resources/assets/components/pages/GeneralPage/GeneralPage.js
@@ -154,9 +154,8 @@ const GeneralPage = props => {
             buttonText={ctaCopy.buttonText}
           />
         ) : null}
-        {!featureFlag('company_pages') &&
-        additionalContent.display_scholarship_newsletter_cta_popover ===
-          true ? (
+        {additionalContent.display_scholarship_newsletter_cta_popover ===
+        true ? (
           <DismissableElement
             name="cta_popover_scholarship_email"
             context={{ contextSource: 'newsletter_scholarships' }}


### PR DESCRIPTION
### What's this PR do?

This pull request gives us access to additional content via `Page.php` and adds the newsletter cta to all article pages that have `"display_scholarship_newsletter_cta_popover": true` in the additional content section of their Contentful page.


### How should this be reviewed?
Does the logic make sense? Is there a more effective way to do this or is this good for now? 


### Any background context you want to provide?

`"display_scholarship_newsletter_cta_popover": true` has been added to the 4 article pages in Contentful on the master branch: 
How to Apply for Scholarships (SEO) https://www.dosomething.org/us/articles/how-to-apply-for-scholarships-like-a-pro
6 Places to Find No Essay Scholarships (SEO) https://www.dosomething.org/us/6-free-places-to-find-no-essay-scholarships
Scholarships for HS Seniors (SEO) https://www.dosomething.org/us/articles/10-places-to-find-scholarships-for-high-school-seniors
Meet our DoSomething scholarship winners https://www.dosomething.org/us/articles/scholarship-winners 

### Relevant tickets

References [Pivotal #170606459](https://www.pivotaltracker.com/story/show/170606459).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added screenshots of front-end changes on small, medium, and large screens.
- [ ] Added appropriate feature/unit tests.
