### PR TITLE
General Page Scholarship CTA patch

### DIFF
--- a/resources/assets/components/pages/GeneralPage/GeneralPage.js
+++ b/resources/assets/components/pages/GeneralPage/GeneralPage.js
@@ -150,8 +150,11 @@ const GeneralPage = props => {
             buttonText={ctaCopy.buttonText}
           />
         ) : null}
-        {additionalContent.display_scholarship_newsletter_cta_popover ===
-        true ? (
+        {get(
+          additionalContent,
+          'display_scholarship_newsletter_cta_popover',
+          false,
+        ) === true ? (
           <DismissableElement
             name="cta_popover_scholarship_email"
             context={{ contextSource: 'newsletter_scholarships' }}


### PR DESCRIPTION
### What's this PR do?

This pull request is a quick patch to safely retrieve the `additionalContent.display_scholarship_newsletter_cta_popover` property from pages, since they'll be auto set to `null` otherwise.

### How should this be reviewed?
👀 
### Any background context you want to provide?
I've never quite sure if it's better to do this, or to use `withoutNulls` on the parent renderer (`PageDispatcher`) so we get the default prop here. But this should do for now!
