### PR TITLE
Persisting utms revision part deux

### DIFF
--- a/resources/assets/helpers/analytics.js
+++ b/resources/assets/helpers/analytics.js
@@ -2,7 +2,7 @@
 
 import { camelCase, get, mapKeys, snakeCase, startCase } from 'lodash';
 
-import { getUtmParameters } from './utm';
+import { getUtms } from './utm';
 import { debug, stringifyNestedObjects, withoutValueless } from '.';
 
 /**
@@ -189,7 +189,7 @@ export function getPageContext() {
  * @return {Object}
  */
 export function getUtmContext() {
-  const utms = getUtmParameters();
+  const utms = getUtms();
 
   // For analytics, we prefer camelCased keys:
   return mapKeys(utms, (value, key) => camelCase(key));

--- a/resources/assets/helpers/forms.js
+++ b/resources/assets/helpers/forms.js
@@ -3,7 +3,7 @@
 import { forEach, get, isInteger } from 'lodash';
 
 import { withoutValueless } from '.';
-import { getUtmParameters } from './utm';
+import { getUtms } from './utm';
 
 /**
  * Calculate the difference between a total value and a submitted value.
@@ -126,7 +126,7 @@ export function formatPostPayload(data = {}) {
     withoutValueless({
       // @TODO: Pass in 'contentful_id' parameter here w/ the containing page ID.
       // contentful_id: contentfulId,
-      ...getUtmParameters(),
+      ...getUtms(),
     }),
   );
 

--- a/resources/assets/helpers/utm.js
+++ b/resources/assets/helpers/utm.js
@@ -32,8 +32,10 @@ export function getUtms() {
  * @return void
  */
 export function persistUtms() {
+  const utms = parseUtmQuery();
+
   // If there are current query param utms, lets store them:
-  if (!isEmpty(parseUtmQuery())) {
+  if (!isEmpty(utms)) {
     sessionStorage.setItem(UTM_SESSION_KEY, JSON.stringify(utms));
   }
 }

--- a/resources/assets/helpers/utm.js
+++ b/resources/assets/helpers/utm.js
@@ -32,10 +32,8 @@ export function getUtms() {
  * @return void
  */
 export function persistUtms() {
-  const utms = parseUtmQuery();
-
   // If there are current query param utms, lets store them:
-  if (!isEmpty(utms)) {
+  if (!isEmpty(parseUtmQuery())) {
     sessionStorage.setItem(UTM_SESSION_KEY, JSON.stringify(utms));
   }
 }

--- a/resources/assets/selectors/index.js
+++ b/resources/assets/selectors/index.js
@@ -1,4 +1,4 @@
-import { getUtmParameters } from '../helpers/utm';
+import { getUtms } from '../helpers/utm';
 import { query, withoutValueless } from '../helpers';
 import { getCampaignDataForNorthstar } from './campaign';
 import { getStoryPageDataForNorthstar } from './storyPage';
@@ -12,7 +12,7 @@ export function getDataForNorthstar(state) {
     contentful_id: state.campaign.id || state.page.id,
     mode: query('mode') || null,
     referrer_user_id: query('referrer_user_id'),
-    ...getUtmParameters(),
+    ...getUtms(),
   });
 }
 


### PR DESCRIPTION
### What's this PR do?

This pull request simplifies the logic in the `helpers/utm.js` file. Now that we changed the approach to not continually rewrite the URL to persist UTMs in the URL query via `history.pushState`, it significantly simplified the logic.

@DFurnes and I paired quickly and after simplifying things further, we also addressed the changes in the UTMs if a member where to come from a partner site, click around and then head back to partner site and click on a different partner link that brings them back to our site with different UTMs; the system can now account for that and update the session store accordingly!

It also renames the `getUtmParameters()` function to `getUtms()` and updates associated files accordingly.

### How should this be reviewed?

👀 and maybe using ye ole `window.DS.Debug.enableLogs(['google', 'snowplow'])` to confirm context data includes UTMs when testing!

### Relevant tickets

References [Pivotal #169960864](https://www.pivotaltracker.com/story/show/169960864).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Added appropriate feature/unit tests.
