### PR TITLE
Add support for querying CurrentSchoolBlock via GraphQL.

### DIFF
--- a/resources/assets/components/ContentfulEntry/ContentfulEntry.js
+++ b/resources/assets/components/ContentfulEntry/ContentfulEntry.js
@@ -167,6 +167,9 @@ class ContentfulEntry extends React.Component {
       case 'currentSchoolBlock':
         return <CurrentSchoolBlockContainer {...withoutNulls(json.fields)} />;
 
+      case 'CurrentSchoolBlock':
+        return <CurrentSchoolBlockContainer {...withoutNulls(json)} />;
+
       case 'embed':
         return (
           <EmbedBlockContainer

--- a/resources/assets/components/blocks/CurrentSchoolBlock/CurrentSchoolBlock.js
+++ b/resources/assets/components/blocks/CurrentSchoolBlock/CurrentSchoolBlock.js
@@ -7,6 +7,17 @@ import Query from '../../Query';
 import CurrentSchoolImpact from './CurrentSchoolImpact';
 import CurrentSchoolForm from './CurrentSchoolForm';
 
+export const CurrentSchoolBlockFragment = gql`
+  fragment CurrentSchoolBlockFragment on CurrentSchoolBlock {
+    actionId
+    currentSchoolTitle
+    currentSchoolDescription
+    schoolNotAvailableDescription
+    selectSchoolTitle
+    selectSchoolDescription
+  }
+`;
+
 const USER_SCHOOL_QUERY = gql`
   query UserSchoolQuery($userId: String!) {
     user(id: $userId) {

--- a/resources/assets/components/utilities/ContentfulEntryLoader/ContentfulEntryLoader.js
+++ b/resources/assets/components/utilities/ContentfulEntryLoader/ContentfulEntryLoader.js
@@ -35,26 +35,66 @@ const CONTENTFUL_BLOCK_QUERY = gql`
   query ContentfulBlockQuery($id: String!, $preview: Boolean!) {
     block(id: $id, preview: $preview) {
       id
-      ...LinkBlockFragment
-      ...QuizBlockFragment
-      ...ShareBlockFragment
-      ...EmbedBlockFragment
-      ...ImagesBlockFragment
-      ...GalleryBlockFragment
-      ...ContentBlockFragment
-      ...SoftEdgeBlockFragment
-      ...AffirmationBlockFragment
-      ...SocialDriveBlockFragment
-      ...PostGalleryBlockFragment
-      ...CallToActionBlockFragment
-      ...CampaignDashboardFragment
-      ...CampaignUpdateBlockFragment
-      ...TextSubmissionBlockFragment
-      ...PhotoSubmissionBlockFragment
-      ...SixpackExperimentBlockFragment
-      ...VoterRegistrationBlockFragment
-      ...PetitionSubmissionBlockFragment
-      ...SelectionSubmissionBlockFragment
+      ... on LinkBlock {
+        ...LinkBlockFragment
+      }
+      ... on QuizBlock {
+        ...QuizBlockFragment
+      }
+      ... on ShareBlock {
+        ...ShareBlockFragment
+      }
+      ... on EmbedBlock {
+        ...EmbedBlockFragment
+      }
+      ... on ImagesBlock {
+        ...ImagesBlockFragment
+      }
+      ... on GalleryBlock {
+        ...GalleryBlockFragment
+      }
+      ... on ContentBlock {
+        ...ContentBlockFragment
+      }
+      ... on SoftEdgeBlock {
+        ...SoftEdgeBlockFragment
+      }
+      ... on AffirmationBlock {
+        ...AffirmationBlockFragment
+      }
+      ... on SocialDriveBlock {
+        ...SocialDriveBlockFragment
+      }
+      ... on PostGalleryBlock {
+        ...PostGalleryBlockFragment
+      }
+      ... on CallToActionBlock {
+        ...CallToActionBlockFragment
+      }
+      ... on CampaignDashboard {
+        ...CampaignDashboardFragment
+      }
+      ... on CampaignUpdateBlock {
+        ...CampaignUpdateBlockFragment
+      }
+      ... on TextSubmissionBlock {
+        ...TextSubmissionBlockFragment
+      }
+      ... on PhotoSubmissionBlock {
+        ...PhotoSubmissionBlockFragment
+      }
+      ... on SixpackExperimentBlock {
+        ...SixpackExperimentBlockFragment
+      }
+      ... on VoterRegistrationBlock {
+        ...VoterRegistrationBlockFragment
+      }
+      ... on PetitionSubmissionBlock {
+        ...PetitionSubmissionBlockFragment
+      }
+      ... on SelectionSubmissionBlock {
+        ...SelectionSubmissionBlockFragment
+      }
     }
   }
 

--- a/resources/assets/components/utilities/ContentfulEntryLoader/ContentfulEntryLoader.js
+++ b/resources/assets/components/utilities/ContentfulEntryLoader/ContentfulEntryLoader.js
@@ -25,6 +25,7 @@ import { SixpackExperimentBlockFragment } from '../SixpackExperiment/SixpackExpe
 import { CampaignUpdateBlockFragment } from '../../blocks/CampaignUpdate/CampaignUpdate';
 import { SocialDriveBlockFragment } from '../../actions/SocialDriveAction/SocialDriveAction';
 import { PostGalleryBlockFragment } from '../../blocks/PostGalleryBlock/PostGalleryBlockQuery';
+import { CurrentSchoolBlockFragment } from '../../blocks/CurrentSchoolBlock/CurrentSchoolBlock';
 import { TextSubmissionBlockFragment } from '../../actions/TextSubmissionAction/TextSubmissionAction';
 import { PhotoSubmissionBlockFragment } from '../../actions/PhotoSubmissionAction/PhotoSubmissionAction';
 import { VoterRegistrationBlockFragment } from '../../actions/VoterRegistrationAction/VoterRegistrationAction';
@@ -74,6 +75,9 @@ const CONTENTFUL_BLOCK_QUERY = gql`
       ... on CampaignDashboard {
         ...CampaignDashboardFragment
       }
+      ... on CurrentSchoolBlock {
+        ...CurrentSchoolBlockFragment
+      }
       ... on CampaignUpdateBlock {
         ...CampaignUpdateBlockFragment
       }
@@ -111,6 +115,7 @@ const CONTENTFUL_BLOCK_QUERY = gql`
   ${PostGalleryBlockFragment}
   ${CallToActionBlockFragment}
   ${CampaignDashboardFragment}
+  ${CurrentSchoolBlockFragment}
   ${CampaignUpdateBlockFragment}
   ${TextSubmissionBlockFragment}
   ${PhotoSubmissionBlockFragment}


### PR DESCRIPTION
### What's this PR do?

This pull request adds the ability to load `CurrentSchoolBlock` via GraphQL.

### How should this be reviewed?

👀

### Any background context you want to provide?

This is a blocker for updating Phoenix to query all blocks via GraphQL, and is dependent on the changes made in DoSomething/graphql#189 (where I added `CurrentSchoolBlock` to our schema).

I made the `ContentfulEntryLoader` fragments more verbose in 9412638, because I'd run into some bugs with our in-memory GraphQL mock server (for Cypress) on the `blocks/:id` route otherwise... they should be functionally identical, but for some reason this works when the short-syntax doesn't.

🤷‍♂

### Relevant tickets

References [Pivotal #169216496](https://www.pivotaltracker.com/story/show/169216496).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added screenshots of front-end changes on small, medium, and large screens.
- [ ] Added appropriate feature/unit tests.
