### PR TITLE
Renaming old AdminDashboard component.

### DIFF
--- a/resources/assets/components/AdminDashboard/CampaignDashboard/index.js
+++ b/resources/assets/components/AdminDashboard/CampaignDashboard/index.js
@@ -1,3 +1,0 @@
-export CampaignDashboard from './CampaignDashboard';
-
-export default from './CampaignDashboardContainer';

--- a/resources/assets/components/AdminDashboard/index.js
+++ b/resources/assets/components/AdminDashboard/index.js
@@ -1,6 +1,0 @@
-export CampaignDashboardContainer from './CampaignDashboard';
-
-export AdminDashboard from './AdminDashboard';
-export AdminDashboardContainer from './AdminDashboardContainer';
-
-export default './AdminDashboardContainer';

--- a/resources/assets/components/Campaign/Campaign.js
+++ b/resources/assets/components/Campaign/Campaign.js
@@ -15,10 +15,8 @@ import SiteNavigationContainer from '../SiteNavigation/SiteNavigationContainer';
 import DismissableElement from '../utilities/DismissableElement/DismissableElement';
 import TrafficDistribution from '../utilities/TrafficDistribution/TrafficDistribution';
 import VoterRegistrationModal from '../pages/VoterRegistrationModal/VoterRegistrationModal';
-import {
-  AdminDashboardContainer,
-  CampaignDashboardContainer,
-} from '../AdminDashboard';
+import LegacyAdminDashboardContainer from '../LegacyAdminDashboard/LegacyAdminDashboardContainer';
+import LegacyCampaignDashboardContainer from '../LegacyAdminDashboard/LegacyCampaignDashboard/LegacyCampaignDashboardContainer';
 
 const Campaign = props => (
   <ModalRoute
@@ -29,9 +27,9 @@ const Campaign = props => (
     <SiteNavigationContainer />
 
     <main>
-      <AdminDashboardContainer>
-        <CampaignDashboardContainer />
-      </AdminDashboardContainer>
+      <LegacyAdminDashboardContainer>
+        <LegacyCampaignDashboardContainer />
+      </LegacyAdminDashboardContainer>
 
       <NotificationContainer />
 

--- a/resources/assets/components/LegacyAdminDashboard/LegacyAdminDashboard.js
+++ b/resources/assets/components/LegacyAdminDashboard/LegacyAdminDashboard.js
@@ -1,16 +1,16 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-const AdminDashboard = ({ enabled, children }) =>
+const LegacyAdminDashboard = ({ enabled, children }) =>
   enabled ? (
     <div className="bg-gray-200 p-4" data-ref="legacy-admin-dashboard">
       {children}
     </div>
   ) : null;
 
-AdminDashboard.propTypes = {
+LegacyAdminDashboard.propTypes = {
   children: PropTypes.node.isRequired,
   enabled: PropTypes.bool.isRequired,
 };
 
-export default AdminDashboard;
+export default LegacyAdminDashboard;

--- a/resources/assets/components/LegacyAdminDashboard/LegacyAdminDashboardContainer.js
+++ b/resources/assets/components/LegacyAdminDashboard/LegacyAdminDashboardContainer.js
@@ -1,10 +1,10 @@
 import { connect } from 'react-redux';
 
-import AdminDashboard from './AdminDashboard';
 import { userHasRole } from '../../selectors/user';
+import LegacyAdminDashboard from './LegacyAdminDashboard';
 
 const mapStateToProps = state => ({
   enabled: userHasRole(state, ['admin', 'staff']),
 });
 
-export default connect(mapStateToProps)(AdminDashboard);
+export default connect(mapStateToProps)(LegacyAdminDashboard);

--- a/resources/assets/components/LegacyAdminDashboard/LegacyCampaignDashboard/LegacyCampaignDashboard.js
+++ b/resources/assets/components/LegacyAdminDashboard/LegacyCampaignDashboard/LegacyCampaignDashboard.js
@@ -3,7 +3,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-const CampaignDashboard = props => {
+const LegacyCampaignDashboard = props => {
   const {
     campaignId,
     clickedShowAffirmation,
@@ -35,7 +35,7 @@ const CampaignDashboard = props => {
   );
 };
 
-CampaignDashboard.propTypes = {
+LegacyCampaignDashboard.propTypes = {
   campaignId: PropTypes.string.isRequired,
   isSignedUp: PropTypes.bool.isRequired,
   clickedShowAffirmation: PropTypes.func.isRequired,
@@ -43,4 +43,4 @@ CampaignDashboard.propTypes = {
   signupCreated: PropTypes.func.isRequired,
 };
 
-export default CampaignDashboard;
+export default LegacyCampaignDashboard;

--- a/resources/assets/components/LegacyAdminDashboard/LegacyCampaignDashboard/LegacyCampaignDashboardContainer.js
+++ b/resources/assets/components/LegacyAdminDashboard/LegacyCampaignDashboard/LegacyCampaignDashboardContainer.js
@@ -1,6 +1,6 @@
 import { connect } from 'react-redux';
 
-import CampaignDashboard from './CampaignDashboard';
+import LegacyCampaignDashboard from './LegacyCampaignDashboard';
 import {
   clickedShowLandingPage,
   clickedShowActionPage,
@@ -34,4 +34,4 @@ const actionCreators = {
 export default connect(
   mapStateToProps,
   actionCreators,
-)(CampaignDashboard);
+)(LegacyCampaignDashboard);


### PR DESCRIPTION
### What's this PR do?

This pull request simply renames the old `AdminDashboard` component and the `CampaignDashboard` component to `LegacyAdminDashboard` and `LegacyCampaignDashboard` respectively. In the near-ish future I'll be moving the new ✨ Admin Dashboard ✨ from being a Blade template to being a React component and don't want any conflicts. The old legacy dashboard stuff will eventually end up getting incorporated into the new Admin Dashboard once the move is completed 💃 

### How should this be reviewed?

Just a quick looksee to confirm all makes sense!

### Any background context you want to provide?

🛁 
