### PR TITLE
Analytics refactoring

### DIFF
--- a/resources/assets/components/actions/ShareAction/ShareAction.js
+++ b/resources/assets/components/actions/ShareAction/ShareAction.js
@@ -39,8 +39,16 @@ export const ShareBlockFragment = gql`
   }
 `;
 
+const EVENT_CATEGORY = 'campaign_action';
+
 class ShareAction extends PostForm {
   state = { showModal: false };
+
+  contextData = {
+    blockId: this.props.id,
+    campaignId: this.props.campaignId,
+    pageId: this.props.pageId,
+  };
 
   componentDidMount() {
     // If this is a Facebook share action, make sure we load SDK.
@@ -79,40 +87,17 @@ class ShareAction extends PostForm {
     });
   };
 
-  /**
-   * Component helper method for tracking analytics events.
-   *
-   * @param  {String} service
-   * @param  {String} target
-   * @param  {String} verb
-   * @param  {Object} data
-   * @return {Void}
-   */
-  trackEvent = (service, target, verb, data = {}) => {
-    trackAnalyticsEvent({
-      context: {
-        ...data,
-        blockId: this.props.id,
-        campaignId: this.props.campaignId,
-        pageId: this.props.pageId,
-      },
-      metadata: {
-        adjective: service,
-        category: 'campaign_action',
-        label: service,
-        noun: 'share_action',
-        target,
-        verb,
-      },
-    });
-  };
-
   handleFacebookClick = url => {
     const { link, userId } = this.props;
 
     let trackingData = { url: link };
 
-    this.trackEvent('facebook', 'button', 'clicked', trackingData);
+    trackAnalyticsEvent('clicked_share_action_facebook', {
+      action: 'button_clicked',
+      category: EVENT_CATEGORY,
+      label: 'facebook',
+      context: { ...this.contextData, ...trackingData },
+    });
 
     showFacebookShareDialog(url)
       .then(() => {
@@ -127,18 +112,31 @@ class ShareAction extends PostForm {
         return Promise.resolve();
       })
       .then(() => {
-        this.trackEvent('facebook', 'action', 'completed', trackingData);
+        trackAnalyticsEvent('completed_share_action_facebook', {
+          action: 'action_completed',
+          category: EVENT_CATEGORY,
+          label: 'facebook',
+          context: { ...this.contextData, ...trackingData },
+        });
 
         this.setState({ showModal: true });
       })
       .catch(() => {
-        this.trackEvent('facebook', 'action', 'cancelled', trackingData);
+        trackAnalyticsEvent('cancelled_share_action_facebook', {
+          action: 'action_cancelled',
+          category: EVENT_CATEGORY,
+          label: 'facebook',
+          context: { ...this.contextData, ...trackingData },
+        });
       });
   };
 
   handleTwitterClick = url => {
-    this.trackEvent('twitter', 'button', 'clicked', {
-      url: this.props.link,
+    trackAnalyticsEvent('clicked_share_action_twitter', {
+      action: 'button_clicked',
+      category: EVENT_CATEGORY,
+      label: 'twitter',
+      context: { ...this.contextData, url: this.props.link },
     });
 
     showTwitterSharePrompt(url, '', () => this.setState({ showModal: true }));

--- a/resources/assets/components/actions/ShareAction/ShareAction.js
+++ b/resources/assets/components/actions/ShareAction/ShareAction.js
@@ -44,11 +44,11 @@ const EVENT_CATEGORY = 'campaign_action';
 class ShareAction extends PostForm {
   state = { showModal: false };
 
-  contextData = {
+  getContextData = () => ({
     blockId: this.props.id,
     campaignId: this.props.campaignId,
     pageId: this.props.pageId,
-  };
+  });
 
   componentDidMount() {
     // If this is a Facebook share action, make sure we load SDK.
@@ -96,7 +96,7 @@ class ShareAction extends PostForm {
       action: 'button_clicked',
       category: EVENT_CATEGORY,
       label: 'facebook',
-      context: { ...this.contextData, ...trackingData },
+      context: { ...this.getContextData(), ...trackingData },
     });
 
     showFacebookShareDialog(url)
@@ -116,7 +116,7 @@ class ShareAction extends PostForm {
           action: 'action_completed',
           category: EVENT_CATEGORY,
           label: 'facebook',
-          context: { ...this.contextData, ...trackingData },
+          context: { ...this.getContextData(), ...trackingData },
         });
 
         this.setState({ showModal: true });
@@ -126,7 +126,7 @@ class ShareAction extends PostForm {
           action: 'action_cancelled',
           category: EVENT_CATEGORY,
           label: 'facebook',
-          context: { ...this.contextData, ...trackingData },
+          context: { ...this.getContextData(), ...trackingData },
         });
       });
   };
@@ -136,7 +136,7 @@ class ShareAction extends PostForm {
       action: 'button_clicked',
       category: EVENT_CATEGORY,
       label: 'twitter',
-      context: { ...this.contextData, url: this.props.link },
+      context: { ...this.getContextData(), url: this.props.link },
     });
 
     showTwitterSharePrompt(url, '', () => this.setState({ showModal: true }));

--- a/resources/assets/components/actions/ShareAction/ShareAction.test.js
+++ b/resources/assets/components/actions/ShareAction/ShareAction.test.js
@@ -83,16 +83,12 @@ describe('ShareAction component', () => {
       expect(trackEventMock.mock.calls.length).toBeGreaterThan(0);
 
       expect(trackEventMock.mock.calls[0]).toEqual([
+        'clicked_share_action_facebook',
         {
+          action: 'button_clicked',
+          category: 'campaign_action',
           context: trackingData,
-          metadata: {
-            adjective: 'facebook',
-            category: 'campaign_action',
-            noun: 'share_action',
-            label: 'facebook',
-            target: 'button',
-            verb: 'clicked',
-          },
+          label: 'facebook',
         },
       ]);
     });
@@ -133,16 +129,12 @@ describe('ShareAction component', () => {
       expect(trackEventMock.mock.calls.length).toBeGreaterThan(0);
 
       expect(trackEventMock.mock.calls[0]).toEqual([
+        'clicked_share_action_twitter',
         {
+          action: 'button_clicked',
+          category: 'campaign_action',
+          label: 'twitter',
           context: trackingData,
-          metadata: {
-            adjective: 'twitter',
-            category: 'campaign_action',
-            noun: 'share_action',
-            label: 'twitter',
-            target: 'button',
-            verb: 'clicked',
-          },
         },
       ]);
     });

--- a/resources/assets/components/utilities/SocialShareTray/SocialShareTray.js
+++ b/resources/assets/components/utilities/SocialShareTray/SocialShareTray.js
@@ -21,109 +21,100 @@ import {
 
 import './social-share-tray.scss';
 
+const EVENT_CATEGORY = 'social_share';
+
 class SocialShareTray extends React.Component {
   componentDidMount() {
     loadFacebookSDK();
   }
 
-  /**
-   * Component helper method for tracking analytics events.
-   *
-   * @param  {String} service
-   * @param  {String} noun
-   * @param  {String} target
-   * @param  {String} verb
-   * @param  {Object} data
-   * @return {Void}
-   */
-  trackEvent = (service, noun, target, verb, data = {}) => {
-    trackAnalyticsEvent({
-      context: { ...data },
-      metadata: {
-        adjective: service,
-        category: 'social_share',
-        label: service,
-        noun,
-        target,
-        verb,
-      },
-    });
-  };
-
   handleFacebookShareClick = (shareLink, trackLink) => {
-    this.trackEvent('facebook', 'share', 'button', 'clicked', {
-      url: trackLink,
+    trackAnalyticsEvent('clicked_share_facebook', {
+      action: 'button_clicked',
+      category: EVENT_CATEGORY,
+      label: 'facebook',
+      context: { url: trackLink },
     });
 
     showFacebookShareDialog(shareLink)
       .then(() => {
-        this.trackEvent('facebook', 'share', 'action', 'completed', {
-          url: trackLink,
+        trackAnalyticsEvent('completed_share_facebook', {
+          action: 'action_completed',
+          category: EVENT_CATEGORY,
+          label: 'facebook',
+          context: {
+            url: trackLink,
+          },
         });
       })
       .catch(() => {
-        this.trackEvent('facebook', 'share', 'action', 'cancelled', {
-          url: trackLink,
+        trackAnalyticsEvent('cancelled_share_facebook', {
+          action: 'action_cancelled',
+          category: EVENT_CATEGORY,
+          label: 'facebook',
+          context: {
+            url: trackLink,
+          },
         });
       });
   };
 
   handleFacebookMessengerClick = (shareLink, trackLink) => {
-    this.trackEvent('facebook_messenger', 'share', 'button', 'clicked', {
-      url: trackLink,
+    trackAnalyticsEvent('clicked_share_facebook_messenger', {
+      action: 'button_clicked',
+      category: EVENT_CATEGORY,
+      label: 'facebook_messenger',
+      contetxt: { url: trackLink },
     });
 
     if (getFormattedScreenSize() === 'large') {
       // Show Send Dialog for Desktop clients.
       showFacebookSendDialog(shareLink)
         .then(() => {
-          this.trackEvent(
-            'facebook_messenger',
-            'share',
-            'action',
-            'completed',
-            {
-              url: trackLink,
-            },
-          );
+          trackAnalyticsEvent('completed_share_facebook_messenger', {
+            action: 'action_completed',
+            category: EVENT_CATEGORY,
+            label: 'facebook_messenger',
+            context: { url: trackLink },
+          });
         })
         .catch(() => {
-          this.trackEvent(
-            'facebook_messenger',
-            'share',
-            'action',
-            'cancelled',
-            {
-              url: trackLink,
-            },
-          );
+          trackAnalyticsEvent('cancelled_share_facebook_messenger', {
+            action: 'action_cancelled',
+            category: EVENT_CATEGORY,
+            label: 'facebook_messenger',
+            context: { url: trackLink },
+          });
         });
     } else {
       // Redirect mobile / tablet clients to the Messenger app.
       facebookMessengerShare(shareLink)
         .then(() => {
-          this.trackEvent(
-            'facebook_messenger_app',
-            'redirect',
-            'redirect',
-            'successful',
-            { url: trackLink },
-          );
+          trackAnalyticsEvent('successful_redirect_facebook_messenger_app', {
+            action: 'redirect_successful',
+            category: EVENT_CATEGORY,
+            label: 'facebook_messenger_app',
+            context: { url: trackLink },
+          });
         })
         .catch(() => {
-          this.trackEvent(
-            'facebook_messenger_app',
-            'redirect',
-            'redirect',
-            'failed',
-            { url: trackLink },
-          );
+          trackAnalyticsEvent('failed_redirect_facebook_messenger_app', {
+            action: 'redirect_failed',
+            category: EVENT_CATEGORY,
+            label: 'facebook_messenger_app',
+            context: { url: trackLink },
+          });
         });
     }
   };
 
   handleEmailShareClick = (shareLink, trackLink) => {
-    this.trackEvent('email', 'share', 'button', 'clicked', { url: trackLink });
+    trackAnalyticsEvent('clicked_share_email', {
+      action: 'button_clicked',
+      category: EVENT_CATEGORY,
+      label: 'email',
+      context: { url: trackLink },
+    });
 
     window.location = `mailto:?body=${encodeURIComponent(shareLink)}`;
   };

--- a/resources/assets/helpers/analytics.js
+++ b/resources/assets/helpers/analytics.js
@@ -239,6 +239,7 @@ export function trackAnalyticsPageView(history) {
  * Track an analytics event with a specified service.
  * (Defaults to tracking with all services.)
  *
+ * @deprecated
  * @param  {Object} options
  * @param  {Object} options.metadata
  * @param  {Object} options.context

--- a/resources/assets/helpers/analytics.js
+++ b/resources/assets/helpers/analytics.js
@@ -4,7 +4,7 @@ import {
   camelCase,
   get,
   isString,
-  isObject,
+  isPlainObject,
   mapKeys,
   snakeCase,
   startCase,
@@ -280,11 +280,12 @@ export function legacyTrackAnalyticsEvent({ metadata, context = {}, service }) {
  * @param  {String} options.service
  * @return {void}
  */
-export function trackAnalyticsEvent(name, metadata) {
+export function trackAnalyticsEvent(name, metadata = {}) {
   // @REMOVE: Temporarily check to see if name is an object, and if so send it to the
   // old legacyTrackAnalyticsEvent(); this will allow us to incrementally switch
   // calls to the new trackAnalyticsEvent() without breaking everything!
-  if (isObject(name)) {
+  if (isPlainObject(name)) {
+    console.log('🤔 sending to legacy function...');
     legacyTrackAnalyticsEvent(arguments[0]); // eslint-disable-line prefer-rest-params
 
     return;
@@ -295,11 +296,18 @@ export function trackAnalyticsEvent(name, metadata) {
   // checking against whether name is a string or object or will error out.
   const { action, category, label, context = {}, service } = metadata;
 
-  if (!name && !isString(name)) {
+  console.log('🐞 name: ', name);
+  console.log('🐞 !name: ', !name);
+  console.log('🐞 isString: ', isString(name));
+  console.log('🐞 !isString: ', !isString(name));
+
+  if (!isString(name)) {
     console.error('Please provide a string for the event name!');
 
     return;
   }
+
+  console.log('🤷‍♂️ whelp, we are continuing...');
 
   const data = withoutValueless({
     ...context,

--- a/resources/assets/helpers/analytics.js
+++ b/resources/assets/helpers/analytics.js
@@ -1,6 +1,13 @@
 /* global window */
 
-import { camelCase, get, mapKeys, snakeCase, startCase } from 'lodash';
+import {
+  camelCase,
+  get,
+  isString,
+  mapKeys,
+  snakeCase,
+  startCase,
+} from 'lodash';
 
 import { getUtms } from './utm';
 import { debug, stringifyNestedObjects, withoutValueless } from '.';
@@ -237,23 +244,26 @@ export function trackAnalyticsPageView(history) {
  * @param  {String} options.service
  * @return {void}
  */
-export function trackAnalyticsEvent({ metadata, context = {}, service }) {
-  if (!metadata) {
-    console.error('The metadata object is missing!');
+export function trackAnalyticsEvent(name, { metadata, context = {}, service }) {
+  if (!name && !isString(name)) {
+    console.error('Please provide a string for the event name!');
+
     return;
   }
 
-  const { adjective, category, target, noun, verb } = metadata;
-  const label = metadata.label || noun;
-
-  const name = formatEventName(verb, noun, adjective);
-
-  const action = snakeCase(`${target}_${verb}`);
+  const { action, category, label, target } = metadata;
 
   const data = withoutValueless({
     ...context,
     ...getUtmContext(),
   });
 
-  sendToServices(name, category, action, label, data, service);
+  sendToServices(
+    `${APP_PREFIX}_${name}`,
+    category,
+    snakeCase(`${target}_${action}`),
+    label,
+    data,
+    service,
+  );
 }

--- a/resources/assets/helpers/analytics.js
+++ b/resources/assets/helpers/analytics.js
@@ -285,7 +285,6 @@ export function trackAnalyticsEvent(name, metadata = {}) {
   // old legacyTrackAnalyticsEvent(); this will allow us to incrementally switch
   // calls to the new trackAnalyticsEvent() without breaking everything!
   if (isPlainObject(name)) {
-    console.log('🤔 sending to legacy function...');
     legacyTrackAnalyticsEvent(arguments[0]); // eslint-disable-line prefer-rest-params
 
     return;
@@ -296,18 +295,11 @@ export function trackAnalyticsEvent(name, metadata = {}) {
   // checking against whether name is a string or object or will error out.
   const { action, category, label, context = {}, service } = metadata;
 
-  console.log('🐞 name: ', name);
-  console.log('🐞 !name: ', !name);
-  console.log('🐞 isString: ', isString(name));
-  console.log('🐞 !isString: ', !isString(name));
-
   if (!isString(name)) {
     console.error('Please provide a string for the event name!');
 
     return;
   }
-
-  console.log('🤷‍♂️ whelp, we are continuing...');
 
   const data = withoutValueless({
     ...context,

--- a/resources/assets/helpers/index.js
+++ b/resources/assets/helpers/index.js
@@ -741,16 +741,11 @@ export function showTwitterSharePrompt(href, quote = '', callback) {
  * @param {Object} trackingData
  */
 export function handleFacebookShareClick(href, trackingData) {
-  trackAnalyticsEvent({
+  trackAnalyticsEvent('clicked_share_facebook', {
+    action: 'button_clicked',
+    category: 'social_share',
+    label: 'facebook',
     context: { trackingData, url: href },
-    metadata: {
-      category: 'social_share',
-      adjective: 'facebook',
-      label: 'facebook',
-      noun: 'share',
-      target: 'button',
-      verb: 'clicked',
-    },
   });
 
   // @todo 12/13/2018: Use the showFacebookShareDialog to track
@@ -766,16 +761,11 @@ export function handleFacebookShareClick(href, trackingData) {
  * @param {String} quote
  */
 export function handleTwitterShareClick(href, trackingData, quote = '') {
-  trackAnalyticsEvent({
+  trackAnalyticsEvent('clicked_share_twitter', {
+    action: 'button_clicked',
+    category: 'social_share',
+    label: 'twitter',
     context: { trackingData, url: href },
-    metadata: {
-      category: 'social_share',
-      adjective: 'twitter',
-      label: 'twitter',
-      noun: 'share',
-      target: 'button',
-      verb: 'clicked',
-    },
   });
 
   showTwitterSharePrompt(href, quote);


### PR DESCRIPTION
### What's this PR do?

This pull request refactors our approach to analytics in Phoenix.

We wanted to refactor how we track analytics events on DoSomething.org since the system now is a little convoluted because of the need to maintain support for legacy event naming.

The system currently handles dynamically generating the event name based on provided `verb`, `noun`, and `adjective` properties. However, after our recent reconfiguring of analytics data platforms and structure of events, we included `category`, `action`, and `label` which complicated how we set up our custom events.

We've decided it will be easier if we specify the whole event name when triggering an event, instead of dynamically generating it, and thus removing the need for `verb`, `noun`, and `adjective`. We now end up with just `category`, `action`, and `label`, along with the previous `context` object for any extra event data, which matches how our analytics platforms (Google Analytics and Snowplow) register our events.

### How should this be reviewed?

👀 

### Any background context you want to provide?

In an attempt to minimize the number of changes per PR, I've renamed the old analytics event tracking helper function to `legacyTrackAnalyticsEvent()`. Now when `trackAnalyticsEvent()` is called, it checks to see if the first argument is an object and if it is, it means it contains event data in our old format, so I send it off to `legacyTrackAnalyticsEvent()`, otherwise if it's a string, it's using the new format and can continue on its way.

This will allow us to update the slew of event triggers across our system over smaller PRs instead of all in one giant, and intimidating fell swoop of a PR 💃 

### Relevant tickets

References [Pivotal #](https://www.pivotaltracker.com/story/show/170710129).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Added appropriate feature/unit tests.
