### PR TITLE
Quick Phoenix patches

### DIFF
--- a/cypress/integration/beta-referral-page.js
+++ b/cypress/integration/beta-referral-page.js
@@ -13,6 +13,7 @@ describe('Beta Referral Page', () => {
 
     cy.withFeatureFlags({ referral_campaign_ids: [campaignId] }).visit(
       `/us/join?user_id=${userId}&campaign_id=${campaignId}`,
+      // Allow some extra time to prevent timeouts on initial page load:
       { timeout: 10000 },
     );
 

--- a/cypress/integration/beta-referral-page.js
+++ b/cypress/integration/beta-referral-page.js
@@ -13,6 +13,7 @@ describe('Beta Referral Page', () => {
 
     cy.withFeatureFlags({ referral_campaign_ids: [campaignId] }).visit(
       `/us/join?user_id=${userId}&campaign_id=${campaignId}`,
+      { timeout: 10000 },
     );
 
     cy.contains('campaign scholarship');

--- a/resources/assets/components/blocks/ContentBlock/ContentBlock.js
+++ b/resources/assets/components/blocks/ContentBlock/ContentBlock.js
@@ -22,7 +22,7 @@ export const ContentBlockFragment = gql`
       description
     }
     # Aliasing to avoid conflicting with *required* imageAlignment field in GalleryBlockFragment.
-    contentBlockimageAlignment: imageAlignment
+    contentBlockImageAlignment: imageAlignment
   }
 `;
 

--- a/resources/assets/components/pages/HomePage/HomePage.js
+++ b/resources/assets/components/pages/HomePage/HomePage.js
@@ -102,7 +102,7 @@ class HomePage extends React.Component {
           </article>
 
           {featureFlag('nps_survey') ? (
-            <TrafficDistribution percentage={100} feature="nps_survey">
+            <TrafficDistribution percentage={5} feature="nps_survey">
               <DismissableElement
                 name="nps_survey"
                 render={(handleClose, handleComplete) => (

--- a/resources/assets/components/utilities/SocialShareTray/SocialShareTray.js
+++ b/resources/assets/components/utilities/SocialShareTray/SocialShareTray.js
@@ -64,7 +64,7 @@ class SocialShareTray extends React.Component {
       action: 'button_clicked',
       category: EVENT_CATEGORY,
       label: 'facebook_messenger',
-      contetxt: { url: trackLink },
+      context: { url: trackLink },
     });
 
     if (getFormattedScreenSize() === 'large') {

--- a/resources/assets/helpers/index.js
+++ b/resources/assets/helpers/index.js
@@ -762,7 +762,7 @@ export function handleFacebookShareClick(href, trackingData) {
     action: 'button_clicked',
     category: 'social_share',
     label: 'facebook',
-    context: { trackingData, url: href },
+    context: { ...trackingData, url: href },
   });
 
   // @todo 12/13/2018: Use the showFacebookShareDialog to track
@@ -782,7 +782,7 @@ export function handleTwitterShareClick(href, trackingData, quote = '') {
     action: 'button_clicked',
     category: 'social_share',
     label: 'twitter',
-    context: { trackingData, url: href },
+    context: { ...trackingData, url: href },
   });
 
   showTwitterSharePrompt(href, quote);


### PR DESCRIPTION
### What's this PR do?

This pull request patches two small things I spotted in the latest deploy:
- https://github.com/DoSomething/phoenix-next/commit/7a4c812b20754aab8a14ffbbc87ea91f7f91061c a typo in a `context` prop 
- https://github.com/DoSomething/phoenix-next/commit/7e7cb7b29e0a729a2148c057ae0d58c19e84e2cb spreading `trackingData`
- oop! And one more thing. https://github.com/DoSomething/phoenix-next/pull/1901/commits/5c36774a8055aa8c24af32b92942a3772463eae7 reverts the homepage nps survey traffic distribution to its original 5 percent. I think we must have accidentally swapped it while testing at some point 🙃 (We should probably let the data team know, in case this caused an awkward spike or dip in our web NPS?)
- and another! https://github.com/DoSomething/phoenix-next/pull/1901/commits/eb46eca6c36bb4a8a1f06a0a048f57129b7e2dad fixes a typo in the `ContentBlock` graphql fragment for the `imageAlignment` field alias https://dosomething.slack.com/archives/CP2D7UGAU/p1580569340000400

https://github.com/DoSomething/phoenix-next/commit/7e7cb7b29e0a729a2148c057ae0d58c19e84e2cb I'm not completely sure about -- it seems that we've had it this way for a while, but it originally was the top-level context for this event, but we eventually started nesting it _inside_ `context` without spreading the object.
At this point, I'm not sure if it would do more harm then good to start spreading the object since we've been tracking it otherwise for a while? Or if it'll be helpful for when we actually want to start using this data?