### PR TITLE
Add script to create Post Galleries from custom blocks.

### DIFF
--- a/contentful/management-api-scripts/2020_01_30_create_post_galleries.js
+++ b/contentful/management-api-scripts/2020_01_30_create_post_galleries.js
@@ -102,18 +102,20 @@ contentManagementClient.init(async environment => {
 
       await gallery.publish();
 
+      const actionList = `#${actionIds.join(', #')}`; // e.g. #1, #2, #3
       logger.info(
-        `→ Created "${galleryTitle}" (${gallery.sys.id}, action #${photoAction.id}).`,
+        `→ Created "${galleryTitle}" (${gallery.sys.id} for ${actionList}).`,
       );
 
       // Replace the link to the custom block with our new post gallery:
-      page.fields.blocks[LOCALE] = reject(
-        page.fields.blocks[LOCALE],
+      const customBlockIndex = page.fields.blocks[LOCALE].findIndex(
         block => block.sys.id === customBlock.sys.id,
       );
 
-      page.fields.blocks[LOCALE].push(linkReference(gallery.sys.id));
+      const newLink = linkReference(gallery.sys.id);
+      page.fields.blocks[LOCALE].splice(customBlockIndex, 1, newLink);
 
+      // Make sure that we don't publish an unpublished campaign by mistake:
       const wasPublished = await page.isPublished();
       const updatedPage = await page.update();
 
@@ -122,7 +124,6 @@ contentManagementClient.init(async environment => {
         continue;
       }
 
-      // Make sure that we don't publish an unpublished campaign by mistake:
       if (!wasPublished) {
         logger.warn(`→ Needs review: ${updatedPage.sys.id}`);
         continue;

--- a/contentful/management-api-scripts/2020_01_30_create_post_galleries.js
+++ b/contentful/management-api-scripts/2020_01_30_create_post_galleries.js
@@ -1,0 +1,129 @@
+/* eslint-disable no-restricted-syntax, no-await-in-loop, no-continue */
+
+const fetch = require('node-fetch');
+const { reject } = require('lodash');
+
+const { contentManagementClient } = require('./contentManagementClient');
+const {
+  createLogger,
+  getField,
+  withFields,
+  linkReference,
+  constants,
+  sleep,
+} = require('./helpers');
+
+const { LOCALE } = constants;
+
+// @TODO: Support using the appropriate Rogue environment?
+const ROGUE_API = 'https://activity-qa.dosomething.org/api/v3';
+const logger = createLogger('replace_staff_linked_entries_with_person');
+
+contentManagementClient.init(async environment => {
+  const blocks = await environment.getEntries({
+    content_type: 'customBlock',
+    'fields.type': 'gallery',
+  });
+
+  for (let i = 0; i < blocks.items.length; i += 1) {
+    const customBlock = blocks.items[i];
+
+    // Find all Entries which link to this custom block.
+    const linkedEntries = await environment.getEntries({
+      links_to_entry: customBlock.sys.id,
+    });
+
+    const internalTitle = getField(customBlock, 'internalTitle');
+    logger.info(
+      `\n\nProcessing ${linkedEntries.items.length} links to "${internalTitle}".`,
+    );
+
+    for (let j = 0; j < linkedEntries.items.length; j += 1) {
+      const page = linkedEntries.items[j];
+      const id = page.sys.id;
+
+      const isPageArchived = await page.isArchived();
+      if (isPageArchived) {
+        logger.info(`⇢ Skipping '${id}', archived.`);
+        continue;
+      }
+
+      // Cool it a bit to avoid the rate-limit police:
+      await sleep(500);
+
+      // Get the campaign ID for this action page:
+      const campaignQuery = await environment.getEntries({
+        links_to_entry: page.sys.id,
+        limit: 1,
+      });
+
+      const campaign = campaignQuery.items[0];
+      const campaignId = campaign.fields.legacyCampaignId[LOCALE];
+
+      const pageTitle = getField(page, 'internalTitle');
+      logger.info(`Looking at "${pageTitle}" (${campaignId})`);
+
+      // Get the action ID from the first `photo` action for this campaign.
+      const response = await fetch(
+        `${ROGUE_API}/actions?filter[campaign_id]=${campaignId}`,
+      );
+
+      const { data } = await response.json();
+      const photoAction = data.find(action => action.post_type === 'photo');
+
+      if (!photoAction) {
+        logger.info(`⇢ Skipping '${id}', could not find action.`);
+        continue;
+      }
+
+      // Create a new Post Gallery entity for this action.
+      const galleryTitle = `${getField(campaign, 'internalTitle')} Gallery`;
+      const gallery = await environment.createEntry(
+        'postGallery',
+        withFields({
+          internalTitle: galleryTitle,
+          actionIds: [String(photoAction.id)],
+          itemsPerRow: 3,
+          filterType: 'none',
+          hideReactions: false,
+        }),
+      );
+
+      await gallery.publish();
+
+      logger.info(
+        `→ Created "${galleryTitle}" (${gallery.sys.id}, action #${photoAction.id}).`,
+      );
+
+      // Replace the link to the custom block with our new post gallery:
+      page.fields.blocks[LOCALE] = reject(
+        page.fields.blocks[LOCALE],
+        block => block.sys.id === customBlock.sys.id,
+      );
+
+      page.fields.blocks[LOCALE].push(linkReference(gallery.sys.id));
+
+      const wasPublished = await page.isPublished();
+      const updatedPage = await page.update();
+
+      if (!updatedPage) {
+        logger.error(`→ Could not update reference for "${pageTitle}".`);
+        continue;
+      }
+
+      // Make sure that we don't publish an unpublished campaign by mistake:
+      if (!wasPublished) {
+        logger.warn(`→ Needs review: ${updatedPage.sys.id}`);
+        continue;
+      }
+
+      const publishedPage = await updatedPage.publish();
+
+      if (publishedPage) {
+        logger.info(
+          `✔ Published "${pageTitle}": https://qa.dosomething.org/us/campaigns/${publishedPage.fields.slug[LOCALE]}`,
+        );
+      }
+    }
+  }
+});

--- a/contentful/management-api-scripts/2020_01_30_create_post_galleries.js
+++ b/contentful/management-api-scripts/2020_01_30_create_post_galleries.js
@@ -15,11 +15,17 @@ const {
 
 const { LOCALE } = constants;
 
-// @TODO: Support using the appropriate Rogue environment?
-const ROGUE_API = 'https://activity-qa.dosomething.org/api/v3';
-const logger = createLogger('replace_staff_linked_entries_with_person');
+const { ROGUE_URL } = process.env;
+const logger = createLogger('create_post_galleries');
 
 contentManagementClient.init(async environment => {
+  logger.info(
+    `Running 'create_post_galleries', using Contentful's '${environment.sys.id}' environment & '${ROGUE_URL}'.`,
+  );
+  logger.info('Kicking things off in 5 seconds...');
+
+  await sleep(5000);
+
   const blocks = await environment.getEntries({
     content_type: 'customBlock',
     'fields.type': 'gallery',
@@ -65,7 +71,7 @@ contentManagementClient.init(async environment => {
 
       // Get the action ID from the first `photo` action for this campaign.
       const response = await fetch(
-        `${ROGUE_API}/actions?filter[campaign_id]=${campaignId}`,
+        `${ROGUE_URL}/api/v3/actions?filter[campaign_id]=${campaignId}`,
       );
 
       const { data } = await response.json();

--- a/contentful/management-api-scripts/2020_01_30_create_post_galleries.js
+++ b/contentful/management-api-scripts/2020_01_30_create_post_galleries.js
@@ -64,7 +64,7 @@ contentManagementClient.init(async environment => {
       });
 
       const campaign = campaignQuery.items[0];
-      const campaignId = campaign.fields.legacyCampaignId[LOCALE];
+      const campaignId = getField(campaign, 'legacyCampaignId');
 
       const pageTitle = getField(page, 'internalTitle');
       logger.info(`Looking at "${pageTitle}" (${campaignId})`);

--- a/contentful/management-api-scripts/contentManagementClient.js
+++ b/contentful/management-api-scripts/contentManagementClient.js
@@ -1,3 +1,5 @@
+require('dotenv').config();
+
 const { get } = require('lodash');
 const parseArgs = require('minimist');
 const contentful = require('contentful-management');
@@ -13,7 +15,12 @@ async function initContentManagementClient(callback) {
     },
   });
 
-  const { spaceId, accessToken, environmentId } = args;
+  // If run from project root, use environment variables we've configured:
+  const spaceId = args.spaceId || process.env.CONTENTFUL_SPACE_ID;
+  const accessToken =
+    args.accessToken || process.env.CONTENTFUL_MANAGEMENT_API_KEY;
+  const environmentId =
+    args.environmentId || process.env.CONTENTFUL_ENVIRONMENT_ID;
 
   if (!spaceId || !accessToken) {
     console.log(
@@ -24,7 +31,9 @@ async function initContentManagementClient(callback) {
     );
     return;
   }
+
   const environment = await getEnvironment(spaceId, accessToken, environmentId);
+
   callback(environment, args);
 }
 

--- a/contentful/management-api-scripts/contentManagementClient.js
+++ b/contentful/management-api-scripts/contentManagementClient.js
@@ -17,9 +17,11 @@ async function initContentManagementClient(callback) {
 
   if (!spaceId || !accessToken) {
     console.log(
-      'Please provide the space-id and access token arguments in the following format:',
+      'Please provide the space, environment & access token in the following format:',
     );
-    console.log('--space-id [space-id] --access-token [access-token]');
+    console.log(
+      '--space-id [id] --access-token [token] --environment-id [master|qa|dev]',
+    );
     return;
   }
   const environment = await getEnvironment(spaceId, accessToken, environmentId);


### PR DESCRIPTION
### What's this PR do?

This pull request creates "Post Gallery" blocks for each of these older campaigns (the preferred workflow in our new multiple-action world) instead of linking one monolithic `customBlock`.

### How should this be reviewed?

This is my first script! @mendelB, please be kind! 🙈

### Any background context you want to provide?

I avoided using `attempt` since I think it'll be less stressful if the script errors out when it runs into a problem so the operator (me) can hop in, sort out the issue, and then continue along (rather than running it and then having a bunch of things to follow up on).

### Relevant tickets

References [Pivotal #171002750](https://www.pivotaltracker.com/story/show/171002750). Unblocks #1900.

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added screenshots of front-end changes on small, medium, and large screens.
- [ ] Added appropriate feature/unit tests.
