### PR TITLE
Quick bug fix for Content Blocks image alignment

### DIFF
--- a/resources/assets/components/ContentfulEntry/ContentfulEntry.js
+++ b/resources/assets/components/ContentfulEntry/ContentfulEntry.js
@@ -159,7 +159,7 @@ class ContentfulEntry extends React.Component {
             className={className}
             // Resolves the aliases used in the ContentBlockFragment.
             content={json.contentBlockContent}
-            imageAlignment={json.contentBlockImageAlignment}
+            imageAlignment={json.contentBlockImageAlignment || undefined}
             {...withoutNulls(json)}
           />
         );


### PR DESCRIPTION
### What's this PR do?

This pull request patches a quick oversight on my part for GraphQL loaded Content Blocks https://github.com/DoSomething/phoenix-next/pull/1692 where I failed to ensure the _optional_ image alignment field, where we're resolving a field alias and it thus outside our `withoutNulls` safety call, doesn't end up being `null` and overriding the default value (which we process).

### How should this be reviewed?
👀 


### Any background context you want to provide?
This was causing breakage on the[ 👻 test](https://app.ghostinspector.com/tests/5c4b8976638e692a2327b467) for a content block with no image alignment set on Contentful.

We've swapped over to query page blocks via graphql in #1900 

