### PR TITLE
Load post-signup affirmation blocks via GraphQL.

### DIFF
--- a/resources/assets/components/ContentfulEntry/ContentfulEntry.js
+++ b/resources/assets/components/ContentfulEntry/ContentfulEntry.js
@@ -61,26 +61,6 @@ class ContentfulEntry extends React.Component {
     const type = parseContentfulType(json);
 
     switch (type) {
-      case 'affirmation':
-        /**
-         * Note: For Affirmations, the json object includes an onClose function property,
-         * used to close the Affirmation modal. This is a little bit of a hack, as our json
-         * object is not truly json when it includes a function.
-         * @see components/pages/PostSignupModal.js
-         */
-        return (
-          <AffirmationContainer
-            {...withoutNulls(json.fields)}
-            author={
-              json.fields && json.fields.author
-                ? json.fields.author.fields
-                : undefined
-            }
-            onClose={json.onClose}
-          />
-        );
-
-      // @TODO: Need to figure out 'onClose'...
       case 'AffirmationBlock':
         return (
           <AffirmationContainer

--- a/resources/assets/components/pages/CampaignPage/CampaignPage.js
+++ b/resources/assets/components/pages/CampaignPage/CampaignPage.js
@@ -5,7 +5,6 @@ import CampaignPageContent from './CampaignPageContent';
 import { CallToActionContainer } from '../../CallToAction';
 import LedeBannerContainer from '../../LedeBanner/LedeBannerContainer';
 import CampaignInfoBarContainer from '../../CampaignInfoBar/CampaignInfoBarContainer';
-import ContentfulEntryLoader from '../../utilities/ContentfulEntryLoader/ContentfulEntryLoader';
 import CampaignPageNavigationContainer from '../../CampaignPageNavigation/CampaignPageNavigationContainer';
 
 import './campaign-page.scss';
@@ -31,13 +30,8 @@ const CampaignPage = props => {
             <CampaignPageNavigationContainer />
           ) : null}
 
-          <div className="md:w-3/4 mx-auto mt-6 mb-6">
-            {/* @TODO: after Action page migration, refactor and combine CampaignPage & CampaignSubPage and render Contentful Entry within CampaignPage component */}
-            {!entryContent ? (
-              <CampaignPageContent {...props} />
-            ) : (
-              <ContentfulEntryLoader id={entryContent.id} />
-            )}
+          <div className="md:w-3/4 mx-auto my-6">
+            <CampaignPageContent {...props} />
           </div>
 
           {!entryContent ? (

--- a/resources/assets/components/pages/CampaignPage/CampaignPageContent.js
+++ b/resources/assets/components/pages/CampaignPage/CampaignPageContent.js
@@ -1,13 +1,12 @@
 import React from 'react';
-import { find, get } from 'lodash';
+import { find } from 'lodash';
 import PropTypes from 'prop-types';
-import classnames from 'classnames';
 
 import NotFound from '../../NotFound';
 import ScrollConcierge from '../../ScrollConcierge';
 import { CallToActionContainer } from '../../CallToAction';
 import TextContent from '../../utilities/TextContent/TextContent';
-import { isCampaignClosed, parseContentfulType } from '../../../helpers';
+import { isCampaignClosed } from '../../../helpers';
 import ContentfulEntryLoader from '../../utilities/ContentfulEntryLoader/ContentfulEntryLoader';
 
 const CampaignPageContent = props => {
@@ -22,45 +21,6 @@ const CampaignPageContent = props => {
   }
 
   const isClosed = isCampaignClosed(campaignEndDate);
-
-  const renderBlock = json => {
-    const type = parseContentfulType(json);
-
-    // @TODO (2018-10-11) Would like to rethink this approach with fullWidth.
-    let fullWidth = false;
-    if (
-      [
-        'photoSubmissionAction',
-        'gallery',
-        'postGallery',
-        'imagesBlock',
-      ].includes(type)
-    ) {
-      fullWidth = true;
-    }
-
-    // Only setting full column width for Content Blocks with an image
-    if (type === 'contentBlock' && get(json.fields.image, 'url')) {
-      fullWidth = true;
-    }
-
-    // Only setting full column width for Social Drive Actions displaying a page views info card.
-    if (type === 'socialDriveAction' && !json.fields.hidePageViews) {
-      fullWidth = true;
-    }
-
-    return (
-      <div
-        key={json.id}
-        id={`block-${json.id}`}
-        className={classnames('mb-6', 'mx-3', 'clear-both', {
-          primary: !fullWidth,
-        })}
-      >
-        <ContentfulEntryLoader id={json.id} />
-      </div>
-    );
-  };
 
   const { content, sidebar, blocks } = subPage.fields;
 
@@ -85,7 +45,20 @@ const CampaignPageContent = props => {
       ) : null}
 
       <div className="blocks clear-both">
-        {blocks.map(block => renderBlock(block))}
+        {blocks.map(block => (
+          <div key={block.id} id={`block-${block.id}`}>
+            <ContentfulEntryLoader
+              id={block.id}
+              className="mb-6 mx-3 clear-both"
+              classNameByEntryDefault="md:w-3/4"
+              classNameByEntry={{
+                PostGalleryBlock: 'w-full',
+                PhotoSubmissionBlock: 'w-full',
+                ImagesBlock: 'w-full',
+              }}
+            />
+          </div>
+        ))}
       </div>
 
       {isClosed ? null : (

--- a/resources/assets/components/pages/CampaignPage/CampaignPageContent.js
+++ b/resources/assets/components/pages/CampaignPage/CampaignPageContent.js
@@ -52,9 +52,10 @@ const CampaignPageContent = props => {
               className="mb-6 mx-3 clear-both"
               classNameByEntryDefault="md:w-3/4"
               classNameByEntry={{
+                ImagesBlock: 'w-full',
                 PostGalleryBlock: 'w-full',
                 PhotoSubmissionBlock: 'w-full',
-                ImagesBlock: 'w-full',
+                SocialDriveBlock: 'w-full',
               }}
             />
           </div>

--- a/resources/assets/components/pages/PostSignupModal/PostSignupModal.js
+++ b/resources/assets/components/pages/PostSignupModal/PostSignupModal.js
@@ -1,13 +1,24 @@
 import React from 'react';
+import { get } from 'lodash';
 import PropTypes from 'prop-types';
 
+import { withoutNulls } from '../../../helpers';
 import SlideshowContainer from '../../Slideshow';
-import ContentfulEntry from '../../ContentfulEntry';
+import AffirmationContainer from '../../Affirmation/AffirmationContainer';
+import ContentfulEntryLoader from '../../utilities/ContentfulEntryLoader/ContentfulEntryLoader';
 
 const PostSignupModal = ({ affirmation, onClose }) => (
   <div className="modal__slide">
     <SlideshowContainer slideshowId="post-signup-modal" hideCloseButton>
-      <ContentfulEntry json={{ ...affirmation, onClose }} />
+      {affirmation.type === 'affirmation' ? (
+        <AffirmationContainer
+          {...withoutNulls(affirmation.fields)}
+          author={get(affirmation, 'fields.author.fields')}
+          onClose={onClose}
+        />
+      ) : (
+        <ContentfulEntryLoader json={affirmation.id} />
+      )}
     </SlideshowContainer>
   </div>
 );

--- a/resources/assets/components/pages/PostSignupModal/PostSignupModal.js
+++ b/resources/assets/components/pages/PostSignupModal/PostSignupModal.js
@@ -17,7 +17,7 @@ const PostSignupModal = ({ affirmation, onClose }) => (
           onClose={onClose}
         />
       ) : (
-        <ContentfulEntryLoader json={affirmation.id} />
+        <ContentfulEntryLoader id={affirmation.id} />
       )}
     </SlideshowContainer>
   </div>


### PR DESCRIPTION
### What's this PR do?

This pull request updates any post-signup affirmation _blocks_ (e.g. having a voter-registration action pop up after a user signs up for a campaign) to load via `ContentfulEntryLoader`. I've moved the "standard" `affirmation` into the `PostSignupModal` component so we don't need to have this special `onClose` case in our generic loader.

It also fixes an issue where blocks on action pages were not going "full-width" when they were supposed to, like post galleries or photo submission blocks.

### How should this be reviewed?

👀

### Any background context you want to provide?

This is the last case where we might load a block via the legacy content API! I'll follow this up with a cleanup PR to delete all the code that's no longer used.

### Relevant tickets

References [Pivotal #169216496](https://www.pivotaltracker.com/story/show/169216496).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added screenshots of front-end changes on small, medium, and large screens.
- [ ] Added appropriate feature/unit tests.
