### PR TITLE
Updating trackAnalyticsEvent() calls in numerous components (Part 4)

### DIFF
--- a/resources/assets/components/SiteNavigation/SiteNavigation.js
+++ b/resources/assets/components/SiteNavigation/SiteNavigation.js
@@ -31,34 +31,21 @@ class SiteNavigation extends React.Component {
     };
   }
 
-  analyzeEvent = (event, analytics = {}) => {
-    const targets = {
-      A: 'link',
-      BUTTON: 'button',
-    };
+  analyzeEvent = (name, data = {}) => {
+    console.log('💩 event: ', name);
+    console.log('🧻 analytics: ', data);
 
-    const inferredTarget = get(targets, event.target.tagName, 'element');
+    const { action, category, label, context = {} } = data;
 
-    const target = get(analytics, 'target', inferredTarget);
-
-    const context = get(analytics, 'context', {});
-
-    const label = get(analytics, 'label', null);
-
-    trackAnalyticsEvent({
+    trackAnalyticsEvent(name, {
+      action,
+      category,
+      label,
       context: {
         ...getPageContext(),
         ...getUtmContext(),
         referrer: document.referrer,
         ...context,
-      },
-      metadata: {
-        adjective: get(analytics, 'adjective', label),
-        category: get(analytics, 'category', 'navigation'),
-        label,
-        noun: get(analytics, 'noun', 'nav_link'),
-        target,
-        verb: get(analytics, 'verb', 'clicked'),
       },
     });
   };
@@ -94,7 +81,9 @@ class SiteNavigation extends React.Component {
   };
 
   handleOnClickLink = (event, analytics = {}) => {
-    this.analyzeEvent(event, analytics);
+    console.log('🐞 analytics: ', analytics);
+
+    this.analyzeEvent(analytics.name, analytics);
 
     this.setState({
       activeSubNav: null,
@@ -155,7 +144,14 @@ class SiteNavigation extends React.Component {
           <div className="logo-nav">
             <a
               href="/"
-              onClick={e => this.handleOnClickLink(e, { label: 'homepage' })}
+              onClick={e =>
+                this.handleOnClickLink(e, {
+                  name: 'clicked_nav_link_homepage',
+                  action: 'link_clicked',
+                  category: 'navigation',
+                  label: 'homepage',
+                })
+              }
             >
               <DoSomethingLogo />
             </a>
@@ -182,6 +178,9 @@ class SiteNavigation extends React.Component {
                         href="/campaigns"
                         onClick={e =>
                           this.handleOnClickLink(e, {
+                            name: 'clicked_nav_link_causes',
+                            action: 'link_clicked',
+                            category: 'navigation',
                             label: 'causes',
                           })
                         }
@@ -218,7 +217,9 @@ class SiteNavigation extends React.Component {
                             href="/us/causes/education"
                             onClick={e => {
                               this.handleOnClickLink(e, {
-                                noun: 'subnav_link',
+                                name: 'clicked_subnav_link_causes_education',
+                                action: 'link_clicked',
+                                category: 'navigation',
                                 label: 'causes_education',
                               });
                             }}
@@ -231,7 +232,10 @@ class SiteNavigation extends React.Component {
                             href="/us/causes/mental-health"
                             onClick={e => {
                               this.handleOnClickLink(e, {
-                                noun: 'subnav_link',
+                                name:
+                                  'clicked_subnav_link_causes_mental_health',
+                                action: 'link_clicked',
+                                category: 'navigation',
                                 label: 'causes_mental_health',
                               });
                             }}
@@ -244,7 +248,10 @@ class SiteNavigation extends React.Component {
                             href="/us/causes/homelessness-and-poverty"
                             onClick={e => {
                               this.handleOnClickLink(e, {
-                                noun: 'subnav_link',
+                                name:
+                                  'clicked_subnav_link_causes_homelessness_and_poverty',
+                                action: 'link_clicked',
+                                category: 'navigation',
                                 label: 'causes_homelessness_and_poverty',
                               });
                             }}
@@ -257,7 +264,9 @@ class SiteNavigation extends React.Component {
                             href="/us/causes/environment"
                             onClick={e => {
                               this.handleOnClickLink(e, {
-                                noun: 'subnav_link',
+                                name: 'clicked_subnav_link_causes_environment',
+                                action: 'link_clicked',
+                                category: 'navigation',
                                 label: 'causes_environment',
                               });
                             }}
@@ -270,7 +279,9 @@ class SiteNavigation extends React.Component {
                             href="/us/causes/bullying"
                             onClick={e => {
                               this.handleOnClickLink(e, {
-                                noun: 'subnav_link',
+                                name: 'clicked_subnav_link_causes_bullying',
+                                action: 'link_clicked',
+                                category: 'navigation',
                                 label: 'causes_bullying',
                               });
                             }}
@@ -283,7 +294,10 @@ class SiteNavigation extends React.Component {
                             href="/us/campaigns"
                             onClick={e => {
                               this.handleOnClickLink(e, {
-                                noun: 'subnav_link',
+                                name:
+                                  'clicked_subnav_link_causes_all_campaigns',
+                                action: 'link_clicked',
+                                category: 'navigation',
                                 label: 'causes_all_campaigns',
                               });
                             }}
@@ -329,7 +343,12 @@ class SiteNavigation extends React.Component {
               <a
                 href="/us/about/easy-scholarships"
                 onClick={e =>
-                  this.handleOnClickLink(e, { label: 'scholarships' })
+                  this.handleOnClickLink(e, {
+                    name: 'clicked_nav_link_scholarships',
+                    action: 'link_clicked',
+                    category: 'navigation',
+                    label: 'scholarships',
+                  })
                 }
               >
                 Scholarships
@@ -339,7 +358,14 @@ class SiteNavigation extends React.Component {
             <li className="menu-nav__item">
               <a
                 href="https://lets.dosomething.org"
-                onClick={e => this.handleOnClickLink(e, { label: 'articles' })}
+                onClick={e =>
+                  this.handleOnClickLink(e, {
+                    name: 'clicked_nav_link_articles',
+                    action: 'link_clicked',
+                    category: 'navigation',
+                    label: 'articles',
+                  })
+                }
               >
                 Articles
               </a>
@@ -348,7 +374,14 @@ class SiteNavigation extends React.Component {
             <li className="menu-nav__item">
               <a
                 href="https://join.dosomething.org/"
-                onClick={e => this.handleOnClickLink(e, { label: 'about' })}
+                onClick={e =>
+                  this.handleOnClickLink(e, {
+                    name: 'clicked_nav_link_about',
+                    action: 'link_clicked',
+                    category: 'navigation',
+                    label: 'about',
+                  })
+                }
               >
                 About
               </a>

--- a/resources/assets/components/SiteNavigation/SiteNavigation.js
+++ b/resources/assets/components/SiteNavigation/SiteNavigation.js
@@ -2,7 +2,6 @@
 /* eslint-disable id-length, jsx-a11y/interactive-supports-focus, jsx-a11y/no-autofocus */
 
 import React from 'react';
-import { get } from 'lodash';
 import Media from 'react-media';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
@@ -31,11 +30,14 @@ class SiteNavigation extends React.Component {
     };
   }
 
-  analyzeEvent = (name, data = {}) => {
-    console.log('💩 event: ', name);
-    console.log('🧻 analytics: ', data);
-
-    const { action, category, label, context = {} } = data;
+  /**
+   * Parse event data and trigger analytics event.
+   *
+   * @param  {Object} data
+   * @return {null}
+   */
+  analyzeEvent = (data = {}) => {
+    const { action, category, label, name, context = {} } = data;
 
     trackAnalyticsEvent(name, {
       action,
@@ -50,6 +52,12 @@ class SiteNavigation extends React.Component {
     });
   };
 
+  /**
+   * Handle mouse enter events, or otherwise hovering onto an element.
+   *
+   * @param  {String} subNavName
+   * @return {null}
+   */
   handleMouseEnter = subNavName => {
     const { isSubNavFixed } = this.state;
 
@@ -62,6 +70,11 @@ class SiteNavigation extends React.Component {
     });
   };
 
+  /**
+   * Handle mouse leave events, or otherwise hovering off of an element.
+   *
+   * @return {null}
+   */
   handleMouseLeave = () => {
     const { isSubNavFixed } = this.state;
 
@@ -74,16 +87,26 @@ class SiteNavigation extends React.Component {
     });
   };
 
+  /**
+   * Handle on change event on form inputs.
+   *
+   * @param  {Object} event
+   * @return {null}
+   */
   handleOnChange = event => {
     this.setState({
       searchInput: event.target.value,
     });
   };
 
-  handleOnClickLink = (event, analytics = {}) => {
-    console.log('🐞 analytics: ', analytics);
-
-    this.analyzeEvent(analytics.name, analytics);
+  /**
+   * Handle on click events on an element.
+   *
+   * @param  {Object} analytics
+   * @return {null}
+   */
+  handleOnClickLink = (analytics = {}) => {
+    this.analyzeEvent(analytics);
 
     this.setState({
       activeSubNav: null,
@@ -91,10 +114,18 @@ class SiteNavigation extends React.Component {
     });
   };
 
+  /**
+   * Handle on click events that toggle an element.
+   *
+   * @param  {Object} event
+   * @param  {String} subNavName
+   * @param  {Object} analytics
+   * @return {null}
+   */
   handleOnClickToggle = (event, subNavName, analytics = {}) => {
     event.preventDefault();
 
-    this.analyzeEvent(event, analytics);
+    this.analyzeEvent(analytics);
 
     const { activeSubNav, isSubNavFixed } = this.state;
 
@@ -121,19 +152,18 @@ class SiteNavigation extends React.Component {
     });
   };
 
-  handleOnClickClose = (event, analytics = {}) => {
-    this.analyzeEvent(event, analytics);
+  /**
+   * Handle on click events that close a menu item.
+   *
+   * @param  {Object} analytics
+   * @return {null}
+   */
+  handleOnClickClose = (analytics = {}) => {
+    this.analyzeEvent(analytics);
 
     this.setState({
       activeSubNav: null,
       isSubNavFixed: false,
-    });
-  };
-
-  handleOnSubmit = (event, analytics = {}) => {
-    this.analyzeEvent(event, {
-      ...analytics,
-      context: { searchQuery: this.state.searchInput },
     });
   };
 
@@ -144,8 +174,8 @@ class SiteNavigation extends React.Component {
           <div className="logo-nav">
             <a
               href="/"
-              onClick={e =>
-                this.handleOnClickLink(e, {
+              onClick={() =>
+                this.handleOnClickLink({
                   name: 'clicked_nav_link_homepage',
                   action: 'link_clicked',
                   category: 'navigation',
@@ -176,8 +206,8 @@ class SiteNavigation extends React.Component {
                       <a
                         id="main-nav__causes"
                         href="/campaigns"
-                        onClick={e =>
-                          this.handleOnClickLink(e, {
+                        onClick={() =>
+                          this.handleOnClickLink({
                             name: 'clicked_nav_link_causes',
                             action: 'link_clicked',
                             category: 'navigation',
@@ -194,6 +224,9 @@ class SiteNavigation extends React.Component {
                         href="/"
                         onClick={e =>
                           this.handleOnClickToggle(e, 'CausesSubNav', {
+                            name: 'clicked_nav_link_causes',
+                            action: 'link_clicked',
+                            category: 'navigation',
                             label: 'causes',
                           })
                         }
@@ -215,8 +248,8 @@ class SiteNavigation extends React.Component {
                         <li>
                           <a
                             href="/us/causes/education"
-                            onClick={e => {
-                              this.handleOnClickLink(e, {
+                            onClick={() => {
+                              this.handleOnClickLink({
                                 name: 'clicked_subnav_link_causes_education',
                                 action: 'link_clicked',
                                 category: 'navigation',
@@ -230,8 +263,8 @@ class SiteNavigation extends React.Component {
                         <li>
                           <a
                             href="/us/causes/mental-health"
-                            onClick={e => {
-                              this.handleOnClickLink(e, {
+                            onClick={() => {
+                              this.handleOnClickLink({
                                 name:
                                   'clicked_subnav_link_causes_mental_health',
                                 action: 'link_clicked',
@@ -246,8 +279,8 @@ class SiteNavigation extends React.Component {
                         <li>
                           <a
                             href="/us/causes/homelessness-and-poverty"
-                            onClick={e => {
-                              this.handleOnClickLink(e, {
+                            onClick={() => {
+                              this.handleOnClickLink({
                                 name:
                                   'clicked_subnav_link_causes_homelessness_and_poverty',
                                 action: 'link_clicked',
@@ -262,8 +295,8 @@ class SiteNavigation extends React.Component {
                         <li>
                           <a
                             href="/us/causes/environment"
-                            onClick={e => {
-                              this.handleOnClickLink(e, {
+                            onClick={() => {
+                              this.handleOnClickLink({
                                 name: 'clicked_subnav_link_causes_environment',
                                 action: 'link_clicked',
                                 category: 'navigation',
@@ -277,8 +310,8 @@ class SiteNavigation extends React.Component {
                         <li>
                           <a
                             href="/us/causes/bullying"
-                            onClick={e => {
-                              this.handleOnClickLink(e, {
+                            onClick={() => {
+                              this.handleOnClickLink({
                                 name: 'clicked_subnav_link_causes_bullying',
                                 action: 'link_clicked',
                                 category: 'navigation',
@@ -292,8 +325,8 @@ class SiteNavigation extends React.Component {
                         <li>
                           <a
                             href="/us/campaigns"
-                            onClick={e => {
-                              this.handleOnClickLink(e, {
+                            onClick={() => {
+                              this.handleOnClickLink({
                                 name:
                                   'clicked_subnav_link_causes_all_campaigns',
                                 action: 'link_clicked',
@@ -315,10 +348,11 @@ class SiteNavigation extends React.Component {
                         url="/us/campaigns/mirror-messages"
                         title="Mirror Messages"
                         text="Create and post encouraging notes in your school bathrooms to brighten your classmates' day!"
-                        callback={e =>
-                          this.analyzeEvent(e, {
-                            noun: 'subnav_link',
-                            target: 'link',
+                        callback={() =>
+                          this.analyzeEvent({
+                            name: 'clicked_subnav_link_feature_mirror_messages',
+                            action: 'link_clicked',
+                            category: 'navigation',
                             label: 'feature_mirror_messages',
                           })
                         }
@@ -327,10 +361,15 @@ class SiteNavigation extends React.Component {
 
                     {this.state.isSubNavFixed ? (
                       <CloseButton
-                        callback={this.handleOnClickClose}
+                        callback={() =>
+                          this.handleOnClickClose({
+                            name: 'clicked_nav_button_close_subnav',
+                            action: 'button_clicked',
+                            category: 'navigation',
+                            label: 'close_subnav',
+                          })
+                        }
                         className="btn__close--subnav btn__close--main-subnav block"
-                        dataLabel="close_subnav"
-                        dataNoun="nav_button"
                         size="22px"
                       />
                     ) : null}
@@ -342,8 +381,8 @@ class SiteNavigation extends React.Component {
             <li className="menu-nav__item">
               <a
                 href="/us/about/easy-scholarships"
-                onClick={e =>
-                  this.handleOnClickLink(e, {
+                onClick={() =>
+                  this.handleOnClickLink({
                     name: 'clicked_nav_link_scholarships',
                     action: 'link_clicked',
                     category: 'navigation',
@@ -358,8 +397,8 @@ class SiteNavigation extends React.Component {
             <li className="menu-nav__item">
               <a
                 href="https://lets.dosomething.org"
-                onClick={e =>
-                  this.handleOnClickLink(e, {
+                onClick={() =>
+                  this.handleOnClickLink({
                     name: 'clicked_nav_link_articles',
                     action: 'link_clicked',
                     category: 'navigation',
@@ -374,8 +413,8 @@ class SiteNavigation extends React.Component {
             <li className="menu-nav__item">
               <a
                 href="https://join.dosomething.org/"
-                onClick={e =>
-                  this.handleOnClickLink(e, {
+                onClick={() =>
+                  this.handleOnClickLink({
                     name: 'clicked_nav_link_about',
                     action: 'link_clicked',
                     category: 'navigation',
@@ -397,8 +436,10 @@ class SiteNavigation extends React.Component {
                 })}
                 onClick={e =>
                   this.handleOnClickToggle(e, 'SearchSubNav', {
+                    name: 'clicked_nav_button_search_form_toggle',
+                    action: 'link_clicked',
+                    category: 'navigation',
                     label: 'search_form_toggle',
-                    noun: 'nav_button',
                   })
                 }
               >
@@ -416,13 +457,13 @@ class SiteNavigation extends React.Component {
                       acceptCharset="UTF-8"
                       action="/us/search"
                       method="GET"
-                      onSubmit={e =>
-                        this.handleOnSubmit(e, {
+                      onSubmit={() =>
+                        this.analyzeEvent({
+                          name: 'submitted_nav_form_search_subnav',
+                          action: 'form_submitted',
                           category: 'search',
                           label: 'search_subnav',
-                          noun: 'nav_form',
-                          target: 'form',
-                          verb: 'submitted',
+                          context: { searchQuery: this.state.searchInput },
                         })
                       }
                     >
@@ -433,13 +474,12 @@ class SiteNavigation extends React.Component {
                         name="query"
                         autoFocus
                         onChange={this.handleOnChange}
-                        onClick={e =>
-                          this.analyzeEvent(e, {
+                        onClick={() =>
+                          this.analyzeEvent({
+                            name: 'clicked_nav_form_search_subnav',
+                            action: 'form_clicked',
                             category: 'search',
                             label: 'search_subnav',
-                            noun: 'nav_form',
-                            target: 'form',
-                            verb: 'clicked',
                           })
                         }
                         value={this.state.searchInput}
@@ -452,10 +492,13 @@ class SiteNavigation extends React.Component {
                         <li>
                           <a
                             href="/us/about/easy-scholarships"
-                            onClick={e =>
-                              this.analyzeEvent(e, {
+                            onClick={() =>
+                              this.analyzeEvent({
+                                name:
+                                  'clicked_subnav_link_scholarships_top_search',
+                                action: 'link_clicked',
+                                category: 'navigation',
                                 label: 'scholarships_top_search',
-                                noun: 'subnav_link',
                               })
                             }
                           >
@@ -466,10 +509,12 @@ class SiteNavigation extends React.Component {
                         <li>
                           <a
                             href="/us/search?query=bullying"
-                            onClick={e =>
-                              this.analyzeEvent(e, {
+                            onClick={() =>
+                              this.analyzeEvent({
+                                name: 'clicked_subnav_link_bullying_top_search',
+                                action: 'link_clicked',
+                                category: 'navigation',
                                 label: 'bullying_top_search',
-                                noun: 'subnav_link',
                               })
                             }
                           >
@@ -480,10 +525,12 @@ class SiteNavigation extends React.Component {
                         <li>
                           <a
                             href="/us/search?query=animals"
-                            onClick={e =>
-                              this.analyzeEvent(e, {
+                            onClick={() =>
+                              this.analyzeEvent({
+                                name: 'clicked_subnav_link_animals_top_search',
+                                action: 'link_clicked',
+                                category: 'navigation',
                                 label: 'animals_top_search',
-                                noun: 'subnav_link',
                               })
                             }
                           >
@@ -494,10 +541,13 @@ class SiteNavigation extends React.Component {
                         <li>
                           <a
                             href="/us/facts/11-facts-about-cyber-bullying"
-                            onClick={e =>
-                              this.analyzeEvent(e, {
+                            onClick={() =>
+                              this.analyzeEvent({
+                                name:
+                                  'clicked_subnav_link_cyberbullying_top_search',
+                                action: 'link_clicked',
+                                category: 'navigation',
                                 label: 'cyberbullying_top_search',
-                                noun: 'subnav_link',
                               })
                             }
                           >
@@ -508,10 +558,13 @@ class SiteNavigation extends React.Component {
                         <li>
                           <a
                             href="/us/articles/volunteer-opportunities-for-teens"
-                            onClick={e =>
-                              this.analyzeEvent(e, {
+                            onClick={() =>
+                              this.analyzeEvent({
+                                name:
+                                  'clicked_subnav_link_volunteering_top_search',
+                                action: 'link_clicked',
+                                category: 'navigation',
                                 label: 'volunteering_top_search',
-                                noun: 'subnav_link',
                               })
                             }
                           >
@@ -522,10 +575,12 @@ class SiteNavigation extends React.Component {
                     </div>
 
                     <CloseButton
-                      callback={e =>
-                        this.handleOnClickClose(e, {
+                      callback={() =>
+                        this.handleOnClickClose({
+                          name: 'clicked_nav_button_close_search_subnav',
+                          action: 'button_clicked',
+                          category: 'navigation',
                           label: 'close_search_subnav',
-                          noun: 'nav_button',
                         })
                       }
                       className="btn__close--subnav btn__close--search-subnav block"
@@ -543,7 +598,14 @@ class SiteNavigation extends React.Component {
                     id="utility-nav__account-profile"
                     href="/us/account/profile"
                     className="utility-nav__account-profile-icon"
-                    onClick={e => this.analyzeEvent(e, { label: 'profile' })}
+                    onClick={() =>
+                      this.analyzeEvent({
+                        name: 'clicked_nav_link_profile',
+                        action: 'link_clicked',
+                        category: 'navigation',
+                        label: 'profile',
+                      })
+                    }
                   >
                     <ProfileIcon />
                   </a>
@@ -555,7 +617,14 @@ class SiteNavigation extends React.Component {
                   <a
                     id="utility-nav__auth"
                     href={this.props.authLoginUrl}
-                    onClick={e => this.analyzeEvent(e, { label: 'log_in' })}
+                    onClick={() =>
+                      this.analyzeEvent({
+                        name: 'clicked_nav_link_log_in',
+                        action: 'link_clicked',
+                        category: 'navigation',
+                        label: 'log_in',
+                      })
+                    }
                   >
                     Log In
                   </a>
@@ -565,7 +634,14 @@ class SiteNavigation extends React.Component {
                   <a
                     id="utility-nav__join"
                     href={this.props.authRegisterUrl}
-                    onClick={e => this.analyzeEvent(e, { label: 'join_now' })}
+                    onClick={() =>
+                      this.analyzeEvent({
+                        name: 'clicked_nav_link_join_now',
+                        action: 'link_clicked',
+                        category: 'navigation',
+                        label: 'join_now',
+                      })
+                    }
                   >
                     Join Now
                   </a>
@@ -578,10 +654,12 @@ class SiteNavigation extends React.Component {
         {this.state.activeSubNav ? (
           <div
             className="underlay"
-            onClick={e =>
-              this.handleOnClickClose(e, {
+            onClick={() =>
+              this.handleOnClickClose({
+                name: 'clicked_nav_element_underlay_close_subnav',
+                action: 'element_clicked',
+                category: 'navigation',
                 label: 'underlay_close_subnav',
-                noun: 'nav_element',
               })
             }
             role="button"

--- a/resources/assets/components/SiteNavigation/SiteNavigation.js
+++ b/resources/assets/components/SiteNavigation/SiteNavigation.js
@@ -12,9 +12,10 @@ import CloseButton from '../artifacts/CloseButton/CloseButton';
 import ProfileIcon from '../artifacts/ProfileIcon/ProfileIcon';
 import DoSomethingLogo from '../utilities/DoSomethingLogo/DoSomethingLogo';
 import {
-  trackAnalyticsEvent,
+  EVENT_CATEGORIES,
   getUtmContext,
   getPageContext,
+  trackAnalyticsEvent,
 } from '../../helpers/analytics';
 
 import './site-navigation.scss';
@@ -178,7 +179,7 @@ class SiteNavigation extends React.Component {
                 this.handleOnClickLink({
                   name: 'clicked_nav_link_homepage',
                   action: 'link_clicked',
-                  category: 'navigation',
+                  category: EVENT_CATEGORIES.navigation,
                   label: 'homepage',
                 })
               }
@@ -210,7 +211,7 @@ class SiteNavigation extends React.Component {
                           this.handleOnClickLink({
                             name: 'clicked_nav_link_causes',
                             action: 'link_clicked',
-                            category: 'navigation',
+                            category: EVENT_CATEGORIES.navigation,
                             label: 'causes',
                           })
                         }
@@ -226,7 +227,7 @@ class SiteNavigation extends React.Component {
                           this.handleOnClickToggle(e, 'CausesSubNav', {
                             name: 'clicked_nav_link_causes',
                             action: 'link_clicked',
-                            category: 'navigation',
+                            category: EVENT_CATEGORIES.navigation,
                             label: 'causes',
                           })
                         }
@@ -252,7 +253,7 @@ class SiteNavigation extends React.Component {
                               this.handleOnClickLink({
                                 name: 'clicked_subnav_link_causes_education',
                                 action: 'link_clicked',
-                                category: 'navigation',
+                                category: EVENT_CATEGORIES.navigation,
                                 label: 'causes_education',
                               });
                             }}
@@ -268,7 +269,7 @@ class SiteNavigation extends React.Component {
                                 name:
                                   'clicked_subnav_link_causes_mental_health',
                                 action: 'link_clicked',
-                                category: 'navigation',
+                                category: EVENT_CATEGORIES.navigation,
                                 label: 'causes_mental_health',
                               });
                             }}
@@ -284,7 +285,7 @@ class SiteNavigation extends React.Component {
                                 name:
                                   'clicked_subnav_link_causes_homelessness_and_poverty',
                                 action: 'link_clicked',
-                                category: 'navigation',
+                                category: EVENT_CATEGORIES.navigation,
                                 label: 'causes_homelessness_and_poverty',
                               });
                             }}
@@ -299,7 +300,7 @@ class SiteNavigation extends React.Component {
                               this.handleOnClickLink({
                                 name: 'clicked_subnav_link_causes_environment',
                                 action: 'link_clicked',
-                                category: 'navigation',
+                                category: EVENT_CATEGORIES.navigation,
                                 label: 'causes_environment',
                               });
                             }}
@@ -314,7 +315,7 @@ class SiteNavigation extends React.Component {
                               this.handleOnClickLink({
                                 name: 'clicked_subnav_link_causes_bullying',
                                 action: 'link_clicked',
-                                category: 'navigation',
+                                category: EVENT_CATEGORIES.navigation,
                                 label: 'causes_bullying',
                               });
                             }}
@@ -330,7 +331,7 @@ class SiteNavigation extends React.Component {
                                 name:
                                   'clicked_subnav_link_causes_all_campaigns',
                                 action: 'link_clicked',
-                                category: 'navigation',
+                                category: EVENT_CATEGORIES.navigation,
                                 label: 'causes_all_campaigns',
                               });
                             }}
@@ -352,7 +353,7 @@ class SiteNavigation extends React.Component {
                           this.analyzeEvent({
                             name: 'clicked_subnav_link_feature_mirror_messages',
                             action: 'link_clicked',
-                            category: 'navigation',
+                            category: EVENT_CATEGORIES.navigation,
                             label: 'feature_mirror_messages',
                           })
                         }
@@ -365,7 +366,7 @@ class SiteNavigation extends React.Component {
                           this.handleOnClickClose({
                             name: 'clicked_nav_button_close_subnav',
                             action: 'button_clicked',
-                            category: 'navigation',
+                            category: EVENT_CATEGORIES.navigation,
                             label: 'close_subnav',
                           })
                         }
@@ -385,7 +386,7 @@ class SiteNavigation extends React.Component {
                   this.handleOnClickLink({
                     name: 'clicked_nav_link_scholarships',
                     action: 'link_clicked',
-                    category: 'navigation',
+                    category: EVENT_CATEGORIES.navigation,
                     label: 'scholarships',
                   })
                 }
@@ -401,7 +402,7 @@ class SiteNavigation extends React.Component {
                   this.handleOnClickLink({
                     name: 'clicked_nav_link_articles',
                     action: 'link_clicked',
-                    category: 'navigation',
+                    category: EVENT_CATEGORIES.navigation,
                     label: 'articles',
                   })
                 }
@@ -417,7 +418,7 @@ class SiteNavigation extends React.Component {
                   this.handleOnClickLink({
                     name: 'clicked_nav_link_about',
                     action: 'link_clicked',
-                    category: 'navigation',
+                    category: EVENT_CATEGORIES.navigation,
                     label: 'about',
                   })
                 }
@@ -438,7 +439,7 @@ class SiteNavigation extends React.Component {
                   this.handleOnClickToggle(e, 'SearchSubNav', {
                     name: 'clicked_nav_button_search_form_toggle',
                     action: 'link_clicked',
-                    category: 'navigation',
+                    category: EVENT_CATEGORIES.navigation,
                     label: 'search_form_toggle',
                   })
                 }
@@ -461,7 +462,7 @@ class SiteNavigation extends React.Component {
                         this.analyzeEvent({
                           name: 'submitted_nav_form_search_subnav',
                           action: 'form_submitted',
-                          category: 'search',
+                          category: EVENT_CATEGORIES.search,
                           label: 'search_subnav',
                           context: { searchQuery: this.state.searchInput },
                         })
@@ -478,7 +479,7 @@ class SiteNavigation extends React.Component {
                           this.analyzeEvent({
                             name: 'clicked_nav_form_search_subnav',
                             action: 'form_clicked',
-                            category: 'search',
+                            category: EVENT_CATEGORIES.search,
                             label: 'search_subnav',
                           })
                         }
@@ -497,7 +498,7 @@ class SiteNavigation extends React.Component {
                                 name:
                                   'clicked_subnav_link_scholarships_top_search',
                                 action: 'link_clicked',
-                                category: 'navigation',
+                                category: EVENT_CATEGORIES.navigation,
                                 label: 'scholarships_top_search',
                               })
                             }
@@ -513,7 +514,7 @@ class SiteNavigation extends React.Component {
                               this.analyzeEvent({
                                 name: 'clicked_subnav_link_bullying_top_search',
                                 action: 'link_clicked',
-                                category: 'navigation',
+                                category: EVENT_CATEGORIES.navigation,
                                 label: 'bullying_top_search',
                               })
                             }
@@ -529,7 +530,7 @@ class SiteNavigation extends React.Component {
                               this.analyzeEvent({
                                 name: 'clicked_subnav_link_animals_top_search',
                                 action: 'link_clicked',
-                                category: 'navigation',
+                                category: EVENT_CATEGORIES.navigation,
                                 label: 'animals_top_search',
                               })
                             }
@@ -546,7 +547,7 @@ class SiteNavigation extends React.Component {
                                 name:
                                   'clicked_subnav_link_cyberbullying_top_search',
                                 action: 'link_clicked',
-                                category: 'navigation',
+                                category: EVENT_CATEGORIES.navigation,
                                 label: 'cyberbullying_top_search',
                               })
                             }
@@ -563,7 +564,7 @@ class SiteNavigation extends React.Component {
                                 name:
                                   'clicked_subnav_link_volunteering_top_search',
                                 action: 'link_clicked',
-                                category: 'navigation',
+                                category: EVENT_CATEGORIES.navigation,
                                 label: 'volunteering_top_search',
                               })
                             }
@@ -579,7 +580,7 @@ class SiteNavigation extends React.Component {
                         this.handleOnClickClose({
                           name: 'clicked_nav_button_close_search_subnav',
                           action: 'button_clicked',
-                          category: 'navigation',
+                          category: EVENT_CATEGORIES.navigation,
                           label: 'close_search_subnav',
                         })
                       }
@@ -602,7 +603,7 @@ class SiteNavigation extends React.Component {
                       this.analyzeEvent({
                         name: 'clicked_nav_link_profile',
                         action: 'link_clicked',
-                        category: 'navigation',
+                        category: EVENT_CATEGORIES.navigation,
                         label: 'profile',
                       })
                     }
@@ -621,7 +622,7 @@ class SiteNavigation extends React.Component {
                       this.analyzeEvent({
                         name: 'clicked_nav_link_log_in',
                         action: 'link_clicked',
-                        category: 'navigation',
+                        category: EVENT_CATEGORIES.navigation,
                         label: 'log_in',
                       })
                     }
@@ -638,7 +639,7 @@ class SiteNavigation extends React.Component {
                       this.analyzeEvent({
                         name: 'clicked_nav_link_join_now',
                         action: 'link_clicked',
-                        category: 'navigation',
+                        category: EVENT_CATEGORIES.navigation,
                         label: 'join_now',
                       })
                     }
@@ -658,7 +659,7 @@ class SiteNavigation extends React.Component {
               this.handleOnClickClose({
                 name: 'clicked_nav_element_underlay_close_subnav',
                 action: 'element_clicked',
-                category: 'navigation',
+                category: EVENT_CATEGORIES.navigation,
                 label: 'underlay_close_subnav',
               })
             }

--- a/resources/assets/helpers/analytics.js
+++ b/resources/assets/helpers/analytics.js
@@ -310,14 +310,6 @@ export function trackAnalyticsEvent(name, metadata = {}) {
   // checking against whether name is a string or object or will error out.
   const { action, category, label, context = {}, service } = metadata;
 
-  // @TODO: uncomment out this code once all the events have had their categories
-  // updated to use the new EVENT_CATEGORIES object.
-  // if (!EVENT_CATEGORIES[category]) {
-  //   console.error('The event category specified is not valid!');
-
-  //   return;
-  // }
-
   if (!isString(name)) {
     console.error('Please provide a string for the event name!');
 

--- a/resources/assets/helpers/analytics.js
+++ b/resources/assets/helpers/analytics.js
@@ -20,6 +20,21 @@ import { debug, stringifyNestedObjects, withoutValueless } from '.';
  */
 const APP_PREFIX = 'phoenix';
 
+export const EVENT_CATEGORIES = {
+  accountEdit: 'account_edit',
+  authentication: 'authentication',
+  campaignAction: 'campaign_action',
+  focusedField: 'focused_field',
+  modal: 'modal',
+  navigation: 'navigation',
+  onboarding: 'onboarding',
+  search: 'search',
+  signup: 'signup',
+  siteAction: 'site_action',
+  socialShare: 'social_share',
+  waypoint: 'waypoint',
+};
+
 /**
  * Wrapper function to allow executing additional calls when an analytics event is triggered.
  *
@@ -294,6 +309,14 @@ export function trackAnalyticsEvent(name, metadata = {}) {
   // but while we support the legacyTrackAnalyticsEvent(), we need to destruct after
   // checking against whether name is a string or object or will error out.
   const { action, category, label, context = {}, service } = metadata;
+
+  // @TODO: uncomment out this code once all the events have had their categories
+  // updated to use the new EVENT_CATEGORIES object.
+  // if (!EVENT_CATEGORIES[category]) {
+  //   console.error('The event category specified is not valid!');
+
+  //   return;
+  // }
 
   if (!isString(name)) {
     console.error('Please provide a string for the event name!');

--- a/resources/assets/middleware/api.js
+++ b/resources/assets/middleware/api.js
@@ -98,7 +98,7 @@ const postRequest = (payload, dispatch, getState) => {
 
       trackAnalyticsEvent(`${verb}_${formatEventNoun(postType)}`, {
         action: `${postType}_${verb}`,
-        category: 'campaign_action_test',
+        category: 'campaign_action',
         label: campaignId || formatEventNoun(postType), // @TODO: make this the campaign title if available; but also may need to get passed in as an argument.
         context: {
           actionId,

--- a/resources/assets/middleware/api.js
+++ b/resources/assets/middleware/api.js
@@ -93,21 +93,21 @@ const postRequest = (payload, dispatch, getState) => {
         },
       };
 
-      trackAnalyticsEvent({
+      const verb =
+        statusCode === 200 && postType === 'signup' ? 'found' : 'completed';
+
+      console.log('💩 campaign ID: ', campaignId);
+
+      trackAnalyticsEvent(`${verb}_${formatEventNoun(postType)}`, {
+        action: `${postType}_${verb}`,
+        category: 'campaign_action_test',
+        label: campaignId || formatEventNoun(postType), // @TODO: make this the campaign title if available; but also may need to get passed in as an argument.
         context: {
           actionId,
           activityId: response.data.id,
           blockId,
           campaignId,
           pageId,
-        },
-        metadata: {
-          category: 'campaign_action', // @TODO: this may need to get passed in as an argument.
-          label: campaignId, // @TODO: make this the campaign title if available; but also may need to get passed in as an argument.
-          noun: formatEventNoun(postType),
-          target: postType,
-          verb:
-            statusCode === 200 && postType === 'signup' ? 'found' : 'completed',
         },
       });
 
@@ -120,20 +120,16 @@ const postRequest = (payload, dispatch, getState) => {
     .catch(error => {
       report(error);
 
-      trackAnalyticsEvent({
+      trackAnalyticsEvent(`failed_${formatEventNoun(postType)}`, {
+        action: `${postType}_failed`,
+        category: 'campaign_action',
+        label: campaignId || formatEventNoun(postType), // @TODO: make this the campaign title if available; but also may need to get passed in as an argument.
         context: {
           actionId,
           blockId,
           campaignId,
           error,
           pageId,
-        },
-        metadata: {
-          category: 'campaign_action', // @TODO: this may need to get passed in as an argument.
-          label: campaignId, // @TODO: make this the campaign title if available; but also may need to get passed in as an argument.
-          noun: formatEventNoun(postType),
-          target: postType,
-          verb: 'failed',
         },
       });
 

--- a/resources/assets/middleware/api.js
+++ b/resources/assets/middleware/api.js
@@ -96,8 +96,6 @@ const postRequest = (payload, dispatch, getState) => {
       const verb =
         statusCode === 200 && postType === 'signup' ? 'found' : 'completed';
 
-      console.log('💩 campaign ID: ', campaignId);
-
       trackAnalyticsEvent(`${verb}_${formatEventNoun(postType)}`, {
         action: `${postType}_${verb}`,
         category: 'campaign_action_test',

--- a/resources/assets/store/initialState.js
+++ b/resources/assets/store/initialState.js
@@ -22,7 +22,6 @@ const initialState = {
   postSubmissions: {
     items: {},
   },
-  quiz: {},
   signups: {
     data: [],
     thisCampaign: false,


### PR DESCRIPTION
### What's this PR do?

This pull request updates the information passed to `trackAnalyticsEvent()` in numerous components to follow the updates established in #1897.

The `SiteNavigation` component and the API middleware turned out having the more complex analytics event triggers to deal with updating, but I tried to find a reasonable compromise in each situation. For the API middleware, as we move to using more GraphQL calls within our components, I could see this middleware being deprecated, so the event triggering could get even simpler in the future (without the need to be so dynamic in the middleware).

### How should this be reviewed?

👀 

### Relevant tickets

References [Pivotal #170710129](https://www.pivotaltracker.com/story/show/170710129).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Added appropriate feature/unit tests.
