### PR TITLE
More layout touchups for the campaign template.

### DIFF
--- a/cypress/integration/campaign-post.js
+++ b/cypress/integration/campaign-post.js
@@ -59,8 +59,14 @@ describe('Campaign Post', () => {
 
     // We should see one "pending" post for each uploader:
     // @TODO: We need a better selector for this "entire" block...
-    cy.get('#block-3Au9UnzEBGMHjwlBSujlv5 .post').should('have.length', 1);
-    cy.get('#block-6fKwdXz8gYyqJiy42R5c3h .post').should('have.length', 1);
+    cy.get('[data-contentful-id=3Au9UnzEBGMHjwlBSujlv5] .post').should(
+      'have.length',
+      1,
+    );
+    cy.get('[data-contentful-id=6fKwdXz8gYyqJiy42R5c3h] .post').should(
+      'have.length',
+      1,
+    );
   });
 
   it('Create a photo post', () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2319,6 +2319,12 @@
         "@babel/types": "^7.3.0"
       }
     },
+    "@types/color-name": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
+      "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
+      "dev": true
+    },
     "@types/events": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.0.tgz",
@@ -2684,6 +2690,31 @@
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.1.0.tgz",
       "integrity": "sha512-tMUqwBWfLFbJbizRmEcWSLw6HnFzfdJs2sOJEOwwtVPMoH/0Ay+E703oZz78VSXZiiDcZrQ5XKjPIUQixhmgVw==",
       "dev": true
+    },
+    "acorn-node": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/acorn-node/-/acorn-node-1.8.2.tgz",
+      "integrity": "sha512-8mt+fslDufLYntIoPAaIMUe/lrbrehIiwmR3t2k9LljIzoigEPF27eLk2hy8zSGzmR/ogr7zbRKINMo1u0yh5A==",
+      "dev": true,
+      "requires": {
+        "acorn": "^7.0.0",
+        "acorn-walk": "^7.0.0",
+        "xtend": "^4.0.2"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.0.tgz",
+          "integrity": "sha512-kL5CuoXA/dgxlBbVrflsflzQ3PAas7RYZB52NOm/6839iVYJgKMJ3cQJD+t2i5+qFa8h3MDpEOJiS64E8JLnSQ==",
+          "dev": true
+        },
+        "acorn-walk": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-7.0.0.tgz",
+          "integrity": "sha512-7Bv1We7ZGuU79zZbb6rRqcpxo3OY+zrdtloZWoyD8fmGX+FeXRjE+iuGkZjSXLVovLzrsvMGMy0EkwA0E0umxg==",
+          "dev": true
+        }
+      }
     },
     "acorn-walk": {
       "version": "6.2.0",
@@ -5759,6 +5790,12 @@
         }
       }
     },
+    "defined": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
+      "integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM=",
+      "dev": true
+    },
     "del": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/del/-/del-4.1.1.tgz",
@@ -5832,6 +5869,17 @@
       "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-2.1.0.tgz",
       "integrity": "sha1-9B8cEL5LAOh7XxPaaAdZ8sW/0+I=",
       "dev": true
+    },
+    "detective": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/detective/-/detective-5.2.0.tgz",
+      "integrity": "sha512-6SsIx+nUUbuK0EthKjv0zrdnajCCXVYGmbYYiYjFVpzcjwEs/JMDZ8tPRG29J/HhN56t3GJp2cGSWDRjjot8Pg==",
+      "dev": true,
+      "requires": {
+        "acorn-node": "^1.6.1",
+        "defined": "^1.0.0",
+        "minimist": "^1.1.1"
+      }
     },
     "diagnostics": {
       "version": "1.1.1",
@@ -15293,16 +15341,17 @@
       }
     },
     "tailwindcss": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-1.1.4.tgz",
-      "integrity": "sha512-p4AxVa4CKpX7IbNxImwNMGG9MHuLgratOaOE/iGriNd4AsRQRM2xMisoQ3KQHqShunrWuObga7rI7xbNsVoWGA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-1.2.0.tgz",
+      "integrity": "sha512-CKvY0ytB3ze5qvynG7qv4XSpQtFNGPbu9pUn8qFdkqgD8Yo/vGss8mhzbqls44YCXTl4G62p3qVZBj45qrd6FQ==",
       "dev": true,
       "requires": {
         "autoprefixer": "^9.4.5",
         "bytes": "^3.0.0",
-        "chalk": "^2.4.1",
+        "chalk": "^3.0.0",
+        "detective": "^5.2.0",
         "fs-extra": "^8.0.0",
-        "lodash": "^4.17.11",
+        "lodash": "^4.17.15",
         "node-emoji": "^1.8.1",
         "normalize.css": "^8.0.1",
         "postcss": "^7.0.11",
@@ -15311,9 +15360,45 @@
         "postcss-nested": "^4.1.1",
         "postcss-selector-parser": "^6.0.0",
         "pretty-hrtime": "^1.0.3",
-        "reduce-css-calc": "^2.1.6"
+        "reduce-css-calc": "^2.1.6",
+        "resolve": "^1.14.2"
       },
       "dependencies": {
+        "ansi-styles": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "dev": true,
+          "requires": {
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
         "fs-extra": {
           "version": "8.1.0",
           "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
@@ -15323,6 +15408,21 @@
             "graceful-fs": "^4.2.0",
             "jsonfile": "^4.0.0",
             "universalify": "^0.1.0"
+          }
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -161,7 +161,7 @@
     "redux-devtools": "^3.5.0",
     "redux-devtools-dock-monitor": "^1.1.3",
     "redux-devtools-log-monitor": "^1.4.0",
-    "tailwindcss": "^1.1.4",
+    "tailwindcss": "^1.2.0",
     "turndown": "^5.0.3",
     "webpack": "~4.28.0",
     "webpack-bundle-analyzer": "^3.6.0",

--- a/resources/assets/components/Quiz/QuizBlock.js
+++ b/resources/assets/components/Quiz/QuizBlock.js
@@ -45,14 +45,14 @@ const QuizBlock = props => {
   }
 
   return (
-    <div className="mx-3">
+    <>
       {hasNavigated ? <ScrollConcierge trigger={id} /> : null}
       {data.block.__typename === 'QuizBlock' ? (
         <Quiz {...data.block} onComplete={setCurrentId} />
       ) : (
         <QuizResult id={id} campaignId={props.additionalContent.campaignId} />
       )}
-    </div>
+    </>
   );
 };
 

--- a/resources/assets/components/blocks/ContentBlock/ContentBlock.js
+++ b/resources/assets/components/blocks/ContentBlock/ContentBlock.js
@@ -3,8 +3,8 @@ import gql from 'graphql-tag';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 
+import LazyImage from '../../utilities/LazyImage';
 import { contentfulImageUrl } from '../../../helpers';
-import { Figure } from '../../utilities/Figure/Figure';
 import TextContent from '../../utilities/TextContent/TextContent';
 import SectionHeader from '../../utilities/SectionHeader/SectionHeader';
 
@@ -39,23 +39,28 @@ const ContentBlock = props => {
   const contentNode = content ? <TextContent>{content}</TextContent> : null;
 
   return (
-    <div className={classnames('content-block', className)}>
+    <div className={classnames(className, 'pb-6')}>
       {title ? (
         <SectionHeader underlined superTitle={superTitle} title={title} />
       ) : null}
 
-      {image.url ? (
-        <Figure
-          image={contentfulImageUrl(image.url, '600', '600', 'fill')}
-          alt={image.description || 'content-block'}
-          alignment={`${imageAlignment.toLowerCase()}-collapse`}
-          size="one-third"
-        >
-          {contentNode}
-        </Figure>
-      ) : (
-        contentNode
-      )}
+      <div className="md:grid grid-flow-row-dense grid-cols-3 gap-4">
+        {image.url ? (
+          <div
+            className={classnames('mb-3', 'col-span-1', {
+              'order-1': imageAlignment === 'LEFT',
+              'order-2': imageAlignment === 'RIGHT',
+            })}
+          >
+            <LazyImage
+              src={contentfulImageUrl(image.url, '600', '600', 'fill')}
+              alt={image.description || 'content-block'}
+            />
+          </div>
+        ) : null}
+
+        <div className="col-span-2 order-1">{contentNode}</div>
+      </div>
     </div>
   );
 };

--- a/resources/assets/components/blocks/ContentBlock/ContentBlock.js
+++ b/resources/assets/components/blocks/ContentBlock/ContentBlock.js
@@ -8,8 +8,6 @@ import { contentfulImageUrl } from '../../../helpers';
 import TextContent from '../../utilities/TextContent/TextContent';
 import SectionHeader from '../../utilities/SectionHeader/SectionHeader';
 
-import './content-block.scss';
-
 export const ContentBlockFragment = gql`
   fragment ContentBlockFragment on ContentBlock {
     superTitle

--- a/resources/assets/components/blocks/ContentBlock/ContentBlock.test.js
+++ b/resources/assets/components/blocks/ContentBlock/ContentBlock.test.js
@@ -22,7 +22,7 @@ describe('ContentBlock component', () => {
     const wrapper = shallow(<ContentBlock {...props} />);
 
     expect(wrapper.find('SectionHeader').length).toEqual(1);
-    expect(wrapper.find('Figure').length).toEqual(1);
+    expect(wrapper.find('LazyImage').length).toEqual(1);
     expect(wrapper.find('TextContent').length).toEqual(1);
 
     expect(shallowToJson(wrapper)).toMatchSnapshot();
@@ -40,7 +40,7 @@ describe('ContentBlock component', () => {
     const wrapper = shallow(<ContentBlock {...props} image={emptyImage} />);
 
     expect(wrapper.find('SectionHeader').length).toEqual(1);
-    expect(wrapper.find('Figure').length).toEqual(0);
+    expect(wrapper.find('LazyImage').length).toEqual(0);
     expect(wrapper.find('TextContent').length).toEqual(1);
   });
 

--- a/resources/assets/components/blocks/ContentBlock/ContentBlock.test.js
+++ b/resources/assets/components/blocks/ContentBlock/ContentBlock.test.js
@@ -44,14 +44,6 @@ describe('ContentBlock component', () => {
     expect(wrapper.find('TextContent').length).toEqual(1);
   });
 
-  test('it renders the correct alignment class for "left" and "right" image props', () => {
-    let wrapper = shallow(<ContentBlock {...props} imageAlignment="left" />);
-    expect(wrapper.find('Figure').props().alignment).toEqual('left-collapse');
-
-    wrapper = shallow(<ContentBlock {...props} />);
-    expect(wrapper.find('Figure').props().alignment).toEqual('right-collapse');
-  });
-
   test('it works beautifully with content and an empty image prop', () => {
     const wrapper = shallow(
       <ContentBlock content="hi there" image={emptyImage} />,

--- a/resources/assets/components/blocks/ContentBlock/__snapshots__/ContentBlock.test.js.snap
+++ b/resources/assets/components/blocks/ContentBlock/__snapshots__/ContentBlock.test.js.snap
@@ -35,29 +35,39 @@ exports[`ContentBlock component does not include SectionHeader when there's no t
 
 exports[`ContentBlock component is rendered with the proper child components when image is set 1`] = `
 <div
-  className="content-block"
+  className="pb-6"
 >
   <SectionHeader
     superTitle="Test Super Title"
     title="Test Title"
     underlined={true}
   />
-  <Figure
-    alignment="right-collapse"
-    alt="cool image of http://image.com"
-    image="http://image.com/?fit=fill&h=600&w=600"
-    imageClassName={null}
-    size="one-third"
+  <div
+    className="md:grid grid-flow-row-dense grid-cols-3 gap-4"
   >
-    <TextContent
-      className={null}
-      classNameByEntry={Object {}}
-      classNameByEntryDefault={null}
-      styles={Object {}}
+    <div
+      className="mb-3 col-span-1"
     >
-      Test Content
-    </TextContent>
-  </Figure>
+      <LazyImage
+        alt="cool image of http://image.com"
+        asBackground={false}
+        className={null}
+        src="http://image.com/?fit=fill&h=600&w=600"
+      />
+    </div>
+    <div
+      className="col-span-2 order-1"
+    >
+      <TextContent
+        className={null}
+        classNameByEntry={Object {}}
+        classNameByEntryDefault={null}
+        styles={Object {}}
+      >
+        Test Content
+      </TextContent>
+    </div>
+  </div>
 </div>
 `;
 

--- a/resources/assets/components/blocks/ContentBlock/__snapshots__/ContentBlock.test.js.snap
+++ b/resources/assets/components/blocks/ContentBlock/__snapshots__/ContentBlock.test.js.snap
@@ -2,24 +2,34 @@
 
 exports[`ContentBlock component does not include SectionHeader when there's no title 1`] = `
 <div
-  className="content-block"
+  className="pb-6"
 >
-  <Figure
-    alignment="right-collapse"
-    alt="cool image of http://image.com"
-    image="http://image.com/?fit=fill&h=600&w=600"
-    imageClassName={null}
-    size="one-third"
+  <div
+    className="md:grid grid-flow-row-dense grid-cols-3 gap-4"
   >
-    <TextContent
-      className={null}
-      classNameByEntry={Object {}}
-      classNameByEntryDefault={null}
-      styles={Object {}}
+    <div
+      className="mb-3 col-span-1"
     >
-      Test Content
-    </TextContent>
-  </Figure>
+      <LazyImage
+        alt="cool image of http://image.com"
+        asBackground={false}
+        className={null}
+        src="http://image.com/?fit=fill&h=600&w=600"
+      />
+    </div>
+    <div
+      className="col-span-2 order-1"
+    >
+      <TextContent
+        className={null}
+        classNameByEntry={Object {}}
+        classNameByEntryDefault={null}
+        styles={Object {}}
+      >
+        Test Content
+      </TextContent>
+    </div>
+  </div>
 </div>
 `;
 
@@ -53,15 +63,23 @@ exports[`ContentBlock component is rendered with the proper child components whe
 
 exports[`ContentBlock component it works beautifully with content and an empty image prop 1`] = `
 <div
-  className="content-block"
+  className="pb-6"
 >
-  <TextContent
-    className={null}
-    classNameByEntry={Object {}}
-    classNameByEntryDefault={null}
-    styles={Object {}}
+  <div
+    className="md:grid grid-flow-row-dense grid-cols-3 gap-4"
   >
-    hi there
-  </TextContent>
+    <div
+      className="col-span-2 order-1"
+    >
+      <TextContent
+        className={null}
+        classNameByEntry={Object {}}
+        classNameByEntryDefault={null}
+        styles={Object {}}
+      >
+        hi there
+      </TextContent>
+    </div>
+  </div>
 </div>
 `;

--- a/resources/assets/components/blocks/ContentBlock/content-block.scss
+++ b/resources/assets/components/blocks/ContentBlock/content-block.scss
@@ -1,6 +1,0 @@
-@import '../../../scss/next-toolbox.scss';
-
-.content-block {
-  width: 100%;
-  margin-bottom: 36px;
-}

--- a/resources/assets/components/pages/CampaignPage/CampaignPage.js
+++ b/resources/assets/components/pages/CampaignPage/CampaignPage.js
@@ -31,10 +31,15 @@ const CampaignPage = props => {
             <CampaignPageNavigationContainer />
           ) : null}
 
-          <div className="md:w-3/4 mx-auto my-6">
+          <div className="my-6">
             {/* Render an entry (quiz), if provided. */}
             {entryContent ? (
-              <ContentfulEntryLoader id={entryContent.id} />
+              <div className="base-12-grid">
+                <ContentfulEntryLoader
+                  className="grid-wide"
+                  id={entryContent.id}
+                />
+              </div>
             ) : (
               <CampaignPageContent {...props} />
             )}

--- a/resources/assets/components/pages/CampaignPage/CampaignPageContent.js
+++ b/resources/assets/components/pages/CampaignPage/CampaignPageContent.js
@@ -28,12 +28,12 @@ const CampaignPageContent = props => {
     <div className="campaign-page__content" id={subPage.id}>
       <ScrollConcierge />
       {content ? (
-        <div className="row">
-          <div className="primary">
+        <div className="base-12-grid">
+          <div className="grid-wide-7/10">
             <TextContent className="mx-3">{content}</TextContent>
           </div>
           {sidebar.length ? (
-            <div className="secondary">
+            <div className="grid-wide-3/10">
               {sidebar.map(block => (
                 <div className="mb-6 mx-3" key={block.id}>
                   <ContentfulEntryLoader id={block.id} />
@@ -44,21 +44,21 @@ const CampaignPageContent = props => {
         </div>
       ) : null}
 
-      <div className="blocks clear-both">
+      <div className="base-12-grid clear-both">
         {blocks.map(block => (
-          <div key={block.id} id={`block-${block.id}`}>
-            <ContentfulEntryLoader
-              id={block.id}
-              className="mb-6 mx-3 clear-both"
-              classNameByEntryDefault="md:w-3/4"
-              classNameByEntry={{
-                ImagesBlock: 'w-full',
-                PostGalleryBlock: 'w-full',
-                PhotoSubmissionBlock: 'w-full',
-                SocialDriveBlock: 'w-full',
-              }}
-            />
-          </div>
+          <ContentfulEntryLoader
+            key={block.id}
+            id={block.id}
+            className="mb-6 clear-both"
+            classNameByEntryDefault="grid-wide-7/10"
+            classNameByEntry={{
+              ContentBlock: 'grid-wide',
+              ImagesBlock: 'grid-wide',
+              PostGalleryBlock: 'grid-wide',
+              PhotoSubmissionBlock: 'grid-wide',
+              SocialDriveBlock: 'grid-wide',
+            }}
+          />
         ))}
       </div>
 

--- a/resources/assets/components/utilities/ContentfulEntryLoader/ContentfulEntryLoader.js
+++ b/resources/assets/components/utilities/ContentfulEntryLoader/ContentfulEntryLoader.js
@@ -164,7 +164,10 @@ const ContentfulEntryLoader = ({
   );
 
   return (
-    <div className={classnames(className, entryClassNames)}>
+    <div
+      data-contentful-id={id}
+      className={classnames(className, entryClassNames)}
+    >
       <ContentfulEntry json={data.block} />
     </div>
   );


### PR DESCRIPTION
### What's this PR do?

This pull request contains more touch-ups to the campaign template layout, notably updating the CampaignPage and ContentBlock to correctly align to the grid (using Tailwind's new [grid helpers](https://tailwindcss.com/docs/grid-template-columns/)!)

### How should this be reviewed?

Here are some screenshots, but also feel free to bop around on the review app!

![Screen Shot 2020-02-07 at 3 18 14 PM](https://user-images.githubusercontent.com/583202/74063328-3204a300-49be-11ea-89cd-9d0b21cf5aac.png)

![Screen Shot 2020-02-07 at 3 20 54 PM](https://user-images.githubusercontent.com/583202/74063336-3630c080-49be-11ea-85d1-b3ed4bed6593.png)

![Screen Shot 2020-02-07 at 3 21 51 PM](https://user-images.githubusercontent.com/583202/74063338-3761ed80-49be-11ea-8ffc-6fd440945b77.png)


### Any background context you want to provide?

This fixes up a little layout bug introduced in #1910. I'll fix up the Social Drive block layout (where it may expand too far now if it doesn't have a click counter) in a follow-up PR.

### Relevant tickets

References [Pivotal #171161967](https://www.pivotaltracker.com/story/show/171161967).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added screenshots of front-end changes on small, medium, and large screens.
- [ ] Added appropriate feature/unit tests.
