### PR TITLE
Social Drive Action should constrain its own size if hiding page views.

### DIFF
--- a/resources/assets/components/actions/SocialDriveAction/SocialDriveAction.js
+++ b/resources/assets/components/actions/SocialDriveAction/SocialDriveAction.js
@@ -63,6 +63,7 @@ class SocialDriveAction extends React.Component {
   render() {
     const {
       link,
+      fullWidth,
       shareCardDescription,
       shareCardTitle,
       hidePageViews,
@@ -73,7 +74,11 @@ class SocialDriveAction extends React.Component {
       <div
         className={classNames('clearfix pb-6', { 'lg:flex': !hidePageViews })}
       >
-        <div className="social-drive-action lg:w-2/3 lg:pr-3">
+        <div
+          className={classNames('social-drive-action', {
+            'lg:w-2/3 lg:pr-3': !fullWidth,
+          })}
+        >
           <Card title={shareCardTitle} className="rounded bordered">
             {shareCardDescription ? (
               <div className="p-3">
@@ -155,6 +160,7 @@ class SocialDriveAction extends React.Component {
 
 SocialDriveAction.propTypes = {
   campaignId: PropTypes.string,
+  fullWidth: PropTypes.bool,
   link: PropTypes.string.isRequired,
   pageId: PropTypes.string,
   shareCardTitle: PropTypes.string,
@@ -166,6 +172,7 @@ SocialDriveAction.propTypes = {
 
 SocialDriveAction.defaultProps = {
   campaignId: null,
+  fullWidth: false,
   shareCardDescription: null,
   shareCardTitle: 'Your Online Drive',
   pageId: null,

--- a/resources/assets/components/actions/SocialDriveAction/SocialDriveAction.js
+++ b/resources/assets/components/actions/SocialDriveAction/SocialDriveAction.js
@@ -73,11 +73,7 @@ class SocialDriveAction extends React.Component {
       <div
         className={classNames('clearfix pb-6', { 'lg:flex': !hidePageViews })}
       >
-        <div
-          className={classNames('social-drive-action', {
-            'lg:w-2/3 lg:pr-3': !hidePageViews,
-          })}
-        >
+        <div className="social-drive-action lg:w-2/3 lg:pr-3">
           <Card title={shareCardTitle} className="rounded bordered">
             {shareCardDescription ? (
               <div className="p-3">

--- a/resources/assets/components/pages/ReferralPage/Alpha/AlphaPage.js
+++ b/resources/assets/components/pages/ReferralPage/Alpha/AlphaPage.js
@@ -25,6 +25,7 @@ const AlphaPage = ({ userId }) => (
             shareCardTitle="Refer A Friend"
             link={`${PHOENIX_URL}/us/join?user_id=${userId}&campaign_id=${getReferralCampaignId()}`}
             hidePageViews
+            fullWidth
           />
         </div>
 


### PR DESCRIPTION
### What's this PR do?

This pull request fixes the layout of the Social Drive block if page views are hidden:

![Screen Shot 2020-02-07 at 4 30 13 PM](https://user-images.githubusercontent.com/583202/74067474-5d3fc000-49c7-11ea-9ff2-ed8bb8591785.png)

![Screen Shot 2020-02-07 at 4 30 28 PM](https://user-images.githubusercontent.com/583202/74067480-5fa21a00-49c7-11ea-9da7-6b493bc8bdaf.png)


### How should this be reviewed?

👀

### Any background context you want to provide?

There may be a better long-term solution for handling variable-width blocks like this, but this works nicely in the meantime!

### Relevant tickets

References [Pivotal #171161967](https://www.pivotaltracker.com/story/show/171161967).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added screenshots of front-end changes on small, medium, and large screens.
- [ ] Added appropriate feature/unit tests.
