### PR TITLE
Updating trackAnalyticsEvent() calls in numerous components (Part 5)

### DIFF
--- a/resources/assets/actions/post.js
+++ b/resources/assets/actions/post.js
@@ -4,7 +4,7 @@ import { join } from 'path';
 
 import apiRequest from './api';
 import { PHOENIX_URL } from '../constants';
-import { trackAnalyticsEvent } from '../helpers/analytics';
+import { EVENT_CATEGORIES, trackAnalyticsEvent } from '../helpers/analytics';
 import {
   POST_SUBMISSION_FAILED,
   POST_SUBMISSION_INIT_ITEM,
@@ -87,7 +87,7 @@ export function storeCampaignPost(campaignId, data) {
   // Track post submission event.
   trackAnalyticsEvent(`submitted_${type}${EVENT_SUFFIX}`, {
     action: 'form_submitted',
-    category: 'campaign_action',
+    category: EVENT_CATEGORIES.campaignAction,
     label: type,
     context: {
       actionId,
@@ -142,7 +142,7 @@ export function storePost(data) {
   // Track post submission event.
   trackAnalyticsEvent(`submitted_${type}${EVENT_SUFFIX}`, {
     action: 'form_submitted',
-    category: 'campaign_action',
+    category: EVENT_CATEGORIES.campaignAction,
     label: type,
     context: {
       actionId,

--- a/resources/assets/components/PollLocator/PollLocator.js
+++ b/resources/assets/components/PollLocator/PollLocator.js
@@ -4,7 +4,7 @@ import { get } from 'lodash';
 import PropTypes from 'prop-types';
 
 import Spinner from '../artifacts/Spinner/Spinner';
-import { trackAnalyticsEvent } from '../../helpers/analytics';
+import { EVENT_CATEGORIES, trackAnalyticsEvent } from '../../helpers/analytics';
 
 class PollLocator extends React.Component {
   componentDidMount() {
@@ -20,7 +20,7 @@ class PollLocator extends React.Component {
   handleSearchButtonClick = () => {
     trackAnalyticsEvent('clicked_poll_locator', {
       action: 'button_clicked',
-      category: 'campaign_action',
+      category: EVENT_CATEGORIES.campaignAction,
       label: 'poll_locator',
     });
   };
@@ -40,7 +40,7 @@ class PollLocator extends React.Component {
       if (get(addressNotFoundModal, 'style.display') === 'block') {
         trackAnalyticsEvent('opened_modal_poll_locator_not_found', {
           action: 'modal_opened',
-          category: 'modal',
+          category: EVENT_CATEGORIES.modal,
           label: 'poll_locator',
         });
       }
@@ -62,7 +62,7 @@ class PollLocator extends React.Component {
       if (modal) {
         trackAnalyticsEvent('opened_modal_poll_locator', {
           action: 'modal_opened',
-          category: 'modal',
+          category: EVENT_CATEGORIES.modal,
           label: 'poll_locator',
         });
       }

--- a/resources/assets/components/Quiz/Quiz.js
+++ b/resources/assets/components/Quiz/Quiz.js
@@ -5,7 +5,7 @@ import { countBy, every, entries, head, last, maxBy, omit } from 'lodash';
 
 import QuizQuestion from './QuizQuestion';
 import QuizConclusion from './QuizConclusion';
-import { trackAnalyticsEvent } from '../../helpers/analytics';
+import { EVENT_CATEGORIES, trackAnalyticsEvent } from '../../helpers/analytics';
 
 import './quiz.scss';
 
@@ -65,7 +65,7 @@ const Quiz = ({
 
     trackAnalyticsEvent('submitted_quiz', {
       action: 'form_submitted',
-      category: 'campaign_action',
+      category: EVENT_CATEGORIES.campaignAction,
       label: 'quiz',
       context: {
         id,

--- a/resources/assets/components/SignupButton/SignupButton.js
+++ b/resources/assets/components/SignupButton/SignupButton.js
@@ -2,8 +2,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import Button from '../utilities/Button/Button';
-import { trackAnalyticsEvent } from '../../helpers/analytics';
 import { isCampaignClosed, query, withoutNulls } from '../../helpers';
+import { EVENT_CATEGORIES, trackAnalyticsEvent } from '../../helpers/analytics';
 
 const SignupButton = props => {
   const {
@@ -32,7 +32,7 @@ const SignupButton = props => {
     // Track signup button click event before we store the signup.
     trackAnalyticsEvent('clicked_signup', {
       action: 'button_clicked',
-      category: 'signup',
+      category: EVENT_CATEGORIES.signup,
       label: campaignTitle,
       context: {
         campaignId,

--- a/resources/assets/components/actions/LinkAction/templates/CtaTemplate.js
+++ b/resources/assets/components/actions/LinkAction/templates/CtaTemplate.js
@@ -6,8 +6,11 @@ import PropTypes from 'prop-types';
 import Card from '../../../utilities/Card/Card';
 import Button from '../../../utilities/Button/Button';
 import { isExternal, dynamicString } from '../../../../helpers';
-import { trackAnalyticsEvent } from '../../../../helpers/analytics';
 import TextContent from '../../../utilities/TextContent/TextContent';
+import {
+  EVENT_CATEGORIES,
+  trackAnalyticsEvent,
+} from '../../../../helpers/analytics';
 
 import './cta-template.scss';
 
@@ -16,7 +19,7 @@ const onLinkClick = (link, context) => {
 
   trackAnalyticsEvent('clicked_link_action', {
     action: 'button_clicked',
-    category: 'campaign_action',
+    category: EVENT_CATEGORIES.campaignAction,
     label: 'link_action',
     context: { ...context, url: link },
   });

--- a/resources/assets/components/actions/LinkAction/templates/DefaultTemplate.js
+++ b/resources/assets/components/actions/LinkAction/templates/DefaultTemplate.js
@@ -6,14 +6,17 @@ import Card from '../../../utilities/Card/Card';
 import Embed from '../../../utilities/Embed/Embed';
 import { dynamicString } from '../../../../helpers';
 import ButtonLink from '../../../utilities/ButtonLink/ButtonLink';
-import { trackAnalyticsEvent } from '../../../../helpers/analytics';
 import TextContent from '../../../utilities/TextContent/TextContent';
 import AffiliatePromotion from '../../../utilities/AffiliatePromotion/AffiliatePromotion';
+import {
+  EVENT_CATEGORIES,
+  trackAnalyticsEvent,
+} from '../../../../helpers/analytics';
 
 const analyzeClick = (link, context) => {
   trackAnalyticsEvent('clicked_link_action', {
     action: 'button_clicked',
-    category: 'campaign_action',
+    category: EVENT_CATEGORIES.campaignAction,
     label: 'link_action',
     context: { ...context, url: link },
   });

--- a/resources/assets/components/actions/ShareAction/ShareAction.js
+++ b/resources/assets/components/actions/ShareAction/ShareAction.js
@@ -10,11 +10,14 @@ import Modal from '../../utilities/Modal/Modal';
 import Button from '../../utilities/Button/Button';
 import PostCreatedModal from '../PostCreatedModal';
 import { formatPostPayload } from '../../../helpers/forms';
-import { trackAnalyticsEvent } from '../../../helpers/analytics';
 import { SOCIAL_SHARE_TYPE } from '../../../constants/post-types';
 import TextContent from '../../utilities/TextContent/TextContent';
 import AnalyticsWaypoint from '../../utilities/AnalyticsWaypoint/AnalyticsWaypoint';
 import ContentfulEntryLoader from '../../utilities/ContentfulEntryLoader/ContentfulEntryLoader';
+import {
+  EVENT_CATEGORIES,
+  trackAnalyticsEvent,
+} from '../../../helpers/analytics';
 import {
   dynamicString,
   loadFacebookSDK,
@@ -38,8 +41,6 @@ export const ShareBlockFragment = gql`
     additionalContent
   }
 `;
-
-const EVENT_CATEGORY = 'campaign_action';
 
 class ShareAction extends PostForm {
   state = { showModal: false };
@@ -94,7 +95,7 @@ class ShareAction extends PostForm {
 
     trackAnalyticsEvent('clicked_share_action_facebook', {
       action: 'button_clicked',
-      category: EVENT_CATEGORY,
+      category: EVENT_CATEGORIES.campaignAction,
       label: 'facebook',
       context: { ...this.getContextData(), ...trackingData },
     });
@@ -114,7 +115,7 @@ class ShareAction extends PostForm {
       .then(() => {
         trackAnalyticsEvent('completed_share_action_facebook', {
           action: 'action_completed',
-          category: EVENT_CATEGORY,
+          category: EVENT_CATEGORIES.campaignAction,
           label: 'facebook',
           context: { ...this.getContextData(), ...trackingData },
         });
@@ -124,7 +125,7 @@ class ShareAction extends PostForm {
       .catch(() => {
         trackAnalyticsEvent('cancelled_share_action_facebook', {
           action: 'action_cancelled',
-          category: EVENT_CATEGORY,
+          category: EVENT_CATEGORIES.campaignAction,
           label: 'facebook',
           context: { ...this.getContextData(), ...trackingData },
         });
@@ -134,7 +135,7 @@ class ShareAction extends PostForm {
   handleTwitterClick = url => {
     trackAnalyticsEvent('clicked_share_action_twitter', {
       action: 'button_clicked',
-      category: EVENT_CATEGORY,
+      category: EVENT_CATEGORIES.campaignAction,
       label: 'twitter',
       context: { ...this.getContextData(), url: this.props.link },
     });

--- a/resources/assets/components/actions/SocialDriveAction/SocialDriveAction.js
+++ b/resources/assets/components/actions/SocialDriveAction/SocialDriveAction.js
@@ -9,9 +9,12 @@ import linkIcon from './linkIcon.svg';
 import Card from '../../utilities/Card/Card';
 import Embed from '../../utilities/Embed/Embed';
 import { postRequest } from '../../../helpers/api';
-import { trackAnalyticsEvent } from '../../../helpers/analytics';
 import { dynamicString, withoutTokens } from '../../../helpers';
 import SocialShareTray from '../../utilities/SocialShareTray/SocialShareTray';
+import {
+  EVENT_CATEGORIES,
+  trackAnalyticsEvent,
+} from '../../../helpers/analytics';
 
 import './social-drive.scss';
 
@@ -50,7 +53,7 @@ class SocialDriveAction extends React.Component {
 
     trackAnalyticsEvent('clicked_copy_to_clipboard', {
       action: 'button_clicked',
-      category: 'campaign_action',
+      category: EVENT_CATEGORIES.campaignAction,
       label: 'copy_to_clipboard',
       context: {
         campaignId: this.props.campaignId,

--- a/resources/assets/components/actions/TextSubmissionAction/TextSubmissionAction.js
+++ b/resources/assets/components/actions/TextSubmissionAction/TextSubmissionAction.js
@@ -9,13 +9,16 @@ import Card from '../../utilities/Card/Card';
 import Button from '../../utilities/Button/Button';
 import PostCreatedModal from '../PostCreatedModal';
 import ActionInformation from '../ActionInformation';
-import { trackAnalyticsEvent } from '../../../helpers/analytics';
 import FormValidation from '../../utilities/Form/FormValidation';
 import { withoutUndefined, withoutNulls } from '../../../helpers';
 import { getFieldErrors, formatPostPayload } from '../../../helpers/forms';
 import CharacterLimit from '../../utilities/CharacterLimit/CharacterLimit';
 import PrivacyLanguage from '../../utilities/PrivacyLanguage/PrivacyLanguage';
 import AnalyticsWaypoint from '../../utilities/AnalyticsWaypoint/AnalyticsWaypoint';
+import {
+  EVENT_CATEGORIES,
+  trackAnalyticsEvent,
+} from '../../../helpers/analytics';
 
 import './text-submission-action.scss';
 
@@ -73,7 +76,7 @@ class TextSubmissionAction extends PostForm {
   handleFocus = () => {
     trackAnalyticsEvent('focused_text_submission_action_text', {
       action: 'field_focused',
-      category: 'campaign_action',
+      category: EVENT_CATEGORIES.campaignAction,
       label: 'text_submission_action',
       context: { blockId: this.props.id, pageId: this.props.pageId },
     });

--- a/resources/assets/components/actions/VoterRegistrationAction/VoterRegistrationAction.js
+++ b/resources/assets/components/actions/VoterRegistrationAction/VoterRegistrationAction.js
@@ -6,9 +6,12 @@ import Card from '../../utilities/Card/Card';
 import { set } from '../../../helpers/storage';
 import { dynamicString } from '../../../helpers';
 import ButtonLink from '../../utilities/ButtonLink/ButtonLink';
-import { trackAnalyticsEvent } from '../../../helpers/analytics';
 import TextContent from '../../utilities/TextContent/TextContent';
 import AnalyticsWaypoint from '../../utilities/AnalyticsWaypoint/AnalyticsWaypoint';
+import {
+  EVENT_CATEGORIES,
+  trackAnalyticsEvent,
+} from '../../../helpers/analytics';
 
 import './voter-registration-action.scss';
 
@@ -37,7 +40,7 @@ const VoterRegistrationAction = props => {
   const handleClick = () => {
     trackAnalyticsEvent('clicked_voter_registration_action', {
       action: 'button_clicked',
-      category: 'campaign_action',
+      category: EVENT_CATEGORIES.campaignAction,
       label: 'voter_registration',
       context: {
         blockId,

--- a/resources/assets/components/pages/AccountPage/Profile.js
+++ b/resources/assets/components/pages/AccountPage/Profile.js
@@ -4,9 +4,10 @@ import PropTypes from 'prop-types';
 import FormItem from './FormItem';
 import { env } from '../../../helpers/index';
 import {
-  trackAnalyticsEvent,
+  EVENT_CATEGORIES,
   getPageContext,
   getUtmContext,
+  trackAnalyticsEvent,
 } from '../../../helpers/analytics';
 // import VoterRegStatusBlock from './VoterRegStatusBlock';
 
@@ -64,7 +65,7 @@ const Profile = props => (
               trackAnalyticsEvent('clicked_nav_link_log_out', {
                 action: 'link_clicked',
                 // @TODO: we should rename the category to "authentication"
-                category: 'navigation',
+                category: EVENT_CATEGORIES.navigation,
                 label: 'log_out',
                 context: {
                   ...getPageContext(),

--- a/resources/assets/components/utilities/AnalyticsWaypoint/AnalyticsWaypoint.js
+++ b/resources/assets/components/utilities/AnalyticsWaypoint/AnalyticsWaypoint.js
@@ -2,7 +2,10 @@ import PropTypes from 'prop-types';
 import React, { useEffect } from 'react';
 import { useInView } from 'react-intersection-observer';
 
-import { trackAnalyticsEvent } from '../../../helpers/analytics';
+import {
+  EVENT_CATEGORIES,
+  trackAnalyticsEvent,
+} from '../../../helpers/analytics';
 
 const AnalyticsWaypoint = ({ name, context }) => {
   const [ref, inView] = useInView({
@@ -13,7 +16,7 @@ const AnalyticsWaypoint = ({ name, context }) => {
     if (inView) {
       trackAnalyticsEvent('reached_waypoint', {
         action: 'waypoint_reached',
-        category: 'waypoint',
+        category: EVENT_CATEGORIES.waypoint,
         label: name,
         context: {
           ...context,

--- a/resources/assets/components/utilities/CtaBanner/CtaBanner.js
+++ b/resources/assets/components/utilities/CtaBanner/CtaBanner.js
@@ -1,7 +1,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import { trackAnalyticsEvent } from '../../../helpers/analytics';
+import {
+  EVENT_CATEGORIES,
+  trackAnalyticsEvent,
+} from '../../../helpers/analytics';
 
 import './cta-banner.scss';
 
@@ -9,7 +12,7 @@ const CtaBanner = ({ buttonText, content, link, title }) => {
   const handleClick = () =>
     trackAnalyticsEvent('clicked_call_to_action_banner', {
       action: 'button_clicked',
-      category: 'site_action',
+      category: EVENT_CATEGORIES.siteAction,
       label: 'call_to_action_banner',
       context: {
         url: link,

--- a/resources/assets/components/utilities/CtaPopover/CtaPopoverButton.js
+++ b/resources/assets/components/utilities/CtaPopover/CtaPopoverButton.js
@@ -3,13 +3,16 @@ import PropTypes from 'prop-types';
 
 import './cta-popover-button.scss';
 import ButtonLink from '../ButtonLink/ButtonLink';
-import { trackAnalyticsEvent } from '../../../helpers/analytics';
+import {
+  EVENT_CATEGORIES,
+  trackAnalyticsEvent,
+} from '../../../helpers/analytics';
 
 const CtaPopoverButton = ({ buttonText, link }) => {
   const handleClick = () =>
     trackAnalyticsEvent('clicked_call_to_action_popover', {
       action: 'button_clicked',
-      category: 'site_action',
+      category: EVENT_CATEGORIES.siteAction,
       label: 'call_to_action_popover',
       context: {
         url: link,

--- a/resources/assets/components/utilities/CtaPopover/CtaPopoverEmailForm.js
+++ b/resources/assets/components/utilities/CtaPopover/CtaPopoverEmailForm.js
@@ -7,7 +7,10 @@ import Button from '../Button/Button';
 import { env, report } from '../../../helpers/index';
 import { tabularLog } from '../../../helpers/api';
 import './cta-popover-email-form.scss';
-import { trackAnalyticsEvent } from '../../../helpers/analytics';
+import {
+  EVENT_CATEGORIES,
+  trackAnalyticsEvent,
+} from '../../../helpers/analytics';
 
 const CtaPopoverEmailForm = ({ handleComplete }) => {
   const [emailValue, setEmailValue] = useState('');
@@ -18,7 +21,7 @@ const CtaPopoverEmailForm = ({ handleComplete }) => {
   const handleFocus = () => {
     trackAnalyticsEvent('focused_call_to_action_popover_email', {
       action: 'field_focused',
-      category: 'site_action',
+      category: EVENT_CATEGORIES.siteAction,
       label: 'call_to_action_popover',
       context: { contextSource: 'newsletter_scholarships' },
     });
@@ -29,7 +32,7 @@ const CtaPopoverEmailForm = ({ handleComplete }) => {
 
     trackAnalyticsEvent('submitted_call_to_action_popover', {
       action: 'form_submitted',
-      category: 'site_action',
+      category: EVENT_CATEGORIES.siteAction,
       label: 'call_to_action_popover',
       context: { contextSource: 'newsletter_scholarships' },
     });
@@ -64,7 +67,7 @@ const CtaPopoverEmailForm = ({ handleComplete }) => {
 
         trackAnalyticsEvent('failed_call_to_action_popover_submission', {
           action: 'form_failed',
-          category: 'site_action',
+          category: EVENT_CATEGORIES.siteAction,
           label: 'call_to_action_popover_submission',
           context: {
             contextSource: 'newsletter_scholarships',

--- a/resources/assets/components/utilities/DismissableElement/DismissableElement.js
+++ b/resources/assets/components/utilities/DismissableElement/DismissableElement.js
@@ -3,7 +3,10 @@ import { useState, useEffect } from 'react';
 
 import { isTimestampValid, query } from '../../../helpers';
 import { get as getStorage, set as setStorage } from '../../../helpers/storage';
-import { trackAnalyticsEvent } from '../../../helpers/analytics';
+import {
+  EVENT_CATEGORIES,
+  trackAnalyticsEvent,
+} from '../../../helpers/analytics';
 
 const DismissableElement = ({ name, render, context }) => {
   const [showElement, setShowElement] = useState(true);
@@ -22,7 +25,7 @@ const DismissableElement = ({ name, render, context }) => {
         // @TODO: will discuss with Data Team possibility of reducing
         // the action to just "element_dismissed".
         action: 'dismissable_element_dismissed',
-        category: 'site_action',
+        category: EVENT_CATEGORIES.siteAction,
         label: name,
         context,
       });

--- a/resources/assets/components/utilities/Embed/Embed.js
+++ b/resources/assets/components/utilities/Embed/Embed.js
@@ -37,7 +37,7 @@ const Embed = props => {
   const onClick = () => {
     trackAnalyticsEvent('clicked_link_embed', {
       action: 'link_clicked',
-      category: 'site_action',
+      category: EVENT_CATEGORIES.siteAction,
       label: 'embed',
       context: {
         url,

--- a/resources/assets/components/utilities/Modal/Modal.js
+++ b/resources/assets/components/utilities/Modal/Modal.js
@@ -5,7 +5,10 @@ import PropTypes from 'prop-types';
 import ReactDom from 'react-dom';
 
 import ModalContent from './ModalContent';
-import { trackAnalyticsEvent } from '../../../helpers/analytics';
+import {
+  EVENT_CATEGORIES,
+  trackAnalyticsEvent,
+} from '../../../helpers/analytics';
 
 import './modal.scss';
 
@@ -35,7 +38,7 @@ class Modal extends React.Component {
     if (this.props.trackingId) {
       trackAnalyticsEvent('opened_modal', {
         action: 'modal_opened',
-        category: 'modal',
+        category: EVENT_CATEGORIES.modal,
         label: this.props.trackingId || 'modal',
         context: {
           ...this.props.context,
@@ -56,7 +59,7 @@ class Modal extends React.Component {
     if (this.props.trackingId) {
       trackAnalyticsEvent('closed_modal', {
         action: 'modal_closed',
-        category: 'modal',
+        category: EVENT_CATEGORIES.modal,
         label: this.props.trackingId || 'modal',
         context: {
           ...this.props.context,

--- a/resources/assets/components/utilities/SocialShareTray/SocialShareTray.js
+++ b/resources/assets/components/utilities/SocialShareTray/SocialShareTray.js
@@ -9,7 +9,10 @@ import emailIcon from './emailIcon.svg';
 import twitterIcon from './twitterIcon.svg';
 import facebookIcon from './facebookIcon.svg';
 import messengerIcon from './messengerIcon.svg';
-import { trackAnalyticsEvent } from '../../../helpers/analytics';
+import {
+  EVENT_CATEGORIES,
+  trackAnalyticsEvent,
+} from '../../../helpers/analytics';
 import {
   loadFacebookSDK,
   handleTwitterShareClick,
@@ -21,8 +24,6 @@ import {
 
 import './social-share-tray.scss';
 
-const EVENT_CATEGORY = 'social_share';
-
 class SocialShareTray extends React.Component {
   componentDidMount() {
     loadFacebookSDK();
@@ -31,7 +32,7 @@ class SocialShareTray extends React.Component {
   handleFacebookShareClick = (shareLink, trackLink) => {
     trackAnalyticsEvent('clicked_share_facebook', {
       action: 'button_clicked',
-      category: EVENT_CATEGORY,
+      category: EVENT_CATEGORIES.socialShare,
       label: 'facebook',
       context: { url: trackLink },
     });
@@ -40,7 +41,7 @@ class SocialShareTray extends React.Component {
       .then(() => {
         trackAnalyticsEvent('completed_share_facebook', {
           action: 'action_completed',
-          category: EVENT_CATEGORY,
+          category: EVENT_CATEGORIES.socialShare,
           label: 'facebook',
           context: {
             url: trackLink,
@@ -50,7 +51,7 @@ class SocialShareTray extends React.Component {
       .catch(() => {
         trackAnalyticsEvent('cancelled_share_facebook', {
           action: 'action_cancelled',
-          category: EVENT_CATEGORY,
+          category: EVENT_CATEGORIES.socialShare,
           label: 'facebook',
           context: {
             url: trackLink,
@@ -62,7 +63,7 @@ class SocialShareTray extends React.Component {
   handleFacebookMessengerClick = (shareLink, trackLink) => {
     trackAnalyticsEvent('clicked_share_facebook_messenger', {
       action: 'button_clicked',
-      category: EVENT_CATEGORY,
+      category: EVENT_CATEGORIES.socialShare,
       label: 'facebook_messenger',
       context: { url: trackLink },
     });
@@ -73,7 +74,7 @@ class SocialShareTray extends React.Component {
         .then(() => {
           trackAnalyticsEvent('completed_share_facebook_messenger', {
             action: 'action_completed',
-            category: EVENT_CATEGORY,
+            category: EVENT_CATEGORIES.socialShare,
             label: 'facebook_messenger',
             context: { url: trackLink },
           });
@@ -81,7 +82,7 @@ class SocialShareTray extends React.Component {
         .catch(() => {
           trackAnalyticsEvent('cancelled_share_facebook_messenger', {
             action: 'action_cancelled',
-            category: EVENT_CATEGORY,
+            category: EVENT_CATEGORIES.socialShare,
             label: 'facebook_messenger',
             context: { url: trackLink },
           });
@@ -92,7 +93,7 @@ class SocialShareTray extends React.Component {
         .then(() => {
           trackAnalyticsEvent('successful_redirect_facebook_messenger_app', {
             action: 'redirect_successful',
-            category: EVENT_CATEGORY,
+            category: EVENT_CATEGORIES.socialShare,
             label: 'facebook_messenger_app',
             context: { url: trackLink },
           });
@@ -100,7 +101,7 @@ class SocialShareTray extends React.Component {
         .catch(() => {
           trackAnalyticsEvent('failed_redirect_facebook_messenger_app', {
             action: 'redirect_failed',
-            category: EVENT_CATEGORY,
+            category: EVENT_CATEGORIES.socialShare,
             label: 'facebook_messenger_app',
             context: { url: trackLink },
           });
@@ -111,7 +112,7 @@ class SocialShareTray extends React.Component {
   handleEmailShareClick = (shareLink, trackLink) => {
     trackAnalyticsEvent('clicked_share_email', {
       action: 'button_clicked',
-      category: EVENT_CATEGORY,
+      category: EVENT_CATEGORIES.socialShare,
       label: 'email',
       context: { url: trackLink },
     });

--- a/resources/assets/helpers/analytics.js
+++ b/resources/assets/helpers/analytics.js
@@ -52,23 +52,6 @@ export function analyze(type, args, callback) {
 }
 
 /**
- * Parse analytics event name parameters into a snake cased string.
- *
- * @param  {String}      verb
- * @param  {String}      noun
- * @param  {String|Null} [adjective=null]
- * @return {void}
- */
-const formatEventName = (verb, noun, adjective = null) => {
-  let eventName = `${APP_PREFIX}_${snakeCase(verb)}_${snakeCase(noun)}`;
-
-  // Append adjective if defined.
-  eventName += adjective ? `_${snakeCase(adjective)}` : '';
-
-  return eventName;
-};
-
-/**
  * Send event to analyze with Google Analytics.
  *
  * @param  {String} category

--- a/resources/assets/helpers/analytics.js
+++ b/resources/assets/helpers/analytics.js
@@ -4,7 +4,6 @@ import {
   camelCase,
   get,
   isString,
-  isPlainObject,
   mapKeys,
   snakeCase,
   startCase,
@@ -20,6 +19,9 @@ import { debug, stringifyNestedObjects, withoutValueless } from '.';
  */
 const APP_PREFIX = 'phoenix';
 
+/**
+ * List of available event categories.
+ */
 export const EVENT_CATEGORIES = {
   accountEdit: 'account_edit',
   authentication: 'authentication',
@@ -254,64 +256,28 @@ export function trackAnalyticsPageView(history) {
  * Track an analytics event with a specified service.
  * (Defaults to tracking with all services.)
  *
- * @deprecated
- * @param  {Object} options
- * @param  {Object} options.metadata
- * @param  {Object} options.context
- * @param  {String} options.service
- * @return {void}
- */
-export function legacyTrackAnalyticsEvent({ metadata, context = {}, service }) {
-  if (!metadata) {
-    console.error('The metadata object is missing!');
-    return;
-  }
-
-  const { adjective, category, target, noun, verb } = metadata;
-  const label = metadata.label || noun;
-
-  const name = formatEventName(verb, noun, adjective);
-
-  const action = snakeCase(`${target}_${verb}`);
-
-  const data = withoutValueless({
-    ...context,
-    ...getUtmContext(),
-  });
-
-  sendToServices(name, category, action, label, data, service);
-}
-
-/**
- * Track an analytics event with a specified service.
- * (Defaults to tracking with all services.)
- *
  * @param  {String} name
  * @param  {Object} metadata
- * @param  {String} options.action
- * @param  {String} options.category
- * @param  {String} options.label
- * @param  {Object} options.context
- * @param  {String} options.service
+ * @param  {String} metadata.action
+ * @param  {String} metadata.category
+ * @param  {String} metadata.label
+ * @param  {Object} metadata.context
+ * @param  {String} metadata.service
  * @return {void}
  */
 export function trackAnalyticsEvent(name, metadata = {}) {
-  // @REMOVE: Temporarily check to see if name is an object, and if so send it to the
-  // old legacyTrackAnalyticsEvent(); this will allow us to incrementally switch
-  // calls to the new trackAnalyticsEvent() without breaking everything!
-  if (isPlainObject(name)) {
-    legacyTrackAnalyticsEvent(arguments[0]); // eslint-disable-line prefer-rest-params
+  const { action, category, label, context = {}, service } = metadata;
+
+  // Event name is required.
+  if (!isString(name)) {
+    console.error('Please provide a string for the event name!');
 
     return;
   }
 
-  // @REMOVE: We will switch back to destructuring the variables in the function signature,
-  // but while we support the legacyTrackAnalyticsEvent(), we need to destruct after
-  // checking against whether name is a string or object or will error out.
-  const { action, category, label, context = {}, service } = metadata;
-
-  if (!isString(name)) {
-    console.error('Please provide a string for the event name!');
+  // Event category should exist in list of available categories.
+  if (!Object.values(EVENT_CATEGORIES).includes(category)) {
+    console.error('The event category specified is not valid!');
 
     return;
   }

--- a/resources/assets/helpers/auth.js
+++ b/resources/assets/helpers/auth.js
@@ -3,7 +3,7 @@ import { isEmpty } from 'lodash';
 import queryString from 'query-string';
 
 import { withoutValueless } from '.';
-import { trackAnalyticsEvent } from './analytics';
+import { EVENT_CATEGORIES, trackAnalyticsEvent } from './analytics';
 
 /**
  * Get the current UNIX timestamp (in seconds), optionally
@@ -39,7 +39,7 @@ export function bindTokenRefreshEvent() {
 
         trackAnalyticsEvent('refreshed_token', {
           action: 'token_refreshed',
-          category: 'authentication',
+          category: EVENT_CATEGORIES.authentication,
           label: 'token',
           context: { skew },
         });

--- a/resources/assets/helpers/index.js
+++ b/resources/assets/helpers/index.js
@@ -19,7 +19,7 @@ import {
 import Debug from '../services/Debug';
 import Sixpack from '../services/Sixpack';
 import { isSignedUp } from '../selectors/signup';
-import { trackAnalyticsEvent } from './analytics';
+import { EVENT_CATEGORIES, trackAnalyticsEvent } from './analytics';
 
 // Helper Constants
 export const EMPTY_IMAGE =
@@ -760,7 +760,7 @@ export function showTwitterSharePrompt(href, quote = '', callback) {
 export function handleFacebookShareClick(href, trackingData) {
   trackAnalyticsEvent('clicked_share_facebook', {
     action: 'button_clicked',
-    category: 'social_share',
+    category: EVENT_CATEGORIES.socialShare,
     label: 'facebook',
     context: { ...trackingData, url: href },
   });
@@ -780,7 +780,7 @@ export function handleFacebookShareClick(href, trackingData) {
 export function handleTwitterShareClick(href, trackingData, quote = '') {
   trackAnalyticsEvent('clicked_share_twitter', {
     action: 'button_clicked',
-    category: 'social_share',
+    category: EVENT_CATEGORIES.socialShare,
     label: 'twitter',
     context: { ...trackingData, url: href },
   });

--- a/resources/assets/middleware/api.js
+++ b/resources/assets/middleware/api.js
@@ -8,7 +8,11 @@ import { PHOENIX_URL } from '../constants';
 import { API } from '../constants/action-types';
 import { getUserToken } from '../selectors/user';
 import { getRequest, setRequestHeaders, tabularLog } from '../helpers/api';
-import { formatEventNoun, trackAnalyticsEvent } from '../helpers/analytics';
+import {
+  EVENT_CATEGORIES,
+  formatEventNoun,
+  trackAnalyticsEvent,
+} from '../helpers/analytics';
 
 /**
  * Send a GET request and dispatch actions.
@@ -98,7 +102,7 @@ const postRequest = (payload, dispatch, getState) => {
 
       trackAnalyticsEvent(`${verb}_${formatEventNoun(postType)}`, {
         action: `${postType}_${verb}`,
-        category: 'campaign_action',
+        category: EVENT_CATEGORIES.campaignAction,
         label: campaignId || formatEventNoun(postType), // @TODO: make this the campaign title if available; but also may need to get passed in as an argument.
         context: {
           actionId,
@@ -120,7 +124,7 @@ const postRequest = (payload, dispatch, getState) => {
 
       trackAnalyticsEvent(`failed_${formatEventNoun(postType)}`, {
         action: `${postType}_failed`,
-        category: 'campaign_action',
+        category: EVENT_CATEGORIES.campaignAction,
         label: campaignId || formatEventNoun(postType), // @TODO: make this the campaign title if available; but also may need to get passed in as an argument.
         context: {
           actionId,


### PR DESCRIPTION
### What's this PR do?

This pull request updates the information passed to `trackAnalyticsEvent()` in numerous components to follow the updates established in #1897.

Back in #1911 we added a constant that references an object with all the available Analytics Event Categories. This PR simply goes through all the events and updates each to utilize this new constant.

A nice effect is that Editors can easy auto-suggest the category you're looking for:
![Event Categories Auto-suggest in Editor](https://user-images.githubusercontent.com/105849/74069967-aabf2b80-49cd-11ea-9a03-8b3bedd57da2.gif)


Additionally, the `trackAnalyticsEvent()` check the provided `category` against the available list and will trigger an error if the provided category is not found in the list!

### How should this be reviewed?

👀 

### Relevant tickets

References [Pivotal #170710129](https://www.pivotaltracker.com/story/show/170710129).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Added appropriate feature/unit tests.
