### PR TITLE
Rogue campaign contentful ID backfill script

### DIFF
--- a/contentful/management-api-scripts/2020_02_04_backfill_rogue_contentful_campaign_ids.js
+++ b/contentful/management-api-scripts/2020_02_04_backfill_rogue_contentful_campaign_ids.js
@@ -1,0 +1,129 @@
+const fetch = require('node-fetch');
+
+const { contentManagementClient } = require('./contentManagementClient.js');
+const {
+  attempt,
+  createLogger,
+  getField,
+  processEntries,
+  sleep,
+} = require('./helpers');
+
+let NORTHSTAR_BEARER_TOKEN;
+const {
+  ROGUE_URL,
+  NORTHSTAR_URL,
+  NORTHSTAR_AUTHORIZATION_ID,
+  NORTHSTAR_AUTHORIZATION_SECRET,
+} = process.env;
+
+const NORTHSTAR_TOKEN_ENDPOINT = `${NORTHSTAR_URL}/v2/auth/token`;
+const ROGUE_CAMPAIGNS_ENDPOINT = `${ROGUE_URL}/api/v3/campaigns`;
+
+const logger = createLogger('backfill_rogue_contentful_campaign_ids');
+
+const backfillRogueContentfulCampaignIds = async (
+  environment,
+  campaignEntry,
+) => {
+  const campaignContentfulId = campaignEntry.sys.id;
+  const campaignInternalTitle = getField(campaignEntry, 'internalTitle');
+  const rogueCampaignId = getField(campaignEntry, 'legacyCampaignId');
+
+  if (!rogueCampaignId) {
+    logger.info(
+      `\n\nSkipping ${campaignInternalTitle} - no Rogue campaign ID.`,
+    );
+    return;
+  }
+
+  if (await !campaignEntry.isPublished()) {
+    logger.info(`\n\nSkipping ${campaignInternalTitle} - unpublished entry.`);
+    return;
+  }
+
+  logger.info(
+    `\n\nProcessing ${campaignInternalTitle} with Rogue campaign ID: ${rogueCampaignId}.`,
+  );
+
+  const ROGUE_CAMPAIGN_ENDPOINT = `${ROGUE_CAMPAIGNS_ENDPOINT}/${rogueCampaignId}`;
+
+  // Let's first make sure that a Rogue campaign with this ID actually exists!
+  const isValidRogueCampaign = await fetch(ROGUE_CAMPAIGN_ENDPOINT)
+    // node-fetch won't throw an exception for 404's.
+    .then(res => (res.ok ? res.json() : false))
+    .catch(err => logger.error(err));
+
+  if (!isValidRogueCampaign) {
+    logger.info(
+      `⇢ Unable to update Campaign ID: ${rogueCampaignId}. The ID is invalid!`,
+    );
+    return;
+  }
+
+  await fetch(ROGUE_CAMPAIGN_ENDPOINT, {
+    method: 'PATCH',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${NORTHSTAR_BEARER_TOKEN}`,
+    },
+    body: JSON.stringify({ contentful_campaign_id: campaignContentfulId }),
+  })
+    .then(response => response.json())
+    .then(result =>
+      logger.info(
+        `✔ Updated Campaign ID: ${rogueCampaignId} with Contentful Campaign ID: ${campaignContentfulId}!`,
+      ),
+    )
+    .catch(error =>
+      logger.error(
+        `☓ Failed to update Campaign ID: ${rogueCampaignId}. ERROR:\n${error}`,
+      ),
+    );
+};
+
+contentManagementClient.init(async (environment, args) => {
+  logger.info(
+    `Running 'backfill_rogue_contentful_campaign_ids', using Contentful's '${environment.sys.id}' environment & '${ROGUE_URL}'.`,
+  );
+  logger.info('Kicking things off in 5 seconds...');
+
+  await sleep(5000);
+
+  logger.info('\nObtaining Northstar access token.');
+
+  await fetch(NORTHSTAR_TOKEN_ENDPOINT, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      grant_type: 'client_credentials',
+      client_id: NORTHSTAR_AUTHORIZATION_ID,
+      client_secret: NORTHSTAR_AUTHORIZATION_SECRET,
+      scope: 'role:admin',
+    }),
+  })
+    .then(response => response.json())
+    .then(result => {
+      logger.info('✔ Obtained Northstar access token.');
+      NORTHSTAR_BEARER_TOKEN = result.access_token;
+    })
+    .catch(error =>
+      logger.error(
+        `☓ Failed to obtain Northstar access token. ERROR:\n${error}`,
+      ),
+    );
+
+  if (!NORTHSTAR_BEARER_TOKEN) {
+    logger.error(`Cannot run script, no Northstar access token!`);
+    return;
+  }
+
+  processEntries(
+    environment,
+    args,
+    'campaign',
+    backfillRogueContentfulCampaignIds,
+  );
+});


### PR DESCRIPTION
### What's this PR do?

This pull request adds a Contentful management script which for every Contentful campaign, finds it's associated Rogue campaign and assigns the entry ID as the Rogue campaign's `contentful_campaign_id`.

### How should this be reviewed?
The logical flow _should_ be fairly straightforward. I opted to make the call to Northstar for an access token using the [Client credentials grant](https://github.com/DoSomething/northstar/blob/master/documentation/endpoints/auth.md#create-token-client-credentials-grant). The local .env should set the NS config variables to the machine client.

There's some conversation in the Pivotal story about campaigns with multiple corresponding 'website campaigns' in Contentful. It shouldn't ultimately have much bearing on us running this script as we have only two of these instances on contentful with a definitive 'primary' campaign we'll use as the associated one on Rogue -- which we'll do manually before running this script. 

### Any background context you want to provide?
This will wrap up our work to allow querying Rogue campaigns _together_ with their associated 'Website campaign' via GraphQL https://github.com/DoSomething/graphql/pull/191.

### Relevant tickets

References [Pivotal #171028343](https://www.pivotaltracker.com/story/show/171028343).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
