### PR TITLE
Fix content widths on general pages.

### DIFF
--- a/resources/assets/components/blocks/ContentBlock/ContentBlock.js
+++ b/resources/assets/components/blocks/ContentBlock/ContentBlock.js
@@ -57,7 +57,14 @@ const ContentBlock = props => {
           </div>
         ) : null}
 
-        <div className="col-span-2 order-1">{contentNode}</div>
+        <div
+          className={classnames('col-span-2', 'order-1', {
+            /* HACK: See 'general-page.scss'. */
+            'hack-article-content-widths': !image.url,
+          })}
+        >
+          {contentNode}
+        </div>
       </div>
     </div>
   );

--- a/resources/assets/components/blocks/ContentBlock/__snapshots__/ContentBlock.test.js.snap
+++ b/resources/assets/components/blocks/ContentBlock/__snapshots__/ContentBlock.test.js.snap
@@ -79,7 +79,7 @@ exports[`ContentBlock component it works beautifully with content and an empty i
     className="md:grid grid-flow-row-dense grid-cols-3 gap-4"
   >
     <div
-      className="col-span-2 order-1"
+      className="col-span-2 order-1 hack-article-content-widths"
     >
       <TextContent
         className={null}

--- a/resources/assets/components/pages/GeneralPage/general-page.scss
+++ b/resources/assets/components/pages/GeneralPage/general-page.scss
@@ -3,6 +3,12 @@
 .general-page {
   position: inherit;
 
+  // HACK: If a Content Block is found on a "general page" without an
+  // image, we want to force it to full-width so it looks normal.
+  .hack-article-content-widths {
+    grid-column: span 3 / span 3 !important;
+  }
+
   .general-page__heading {
     .general-page__title {
       font-family: theme('fontFamily.league-gothic');


### PR DESCRIPTION
### What's this PR do?

This pull request fixes an issue [flagged by @mendelB in Slack](https://dosomething.slack.com/archives/C3ASB4204/p1581355562011000): now that Content Blocks handle their own layout, they're appearing too narrow on Article/Fact pages:

![Screen Shot 2020-02-10 at 1 24 01 PM](https://user-images.githubusercontent.com/583202/74177916-a599f080-4c08-11ea-8ac4-abea4194004e.png)

As a quick fix, I've added a class that lets us conditionally "force" these full-width on articles:

![Screen Shot 2020-02-10 at 1 24 16 PM](https://user-images.githubusercontent.com/583202/74177940-b3e80c80-4c08-11ea-9ed7-11a91ae28784.png)


### How should this be reviewed?

🙈 

### Any background context you want to provide?

This is definitely not a good long-term solution, but it should unblock today's deploy!

### Relevant tickets

References [Pivotal #171190791](https://www.pivotaltracker.com/story/show/171190791).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added screenshots of front-end changes on small, medium, and large screens.
- [ ] Added appropriate feature/unit tests.
