### PR TITLE
Fix ability to parse Quizzes via PHP.

### DIFF
--- a/app/Entities/Campaign.php
+++ b/app/Entities/Campaign.php
@@ -109,12 +109,7 @@ class Campaign extends Entity implements JsonSerializable
     public function parseQuizzes($quizzes)
     {
         return collect($quizzes)->map(function ($quiz) {
-            switch ($quiz->getContentType()) {
-                case 'quizBeta':
-                    return new LegacyQuiz($quiz->entry);
-                case 'quiz':
-                    return new Quiz($quiz->entry);
-            }
+            return new Quiz($quiz->entry);
         });
     }
 

--- a/app/Entities/Quiz.php
+++ b/app/Entities/Quiz.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace App\Entities;
+
+use JsonSerializable;
+
+class Quiz extends Entity implements JsonSerializable
+{
+    /**
+     * Parse choices to add ID based on index.
+     *
+     * @param  array $choices
+     * @return array
+     */
+    private function parseChoices($choices)
+    {
+        return collect($choices)->map(function ($choice, $index) {
+            $choice['id'] = (string) $index;
+
+            return $choice;
+        });
+    }
+
+    /**
+     * Parse questions to add ID based on index and parse through choices.
+     *
+     * @param  array $questions
+     * @return array
+     */
+    private function parseQuestions($questions)
+    {
+        return collect($questions)->map(function ($question, $index) {
+            $question['id'] = (string) $index;
+            $question['choices'] = $this->parseChoices($question['choices']);
+
+            return $question;
+        });
+    }
+
+    /**
+     * Parse results to add an ABC based ID based on the index.
+     *
+     * @param  array $results
+     * @return array
+     */
+    private function parseResults($results)
+    {
+        return collect($results)->map(function ($result, $index) {
+            $resultId = chr($index + 65);
+            $result['id'] = $resultId;
+
+            return $result;
+        });
+    }
+
+    /**
+     * Convert the object into something JSON serializable.
+     *
+     * @return array
+     */
+    public function jsonSerialize()
+    {
+        return [
+            'id' => $this->entry->getId(),
+            'type' => $this->getContentType(),
+            'fields' => [
+                'title' => $this->title,
+                'slug' => $this->slug,
+                'autoSubmit' => $this->autoSubmit,
+                'results' => $this->parseResults($this->results),
+                'questions' => $this->parseQuestions($this->questions),
+                'resultBlocks' => $this->parseBlocks($this->resultBlocks),
+                'defaultResultBlock' => $this->parseBlock($this->defaultResultBlock),
+                'hideQuestionNumber' => $this->hideQuestionNumber,
+                'additionalContent' => $this->additionalContent,
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
### What's this PR do?

This pull request re-enables support for parsing a `quiz` as part of a Campaign entity.

### How should this be reviewed?

👀

### Any background context you want to provide?

I accidentally deleted this file in #1918.

### Relevant tickets

References [Pivotal #171198109](https://www.pivotaltracker.com/story/show/171198109).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added screenshots of front-end changes on small, medium, and large screens.
- [ ] Added appropriate feature/unit tests.
