### PR TITLE
Fix issue iterating over field-less page/quiz entries.

### DIFF
--- a/resources/assets/helpers/index.js
+++ b/resources/assets/helpers/index.js
@@ -803,7 +803,8 @@ export function findContentfulEntry(state, identifier) {
 
   return find(
     contentfulEntries,
-    entry => entry.id === identifier || entry.fields.slug === identifier,
+    entry =>
+      entry.id === identifier || get(entry, 'fields.slug') === identifier,
   );
 }
 


### PR DESCRIPTION
### What's this PR do?

This pull request fixes an issue where a block inserted into `Campaign.pages` would cause this helper to fail (since `entry.fields` would be undefined). Lodash's `get` helper lets us do this safely.

### How should this be reviewed?

👀

### Any background context you want to provide?

🔥

### Relevant tickets

References [Pivotal #171198109](https://www.pivotaltracker.com/story/show/171198109).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added screenshots of front-end changes on small, medium, and large screens.
- [ ] Added appropriate feature/unit tests.
