### PR TITLE
Paginated Campaigns Gallery

### DIFF
--- a/resources/assets/components/blocks/GalleryBlock/GalleryBlock.js
+++ b/resources/assets/components/blocks/GalleryBlock/GalleryBlock.js
@@ -62,7 +62,7 @@ const renderBlock = (block, imageAlignment, imageFit) => {
           showcaseTitle={fields.title}
           showcaseDescription={fields.tagline}
           showcaseImage={fields.coverImage}
-          {...fields}
+          {...withoutNulls(fields)}
         />
       );
 

--- a/resources/assets/components/utilities/Gallery/templates/CampaignGalleryItem/CampaignGalleryItem.js
+++ b/resources/assets/components/utilities/Gallery/templates/CampaignGalleryItem/CampaignGalleryItem.js
@@ -11,7 +11,7 @@ const CampaignGalleryItem = ({
   showcaseImage,
   slug,
 }) => (
-  <Card className="rounded">
+  <Card className="rounded h-full">
     <a className="campaign-gallery-item block" href={`/us/campaigns/${slug}`}>
       <Figure
         alt={`${showcaseImage.description || showcaseTitle}-photo`}

--- a/resources/assets/components/utilities/Gallery/templates/CampaignGalleryItem/CampaignGalleryItem.js
+++ b/resources/assets/components/utilities/Gallery/templates/CampaignGalleryItem/CampaignGalleryItem.js
@@ -34,8 +34,12 @@ CampaignGalleryItem.propTypes = {
   showcaseImage: PropTypes.shape({
     url: PropTypes.string,
     description: PropTypes.string,
-  }).isRequired,
+  }),
   slug: PropTypes.string.isRequired,
+};
+
+CampaignGalleryItem.defaultProps = {
+  showcaseImage: {},
 };
 
 export default CampaignGalleryItem;

--- a/resources/assets/components/utilities/Gallery/templates/PageGalleryItem/PageGalleryItem.js
+++ b/resources/assets/components/utilities/Gallery/templates/PageGalleryItem/PageGalleryItem.js
@@ -12,7 +12,7 @@ const PageGalleryItem = ({
   showcaseImage,
   slug,
 }) => (
-  <Card className="rounded">
+  <Card className="rounded h-full">
     <a className="page-gallery-item block" href={`/us/${slug}`}>
       <Figure
         alt={`${showcaseImage.description || showcaseTitle}-photo`}

--- a/resources/assets/components/utilities/PaginatedCampaignGallery/PaginatedCampaignGallery.js
+++ b/resources/assets/components/utilities/PaginatedCampaignGallery/PaginatedCampaignGallery.js
@@ -1,0 +1,135 @@
+import React from 'react';
+import gql from 'graphql-tag';
+import PropTypes from 'prop-types';
+import { useQuery } from '@apollo/react-hooks';
+import { get, isArray, mergeWith } from 'lodash';
+
+import Button from '../Button/Button';
+import Spinner from '../../artifacts/Spinner/Spinner';
+import ErrorBlock from '../../blocks/ErrorBlock/ErrorBlock';
+import GalleryBlock from '../../blocks/GalleryBlock/GalleryBlock';
+
+const PAGINATED_CAMPAIGNS_QUERY = gql`
+  query campaignsByCauseQuery(
+    $causes: [String]
+    $cursor: String
+    $first: Int
+    $hasWebsite: Boolean
+    $isOpen: Boolean
+    $orderBy: String
+  ) {
+    campaigns: paginatedCampaigns(
+      after: $cursor
+      causes: $causes
+      first: $first
+      hasWebsite: $hasWebsite
+      isOpen: $isOpen
+      orderBy: $orderBy
+    ) {
+      edges {
+        cursor
+        node {
+          id
+          campaignWebsite {
+            id
+            slug
+            showcaseTitle
+            showcaseDescription
+            showcaseImage {
+              url
+              description
+            }
+          }
+        }
+      }
+      pageInfo {
+        endCursor
+        hasNextPage
+      }
+    }
+  }
+`;
+
+const PaginatedCampaignGallery = ({ className, itemsPerRow, variables }) => {
+  const { error, loading, data, fetchMore } = useQuery(
+    PAGINATED_CAMPAIGNS_QUERY,
+    {
+      variables: { ...variables, hasWebsite: true },
+      notifyOnNetworkStatusChange: true,
+    },
+  );
+
+  const { endCursor, hasNextPage } = get(data, 'campaigns.pageInfo', {});
+
+  const handleViewMore = () => {
+    fetchMore({
+      variables: { cursor: endCursor },
+      updateQuery: (previous, { fetchMoreResult }) =>
+        mergeWith({}, previous, fetchMoreResult, (dest, src) =>
+          // By default, Lodash's `merge` would try to merge *each* array
+          // item (e.g. `edges[0]` with then next page's `edges[0]`).
+          isArray(dest) ? [...dest, ...src] : undefined,
+        ),
+    });
+  };
+
+  // Parse out the nested campaign website nodes so we can pass them to the Gallery Block.
+  const campaigns = get(data, 'campaigns.edges', []).map(edge =>
+    get(edge, 'node.campaignWebsite'),
+  );
+
+  if (error) {
+    return (
+      <div className={className}>
+        <ErrorBlock error={error} />
+      </div>
+    );
+  }
+
+  if (loading && !data) {
+    return (
+      <div className={className}>
+        <Spinner className="flex justify-center" />
+      </div>
+    );
+  }
+
+  return (
+    <div className={className}>
+      <GalleryBlock
+        blocks={campaigns}
+        itemsPerRow={itemsPerRow}
+        imageAlignment="TOP"
+      />
+      {hasNextPage ? (
+        <div className="p-6 text-center">
+          <Button
+            className="-tertiary"
+            onClick={handleViewMore}
+            disabled={loading}
+          >
+            view more...
+          </Button>
+        </div>
+      ) : null}
+    </div>
+  );
+};
+
+PaginatedCampaignGallery.propTypes = {
+  className: PropTypes.string,
+  itemsPerRow: PropTypes.oneOf([2, 3, 4, 5]).isRequired,
+  variables: PropTypes.shape({
+    causes: PropTypes.arrayOf(PropTypes.string),
+    isOpen: PropTypes.bool,
+    orderBy: PropTypes.string,
+    first: PropTypes.number,
+  }),
+};
+
+PaginatedCampaignGallery.defaultProps = {
+  className: null,
+  variables: {},
+};
+
+export default PaginatedCampaignGallery;

--- a/resources/assets/components/utilities/PaginatedCampaignGallery/PaginatedCampaignGallery.js
+++ b/resources/assets/components/utilities/PaginatedCampaignGallery/PaginatedCampaignGallery.js
@@ -1,10 +1,11 @@
 import React from 'react';
+import { get } from 'lodash';
 import gql from 'graphql-tag';
 import PropTypes from 'prop-types';
 import { useQuery } from '@apollo/react-hooks';
-import { get, isArray, mergeWith } from 'lodash';
 
 import Button from '../Button/Button';
+import { updateQuery } from '../../../helpers';
 import Spinner from '../../artifacts/Spinner/Spinner';
 import ErrorBlock from '../../blocks/ErrorBlock/ErrorBlock';
 import GalleryBlock from '../../blocks/GalleryBlock/GalleryBlock';
@@ -63,12 +64,7 @@ const PaginatedCampaignGallery = ({ className, itemsPerRow, variables }) => {
   const handleViewMore = () => {
     fetchMore({
       variables: { cursor: endCursor },
-      updateQuery: (previous, { fetchMoreResult }) =>
-        mergeWith({}, previous, fetchMoreResult, (dest, src) =>
-          // By default, Lodash's `merge` would try to merge *each* array
-          // item (e.g. `edges[0]` with then next page's `edges[0]`).
-          isArray(dest) ? [...dest, ...src] : undefined,
-        ),
+      updateQuery,
     });
   };
 

--- a/resources/assets/components/utilities/PaginatedCampaignGallery/PaginatedCampaignGallery.js
+++ b/resources/assets/components/utilities/PaginatedCampaignGallery/PaginatedCampaignGallery.js
@@ -14,7 +14,6 @@ const PAGINATED_CAMPAIGNS_QUERY = gql`
     $causes: [String]
     $cursor: String
     $first: Int
-    $hasWebsite: Boolean
     $isOpen: Boolean
     $orderBy: String
   ) {
@@ -22,7 +21,7 @@ const PAGINATED_CAMPAIGNS_QUERY = gql`
       after: $cursor
       causes: $causes
       first: $first
-      hasWebsite: $hasWebsite
+      hasWebsite: true
       isOpen: $isOpen
       orderBy: $orderBy
     ) {
@@ -54,7 +53,7 @@ const PaginatedCampaignGallery = ({ className, itemsPerRow, variables }) => {
   const { error, loading, data, fetchMore } = useQuery(
     PAGINATED_CAMPAIGNS_QUERY,
     {
-      variables: { ...variables, hasWebsite: true },
+      variables: { ...variables },
       notifyOnNetworkStatusChange: true,
     },
   );

--- a/resources/assets/components/utilities/PaginatedCampaignGallery/PaginatedCampaignGallery.js
+++ b/resources/assets/components/utilities/PaginatedCampaignGallery/PaginatedCampaignGallery.js
@@ -10,7 +10,7 @@ import ErrorBlock from '../../blocks/ErrorBlock/ErrorBlock';
 import GalleryBlock from '../../blocks/GalleryBlock/GalleryBlock';
 
 const PAGINATED_CAMPAIGNS_QUERY = gql`
-  query campaignsByCauseQuery(
+  query CampaignsByCauseQuery(
     $causes: [String]
     $cursor: String
     $first: Int

--- a/resources/assets/components/utilities/PaginatedCampaignGallery/PaginatedCampaignGallery.js
+++ b/resources/assets/components/utilities/PaginatedCampaignGallery/PaginatedCampaignGallery.js
@@ -50,7 +50,12 @@ const PAGINATED_CAMPAIGNS_QUERY = gql`
   }
 `;
 
-const PaginatedCampaignGallery = ({ className, itemsPerRow, variables }) => {
+const PaginatedCampaignGallery = ({
+  className,
+  itemsPerRow,
+  title,
+  variables,
+}) => {
   const { error, loading, data, fetchMore } = useQuery(
     PAGINATED_CAMPAIGNS_QUERY,
     {
@@ -95,6 +100,7 @@ const PaginatedCampaignGallery = ({ className, itemsPerRow, variables }) => {
         blocks={campaigns}
         itemsPerRow={itemsPerRow}
         imageAlignment="TOP"
+        title={title}
       />
       {hasNextPage ? (
         <div className="p-6 text-center">
@@ -114,6 +120,7 @@ const PaginatedCampaignGallery = ({ className, itemsPerRow, variables }) => {
 PaginatedCampaignGallery.propTypes = {
   className: PropTypes.string,
   itemsPerRow: PropTypes.oneOf([2, 3, 4, 5]).isRequired,
+  title: PropTypes.string,
   variables: PropTypes.shape({
     causes: PropTypes.arrayOf(PropTypes.string),
     isOpen: PropTypes.bool,
@@ -124,6 +131,7 @@ PaginatedCampaignGallery.propTypes = {
 
 PaginatedCampaignGallery.defaultProps = {
   className: null,
+  title: null,
   variables: {},
 };
 

--- a/resources/assets/helpers/index.js
+++ b/resources/assets/helpers/index.js
@@ -13,6 +13,7 @@ import {
   isUndefined,
   mapValues,
   merge,
+  mergeWith,
   omitBy,
 } from 'lodash';
 
@@ -890,7 +891,7 @@ export function stringifyNestedObjects(data) {
 /**
  * Determine if a page is an 'Action' page.
  *
- * @param  {Object} dpage
+ * @param  {Object} page
  * @return {Boolean}
  */
 export function isActionPage(page) {
@@ -942,4 +943,18 @@ export function toggleClassHandler(button, target, toggleClass) {
   }
 
   button.addEventListener('mousedown', clickHandler, false);
+}
+
+/**
+ * Merge paginated GraphQL queries.
+ *
+ * @param {Object} previous
+ * @param {Object} [fetchMoreResult]
+ */
+export function updateQuery(previous, { fetchMoreResult }) {
+  return mergeWith({}, previous, fetchMoreResult, (dest, src) =>
+    // By default, Lodash's `merge` would try to merge *each* array
+    // item (e.g. `edges[0]` with then next page's `edges[0]`).
+    isArray(dest) ? [...dest, ...src] : undefined,
+  );
 }


### PR DESCRIPTION
### What's this PR do?

This pull request is a collaboration with @lindsayrmaher which adds a new `PaginatedCampaignGallery` component which...surprise! Displays campaigns in a paginated gallery! 

We heavily modeled this after the [`CampaignsTable`](https://github.com/DoSomething/rogue/blob/7aca5b68c993da35c260df987aea2b28d1fdeef9/resources/assets/components/CampaignsTable.js) in Rogue which provides similar functionality from a query / pagination perspective.

### How should this be reviewed?
- How's the component naming? 
- Do you agree that this belongs in `/utilities`?
- We opted not to add a general 'PaginatedQuery' component, but that can be abstracted away from this if necessary in the future to model the current [`PaginatedQuery`](https://github.com/DoSomething/phoenix-next/blob/3f01a957318661e4a213876594b2849f53183c28/resources/assets/components/PaginatedQuery.js) which uses the 'page' pagination format.
- We're rendering a wrapping div for error, loading, and the main case to allow e.g. grid formatting. Should we clean this up and have one rendering div which accepts the diverse set of children?
- We hardcoded the `hasWebsite` filter for this query, since this is presumably the only use case for this gallery!

### Any background context you want to provide?
We'll be using this for two impending features: 
1. Auto pulling cause-related campaigns into cause pages ([Pivotal ID#170606523](https://www.pivotaltracker.com/n/projects/2401401/stories/170606523))
2. The new and improved Explore Campaigns page #1907 

I'll add a Cypress test for this once we add this to the cause-page, to test it in that context! (And documentation for this utility once this is approved!)

https://github.com/DoSomething/phoenix-next/pull/1925/commits/538603582eff33e61e039d038507c07593468167 Also as a bonus re Leah's request to alighn the gallery items 'article' whitespace to align with the rest of the items on the row cc @lkpttn 

Before
![image](https://user-images.githubusercontent.com/12417657/74372457-a8334c00-4da8-11ea-9278-195b93410851.png)

After
![image](https://user-images.githubusercontent.com/12417657/74372477-b1bcb400-4da8-11ea-9c56-58e8d8b160f5.png)


### Relevant tickets

References [Pivotal #170606523](https://www.pivotaltracker.com/n/projects/2401401/stories/170606523).
References [Pivotal #170823582](https://www.pivotaltracker.com/story/show/170823582).

![Kapture 2020-02-12 at 14 54 43](https://user-images.githubusercontent.com/12417657/74371903-a9b04480-4da7-11ea-9b46-e92dada191d3.gif)

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added screenshots of front-end changes on small, medium, and large screens.
- [ ] Added appropriate feature/unit tests.
