### PR TITLE
Moves Scholarship Deadline Amount to Top of Campaign Info Card

### DIFF
--- a/resources/assets/components/LedeBanner/templates/HeroTemplate.js
+++ b/resources/assets/components/LedeBanner/templates/HeroTemplate.js
@@ -120,6 +120,7 @@ const HeroTemplate = ({
               <CampaignInfoBlock
                 campaignId={numCampaignId}
                 scholarshipAmount={scholarshipAmount}
+                scholarshipDeadline={scholarshipDeadline}
               />
             </div>
           </div>

--- a/resources/assets/components/blocks/CampaignInfoBlock/CampaignInfoBlock.js
+++ b/resources/assets/components/blocks/CampaignInfoBlock/CampaignInfoBlock.js
@@ -33,8 +33,6 @@ const CampaignInfoBlock = ({
   scholarshipDeadline,
 }) => (
   <Card className="bordered p-3 rounded campaign-info">
-    <h1 className="mb-3 text-lg uppercase">Campaign Info</h1>
-
     <dl className="clearfix">
       <Query query={CAMPAIGN_INFO_QUERY} variables={{ campaignId }}>
         {res => {
@@ -51,6 +49,7 @@ const CampaignInfoBlock = ({
           }
           return (
             <>
+              <h1 className="mb-3 text-lg uppercase">Campaign Info</h1>
               {scholarshipAmount && isOpen ? (
                 <React.Fragment>
                   <dt className="campaign-info__scholarship">
@@ -59,14 +58,14 @@ const CampaignInfoBlock = ({
                   <dd className="campaign-info__scholarship">
                     {`$${scholarshipAmount.toLocaleString()}`}
                   </dd>
+
+                  <dt>Scholarship Deadline</dt>
+                  <dd>{getHumanFriendlyDate(scholarshipDeadline)}</dd>
                 </React.Fragment>
               ) : null}
 
               {endDate && !scholarshipAmount ? (
                 <>
-                  <dt>Scholarship Deadline</dt>
-                  <dd>{getHumanFriendlyDate(scholarshipDeadline)}</dd>
-
                   <dt>Deadline</dt>
                   <dd>{getHumanFriendlyDate(endDate)}</dd>
                 </>

--- a/resources/assets/components/blocks/CampaignInfoBlock/CampaignInfoBlock.js
+++ b/resources/assets/components/blocks/CampaignInfoBlock/CampaignInfoBlock.js
@@ -33,23 +33,25 @@ const CampaignInfoBlock = ({
   scholarshipDeadline,
 }) => (
   <Card className="bordered p-3 rounded campaign-info">
-    <dl className="clearfix">
-      <Query query={CAMPAIGN_INFO_QUERY} variables={{ campaignId }}>
-        {res => {
-          const endDate = res.campaign.endDate;
-          const actions = res.campaign.actions || [];
-          const isOpen = res.campaign.isOpen;
+    <Query query={CAMPAIGN_INFO_QUERY} variables={{ campaignId }}>
+      {res => {
+        const endDate = res.campaign.endDate;
+        const actions = res.campaign.actions || [];
+        const isOpen = res.campaign.isOpen;
 
-          let actionItem = actions.find(
-            action => action.reportback && action.scholarshipEntry,
-          );
+        let actionItem = actions.find(
+          action => action.reportback && action.scholarshipEntry,
+        );
 
-          if (!actionItem) {
-            actionItem = actions.find(action => action.reportback);
-          }
-          return (
-            <>
+        if (!actionItem) {
+          actionItem = actions.find(action => action.reportback);
+        }
+        return (
+          <>
+            {!scholarshipAmount ? (
               <h1 className="mb-3 text-lg uppercase">Campaign Info</h1>
+            ) : null}
+            <dl className="clearfix">
               {scholarshipAmount && isOpen ? (
                 <React.Fragment>
                   <dt className="campaign-info__scholarship">
@@ -72,7 +74,7 @@ const CampaignInfoBlock = ({
               ) : null}
               {actionItem && actionItem.timeCommitmentLabel ? (
                 <React.Fragment>
-                  <dt>Time</dt>
+                  <dt className="campaign-info__time">Time</dt>
                   <dd>{actionItem.timeCommitmentLabel}</dd>
                 </React.Fragment>
               ) : null}
@@ -82,11 +84,11 @@ const CampaignInfoBlock = ({
                   <dd>{actionItem.actionLabel}</dd>
                 </React.Fragment>
               ) : null}
-            </>
-          );
-        }}
-      </Query>
-    </dl>
+            </dl>
+          </>
+        );
+      }}
+    </Query>
   </Card>
 );
 

--- a/resources/assets/components/blocks/CampaignInfoBlock/CampaignInfoBlock.js
+++ b/resources/assets/components/blocks/CampaignInfoBlock/CampaignInfoBlock.js
@@ -63,6 +63,7 @@ const CampaignInfoBlock = ({
 
                   <dt>Scholarship Deadline</dt>
                   <dd>{getHumanFriendlyDate(scholarshipDeadline)}</dd>
+                  <hr className="clear-both pb-3 colors-gray-600" />
                 </React.Fragment>
               ) : null}
 
@@ -74,7 +75,7 @@ const CampaignInfoBlock = ({
               ) : null}
               {actionItem && actionItem.timeCommitmentLabel ? (
                 <React.Fragment>
-                  <dt className="campaign-info__time">Time</dt>
+                  <dt>Time</dt>
                   <dd>{actionItem.timeCommitmentLabel}</dd>
                 </React.Fragment>
               ) : null}

--- a/resources/assets/components/blocks/CampaignInfoBlock/CampaignInfoBlock.js
+++ b/resources/assets/components/blocks/CampaignInfoBlock/CampaignInfoBlock.js
@@ -63,7 +63,7 @@ const CampaignInfoBlock = ({
 
                   <dt>Scholarship Deadline</dt>
                   <dd>{getHumanFriendlyDate(scholarshipDeadline)}</dd>
-                  <hr className="clear-both pb-3 colors-gray-600" />
+                  <hr className="clear-both pb-3 border-gray-500" />
                 </React.Fragment>
               ) : null}
 

--- a/resources/assets/components/blocks/CampaignInfoBlock/CampaignInfoBlock.js
+++ b/resources/assets/components/blocks/CampaignInfoBlock/CampaignInfoBlock.js
@@ -61,7 +61,7 @@ const CampaignInfoBlock = ({
                     {`$${scholarshipAmount.toLocaleString()}`}
                   </dd>
 
-                  <dt>Scholarship Deadline</dt>
+                  <dt>Next Deadline</dt>
                   <dd>{getHumanFriendlyDate(scholarshipDeadline)}</dd>
                   <hr className="clear-both pb-3 border-gray-500" />
                 </React.Fragment>

--- a/resources/assets/components/blocks/CampaignInfoBlock/CampaignInfoBlock.js
+++ b/resources/assets/components/blocks/CampaignInfoBlock/CampaignInfoBlock.js
@@ -64,6 +64,9 @@ const CampaignInfoBlock = ({
 
               {endDate && !scholarshipAmount ? (
                 <>
+                  <dt>Scholarship Deadline</dt>
+                  <dd>{getHumanFriendlyDate(scholarshipDeadline)}</dd>
+
                   <dt>Deadline</dt>
                   <dd>{getHumanFriendlyDate(endDate)}</dd>
                 </>

--- a/resources/assets/components/blocks/CampaignInfoBlock/CampaignInfoBlock.js
+++ b/resources/assets/components/blocks/CampaignInfoBlock/CampaignInfoBlock.js
@@ -27,7 +27,11 @@ const CAMPAIGN_INFO_QUERY = gql`
   }
 `;
 
-const CampaignInfoBlock = ({ campaignId, scholarshipAmount }) => (
+const CampaignInfoBlock = ({
+  campaignId,
+  scholarshipAmount,
+  scholarshipDeadline,
+}) => (
   <Card className="bordered p-3 rounded campaign-info">
     <h1 className="mb-3 text-lg uppercase">Campaign Info</h1>
 
@@ -45,10 +49,20 @@ const CampaignInfoBlock = ({ campaignId, scholarshipAmount }) => (
           if (!actionItem) {
             actionItem = actions.find(action => action.reportback);
           }
-
           return (
             <>
-              {endDate ? (
+              {scholarshipAmount && isOpen ? (
+                <React.Fragment>
+                  <dt className="campaign-info__scholarship">
+                    Win A Scholarship
+                  </dt>
+                  <dd className="campaign-info__scholarship">
+                    {`$${scholarshipAmount.toLocaleString()}`}
+                  </dd>
+                </React.Fragment>
+              ) : null}
+
+              {endDate && !scholarshipAmount ? (
                 <>
                   <dt>Deadline</dt>
                   <dd>{getHumanFriendlyDate(endDate)}</dd>
@@ -66,16 +80,6 @@ const CampaignInfoBlock = ({ campaignId, scholarshipAmount }) => (
                   <dd>{actionItem.actionLabel}</dd>
                 </React.Fragment>
               ) : null}
-              {scholarshipAmount && isOpen ? (
-                <React.Fragment>
-                  <dt className="campaign-info__scholarship">
-                    Win A Scholarship
-                  </dt>
-                  <dd className="campaign-info__scholarship">
-                    {`$${scholarshipAmount.toLocaleString()}`}
-                  </dd>
-                </React.Fragment>
-              ) : null}
             </>
           );
         }}
@@ -87,10 +91,12 @@ const CampaignInfoBlock = ({ campaignId, scholarshipAmount }) => (
 CampaignInfoBlock.propTypes = {
   campaignId: PropTypes.number.isRequired,
   scholarshipAmount: PropTypes.number,
+  scholarshipDeadline: PropTypes.number,
 };
 
 CampaignInfoBlock.defaultProps = {
   scholarshipAmount: null,
+  scholarshipDeadline: null,
 };
 
 export default CampaignInfoBlock;

--- a/resources/assets/components/blocks/CampaignInfoBlock/campaign-info-block.scss
+++ b/resources/assets/components/blocks/CampaignInfoBlock/campaign-info-block.scss
@@ -20,11 +20,6 @@
       padding-bottom: theme('spacing.3');
     }
   }
-  .campaign-info__time {
-    border-top: 1px solid theme('colors.gray.300');
-    float: none;
-    padding-top: theme('spacing.3');
-  }
 
   dt {
     clear: right;
@@ -56,10 +51,5 @@
     font-family: theme('fontFamily.league-gothic');
     font-size: theme('fontSize.3xl');
     line-height: 1;
-  }
-  dd.campaign-info__time {
-    border-top: 1px solid theme('colors.gray.300');
-    float: none;
-    padding-top: theme('spacing.3');
   }
 }

--- a/resources/assets/components/blocks/CampaignInfoBlock/campaign-info-block.scss
+++ b/resources/assets/components/blocks/CampaignInfoBlock/campaign-info-block.scss
@@ -42,7 +42,6 @@
   }
 
   dt.campaign-info__scholarship {
-    border-top: 1px solid theme('colors.gray.300');
     float: none;
     padding-top: theme('spacing.3');
   }
@@ -52,5 +51,10 @@
     font-family: theme('fontFamily.league-gothic');
     font-size: theme('fontSize.3xl');
     line-height: 1;
+  }
+  dd.campaign-info__time {
+    border-top: 1px solid theme('colors.gray.300');
+    float: none;
+    padding-top: theme('spacing.3');
   }
 }

--- a/resources/assets/components/blocks/CampaignInfoBlock/campaign-info-block.scss
+++ b/resources/assets/components/blocks/CampaignInfoBlock/campaign-info-block.scss
@@ -20,6 +20,11 @@
       padding-bottom: theme('spacing.3');
     }
   }
+  .campaign-info__time {
+    border-top: 1px solid theme('colors.gray.300');
+    float: none;
+    padding-top: theme('spacing.3');
+  }
 
   dt {
     clear: right;


### PR DESCRIPTION
### What's this PR do?

This pull request will move the scholarship amount to the top of campaign info card & make "Deadline" reflect the actual scholarship deadline. 

Small
<img width="305" alt="Screen Shot 2020-02-18 at 1 37 04 PM" src="https://user-images.githubusercontent.com/18747117/74780435-9866ac80-526d-11ea-9d43-6e7be60112ce.png">

Medium
<img width="551" alt="Screen Shot 2020-02-18 at 1 37 16 PM" src="https://user-images.githubusercontent.com/18747117/74780474-ac121300-526d-11ea-8fa3-3d3cd25afd77.png">

Large
<img width="1001" alt="Screen Shot 2020-02-18 at 1 37 34 PM" src="https://user-images.githubusercontent.com/18747117/74780499-b6341180-526d-11ea-82ea-eb66ac532fed.png">


### How should this be reviewed?

👀

### Any background context you want to provide?

This fix will allow more clarity for users and auto-update the deadline so that they no longer have to be updated manually.

### Relevant tickets

References [Pivotal #171053281](https://www.pivotaltracker.com/story/show/171053281).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added screenshots of front-end changes on small, medium, and large screens.
- [ ] Added appropriate feature/unit tests.
