### PR TITLE
Remove deprecated Landing Page fields

### DIFF
--- a/contentful/content-types/landingPage.js
+++ b/contentful/content-types/landingPage.js
@@ -35,48 +35,6 @@ module.exports = function(migration) {
     .omitted(false);
 
   landingPage
-    .createField('sidebar')
-    .name('Sidebar')
-    .type('Array')
-    .localized(false)
-    .required(false)
-    .validations([])
-    .disabled(false)
-    .omitted(false)
-    .items({
-      type: 'Link',
-
-      validations: [
-        {
-          linkContentType: ['callToAction', 'contentBlock', 'customBlock'],
-        },
-      ],
-
-      linkType: 'Entry',
-    });
-
-  landingPage
-    .createField('blocks')
-    .name('Blocks')
-    .type('Array')
-    .localized(false)
-    .required(false)
-    .validations([])
-    .disabled(true)
-    .omitted(false)
-    .items({
-      type: 'Link',
-
-      validations: [
-        {
-          linkContentType: ['callToAction', 'contentBlock', 'customBlock'],
-        },
-      ],
-
-      linkType: 'Entry',
-    });
-
-  landingPage
     .createField('additionalContent')
     .name('Additional Content')
     .type('Object')
@@ -88,16 +46,12 @@ module.exports = function(migration) {
   landingPage.changeFieldControl('internalTitle', 'builtin', 'singleLine', {});
   landingPage.changeFieldControl('content', 'builtin', 'richTextEditor', {});
 
-  landingPage.changeFieldControl('sidebar', 'builtin', 'entryLinksEditor', {
-    helpText: 'Deprecated -- only displayed on legacy template',
-    bulkEditing: false,
-  });
-
-  landingPage.changeFieldControl('blocks', 'builtin', 'entryLinksEditor', {});
   landingPage.changeFieldControl(
     'additionalContent',
     'builtin',
     'objectEditor',
-    {},
+    {
+      helpText: 'Only used for legacy template',
+    },
   );
 };


### PR DESCRIPTION
### What's this PR do?

This pull request removes two fields from the Landing Page content type in Contentful:

* `sidebar` - we no longer need this now that legacy template campaigns have closed (and we don't want to show scholarship information)

* `blocks` - this has long been disabled from editing and is not used

It also adds help text to `additionalContent` to explain that's only needed for legacy templates (which we aim to deprecate over in https://www.pivotaltracker.com/n/projects/2401401/stories/170879500, when we port over these campaigns to current template)

### How should this be reviewed?

:eyes:

### Any background context you want to provide?

I've manually deleted this fields in dev, and will delete them on QA (then production) on merge per our [workflow](https://dosomething.gitbook.io/phoenix-documentation/development/contentful/workflow#5-upon-merge-apply-changes-to-contentful-qa-and-master).

### Relevant tickets

References [Pivotal #170735375](https://www.pivotaltracker.com/n/projects/2401401/stories/170735375).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added screenshots of front-end changes on small, medium, and large screens.
- [ ] Added appropriate feature/unit tests.
