### PR TITLE
Remove server-side 404 if user not found in beta referral page

### DIFF
--- a/app/Http/Controllers/ReferralPageController.php
+++ b/app/Http/Controllers/ReferralPageController.php
@@ -19,6 +19,7 @@ class ReferralPageController extends Controller
          * @see https://github.com/DoSomething/phoenix-next/pull/1932#issuecomment-587720454
          */
         $title = 'Do Something Good With Your Friend!';
+
         return response()->view('app', [
             'headTitle' => $title,
             // @TODO: Create an $entity object to pass to the get_metadata helper

--- a/app/Http/Controllers/ReferralPageController.php
+++ b/app/Http/Controllers/ReferralPageController.php
@@ -21,12 +21,7 @@ class ReferralPageController extends Controller
 
         // Fetch user to display their first name in page metadata.
         $user = gateway('northstar')->getUser('id', $userId);
-
-        if (! $user) {
-            abort(404);
-        }
-
-        $title = 'Do Something Good With '.$user->first_name.'!';
+        $title = $user ? 'Do Something Good With '.$user->first_name.'!' : null;
 
         return response()->view('app', [
             'headTitle' => $title,
@@ -34,7 +29,7 @@ class ReferralPageController extends Controller
             // (and refactor get_metadata helper to expect an $entity instead of $campaign)
             'metadata' => [
                 'title' => $title,
-                'description' => 'Make an impact with '.$user->first_name.' by completing one of DoSomething\'s volunteer campaigns. (You\'ll both increase your chances of winning the campaign scholarship!)',
+                'description' => $user ? 'Make an impact with '.$user->first_name.' by completing one of DoSomething\'s volunteer campaigns. (You\'ll both increase your chances of winning the campaign scholarship!)' : null,
                 'facebook_app_id' =>  config('services.analytics.facebook_id'),
                 'image' => [
                     'url' => asset('images/money-hand.png'),

--- a/app/Http/Controllers/ReferralPageController.php
+++ b/app/Http/Controllers/ReferralPageController.php
@@ -19,15 +19,9 @@ class ReferralPageController extends Controller
             abort(404);
         }
 
+        // Fetch user to display their first name in page metadata.
         $user = gateway('northstar')->getUser('id', $userId);
-
-        if (! $user) {
-            abort(404);
-        }
-
-        $firstName = $user->first_name;
-        $title = 'Do Something Good With '.$firstName.'!';
-        $callToAction = 'Make an impact with '.$firstName.' by completing one of DoSomething\'s volunteer campaigns. (You\'ll both increase your chances of winning the campaign scholarship!)';
+        $title = $user ? 'Do Something Good With '.$user->first_name.'!' : null;
 
         return response()->view('app', [
             'headTitle' => $title,
@@ -35,7 +29,7 @@ class ReferralPageController extends Controller
             // (and refactor get_metadata helper to expect an $entity instead of $campaign)
             'metadata' => [
                 'title' => $title,
-                'description' => $callToAction,
+                'description' => $user ? 'Make an impact with '.$user->first_name.' by completing one of DoSomething\'s volunteer campaigns. (You\'ll both increase your chances of winning the campaign scholarship!)' : null,
                 'facebook_app_id' =>  config('services.analytics.facebook_id'),
                 'image' => [
                     'url' => asset('images/money-hand.png'),

--- a/app/Http/Controllers/ReferralPageController.php
+++ b/app/Http/Controllers/ReferralPageController.php
@@ -13,23 +13,19 @@ class ReferralPageController extends Controller
      */
     public function show(Request $request)
     {
-        $userId = $request->query('user_id');
-
-        if (! $userId) {
-            abort(404);
-        }
-
-        // Fetch user to display their first name in page metadata.
-        $user = gateway('northstar')->getUser('id', $userId);
-        $title = $user ? 'Do Something Good With '.$user->first_name.'!' : null;
-
+        /**
+         * Note: We avoid querying Northstar to display user's first name because the Cypress tests
+         * for this page time out.
+         * @see https://github.com/DoSomething/phoenix-next/pull/1932#issuecomment-587720454
+         */
+        $title = 'Do Something Good With Your Friend!';
         return response()->view('app', [
             'headTitle' => $title,
             // @TODO: Create an $entity object to pass to the get_metadata helper
             // (and refactor get_metadata helper to expect an $entity instead of $campaign)
             'metadata' => [
                 'title' => $title,
-                'description' => $user ? 'Make an impact with '.$user->first_name.' by completing one of DoSomething\'s volunteer campaigns. (You\'ll both increase your chances of winning the campaign scholarship!)' : null,
+                'description' => 'Make an impact with your friend by completing one of DoSomething\'s volunteer campaigns. (You\'ll both increase your chances of winning the campaign scholarship!)',
                 'facebook_app_id' =>  config('services.analytics.facebook_id'),
                 'image' => [
                     'url' => asset('images/money-hand.png'),

--- a/app/Http/Controllers/ReferralPageController.php
+++ b/app/Http/Controllers/ReferralPageController.php
@@ -21,7 +21,12 @@ class ReferralPageController extends Controller
 
         // Fetch user to display their first name in page metadata.
         $user = gateway('northstar')->getUser('id', $userId);
-        $title = $user ? 'Do Something Good With '.$user->first_name.'!' : null;
+
+        if (! $user) {
+            abort(404);
+        }
+
+        $title = 'Do Something Good With '.$user->first_name.'!';
 
         return response()->view('app', [
             'headTitle' => $title,
@@ -29,7 +34,7 @@ class ReferralPageController extends Controller
             // (and refactor get_metadata helper to expect an $entity instead of $campaign)
             'metadata' => [
                 'title' => $title,
-                'description' => $user ? 'Make an impact with '.$user->first_name.' by completing one of DoSomething\'s volunteer campaigns. (You\'ll both increase your chances of winning the campaign scholarship!)' : null,
+                'description' => 'Make an impact with '.$user->first_name.' by completing one of DoSomething\'s volunteer campaigns. (You\'ll both increase your chances of winning the campaign scholarship!)',
                 'facebook_app_id' =>  config('services.analytics.facebook_id'),
                 'image' => [
                     'url' => asset('images/money-hand.png'),

--- a/cypress/integration/beta-referral-page.js
+++ b/cypress/integration/beta-referral-page.js
@@ -1,10 +1,5 @@
 /// <reference types="Cypress" />
 
-/**
- * Note: For now, We're skipping all of these tests because the Beta Referral Page's server-side
- * Northstar request, which is blocking, and causes these tests to timeout.
- * @see https://github.com/DoSomething/phoenix-next/pull/1932
- */
 import { userFactory } from '../fixtures/user';
 import { userId } from '../fixtures/constants';
 import { campaignId } from '../fixtures/constants';
@@ -13,7 +8,7 @@ describe('Beta Referral Page', () => {
   // Configure a new "mock" server before each test:
   beforeEach(() => cy.configureMocks());
 
-  it.skip('Visit beta referral page, with valid user and campaign IDs', () => {
+  it('Visit beta referral page, with valid user and campaign IDs', () => {
     const user = userFactory();
 
     cy.withFeatureFlags({ referral_campaign_ids: [campaignId] }).visit(
@@ -32,7 +27,7 @@ describe('Beta Referral Page', () => {
       .and('include', `referrer_user_id=${userId}`);
   });
 
-  it.skip('Visit beta referral page, with invalid user ID', () => {
+  it('Visit beta referral page, with invalid user ID', () => {
     const user = userFactory();
 
     // Our mock user ID won't exist in dev, we can expect a 404.
@@ -41,14 +36,14 @@ describe('Beta Referral Page', () => {
     cy.contains('Not Found');
   });
 
-  it.skip('Visit beta referral page, with missing user ID', () => {
+  it('Visit beta referral page, with missing user ID', () => {
     cy.visit('/us/join', { failOnStatusCode: false });
 
     // Our mock user ID won't exist in dev, we can expect a 404.
     cy.contains('Not Found');
   });
 
-  it.skip('Visit beta referral page, with valid user ID and no campaign ID', () => {
+  it('Visit beta referral page, with valid user ID and no campaign ID', () => {
     const user = userFactory();
 
     cy.withFeatureFlags({ default_referral_campaign_id: campaignId }).visit(

--- a/cypress/integration/beta-referral-page.js
+++ b/cypress/integration/beta-referral-page.js
@@ -8,7 +8,7 @@ describe('Beta Referral Page', () => {
   // Configure a new "mock" server before each test:
   beforeEach(() => cy.configureMocks());
 
-  it('Visit beta referral page, with valid user and campaign IDs', () => {
+  it('Visit beta referral page, with valid user and campaign ID set', () => {
     const user = userFactory();
 
     cy.withFeatureFlags({ referral_campaign_ids: [campaignId] }).visit(
@@ -27,28 +27,11 @@ describe('Beta Referral Page', () => {
       .and('include', `referrer_user_id=${userId}`);
   });
 
-  // How were these working before?
-  it.skip('Visit beta referral page, with invalid user ID', () => {
-    const user = userFactory();
-
-    // Our mock user ID won't exist in dev, we can expect a 404.
-    cy.visit(`/us/join?user_id=${user.id}}`, { failOnStatusCode: false });
-
-    cy.contains('Not Found');
-  });
-
-  it.skip('Visit beta referral page, with missing user ID', () => {
-    cy.visit('/us/join', { failOnStatusCode: false });
-
-    // Our mock user ID won't exist in dev, we can expect a 404.
-    cy.contains('Not Found');
-  });
-
-  it('Visit beta referral page, with valid user ID and no campaign ID', () => {
+  it('Visit beta referral page, with valid user ID and no campaign ID set', () => {
     const user = userFactory();
 
     cy.withFeatureFlags({ default_referral_campaign_id: campaignId }).visit(
-      `/us/join?user_id=${userId}&campaign_id=${campaignId}`,
+      `/us/join?user_id=${userId}}`,
     );
 
     cy.get('.referral-page-campaign').should('have.length', 1);
@@ -56,5 +39,16 @@ describe('Beta Referral Page', () => {
     cy.get('.referral-page-campaign > a')
       .should('have.attr', 'href')
       .and('include', `referrer_user_id=${userId}`);
+  });
+
+  it('Visit beta referral page, without user ID set', () => {
+    const user = userFactory();
+
+    cy.withFeatureFlags({ default_referral_campaign_id: campaignId }).visit(
+      `/us/join?campaign_id=${campaignId}}`,
+    );
+
+    cy.get('.referral-page-campaign').should('have.length', 0);
+    cy.get('.error-page').should('have.length', 1);
   });
 });

--- a/cypress/integration/beta-referral-page.js
+++ b/cypress/integration/beta-referral-page.js
@@ -27,7 +27,8 @@ describe('Beta Referral Page', () => {
       .and('include', `referrer_user_id=${userId}`);
   });
 
-  it('Visit beta referral page, with invalid user ID', () => {
+  // How were these working before?
+  it.skip('Visit beta referral page, with invalid user ID', () => {
     const user = userFactory();
 
     // Our mock user ID won't exist in dev, we can expect a 404.
@@ -36,7 +37,7 @@ describe('Beta Referral Page', () => {
     cy.contains('Not Found');
   });
 
-  it('Visit beta referral page, with missing user ID', () => {
+  it.skip('Visit beta referral page, with missing user ID', () => {
     cy.visit('/us/join', { failOnStatusCode: false });
 
     // Our mock user ID won't exist in dev, we can expect a 404.

--- a/cypress/integration/beta-referral-page.js
+++ b/cypress/integration/beta-referral-page.js
@@ -1,5 +1,10 @@
 /// <reference types="Cypress" />
 
+/**
+ * Note: For now, We're skipping all of these tests because the Beta Referral Page's server-side
+ * Northstar request, which is blocking, and causes these tests to timeout.
+ * @see https://github.com/DoSomething/phoenix-next/pull/1932
+ */
 import { userFactory } from '../fixtures/user';
 import { userId } from '../fixtures/constants';
 import { campaignId } from '../fixtures/constants';
@@ -8,7 +13,7 @@ describe('Beta Referral Page', () => {
   // Configure a new "mock" server before each test:
   beforeEach(() => cy.configureMocks());
 
-  it('Visit beta referral page, with valid user and campaign IDs', () => {
+  it.skip('Visit beta referral page, with valid user and campaign IDs', () => {
     const user = userFactory();
 
     cy.withFeatureFlags({ referral_campaign_ids: [campaignId] }).visit(
@@ -27,7 +32,7 @@ describe('Beta Referral Page', () => {
       .and('include', `referrer_user_id=${userId}`);
   });
 
-  it('Visit beta referral page, with invalid user ID', () => {
+  it.skip('Visit beta referral page, with invalid user ID', () => {
     const user = userFactory();
 
     // Our mock user ID won't exist in dev, we can expect a 404.
@@ -36,14 +41,14 @@ describe('Beta Referral Page', () => {
     cy.contains('Not Found');
   });
 
-  it('Visit beta referral page, with missing user ID', () => {
+  it.skip('Visit beta referral page, with missing user ID', () => {
     cy.visit('/us/join', { failOnStatusCode: false });
 
     // Our mock user ID won't exist in dev, we can expect a 404.
     cy.contains('Not Found');
   });
 
-  it('Visit beta referral page, with valid user ID and no campaign ID', () => {
+  it.skip('Visit beta referral page, with valid user ID and no campaign ID', () => {
     const user = userFactory();
 
     cy.withFeatureFlags({ default_referral_campaign_id: campaignId }).visit(


### PR DESCRIPTION
### What's this PR do?

This pull request removes the check for a valid user ID from our web `ReferralPageController`, handling a user-not-found error in the `BetaReferralPage` component instead.


### How should this be reviewed?

Visit a beta referral page with an invalid user (`/us/join?user_id=puppet`) and verify the BetaReferralPage component is rendered, displaying an error message.

### Any background context you want to provide?


I was hoping this would help with flaky Cypress timeouts per https://www.pivotaltracker.com/n/projects/2328687/stories/171185760 -- but am I correct in assuming that we still need to query Northstar server-side if we want to directly pass title and description metadata for link sharing purposes?

### Relevant tickets

References [Pivotal #171185760](https://www.pivotaltracker.com/n/projects/2328687/stories/171185760).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added screenshots of front-end changes on small, medium, and large screens.
- [x] Added appropriate feature/unit tests.
