### PR TITLE
Updates the loading state for view more on campaigns/hubs

### DIFF
--- a/resources/assets/components/utilities/PaginatedCampaignGallery/PaginatedCampaignGallery.js
+++ b/resources/assets/components/utilities/PaginatedCampaignGallery/PaginatedCampaignGallery.js
@@ -104,13 +104,13 @@ const PaginatedCampaignGallery = ({
       />
       {hasNextPage ? (
         <div className="p-6 text-center">
-          <Button
-            className="-tertiary"
-            onClick={handleViewMore}
-            disabled={loading}
-          >
-            view more...
-          </Button>
+          {!loading ? (
+            <Button className="-tertiary" onClick={handleViewMore}>
+              view more...
+            </Button>
+          ) : (
+            <Spinner className="flex justify-center" />
+          )}
         </div>
       ) : null}
     </div>


### PR DESCRIPTION
### What's this PR do?

This pull request updates the load state from a disabled button to the loading spinner! Request from the design team to make this a more clear experience for users.

![Kapture 2020-02-18 at 16 57 34](https://user-images.githubusercontent.com/15236023/74781619-c947e100-526f-11ea-8464-42edc26272dd.gif)

### How should this be reviewed?

👀 

### Any background context you want to provide?

Small tweak based on design feedback!

### Relevant tickets

References [Pivotal # 170823582](https://www.pivotaltracker.com/story/show/170823582).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added screenshots of front-end changes on small, medium, and large screens.
- [ ] Added appropriate feature/unit tests.
