### PR TITLE
Landing Page cleanup

### DIFF
--- a/docs/development/content-types/landing-page.md
+++ b/docs/development/content-types/landing-page.md
@@ -10,6 +10,4 @@ The landing page displayed on a [campaign](development/content-types/campaign.md
 
 - **Content** : A Rich Text field, which can embed `contentBlock`, `imagesBlock`, and `linkAction` entries.
 
-- **Sidebar** : A multi-value reference field, only displayed on the legacy campaign template.
-
-- **Additonal Content** : The legacy campaign template uses this field to display Landing Page content, expecting a `legacyTemplateContent` property.
+- **Additional Content** : The legacy campaign template uses this field to display Landing Page content, expecting a `legacyTemplateContent` property.

--- a/resources/assets/components/pages/LandingPage/LandingPage.js
+++ b/resources/assets/components/pages/LandingPage/LandingPage.js
@@ -87,7 +87,7 @@ const LandingPage = props => {
             <div className="md:w-3/4 mx-auto py-6 px-3 pitch-landing-page">
               <div className="campaign-page__content clearfix">
                 <div className="primary">
-                  <TextContent>{content}</TextContent>
+                  {content ? <TextContent>{content}</TextContent> : null}
                 </div>
               </div>
             </div>


### PR DESCRIPTION
### What's this PR do?

This pull request fixes a `Failed prop type` warning triggered when a `LandingPage` component doesn't have a `content` field value set, and adds documentation updates that were missing over in #1931

### How should this be reviewed?

👀 

### Any background context you want to provide?

📖 

### Relevant tickets

References [Pivotal #170735375](https://www.pivotaltracker.com/n/projects/2401401/stories/170735375).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [x] Documentation added for new features/changed endpoints.
