### PR TITLE
Remove usage of Lorempixel in tests to fix timeouts.

### DIFF
--- a/cypress/fixtures/graphql.js
+++ b/cypress/fixtures/graphql.js
@@ -51,7 +51,7 @@ export const operations = {
       title: faker.lorem.words(),
       description: faker.lorem.sentence(),
       providerName: faker.company.companyName(),
-      thumbnailUrl: faker.image.imageUrl(),
+      thumbnailUrl: '/apple-touch-icon.png',
       html: null,
     },
   },

--- a/cypress/integration/beta-referral-page.js
+++ b/cypress/integration/beta-referral-page.js
@@ -9,12 +9,8 @@ describe('Beta Referral Page', () => {
   beforeEach(() => cy.configureMocks());
 
   it('Visit beta referral page, with valid user and campaign ID set', () => {
-    const user = userFactory();
-
     cy.withFeatureFlags({ referral_campaign_ids: [campaignId] }).visit(
       `/us/join?user_id=${userId}&campaign_id=${campaignId}`,
-      // Allow some extra time to prevent timeouts on initial page load:
-      { timeout: 10000 },
     );
 
     cy.contains('campaign scholarship');
@@ -28,8 +24,6 @@ describe('Beta Referral Page', () => {
   });
 
   it('Visit beta referral page, with valid user ID and no campaign ID set', () => {
-    const user = userFactory();
-
     cy.withFeatureFlags({ default_referral_campaign_id: campaignId }).visit(
       `/us/join?user_id=${userId}}`,
     );
@@ -42,8 +36,6 @@ describe('Beta Referral Page', () => {
   });
 
   it('Visit beta referral page, without user ID set', () => {
-    const user = userFactory();
-
     cy.withFeatureFlags({ default_referral_campaign_id: campaignId }).visit(
       `/us/join?campaign_id=${campaignId}}`,
     );


### PR DESCRIPTION
### What's this PR do?

This pull request swaps this usage of `faker.image.imageUrl` (which gives a random [lorempixel](http://lorempixel.com) URL) to a static image on our local web server. When this third-party service was down (like it is now), it could cause any tests that include an Embed component to time out.

### How should this be reviewed?

Tests should pass without timing out!

### Any background context you want to provide?

This seems to be a [known recurring issue](https://git.io/JvRvW) with this service.

### Relevant tickets

References [Pivotal #171185760](https://www.pivotaltracker.com/story/show/171185760).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added screenshots of front-end changes on small, medium, and large screens.
- [ ] Added appropriate feature/unit tests.
