### PR TITLE
Fix issue rendering campaign's `/modal/:id` route.

### DIFF
--- a/resources/assets/components/utilities/Modal/modal.scss
+++ b/resources/assets/components/utilities/Modal/modal.scss
@@ -1,5 +1,11 @@
 @import '../../../scss/next-toolbox.scss';
 
+// HACK: If a Content Block is found inside a "modal" without an
+// image, we want to force it to full-width so it looks normal.
+.modal .hack-article-content-widths {
+  grid-column: span 3 / span 3 !important;
+}
+
 .modal-portal {
   background-color: rgba(34, 34, 34, 0.9);
   display: none;

--- a/resources/assets/components/utilities/ModalRoute/ModalRoute.js
+++ b/resources/assets/components/utilities/ModalRoute/ModalRoute.js
@@ -7,7 +7,7 @@ import { StaticRouter } from 'react-router';
 import ReactRouterPropTypes from 'react-router-prop-types';
 
 import Modal from '../Modal/Modal';
-import ContentfulEntryContainer from '../../ContentfulEntry/ContentfulEntryContainer';
+import ContentfulEntryLoader from '../ContentfulEntryLoader/ContentfulEntryLoader';
 
 // Helpers:
 const isModal = location => location.pathname.includes('/modal/');
@@ -47,7 +47,9 @@ class ModalRoute extends React.Component {
           path={`${match.url}/modal/:id`}
           render={routingProps => (
             <Modal onClose={() => history.push(this.previousLocation)}>
-              <ContentfulEntryContainer id={routingProps.match.params.id} />
+              <ContentfulEntryLoader
+                id={routingProps.match.params.id}
+              />
             </Modal>
           )}
         />

--- a/resources/assets/components/utilities/ModalRoute/ModalRoute.js
+++ b/resources/assets/components/utilities/ModalRoute/ModalRoute.js
@@ -49,6 +49,7 @@ class ModalRoute extends React.Component {
             <Modal onClose={() => history.push(this.previousLocation)}>
               <ContentfulEntryLoader
                 id={routingProps.match.params.id}
+                classNameByEntry={{ ContentBlock: 'bg-white rounded p-6' }}
               />
             </Modal>
           )}


### PR DESCRIPTION
### What's this PR do?

This pull request fixes [an issue](https://www.pivotaltracker.com/story/show/171369910) rendering the campaign's `/modal/:id` route.

![Screen Shot 2020-02-20 at 1 29 55 PM](https://user-images.githubusercontent.com/583202/74966616-5fe9de80-53e5-11ea-8fc1-7b236924898c.png)

Here's how this looks on [medium devices](https://user-images.githubusercontent.com/583202/74966785-c40ca280-53e5-11ea-9d25-9010fc43e921.png) and [small devices](https://user-images.githubusercontent.com/583202/74966795-c8d15680-53e5-11ea-8359-9bc8fca47f49.png).

### How should this be reviewed?

👀

### Any background context you want to provide?

I'd like to give more thought to how we handle this in the future (such as what to do about things like `ContentBlock` that have transparent backgrounds or uneven sizes), but this fixes up the immediate problem!

### Relevant tickets

References [Pivotal #171369910](https://www.pivotaltracker.com/story/show/171369910).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added screenshots of front-end changes on small, medium, and large screens.
- [ ] Added appropriate feature/unit tests.
