### PR TITLE
Homepage content type updates

### DIFF
--- a/contentful/content-types/homePage.js
+++ b/contentful/content-types/homePage.js
@@ -4,48 +4,122 @@ module.exports = function(migration) {
     .name('Home Page')
     .description('The Home Page for DoSomething.org.')
     .displayField('internalTitle');
-
   homePage
     .createField('internalTitle')
     .name('Internal Title')
     .type('Symbol')
+    .localized(false)
     .required(true)
-    .localized(false);
-
+    .validations([])
+    .disabled(false)
+    .omitted(false);
   homePage
     .createField('title')
     .name('Title')
     .type('Symbol')
+    .localized(true)
     .required(true)
-    .localized(true);
-
+    .validations([])
+    .disabled(false)
+    .omitted(false);
   homePage
     .createField('subTitle')
     .name('Subtitle')
     .type('Symbol')
+    .localized(true)
     .required(true)
-    .localized(true);
+    .validations([])
+    .disabled(false)
+    .omitted(false);
 
   homePage
     .createField('blocks')
     .name('Blocks')
     .type('Array')
+    .localized(false)
+    .required(true)
+    .validations([])
+    .disabled(false)
+    .omitted(false)
     .items({
       type: 'Link',
-      linkType: 'Entry',
+
       validations: [
         {
           linkContentType: ['campaign', 'page', 'storyPage'],
         },
       ],
-    })
-    .required(true)
-    .localized(false);
+
+      linkType: 'Entry',
+    });
+
+  homePage
+    .createField('campaigns')
+    .name('Campaigns')
+    .type('Array')
+    .localized(false)
+    .required(false)
+    .validations([])
+    .disabled(false)
+    .omitted(false)
+    .items({
+      type: 'Link',
+
+      validations: [
+        {
+          linkContentType: ['campaign', 'storyPage'],
+          message: 'Only Campaign and StoryPage entries are valid.',
+        },
+      ],
+
+      linkType: 'Entry',
+    });
+
+  homePage
+    .createField('articles')
+    .name('Articles')
+    .type('Array')
+    .localized(false)
+    .required(false)
+    .validations([])
+    .disabled(false)
+    .omitted(false)
+    .items({
+      type: 'Link',
+
+      validations: [
+        {
+          linkContentType: ['page'],
+        },
+      ],
+
+      linkType: 'Entry',
+    });
 
   homePage
     .createField('additionalContent')
     .name('Additional Content')
     .type('Object')
+    .localized(false)
     .required(false)
-    .localized(false);
+    .validations([])
+    .disabled(false)
+    .omitted(false);
+  homePage.changeEditorInterface('internalTitle', 'singleLine', {});
+  homePage.changeEditorInterface('title', 'singleLine', {});
+  homePage.changeEditorInterface('subTitle', 'singleLine', {});
+
+  homePage.changeEditorInterface('blocks', 'entryLinksEditor', {
+    bulkEditing: false,
+  });
+
+  homePage.changeEditorInterface('campaigns', 'entryLinksEditor', {
+    bulkEditing: false,
+  });
+
+  homePage.changeEditorInterface('articles', 'entryLinksEditor', {
+    bulkEditing: false,
+  });
+
+  homePage.changeEditorInterface('additionalContent', 'objectEditor', {});
 };

--- a/contentful/content-types/homePage.js
+++ b/contentful/content-types/homePage.js
@@ -114,10 +114,13 @@ module.exports = function(migration) {
   });
 
   homePage.changeEditorInterface('campaigns', 'entryLinksEditor', {
+    helpText:
+      'Add campaigns (Campaign or StoryPage entries) to showcase on the home page.',
     bulkEditing: false,
   });
 
   homePage.changeEditorInterface('articles', 'entryLinksEditor', {
+    helpText: 'Add articles (Page entries) to showcase on the home page.',
     bulkEditing: false,
   });
 


### PR DESCRIPTION
### What's this PR do?

This pull request updates the Contentful `HomePage` content type to include two new reference fields; one for campaigns and one for articles. This is for the upcoming Home Page updates.

### How should this be reviewed?

Instead of repurposing the `blocks` fields, we felt it would be better to just add the two new fields so that the HomePage can still behave as expected for the old design and easily use feature flags to handle the new design and the supplied content in these new fields.

### Relevant tickets

References [Pivotal #171056257](https://www.pivotaltracker.com/story/show/171056257).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
