### PR TITLE
Update Campaign Info Bar Help Link

### DIFF
--- a/app/Entities/Campaign.php
+++ b/app/Entities/Campaign.php
@@ -57,7 +57,7 @@ class Campaign extends Entity implements JsonSerializable
         }
 
         // @TODO (2018-08-29): we should do away with this additional content item.
-        $email = $additionalContent['campaignLead']['email'] ?? 'campaignshelp@dosomething.org';
+        $email = $additionalContent['campaignLead']['email'] ?? 'campaignhelp@dosomething.org';
         $name = $additionalContent['campaignLead']['name'] ?? 'Us';
 
         return [

--- a/app/Entities/Campaign.php
+++ b/app/Entities/Campaign.php
@@ -57,7 +57,7 @@ class Campaign extends Entity implements JsonSerializable
         }
 
         // @TODO (2018-08-29): we should do away with this additional content item.
-        $email = $additionalContent['campaignLead']['email'] ?? 'help@dosomething.org';
+        $email = $additionalContent['campaignLead']['email'] ?? 'campaignshelp@dosomething.org';
         $name = $additionalContent['campaignLead']['name'] ?? 'Us';
 
         return [

--- a/cypress/integration/campaign-info-bar.js
+++ b/cypress/integration/campaign-info-bar.js
@@ -15,24 +15,19 @@ describe('Campaign Info Bar', () => {
   });
 
   context('Unaffiliated users', () => {
-    it("Displays a mailto link to the campaign lead's email address", () => {
-      const campaignLeadEmail =
-        exampleCampaign.campaign.campaignLead.fields.email;
+    it('Displays a link to the help center', () => {
+      cy.anonVisitCampaign(exampleCampaign);
 
-      cy.withState(exampleCampaign).visit(
-        '/us/campaigns/test-example-campaign',
+      cy.get('.info-bar .info-bar__secondary a').contains(
+        'Visit our Help Center',
       );
-
-      cy.get('.info-bar .info-bar__secondary a')
-        .should('have.attr', 'href')
-        .and('include', `mailto:${campaignLeadEmail}`);
     });
   });
 
   context('Affiliated users', () => {
     it('Displays a button triggering the Zendesk Form in a modal', () => {
       const user = userFactory();
-      cy.authVisitCampaignWithSignup(user, exampleCampaign);
+      cy.authVisitCampaignWithoutSignup(user, exampleCampaign);
 
       cy.get('.info-bar .info-bar__secondary button')
         .contains('button', 'Contact Us')

--- a/cypress/integration/campaign-info-bar.js
+++ b/cypress/integration/campaign-info-bar.js
@@ -14,17 +14,20 @@ describe('Campaign Info Bar', () => {
     cy.get('.info-bar').should('contain', affiliateTitle);
   });
 
-  context('Unaffiliated users', () => {
-    it('Displays a link to the help center', () => {
+  context('Unauthenticated users', () => {
+    it("Displays a mailto link to the campaign lead's email address", () => {
+      const campaignLeadEmail =
+        exampleCampaign.campaign.campaignLead.fields.email;
+
       cy.anonVisitCampaign(exampleCampaign);
 
-      cy.get('.info-bar .info-bar__secondary a').contains(
-        'Visit our Help Center',
-      );
+      cy.get('.info-bar .info-bar__secondary a')
+        .should('have.attr', 'href')
+        .and('include', `mailto:${campaignLeadEmail}`);
     });
   });
 
-  context('Affiliated users', () => {
+  context('Authenticated users', () => {
     it('Displays a button triggering the Zendesk Form in a modal', () => {
       const user = userFactory();
       cy.authVisitCampaignWithoutSignup(user, exampleCampaign);

--- a/cypress/integration/zendesk-form.js
+++ b/cypress/integration/zendesk-form.js
@@ -5,40 +5,56 @@ import exampleCampaign from '../fixtures/contentful/exampleCampaign';
 const QUESTION = 'causeyhippo';
 
 describe('Zendesk Modal', () => {
-  beforeEach(() => {
-    cy.configureMocks();
+  context('Unauthenticated users', () => {
+    beforeEach(() => {
+      cy.configureMocks();
+    });
 
-    const user = userFactory();
-    cy.authVisitCampaignWithSignup(user, exampleCampaign);
+    it('Displays a link to the help center', () => {
+      cy.anonVisitCampaign(exampleCampaign);
 
-    cy.get('.info-bar .info-bar__secondary button')
-      .contains('button', 'Contact Us')
-      .click();
-
-    cy.get('.modal .zendesk-form').contains('h1', 'Contact Us');
-    cy.get('a.zendesk-form__faqs-link')
-      .should('have.attr', 'href')
-      .and('include', `/us/campaigns/${exampleCampaign.campaign.slug}/faqs`);
+      cy.get('.info-bar .info-bar__secondary a').contains(
+        'Visit our Help Center',
+      );
+    });
   });
 
-  it('Submits a question successfully and displays affirmation', () => {
-    cy.route('POST', '/api/v2/zendesk-tickets', []);
+  context('Authenticated users', () => {
+    beforeEach(() => {
+      cy.configureMocks();
 
-    cy.get('.zendesk-form textarea').type(QUESTION);
+      const user = userFactory();
+      cy.authVisitCampaignWithoutSignup(user, exampleCampaign);
 
-    cy.get('.zendesk-form button').click();
+      cy.get('.info-bar .info-bar__secondary button')
+        .contains('button', 'Contact Us')
+        .click();
 
-    cy.get('.zendesk-form h1').contains('Thank You');
-  });
+      cy.get('.modal .zendesk-form').contains('h1', 'Contact Us');
+      cy.get('a.zendesk-form__faqs-link')
+        .should('have.attr', 'href')
+        .and('include', `/us/campaigns/${exampleCampaign.campaign.slug}/faqs`);
+    });
 
-  it('Submits a question unsuccessfully and displays error message', () => {
-    cy.route({ method: 'POST', url: '/api/v2/zendesk-tickets', status: 500 });
+    it('Submits a question successfully and displays affirmation', () => {
+      cy.route('POST', '/api/v2/zendesk-tickets', []);
 
-    cy.get('.zendesk-form textarea').type(QUESTION);
-    cy.get('.zendesk-form button').click();
+      cy.get('.zendesk-form textarea').type(QUESTION);
 
-    cy.get('.zendesk-form h1').contains('Contact Us');
-    cy.get('.zendesk-form').contains('Something went wrong!');
-    cy.get('.zendesk-form textarea').contains(QUESTION);
+      cy.get('.zendesk-form button').click();
+
+      cy.get('.zendesk-form h1').contains('Thank You');
+    });
+
+    it('Submits a question unsuccessfully and displays error message', () => {
+      cy.route({ method: 'POST', url: '/api/v2/zendesk-tickets', status: 500 });
+
+      cy.get('.zendesk-form textarea').type(QUESTION);
+      cy.get('.zendesk-form button').click();
+
+      cy.get('.zendesk-form h1').contains('Contact Us');
+      cy.get('.zendesk-form').contains('Something went wrong!');
+      cy.get('.zendesk-form textarea').contains(QUESTION);
+    });
   });
 });

--- a/cypress/integration/zendesk-form.js
+++ b/cypress/integration/zendesk-form.js
@@ -5,56 +5,40 @@ import exampleCampaign from '../fixtures/contentful/exampleCampaign';
 const QUESTION = 'causeyhippo';
 
 describe('Zendesk Modal', () => {
-  context('Unauthenticated users', () => {
-    beforeEach(() => {
-      cy.configureMocks();
-    });
+  beforeEach(() => {
+    cy.configureMocks();
 
-    it('Displays a link to the help center', () => {
-      cy.anonVisitCampaign(exampleCampaign);
+    const user = userFactory();
+    cy.authVisitCampaignWithoutSignup(user, exampleCampaign);
 
-      cy.get('.info-bar .info-bar__secondary a').contains(
-        'Visit our Help Center',
-      );
-    });
+    cy.get('.info-bar .info-bar__secondary button')
+      .contains('button', 'Contact Us')
+      .click();
+
+    cy.get('.modal .zendesk-form').contains('h1', 'Contact Us');
+    cy.get('a.zendesk-form__faqs-link')
+      .should('have.attr', 'href')
+      .and('include', `/us/campaigns/${exampleCampaign.campaign.slug}/faqs`);
   });
 
-  context('Authenticated users', () => {
-    beforeEach(() => {
-      cy.configureMocks();
+  it('Submits a question successfully and displays affirmation', () => {
+    cy.route('POST', '/api/v2/zendesk-tickets', []);
 
-      const user = userFactory();
-      cy.authVisitCampaignWithoutSignup(user, exampleCampaign);
+    cy.get('.zendesk-form textarea').type(QUESTION);
 
-      cy.get('.info-bar .info-bar__secondary button')
-        .contains('button', 'Contact Us')
-        .click();
+    cy.get('.zendesk-form button').click();
 
-      cy.get('.modal .zendesk-form').contains('h1', 'Contact Us');
-      cy.get('a.zendesk-form__faqs-link')
-        .should('have.attr', 'href')
-        .and('include', `/us/campaigns/${exampleCampaign.campaign.slug}/faqs`);
-    });
+    cy.get('.zendesk-form h1').contains('Thank You');
+  });
 
-    it('Submits a question successfully and displays affirmation', () => {
-      cy.route('POST', '/api/v2/zendesk-tickets', []);
+  it('Submits a question unsuccessfully and displays error message', () => {
+    cy.route({ method: 'POST', url: '/api/v2/zendesk-tickets', status: 500 });
 
-      cy.get('.zendesk-form textarea').type(QUESTION);
+    cy.get('.zendesk-form textarea').type(QUESTION);
+    cy.get('.zendesk-form button').click();
 
-      cy.get('.zendesk-form button').click();
-
-      cy.get('.zendesk-form h1').contains('Thank You');
-    });
-
-    it('Submits a question unsuccessfully and displays error message', () => {
-      cy.route({ method: 'POST', url: '/api/v2/zendesk-tickets', status: 500 });
-
-      cy.get('.zendesk-form textarea').type(QUESTION);
-      cy.get('.zendesk-form button').click();
-
-      cy.get('.zendesk-form h1').contains('Contact Us');
-      cy.get('.zendesk-form').contains('Something went wrong!');
-      cy.get('.zendesk-form textarea').contains(QUESTION);
-    });
+    cy.get('.zendesk-form h1').contains('Contact Us');
+    cy.get('.zendesk-form').contains('Something went wrong!');
+    cy.get('.zendesk-form textarea').contains(QUESTION);
   });
 });

--- a/docs/development/features/zendesk-form.md
+++ b/docs/development/features/zendesk-form.md
@@ -10,7 +10,7 @@ The form submits via the internal `api/v2/zendesk-tickets` API which creates a n
 
 Render the `<ZendeskFormContainer/>` component from any page with a valid `campaign` in Redux state.
 
-Be sure to render the `ZendeskFormContainer` conditionally for affiliated users, since the zendesk tickets endpoint is gated and requires an authenticated user. Additionally, we prefer to only render the form for users signed up for the campaign.
+Be sure to render the `ZendeskFormContainer` conditionally for authenticated users, since the zendesk tickets endpoint is gated and requires an authenticated user.
 
 {% hint style="info" %}
 If testing the Zendesk form, use 'causeyhippo' as the question text which will trigger an automatic resolve and categorization over in our Zendesk space.

--- a/resources/assets/components/CampaignInfoBar/CampaignInfoBar.js
+++ b/resources/assets/components/CampaignInfoBar/CampaignInfoBar.js
@@ -68,7 +68,7 @@ CampaignInfoBar.defaultProps = {
   affiliateSponsors: [],
   affiliatePartners: [],
   campaignTitle: 'Campaign',
-  contactEmail: 'campaignshelp@dosomething.org',
+  contactEmail: 'campaignhelp@dosomething.org',
 };
 
 export default CampaignInfoBar;

--- a/resources/assets/components/CampaignInfoBar/CampaignInfoBar.js
+++ b/resources/assets/components/CampaignInfoBar/CampaignInfoBar.js
@@ -1,7 +1,6 @@
 import PropTypes from 'prop-types';
 import React, { useState } from 'react';
 
-import { HELP_LINK } from '../../constants';
 import Modal from '../utilities/Modal/Modal';
 import { isAuthenticated } from '../../helpers/auth';
 import AffiliateCredits from '../utilities/AffiliateCredits/AffiliateCredits';
@@ -11,6 +10,7 @@ const CampaignInfoBar = ({
   affiliateCreditText,
   affiliateSponsors,
   affiliatePartners,
+  contactEmail,
 }) => {
   const [showZendeskModal, setShowZendeskModal] = useState(false);
 
@@ -40,9 +40,7 @@ const CampaignInfoBar = ({
               Contact Us
             </button>
           ) : (
-            <a href={HELP_LINK} target="_blank" rel="noopener noreferrer">
-              Visit our Help Center
-            </a>
+            <a href={`mailto:${contactEmail}`}>Contact {contactEmail}</a>
           )}
         </div>
       </div>
@@ -54,12 +52,14 @@ CampaignInfoBar.propTypes = {
   affiliateCreditText: PropTypes.string,
   affiliateSponsors: PropTypes.arrayOf(PropTypes.object),
   affiliatePartners: PropTypes.arrayOf(PropTypes.object),
+  contactEmail: PropTypes.string,
 };
 
 CampaignInfoBar.defaultProps = {
   affiliateCreditText: undefined,
   affiliateSponsors: [],
   affiliatePartners: [],
+  contactEmail: 'campaignshelp@dosomething.org',
 };
 
 export default CampaignInfoBar;

--- a/resources/assets/components/CampaignInfoBar/CampaignInfoBar.js
+++ b/resources/assets/components/CampaignInfoBar/CampaignInfoBar.js
@@ -10,6 +10,7 @@ const CampaignInfoBar = ({
   affiliateCreditText,
   affiliateSponsors,
   affiliatePartners,
+  campaignTitle,
   contactEmail,
 }) => {
   const [showZendeskModal, setShowZendeskModal] = useState(false);
@@ -40,7 +41,13 @@ const CampaignInfoBar = ({
               Contact Us
             </button>
           ) : (
-            <a href={`mailto:${contactEmail}`}>Contact {contactEmail}</a>
+            <a
+              href={encodeURI(
+                `mailto:${contactEmail}?subject=Question About ${campaignTitle}`,
+              )}
+            >
+              Contact {contactEmail}
+            </a>
           )}
         </div>
       </div>
@@ -52,6 +59,7 @@ CampaignInfoBar.propTypes = {
   affiliateCreditText: PropTypes.string,
   affiliateSponsors: PropTypes.arrayOf(PropTypes.object),
   affiliatePartners: PropTypes.arrayOf(PropTypes.object),
+  campaignTitle: PropTypes.string,
   contactEmail: PropTypes.string,
 };
 
@@ -59,6 +67,7 @@ CampaignInfoBar.defaultProps = {
   affiliateCreditText: undefined,
   affiliateSponsors: [],
   affiliatePartners: [],
+  campaignTitle: 'Campaign',
   contactEmail: 'campaignshelp@dosomething.org',
 };
 

--- a/resources/assets/components/CampaignInfoBar/CampaignInfoBar.js
+++ b/resources/assets/components/CampaignInfoBar/CampaignInfoBar.js
@@ -46,7 +46,7 @@ const CampaignInfoBar = ({
                 `mailto:${contactEmail}?subject=Question About ${campaignTitle}`,
               )}
             >
-              Contact {contactEmail}
+              Email Us
             </a>
           )}
         </div>

--- a/resources/assets/components/CampaignInfoBar/CampaignInfoBar.js
+++ b/resources/assets/components/CampaignInfoBar/CampaignInfoBar.js
@@ -1,7 +1,9 @@
 import PropTypes from 'prop-types';
 import React, { useState } from 'react';
 
+import { HELP_LINK } from '../../constants';
 import Modal from '../utilities/Modal/Modal';
+import { isAuthenticated } from '../../helpers/auth';
 import AffiliateCredits from '../utilities/AffiliateCredits/AffiliateCredits';
 import ZendeskFormContainer from '../utilities/ZendeskForm/ZendeskFormContainer';
 
@@ -9,8 +11,6 @@ const CampaignInfoBar = ({
   affiliateCreditText,
   affiliateSponsors,
   affiliatePartners,
-  contactEmail,
-  isAffiliated,
 }) => {
   const [showZendeskModal, setShowZendeskModal] = useState(false);
 
@@ -31,7 +31,7 @@ const CampaignInfoBar = ({
 
         <div className="info-bar__secondary">
           Questions?{' '}
-          {isAffiliated ? (
+          {isAuthenticated() ? (
             <button
               type="button"
               className="underline"
@@ -40,7 +40,9 @@ const CampaignInfoBar = ({
               Contact Us
             </button>
           ) : (
-            <a href={`mailto:${contactEmail}`}>Contact {contactEmail}</a>
+            <a href={HELP_LINK} target="_blank" rel="noopener noreferrer">
+              Visit our Help Center
+            </a>
           )}
         </div>
       </div>
@@ -52,16 +54,12 @@ CampaignInfoBar.propTypes = {
   affiliateCreditText: PropTypes.string,
   affiliateSponsors: PropTypes.arrayOf(PropTypes.object),
   affiliatePartners: PropTypes.arrayOf(PropTypes.object),
-  contactEmail: PropTypes.string,
-  isAffiliated: PropTypes.bool,
 };
 
 CampaignInfoBar.defaultProps = {
   affiliateCreditText: undefined,
   affiliateSponsors: [],
   affiliatePartners: [],
-  contactEmail: 'help@dosomething.org',
-  isAffiliated: false,
 };
 
 export default CampaignInfoBar;

--- a/resources/assets/components/CampaignInfoBar/CampaignInfoBarContainer.js
+++ b/resources/assets/components/CampaignInfoBar/CampaignInfoBarContainer.js
@@ -12,6 +12,7 @@ const mapStateToProps = state => {
     ),
     affiliateSponsors: state.campaign.affiliateSponsors,
     affiliatePartners: state.campaign.affiliatePartners,
+    contactEmail: get(state, 'campaign.campaignLead.fields.email', undefined),
   };
 };
 

--- a/resources/assets/components/CampaignInfoBar/CampaignInfoBarContainer.js
+++ b/resources/assets/components/CampaignInfoBar/CampaignInfoBarContainer.js
@@ -2,7 +2,6 @@ import { get } from 'lodash';
 import { connect } from 'react-redux';
 
 import CampaignInfoBar from './CampaignInfoBar';
-import { isSignedUp } from '../../selectors/signup';
 
 const mapStateToProps = state => {
   return {
@@ -13,8 +12,6 @@ const mapStateToProps = state => {
     ),
     affiliateSponsors: state.campaign.affiliateSponsors,
     affiliatePartners: state.campaign.affiliatePartners,
-    contactEmail: get(state, 'campaign.campaignLead.fields.email', undefined),
-    isAffiliated: isSignedUp(state),
   };
 };
 

--- a/resources/assets/components/CampaignInfoBar/CampaignInfoBarContainer.js
+++ b/resources/assets/components/CampaignInfoBar/CampaignInfoBarContainer.js
@@ -13,6 +13,7 @@ const mapStateToProps = state => {
     affiliateSponsors: state.campaign.affiliateSponsors,
     affiliatePartners: state.campaign.affiliatePartners,
     contactEmail: get(state, 'campaign.campaignLead.fields.email', undefined),
+    campaignTitle: get(state, 'campaign.title'),
   };
 };
 

--- a/resources/assets/selectors/campaign.js
+++ b/resources/assets/selectors/campaign.js
@@ -42,7 +42,7 @@ export function getCampaignFaqsPath(state) {
   // Find the FAQs page & grab its slug value.
   const faqsSlug = get(
     state.campaign.pages.find(page =>
-      get(page, 'fields.slug', '').endsWith('/faqs'),
+      get(page, 'fields.slug', '').match(/faqs?$/),
     ),
     'fields.slug',
   );


### PR DESCRIPTION
### What's this PR do?

This pull request updates the help link in our `CampaignInfoBar` component to show a link to the Help Center for unauthenticated users (instead of the mailto link to the campaign lead), and the Zendesk Form link for authenticated users (instead of only _signed up_ users.)

UPDATE: We're keeping the mailto link to campaigns leads, but appending a Subject Line with the campaign title so we can better categorize these messages on Zendesk.

We've also added a new default email help address.

https://github.com/DoSomething/phoenix-next/commit/a2b8b5738a436c8f93e6a8dfd6918992b6230d00 updates the function to find the campaign's FAQs page to also look for `.../faq` (without the trailing S) since we have instances of both (sigh). ([See example from Slack](https://dosomething.slack.com/archives/C03T8SDLY/p1581112677007400?thread_ts=1580920284.003800&cid=C03T8SDLY))

### How should this be reviewed?
👁 
How's the new copy?

### Any background context you want to provide?
As per feedback from Hannah for what the best and most helpful flow is! This will ~prevent an influx of avoidable questions while increasing~ increase the flow of categorized questions via our Zendesk API.


### Relevant tickets

References [Pivotal #171202296](https://www.pivotaltracker.com/story/show/171202296).
https://dosomething.slack.com/archives/C03T8SDLY/p1581112677007400?thread_ts=1580920284.003800&cid=C03T8SDLY

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [x] Documentation added for new features/changed endpoints.
- [x] Added screenshots of front-end changes on large screens.
- [x] Added appropriate feature/unit tests.


![image](https://user-images.githubusercontent.com/12417657/75376908-d5025b80-589e-11ea-89dc-75828cadbfb9.png)
![image](https://user-images.githubusercontent.com/12417657/75387905-05072a00-58b2-11ea-995f-5d603e380737.png)

