### PR TITLE
Deprecate Legacy Generated Campaign Lead

### DIFF
--- a/app/Entities/Campaign.php
+++ b/app/Entities/Campaign.php
@@ -42,38 +42,18 @@ class Campaign extends Entity implements JsonSerializable
     }
 
     /**
-     * Parse the campaign lead from other
+     * Parse the campaign lead
      *
      * @param  Entry $campaignlead
-     * @param  array $additionalContent
      * @return array
      */
-    public function parseCampaignLead($campaignlead, $additionalContent)
+    public function parseCampaignLead($campaignlead)
     {
         if ($campaignlead) {
             // @TODO (2018-09-13): We should make the CampaignLead field required and thus
             // no longer need a conditional check here.
             return  new Person($campaignlead->entry);
         }
-
-        // @TODO (2018-08-29): we should do away with this additional content item.
-        $email = $additionalContent['campaignLead']['email'] ?? 'campaignhelp@dosomething.org';
-        $name = $additionalContent['campaignLead']['name'] ?? 'Us';
-
-        return [
-            'id' => str_random(22),
-            'type' => 'person',
-            'fields' => [
-                'name' => $name,
-                'type' => 'staff',
-                'active' => true,
-                'jobTitle' => null,
-                'email' => $email,
-                'photo' => null,
-                'alternatePhoto' => null,
-                'description' => null,
-            ],
-        ];
     }
 
     /**
@@ -138,7 +118,7 @@ class Campaign extends Entity implements JsonSerializable
                 'url' => get_image_url($this->coverImage),
                 'landscapeUrl' => get_image_url($this->coverImage, 'landscape'),
             ],
-            'campaignLead' => $this->parseCampaignLead($this->campaignLead, $this->additionalContent),
+            'campaignLead' => $this->parseCampaignLead($this->campaignLead),
             'affiliateSponsors' => $this->parseAffiliates($this->affiliateSponsors),
             'affiliatePartners' => $this->parseAffiliates($this->affiliatePartners),
             'quizzes' => $this->parseQuizzes($this->quizzes),

--- a/resources/assets/components/Campaign/CampaignRoute/CampaignRoute.js
+++ b/resources/assets/components/Campaign/CampaignRoute/CampaignRoute.js
@@ -17,11 +17,7 @@ import CampaignPageContainer from '../../pages/CampaignPage/CampaignPageContaine
 
 const CampaignRoute = props => {
   const {
-    affiliateCreditText,
-    affiliatePartners,
-    affiliateSponsors,
     affirmation,
-    campaignLead,
     clickedHideAffirmation,
     endDate,
     hasCommunityPage,
@@ -70,15 +66,7 @@ const CampaignRoute = props => {
                 );
               }
 
-              return (
-                <CampaignClosedPage
-                  endDate={props.endDate}
-                  affiliateCreditText={affiliateCreditText}
-                  affiliatePartners={affiliatePartners}
-                  affiliateSponsors={affiliateSponsors}
-                  campaignLead={campaignLead}
-                />
-              );
+              return <CampaignClosedPage endDate={props.endDate} />;
             }
 
             if (!isClosed && isSignedUp) {
@@ -146,14 +134,7 @@ const CampaignRoute = props => {
 };
 
 CampaignRoute.propTypes = {
-  affiliateCreditText: PropTypes.string,
-  affiliatePartners: PropTypes.arrayOf(PropTypes.object),
-  affiliateSponsors: PropTypes.arrayOf(PropTypes.object),
   affirmation: PropTypes.object.isRequired,
-  campaignLead: PropTypes.shape({
-    name: PropTypes.string,
-    email: PropTypes.string,
-  }),
   clickedHideAffirmation: PropTypes.func.isRequired,
   endDate: PropTypes.string,
   hasCommunityPage: PropTypes.bool.isRequired,
@@ -165,10 +146,6 @@ CampaignRoute.propTypes = {
 };
 
 CampaignRoute.defaultProps = {
-  affiliateCreditText: undefined,
-  affiliatePartners: [],
-  affiliateSponsors: [],
-  campaignLead: {},
   endDate: null,
   landingPage: {},
 };

--- a/resources/assets/components/Campaign/CampaignRoute/CampaignRouteContainer.js
+++ b/resources/assets/components/Campaign/CampaignRoute/CampaignRouteContainer.js
@@ -9,15 +9,7 @@ import { isCampaignSignUpInState } from '../../../selectors/signup';
  * Provide state from the Redux store as props for this component.
  */
 const mapStateToProps = state => ({
-  affiliateCreditText: get(
-    state,
-    'campaign.additionalContent.affiliateCreditText',
-    undefined,
-  ),
-  affiliateSponsors: state.campaign.affiliateSponsors,
-  affiliatePartners: state.campaign.affiliatePartners,
   affirmation: state.campaign.affirmation,
-  campaignLead: get(state, 'campaign.campaignLead.fields', null),
   endDate: state.campaign.endDate,
   hasCommunityPage: Boolean(
     state.campaign.pages.find(


### PR DESCRIPTION
### What's this PR do?

This pull request removes some legacy logic we used to generate a Campaign Lead for campaigns pulling from additional content.

There were two campaigns still doing this, and I just updated them to use the new Campaign Lead entry. We also no longer rely on the Campaign necessarily having a referenced campaign lead entry so this is safe to remove.

### How should this be reviewed?
👀 
Any edge case or context I'm missing?

### Any background context you want to provide?
Bumped into this opportunity in #1944 where I noticed we were hardcoding the campaign lead email for any campaign without a defined campaign lead.

### Relevant tickets

https://github.com/DoSomething/phoenix-next/pull/1944#discussion_r384808882
