### PR TITLE
Add self-service account deletion page.

### DIFF
--- a/resources/assets/components/pages/AccountPage/AccountRoute.js
+++ b/resources/assets/components/pages/AccountPage/AccountRoute.js
@@ -6,6 +6,7 @@ import BadgesTab from './BadgesTab';
 import Profile from './Profile';
 import Subscriptions from './Subscriptions';
 import UserPostsQuery from './UserPostsQuery';
+import DeleteAccountTab from './DeleteAccountTab';
 
 const AccountRoute = props => (
   <Switch>
@@ -20,6 +21,10 @@ const AccountRoute = props => (
       render={() => <Subscriptions {...props} />}
     />
     <Route path="/us/account/profile" render={() => <Profile {...props} />} />
+    <Route
+      path="/us/account/delete"
+      render={() => <DeleteAccountTab {...props} />}
+    />
     <Route
       path="/us/account/campaigns"
       render={() => <UserPostsQuery userId={props.userId} />}

--- a/resources/assets/components/pages/AccountPage/DeleteAccountTab.js
+++ b/resources/assets/components/pages/AccountPage/DeleteAccountTab.js
@@ -18,6 +18,7 @@ const DeleteAccountMutation = gql`
     requestDeletion(id: $id) {
       id
       deletionRequestedAt
+      emailSubscriptionTopics
     }
   }
 `;

--- a/resources/assets/components/pages/AccountPage/DeleteAccountTab.js
+++ b/resources/assets/components/pages/AccountPage/DeleteAccountTab.js
@@ -13,6 +13,9 @@ const DeleteAccountQuery = gql`
   }
 `;
 
+// We're including 'emailSubscriptionTopics' in this query so that
+// if the user clicks over to their subscriptions tab, this update
+// will be displayed (without a full page refresh).
 const DeleteAccountMutation = gql`
   mutation DeleteAccountMutation($id: String!) {
     requestDeletion(id: $id) {

--- a/resources/assets/components/pages/AccountPage/DeleteAccountTab.js
+++ b/resources/assets/components/pages/AccountPage/DeleteAccountTab.js
@@ -1,0 +1,129 @@
+import React from 'react';
+import gql from 'graphql-tag';
+import classnames from 'classnames';
+import { format } from 'date-fns';
+import { useQuery, useMutation } from '@apollo/react-hooks';
+
+const DeleteAccountQuery = gql`
+  query DeleteAccountQuery($id: String!) {
+    user(id: $id) {
+      id
+      deletionRequestedAt
+    }
+  }
+`;
+
+const DeleteAccountMutation = gql`
+  mutation DeleteAccountMutation($id: String!) {
+    requestDeletion(id: $id) {
+      id
+      deletionRequestedAt
+    }
+  }
+`;
+
+const UndoAccountDeletionMutation = gql`
+  mutation UndoAccountDeletionMutation($id: String!) {
+    undoDeletionRequest(id: $id) {
+      id
+      deletionRequestedAt
+    }
+  }
+`;
+
+const DeleteAccountForm = () => {
+  const options = { variables: { id: window.AUTH.id } };
+
+  const { data, loading, error } = useQuery(DeleteAccountQuery, options);
+
+  const [undo] = useMutation(UndoAccountDeletionMutation, options);
+  const [deleteUser, { loading: modifying }] = useMutation(
+    DeleteAccountMutation,
+    options,
+  );
+
+  if (error) {
+    return <p>Something went wrong!</p>;
+  }
+
+  if (loading) {
+    return <div className="spinner" />;
+  }
+
+  const pendingDeletionRequest = data.user.deletionRequestedAt;
+
+  // If we don't have a pending deletion request, let user submit one:
+  if (!pendingDeletionRequest) {
+    return (
+      <button
+        onClick={deleteUser}
+        type="button"
+        className={classnames('button bg-red-500 hover:bg-red-300', {
+          'is-loading': modifying,
+        })}
+      >
+        Delete My Account
+      </button>
+    );
+  }
+
+  // Otherwise, display some information about their request:
+  return (
+    <>
+      <p>
+        <strong className="text-red-500">
+          We received your account deletion request on{' '}
+          {format(data.user.deletionRequestedAt, 'PPP')}.
+        </strong>{' '}
+        You&apos;ve been unsubscribed from all emails and text messages, and
+        your account will be permanently deleted in 14 days.
+      </p>
+      <p>
+        We&apos;ll send you one final reminder message before that happens. In
+        the meantime, you can always change your mind:
+      </p>
+      <p>
+        <button type="button" className="link-button" onClick={undo}>
+          I changed my mind! Don&apos;t delete my account.
+        </button>
+      </p>
+    </>
+  );
+};
+
+const DeleteAccountTab = () => {
+  return (
+    <>
+      <div className="grid-wide-2/3 pb-6">
+        <h2>Delete My Account</h2>
+        <p>We&apos;re sorry to see you go!</p>
+
+        <p>
+          Requesting to delete your account will immediately unsubscribe you
+          from receiving email &amp; text marketing. After 14 days, we will also
+          delete all of your data from our systems. This includes:
+        </p>
+        <ul className="list">
+          <li>
+            Profile information (such as name, preferences, &amp; contact
+            methods)
+          </li>
+          <li>
+            Campaign submissions, including photos &amp; scholarship entries
+          </li>
+          <li>Email and SMS messaging history</li>
+        </ul>
+
+        <p>
+          After this process is complete, it will be{' '}
+          <strong>impossible to recover</strong> your account.
+        </p>
+      </div>
+      <div className="grid-wide-2/3 pb-6">
+        <DeleteAccountForm />
+      </div>
+    </>
+  );
+};
+
+export default DeleteAccountTab;

--- a/resources/assets/components/pages/AccountPage/Profile.js
+++ b/resources/assets/components/pages/AccountPage/Profile.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { Link } from 'react-router-dom';
 
 import FormItem from './FormItem';
 import { env } from '../../../helpers/index';
@@ -46,12 +47,12 @@ const Profile = props => (
       <h3>Data and Privacy</h3>
       <ul className="mt-3">
         <li>
-          <a
-            href="mailto:trust@dosomething.org?subject=Delete my account"
+          <Link
+            to="/us/account/delete"
             className="text-gray-600 font-normal underline"
           >
             Delete my account
-          </a>
+          </Link>
         </li>
       </ul>
 

--- a/resources/assets/scss/base.scss
+++ b/resources/assets/scss/base.scss
@@ -90,6 +90,23 @@ button {
   }
 }
 
+// Utility class for treating buttons like links:
+.link-button {
+  background-color: transparent;
+  border: none;
+  cursor: pointer;
+  color: theme('colors.blue.500');
+  text-decoration: underline;
+  display: inline;
+  margin: 0;
+  padding: 0;
+}
+
+.link-button:hover,
+.link-button:focus {
+  color: theme('colors.blue.300');
+}
+
 h1,
 h2,
 h3,

--- a/resources/assets/scss/base.scss
+++ b/resources/assets/scss/base.scss
@@ -39,6 +39,16 @@ $forge-path: '../../../node_modules/@dosomething/forge/assets/';
   box-shadow: 0 0 3px theme('colors.blue.500');
 }
 
+// Helper class to style 'button' elements as links:
+.link-button {
+  @apply inline bg-transparent border-none cursor-pointer text-blue-500 underline m-0 p-0;
+}
+
+.link-button:hover,
+.link-button:focus {
+  @apply text-blue-300;
+}
+
 @tailwind utilities;
 
 /*
@@ -88,23 +98,6 @@ button {
     border: none;
     box-shadow: 0 0 3px $blue, inset 0 0 1px rgba(0, 0, 0, 0.4);
   }
-}
-
-// Utility class for treating buttons like links:
-.link-button {
-  background-color: transparent;
-  border: none;
-  cursor: pointer;
-  color: theme('colors.blue.500');
-  text-decoration: underline;
-  display: inline;
-  margin: 0;
-  padding: 0;
-}
-
-.link-button:hover,
-.link-button:focus {
-  color: theme('colors.blue.300');
 }
 
 h1,


### PR DESCRIPTION
### What's this PR do?

This pull request adds a self-service interface for requesting account deletion, wrapping up the [Self-Service Account Deletion](https://docs.google.com/document/d/1vj_AcfZ_I92dtBH6y83RhSFYJCshQy2wAXhpecAWlWo/edit#) product build. They'll see the following form when hitting "Delete My Account" in the sidebar of their "My Account" page:

<img width="1212" alt="Screen Shot 2020-02-27 at 1 05 37 PM" src="https://user-images.githubusercontent.com/583202/75472745-f710e200-5961-11ea-82ed-95de20bf2bb7.png">

If a user changes their mind before the end of the 14-day "grace period", they can always undo:

<img width="1212" alt="Screen Shot 2020-02-27 at 1 05 49 PM" src="https://user-images.githubusercontent.com/583202/75472754-f9733c00-5961-11ea-8109-5690b542367a.png">

### How should this be reviewed?

This is pending some additional work in Northstar so that account deletion requests automatically unsubscribe users from all further messaging (since that's a common theme in these requests).

👀

### Any background context you want to provide?

🔥

### Relevant tickets

References [Pivotal #170953839](https://www.pivotaltracker.com/story/show/170953839).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added screenshots of front-end changes on small, medium, and large screens.
- [ ] Added appropriate feature/unit tests.
