### PR TITLE
Pass the preview config to referral page campaign query

### DIFF
--- a/resources/assets/components/pages/ReferralPage/Beta/BetaPageCampaignLink.js
+++ b/resources/assets/components/pages/ReferralPage/Beta/BetaPageCampaignLink.js
@@ -3,12 +3,13 @@ import PropTypes from 'prop-types';
 import gql from 'graphql-tag';
 
 import Query from '../../../Query';
+import { env } from '../../../../helpers';
 import Embed from '../../../utilities/Embed/Embed';
 import ErrorBlock from '../../../blocks/ErrorBlock/ErrorBlock';
 
 const REFERRAL_PAGE_CAMPAIGN = gql`
-  query ReferralPageCampaignQuery($campaignId: String!) {
-    campaignWebsiteByCampaignId(campaignId: $campaignId) {
+  query ReferralPageCampaignQuery($campaignId: String!, $preview: Boolean!) {
+    campaignWebsiteByCampaignId(campaignId: $campaignId, preview: $preview) {
       id
       url
     }
@@ -16,7 +17,13 @@ const REFERRAL_PAGE_CAMPAIGN = gql`
 `;
 
 const ReferralPageCampaignLink = ({ campaignId, userId }) => (
-  <Query query={REFERRAL_PAGE_CAMPAIGN} variables={{ campaignId }}>
+  <Query
+    query={REFERRAL_PAGE_CAMPAIGN}
+    variables={{
+      campaignId,
+      preview: env('CONTENTFUL_USE_PREVIEW_API', false),
+    }}
+  >
     {res => {
       const data = res.campaignWebsiteByCampaignId;
 


### PR DESCRIPTION
### What's this PR do?

This pull request adds the `preview` variable to the campaign GraphQL query used in Beta Referral Pages.

### How should this be reviewed?
👀 

### Any background context you want to provide?
This will allow us to QA unpublished campaigns using the referral feature!

### Relevant tickets
https://dosomething.slack.com/archives/C3ASB4204/p1582837340011400
