### PR TITLE
Updating event naming to standard.

### DIFF
--- a/resources/assets/components/utilities/CtaPopover/CtaPopoverEmailForm.js
+++ b/resources/assets/components/utilities/CtaPopover/CtaPopoverEmailForm.js
@@ -65,10 +65,10 @@ const CtaPopoverEmailForm = ({ handleComplete }) => {
           console.log('🚫 failed response? caught the error!', error);
         }
 
-        trackAnalyticsEvent('failed_call_to_action_popover_submission', {
+        trackAnalyticsEvent('failed_call_to_action_popover', {
           action: 'form_failed',
           category: EVENT_CATEGORIES.siteAction,
-          label: 'call_to_action_popover_submission',
+          label: 'call_to_action_popover',
           context: {
             contextSource: 'newsletter_scholarships',
             error,


### PR DESCRIPTION
### What's this PR do?

This pull request updates the event naming for `failed_call_to_action_popover` to align with other event names in the system defined in the [Event Builder](https://docs.google.com/spreadsheets/d/1hNZdkcS7orp7xU0mOHSRKPodNoif0EP5UC2YwOnDmPI/edit#gid=118684449) document.

### How should this be reviewed?

👀 

### Relevant tickets

References [Pivotal #171388718](https://www.pivotaltracker.com/story/show/171388718).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
