### PR TITLE
Update countdown with remaining days until account deletion.

### DIFF
--- a/resources/assets/components/pages/AccountPage/DeleteAccountTab.js
+++ b/resources/assets/components/pages/AccountPage/DeleteAccountTab.js
@@ -85,8 +85,9 @@ const DeleteAccountForm = () => {
           We received your account deletion request on{' '}
           {format(deletionRequestedAt, 'PPP')}.
         </strong>{' '}
-        You have been unsubscribed from all emails and text messages, and your
-        account will be permanently deleted within {remainingDays}.
+        You have been unsubscribed from all DoSomething.org emails &amp; text
+        marketing, and your account will be permanently deleted within{' '}
+        {remainingDays}.
       </p>
       <p>
         We&apos;ll send you one final reminder message before that happens. In

--- a/resources/assets/components/pages/AccountPage/DeleteAccountTab.js
+++ b/resources/assets/components/pages/AccountPage/DeleteAccountTab.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import gql from 'graphql-tag';
 import classnames from 'classnames';
-import { format } from 'date-fns';
+import { format, formatDistanceStrict, addDays } from 'date-fns';
 import { useQuery, useMutation } from '@apollo/react-hooks';
 
 const DeleteAccountQuery = gql`
@@ -54,10 +54,10 @@ const DeleteAccountForm = () => {
     return <div className="spinner" />;
   }
 
-  const pendingDeletionRequest = data.user.deletionRequestedAt;
+  const { deletionRequestedAt } = data.user;
 
   // If we don't have a pending deletion request, let user submit one:
-  if (!pendingDeletionRequest) {
+  if (!deletionRequestedAt) {
     return (
       <button
         onClick={deleteUser}
@@ -71,16 +71,22 @@ const DeleteAccountForm = () => {
     );
   }
 
+  const scheduledDeletion = addDays(deletionRequestedAt, 14);
+  const remainingDays = formatDistanceStrict(new Date(), scheduledDeletion, {
+    unit: 'day',
+    roundingMethod: 'ceil',
+  });
+
   // Otherwise, display some information about their request:
   return (
     <>
       <p>
         <strong className="text-red-500">
           We received your account deletion request on{' '}
-          {format(data.user.deletionRequestedAt, 'PPP')}.
+          {format(deletionRequestedAt, 'PPP')}.
         </strong>{' '}
-        You&apos;ve been unsubscribed from all emails and text messages, and
-        your account will be permanently deleted in 14 days.
+        You have been unsubscribed from all emails and text messages, and your
+        account will be permanently deleted within {remainingDays}.
       </p>
       <p>
         We&apos;ll send you one final reminder message before that happens. In


### PR DESCRIPTION
### What's this PR do?

This pull request updates the "Delete My Account" page (added in #1946) to show the remaining days until the account is permanently deleted (rather than the hard-coded 14 days).

For example, if I'd requested to delete my account on February 23rd:

![Screen Shot 2020-02-28 at 2 19 39 PM](https://user-images.githubusercontent.com/583202/75580429-c00c0080-5a35-11ea-9502-c354b3aa888f.png)

The countdown rounds up, so a user will see "within 1 day" on their scheduled deletion date:

![Screen Shot 2020-02-28 at 2 19 58 PM](https://user-images.githubusercontent.com/583202/75580491-ddd96580-5a35-11ea-9b57-26da3e64209a.png)

### How should this be reviewed?

👀

### Any background context you want to provide?

Hopefully this reduces confusion if users return to this page later!

### Relevant tickets

References [Pivotal #170953839](https://www.pivotaltracker.com/story/show/170953839).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added screenshots of front-end changes on small, medium, and large screens.
- [ ] Added appropriate feature/unit tests.
