### PR TITLE
Only show scholarship info if amount and deadline are both set

### DIFF
--- a/resources/assets/components/blocks/CampaignInfoBlock/CampaignInfoBlock.js
+++ b/resources/assets/components/blocks/CampaignInfoBlock/CampaignInfoBlock.js
@@ -52,7 +52,7 @@ const CampaignInfoBlock = ({
               <h1 className="mb-3 text-lg uppercase">Campaign Info</h1>
             ) : null}
             <dl className="clearfix">
-              {scholarshipAmount && isOpen ? (
+              {scholarshipAmount && scholarshipDeadline && isOpen ? (
                 <React.Fragment>
                   <dt className="campaign-info__scholarship">
                     Win A Scholarship


### PR DESCRIPTION
### What's this PR do?

This pull request makes sure "Invalid Date" doesn't show up in the campaign info block for a scholarship deadline. Currently, we show scholarship info (amount, deadline) if the campaign is open and has a scholarship amount. Moving forward, we will only show this info if the campaign is open, has a scholarship amount, AND has a scholarship deadline.

Info block when campaign is open, has scholarship amount, and deadline:
<img width="348" alt="Screen Shot 2020-02-28 at 11 00 35 AM" src="https://user-images.githubusercontent.com/4240292/75585373-ce065500-5a26-11ea-9368-26b3788087c0.png">

Info block when scholarship amount OR scholarship deadline are missing:
<img width="349" alt="Screen Shot 2020-02-28 at 10 51 17 AM" src="https://user-images.githubusercontent.com/4240292/75585392-dced0780-5a26-11ea-8b7a-c4407cba3619.png">

### How should this be reviewed?

Are we showing scholarship information only when it makes sense to?

### Any background context you want to provide?

We think there are campaigns with scholarship amounts but no deadlines leftover from when we moved all that information over from Ashes.

### Relevant tickets

References [Pivotal #171439576](https://www.pivotaltracker.com/story/show/171439576).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added screenshots of front-end changes on small, medium, and large screens.
- [ ] Added appropriate feature/unit tests.
