### PR TITLE
Zendesk Ticket Grouping

### DIFF
--- a/app/Http/Controllers/Api/ZendeskTicketsController.php
+++ b/app/Http/Controllers/Api/ZendeskTicketsController.php
@@ -23,7 +23,7 @@ class ZendeskTicketsController extends Controller
     public function __construct(Zendesk $zendesk)
     {
         $this->middleware('auth:api');
-        // $this->middleware('throttle:10,60');
+        $this->middleware('throttle:10,60');
 
         $this->zendesk = $zendesk;
     }

--- a/app/Http/Controllers/Api/ZendeskTicketsController.php
+++ b/app/Http/Controllers/Api/ZendeskTicketsController.php
@@ -60,9 +60,12 @@ class ZendeskTicketsController extends Controller
             'question' => str_limit($question, 5000, '(...)'),
         ]);
 
-        $zendeskGroups = Zendesk::groups()->findAll();
-        // Find the Zendesk group whose name matches the Campaign's first cause name.
-        $zendeskGroup = collect($zendeskGroups->groups)->firstWhere('name', $campaignCause);
+        // Find the Zendesk groups where the name matches the Campaign's first cause name.
+        $zendeskGroups = optional(
+            Zendesk::search()->find('type:group name:".'.$campaignCause.'"')
+        )->results;
+        // Filter out the *exact* matching group. (The search API includes a more generous matching logic).
+        $zendeskGroup = collect($zendeskGroups)->firstWhere('name', $campaignCause);
         $zendeskGroupId = optional($zendeskGroup)->id;
 
         $zendeskUser = Zendesk::users()->createOrUpdate([

--- a/app/Http/Controllers/Api/ZendeskTicketsController.php
+++ b/app/Http/Controllers/Api/ZendeskTicketsController.php
@@ -42,7 +42,8 @@ class ZendeskTicketsController extends Controller
         $question = $request->question;
 
         $rogueCampaign = $this->rogueCampaignRepository->getCampaign($request->campaign_id);
-        $campaignCause = data_get($rogueCampaign, 'data.cause_names', [])[0];
+        $campaignCauses = data_get($rogueCampaign, 'data.cause_names', []);
+        $campaignCause = array_shift($campaignCauses);
 
         $northstarId = auth()->id();
 

--- a/app/Http/Controllers/Api/ZendeskTicketsController.php
+++ b/app/Http/Controllers/Api/ZendeskTicketsController.php
@@ -28,11 +28,15 @@ class ZendeskTicketsController extends Controller
         $campaignName = $request->campaign_name;
         $question = $request->question;
 
-        $user = gateway('northstar')->withToken(token())->get('v1/profile');
+        $northstarId = auth()->id();
 
-        $northstarId = data_get($user, 'data.id');
+        // Fetch user details from Northstar:
+        $user = gateway('northstar')->withToken(token())->get('v2/users/'.$northstarId, [
+            'include' => 'email',
+        ]);
+
         $userEmail = data_get($user, 'data.email');
-        $userName = data_get($user, 'data.first_name').' '.data_get($user, 'data.last_initial').'.';
+        $userName = data_get($user, 'data.display_name');
 
         Log::debug('[Phoenix] ZendeskTicketsController@store: Creating Zendesk ticket:', [
             'northstar_id' => $northstarId,

--- a/app/Repositories/RogueCampaignRepository.php
+++ b/app/Repositories/RogueCampaignRepository.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Repositories;
+
+use DoSomething\Gateway\Common\RestApiClient;
+
+class RogueCampaignRepository extends RestApiClient
+{
+    /**
+     * Create a new RogueCampaignRepository instance.
+     */
+    public function __construct()
+    {
+        $base_url = config('services.rogue.url').'/api/';
+
+        parent::__construct($base_url);
+    }
+
+    /**
+     * Fetch campaign from Rogue by Campaign ID.
+     *
+     * @param string $campaignId
+     * @return array - JSON response
+     */
+    public function getCampaign($campaignId)
+    {
+        return $this->get('v3/campaigns/'.$campaignId);
+    }
+}

--- a/app/Services/Zendesk.php
+++ b/app/Services/Zendesk.php
@@ -134,8 +134,10 @@ class Zendesk
         $firstCampaignCause = $this->getFirstCampaignCauseName($campaignId);
 
         $zendeskGroups = optional(
-            // Zendesk Search API: http://bit.ly/2TihwCC
-            ZendeskClient::search()->find('type:group name:".'.$firstCampaignCause.'"')
+            remember('zendesk_groups', 15, function () use ($firstCampaignCause) {
+                // Zendesk Search API: http://bit.ly/2TihwCC
+                return ZendeskClient::search()->find('type:group name:".'.$firstCampaignCause.'"');
+            })
         )->results;
 
         // Filter out the *exact* matching group. (The search API includes a more generous matching logic).

--- a/app/Services/Zendesk.php
+++ b/app/Services/Zendesk.php
@@ -64,9 +64,7 @@ class Zendesk
             // ],
         ];
 
-        $zendeskTicket = ZendeskClient::tickets()->create($zendeskTicketData);
-
-        return [$zendeskTicket, $zendeskUser];
+        return ZendeskClient::tickets()->create($zendeskTicketData);
     }
 
     /**

--- a/app/Services/Zendesk.php
+++ b/app/Services/Zendesk.php
@@ -1,0 +1,148 @@
+<?php
+
+namespace App\Services;
+
+use Illuminate\Support\Facades\Log;
+use App\Repositories\RogueCampaignRepository;
+use Huddle\Zendesk\Facades\Zendesk as ZendeskClient;
+
+class Zendesk
+{
+    /**
+     * Rogue Campaign repository instance.
+     * @var RogueCampaignRepository
+     */
+    private $rogueCampaignRepository;
+
+    /**
+     * Zendesk constructor.
+     *
+     * @param RogueCampaignRepository $rogueCampaignRepository
+     */
+    public function __construct(RogueCampaignRepository $rogueCampaignRepository)
+    {
+        $this->rogueCampaignRepository = $rogueCampaignRepository;
+    }
+
+    /**
+     * Create/Update a Zendesk User for this Northstar user and open a new
+     * ticket for them with their submitted question.
+     *
+     * @param string  $campaignId
+     * @param string  $campaignName
+     * @param string  $question
+     * @return string
+     */
+    public function createTicket($campaignId, $campaignName, $question)
+    {
+        $northstarId = auth()->id();
+
+        Log::debug('[Phoenix] ZendeskTicketsController@store: Creating Zendesk ticket:', [
+            'northstar_id' => $northstarId,
+            'question' => str_limit($question, 5000, '(...)'),
+        ]);
+
+        $zendeskUser = $this->createOrUpdateZendeskUser($northstarId);
+
+        $questionSubject = 'Question about '.$campaignName;
+
+        $zendeskTicketData = [
+            'requester' => [
+                'email' => data_get($zendeskUser, 'user.email'),
+            ],
+            'subject' => $questionSubject,
+            'comment' => [
+                'body' => $questionSubject.': '.$question,
+            ],
+            'group_id' => $this->getZendeskGroupIdFromCampaign($campaignId),
+            // @TODO: Assign priority based on campaign's staff pick status.
+            // 'priority' => 'normal',
+            // @TODO: Append browser & ip address using env variable zendesk field IDs.
+            // 'custom_fields' = [
+            //      ['id' => 'browser...', 'value' => $request->userAgent()],
+            //      ['id' => 'ip...', 'value' => $request->ip()],
+            // ],
+        ];
+
+        $zendeskTicket = ZendeskClient::tickets()->create($zendeskTicketData);
+
+        return [$zendeskTicket, $zendeskUser];
+    }
+
+    /**
+     * Fetch user email and display name from Northstar.
+     *
+     * @param string $northstarId
+     * @return array
+     */
+    protected function getUserDataFromNorthstar($northstarId)
+    {
+        $user = gateway('northstar')->withToken(token())->get('v2/users/'.$northstarId, [
+            'include' => 'email',
+        ]);
+
+        return [
+            data_get($user, 'data.email'),
+            data_get($user, 'data.display_name'),
+        ];
+    }
+
+    /**
+     * Fetch user details from Northstar and create or update a new Zendesk
+     * user with custom profile fields.
+     *
+     * @param string $northstarId
+     * @return array
+     */
+    protected function createOrUpdateZendeskUser($northstarId)
+    {
+        [$userEmail, $userName] = $this->getUserDataFromNorthstar($northstarId);
+
+        return ZendeskClient::users()->createOrUpdate([
+            'email' => $userEmail,
+            'name' => $userName,
+            // Custom user attributes:
+            'user_fields' => [
+                'profile_uid' => $northstarId,
+                // User's Rogue profile URL:
+                'profile_url' => config('services.rogue.url').'/users/'.$northstarId,
+            ],
+        ]);
+    }
+
+    /**
+     * Fetch Campaign from Rogue and parse out its first cause name.
+     *
+     * @param string  $campaignId
+     * @return string
+     */
+    protected function getFirstCampaignCauseName($campaignId)
+    {
+        $rogueCampaign = $this->rogueCampaignRepository->getCampaign($campaignId);
+        $campaignCauses = data_get($rogueCampaign, 'data.cause_names', []);
+
+        return array_shift($campaignCauses);
+    }
+
+    /**
+     * Fetch Rogue Campaign's first cause name and use it to filter out
+     * the corresponding Zendesk group ID.
+     *
+     * @param string  $campaignId
+     * @return string
+     */
+    protected function getZendeskGroupIdFromCampaign($campaignId)
+    {
+        $firstCampaignCause = $this->getFirstCampaignCauseName($campaignId);
+
+        $zendeskGroups = optional(
+            // Zendesk Search API: http://bit.ly/2TihwCC
+            ZendeskClient::search()->find('type:group name:".'.$firstCampaignCause.'"')
+        )->results;
+
+        // Filter out the *exact* matching group. (The search API includes a more generous matching logic).
+        $zendeskGroup = collect($zendeskGroups)->firstWhere('name', $firstCampaignCause);
+
+        return optional($zendeskGroup)->id;
+    }
+}

--- a/docs/api-reference/api-v2/zendesk-tickets.md
+++ b/docs/api-reference/api-v2/zendesk-tickets.md
@@ -7,12 +7,15 @@ Create a Zendesk Ticket for an authenticated user.
 
 {% api-method-description %}
 Fetches user data via northstar then creates or updates a Zendesk user using the account email address with Northstar ID and Rogue profile URL.
-Creates new Zendesk ticket for the user with the campaign title and question data.
+Creates new Zendesk ticket for the user with the campaign title and question data. Assigns a group ID using the campaign's first Cause Name to match an existing Zendesk Group.
 {% endapi-method-description %}
 
 {% api-method-spec %}
 {% api-method-request %}
 {% api-method-path-parameters %}
+{% api-method-parameter name="campaign_id" type="string" required=true %}
+e.g.: '9001'
+{% endapi-method-parameter %}
 {% api-method-parameter name="campaign_name" type="string" required=true %}
 e.g.: 'Teens for Jeans'
 {% endapi-method-parameter %}
@@ -28,23 +31,13 @@ e.g.: 'I\'m having trouble reporting back on this campaign.'
 
 {% endapi-method-response-example-description %}
 
-```javascript
+```json
 {
-    "zendesk_ticket": {
-      "ticket": {
-        "id":      35436,
-        "subject": "My printer is on fire!",
-        ...
-      }
-    },
-    "zendesk_user": {
-        "user": {
-            "id": 123,
-            "name": "Mendel B.",
-            "email": "mendel.com",
-            ...
-        }
-    }
+  "ticket": {
+    "id": 1234,
+    "subject": "My printer is on fire!"
+    // ...
+  }
 }
 ```
 

--- a/resources/assets/components/utilities/ZendeskForm/ZendeskForm.js
+++ b/resources/assets/components/utilities/ZendeskForm/ZendeskForm.js
@@ -8,7 +8,7 @@ import { report } from '../../../helpers';
 import { postRequest } from '../../../helpers/api';
 import { HELP_LINK, HELP_REQUEST_LINK } from '../../../constants';
 
-const ZendeskForm = ({ campaignName, faqsLink, token }) => {
+const ZendeskForm = ({ campaignId, campaignName, faqsLink, token }) => {
   const [question, setQuestion] = useState('');
   const [status, setStatus] = useState({
     loading: false,
@@ -21,7 +21,11 @@ const ZendeskForm = ({ campaignName, faqsLink, token }) => {
 
     setStatus({ ...status, loading: true });
 
-    const data = { campaign_name: campaignName, question };
+    const data = {
+      campaign_id: campaignId,
+      campaign_name: campaignName,
+      question,
+    };
 
     postRequest('/api/v2/zendesk-tickets', data, token)
       .then(() => setStatus({ ...status, loading: false, success: true }))
@@ -109,6 +113,7 @@ const ZendeskForm = ({ campaignName, faqsLink, token }) => {
 };
 
 ZendeskForm.propTypes = {
+  campaignId: PropTypes.string.isRequired,
   campaignName: PropTypes.string.isRequired,
   token: PropTypes.string.isRequired,
   faqsLink: PropTypes.string,

--- a/resources/assets/components/utilities/ZendeskForm/ZendeskFormContainer.js
+++ b/resources/assets/components/utilities/ZendeskForm/ZendeskFormContainer.js
@@ -9,6 +9,7 @@ import { getCampaignFaqsPath } from '../../../selectors/campaign';
  */
 const mapStateToProps = state => ({
   token: getUserToken(state),
+  campaignId: state.campaign.campaignId,
   campaignName: state.campaign.title,
   faqsLink: getCampaignFaqsPath(state),
 });


### PR DESCRIPTION
### What's this PR do?

This pull request uses the current campaign's first assigned Cause name to assign a Zendesk group ID to new Zendesk tickets created via our Zendesk API. (Say Zendesk one more time).



### How should this be reviewed?
You can commit-by-commit this one! Here's some info on the notable commits:

- https://github.com/DoSomething/phoenix-next/commit/82852fd8e01f84ebe55030a28097262e734f439b upgrades to using the Northstar V2 API for fetching the user. I hadn't realized during the first iteration of this that we could. This gives us the `display_name` so we don't have to compute that ourselves, plus forces us to explicitly request the sensitive email field. Neato!
- https://github.com/DoSomething/phoenix-next/commit/8a9e9d61437ba52fb0a9043ceb2102df5a84626d adds a `RogueCampaignRepository` which uses our Gateway `RestApiClient` to fetch campaigns from Rogue by ID so we can parse out the first cause name. I wasn't sure if this was overkill, but it felt like a good approach here. (Should we just use Guzzle or something for this, or is it cool to utilize our own library, though there's no auth or anything?)
- https://github.com/DoSomething/phoenix-next/commit/8332f459afc382352e4bbafcb6ab6de2041a6f10, https://github.com/DoSomething/phoenix-next/commit/0ecf55d1030e08150ce0e627f797705426990733 (update), https://github.com/DoSomething/phoenix-next/commit/0ecf55d1030e08150ce0e627f797705426990733 (patch) is where the fun happens. We add a `campaign_id` param to this request which we use to fetch the campaign from Rogue and parse out its first Cause name. We then ~ask Zendesk for its index of Groups~ search Zendesk for groups fuzzy matching this cause name (though the documentation implies it, [they don't](https://support.zendesk.com/hc/en-us/articles/203663226/comments/204720757) seem to allow _exact_ phrase matching which is frustrating so we have to) then filter out the group with an _exact_ matching name so we can use its ID as our tickets assigned `group_id`. Zendesk doesn't seem to have a `findByName` or some other filter method for the groups API. lame!
- finally, https://github.com/DoSomething/phoenix-next/commit/7d820a9652ba420e7e031f7788df765eb4c889f2 passes through the new `campaign_id` param from our `ZendeskForm` in React land.

#### Questions:
Is the logic to assign the group_id too gnarly? It felt like the best way to do this for now, and since our ticket volume is quite low, the extra non-cached API request to fetch the groups shouldn't be a big deal. I figure worse comes to worst we have two improvement options:
1. Start caching these group requests for a while since we wouldn't anticipate these groups to change much
2. Store a mapping of cause names to group ID's locally, either via config variable or in some JSON file in storage.

#### Refactor!
This controller action is feeling crowded! I'd love to follow up on this PR with some general cleanup. Including, pulling most of this logic into a `ZendeskRepository`!

### Any background context you want to provide?
Check out the Pivotal Story, but this is essentially a simple way for us to start grouping Zendesk Tickets for Agent assignment, which should help preserve Hannah's sanity and declutter the Zendesk inbox!

### Relevant tickets

References [Pivotal #171191450](https://www.pivotaltracker.com/story/show/171191450).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [x] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
