### PR TITLE
🐛 Post Created Modal & Campaign Block Page bugs

### DIFF
--- a/resources/assets/components/Campaign/CampaignRoute/CampaignRoute.js
+++ b/resources/assets/components/Campaign/CampaignRoute/CampaignRoute.js
@@ -43,7 +43,12 @@ const CampaignRoute = props => {
       ) : null}
 
       <Switch>
-        <Route path={join(baseUrl, 'blocks/:id')} component={BlockPage} />
+        <Route
+          path={join(baseUrl, 'blocks/:id')}
+          render={routeProps => (
+            <BlockPage hideNavigation match={routeProps.match} />
+          )}
+        />
 
         <Route
           path={join(baseUrl, 'quiz/:slug')}

--- a/resources/assets/components/actions/PostCreatedModal.js
+++ b/resources/assets/components/actions/PostCreatedModal.js
@@ -27,54 +27,63 @@ const POST_COUNT_BADGE = gql`
 const PostCreatedModal = ({ affirmationContent, onClose, title, userId }) => (
   <Modal onClose={onClose}>
     <Card className="bordered rounded" title={title}>
-      <Query query={BADGE_QUERY} variables={{ userId }} hideSpinner>
-        {badgeData =>
-          get(badgeData, 'user.hasBadgesFlag', false) ? (
-            <Query query={POST_COUNT_BADGE} variables={{ userId }} hideSpinner>
-              {postData => {
-                const count = postData.postsCount;
+      {userId ? (
+        <Query query={BADGE_QUERY} variables={{ userId }} hideSpinner>
+          {badgeData =>
+            get(badgeData, 'user.hasBadgesFlag', false) ? (
+              <Query
+                query={POST_COUNT_BADGE}
+                variables={{ userId }}
+                hideSpinner
+              >
+                {postData => {
+                  const count = postData.postsCount;
 
-                if (count > 3) {
-                  return null;
-                }
+                  if (count > 3) {
+                    return null;
+                  }
 
-                const config = {
-                  1: {
-                    className: 'onePostBadge',
-                    descriptor: 'first',
-                  },
-                  2: {
-                    className: 'twoPostsBadge',
-                    descriptor: 'second',
-                  },
-                  3: {
-                    className: 'threePostsBadge',
-                    descriptor: 'third',
-                  },
-                };
+                  const config = {
+                    1: {
+                      className: 'onePostBadge',
+                      descriptor: 'first',
+                    },
+                    2: {
+                      className: 'twoPostsBadge',
+                      descriptor: 'second',
+                    },
+                    3: {
+                      className: 'threePostsBadge',
+                      descriptor: 'third',
+                    },
+                  };
 
-                return (
-                  <Badge
-                    earned
-                    className="badge p-3"
-                    size="medium"
-                    name={config[count].className}
-                  >
-                    <h4>
-                      {count} Action{count > 1 ? 's' : null}
-                    </h4>
-                    <p>
-                      Ohhh HECK yes! You just earned a new badge for completing
-                      your {config[count].descriptor} campaign. Congratulations!
-                    </p>
-                    <a href="/us/account/profile/badges">View all my badges</a>
-                  </Badge>
-                );
-              }}
-            </Query>
-          ) : null
-        }
-      </Query>
+                  return (
+                    <Badge
+                      earned
+                      className="badge p-3"
+                      size="medium"
+                      name={config[count].className}
+                    >
+                      <h4>
+                        {count} Action{count > 1 ? 's' : null}
+                      </h4>
+                      <p>
+                        Ohhh HECK yes! You just earned a new badge for
+                        completing your {config[count].descriptor} campaign.
+                        Congratulations!
+                      </p>
+                      <a href="/us/account/profile/badges">
+                        View all my badges
+                      </a>
+                    </Badge>
+                  );
+                }}
+              </Query>
+            ) : null
+          }
+        </Query>
+      ) : null}
 
       <TextContent className="p-3">{affirmationContent}</TextContent>
     </Card>
@@ -85,7 +94,11 @@ PostCreatedModal.propTypes = {
   affirmationContent: PropTypes.string.isRequired,
   onClose: PropTypes.func.isRequired,
   title: PropTypes.string.isRequired,
-  userId: PropTypes.string.isRequired,
+  userId: PropTypes.string,
+};
+
+PostCreatedModal.defaultProps = {
+  userId: null,
 };
 
 export default PostCreatedModal;

--- a/resources/assets/components/pages/BlockPage/BlockPage.js
+++ b/resources/assets/components/pages/BlockPage/BlockPage.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import ReactRouterPropTypes from 'react-router-prop-types';
 
 import SiteFooter from '../../utilities/SiteFooter/SiteFooter';
@@ -10,9 +11,9 @@ import ContentfulEntryLoader from '../../utilities/ContentfulEntryLoader/Content
  *
  * @returns {ReactElement}
  */
-const BlockPage = ({ match }) => (
+const BlockPage = ({ match, hideNavigation }) => (
   <>
-    <SiteNavigationContainer />
+    {!hideNavigation ? <SiteNavigationContainer /> : null}
 
     <main className="clearfix">
       <div className="md:w-3/4 mx-auto my-16 px-3">
@@ -25,7 +26,12 @@ const BlockPage = ({ match }) => (
 );
 
 BlockPage.propTypes = {
+  hideNavigation: PropTypes.bool,
   match: ReactRouterPropTypes.match.isRequired,
+};
+
+BlockPage.defaultProps = {
+  hideNavigation: false,
 };
 
 export default BlockPage;


### PR DESCRIPTION
### What's this PR do? 

This pull request fixes two quick bugs:
- https://github.com/DoSomething/phoenix-next/commit/664bfe296a1414dc75abf42851db03cb0b037f2a we're running a GraphQL query to fetch the user's info in all post affirmations, but there's the possibility of invoking this from [`ShareAction`s](https://github.com/DoSomething/phoenix-next/blob/00080e5c7fd417d1dc2de487049d21eed6b165cc/resources/assets/components/actions/ShareAction/ShareAction.js#L208-L213) which can run in an unauthenticated context.
- https://github.com/DoSomething/phoenix-next/commit/17982e5539df000347e7ee3313429c57730d3c9e adds the option to hide the navigation bar in `BlockPage`s since they can run in a nested campaign context which will already have appended [its own navigation bar](https://github.com/DoSomething/phoenix-next/blob/00080e5c7fd417d1dc2de487049d21eed6b165cc/resources/assets/components/Campaign/Campaign.js#L27).

### How should this be reviewed?
👀 


### Relevant tickets
https://dosomething.slack.com/archives/CUQMTP0RM/p1583170321003800

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added screenshots of front-end changes on small, medium, and large screens.
- [ ] Added appropriate feature/unit tests.

![image](https://user-images.githubusercontent.com/12417657/75705278-0f963a80-5c89-11ea-87d4-758b0abd876d.png)

![image](https://user-images.githubusercontent.com/12417657/75705298-17ee7580-5c89-11ea-8f12-31f9ec32b27a.png)

