### PR TITLE
Update Post Created Modal's User Badge Query name

### DIFF
--- a/resources/assets/components/actions/PostCreatedModal.js
+++ b/resources/assets/components/actions/PostCreatedModal.js
@@ -10,7 +10,7 @@ import Badge from '../pages/AccountPage/Badge';
 import TextContent from '../utilities/TextContent/TextContent';
 
 const BADGE_QUERY = gql`
-  query AccountQuery($userId: String!) {
+  query UserBadgeQuery($userId: String!) {
     user(id: $userId) {
       id
       hasBadgesFlag: hasFeatureFlag(feature: "badges")


### PR DESCRIPTION
### What's this PR do?

This pull request updates the GraphQL query name for the user's badge query we make in the `PostCreatedModal`.

This query name [is used](https://github.com/DoSomething/phoenix-next/blob/86aa82c060eb9e2cdf8ad166efa3b31307aab737/resources/assets/components/pages/AccountPage/AccountQuery.js#L9) in the `AccountQuery` component for the account pages which makes debugging tricky.

### How should this be reviewed?
📛 


### Relevant tickets
https://dosomething.slack.com/archives/CUQMTP0RM/p1583175709011600?thread_ts=1583170321.003800&cid=CUQMTP0RM
