### PR TITLE
Contentful Script to Replace Page Entry Modal Links

### DIFF
--- a/contentful/management-api-scripts/2020_03_05_replace_page_modals_with_content_blocks.js
+++ b/contentful/management-api-scripts/2020_03_05_replace_page_modals_with_content_blocks.js
@@ -1,0 +1,135 @@
+const { contentManagementClient } = require('./contentManagementClient');
+const {
+  constants,
+  createLogger,
+  getField,
+  processEntries,
+  sleep,
+  withFields,
+} = require('./helpers');
+
+const { LOCALE } = constants;
+
+const logger = createLogger('replace_page_modals_with_content_blocks');
+
+const replacedPagesIdList = [];
+
+const replacePageModalsWithContentBlocks = async (
+  environment,
+  contentBlockEntry,
+) => {
+  const contentBlockInternalTitle = getField(
+    contentBlockEntry,
+    'internalTitle',
+  );
+  const contentBlockContent = getField(contentBlockEntry, 'content') || '';
+
+  // Find all markdown links to modals.
+  const modalLinks = contentBlockContent.match(
+    /\[.+\]\(\/us\/campaigns\/.+\/modal\/[a-zA-Z0-9]+?(\s\".+\")\)/g,
+  );
+
+  if (!modalLinks) {
+    return;
+  }
+
+  logger.info(
+    `\n\nProcessing ${contentBlockInternalTitle} - ${modalLinks.length} modal links.`,
+  );
+
+  let contentBlockWasUpdated = false;
+
+  for (let i = 0; i < modalLinks.length; i++) {
+    const modalLink = modalLinks[i];
+
+    // Find the modal link itself and parse out the Contentful ID.
+    const modalEntryId = modalLink
+      .match(/\/modal\/[a-zA-Z0-9]+/)[0]
+      .replace('/modal/', '');
+
+    const modalEntry = await environment.getEntry(modalEntryId);
+
+    if (!modalEntry) {
+      logger.info(`⇢ Skipping ${modalEntryId} - unable to fetch.`);
+      continue;
+    }
+
+    const modalLinkContentType = modalEntry.sys.contentType.sys.id;
+
+    if (modalLinkContentType !== 'page') {
+      logger.info(`⇢ Skipping ${modalEntryId} - it isn't a page entry 😌.`);
+      continue;
+    }
+
+    const modalEntryInternalTitle = getField(modalEntry, 'internalTitle');
+
+    logger.info(`⇢ Deriving new ContentBlock from ${modalEntryInternalTitle}.`);
+
+    const derivedContentBlock = await environment.createEntry(
+      'contentBlock',
+      withFields({
+        internalTitle: modalEntryInternalTitle,
+        title: getField(modalEntry, 'title'),
+        content: getField(modalEntry, 'content'),
+      }),
+    );
+
+    await derivedContentBlock.publish();
+
+    logger.info(
+      `⇢ Replacing ${modalEntryId} with ${derivedContentBlock.sys.id}.`,
+    );
+
+    // Replace the page modal Contentful ID with the derived Content Block ID.
+    contentBlockEntry.fields.content[LOCALE] = contentBlockContent.replace(
+      modalEntryId,
+      derivedContentBlock.sys.id,
+    );
+
+    replacedPagesIdList.push(modalEntryId);
+
+    contentBlockWasUpdated = true;
+  }
+
+  if (!contentBlockWasUpdated) {
+    return;
+  }
+
+  const updatedContentBlock = await contentBlockEntry.update();
+
+  if (!updatedContentBlock) {
+    logger.info(`☓ Unable to update ${contentBlockInternalTitle}.`);
+    return;
+  }
+
+  publishedUpdatedContentBlock = await updatedContentBlock.publish();
+
+  if (!publishedUpdatedContentBlock) {
+    logger.info(`☓ Unable to publish updated ${contentBlockInternalTitle}.`);
+    return;
+  }
+
+  logger.info(`✔ Published updated ${contentBlockInternalTitle}.`);
+
+  await sleep(500);
+};
+
+contentManagementClient.init(async (environment, args) => {
+  logger.info(
+    `Running 'replace_page_modals_with_content_blocks', using Contentful's '${environment.sys.id}' environment.`,
+  );
+  logger.info('Kicking things off in 5 seconds...');
+
+  await sleep(5000);
+
+  await processEntries(
+    environment,
+    args,
+    'contentBlock',
+    replacePageModalsWithContentBlocks,
+  );
+
+  logger.info(
+    `\n\n\nHere are all the ${replacedPagesIdList.length} replaced pages:\n ${replacedPagesIdList}`,
+  );
+});

--- a/contentful/management-api-scripts/helpers.js
+++ b/contentful/management-api-scripts/helpers.js
@@ -96,7 +96,9 @@ async function processEntries(environment, args, entryType, process) {
     }
 
     // Finally, yield each entry to the provided process function.
-    for (let entry of entryItems) {
+    for (let i = 0; i < entryItems.length; i++) {
+      const entry = entryItems[i];
+
       await process(environment, entry);
     }
   }


### PR DESCRIPTION
### What's this PR do?

This pull request adds a Contentful Management API script to fix an issue with broken modal links.

### How should this be reviewed?
👀 
https://dosomething.gitbook.io/phoenix-documentation/development/contentful/content-management-api-scripts

### Any background context you want to provide?
With the advent of our GraphQL block querying work, we've deprecated the ability to link to Page entries [as modals](https://github.com/DoSomething/phoenix-next/blob/f675b3c725d9b0576531d54443d1892294b4a5ba/resources/assets/components/utilities/ModalRoute/ModalRoute.js#L49-L54) on Phoenix. We only support linking to entries which have a corresponding GraphQL Type implementing the [`Block` interface](https://github.com/DoSomething/graphql/blob/master/src/schema/contentful/phoenix.js#L55). That's how we query Contentful entries on the fly in the [`ContentfulEntryLoader`](https://github.com/DoSomething/phoenix-next/blob/f675b3c725d9b0576531d54443d1892294b4a5ba/resources/assets/components/utilities/ContentfulEntryLoader/ContentfulEntryLoader.js) (which makes sense. Only blocks should be embedded on pages, not pages themselves!)

The trouble is, we have a rather large list of database campaigns that link to Page entries as modals. ~250 or so Content Blocks with these broken links.

This script will:
- find all modal links in Content Blocks
- fetch the linked entry
- determine if said entry is a `page`
- replace any `page`s with a derived Content Block
- replace the broken link with a link to the new Content Block
- dump the list of replaced pages (we aren't doing the work to delete these pages right now, so it'll be nice to have a logged list)


### Relevant tickets

References [Pivotal #171631131](https://www.pivotaltracker.com/story/show/171631131).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added screenshots of front-end changes on small, medium, and large screens.
- [ ] Added appropriate feature/unit tests.
