### PR TITLE
Patch for Contentful Modal replacement script

### DIFF
--- a/contentful/management-api-scripts/2020_03_05_replace_page_modals_with_content_blocks.js
+++ b/contentful/management-api-scripts/2020_03_05_replace_page_modals_with_content_blocks.js
@@ -81,10 +81,10 @@ const replacePageModalsWithContentBlocks = async (
     );
 
     // Replace the page modal Contentful ID with the derived Content Block ID.
-    contentBlockEntry.fields.content[LOCALE] = contentBlockContent.replace(
-      modalEntryId,
-      derivedContentBlock.sys.id,
-    );
+    contentBlockEntry.fields.content[LOCALE] = getField(
+      contentBlockEntry,
+      'content',
+    ).replace(modalEntryId, derivedContentBlock.sys.id);
 
     replacedPagesIdList.push(modalEntryId);
 


### PR DESCRIPTION
### What's this PR do?

This pull request patches a bug in the `replace_page_modals_with_content_blocks` contentful script (#1956) to ensure that we always run the modal ID replacement on the _current_ updated content field (which means that if there are two faulty modal links they'd _both_ be replaced).

I've already run this script and patched things up manually, but this ensures we have this working for posterity I suppose or at least for history's sake.

https://dosomething.slack.com/archives/CUQMTP0RM/p1583528907008000?thread_ts=1583526416.006400&cid=CUQMTP0RM