### PR TITLE
Scholarship Info Block UI Bug

### DIFF
--- a/resources/assets/components/blocks/ScholarshipInfoBlock/ScholarshipInfoBlock.js
+++ b/resources/assets/components/blocks/ScholarshipInfoBlock/ScholarshipInfoBlock.js
@@ -120,7 +120,7 @@ const ScholarshipInfoBlock = ({
             </>
           ) : null}
         </div>
-        <div className="pt-6 pb-8">
+        <div className="pt-6 pb-8 clear-both">
           {isLoaded ? (
             <strong className="text-lg">
               Welcome


### PR DESCRIPTION
### What's this PR do?

This pull request patches a small ui bug I noticed this morning, where on narrower versions of the large display, the welcome message would be pull into the `float`ed logo above it.

### How should this be reviewed?
👁 

Before:
![image](https://user-images.githubusercontent.com/12417657/76249274-564fdb80-6219-11ea-91ff-c84789d1774d.png)

After:
![image](https://user-images.githubusercontent.com/12417657/76249299-67005180-6219-11ea-84e1-405022bc3d14.png)
