### PR TITLE
Fixing EmotionJS & React bug.

### DIFF
--- a/resources/assets/components/blocks/ScholarshipInfoBlock/ScholarshipInfoBlock.js
+++ b/resources/assets/components/blocks/ScholarshipInfoBlock/ScholarshipInfoBlock.js
@@ -1,7 +1,6 @@
 /** @jsx jsx */
 
-// eslint-disable-next-line no-unused-vars
-import React, { useState } from 'react';
+import { Fragment, useState } from 'react';
 import { get } from 'lodash';
 import gql from 'graphql-tag';
 import Media from 'react-media';
@@ -106,7 +105,7 @@ const ScholarshipInfoBlock = ({
             <DoSomethingLogo className="h-16" />
           </div>
           {affiliateSponsors.length ? (
-            <>
+            <Fragment>
               <div className="h-full pt-2 float-left text-4xl text-black leading-none">
                 &times;
               </div>
@@ -117,7 +116,7 @@ const ScholarshipInfoBlock = ({
                   alt={affiliateSponsors[0].fields.logo.title}
                 />
               </div>
-            </>
+            </Fragment>
           ) : null}
         </div>
         <div className="pt-6 pb-8 clear-both">
@@ -189,7 +188,7 @@ const ScholarshipInfoBlock = ({
               ) : null}
               <Media queries={{ small: '(max-width: 480px)' }}>
                 {matches => (
-                  <>
+                  <Fragment>
                     {matches.small ? (
                       <div css={!drawerOpen ? isVisible : null}>
                         <ScholarshipActionType
@@ -203,14 +202,14 @@ const ScholarshipInfoBlock = ({
                         actionLabel={actionType}
                       />
                     )}
-                  </>
+                  </Fragment>
                 )}
               </Media>
             </div>
             <div className="lg:flex">
               <Media queries={{ small: '(max-width: 480px)' }}>
                 {matches => (
-                  <>
+                  <Fragment>
                     {matches.small ? (
                       <div css={!drawerOpen ? isVisible : null}>
                         <ScholarshipRequirements />
@@ -218,12 +217,12 @@ const ScholarshipInfoBlock = ({
                     ) : (
                       <ScholarshipRequirements />
                     )}
-                  </>
+                  </Fragment>
                 )}
               </Media>
               <Media queries={{ small: '(max-width: 480px)' }}>
                 {matches => (
-                  <>
+                  <Fragment>
                     {matches.small ? (
                       <div css={!drawerOpen ? isVisible : null}>
                         <ScholarshipInstructions
@@ -237,7 +236,7 @@ const ScholarshipInfoBlock = ({
                         endDate={getHumanFriendlyDate(endDate)}
                       />
                     )}
-                  </>
+                  </Fragment>
                 )}
               </Media>
             </div>


### PR DESCRIPTION
### What's this PR do?

This pull request fixes a small bug we found with ESLint and React, that before was dealt with by commenting out the ESLint warning about importing `React` and not using it. 

### How should this be reviewed?

👀 

### Any background context you want to provide?

With EmotionJS there was a bug that would stop rendering because it was indicating that `React` was missing, however with EmotionJS we are meant to use the `jsx` wrapper they provide. When adding it back in the bug went away, but then we would get an ESLint error indicating that `React` was imported and not used. So the solution at the time was to just disable that specific line from ESLint.

I encountered this in my PR #1957 and dug a bit further and found that the issue lies in the shorthand `<>...</>` React fragment syntax. EmotionJS doesn't yet support the shorthand syntax, so if we change this by importing `Fragment` and using `<Fragment>...</Fragment>` it ends  up solving the issue and no need to comment out any ESLint lines 💃

### Relevant tickets

🌵🐞 
