### PR TITLE
Pull scholarship CTA and description into LedeBanner

### DIFF
--- a/resources/assets/components/LedeBanner/LedeBannerContainer.js
+++ b/resources/assets/components/LedeBanner/LedeBannerContainer.js
@@ -44,7 +44,9 @@ const mapStateToProps = (state, props) => ({
   ),
   isAffiliated: isSignedUp(state),
   scholarshipAmount: state.campaign.scholarshipAmount,
+  scholarshipCallToAction: state.campaign.scholarshipCallToAction,
   scholarshipDeadline: state.campaign.scholarshipDeadline,
+  scholarshipDescription: state.campaign.scholarshipDescription,
   subtitle: get(props, 'subtitle', state.campaign.callToAction),
   title: get(props, 'title', state.campaign.title),
 });


### PR DESCRIPTION
### What's this PR do?

This pull request fixes a bug where the scholarship CTA and description were not pulled in from Contentful, so we always displayed the defaults for these fields.

Data in Contentful:
<img width="728" alt="image" src="https://user-images.githubusercontent.com/4240292/76577578-1855f000-6483-11ea-9b01-25e675043ba6.png">

and that data now showing up as expected in the modal!
<img width="1085" alt="image" src="https://user-images.githubusercontent.com/4240292/76577593-24da4880-6483-11ea-8c7b-e7c4345831bb.png">

### How should this be reviewed?

Is the content being pulled in as expected now?

### Any background context you want to provide?

This was a flagged earlier this week.

I'm bumping Cypress tests to a future PR because the content is coming straight from Contentful, not GraphQL so I can't just easily mock (is that true??) it and I want to get this fix out!

### Relevant tickets

References [Pivotal #171726725](https://www.pivotaltracker.com/story/show/171726725).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Added appropriate feature/unit tests.
