### PR TITLE
Fix company page background now that it isn't baked into CSS.

### DIFF
--- a/resources/assets/components/pages/CompanyPage/CompanyPage.js
+++ b/resources/assets/components/pages/CompanyPage/CompanyPage.js
@@ -36,7 +36,7 @@ const CompanyPageTemplate = props => {
       <SiteNavigationContainer />
 
       <main className="wrapper base-12-grid company-page">
-        <article className="grid-wide card rounded border border-solid border-gray-300">
+        <article className="grid-wide bg-white rounded border border-solid border-gray-300 overflow-hidden">
           {coverImage.url ? (
             <LazyImage
               className="w-full"


### PR DESCRIPTION
### What's this PR do?

This pull request fixes a tiny visual bug introduced in #1965.

### How should this be reviewed?

Here's a before/after comparison.

#### Before:

<img width="1392" alt="Screen Shot 2020-03-13 at 2 23 24 PM" src="https://user-images.githubusercontent.com/583202/76649095-53652b80-6536-11ea-88cb-c590a002ea05.png">

#### After:

<img width="1392" alt="Screen Shot 2020-03-13 at 2 23 13 PM" src="https://user-images.githubusercontent.com/583202/76649113-59f3a300-6536-11ea-901d-b7819963143e.png">

### Any background context you want to provide?

A good reminder of how CSS's implicit global namespace can bite us!

### Relevant tickets

N/A

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added screenshots of front-end changes on small, medium, and large screens.
- [ ] Added appropriate feature/unit tests.
