### PR TITLE
New Account Profile Credits Tab for Volunteer Credits Table

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -42,13 +42,11 @@ class AppServiceProvider extends ServiceProvider
                 'FACEBOOK_APP_ID' => config('services.analytics.facebook_id'),
                 'GRAPHQL_URL' => config('services.graphql.url'),
                 'NORTHSTAR_URL' => config('services.northstar.url'),
-                'NPS_SURVEY_ENABLED' => config('services.timed_modals.nps_survey.enabled'),
                 'PHOENIX_URL' => config('app.url'),
                 'SIXPACK_BASE_URL' => config('services.sixpack.url'),
                 'SIXPACK_COOKIE_PREFIX' => config('services.sixpack.prefix'),
                 'SIXPACK_ENABLED' => config('services.sixpack.enabled'),
                 'SIXPACK_TIMEOUT' => config('services.sixpack.timeout'),
-                'VOTER_REG_MODAL_ENABLED' => config('services.timed_modals.voter_reg_modal.enabled'),
                 'CONTENTFUL_USE_PREVIEW_API' => config('contentful')['delivery.preview'],
                 'FEATURE_FLAGS' => config('features'),
             ]);

--- a/config/features.php
+++ b/config/features.php
@@ -16,4 +16,5 @@ return [
     'nps_survey' => env('DS_ENABLE_NPS_SURVEY', false),
     'voter_reg_modal' => env('DS_ENABLE_VOTER_REG_MODAL', false),
     'dynamic_explore_campaigns' => env('DS_ENABLE_DYNAMIC_CAMPAIGNS_PAGE', false),
+    'volunteer_credits' => env('DS_ENABLE_VOLUNTEER_CREDITS', false),
 ];

--- a/resources/assets/components/pages/AccountPage/AccountNavigation.js
+++ b/resources/assets/components/pages/AccountPage/AccountNavigation.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
+import { featureFlag } from '../../../helpers';
 import NavigationLink from '../../utilities/NavigationLink/NavigationLink';
 
 const AccountNavigation = props => (
@@ -9,6 +10,11 @@ const AccountNavigation = props => (
       <NavigationLink to="/us/account/campaigns">Campaigns</NavigationLink>
       {props.user.hasBadgesFlag ? (
         <NavigationLink to="/us/account/profile/badges">Badges</NavigationLink>
+      ) : null}
+      {featureFlag('volunteer_credits') ? (
+        <NavigationLink to="/us/account/profile/credits">
+          Credits
+        </NavigationLink>
       ) : null}
       <NavigationLink exact to="/us/account/profile">
         Profile

--- a/resources/assets/components/pages/AccountPage/AccountRoute.js
+++ b/resources/assets/components/pages/AccountPage/AccountRoute.js
@@ -6,6 +6,7 @@ import Profile from './Profile';
 import BadgesTab from './BadgesTab';
 import Subscriptions from './Subscriptions';
 import UserPostsQuery from './UserPostsQuery';
+import { featureFlag } from '../../../helpers';
 import DeleteAccountTab from './DeleteAccountTab';
 
 const AccountRoute = props => (
@@ -14,6 +15,19 @@ const AccountRoute = props => (
       <Route
         path="/us/account/profile/badges"
         render={() => <BadgesTab {...props} />}
+      />
+    ) : null}
+    {featureFlag('volunteer_credits') ? (
+      <Route
+        path="/us/account/profile/credits"
+        render={() => (
+          <h1 className="grid-wide">
+            I&apos;m a credits teapot{' '}
+            <span role="img" aria-label="a little teapot emoji">
+              🍵
+            </span>
+          </h1>
+        )}
       />
     ) : null}
     <Route

--- a/resources/assets/components/pages/AccountPage/AccountRoute.js
+++ b/resources/assets/components/pages/AccountPage/AccountRoute.js
@@ -1,9 +1,9 @@
 import React from 'react';
-import { Switch, Route } from 'react-router-dom';
 import PropTypes from 'prop-types';
+import { Switch, Route } from 'react-router-dom';
 
-import BadgesTab from './BadgesTab';
 import Profile from './Profile';
+import BadgesTab from './BadgesTab';
 import Subscriptions from './Subscriptions';
 import UserPostsQuery from './UserPostsQuery';
 import DeleteAccountTab from './DeleteAccountTab';


### PR DESCRIPTION
### What's this PR do?

This pull request adds a new `/account/profile/credits` tab which will eventually contain the impending Volunteer Credits certificate table. This is feature flagged under the newly added `volunteer_credits` feature flag.

### How should this be reviewed?
👀 

### Any background context you want to provide?
We do intend to bunch together this and the badges tab under a new 'Rewards' tab. But we want to collect some specific data for this feature first, hance the individual tabs for the time being.

### Relevant tickets

References [Pivotal #171729086](https://www.pivotaltracker.com/story/show/171729086).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added screenshots of front-end changes on small, medium, and large screens.
- [ ] Added appropriate feature/unit tests.

![image](https://user-images.githubusercontent.com/12417657/76777421-8bf74600-677e-11ea-9291-48bab1f56ca0.png)
