### PR TITLE
Use aliases for conflicting LinkBlock fragment fields

### DIFF
--- a/resources/assets/components/ContentfulEntry/ContentfulEntry.js
+++ b/resources/assets/components/ContentfulEntry/ContentfulEntry.js
@@ -141,7 +141,16 @@ class ContentfulEntry extends React.Component {
         return <LandingPageContainer {...json.fields} />;
 
       case 'LinkBlock':
-        return <LinkActionContainer {...withoutNulls(json)} />;
+        return (
+          <LinkActionContainer
+            {...withoutNulls({
+              ...json,
+              // Resolves the aliases used in the LinkBlockFragment.
+              title: json.linkBlockTitle,
+              link: json.linkActionLink,
+            })}
+          />
+        );
 
       case 'PetitionSubmissionBlock':
         return (

--- a/resources/assets/components/actions/LinkAction/LinkAction.js
+++ b/resources/assets/components/actions/LinkAction/LinkAction.js
@@ -9,9 +9,9 @@ import AnalyticsWaypoint from '../../utilities/AnalyticsWaypoint/AnalyticsWaypoi
 
 export const LinkBlockFragment = gql`
   fragment LinkBlockFragment on LinkBlock {
-    title
+    linkBlockTitle: title
     content
-    link
+    linkBlockLink: link
     buttonText
     affiliateLogo {
       url(w: 200, h: 100)


### PR DESCRIPTION
### What's this PR do?

This pull request adds [aliases](https://graphql.org/learn/queries/#aliases) to two conflicting fields in the `LinkBlockFragment`. The `title` & `link` conflict with other `block` fields of the same name which are _not_ required.

We've updated them to required in https://github.com/DoSomething/graphql/commit/53806590a533f2863a096c4e9b0c0dccfa1d9083 which broke our epic block query [here](https://github.com/DoSomething/phoenix-next/blob/92040861169ab80d1d927c82d3077e793d89a683/resources/assets/components/utilities/ContentfulEntryLoader/ContentfulEntryLoader.js#L35)

### How should this be reviewed?
👀 

### Any background context you want to provide?
You can check out the PR description here for more context on these aliases https://github.com/DoSomething/phoenix-next/pull/1681

### Relevant tickets

References [Pivotal #171824364](https://www.pivotaltracker.com/story/show/171824364).
https://dosomething.slack.com/archives/C02BBP0CU/p1584540907002700?thread_ts=1584540771.002300&cid=C02BBP0CU
### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added screenshots of front-end changes on small, medium, and large screens.
- [ ] Added appropriate feature/unit tests.
