### PR TITLE
Link Action patch - fix faulty alias reference

### DIFF
--- a/resources/assets/components/ContentfulEntry/ContentfulEntry.js
+++ b/resources/assets/components/ContentfulEntry/ContentfulEntry.js
@@ -147,7 +147,7 @@ class ContentfulEntry extends React.Component {
               ...json,
               // Resolves the aliases used in the LinkBlockFragment.
               title: json.linkBlockTitle,
-              link: json.linkActionLink,
+              link: json.linkBlockLink,
             })}
           />
         );


### PR DESCRIPTION
### What's this PR do?

This pull request fixes a faulty alias field reference in #1972 

![meme](https://wompampsupport.azureedge.net/fetchimage?siteId=7575&v=2&jpgQuality=100&width=700&url=https%3A%2F%2Fi.kym-cdn.com%2Fentries%2Ficons%2Ffacebook%2F000%2F021%2F516%2Fthey_ask_you_how_you_are.jpg)