### PR TITLE
Changes image crop parameter to common 16:9 ratios

### DIFF
--- a/resources/assets/components/LedeBanner/templates/HeroTemplate.js
+++ b/resources/assets/components/LedeBanner/templates/HeroTemplate.js
@@ -51,7 +51,7 @@ const HeroTemplate = ({
   // @TODO: If this experiment is successful we should turn generating the series urls for
   // the cover image photo at different sizes into a helper function!
   const coverImageUrls = {
-    extraLarge: contentfulImageUrl(coverImage.url, '1920', '1080', 'fill'),
+    extraLarge: contentfulImageUrl(coverImage.url, '2880', '1620', 'fill'),
     large: contentfulImageUrl(coverImage.url, '1440', '810', 'fill'),
     medium: contentfulImageUrl(coverImage.url, '1024', '576', 'fill'),
     small: contentfulImageUrl(coverImage.url, '640', '360', 'fill'),
@@ -67,7 +67,7 @@ const HeroTemplate = ({
           <img
             className="grid-wide"
             alt={coverImage.description || `cover photo for ${title}`}
-            srcSet={`${coverImageUrls.small} 360w, ${coverImageUrls.medium} 720w, ${coverImageUrls.large} 1440w, ${coverImageUrls.extraLarge} 2880w`}
+            srcSet={`${coverImageUrls.small} 640w, ${coverImageUrls.medium} 1024w, ${coverImageUrls.large} 1440w, ${coverImageUrls.extraLarge} 2880w`}
             src={coverImageUrls.small}
           />
         </div>

--- a/resources/assets/components/LedeBanner/templates/HeroTemplate.js
+++ b/resources/assets/components/LedeBanner/templates/HeroTemplate.js
@@ -51,10 +51,10 @@ const HeroTemplate = ({
   // @TODO: If this experiment is successful we should turn generating the series urls for
   // the cover image photo at different sizes into a helper function!
   const coverImageUrls = {
-    extraLarge: contentfulImageUrl(coverImage.url, '2232', '1000', 'fill'),
-    large: contentfulImageUrl(coverImage.url, '1116', '500', 'fill'),
-    medium: contentfulImageUrl(coverImage.url, '720', '350', 'fill'),
-    small: contentfulImageUrl(coverImage.url, '360', '200', 'fill'),
+    extraLarge: contentfulImageUrl(coverImage.url, '1920', '1080', 'fill'),
+    large: contentfulImageUrl(coverImage.url, '1440', '810', 'fill'),
+    medium: contentfulImageUrl(coverImage.url, '1024', '576', 'fill'),
+    small: contentfulImageUrl(coverImage.url, '640', '360', 'fill'),
   };
   return (
     <>


### PR DESCRIPTION
### What's this PR do?

This pull request updates the Hero Template of the Lede Banner component to use proper (and common) 16:9 crops, to better match with assets we're receiving from Creative/Marketing/Campaigns. We'll now serve the following sizes for cropped images:

- Extra-Large is 2880x1620
- Large is 1440 x 810
- Medium is 1024×576
- Small is 640x360

### How should this be reviewed?

👀 

### Any background context you want to provide?

When we swapped over from the mosaic template to the hero template, we wanted to lower the amount of differences displaying creative assets so we decided that all campaign images in the lede banner, galleries, articles, etc would be in the common 16:9 format. There was some miscommunication in the lede banner which would lead to parts of people's faces or other important image parts being cut off, so we're correcting the cropped image aspect ratios.

### Relevant tickets

References [Pivotal #171859459](https://www.pivotaltracker.com/story/show/171859459).

**Before**
![poorcrop](https://user-images.githubusercontent.com/1865372/76992110-18416e80-6921-11ea-9647-ea1bc5a0081e.png)

**After**
![propercrop](https://user-images.githubusercontent.com/1865372/76992132-21cad680-6921-11ea-8188-8a892ee266f4.png)
