### PR TITLE
Subscription center fast fixes

### DIFF
--- a/resources/assets/components/pages/AccountPage/Subscriptions/EmailSubscriptionItem.js
+++ b/resources/assets/components/pages/AccountPage/Subscriptions/EmailSubscriptionItem.js
@@ -63,8 +63,8 @@ const EmailSubscriptionItem = ({ topic, name, image, description }) => {
           type="button"
           className={
             !topics.includes(topic)
-              ? 'btn mx-4 mb-4 bg-blurple-500 text-white border border-solid border-blurple-500 hover:bg-blurple-300'
-              : 'btn mx-4 mb-4 bg-white border border-solid border-blurple-500 text-blurple-500 hover:border-blurple-300 hover:text-blurple-200 focus:bg-blurple-500 focus:text-white focus:outline-none'
+              ? 'btn mx-4 mb-4 bg-blurple-500 text-white border border-solid border-blurple-500 hover:bg-blurple-300 focus:bg-blurple-500 focus:text-white focus:outline-none'
+              : 'btn mx-4 mb-4 bg-white text-blurple-500 border border-solid border-blurple-500 hover:border-blurple-300 hover:text-blurple-200 focus:bg-white focus:text-blurple-500 focus:outline-none'
           }
           onClick={() =>
             updateSubscription({

--- a/resources/assets/components/pages/AccountPage/Subscriptions/EmailSubscriptionItem.js
+++ b/resources/assets/components/pages/AccountPage/Subscriptions/EmailSubscriptionItem.js
@@ -64,7 +64,7 @@ const EmailSubscriptionItem = ({ topic, name, image, description }) => {
           className={
             !topics.includes(topic)
               ? 'btn mx-4 mb-4 bg-blurple-500 text-white border border-solid border-blurple-500 hover:bg-blurple-300'
-              : 'btn mx-4 mb-4 bg-white border border-solid border-blurple-500 text-blurple-500 hover:border-blurple-300 hover:text-blurple-200'
+              : 'btn mx-4 mb-4 bg-white border border-solid border-blurple-500 text-blurple-500 hover:border-blurple-300 hover:text-blurple-200 focus:bg-blurple-500 focus:text-white focus:outline-none'
           }
           onClick={() =>
             updateSubscription({

--- a/resources/assets/components/pages/AccountPage/Subscriptions/Subscriptions.js
+++ b/resources/assets/components/pages/AccountPage/Subscriptions/Subscriptions.js
@@ -7,10 +7,6 @@ const Subscriptions = props => (
   <div className="grid-wide">
     <div className="pb-4">
       <h2 className="text-lg">Email Subscriptions</h2>
-      <p>
-        We tailor your emails and other communication based on your favorite
-        cause areas.
-      </p>
     </div>
 
     <EmailSubscriptions {...props} />


### PR DESCRIPTION
### What's this PR do?

This pull request fixes a couple lingering design issues with the new subscription center:
- Some demo copy slipped through describing the subscription center
- The focus state of the button needed to be overridden

### How should this be reviewed?

Run the app and click around the subscription center

### Relevant tickets

References [Pivotal #171544380](https://www.pivotaltracker.com/story/show/171544380).

Before:
<img width="253" alt="Screen Shot 2020-03-18 at 4 20 49 PM" src="https://user-images.githubusercontent.com/1865372/77077651-e3d6bc80-69cb-11ea-94bc-3f830df124f6.png">

After:
<img width="281" alt="Screen Shot 2020-03-19 at 10 25 33 AM" src="https://user-images.githubusercontent.com/1865372/77077727-ff41c780-69cb-11ea-9df9-ebe03e37fde9.png">