### PR TITLE
Update Coronavirus collection metadata img url

### DIFF
--- a/app/helpers.php
+++ b/app/helpers.php
@@ -429,7 +429,7 @@ function metadata_fallback()
             'title' => 'Don\'t let COVID-19 stop you from changing the world.',
             'description' => 'Join millions of DoSomething members using our resources to stay healthy, fight anxiety, and make a difference on the causes we care about, from mental health to climate change and beyond. Let’s Do This.',
             'image' => [
-                'url' => 'https://images.ctfassets.net/81iqaqpfd8fy/1IkA8BVk0iBqJhQfsX1uF3/0dece4512c587291aa3eab7e22f21984/corona_banner.jpg?f=center&fit=fill&h=1200&w=1200',
+                'url' => 'https://images.ctfassets.net/81iqaqpfd8fy/6Ko2KXJ0fCKmZIm2G6ATEs/2ef1f7694fb81a824940aa697d27cb9f/COVID_metadata.jpg?f=center&fit=fill&h=1200&w=1200',
                 'width' => '1200',
                 'height' => '1200',
             ],


### PR DESCRIPTION
### What's this PR do?

This pull request updates the custom metadata image URL we're setting for the Coronavirus collection page #1979 

https://dosomething.slack.com/archives/C09ANFQLA/p1584567463258400?thread_ts=1584543360.240800&cid=C09ANFQLA