### PR TITLE
Adding new helper for srcset Contentful content images.

### DIFF
--- a/resources/assets/components/LedeBanner/templates/HeroTemplate.js
+++ b/resources/assets/components/LedeBanner/templates/HeroTemplate.js
@@ -13,6 +13,7 @@ import ScholarshipInfoBlock from '../../blocks/ScholarshipInfoBlock/ScholarshipI
 import AffiliateOptInToggleContainer from '../../AffiliateOptInToggle/AffiliateOptInToggleContainer';
 import {
   contentfulImageUrl,
+  contentfulImageSrcset,
   isScholarshipAffiliateReferral,
   getScholarshipAffiliateLabel,
 } from '../../../helpers';
@@ -48,14 +49,13 @@ const HeroTemplate = ({
     }
   }, []);
 
-  // @TODO: If this experiment is successful we should turn generating the series urls for
-  // the cover image photo at different sizes into a helper function!
-  const coverImageUrls = {
-    extraLarge: contentfulImageUrl(coverImage.url, '2880', '1620', 'fill'),
-    large: contentfulImageUrl(coverImage.url, '1440', '810', 'fill'),
-    medium: contentfulImageUrl(coverImage.url, '1024', '576', 'fill'),
-    small: contentfulImageUrl(coverImage.url, '640', '360', 'fill'),
-  };
+  const srcset = contentfulImageSrcset(coverImage.url, [
+    { height: 360, width: 640 },
+    { height: 576, width: 1024 },
+    { height: 810, width: 1440 },
+    { height: 1620, width: 2880 },
+  ]);
+
   return (
     <>
       {/*
@@ -67,8 +67,8 @@ const HeroTemplate = ({
           <img
             className="grid-wide"
             alt={coverImage.description || `cover photo for ${title}`}
-            srcSet={`${coverImageUrls.small} 640w, ${coverImageUrls.medium} 1024w, ${coverImageUrls.large} 1440w, ${coverImageUrls.extraLarge} 2880w`}
-            src={coverImageUrls.small}
+            srcSet={srcset}
+            src={contentfulImageUrl(coverImage.url, '1440', '810', 'fill')}
           />
         </div>
 

--- a/resources/assets/components/pages/HomePage/NewHomePage.js
+++ b/resources/assets/components/pages/HomePage/NewHomePage.js
@@ -5,8 +5,8 @@ import { React, Fragment } from 'react';
 
 import PageQuery from '../PageQuery';
 import sponsorList from './sponsor-list';
-import { contentfulImageUrl, tailwind } from '../../../helpers';
 import SiteFooter from '../../utilities/SiteFooter/SiteFooter';
+import { contentfulImageUrl, tailwind } from '../../../helpers';
 import HomePageCampaignGallery from './HomePageCampaignGallery';
 import SiteNavigationContainer from '../../SiteNavigation/SiteNavigationContainer';
 

--- a/resources/assets/components/utilities/Gallery/templates/CampaignGalleryItem/CampaignGalleryItemV2.js
+++ b/resources/assets/components/utilities/Gallery/templates/CampaignGalleryItem/CampaignGalleryItemV2.js
@@ -1,7 +1,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import { contentfulImageUrl } from '../../../../../helpers';
+import {
+  contentfulImageUrl,
+  contentfulImageSrcset,
+} from '../../../../../helpers';
 
 const CampaignGalleryItemV2 = ({
   showcaseDescription,
@@ -9,12 +12,17 @@ const CampaignGalleryItemV2 = ({
   showcaseTitle,
   url,
 }) => {
+  const srcset = contentfulImageSrcset(showcaseImage.url, [
+    { height: 205, width: 365 },
+    { height: 410, width: 730 },
+  ]);
+
   return (
     <article className="flex flex-col h-full relative text-left">
       <img
         alt={showcaseImage.description || `Cover photo for ${showcaseTitle}`}
-        className="w-full"
-        src={contentfulImageUrl(showcaseImage.url, '360', '200', 'fill')}
+        srcSet={srcset}
+        src={contentfulImageUrl(showcaseImage.url, '365', '205', 'fill')}
       />
 
       <div className="bg-white border border-b border-l border-r border-gray-300 border-solid flex flex-col flex-grow p-4 rounded-b-sm">

--- a/resources/assets/helpers/index.js
+++ b/resources/assets/helpers/index.js
@@ -149,6 +149,22 @@ export function contentfulImageUrl(
 }
 
 /**
+ * Generate srcset value at specified sizes for a Contentful Image URL.
+ *
+ * @param {String} url
+ * @param {Object} sizes
+ */
+export function contentfulImageSrcset(url, sizes) {
+  const sources = sizes.map(size => {
+    return `${contentfulImageUrl(url, size.width, size.height, 'fill')} ${
+      size.width
+    }w`;
+  });
+
+  return sources.join(', ');
+}
+
+/**
  * Return a string with tokens replaced by specified values.
  *
  * @param  {String} string


### PR DESCRIPTION
### What's this PR do?

This pull request adds a new `contentfulImageSrcset()` helper function to help generate the long string for the `srcset` on the `<img>` based on the supplied URL and an array of objects defining sizes.

E.g.

```jsx
// generating the srcset attribute value
const srcset = contentfulImageSrcset(coverImage.url, [
  { height: 360, width: 640 },
  { height: 576, width: 1024 },
  { height: 810, width: 1440 },
  { height: 1620, width: 2880 },
]);

// in use
<img
  className="grid-wide"
  alt={coverImage.description || `cover photo for ${title}`}
  srcSet={srcset}
  src={contentfulImageUrl(coverImage.url, '1440', '810', 'fill')}
/>
```

In the above example, you can see that I set the default `src` image to the large `1440px` wide image which is good for older browsers (likely on desktop computers) that don't support `srcset`. This may not always be the need for every `<img />` and maybe the smaller size is more appropriate for the default. I find it useful that the helper just helps with the convoluted (and easy to mess up) syntax for `srcset` and that's it.

Thanks to `srcset` browsers can decide which is the most appropriate image to download based on their device pixel ratio and the image size needs, which is particularly important for reducing bandwidth and data usage on small screen devices which can use smaller images.

### How should this be reviewed?

👀

### Any background context you want to provide?

Why didn't I go the route of a `<ContentfulResponsiveImage />` component and supply everything as props? 

We've gone down this road before with good intentions but then end up needing to add more versatility to a component or it causes too many headaches when it tries to do too much for a very nuanced solutions (👋 `<Flex />` & `<FlexCell />`).

While it could be convenient to have a distinct component, I worried it would lead us down a less versatile/adaptable path. Potentially needing to add extra logic to decide which is the default size for an `<img />` applied to the `src` attribute. Having to deal with passing `className`'s, `alt` values, etc, it seemed the added versatility of just a convenience helper function for the `srcset` values could do just enough to simplify things. If it turns out we _do_ want a specific component in the future, this helper function is still useful and can be used in said component anyhoo!

### Relevant tickets

References [Pivotal #]().

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
