### PR TITLE
Cause/Interests Page!!

### DIFF
--- a/resources/assets/components/pages/AccountPage/Account/AccountQuery.js
+++ b/resources/assets/components/pages/AccountPage/Account/AccountQuery.js
@@ -16,6 +16,7 @@ const ACCOUNT_QUERY = gql`
       email
       emailSubscriptionTopics
       hasBadgesFlag: hasFeatureFlag(feature: "badges")
+      causes
     }
   }
 `;

--- a/resources/assets/components/pages/AccountPage/Account/AccountQuery.js
+++ b/resources/assets/components/pages/AccountPage/Account/AccountQuery.js
@@ -16,7 +16,6 @@ const ACCOUNT_QUERY = gql`
       email
       emailSubscriptionTopics
       hasBadgesFlag: hasFeatureFlag(feature: "badges")
-      causes
     }
   }
 `;

--- a/resources/assets/components/pages/AccountPage/Account/AccountRoute.js
+++ b/resources/assets/components/pages/AccountPage/Account/AccountRoute.js
@@ -34,7 +34,7 @@ const AccountRoute = props => (
     {featureFlag('cause_preferences') ? (
       <Route
         path="/us/account/profile/interests"
-        render={() => <Interests {...props} />}
+        render={() => <Interests />}
       />
     ) : null}
     <Route

--- a/resources/assets/components/pages/AccountPage/Interests/CausePreferenceItem.js
+++ b/resources/assets/components/pages/AccountPage/Interests/CausePreferenceItem.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import gql from 'graphql-tag';
 import PropTypes from 'prop-types';
-// import classNames from 'classnames';
+import classNames from 'classnames';
 import { useMutation } from '@apollo/react-hooks';
 
 const CAUSE_PREFERENCE_MUTATION = gql`
@@ -26,18 +26,20 @@ const CausePreferenceItem = ({ cause, causes, description, title }) => {
   const [updateInterest] = useMutation(CAUSE_PREFERENCE_MUTATION, options);
 
   return (
-    <div className="border border-solid border-gray-300 p-4 rounded-md flex space-between">
-      <div>
+    <div className="border border-solid border-gray-300 p-4 rounded-md flex justify-between">
+      <div className="align-middle md:mt-4">
         <h1 className="text-blurple-500 text-base text-bold">{title}</h1>
         <p className="text-sm text-gray-500">{description}</p>
       </div>
+
       <button
         type="button"
-        className={
+        className={classNames(
+          'btn mx-4 mb-6 md:my-4 border border-solid border-blurple-500 focus:outline-none align-middle',
           !causes.includes(cause)
-            ? 'btn mx-4 mb-4 bg-blurple-500 text-white border border-solid border-blurple-500 hover:bg-blurple-300 focus:bg-blurple-500 focus:text-white focus:outline-none'
-            : 'btn mx-4 mb-4 bg-white border border-solid border-blurple-500 text-blurple-500 hover:border-blurple-300 hover:text-blurple-200 focus:bg-white focus:text-blurple-500 focus:outline-none'
-        }
+            ? 'bg-blurple-500 text-white hover:bg-blurple-300 focus:bg-blurple-500 focus:text-white'
+            : 'bg-white border text-blurple-500 border-solid hover:border-blurple-300 hover:text-blurple-200 focus:bg-white focus:text-blurple-500',
+        )}
         onClick={() =>
           updateInterest({
             variables: {

--- a/resources/assets/components/pages/AccountPage/Interests/CausePreferenceItem.js
+++ b/resources/assets/components/pages/AccountPage/Interests/CausePreferenceItem.js
@@ -1,0 +1,33 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const CausePreferenceItem = ({
+  cause,
+  description,
+  title,
+  userCauses,
+  userId,
+}) => {
+  console.log('cause:', cause, 'user id:', userId, 'userCauses:', userCauses);
+  return (
+    <>
+      <h1>{title}</h1>
+      <p>{description}</p>
+    </>
+  );
+};
+
+CausePreferenceItem.propTypes = {
+  cause: PropTypes.string.isRequired,
+  description: PropTypes.string,
+  title: PropTypes.string,
+  userCauses: PropTypes.instanceOf(Array).isRequired,
+  userId: PropTypes.string.isRequired,
+};
+
+CausePreferenceItem.defaultProps = {
+  description: null,
+  title: null,
+};
+
+export default CausePreferenceItem;

--- a/resources/assets/components/pages/AccountPage/Interests/CausePreferenceItem.js
+++ b/resources/assets/components/pages/AccountPage/Interests/CausePreferenceItem.js
@@ -5,8 +5,6 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { useMutation, useQuery } from '@apollo/react-hooks';
 
-import PlaceholderText from '../../../utilities/PlaceholderText/PlaceholderText';
-
 const CAUSE_PREFERENCE_QUERY = gql`
   query CausePreferenceQuery($userId: String!) {
     user(id: $userId) {

--- a/resources/assets/components/pages/AccountPage/Interests/CausePreferenceItem.js
+++ b/resources/assets/components/pages/AccountPage/Interests/CausePreferenceItem.js
@@ -1,19 +1,74 @@
 import React from 'react';
+import gql from 'graphql-tag';
 import PropTypes from 'prop-types';
+import { useMutation, useQuery } from '@apollo/react-hooks';
 
-const CausePreferenceItem = ({
-  cause,
-  description,
-  title,
-  userCauses,
-  userId,
-}) => {
-  console.log('cause:', cause, 'user id:', userId, 'userCauses:', userCauses);
+const CAUSE_PREFERENCE_QUERY = gql`
+  query CausePreferenceQuery($userId: String!) {
+    user(id: $userId) {
+      id
+      causes
+    }
+  }
+`;
+
+const CAUSE_PREFERENCE_MUTATION = gql`
+  mutation CausePreferences(
+    $userId: String!
+    $cause: CauseIdentifier!
+    $interested: Boolean!
+  ) {
+    updateCausePreferences(
+      id: $userId
+      cause: $cause
+      interested: $interested
+    ) {
+      id
+      causes
+    }
+  }
+`;
+
+const CausePreferenceItem = ({ cause, description, title }) => {
+  const options = { variables: { userId: window.AUTH.id } };
+
+  // Make the initial query to get the user's subscriptions
+  const { data, loading, error } = useQuery(CAUSE_PREFERENCE_QUERY, options);
+  const [updateInterest] = useMutation(CAUSE_PREFERENCE_MUTATION, options);
+
+  if (error) {
+    return <p>Something went wrong!</p>;
+  }
+
+  if (loading) {
+    return <div className="spinner" />;
+  }
+
+  const { causes } = data.user;
+
   return (
-    <>
-      <h1>{title}</h1>
+    <div className="border border-solid border-gray-300">
+      <h1 className="text-blurple-500 text-base text-bold">{title}</h1>
       <p>{description}</p>
-    </>
+      <button
+        type="button"
+        className={
+          !causes.includes(cause)
+            ? 'btn mx-4 mb-4 bg-blurple-500 text-white border border-solid border-blurple-500 hover:bg-blurple-300 focus:bg-blurple-500 focus:text-white focus:outline-none'
+            : 'btn mx-4 mb-4 bg-white border border-solid border-blurple-500 text-blurple-500 hover:border-blurple-300 hover:text-blurple-200 focus:bg-white focus:text-blurple-500 focus:outline-none'
+        }
+        onClick={() =>
+          updateInterest({
+            variables: {
+              cause,
+              interested: !causes.includes(cause),
+            },
+          })
+        }
+      >
+        {causes.includes(cause) ? 'Unfollow' : 'Follow'}
+      </button>
+    </div>
   );
 };
 
@@ -21,8 +76,6 @@ CausePreferenceItem.propTypes = {
   cause: PropTypes.string.isRequired,
   description: PropTypes.string,
   title: PropTypes.string,
-  userCauses: PropTypes.instanceOf(Array).isRequired,
-  userId: PropTypes.string.isRequired,
 };
 
 CausePreferenceItem.defaultProps = {

--- a/resources/assets/components/pages/AccountPage/Interests/CausePreferenceItem.js
+++ b/resources/assets/components/pages/AccountPage/Interests/CausePreferenceItem.js
@@ -1,16 +1,8 @@
 import React from 'react';
 import gql from 'graphql-tag';
 import PropTypes from 'prop-types';
-import { useMutation, useQuery } from '@apollo/react-hooks';
-
-const CAUSE_PREFERENCE_QUERY = gql`
-  query CausePreferenceQuery($userId: String!) {
-    user(id: $userId) {
-      id
-      causes
-    }
-  }
-`;
+// import classNames from 'classnames';
+import { useMutation } from '@apollo/react-hooks';
 
 const CAUSE_PREFERENCE_MUTATION = gql`
   mutation CausePreferences(
@@ -29,27 +21,16 @@ const CAUSE_PREFERENCE_MUTATION = gql`
   }
 `;
 
-const CausePreferenceItem = ({ cause, description, title }) => {
+const CausePreferenceItem = ({ cause, causes, description, title }) => {
   const options = { variables: { userId: window.AUTH.id } };
-
-  // Make the initial query to get the user's subscriptions
-  const { data, loading, error } = useQuery(CAUSE_PREFERENCE_QUERY, options);
   const [updateInterest] = useMutation(CAUSE_PREFERENCE_MUTATION, options);
 
-  if (error) {
-    return <p>Something went wrong!</p>;
-  }
-
-  if (loading) {
-    return <div className="spinner" />;
-  }
-
-  const { causes } = data.user;
-
   return (
-    <div className="border border-solid border-gray-300">
-      <h1 className="text-blurple-500 text-base text-bold">{title}</h1>
-      <p>{description}</p>
+    <div className="border border-solid border-gray-300 p-4 rounded-md flex space-between">
+      <div>
+        <h1 className="text-blurple-500 text-base text-bold">{title}</h1>
+        <p className="text-sm text-gray-500">{description}</p>
+      </div>
       <button
         type="button"
         className={
@@ -74,6 +55,7 @@ const CausePreferenceItem = ({ cause, description, title }) => {
 
 CausePreferenceItem.propTypes = {
   cause: PropTypes.string.isRequired,
+  causes: PropTypes.instanceOf(Array).isRequired,
   description: PropTypes.string,
   title: PropTypes.string,
 };

--- a/resources/assets/components/pages/AccountPage/Interests/CausePreferences.js
+++ b/resources/assets/components/pages/AccountPage/Interests/CausePreferences.js
@@ -1,17 +1,6 @@
 import React from 'react';
-import gql from 'graphql-tag';
-import { useQuery } from '@apollo/react-hooks';
 
 import CausePreferenceItem from './CausePreferenceItem';
-
-const CAUSE_PREFERENCE_QUERY = gql`
-  query CausePreferenceQuery($userId: String!) {
-    user(id: $userId) {
-      id
-      causes
-    }
-  }
-`;
 
 const CausePreferences = () => {
   const causeItems = {
@@ -70,28 +59,11 @@ const CausePreferences = () => {
         'Do Something about sexual harassment, assault, and violence near you.',
     },
   };
-
-  const options = { variables: { userId: window.AUTH.id } };
-
-  // Make the initial query to get the user's subscriptions
-  const { data, loading, error } = useQuery(CAUSE_PREFERENCE_QUERY, options);
-
-  if (error) {
-    return <p>Something went wrong!</p>;
-  }
-
-  if (loading) {
-    return <div className="spinner align-center" />;
-  }
-
-  const { causes } = data.user;
-
   return (
     <div className="gallery-grid gallery-grid-duo my-6">
       {Object.keys(causeItems).map(cause => (
         <CausePreferenceItem
           cause={cause}
-          causes={causes}
           title={causeItems[cause].title}
           description={causeItems[cause].description}
         />

--- a/resources/assets/components/pages/AccountPage/Interests/CausePreferences.js
+++ b/resources/assets/components/pages/AccountPage/Interests/CausePreferences.js
@@ -87,7 +87,7 @@ const CausePreferences = () => {
   const { causes } = data.user;
 
   return (
-    <div className="gallery-grid gallery-grid-duo">
+    <div className="gallery-grid gallery-grid-duo my-6">
       {Object.keys(causeItems).map(cause => (
         <CausePreferenceItem
           cause={cause}

--- a/resources/assets/components/pages/AccountPage/Interests/CausePreferences.js
+++ b/resources/assets/components/pages/AccountPage/Interests/CausePreferences.js
@@ -1,9 +1,80 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
-const CausePreferences = () => (
-  <>
-    <p>Our causes will go here!</p>
-  </>
-);
+import CausePreferenceItem from './CausePreferenceItem';
+
+const CausePreferences = ({ user }) => {
+  const causeItems = {
+    ANIMAL_WELFARE: {
+      title: 'Animal Welfare',
+      description: 'Some description',
+    },
+    BULLYING: {
+      title: 'Bullying',
+      description: 'Some description',
+    },
+    EDUCATION: {
+      title: 'Education',
+      description: 'Some description',
+    },
+    ENVIRONMENT: {
+      title: 'Environment',
+      description: 'Some description',
+    },
+    GENDER_RIGHTS_EQUALITY: {
+      title: 'Gender Rights & Equality',
+      description: 'Some description',
+    },
+    HOMELESSNESS_POVERTY: {
+      title: 'Homelessness & Poverty',
+      description: 'Some description',
+    },
+    IMMIGRATION: {
+      title: 'Immigration & Refugees',
+      description: 'Some description',
+    },
+    LGBTQ_RIGHTS_EQUALITY: {
+      title: 'LGBTQ+ Rights & Equality',
+      description: 'Some description',
+    },
+    MENTAL_HEALTH: {
+      title: 'Mental Health',
+      description: 'Some description',
+    },
+    PHYSICAL_HEALTH: {
+      title: 'Physical Health',
+      description: 'Some description',
+    },
+    RACIAL_JUSTICE_EQUITY: {
+      title: 'Racial Justice & Equity',
+      description: 'Some description',
+    },
+    SEXUAL_HARASSMENT_ASSAULT: {
+      title: 'Sexual Harassment & Assault',
+      description: 'Some description',
+    },
+  };
+
+  return (
+    <div className="gallery-grid gallery-grid-duo">
+      {Object.keys(causeItems).map(cause => (
+        <CausePreferenceItem
+          cause={cause}
+          title={causeItems[cause].title}
+          description={causeItems[cause].description}
+          userId={user.id}
+          userCauses={user.causes}
+        />
+      ))}
+    </div>
+  );
+};
+
+CausePreferences.propTypes = {
+  user: PropTypes.shape({
+    causes: PropTypes.array,
+    id: PropTypes.string,
+  }).isRequired,
+};
 
 export default CausePreferences;

--- a/resources/assets/components/pages/AccountPage/Interests/CausePreferences.js
+++ b/resources/assets/components/pages/AccountPage/Interests/CausePreferences.js
@@ -1,64 +1,97 @@
 import React from 'react';
+import gql from 'graphql-tag';
+import { useQuery } from '@apollo/react-hooks';
 
 import CausePreferenceItem from './CausePreferenceItem';
+
+const CAUSE_PREFERENCE_QUERY = gql`
+  query CausePreferenceQuery($userId: String!) {
+    user(id: $userId) {
+      id
+      causes
+    }
+  }
+`;
 
 const CausePreferences = () => {
   const causeItems = {
     ANIMAL_WELFARE: {
       title: 'Animal Welfare',
-      description: 'Some description',
+      description: 'Doggos and kitties and elephants, oh my!',
     },
     BULLYING: {
       title: 'Bullying',
-      description: 'Some description',
+      description:
+        'Bullying affects at least 1 in 5 students.  Let’s Do Something about it.',
     },
     EDUCATION: {
       title: 'Education',
-      description: 'Some description',
+      description:
+        'Make schools fairer, safer, better, and more affordable for everyone.',
     },
     ENVIRONMENT: {
       title: 'Environment',
-      description: 'Some description',
+      description: 'Join the youth-led movement to tackle our climate crisis.',
     },
     GENDER_RIGHTS_EQUALITY: {
       title: 'Gender Rights & Equality',
-      description: 'Some description',
+      description: 'Closing the wage gap is just the beginning.',
     },
     HOMELESSNESS_POVERTY: {
       title: 'Homelessness & Poverty',
-      description: 'Some description',
+      description:
+        'Homelessness affects 500,000 people in the US. Let’s change that.',
     },
     IMMIGRATION_REFUGEES: {
       title: 'Immigration & Refugees',
-      description: 'Some description',
+      description:
+        'To the US border and beyond, we need action now more than ever.',
     },
     LGBTQ_RIGHTS_EQUALITY: {
       title: 'LGBTQ+ Rights & Equality',
-      description: 'Some description',
+      description: 'Be an ally and fight for justice for the LGBTQ+ community.',
     },
     MENTAL_HEALTH: {
       title: 'Mental Health',
-      description: 'Some description',
+      description: 'Do Something about depression, anxiety, stress, and more.',
     },
     PHYSICAL_HEALTH: {
       title: 'Physical Health',
-      description: 'Some description',
+      description:
+        'Protect the wellbeing of your friends, family, and community.',
     },
     RACIAL_JUSTICE_EQUITY: {
       title: 'Racial Justice & Equity',
-      description: 'Some description',
+      description: 'Injustice stops with this generation.',
     },
     SEXUAL_HARASSMENT_ASSAULT: {
       title: 'Sexual Harassment & Assault',
-      description: 'Some description',
+      description:
+        'Do Something about sexual harassment, assault, and violence near you.',
     },
   };
+
+  const options = { variables: { userId: window.AUTH.id } };
+
+  // Make the initial query to get the user's subscriptions
+  const { data, loading, error } = useQuery(CAUSE_PREFERENCE_QUERY, options);
+
+  if (error) {
+    return <p>Something went wrong!</p>;
+  }
+
+  if (loading) {
+    return <div className="spinner align-center" />;
+  }
+
+  const { causes } = data.user;
 
   return (
     <div className="gallery-grid gallery-grid-duo">
       {Object.keys(causeItems).map(cause => (
         <CausePreferenceItem
           cause={cause}
+          causes={causes}
           title={causeItems[cause].title}
           description={causeItems[cause].description}
         />

--- a/resources/assets/components/pages/AccountPage/Interests/CausePreferences.js
+++ b/resources/assets/components/pages/AccountPage/Interests/CausePreferences.js
@@ -1,9 +1,8 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 import CausePreferenceItem from './CausePreferenceItem';
 
-const CausePreferences = ({ user }) => {
+const CausePreferences = () => {
   const causeItems = {
     ANIMAL_WELFARE: {
       title: 'Animal Welfare',
@@ -29,7 +28,7 @@ const CausePreferences = ({ user }) => {
       title: 'Homelessness & Poverty',
       description: 'Some description',
     },
-    IMMIGRATION: {
+    IMMIGRATION_REFUGEES: {
       title: 'Immigration & Refugees',
       description: 'Some description',
     },
@@ -62,19 +61,10 @@ const CausePreferences = ({ user }) => {
           cause={cause}
           title={causeItems[cause].title}
           description={causeItems[cause].description}
-          userId={user.id}
-          userCauses={user.causes}
         />
       ))}
     </div>
   );
-};
-
-CausePreferences.propTypes = {
-  user: PropTypes.shape({
-    causes: PropTypes.array,
-    id: PropTypes.string,
-  }).isRequired,
 };
 
 export default CausePreferences;

--- a/resources/assets/components/pages/AccountPage/Interests/Interests.js
+++ b/resources/assets/components/pages/AccountPage/Interests/Interests.js
@@ -2,7 +2,7 @@ import React from 'react';
 
 import CausePreferences from './CausePreferences';
 
-const Interests = props => (
+const Interests = () => (
   <div className="grid-wide">
     <h1>Your Cause Interests</h1>
     <p>
@@ -10,7 +10,7 @@ const Interests = props => (
       areas.
     </p>
 
-    <CausePreferences {...props} />
+    <CausePreferences />
   </div>
 );
 

--- a/resources/assets/components/pages/AccountPage/Interests/Interests.js
+++ b/resources/assets/components/pages/AccountPage/Interests/Interests.js
@@ -4,8 +4,8 @@ import CausePreferences from './CausePreferences';
 
 const Interests = () => (
   <div className="grid-wide">
-    <h1>Your Cause Interests</h1>
-    <p>
+    <h1 className="pl-4">Your Cause Interests</h1>
+    <p className="pl-4">
       We tailor your emails and other communication based on your favorite cause
       areas.
     </p>

--- a/resources/assets/components/pages/AccountPage/Interests/Interests.js
+++ b/resources/assets/components/pages/AccountPage/Interests/Interests.js
@@ -4,7 +4,7 @@ import CausePreferences from './CausePreferences';
 
 const Interests = () => (
   <div className="grid-wide">
-    <h1 className="pl-4">Your Cause Interests</h1>
+    <h1 className="pl-4 text-lg">Your Cause Interests</h1>
     <p className="pl-4">
       We tailor your emails and other communication based on your favorite cause
       areas.


### PR DESCRIPTION
### What's this PR do?

This pull request adds the cause preferences section to our Interests tab in a users' profile! There is a small bit of styling love that needs to happen on the buttons and spacing for mobile, but since this is behind a feature flag I wanted to get the meatier portion of this into a PR while I work that out. 

### How should this be reviewed?

Let me know if you have any specific thoughts about structure. I took a slightly different approach to where I'm querying for the user's cause array since I didn't feel that 12 loader spinner on the page was a great user experience. So i did that in the outer cause preference component.

### Any background context you want to provide?

Again, i know there are some CSS bugs to work out (see screenshots lol) BUT i think this is ready for some 👀 

Large Screen:
<img width="1176" alt="Screen Shot 2020-03-20 at 3 40 05 PM" src="https://user-images.githubusercontent.com/15236023/77201320-abfe7080-6ac2-11ea-889e-ab3179a55a05.png">

Medium Screen:
<img width="671" alt="Screen Shot 2020-03-20 at 3 43 36 PM" src="https://user-images.githubusercontent.com/15236023/77201352-b7ea3280-6ac2-11ea-9859-e745aee1f78e.png">

Small:
<img width="301" alt="Screen Shot 2020-03-20 at 3 42 59 PM" src="https://user-images.githubusercontent.com/15236023/77201363-bf114080-6ac2-11ea-86b9-d458b3804db6.png">


### Relevant tickets

References [Pivotal # 171439769](https://www.pivotaltracker.com/story/show/171439769).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added screenshots of front-end changes on small, medium, and large screens.
- [ ] Added appropriate feature/unit tests.
