### PR TITLE
Adds `rel="noopener noreferrer"` to external links.

### DIFF
--- a/resources/assets/helpers/text.js
+++ b/resources/assets/helpers/text.js
@@ -48,7 +48,10 @@ function cleanupStandardMarkdown(markdown) {
 function getMarkdownItInstance() {
   const markdownIt = new MarkdownIt();
 
+  // Add support for Markdown[^1] footnotes syntax. [^1]: https://git.io/JvMXJ
   markdownIt.use(markdownItFootnote);
+
+  // Open external Markdown links in new tabs.
   markdownIt.use(iterator, 'url_new_win', 'link_open', (tokens, index) => {
     const token = tokens[index];
     const hrefIndex = token.attrIndex('href');
@@ -56,6 +59,7 @@ function getMarkdownItInstance() {
 
     if (isExternal(url)) {
       token.attrPush(['target', '_blank']);
+      token.attrPush(['rel', 'noopener noreferrer']); // See: https://mathiasbynens.github.io/rel-noopener/
     }
   });
 


### PR DESCRIPTION
### What's this PR do?

This pull request adds `rel="noopener noreferrer"` to external links in our Markdown, which fixes a [nasty little issue](https://mathiasbynens.github.io/rel-noopener/).

### How should this be reviewed?

👀

### Any background context you want to provide?

Hat-tip to @mendelB for [flagging this](https://dosomething.slack.com/archives/CUQMU4Q6B/p1584734860027700?thread_ts=1584733497.023200&cid=CUQMU4Q6B) earlier today!

### Relevant tickets

References [Pivotal #171906949](https://www.pivotaltracker.com/story/show/171906949).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added screenshots of front-end changes on small, medium, and large screens.
- [ ] Added appropriate feature/unit tests.
