### PR TITLE
Updates to wrap up the homepage campaign featured item.

### DIFF
--- a/app.json
+++ b/app.json
@@ -59,6 +59,7 @@
     "SIXPACK_ENABLED": "true",
     "SIXPACK_TIMEOUT": {
       "required": true
-    }
+    },
+    "DS_ENABLE_NEW_HOMEPAGE": "true"
   }
 }

--- a/resources/assets/components/pages/HomePage/NewHomePage.js
+++ b/resources/assets/components/pages/HomePage/NewHomePage.js
@@ -60,7 +60,10 @@ const NewsletterItem = ({ content, image, link, title }) => (
     />
     <h3 className="mb-2 text-white">{title}</h3>
     <p className="mb-4 flex-grow text-white">{content}</p>
-    <a href={link.url} className="font-normal text-white underline">
+    <a
+      href={link.url}
+      className="font-normal text-white hover:text-yellow-300 underline hover:no-underline"
+    >
       {link.copy}
     </a>
   </div>
@@ -134,7 +137,7 @@ const NewHomePageTemplate = ({ campaigns, title }) => {
             >
               <div className="px-4 py-5 text-center">
                 <p className="font-league-gothic text-5xl text-teal-300 uppercase">
-                  5 million+
+                  5 million
                 </p>
                 <p className="m-0 text-white uppercase">Jeans Donated</p>
                 <p className="italic m-0 text-white">Teens for Jeans</p>
@@ -142,7 +145,7 @@ const NewHomePageTemplate = ({ campaigns, title }) => {
 
               <div className="px-4 py-5 text-center">
                 <p className="font-league-gothic text-5xl text-teal-300 uppercase">
-                  3.7 million+
+                  3.7 million
                 </p>
                 <p className="m-0 text-white uppercase">
                   Cigarette Butts Collected
@@ -152,10 +155,12 @@ const NewHomePageTemplate = ({ campaigns, title }) => {
 
               <div className="px-4 py-5 text-center">
                 <p className="font-league-gothic text-5xl text-teal-300 uppercase">
-                  1,572+
+                  585,965
                 </p>
-                <p className="m-0 text-white uppercase">Photographs Burned</p>
-                <p className="italic m-0 text-white">Breakup Bash</p>
+                <p className="m-0 text-white uppercase">
+                  Period Products Donated
+                </p>
+                <p className="italic m-0 text-white">Power to the Period</p>
               </div>
             </div>
           </header>
@@ -181,19 +186,16 @@ const NewHomePageTemplate = ({ campaigns, title }) => {
                 />
               </h2>
 
-              <p className="my-6 text-lg">
-                You can even{' '}
+              <p className="my-6 lg:mb-8 text-lg">
+                Choose a campaign below to make an impact and enter for a chance
+                to{' '}
                 <a
                   href="/us/about/easy-scholarships"
-                  className="font-normal text-blurple-500 underline"
+                  className="font-normal text-blurple-500 hover:text-blurple-300 underline hover:no-underline"
                 >
-                  win scholarships
-                </a>{' '}
-                and{' '}
-                <a href="/" className="font-normal text-blurple-500 underline">
-                  earn volunteer credits
-                </a>{' '}
-                for school! Seriously.
+                  earn scholarships
+                </a>
+                . (Talk about a win-win.)
               </p>
 
               <HomePageCampaignGallery campaigns={campaigns} />
@@ -230,7 +232,10 @@ const NewHomePageTemplate = ({ campaigns, title }) => {
                     content="Create change with millions of others."
                     title="Community"
                     image={NewsletterImages.Community}
-                    link={{ copy: 'Join the Communty', url: '/' }}
+                    link={{
+                      copy: 'Join the Communty',
+                      url: 'https://wyd.dosomething.org',
+                    }}
                   />
                 </li>
 
@@ -239,7 +244,10 @@ const NewHomePageTemplate = ({ campaigns, title }) => {
                     content="Make an impact on today's headlines."
                     title="News"
                     image={NewsletterImages.News}
-                    link={{ copy: 'Get News', url: '/' }}
+                    link={{
+                      copy: 'Get News',
+                      url: 'https://breakdown.dosomething.org',
+                    }}
                   />
                 </li>
 
@@ -248,7 +256,10 @@ const NewHomePageTemplate = ({ campaigns, title }) => {
                     content="Live your best life and help others do the same."
                     title="Lifestyle"
                     image={NewsletterImages.Lifestyle}
-                    link={{ copy: 'Start Reading', url: '/' }}
+                    link={{
+                      copy: 'Start Reading',
+                      url: 'https://boost.dosomething.org',
+                    }}
                   />
                 </li>
 
@@ -257,7 +268,10 @@ const NewHomePageTemplate = ({ campaigns, title }) => {
                     content="Qualify for easy scholarships, no GPA or essay required."
                     title="Scholarships"
                     image={NewsletterImages.Scholarships}
-                    link={{ copy: 'Find Scholarships', url: '/' }}
+                    link={{
+                      copy: 'Find Scholarships',
+                      url: 'https://pays.dosomething.org',
+                    }}
                   />
                 </li>
               </ul>

--- a/resources/assets/components/utilities/Gallery/templates/CampaignGalleryFeaturedItem/CampaignGalleryFeaturedItem.js
+++ b/resources/assets/components/utilities/Gallery/templates/CampaignGalleryFeaturedItem/CampaignGalleryFeaturedItem.js
@@ -39,6 +39,7 @@ const CampaignGalleryFeaturedItem = ({
               '826',
               'fill',
             )}');
+            background-position: center;
             background-repeat: no-repeat;
             background-size: cover;
           }

--- a/resources/assets/components/utilities/Gallery/templates/CampaignGalleryFeaturedItem/CampaignGalleryFeaturedItem.js
+++ b/resources/assets/components/utilities/Gallery/templates/CampaignGalleryFeaturedItem/CampaignGalleryFeaturedItem.js
@@ -1,7 +1,12 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { css } from '@emotion/core';
 
-import { contentfulImageUrl } from '../../../../../helpers';
+import {
+  contentfulImageUrl,
+  contentfulImageSrcset,
+  tailwind,
+} from '../../../../../helpers';
 
 const CampaignGalleryFeaturedItem = ({
   showcaseDescription,
@@ -9,27 +14,57 @@ const CampaignGalleryFeaturedItem = ({
   showcaseTitle,
   url,
 }) => {
-  return (
-    <article className="flex flex-col h-full relative text-left">
-      <img
-        alt={showcaseImage.description || `Cover photo for ${showcaseTitle}`}
-        className="w-full"
-        src={contentfulImageUrl(showcaseImage.url, '360', '200', 'fill')}
-      />
+  const tailwindGray = tailwind('colors.gray');
+  const tailwindScreens = tailwind('screens');
 
-      <div className="bg-white border border-b border-l border-r border-gray-300 border-solid flex flex-col flex-grow p-4 rounded-b-sm">
-        <div className="font-bold text-base text-purple-500 uppercase">
+  const srcset = contentfulImageSrcset(showcaseImage.url, [
+    { height: 205, width: 365 },
+    { height: 410, width: 730 },
+  ]);
+
+  return (
+    <article
+      className="xxl:bg-white xxl:col-gap-8 flex flex-col xxl:grid xxl:grid-cols-3 h-full text-left rounded"
+      css={css`
+        box-shadow: inset 0px 0px 0px 1px ${tailwindGray['300']};
+      `}
+    >
+      <div
+        className="xxl:col-span-2 w-full"
+        css={css`
+          @media (min-width: ${tailwindScreens.xxl}) {
+            background-image: url('${contentfulImageUrl(
+              showcaseImage.url,
+              '1468',
+              '826',
+              'fill',
+            )}');
+            background-repeat: no-repeat;
+            background-size: cover;
+          }
+        `}
+      >
+        <img
+          alt={showcaseImage.description || `Cover photo for ${showcaseTitle}`}
+          className="xxl:invisible"
+          srcSet={srcset}
+          src={contentfulImageUrl(showcaseImage.url, '365', '205', 'fill')}
+        />
+      </div>
+
+      <div className="bg-white border-b border-l xxl:border-l-0 border-r xxl:border-t border-gray-300 border-solid flex xxl:block flex-col flex-grow p-4 xxl:p-8 xxl:pl-0 rounded-b-sm">
+        <div className="font-bold text-base text-purple-500 xxl:text-lg uppercase">
           Featured
         </div>
 
-        <h1 className="font-normal font-league-gothic mb-3 text-3xl text-gray-900">
+        <h1 className="font-normal font-league-gothic mb-3 text-3xl text-gray-900 uppercase">
           {showcaseTitle}
         </h1>
 
-        <p className="flex-grow">{showcaseDescription}</p>
+        <p className="flex-grow xxl:text-lg">{showcaseDescription}</p>
 
         <a
-          className="btn bg-blurple-500 hover:bg-blurple-300 text-white hover:text-white mt-4 hover:no-underline py-4 text-lg w-full"
+          className="btn bg-blurple-500 hover:bg-blurple-300 text-white hover:text-white mt-4 xxl:mt-8 hover:no-underline p-4 xxl:px-8 text-lg w-full xxl:w-auto"
           href={url}
         >
           Get Started

--- a/resources/assets/components/utilities/Gallery/templates/CampaignGalleryItem/CampaignGalleryItemV2.js
+++ b/resources/assets/components/utilities/Gallery/templates/CampaignGalleryItem/CampaignGalleryItemV2.js
@@ -25,7 +25,7 @@ const CampaignGalleryItemV2 = ({
         src={contentfulImageUrl(showcaseImage.url, '365', '205', 'fill')}
       />
 
-      <div className="bg-white border border-b border-l border-r border-gray-300 border-solid flex flex-col flex-grow p-4 rounded-b-sm">
+      <div className="bg-white border-b border-l border-r border-gray-300 border-solid flex flex-col flex-grow p-4 rounded-b-sm">
         <div className="absolute bg-purple-500 font-bold px-3 py-1 right-0 text-base text-white top-0 uppercase">
           Featured
         </div>


### PR DESCRIPTION
### What's this PR do?

This pull request wraps up the new `CampaignGalleryFeaturedItem` component for showcasing a featured item in the campaign gallery on the new Homepage. It also does some additional cleanup and other small updates.

![Homepage Campaign Featured Item](https://user-images.githubusercontent.com/105849/77448496-44e50280-6dc7-11ea-9240-e17e93f3e7f8.gif)

### How should this be reviewed?

👀 on the generated [review app](https://dosomething-phoenix-de-pr-1991.herokuapp.com/us)!

### Any background context you want to provide?

There's some trickery going on with the image in this component when it hits the `xxl` size. Since the image ratio isn't the most ideal size for responsive adjustments as the viewport increases in size, to fit better when the layout changes to a side-by-side style, I ended up visually hiding the `<img>` and using a `background-image` on the parent `<div>` to execute on the desired effect.

### Relevant tickets

References [Pivotal #171056375](https://www.pivotaltracker.com/story/show/171056375).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [x] Added screenshots of front-end changes on small, medium, and large screens.
