### PR TITLE
New Hub (Cause Page) Links In Site Navigation

### DIFF
--- a/resources/assets/components/SiteNavigation/SiteNavigation.js
+++ b/resources/assets/components/SiteNavigation/SiteNavigation.js
@@ -260,6 +260,19 @@ class SiteNavigation extends React.Component {
                           >
                             Education
                           </a>
+                          <a
+                            href="/us/causes/gun-violence"
+                            onClick={() => {
+                              this.handleOnClickLink({
+                                name: 'clicked_subnav_link_causes_gun_violence',
+                                action: 'link_clicked',
+                                category: EVENT_CATEGORIES.navigation,
+                                label: 'causes_gun_violence',
+                              });
+                            }}
+                          >
+                            Gun Violence
+                          </a>
                         </li>
                         <li>
                           <a
@@ -275,6 +288,22 @@ class SiteNavigation extends React.Component {
                             }}
                           >
                             Mental Health
+                          </a>
+                        </li>
+                        <li>
+                          <a
+                            href="/us/causes/physical-health"
+                            onClick={() => {
+                              this.handleOnClickLink({
+                                name:
+                                  'clicked_subnav_link_causes_physical_health',
+                                action: 'link_clicked',
+                                category: EVENT_CATEGORIES.navigation,
+                                label: 'causes_physical_health',
+                              });
+                            }}
+                          >
+                            Physical Health
                           </a>
                         </li>
                         <li>
@@ -310,6 +339,22 @@ class SiteNavigation extends React.Component {
                         </li>
                         <li>
                           <a
+                            href="/us/causes/sexual-harassment"
+                            onClick={() => {
+                              this.handleOnClickLink({
+                                name:
+                                  'clicked_subnav_link_causes_sexual_harassment',
+                                action: 'link_clicked',
+                                category: EVENT_CATEGORIES.navigation,
+                                label: 'causes_sexual_harassment',
+                              });
+                            }}
+                          >
+                            Sexual Harassment
+                          </a>
+                        </li>
+                        <li>
+                          <a
                             href="/us/causes/bullying"
                             onClick={() => {
                               this.handleOnClickLink({
@@ -321,6 +366,85 @@ class SiteNavigation extends React.Component {
                             }}
                           >
                             Bullying
+                          </a>
+                        </li>
+                        <li>
+                          <a
+                            href="/us/causes/gender-rights"
+                            onClick={() => {
+                              this.handleOnClickLink({
+                                name:
+                                  'clicked_subnav_link_causes_gender_rights',
+                                action: 'link_clicked',
+                                category: EVENT_CATEGORIES.navigation,
+                                label: 'causes_gender_rights',
+                              });
+                            }}
+                          >
+                            Gender Rights
+                          </a>
+                        </li>
+                        <li>
+                          <a
+                            href="/us/causes/racial-justice"
+                            onClick={() => {
+                              this.handleOnClickLink({
+                                name:
+                                  'clicked_subnav_link_causes_racial_justice',
+                                action: 'link_clicked',
+                                category: EVENT_CATEGORIES.navigation,
+                                label: 'causes_racial_justice',
+                              });
+                            }}
+                          >
+                            Racial Justice
+                          </a>
+                        </li>
+                        <li>
+                          <a
+                            href="/us/causes/discrimination"
+                            onClick={() => {
+                              this.handleOnClickLink({
+                                name:
+                                  'clicked_subnav_link_causes_discrimination',
+                                action: 'link_clicked',
+                                category: EVENT_CATEGORIES.navigation,
+                                label: 'causes_discrimination',
+                              });
+                            }}
+                          >
+                            Discrimination
+                          </a>
+                        </li>
+                        <li>
+                          <a
+                            href="/us/causes/lgbtq-rights"
+                            onClick={() => {
+                              this.handleOnClickLink({
+                                name: 'clicked_subnav_link_causes_lgbtq_rights',
+                                action: 'link_clicked',
+                                category: EVENT_CATEGORIES.navigation,
+                                label: 'causes_lgbtq_rights',
+                              });
+                            }}
+                          >
+                            LGBTQ+ Rights
+                          </a>
+                        </li>
+                        <li>
+                          <a
+                            href="/us/causes/voter-registration"
+                            onClick={() => {
+                              this.handleOnClickLink({
+                                name:
+                                  'clicked_subnav_link_causes_voter_registration',
+                                action: 'link_clicked',
+                                category: EVENT_CATEGORIES.navigation,
+                                label: 'causes_voter_registration',
+                              });
+                            }}
+                          >
+                            Voter Registration
                           </a>
                         </li>
                         <li>


### PR DESCRIPTION
### What's this PR do?

This pull request adds the new Cause Page links to the causes dropdown in our site navigation, along with the requisite analytics events.

### How should this be reviewed?
👀 I've manually clicked through the links locally using the Contentful `master` environment to ensure all the links/pages are working, and all the analytics events are triggering.

### Relevant tickets

References [Pivotal #171420697](https://www.pivotaltracker.com/story/show/171420697).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [x] Added screenshots of front-end changes on small, medium, and large screens.
- [ ] Added appropriate feature/unit tests.

![image](https://user-images.githubusercontent.com/12417657/77655883-71288c80-6f49-11ea-9bd7-0e93760c19f5.png)

- [Medium](https://user-images.githubusercontent.com/12417657/77655925-84d3f300-6f49-11ea-8d7d-b5ea8afe2599.png)

- [Small](https://user-images.githubusercontent.com/12417657/77655972-974e2c80-6f49-11ea-9ec5-be797e82f1e4.png)
