### PR TITLE
Homepage article gallery

### DIFF
--- a/resources/assets/components/pages/HomePage/HomePageArticleGallery.js
+++ b/resources/assets/components/pages/HomePage/HomePageArticleGallery.js
@@ -4,8 +4,6 @@ import PropTypes from 'prop-types';
 import PageGalleryItem from '../../utilities/Gallery/templates/PageGalleryItem/PageGalleryItemV2';
 
 const HomePageArticleGallery = ({ articles }) => {
-  console.log('🤬', articles);
-
   return (
     <ul className="article-gallery mt-0 gap-8 grid grid-cols-1 md:grid-cols-2 xxl:grid-cols-4">
       {articles.map(article => {

--- a/resources/assets/components/pages/HomePage/HomePageArticleGallery.js
+++ b/resources/assets/components/pages/HomePage/HomePageArticleGallery.js
@@ -1,0 +1,31 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import PageGalleryItem from '../../utilities/Gallery/templates/PageGalleryItem/PageGalleryItemV2';
+
+const HomePageArticleGallery = ({ articles }) => {
+  console.log('🤬', articles);
+
+  return (
+    <ul className="article-gallery mt-0 gap-8 grid grid-cols-1 md:grid-cols-2 xxl:grid-cols-4">
+      {articles.map(article => {
+        return (
+          <li key={article.id}>
+            <PageGalleryItem
+              showcaseDescription={article.showcaseDescription}
+              showcaseImage={article.showcaseImage}
+              showcaseTitle={article.showcaseTitle}
+              slug={article.slug}
+            />
+          </li>
+        );
+      })}
+    </ul>
+  );
+};
+
+HomePageArticleGallery.propTypes = {
+  articles: PropTypes.arrayOf(PropTypes.object).isRequired,
+};
+
+export default HomePageArticleGallery;

--- a/resources/assets/components/pages/HomePage/NewHomePage.js
+++ b/resources/assets/components/pages/HomePage/NewHomePage.js
@@ -6,6 +6,7 @@ import { React, Fragment } from 'react';
 import PageQuery from '../PageQuery';
 import sponsorList from './sponsor-list';
 import * as NewsletterImages from './NewsletterImages';
+import HomePageArticleGallery from './HomePageArticleGallery';
 import SiteFooter from '../../utilities/SiteFooter/SiteFooter';
 import { contentfulImageUrl, tailwind } from '../../../helpers';
 import HomePageCampaignGallery from './HomePageCampaignGallery';
@@ -35,6 +36,7 @@ const HOME_PAGE_QUERY = gql`
         }
       }
       articles {
+        id
         showcaseTitle
         showcaseDescription
         showcaseImage {
@@ -79,7 +81,7 @@ NewsletterItem.propTypes = {
   title: PropTypes.string.isRequired,
 };
 
-const NewHomePageTemplate = ({ campaigns, title }) => {
+const NewHomePageTemplate = ({ articles, campaigns, title }) => {
   const tailwindGray = tailwind('colors.gray');
   const tailwindScreens = tailwind('screens');
 
@@ -176,7 +178,7 @@ const NewHomePageTemplate = ({ campaigns, title }) => {
             `}
           >
             <div className="grid-wide text-center">
-              <h2 className="relative">
+              <h2 className="mb-6 relative">
                 <span className="bg-white font-league-gothic font-normal leading-tight inline-block py-2 px-6 relative text-3xl tracking-wide uppercase z-10">
                   Take Action
                 </span>
@@ -186,7 +188,7 @@ const NewHomePageTemplate = ({ campaigns, title }) => {
                 />
               </h2>
 
-              <p className="my-6 lg:mb-8 text-lg">
+              <p className="mb-6 lg:mb-8 text-lg">
                 Choose a campaign below to make an impact and enter for a chance
                 to{' '}
                 <a
@@ -280,7 +282,7 @@ const NewHomePageTemplate = ({ campaigns, title }) => {
 
           <section className="base-12-grid bg-gray-100">
             <div className="grid-wide text-center">
-              <h2 className="relative">
+              <h2 className="mb-6 relative">
                 <span className="bg-gray-100 font-league-gothic font-normal leading-tight inline-block py-2 px-6 relative text-3xl tracking-wide uppercase z-10">
                   Read About It
                 </span>
@@ -290,7 +292,7 @@ const NewHomePageTemplate = ({ campaigns, title }) => {
                 />
               </h2>
 
-              {/* <HomePageArticlesGallery /> */}
+              <HomePageArticleGallery articles={articles} />
 
               <a
                 href="/us/articles"
@@ -353,8 +355,9 @@ const NewHomePageTemplate = ({ campaigns, title }) => {
 };
 
 NewHomePageTemplate.propTypes = {
-  title: PropTypes.string,
+  articles: PropTypes.arrayOf(PropTypes.object).isRequired,
   campaigns: PropTypes.arrayOf(PropTypes.object).isRequired,
+  title: PropTypes.string,
 };
 
 NewHomePageTemplate.defaultProps = {

--- a/resources/assets/components/utilities/Gallery/templates/CampaignGalleryFeaturedItem/CampaignGalleryFeaturedItem.js
+++ b/resources/assets/components/utilities/Gallery/templates/CampaignGalleryFeaturedItem/CampaignGalleryFeaturedItem.js
@@ -53,7 +53,7 @@ const CampaignGalleryFeaturedItem = ({
         />
       </div>
 
-      <div className="bg-white border-b border-l xxl:border-l-0 border-r xxl:border-t border-gray-300 border-solid flex xxl:block flex-col flex-grow p-4 xxl:p-8 xxl:pl-0 rounded-b-sm">
+      <div className="bg-white border-b border-l xxl:border-l-0 border-r xxl:border-t border-gray-300 border-solid flex xxl:block flex-col flex-grow p-4 xxl:p-8 xxl:pl-0 rounded-b xxl:rounded-b-none">
         <div className="font-bold text-base text-purple-500 xxl:text-lg uppercase">
           Featured
         </div>

--- a/resources/assets/components/utilities/Gallery/templates/CampaignGalleryItem/CampaignGalleryItemV2.js
+++ b/resources/assets/components/utilities/Gallery/templates/CampaignGalleryItem/CampaignGalleryItemV2.js
@@ -2,11 +2,11 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import {
-  contentfulImageUrl,
   contentfulImageSrcset,
+  contentfulImageUrl,
 } from '../../../../../helpers';
 
-const CampaignGalleryItemV2 = ({
+const CampaignGalleryItem = ({
   showcaseDescription,
   showcaseImage,
   showcaseTitle,
@@ -25,7 +25,7 @@ const CampaignGalleryItemV2 = ({
         src={contentfulImageUrl(showcaseImage.url, '365', '205', 'fill')}
       />
 
-      <div className="bg-white border-b border-l border-r border-gray-300 border-solid flex flex-col flex-grow p-4 rounded-b-sm">
+      <div className="bg-white border-b border-l border-r border-gray-300 border-solid flex flex-col flex-grow p-4 rounded-b">
         <div className="absolute bg-purple-500 font-bold px-3 py-1 right-0 text-base text-white top-0 uppercase">
           Featured
         </div>
@@ -47,11 +47,11 @@ const CampaignGalleryItemV2 = ({
   );
 };
 
-CampaignGalleryItemV2.propTypes = {
+CampaignGalleryItem.propTypes = {
   showcaseDescription: PropTypes.string.isRequired,
   showcaseImage: PropTypes.object.isRequired,
   showcaseTitle: PropTypes.string.isRequired,
   url: PropTypes.string.isRequired,
 };
 
-export default CampaignGalleryItemV2;
+export default CampaignGalleryItem;

--- a/resources/assets/components/utilities/Gallery/templates/PageGalleryItem/PageGalleryItemV2.js
+++ b/resources/assets/components/utilities/Gallery/templates/PageGalleryItem/PageGalleryItemV2.js
@@ -1,0 +1,51 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import {
+  contentfulImageSrcset,
+  contentfulImageUrl,
+} from '../../../../../helpers';
+
+const PageGalleryItem = ({
+  showcaseDescription,
+  showcaseImage,
+  showcaseTitle,
+  slug,
+}) => {
+  const srcset = contentfulImageSrcset(showcaseImage.url, [
+    { height: 205, width: 365 },
+    { height: 410, width: 730 },
+  ]);
+
+  return (
+    <article className="h-full text-left">
+      <a
+        href={`/us/${slug}`}
+        className="flex flex-col h-full hover:no-underline"
+      >
+        <img
+          alt={showcaseImage.description || `Cover photo for ${showcaseTitle}`}
+          srcSet={srcset}
+          src={contentfulImageUrl(showcaseImage.url, '365', '205', 'fill')}
+        />
+
+        <div className="bg-white border-b border-l border-r border-gray-300 border-solid flex-grow p-4 rounded-b">
+          <h1 className="font-bold mb-3 text-base text-blurple-500">
+            {showcaseTitle}
+          </h1>
+
+          <p className="flex-grow font-normal">{showcaseDescription}</p>
+        </div>
+      </a>
+    </article>
+  );
+};
+
+PageGalleryItem.propTypes = {
+  showcaseDescription: PropTypes.string.isRequired,
+  showcaseImage: PropTypes.object.isRequired,
+  showcaseTitle: PropTypes.string.isRequired,
+  slug: PropTypes.string.isRequired,
+};
+
+export default PageGalleryItem;


### PR DESCRIPTION
### What's this PR do?

This pull request wraps up the Article Gallery on the new Homepage. It also does a few small style tweaks previously missed.

Responsive example:
![Homepage Article Gallery](https://user-images.githubusercontent.com/105849/77670738-f8cbc680-6f5c-11ea-8730-c4a3e7841495.gif)

### How should this be reviewed?

👀 

### Any background context you want to provide?

I ended up not handling a fallback if an attached article does not have a a `showcaseImage`. I previously had a default option of the DS logo, but made things difficult if it's treated a bit different than the other showcase images coming from Contentful's Images API. So we're going to instead have GraphQL deal with this in a smarter fashion and retrieve a proper default image if an entry happens to be missing a proper cover image!

### Relevant tickets

References [Pivotal #171337029](https://www.pivotaltracker.com/story/show/171337029).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [x] Added GIF of front-end changes on small, medium, and large screens.
