### PR TITLE
Query GraphQL for count of voter registration referrals

### DIFF
--- a/resources/assets/components/actions/SocialDriveAction/SocialDriveAction.js
+++ b/resources/assets/components/actions/SocialDriveAction/SocialDriveAction.js
@@ -9,6 +9,7 @@ import linkIcon from './linkIcon.svg';
 import Card from '../../utilities/Card/Card';
 import Embed from '../../utilities/Embed/Embed';
 import { postRequest } from '../../../helpers/api';
+import VoterRegistrationStats from './VoterRegistrationStats';
 import { dynamicString, withoutTokens, featureFlag } from '../../../helpers';
 import SocialShareTray from '../../utilities/SocialShareTray/SocialShareTray';
 import {
@@ -69,6 +70,7 @@ class SocialDriveAction extends React.Component {
       shareCardDescription,
       shareCardTitle,
       hidePageViews,
+      userId,
     } = this.props;
     const { shortenedLink } = this.state;
     return (
@@ -127,42 +129,10 @@ class SocialDriveAction extends React.Component {
         </div>
 
         {!hidePageViews ? (
-          <div
-            className={classNames('social-drive-information mt-6', {
-              'lg:w-1/3 lg:pl-3 lg:mt-0': !hidePageViews,
-            })}
-          >
-            <Card className="bordered rounded" title="More info">
-              <div className="link-info p-3">
-                <p className="info__title">What happens next?</p>
-
-                <p className="info__text">
-                  As you share your voter registration page, we&#39;ll keep
-                  track of how many people you bring in. Check back often and
-                  try to get as many views as possible!
-                </p>
-              </div>
-
-              <div className="p-3 page-views">
-                <span className="page-views__text uppercase">
-                  total page views
-                </span>
-                <h1 className="page-views__amount">
-                  {shortenedLink ? this.state.count : '?'}
-                </h1>
-              </div>
-              {featureFlag('voter_reg_drive_total') ? (
-                <div className="p-3 voter-registrations">
-                  <span className="voter-registrations__text uppercase">
-                    total voter registrations
-                  </span>
-                  <h1 className="voter-registrations__amount">
-                    {shortenedLink ? this.state.count : '?'}
-                  </h1>
-                </div>
-              ) : null}
-            </Card>
-          </div>
+          <VoterRegistrationStats
+            userId={userId}
+            pageViewsCount={this.state.count}
+          />
         ) : null}
       </div>
     );

--- a/resources/assets/components/actions/SocialDriveAction/SocialDriveAction.js
+++ b/resources/assets/components/actions/SocialDriveAction/SocialDriveAction.js
@@ -10,7 +10,7 @@ import Card from '../../utilities/Card/Card';
 import Embed from '../../utilities/Embed/Embed';
 import { postRequest } from '../../../helpers/api';
 import VoterRegistrationStats from './VoterRegistrationStats';
-import { dynamicString, withoutTokens, featureFlag } from '../../../helpers';
+import { dynamicString, withoutTokens } from '../../../helpers';
 import SocialShareTray from '../../utilities/SocialShareTray/SocialShareTray';
 import {
   EVENT_CATEGORIES,

--- a/resources/assets/components/actions/SocialDriveAction/VoterRegistrationStats.js
+++ b/resources/assets/components/actions/SocialDriveAction/VoterRegistrationStats.js
@@ -1,10 +1,12 @@
 import React from 'react';
 import gql from 'graphql-tag';
 import PropTypes from 'prop-types';
-import classNames from 'classnames';
 
+import { featureFlag } from '../../../helpers';
 import Query from '../../Query';
 import Card from '../../utilities/Card/Card';
+
+// @TODO: This query needs to filter by completed voter registrations before we go live.
 
 const USER_VOTER_REGISTRATION_REFERRAL_COUNT_QUERY = gql`
   query UserVoterRegistrationReferralCount($userId: String!) {
@@ -28,22 +30,35 @@ const VoterRegistrationStats = ({ pageViewsCount, userId }) => {
           <span className="page-views__text uppercase">Total page views</span>
           <h1 className="page-views__amount">{pageViewsCount}</h1>
         </div>
-        <div className="p-3 voter-registrations">
-          <span className="voter-registrations__text uppercase">
-            Total voter registrations
-          </span>
-          <Query
-            query={USER_VOTER_REGISTRATION_REFERRAL_COUNT_QUERY}
-            variables={{ userId }}
-          >
-            {data => (
-              <h1 className="voter-registrations__amount">{data.postsCount}</h1>
-            )}
-          </Query>
-        </div>
+        {featureFlag('voter_reg_drive_total') ? (
+          <div className="p-3 voter-registrations">
+            <span className="voter-registrations__text uppercase">
+              Total voter registrations
+            </span>
+            <Query
+              query={USER_VOTER_REGISTRATION_REFERRAL_COUNT_QUERY}
+              variables={{ userId }}
+            >
+              {data => (
+                <h1 className="voter-registrations__amount">
+                  {data.postsCount}
+                </h1>
+              )}
+            </Query>
+          </div>
+        ) : null}
       </Card>
     </div>
   );
+};
+
+VoterRegistrationStats.propTypes = {
+  pageViewsCount: PropTypes.string,
+  userId: PropTypes.string.isRequired,
+};
+
+VoterRegistrationStats.defaultProps = {
+  pageViewsCount: '?',
 };
 
 export default VoterRegistrationStats;

--- a/resources/assets/components/actions/SocialDriveAction/VoterRegistrationStats.js
+++ b/resources/assets/components/actions/SocialDriveAction/VoterRegistrationStats.js
@@ -1,0 +1,48 @@
+import React from 'react';
+import gql from 'graphql-tag';
+import PropTypes from 'prop-types';
+import classNames from 'classnames';
+
+import Card from '../../utilities/Card/Card';
+
+const USER_VOTER_REGISTRATION_REFERRAL_COUNT_QUERY = gql`
+  query UserVoterRegistrationReferralCount($id: String!) {
+    user(id: $id) {
+      id
+      firstName
+    }
+  }
+`;
+
+const VoterRegistrationStats = ({ hidePageViews, userId, pageViewsCount }) => {
+  return (
+    <div
+      className={classNames('social-drive-information mt-6', {
+        'lg:w-1/3 lg:pl-3 lg:mt-0': !hidePageViews,
+      })}
+    >
+      <Card className="bordered rounded" title="More info">
+        <div className="link-info p-3">
+          <p className="info__title">What happens next?</p>
+          <p className="info__text">
+            As you share your voter registration page, we&#39;ll keep track of
+            how many people you bring in. Check back often and try to get as
+            many views as possible!
+          </p>
+        </div>
+        <div className="p-3 page-views">
+          <span className="page-views__text uppercase">Total page views</span>
+          <h1 className="page-views__amount">{pageViewsCount}</h1>
+        </div>
+        <div className="p-3 voter-registrations">
+          <span className="voter-registrations__text uppercase">
+            Total voter registrations
+          </span>
+          <h1 className="voter-registrations__amount">?</h1>
+        </div>
+      </Card>
+    </div>
+  );
+};
+
+export default VoterRegistrationStats;

--- a/resources/assets/components/actions/SocialDriveAction/VoterRegistrationStats.js
+++ b/resources/assets/components/actions/SocialDriveAction/VoterRegistrationStats.js
@@ -3,24 +3,18 @@ import gql from 'graphql-tag';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
+import Query from '../../Query';
 import Card from '../../utilities/Card/Card';
 
 const USER_VOTER_REGISTRATION_REFERRAL_COUNT_QUERY = gql`
-  query UserVoterRegistrationReferralCount($id: String!) {
-    user(id: $id) {
-      id
-      firstName
-    }
+  query UserVoterRegistrationReferralCount($userId: String!) {
+    postsCount(referrerUserId: $userId, type: "voter-reg", limit: 50)
   }
 `;
 
-const VoterRegistrationStats = ({ hidePageViews, userId, pageViewsCount }) => {
+const VoterRegistrationStats = ({ pageViewsCount, userId }) => {
   return (
-    <div
-      className={classNames('social-drive-information mt-6', {
-        'lg:w-1/3 lg:pl-3 lg:mt-0': !hidePageViews,
-      })}
-    >
+    <div className="social-drive-information mt-6' lg:w-1/3 lg:pl-3 lg:mt-0'">
       <Card className="bordered rounded" title="More info">
         <div className="link-info p-3">
           <p className="info__title">What happens next?</p>
@@ -38,7 +32,14 @@ const VoterRegistrationStats = ({ hidePageViews, userId, pageViewsCount }) => {
           <span className="voter-registrations__text uppercase">
             Total voter registrations
           </span>
-          <h1 className="voter-registrations__amount">?</h1>
+          <Query
+            query={USER_VOTER_REGISTRATION_REFERRAL_COUNT_QUERY}
+            variables={{ userId }}
+          >
+            {data => (
+              <h1 className="voter-registrations__amount">{data.postsCount}</h1>
+            )}
+          </Query>
         </div>
       </Card>
     </div>


### PR DESCRIPTION
### What's this PR do?

This pull request adds a GraphQL query to find the total number of voter registration referrals for the logged in user, replacing the placeholder value added in #1978.

The only trouble is that we need the posts count query to filter by status, which it currently doesn't support. We only want to count the total number of completed voter registration posts -- which is why this still remains feature flagged and should be committed with a big ol' `@TODO`

### How should this be reviewed?

Our review app should be created with `DS_ENABLE_VOTER_REG_DRIVE_TOTAL` set to true, so the total will be visible -- but it will be 0 across the board unless we manually edit the `referrer_user_id` in posts to your logged in user... which, is not ideal. I'll aim to add Cypress tests for this once GraphQL / Rogue is updated to support filtering by status - as we're hoping to launch this Monday.

### Any background context you want to provide?

Created a `VoterRegistrationStats` component to remove all of this voter registration specific logic out of the `SocialActionDrive` component.

### Relevant tickets

References [Pivotal #170775705](https://www.pivotaltracker.com/story/show/170775705).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added screenshots of front-end changes on small, medium, and large screens.
- [ ] Added appropriate feature/unit tests.
