### PR TITLE
Update Account Query to use Page state/styling

### DIFF
--- a/resources/assets/components/pages/AccountPage/Account/AccountQuery.js
+++ b/resources/assets/components/pages/AccountPage/Account/AccountQuery.js
@@ -1,9 +1,12 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import gql from 'graphql-tag';
+import PropTypes from 'prop-types';
+import { useQuery } from '@apollo/react-hooks';
 
+import ErrorPage from '../../ErrorPage';
+import NotFoundPage from '../../NotFoundPage';
 import Loader from '../../../utilities/Loader';
-import Query from '../../../Query';
+import Placeholder from '../../../utilities/Placeholder';
 
 const ACCOUNT_QUERY = gql`
   query AccountQuery($userId: String!) {
@@ -21,12 +24,24 @@ const ACCOUNT_QUERY = gql`
 `;
 
 const AccountQuery = ({ userId }) => {
+  const { loading, error, data } = useQuery(ACCOUNT_QUERY, {
+    variables: { userId },
+  });
+
+  if (loading) {
+    return <Placeholder />;
+  }
+
+  if (error) {
+    return <ErrorPage />;
+  }
+
+  if (!data.user) {
+    return <NotFoundPage />;
+  }
+
   const Account = Loader(import('./Account'));
-  return (
-    <Query query={ACCOUNT_QUERY} variables={{ userId }}>
-      {result => <Account {...result} userId={userId} />}
-    </Query>
-  );
+  return <Account {...data} userId={userId} />;
 };
 
 AccountQuery.propTypes = {

--- a/resources/assets/components/pages/ErrorPage.js
+++ b/resources/assets/components/pages/ErrorPage.js
@@ -1,48 +1,72 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
+import { report } from '../../helpers';
+import { HELP_REQUEST_LINK } from '../../constants';
 import SiteFooter from '../utilities/SiteFooter/SiteFooter';
 import SiteNavigationContainer from '../SiteNavigation/SiteNavigationContainer';
 
-const ErrorPage = () => (
-  <>
-    <SiteNavigationContainer />
+const DEBUGGING = process.env.NODE_ENV !== 'production';
 
-    <main className="py-20">
-      <article className="error-page max-w-xl mx-auto text-center px-4 leading-relaxed mb-8">
-        <header className="mb-8">
-          <h2 className="text-purple-900 text-xl md:text-2xl mb-2">
-            Something went wrong.
-          </h2>
+const ErrorPage = ({ error }) => {
+  // Print error to console & report to New Relic:
+  if (error) {
+    console.error(`[ErrorPage] ${error}`);
+    report(error);
+  }
 
-          <h3 className="text-lg">
-            We&apos;ve noted the problem & will get it fixed soon!
-          </h3>
-        </header>
+  return (
+    <>
+      <SiteNavigationContainer />
 
-        <p className="mb-8">
-          Try doing the same thing again - it may work the second time! If not,
-          we&apos;ve already noted the problem and our tech team will get it
-          fixed as soon as possible! You can also find ways to{' '}
-          <a href="/us/campaigns?utm_source=500">Take Action</a> and join a
-          movement of 5 million young people making an impact in their
-          communities.
-        </p>
+      <main className="py-20">
+        <article className="error-page max-w-xl mx-auto text-center px-4 leading-relaxed mb-8">
+          <header className="mb-8">
+            <h2 className="text-purple-900 text-xl md:text-2xl mb-2">
+              Something went wrong.
+            </h2>
 
-        <p className="text-sm text-gray-800 m-0">
-          If you continue to run into problems, contact our{' '}
-          <a
-            href="https://help.dosomething.org"
-            className="font-semibold text-gray-800 hover:text-gray-400 underline"
-          >
-            support squad
-          </a>
-          !
-        </p>
-      </article>
-    </main>
+            <h3 className="text-lg">
+              We&apos;ve noted the problem & will get it fixed soon!
+            </h3>
+          </header>
+          <p className="mb-8">
+            Try doing the same thing again - it may work the second time! If
+            not, we&apos;ve already noted the problem and our tech team will get
+            it fixed as soon as possible! You can also find ways to{' '}
+            <a href="/us/campaigns?utm_source=500">Take Action</a> and join a
+            movement of 5 million young people making an impact in their
+            communities.
+          </p>
+          <p className="text-sm text-gray-800 m-0">
+            If you continue to run into problems, contact our{' '}
+            <a
+              href={HELP_REQUEST_LINK}
+              className="font-semibold text-gray-800 hover:text-gray-400 underline"
+            >
+              support squad
+            </a>
+            !
+          </p>
+          {DEBUGGING && error ? (
+            <p className="color-error text-center my-4">
+              <code>{JSON.stringify(error)}</code>
+            </p>
+          ) : null}
+        </article>
+      </main>
 
-    <SiteFooter />
-  </>
-);
+      <SiteFooter />
+    </>
+  );
+};
+
+ErrorPage.propTypes = {
+  error: PropTypes.oneOf([PropTypes.object, PropTypes.string]),
+};
+
+ErrorPage.defaultProps = {
+  error: null,
+};
 
 export default ErrorPage;


### PR DESCRIPTION
### What's this PR do?

This pull request updates the `AccountQuery` to use a GraphQL query hook so we can use page-level states:

- centered placeholder spinner (it was attached to the top of the page previously)
- formalized page-level error state

Also updates the `ErrorPage` to align with the [`ErrorBlock`](https://github.com/DoSomething/phoenix-next/blob/c8779e41c5b47104f0192a9ff195f5d4ce5630e8/resources/assets/components/blocks/ErrorBlock/ErrorBlock.js) particularly in ingesting an optional `error` prop and reporting and logging it.

### How should this be reviewed?
Does this update make sense? Is it a sensible improvement?

### Any background context you want to provide?
I bumped into some errors on the page while working on #1992 and this felt like a super quick and easy improvement!


![image](https://user-images.githubusercontent.com/12417657/77758536-8238d280-7009-11ea-97ae-ecc2314e35c5.png)


![image](https://user-images.githubusercontent.com/12417657/77758498-751be380-7009-11ea-978b-ae6a35193fbc.png)
