### PR TITLE
Homepage staff pick feature

### DIFF
--- a/resources/assets/components/pages/HomePage/HomePageCampaignGallery.js
+++ b/resources/assets/components/pages/HomePage/HomePageCampaignGallery.js
@@ -55,6 +55,7 @@ const HomePageCampaignGallery = ({ campaigns }) => {
                 showcaseDescription={campaign.showcaseDescription}
                 showcaseImage={campaign.showcaseImage}
                 showcaseTitle={campaign.showcaseTitle}
+                staffPick={campaign.staffPick}
                 url={campaign.url}
               />
             )}

--- a/resources/assets/components/pages/HomePage/NewHomePage.js
+++ b/resources/assets/components/pages/HomePage/NewHomePage.js
@@ -114,7 +114,7 @@ const NewHomePageTemplate = ({ articles, campaigns, coverImage, title }) => {
     }
   `;
 
-  const headerBackgroundStyles = !coverImage
+  const headerBackgroundStyles = coverImage
     ? css`
         background-image: url(${contentfulImageUrl(
           coverImage.url,

--- a/resources/assets/components/pages/HomePage/NewHomePage.js
+++ b/resources/assets/components/pages/HomePage/NewHomePage.js
@@ -407,11 +407,12 @@ NewHomePageTemplate.propTypes = {
   campaigns: PropTypes.arrayOf(PropTypes.object).isRequired,
   coverImage: PropTypes.shape({
     url: PropTypes.string.isRequired,
-  }).isRequired,
+  }),
   title: PropTypes.string,
 };
 
 NewHomePageTemplate.defaultProps = {
+  coverImage: null,
   title: 'We Are A Youth-Led Movement For Good',
 };
 

--- a/resources/assets/components/pages/HomePage/NewHomePage.js
+++ b/resources/assets/components/pages/HomePage/NewHomePage.js
@@ -259,7 +259,7 @@ const NewHomePageTemplate = ({ articles, campaigns, coverImage, title }) => {
             </div>
           </section>
 
-          <article className="newsletters-cta base-12-grid bg-purple-400">
+          <article className="newsletters-cta base-12-grid bg-purple-700">
             <div className="grid-wide text-center py-5 lg:py-10">
               <h2 className="text-white mb-4">
                 <span className="block lg:inline-block font-league-gothic font-normal tracking-wide text-4xl uppercase">

--- a/resources/assets/components/pages/HomePage/NewHomePage.js
+++ b/resources/assets/components/pages/HomePage/NewHomePage.js
@@ -149,7 +149,7 @@ const NewHomePageTemplate = ({ articles, campaigns, coverImage, title }) => {
       <SiteNavigationContainer />
 
       <main>
-        <article className="home-page">
+        <article data-test="home-page">
           <header role="banner" className="bg-white pb-4">
             <div
               className="base-12-grid bg-gray-200"
@@ -216,7 +216,7 @@ const NewHomePageTemplate = ({ articles, campaigns, coverImage, title }) => {
           </header>
 
           <section
-            className="campaigns-section base-12-grid bg-gray-100"
+            className="base-12-grid bg-gray-100"
             css={css`
               background: linear-gradient(
                 to bottom,
@@ -224,6 +224,7 @@ const NewHomePageTemplate = ({ articles, campaigns, coverImage, title }) => {
                 ${tailwindGray['100']}
               );
             `}
+            data-test="campaigns-section"
           >
             <div className="grid-wide text-center">
               <h2 className="mb-6 relative">
@@ -259,7 +260,10 @@ const NewHomePageTemplate = ({ articles, campaigns, coverImage, title }) => {
             </div>
           </section>
 
-          <article className="newsletters-cta base-12-grid bg-purple-700">
+          <article
+            className="base-12-grid bg-purple-700"
+            data-test="newsletters-cta"
+          >
             <div className="grid-wide text-center py-5 lg:py-10">
               <h2 className="text-white mb-4">
                 <span className="block lg:inline-block font-league-gothic font-normal tracking-wide text-4xl uppercase">
@@ -328,7 +332,10 @@ const NewHomePageTemplate = ({ articles, campaigns, coverImage, title }) => {
             </div>
           </article>
 
-          <section className="articles-section base-12-grid bg-gray-100">
+          <section
+            className="base-12-grid bg-gray-100"
+            data-test="articles-section"
+          >
             <div className="grid-wide text-center">
               <h2 className="mb-6 relative">
                 <span className="bg-gray-100 font-league-gothic font-normal leading-tight inline-block py-2 px-6 relative text-3xl tracking-wide uppercase z-10">
@@ -353,7 +360,10 @@ const NewHomePageTemplate = ({ articles, campaigns, coverImage, title }) => {
 
           {/* @TODO: Need to remove the top/bottom padding from base-12-grid class and
           let components add their own padding otherwise it is hard to override. */}
-          <section className="sponsors-section base-12-grid bg-white py-8">
+          <section
+            className="base-12-grid bg-white py-8"
+            data-test="sponsors-section"
+          >
             <div className="grid-wide text-center">
               <h2 className="font-bold mb-3 text-base text-center text-gray-500 uppercase">
                 Sponsors
@@ -374,7 +384,10 @@ const NewHomePageTemplate = ({ articles, campaigns, coverImage, title }) => {
           </section>
 
           {/* @TODO: See earlier comment regarding base-12-grid. */}
-          <article className="signup-cta base-12-grid bg-yellow-500 py-4">
+          <article
+            className="base-12-grid bg-yellow-500 py-4"
+            data-test="signup-cta"
+          >
             <div className="grid-wide py-4 text-center">
               <div className="text-left">
                 <h1 className="font-bold text-2xl">

--- a/resources/assets/components/pages/HomePage/NewHomePage.js
+++ b/resources/assets/components/pages/HomePage/NewHomePage.js
@@ -18,6 +18,9 @@ const HOME_PAGE_QUERY = gql`
       id
       title
       subTitle
+      coverImage {
+        url
+      }
       campaigns {
         ... on Showcasable {
           showcaseTitle
@@ -28,6 +31,7 @@ const HOME_PAGE_QUERY = gql`
         }
         ... on CampaignWebsite {
           id
+          staffPick
           url
         }
         ... on StoryPageWebsite {
@@ -99,7 +103,7 @@ NewsletterItem.propTypes = {
   title: PropTypes.string.isRequired,
 };
 
-const NewHomePageTemplate = ({ articles, campaigns, title }) => {
+const NewHomePageTemplate = ({ articles, campaigns, coverImage, title }) => {
   const tailwindGray = tailwind('colors.gray');
   const tailwindScreens = tailwind('screens');
 
@@ -110,6 +114,35 @@ const NewHomePageTemplate = ({ articles, campaigns, title }) => {
     }
   `;
 
+  const headerBackgroundStyles = coverImage
+    ? css`
+        background-image: url(${contentfulImageUrl(
+          coverImage.url,
+          '400',
+          '775',
+          'fill',
+        )});
+
+        @media (min-width: ${tailwindScreens.md}) {
+          background-image: url(${contentfulImageUrl(
+            coverImage.url,
+            '700',
+            '700',
+            'fill',
+          )});
+        }
+
+        @media (min-width: ${tailwindScreens.lg}) {
+          background-image: url(${contentfulImageUrl(
+            coverImage.url,
+            '1440',
+            '539',
+            'fill',
+          )});
+        }
+      `
+    : null;
+
   return (
     <Fragment>
       {/* @TODO: Once EmotionJS supports shorthand syntax for React.Fragment, switch <Fragment> out for <> syntax! */}
@@ -119,21 +152,18 @@ const NewHomePageTemplate = ({ articles, campaigns, title }) => {
         <article>
           <header role="banner" className="bg-white pb-4">
             <div
-              className="base-12-grid"
+              className="base-12-grid bg-purple-500"
               css={css`
-                background-image: url('https://images.ctfassets.net/81iqaqpfd8fy/4k8rv5sN0kii0AoCawc6UQ/c22c3c132d1bb43055b6bafc248fcea5/vn7gpbosm9rx.jpg?fit=fill&f=center&h=775&w=400');
                 background-position: center center;
                 background-repeat: no-repeat;
                 background-size: cover;
                 padding-bottom: 250px;
 
                 @media (min-width: ${tailwindScreens.md}) {
-                  background-image: url('https://images.ctfassets.net/81iqaqpfd8fy/4k8rv5sN0kii0AoCawc6UQ/c22c3c132d1bb43055b6bafc248fcea5/vn7gpbosm9rx.jpg?fit=fill&f=center&h=700&w=700');
                   padding-bottom: 100px;
                 }
-                @media (min-width: ${tailwindScreens.lg}) {
-                  background-image: url('https://images.ctfassets.net/81iqaqpfd8fy/4k8rv5sN0kii0AoCawc6UQ/c22c3c132d1bb43055b6bafc248fcea5/vn7gpbosm9rx.jpg?fit=fill&f=center&h=539&w=1440');
-                }
+
+                ${headerBackgroundStyles}
               `}
             >
               <h1
@@ -375,6 +405,9 @@ const NewHomePageTemplate = ({ articles, campaigns, title }) => {
 NewHomePageTemplate.propTypes = {
   articles: PropTypes.arrayOf(PropTypes.object).isRequired,
   campaigns: PropTypes.arrayOf(PropTypes.object).isRequired,
+  coverImage: PropTypes.shape({
+    url: PropTypes.string.isRequired,
+  }).isRequired,
   title: PropTypes.string,
 };
 

--- a/resources/assets/components/pages/HomePage/NewHomePage.js
+++ b/resources/assets/components/pages/HomePage/NewHomePage.js
@@ -114,7 +114,7 @@ const NewHomePageTemplate = ({ articles, campaigns, coverImage, title }) => {
     }
   `;
 
-  const headerBackgroundStyles = coverImage
+  const headerBackgroundStyles = !coverImage
     ? css`
         background-image: url(${contentfulImageUrl(
           coverImage.url,
@@ -152,7 +152,7 @@ const NewHomePageTemplate = ({ articles, campaigns, coverImage, title }) => {
         <article className="home-page">
           <header role="banner" className="bg-white pb-4">
             <div
-              className="base-12-grid bg-purple-500"
+              className="base-12-grid bg-gray-200"
               css={css`
                 background-position: center center;
                 background-repeat: no-repeat;

--- a/resources/assets/components/pages/HomePage/NewHomePage.js
+++ b/resources/assets/components/pages/HomePage/NewHomePage.js
@@ -149,7 +149,7 @@ const NewHomePageTemplate = ({ articles, campaigns, coverImage, title }) => {
       <SiteNavigationContainer />
 
       <main>
-        <article>
+        <article className="home-page">
           <header role="banner" className="bg-white pb-4">
             <div
               className="base-12-grid bg-purple-500"
@@ -216,7 +216,7 @@ const NewHomePageTemplate = ({ articles, campaigns, coverImage, title }) => {
           </header>
 
           <section
-            className="base-12-grid bg-gray-100"
+            className="campaigns-section base-12-grid bg-gray-100"
             css={css`
               background: linear-gradient(
                 to bottom,
@@ -259,7 +259,7 @@ const NewHomePageTemplate = ({ articles, campaigns, coverImage, title }) => {
             </div>
           </section>
 
-          <article className="base-12-grid bg-purple-400">
+          <article className="newsletters-cta base-12-grid bg-purple-400">
             <div className="grid-wide text-center py-5 lg:py-10">
               <h2 className="text-white mb-4">
                 <span className="block lg:inline-block font-league-gothic font-normal tracking-wide text-4xl uppercase">
@@ -328,7 +328,7 @@ const NewHomePageTemplate = ({ articles, campaigns, coverImage, title }) => {
             </div>
           </article>
 
-          <section className="base-12-grid bg-gray-100">
+          <section className="articles-section base-12-grid bg-gray-100">
             <div className="grid-wide text-center">
               <h2 className="mb-6 relative">
                 <span className="bg-gray-100 font-league-gothic font-normal leading-tight inline-block py-2 px-6 relative text-3xl tracking-wide uppercase z-10">
@@ -353,7 +353,7 @@ const NewHomePageTemplate = ({ articles, campaigns, coverImage, title }) => {
 
           {/* @TODO: Need to remove the top/bottom padding from base-12-grid class and
           let components add their own padding otherwise it is hard to override. */}
-          <section className="base-12-grid bg-white py-8">
+          <section className="sponsors-section base-12-grid bg-white py-8">
             <div className="grid-wide text-center">
               <h2 className="font-bold mb-3 text-base text-center text-gray-500 uppercase">
                 Sponsors
@@ -374,7 +374,7 @@ const NewHomePageTemplate = ({ articles, campaigns, coverImage, title }) => {
           </section>
 
           {/* @TODO: See earlier comment regarding base-12-grid. */}
-          <article className="base-12-grid bg-yellow-500 py-4">
+          <article className="signup-cta base-12-grid bg-yellow-500 py-4">
             <div className="grid-wide py-4 text-center">
               <div className="text-left">
                 <h1 className="font-bold text-2xl">

--- a/resources/assets/components/utilities/Gallery/templates/CampaignGalleryItem/CampaignGalleryItemV2.js
+++ b/resources/assets/components/utilities/Gallery/templates/CampaignGalleryItem/CampaignGalleryItemV2.js
@@ -10,6 +10,7 @@ const CampaignGalleryItem = ({
   showcaseDescription,
   showcaseImage,
   showcaseTitle,
+  staffPick,
   url,
 }) => {
   const srcset = contentfulImageSrcset(showcaseImage.url, [
@@ -26,9 +27,11 @@ const CampaignGalleryItem = ({
       />
 
       <div className="bg-white border-b border-l border-r border-gray-300 border-solid flex flex-col flex-grow p-4 rounded-b">
-        <div className="absolute bg-purple-500 font-bold px-3 py-1 right-0 text-base text-white top-0 uppercase">
-          Featured
-        </div>
+        {staffPick ? (
+          <div className="absolute bg-purple-500 font-bold px-3 py-1 right-0 text-base text-white top-0 uppercase">
+            Featured
+          </div>
+        ) : null}
 
         <h1 className="font-bold mb-3 text-base text-blurple-500">
           {showcaseTitle}
@@ -51,7 +54,12 @@ CampaignGalleryItem.propTypes = {
   showcaseDescription: PropTypes.string.isRequired,
   showcaseImage: PropTypes.object.isRequired,
   showcaseTitle: PropTypes.string.isRequired,
+  staffPick: PropTypes.bool,
   url: PropTypes.string.isRequired,
+};
+
+CampaignGalleryItem.defaultProps = {
+  staffPick: false,
 };
 
 export default CampaignGalleryItem;


### PR DESCRIPTION
### What's this PR do?

This pull request does some last cleanup to utilize the new fields accessible after the GraphQL updates in https://github.com/DoSomething/graphql/pull/211. Campaigns that are designated as `staffPick` in Contentful will now properly show a "featured" badge in the top-right corner when presented in the new home page campaign gallery (note, this does not apply to `StoryPage` style campaigns, since they do not have a field for it; we've created a [ticket](https://www.pivotaltracker.com/story/show/172031799) on the Platforms team to address this during a cleanup sprint).

This also updates the new home page to use the new `coverImage` field in the `homePage` content type on Contentful, so the impact header background can be changed by content managers instead of having it be hardcoded.

Lastly, this PR also adds some nice class name hooks for use in our upcoming updates to our Ghost Inspector test for the home page.

### How should this be reviewed?

👀 


### Relevant tickets

References [Pivotal #171336897](https://www.pivotaltracker.com/story/show/171336897).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Added screenshots of front-end changes on small, medium, and large screens.
