### PR TITLE
Updates to the base grid vertical padding.

### DIFF
--- a/resources/assets/components/LedeBanner/templates/HeroTemplate.js
+++ b/resources/assets/components/LedeBanner/templates/HeroTemplate.js
@@ -63,7 +63,7 @@ const HeroTemplate = ({
         Should eventually be removed and use Tailwind. This will also help clean up the element hierarchy.
       */}
       <div className="hero-landing-page">
-        <div className="base-12-grid bg-gray-100 cover-image">
+        <div className="base-12-grid bg-gray-100 cover-image py-3 md:py-6">
           <img
             className="grid-wide"
             alt={coverImage.description || `cover photo for ${title}`}
@@ -73,7 +73,7 @@ const HeroTemplate = ({
         </div>
 
         <div className="clearfix bg-gray-100">
-          <div className="base-12-grid">
+          <div className="base-12-grid py-3 md:py-6">
             <header role="banner" className="hero-banner">
               <h1 className="hero-banner__headline-title">{title}</h1>
               <h2 className="hero-banner__headline-subtitle">{subtitle}</h2>

--- a/resources/assets/components/SiteNavigation/SiteNavigation.js
+++ b/resources/assets/components/SiteNavigation/SiteNavigation.js
@@ -242,7 +242,7 @@ class SiteNavigation extends React.Component {
 
               {this.state.activeSubNav === 'CausesSubNav' ? (
                 <div className="main-subnav menu-subnav">
-                  <div className="wrapper base-12-grid">
+                  <div className="wrapper base-12-grid py-3 md:py-6">
                     <section className="main-subnav__links-causes menu-subnav__links menu-subnav__section">
                       <h1>Causes</h1>
                       <ul>
@@ -576,7 +576,7 @@ class SiteNavigation extends React.Component {
 
               {this.state.activeSubNav === 'SearchSubNav' ? (
                 <div className="utility-subnav menu-subnav" name="search">
-                  <div className="wrapper base-12-grid">
+                  <div className="wrapper base-12-grid py-3 md:py-6">
                     <form
                       className="search"
                       id="utility-subnav__search"

--- a/resources/assets/components/blocks/SectionBlock/SectionBlock.js
+++ b/resources/assets/components/blocks/SectionBlock/SectionBlock.js
@@ -33,7 +33,7 @@ const SectionBlock = props => {
       <AnalyticsWaypoint name="section_block-top" context={{ blockId: id }} />
 
       <TextContent
-        className="section-block__content base-12-grid"
+        className="section-block__content base-12-grid py-3 md:py-6"
         classNameByEntry={classNameByEntry}
         classNameByEntryDefault={classNameByEntryDefault}
         styles={styles}

--- a/resources/assets/components/pages/AccountPage/Account/Account.js
+++ b/resources/assets/components/pages/AccountPage/Account/Account.js
@@ -12,7 +12,7 @@ const Account = props => (
 
     <main>
       <article className="account-page">
-        <header className="base-12-grid bg-gray-100">
+        <header className="base-12-grid bg-gray-100 py-3 md:py-6">
           <div className="grid-wide pt-12">
             <h1 className="font-league-gothic font-normal text-4xl md:text-5xl uppercase">
               Welcome, {props.user.firstName}!
@@ -21,7 +21,7 @@ const Account = props => (
         </header>
         <AccountNavigation {...props} />
 
-        <div className="base-12-grid bg-white">
+        <div className="base-12-grid bg-white py-3 md:py-6">
           <AccountRoute {...props} />
         </div>
       </article>

--- a/resources/assets/components/pages/AccountPage/Account/AccountNavigation.js
+++ b/resources/assets/components/pages/AccountPage/Account/AccountNavigation.js
@@ -5,7 +5,7 @@ import { featureFlag } from '../../../../helpers';
 import NavigationLink from '../../../utilities/NavigationLink/NavigationLink';
 
 const AccountNavigation = props => (
-  <nav className="base-12-grid page-navigation -no-fade">
+  <nav className="base-12-grid page-navigation py-3 md:py-6 -no-fade">
     <div className="grid-wide nav-items">
       <NavigationLink to="/us/account/campaigns">Campaigns</NavigationLink>
       {props.user.hasBadgesFlag ? (

--- a/resources/assets/components/pages/CampaignPage/CampaignPage.js
+++ b/resources/assets/components/pages/CampaignPage/CampaignPage.js
@@ -34,7 +34,7 @@ const CampaignPage = props => {
           <div className="my-6">
             {/* Render an entry (quiz), if provided. */}
             {entryContent ? (
-              <div className="base-12-grid">
+              <div className="base-12-grid py-3 md:py-6">
                 <ContentfulEntryLoader
                   className="grid-wide"
                   id={entryContent.id}

--- a/resources/assets/components/pages/CampaignPage/CampaignPageContent.js
+++ b/resources/assets/components/pages/CampaignPage/CampaignPageContent.js
@@ -28,7 +28,7 @@ const CampaignPageContent = props => {
     <div className="campaign-page__content" id={subPage.id}>
       <ScrollConcierge />
       {content ? (
-        <div className="base-12-grid">
+        <div className="base-12-grid py-3 md:py-6">
           <div className="grid-wide-7/10">
             <TextContent className="mx-3">{content}</TextContent>
           </div>
@@ -44,23 +44,25 @@ const CampaignPageContent = props => {
         </div>
       ) : null}
 
-      <div className="base-12-grid clear-both">
-        {blocks.map(block => (
-          <ContentfulEntryLoader
-            key={block.id}
-            id={block.id}
-            className="mb-6 clear-both"
-            classNameByEntryDefault="grid-wide-7/10"
-            classNameByEntry={{
-              ContentBlock: 'grid-wide',
-              ImagesBlock: 'grid-wide',
-              PostGalleryBlock: 'grid-wide',
-              PhotoSubmissionBlock: 'grid-wide',
-              SocialDriveBlock: 'grid-wide',
-            }}
-          />
-        ))}
-      </div>
+      {blocks.length ? (
+        <div className="base-12-grid clear-both py-3 md:py-6">
+          {blocks.map(block => (
+            <ContentfulEntryLoader
+              key={block.id}
+              id={block.id}
+              className="mb-6 clear-both"
+              classNameByEntryDefault="grid-wide-7/10"
+              classNameByEntry={{
+                ContentBlock: 'grid-wide',
+                ImagesBlock: 'grid-wide',
+                PostGalleryBlock: 'grid-wide',
+                PhotoSubmissionBlock: 'grid-wide',
+                SocialDriveBlock: 'grid-wide',
+              }}
+            />
+          ))}
+        </div>
+      ) : null}
 
       {isClosed ? null : (
         <CallToActionContainer

--- a/resources/assets/components/pages/CausePage/CausePage.js
+++ b/resources/assets/components/pages/CausePage/CausePage.js
@@ -57,7 +57,7 @@ const CausePageTemplate = ({
         <article className="cause-page">
           <header
             role="banner"
-            className="lede-banner base-12-grid"
+            className="lede-banner base-12-grid py-3 md:py-6"
             style={withoutNulls(styles)}
           >
             <div className="title-lockup my-6">
@@ -104,7 +104,7 @@ const CausePageTemplate = ({
             ) : null}
           </header>
 
-          <div className="base-12-grid">
+          <div className="base-12-grid py-3 md:py-6">
             <PaginatedCampaignGallery
               className="grid-full"
               itemsPerRow={4}
@@ -114,7 +114,7 @@ const CausePageTemplate = ({
           </div>
 
           <TextContent
-            className="base-12-grid"
+            className="base-12-grid py-3 md:py-6"
             classNameByEntry={{
               GalleryBlock: 'grid-full',
               ContentBlock: 'grid-full',

--- a/resources/assets/components/pages/CollectionPage/CollectionPage.js
+++ b/resources/assets/components/pages/CollectionPage/CollectionPage.js
@@ -62,7 +62,7 @@ const CollectionPageTemplate = ({
         <article className="collection-page">
           <header
             role="banner"
-            className="lede-banner base-12-grid"
+            className="lede-banner base-12-grid py-3 md:py-6"
             style={withoutNulls(styles)}
           >
             <div className="title-lockup my-6">
@@ -95,7 +95,7 @@ const CollectionPageTemplate = ({
           </header>
 
           <TextContent
-            className="base-12-grid"
+            className="base-12-grid py-3 md:py-6"
             classNameByEntry={{
               GalleryBlock: 'grid-full',
               ContentBlock: 'grid-full-8/12',

--- a/resources/assets/components/pages/CompanyPage/CompanyPage.js
+++ b/resources/assets/components/pages/CompanyPage/CompanyPage.js
@@ -35,7 +35,7 @@ const CompanyPageTemplate = props => {
     <>
       <SiteNavigationContainer />
 
-      <main className="wrapper base-12-grid company-page">
+      <main className="wrapper base-12-grid company-page py-3 md:py-6">
         <article className="grid-wide bg-white rounded border border-solid border-gray-300 overflow-hidden">
           {coverImage.url ? (
             <LazyImage

--- a/resources/assets/components/pages/GeneralPage/GeneralPage.js
+++ b/resources/assets/components/pages/GeneralPage/GeneralPage.js
@@ -54,7 +54,7 @@ const GeneralPage = props => {
       <SiteNavigationContainer />
 
       <main>
-        <article className="general-page base-12-grid bg-white">
+        <article className="general-page base-12-grid bg-white py-3 md:py-6">
           <div className="grid-narrow">
             <ArticleHeader title={title} subtitle={subTitle}>
               {authors.length ? (

--- a/resources/assets/components/pages/HomePage/NewHomePage.js
+++ b/resources/assets/components/pages/HomePage/NewHomePage.js
@@ -150,9 +150,9 @@ const NewHomePageTemplate = ({ articles, campaigns, coverImage, title }) => {
 
       <main>
         <article data-test="home-page">
-          <header role="banner" className="bg-white pb-4">
+          <header role="banner" className="bg-white">
             <div
-              className="base-12-grid bg-gray-200"
+              className="base-12-grid bg-gray-200 pt-3 md:pt-6"
               css={css`
                 background-position: center center;
                 background-repeat: no-repeat;
@@ -185,8 +185,6 @@ const NewHomePageTemplate = ({ articles, campaigns, coverImage, title }) => {
               className="base-12-grid"
               css={css`
                 margin-top: -250px;
-                padding-bottom: 0;
-                padding-top: 0;
 
                 @media (min-width: ${tailwindScreens.md}) {
                   margin-top: -100px;
@@ -216,7 +214,7 @@ const NewHomePageTemplate = ({ articles, campaigns, coverImage, title }) => {
           </header>
 
           <section
-            className="base-12-grid bg-gray-100"
+            className="base-12-grid bg-gray-100 py-8"
             css={css`
               background: linear-gradient(
                 to bottom,
@@ -228,7 +226,7 @@ const NewHomePageTemplate = ({ articles, campaigns, coverImage, title }) => {
           >
             <div className="grid-wide text-center">
               <h2 className="mb-6 relative">
-                <span className="bg-white font-league-gothic font-normal leading-tight inline-block py-2 px-6 relative text-3xl tracking-wide uppercase z-10">
+                <span className="bg-white font-league-gothic font-normal leading-tight inline-block px-6 relative text-3xl md:text-4xl uppercase z-10">
                   Take Action
                 </span>
                 <span
@@ -253,7 +251,7 @@ const NewHomePageTemplate = ({ articles, campaigns, coverImage, title }) => {
 
               <a
                 href="/us/campaigns"
-                className="btn bg-blurple-500 hover:bg-blurple-300 focus:bg-blurple-700 inline-block my-8 hover:no-underline py-4 px-8 text-lg hover:text-white"
+                className="btn bg-blurple-500 hover:bg-blurple-300 focus:bg-blurple-700 inline-block mt-8 hover:no-underline py-4 px-8 text-lg hover:text-white"
               >
                 See More Campaigns
               </a>
@@ -261,10 +259,10 @@ const NewHomePageTemplate = ({ articles, campaigns, coverImage, title }) => {
           </section>
 
           <article
-            className="base-12-grid bg-purple-700"
+            className="base-12-grid bg-purple-700 py-8 lg:py-12"
             data-test="newsletters-cta"
           >
-            <div className="grid-wide text-center py-5 lg:py-10">
+            <div className="grid-wide text-center">
               <h2 className="text-white mb-4">
                 <span className="block lg:inline-block font-league-gothic font-normal tracking-wide text-4xl uppercase">
                   Get Inspired.
@@ -333,12 +331,12 @@ const NewHomePageTemplate = ({ articles, campaigns, coverImage, title }) => {
           </article>
 
           <section
-            className="base-12-grid bg-gray-100"
+            className="base-12-grid bg-gray-100 py-8"
             data-test="articles-section"
           >
             <div className="grid-wide text-center">
               <h2 className="mb-6 relative">
-                <span className="bg-gray-100 font-league-gothic font-normal leading-tight inline-block py-2 px-6 relative text-3xl tracking-wide uppercase z-10">
+                <span className="bg-gray-100 font-league-gothic font-normal leading-tight inline-block px-6 relative text-3xl md:text-4xl uppercase z-10">
                   Read About It
                 </span>
                 <span
@@ -351,7 +349,7 @@ const NewHomePageTemplate = ({ articles, campaigns, coverImage, title }) => {
 
               <a
                 href="/us/articles"
-                className="btn bg-blurple-500 hover:bg-blurple-300 focus:bg-blurple-700 inline-block my-8 hover:no-underline py-4 px-8 text-lg hover:text-white"
+                className="btn bg-blurple-500 hover:bg-blurple-300 focus:bg-blurple-700 inline-block mt-8 hover:no-underline py-4 px-8 text-lg hover:text-white"
               >
                 See More Articles
               </a>
@@ -383,13 +381,12 @@ const NewHomePageTemplate = ({ articles, campaigns, coverImage, title }) => {
             </div>
           </section>
 
-          {/* @TODO: See earlier comment regarding base-12-grid. */}
           <article
-            className="base-12-grid bg-yellow-500 py-4"
+            className="base-12-grid bg-yellow-500 py-16"
             data-test="signup-cta"
           >
-            <div className="grid-wide py-4 text-center">
-              <div className="text-left">
+            <div className="xl:flex grid-wide xl:items-center text-center">
+              <div className="text-left xl:w-8/12">
                 <h1 className="font-bold text-2xl">
                   Join our youth-led movement for good
                 </h1>
@@ -399,12 +396,14 @@ const NewHomePageTemplate = ({ articles, campaigns, coverImage, title }) => {
                 </p>
               </div>
 
-              <a
-                href="/authorize"
-                className="btn bg-blurple-500 hover:bg-blurple-300 inline-block mt-8 hover:no-underline py-4 px-16 text-lg hover:text-white"
-              >
-                Join Now
-              </a>
+              <div className="flex-grow">
+                <a
+                  href="/authorize"
+                  className="btn bg-blurple-500 hover:bg-blurple-300 inline-block mt-8 xl:m-0 hover:no-underline py-4 px-16 text-lg hover:text-white xl:ml-auto"
+                >
+                  Join Now
+                </a>
+              </div>
             </div>
           </article>
         </article>

--- a/resources/assets/components/pages/ReferralPage/Alpha/AlphaPage.js
+++ b/resources/assets/components/pages/ReferralPage/Alpha/AlphaPage.js
@@ -14,7 +14,7 @@ const AlphaPage = ({ userId }) =>
     <>
       <SiteNavigationContainer />
 
-      <main className="general-page alpha-referral-page base-12-grid relative">
+      <main className="general-page alpha-referral-page base-12-grid py-3 md:py-6 relative">
         <article className="grid-narrow">
           <ArticleHeader title="Want Free Money for School?" />
           <div className="my-6">

--- a/resources/assets/components/pages/ReferralPage/Beta/BetaPage.js
+++ b/resources/assets/components/pages/ReferralPage/Beta/BetaPage.js
@@ -36,7 +36,7 @@ const BetaPage = () => {
         const firstName = data.user.firstName;
 
         return (
-          <div className="main general-page base-12-grid">
+          <div className="main general-page base-12-grid py-3 md:py-6">
             <div className="grid-narrow">
               <div className="my-6">
                 <ArticleHeader title={`Hey, ${firstName}’s friend!`} />

--- a/resources/assets/components/pages/StoryPage/StoryPage.js
+++ b/resources/assets/components/pages/StoryPage/StoryPage.js
@@ -31,7 +31,7 @@ const StoryPage = props => {
         <article className="story-page">
           <header
             role="banner"
-            className="lede-banner base-12-grid"
+            className="lede-banner base-12-grid py-3 md:py-6"
             style={withoutNulls(styles)}
           >
             <div className="wrapper text-center">

--- a/resources/assets/components/utilities/CtaBanner/CtaBanner.js
+++ b/resources/assets/components/utilities/CtaBanner/CtaBanner.js
@@ -20,7 +20,7 @@ const CtaBanner = ({ buttonText, content, link, title }) => {
     });
 
   return (
-    <div className="cta-banner base-12-grid">
+    <div className="cta-banner base-12-grid py-3 md:py-6">
       <div className="grid-narrow m-3">
         <h3 className="text-m text-yellow-500 font-bold uppercase">{title}</h3>
         <p className="text-white mt-3">{content}</p>

--- a/resources/assets/components/utilities/PageNavigation/PageNavigation.js
+++ b/resources/assets/components/utilities/PageNavigation/PageNavigation.js
@@ -63,7 +63,7 @@ class PageNavigation extends React.Component {
       <div
         ref={node => (this.node = node)}
         id="page-navigation"
-        className={classnames('base-12-grid page-navigation', {
+        className={classnames('base-12-grid page-navigation py-3 md:py-6', {
           'is-stuck': this.state.isStuck,
         })}
       >

--- a/resources/assets/scss/base.scss
+++ b/resources/assets/scss/base.scss
@@ -213,13 +213,15 @@ p {
   // 4 columns
   grid-template-columns: [full-start] 1fr 1fr [midway] 1fr 1fr [full-end];
   grid-column-gap: theme('spacing.3');
-  padding: theme('spacing.3');
+  padding-left: theme('spacing.3');
+  padding-right: theme('spacing.3');
 
   @include media($medium) {
     // 8 columns
     grid-template-columns: [full-start] 1fr [main-start] 1fr 1fr 1fr [midway] 1fr 1fr 1fr [main-end] 1fr [full-end];
     grid-column-gap: theme('spacing.6');
-    padding: theme('spacing.6') theme('spacing.12');
+    padding-left: theme('spacing.12');
+    padding-right: theme('spacing.12');
   }
 
   @include media($large) {


### PR DESCRIPTION
### What's this PR do?

This pull request removes the vertical padding on the `base-12-grid` class to allow containers to define their own vertical padding based on mocks.

Prior to this update, overriding the predefined vertical padding on containers with the `base-12-grid` class required  having to add a dedicated stylesheet with more specific declarations since Tailwind classes do not have high enough specificity to override the vertical padding styles.

### How should this be reviewed?

👀 

### Relevant tickets

References [Pivotal #172090293](https://www.pivotaltracker.com/story/show/172090293).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
