### PR TITLE
Re-triggering scroll after campaign signup

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2624,7 +2624,7 @@
     "@types/zen-observable": {
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/@types/zen-observable/-/zen-observable-0.8.0.tgz",
-      "integrity": "sha1-i2OrfxqlMhJIqtWsiQpIVlbc6k0="
+      "integrity": "sha512-te5lMAWii1uEJ4FwLjzdlbw3+n0FZNOvFXHxQDKeT0dilh7HOzdMzV2TrJVUzq8ep7J4Na8OUYPRLSQkJHAlrg=="
     },
     "@webassemblyjs/ast": {
       "version": "1.9.0",

--- a/resources/assets/components/Campaign/CampaignRoute/CampaignRoute.js
+++ b/resources/assets/components/Campaign/CampaignRoute/CampaignRoute.js
@@ -106,7 +106,12 @@ const CampaignRoute = props => {
 
             if (isClosed) {
               if (slug === 'community' && hasCommunityPage) {
-                return <CampaignPageContainer {...routeProps} />;
+                return (
+                  <CampaignPageContainer
+                    {...routeProps}
+                    shouldShowAffirmation={shouldShowAffirmation}
+                  />
+                );
               }
 
               return (
@@ -130,7 +135,12 @@ const CampaignRoute = props => {
               );
             }
 
-            return <CampaignPageContainer {...routeProps} />;
+            return (
+              <CampaignPageContainer
+                {...routeProps}
+                shouldShowAffirmation={shouldShowAffirmation}
+              />
+            );
           }}
         />
       </Switch>

--- a/resources/assets/components/Campaign/CampaignRoute/CampaignRoute.js
+++ b/resources/assets/components/Campaign/CampaignRoute/CampaignRoute.js
@@ -106,12 +106,7 @@ const CampaignRoute = props => {
 
             if (isClosed) {
               if (slug === 'community' && hasCommunityPage) {
-                return (
-                  <CampaignPageContainer
-                    {...routeProps}
-                    shouldShowAffirmation={shouldShowAffirmation}
-                  />
-                );
+                return <CampaignPageContainer {...routeProps} />;
               }
 
               return (
@@ -135,12 +130,7 @@ const CampaignRoute = props => {
               );
             }
 
-            return (
-              <CampaignPageContainer
-                {...routeProps}
-                shouldShowAffirmation={shouldShowAffirmation}
-              />
-            );
+            return <CampaignPageContainer {...routeProps} />;
           }}
         />
       </Switch>

--- a/resources/assets/components/ScrollConcierge.js
+++ b/resources/assets/components/ScrollConcierge.js
@@ -23,4 +23,8 @@ ScrollConcierge.propTypes = {
   trigger: PropTypes.any, // eslint-disable-line
 };
 
+ScrollConcierge.defaultProps = {
+  trigger: null,
+};
+
 export default ScrollConcierge;

--- a/resources/assets/components/pages/CampaignPage/CampaignPageContainer.js
+++ b/resources/assets/components/pages/CampaignPage/CampaignPageContainer.js
@@ -28,6 +28,7 @@ const mapStateToProps = (state, ownProps) => {
     landingPage: get(state.campaign, 'landingPage', null),
     noun: get(state.campaign.additionalContent, 'noun'),
     pages: state.campaign.pages,
+    shouldShowAffirmation: state.signups.shouldShowAffirmation,
     shouldShowLandingPage: shouldShowLandingPage(state, entryContent),
     tagline: get(state.campaign.additionalContent, 'tagline'),
     title: state.campaign.title,

--- a/resources/assets/components/pages/CampaignPage/CampaignPageContent.js
+++ b/resources/assets/components/pages/CampaignPage/CampaignPageContent.js
@@ -10,7 +10,7 @@ import { isCampaignClosed } from '../../../helpers';
 import ContentfulEntryLoader from '../../utilities/ContentfulEntryLoader/ContentfulEntryLoader';
 
 const CampaignPageContent = props => {
-  const { campaignEndDate, match, pages } = props;
+  const { campaignEndDate, match, pages, shouldShowAffirmation } = props;
 
   const subPage = find(pages, page =>
     page.type === 'page' ? page.fields.slug.endsWith(match.params.slug) : false,
@@ -26,7 +26,7 @@ const CampaignPageContent = props => {
 
   return (
     <div className="campaign-page__content" id={subPage.id}>
-      <ScrollConcierge />
+      <ScrollConcierge trigger={!shouldShowAffirmation} />
       {content ? (
         <div className="base-12-grid py-3 md:py-6">
           <div className="grid-wide-7/10">
@@ -93,6 +93,7 @@ CampaignPageContent.propTypes = {
       }),
     }),
   ),
+  shouldShowAffirmation: PropTypes.bool,
 };
 
 CampaignPageContent.defaultProps = {
@@ -101,6 +102,7 @@ CampaignPageContent.defaultProps = {
   match: {
     params: {},
   },
+  shouldShowAffirmation: false,
 };
 
 export default CampaignPageContent;


### PR DESCRIPTION
### What's this PR do?

This pull request fixes a bug on our campaign pages where the `Scroll Concierge` was no longer working as expected. After users signed up and saw a confirmation modal, they were not pulled down to the action page.

### How should this be reviewed?

Does this seem the most efficient? Also wondering if there's anywhere else this needs to be passed in on the `CampaignRoute` page. 

### Any background context you want to provide?


![Kapture 2020-04-01 at 14 45 33](https://user-images.githubusercontent.com/15236023/78174586-7c872680-7427-11ea-9926-1f6ac65eceb8.gif)


### Relevant tickets

References [Pivotal # 170979245](https://www.pivotaltracker.com/story/show/170979245).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added screenshots of front-end changes on small, medium, and large screens.
- [ ] Added appropriate feature/unit tests.
