### PR TITLE
Attach client identifier to requests.

### DIFF
--- a/resources/assets/graphql.js
+++ b/resources/assets/graphql.js
@@ -56,5 +56,6 @@ export default uri => {
   return new ApolloClient({
     link: ApolloLink.from([errorLink, authLink, persistedLink, httpLink]),
     cache: new InMemoryCache({ fragmentMatcher }),
+    name: 'phoenix',
   });
 };


### PR DESCRIPTION
### What's this PR do?

This pull request simply attaches the application name to our GraphQL requests, so that we can segment these out in Apollo Engine when looking at metrics:

![Screen Shot 2020-04-01 at 3 52 55 PM](https://user-images.githubusercontent.com/583202/78180511-de985980-7430-11ea-8578-bce03b980ebd.png)


### How should this be reviewed?

👀

### Any background context you want to provide?

Support for this was added in DoSomething/graphql#213.

### Relevant tickets

References [Pivotal #171001230](https://www.pivotaltracker.com/story/show/171001230).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added screenshots of front-end changes on small, medium, and large screens.
- [ ] Added appropriate feature/unit tests.
