### PR TITLE
Adding the ability to close the modal by Clicking outside!

### DIFF
--- a/cypress/integration/campaign-signup.js
+++ b/cypress/integration/campaign-signup.js
@@ -38,7 +38,7 @@ describe('Campaign Signup', () => {
       .handleLogin(user);
 
     cy.contains('Thanks for joining us!');
-    cy.get('.modal-portal > .wrapper.modal-container').click('topRight');
+    cy.get('body').type('{esc}', { force: true });
     cy.get('.card.affirmation').should('not.exist');
   });
 

--- a/cypress/integration/campaign-signup.js
+++ b/cypress/integration/campaign-signup.js
@@ -38,6 +38,8 @@ describe('Campaign Signup', () => {
       .handleLogin(user);
 
     cy.contains('Thanks for joining us!');
+    cy.get('.modal-portal > .wrapper.modal-container').click('topRight');
+    cy.get('.card.affirmation').should('not.exist');
   });
 
   it('Create signup, as an authenticated user', () => {
@@ -57,6 +59,8 @@ describe('Campaign Signup', () => {
     // Click "Join Now" & should get the affirmation modal:
     cy.contains('button', 'Join Us').click();
     cy.get('.card.affirmation').contains('Thanks for joining us!');
+    cy.get('.modal-portal > .wrapper.modal-container').click('topRight');
+    cy.get('.card.affirmation').should('not.exist');
   });
 
   context('Campaign ID configured as referral campaign', () => {

--- a/resources/assets/components/utilities/Modal/Modal.js
+++ b/resources/assets/components/utilities/Modal/Modal.js
@@ -23,7 +23,8 @@ class Modal extends React.Component {
     this.el.className = 'wrapper';
     this.scrollOffset = window.scrollY;
 
-    this.handleClick = this.handleClick.bind(this);
+    this.handleModalCloseClick = this.handleModalCloseClick.bind(this);
+    this.handleModalCloseEsc = this.handleModalCloseEsc.bind(this);
   }
 
   componentDidMount() {
@@ -34,7 +35,8 @@ class Modal extends React.Component {
     );
     this.modalPortal.classList.add('is-active');
     this.modalPortal.appendChild(this.el);
-    document.addEventListener('click', this.handleClick, false);
+    document.addEventListener('click', this.handleModalCloseClick, false);
+    document.addEventListener('keydown', this.handleModalCloseEsc, false);
 
     // Track in analytics that the modal opened:
     // @TODO: See if this conflicts with the DissmissableElement analytics events.
@@ -57,7 +59,8 @@ class Modal extends React.Component {
     window.scroll(0, this.scrollOffset);
     this.modalPortal.classList.remove('is-active');
     this.modalPortal.removeChild(this.el);
-    document.removeEventListener('click', this.handleClick, false);
+    document.removeEventListener('click', this.handleModalCloseClick, false);
+    document.removeEventListener('keydown', this.handleModalCloseEsc, false);
 
     // Track in analytics that the modal closed:
     if (this.props.trackingId) {
@@ -73,11 +76,17 @@ class Modal extends React.Component {
     }
   }
 
-  handleClick(event) {
+  handleModalCloseClick(event) {
     if (event.target !== this.el) {
       return;
     }
     this.props.onClose();
+  }
+
+  handleModalCloseEsc(event) {
+    if (event.keyCode === 27) {
+      this.props.onClose();
+    }
   }
 
   render() {

--- a/resources/assets/components/utilities/Modal/Modal.js
+++ b/resources/assets/components/utilities/Modal/Modal.js
@@ -22,6 +22,8 @@ class Modal extends React.Component {
     this.el = document.createElement('div');
     this.el.className = 'wrapper';
     this.scrollOffset = window.scrollY;
+
+    this.handleClick = this.handleClick.bind(this);
   }
 
   componentDidMount() {
@@ -32,6 +34,7 @@ class Modal extends React.Component {
     );
     this.modalPortal.classList.add('is-active');
     this.modalPortal.appendChild(this.el);
+    document.addEventListener('click', this.handleClick, false);
 
     // Track in analytics that the modal opened:
     // @TODO: See if this conflicts with the DissmissableElement analytics events.
@@ -54,6 +57,7 @@ class Modal extends React.Component {
     window.scroll(0, this.scrollOffset);
     this.modalPortal.classList.remove('is-active');
     this.modalPortal.removeChild(this.el);
+    document.removeEventListener('click', this.handleClick, false);
 
     // Track in analytics that the modal closed:
     if (this.props.trackingId) {
@@ -67,6 +71,13 @@ class Modal extends React.Component {
         },
       });
     }
+  }
+
+  handleClick(event) {
+    if (event.target !== this.el) {
+      return;
+    }
+    this.props.onClose();
   }
 
   render() {

--- a/resources/assets/components/utilities/Modal/Modal.js
+++ b/resources/assets/components/utilities/Modal/Modal.js
@@ -20,7 +20,8 @@ class Modal extends React.Component {
 
     this.chrome = document.getElementById('chrome');
     this.el = document.createElement('div');
-    this.el.className = 'wrapper';
+    // this.el.className = 'wrapper';
+    this.el.classList = 'wrapper modal-container';
     this.scrollOffset = window.scrollY;
 
     this.handleModalCloseClick = this.handleModalCloseClick.bind(this);
@@ -35,7 +36,7 @@ class Modal extends React.Component {
     );
     this.modalPortal.classList.add('is-active');
     this.modalPortal.appendChild(this.el);
-    document.addEventListener('click', this.handleModalCloseClick, false);
+    this.el.addEventListener('click', this.handleModalCloseClick, false);
     document.addEventListener('keydown', this.handleModalCloseEsc, false);
 
     // Track in analytics that the modal opened:
@@ -59,7 +60,7 @@ class Modal extends React.Component {
     window.scroll(0, this.scrollOffset);
     this.modalPortal.classList.remove('is-active');
     this.modalPortal.removeChild(this.el);
-    document.removeEventListener('click', this.handleModalCloseClick, false);
+    this.el.removeEventListener('click', this.handleModalCloseClick, false);
     document.removeEventListener('keydown', this.handleModalCloseEsc, false);
 
     // Track in analytics that the modal closed:

--- a/resources/assets/components/utilities/Modal/Modal.js
+++ b/resources/assets/components/utilities/Modal/Modal.js
@@ -20,7 +20,6 @@ class Modal extends React.Component {
 
     this.chrome = document.getElementById('chrome');
     this.el = document.createElement('div');
-    // this.el.className = 'wrapper';
     this.el.classList = 'wrapper modal-container';
     this.scrollOffset = window.scrollY;
 


### PR DESCRIPTION
### What's this PR do?

This pull request restores the ability to close a modal on our site by clicking outside of the modal as well as using the `close` button on the modal window. 

### How should this be reviewed?

👀 

Large Screen
![fullsize](https://user-images.githubusercontent.com/15236023/78385023-322db300-75a9-11ea-8694-cb7e12297d8a.gif)

Small Screen
![mobile](https://user-images.githubusercontent.com/15236023/78385086-4bcefa80-75a9-11ea-9b3e-f235d1bcd5b2.gif)


### Any background context you want to provide?

Restoring this [capability that we had](https://github.com/DoSomething/phoenix-next/blob/3bde7a29ad636f7529d54d4b877659da936fba42/resources/assets/components/Modal/Modal.js) before the Modal was updated.

### Relevant tickets

References [Pivotal # 169928815](https://www.pivotaltracker.com/story/show/169928815).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added screenshots of front-end changes on small, medium, and large screens.
- [ ] Added appropriate feature/unit tests.
