### PR TITLE
Fragmenting campaign and page cards for multiple uses.

### DIFF
--- a/resources/assets/components/pages/HomePage/HomePageArticleGallery.js
+++ b/resources/assets/components/pages/HomePage/HomePageArticleGallery.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import PageGalleryItem from '../../utilities/Gallery/templates/PageGalleryItem/PageGalleryItemV2';
+import PageCard from '../../utilities/PageCard/PageCard';
 
 const HomePageArticleGallery = ({ articles }) => {
   return (
@@ -9,12 +9,7 @@ const HomePageArticleGallery = ({ articles }) => {
       {articles.map(article => {
         return (
           <li key={article.id}>
-            <PageGalleryItem
-              showcaseDescription={article.showcaseDescription}
-              showcaseImage={article.showcaseImage}
-              showcaseTitle={article.showcaseTitle}
-              slug={article.slug}
-            />
+            <PageCard page={article} />
           </li>
         );
       })}

--- a/resources/assets/components/pages/HomePage/HomePageCampaignGallery.js
+++ b/resources/assets/components/pages/HomePage/HomePageCampaignGallery.js
@@ -3,8 +3,8 @@ import PropTypes from 'prop-types';
 import { css } from '@emotion/core';
 
 import { tailwind } from '../../../helpers';
-import CampaignGalleryItem from '../../utilities/Gallery/templates/CampaignGalleryItem/CampaignGalleryItemV2';
-import CampaignGalleryFeaturedItem from '../../utilities/Gallery/templates/CampaignGalleryFeaturedItem/CampaignGalleryFeaturedItem';
+import CampaignCard from '../../utilities/CampaignCard/CampaignCard';
+import CampaignCardFeatured from '../../utilities/CampaignCard/CampaignCardFeatured';
 
 const HomePageCampaignGallery = ({ campaigns }) => {
   const tailwindSpacing = tailwind('spacing');
@@ -44,14 +44,14 @@ const HomePageCampaignGallery = ({ campaigns }) => {
             `}
           >
             {firstItem ? (
-              <CampaignGalleryFeaturedItem
+              <CampaignCardFeatured
                 showcaseDescription={campaign.showcaseDescription}
                 showcaseImage={campaign.showcaseImage}
                 showcaseTitle={campaign.showcaseTitle}
                 url={campaign.url}
               />
             ) : (
-              <CampaignGalleryItem
+              <CampaignCard
                 showcaseDescription={campaign.showcaseDescription}
                 showcaseImage={campaign.showcaseImage}
                 showcaseTitle={campaign.showcaseTitle}

--- a/resources/assets/components/pages/HomePage/HomePageCampaignGallery.js
+++ b/resources/assets/components/pages/HomePage/HomePageCampaignGallery.js
@@ -44,12 +44,7 @@ const HomePageCampaignGallery = ({ campaigns }) => {
             `}
           >
             {firstItem ? (
-              <CampaignCardFeatured
-                showcaseDescription={campaign.showcaseDescription}
-                showcaseImage={campaign.showcaseImage}
-                showcaseTitle={campaign.showcaseTitle}
-                url={campaign.url}
-              />
+              <CampaignCardFeatured campaign={campaign} />
             ) : (
               <CampaignCard campaign={campaign} />
             )}

--- a/resources/assets/components/pages/HomePage/HomePageCampaignGallery.js
+++ b/resources/assets/components/pages/HomePage/HomePageCampaignGallery.js
@@ -51,13 +51,7 @@ const HomePageCampaignGallery = ({ campaigns }) => {
                 url={campaign.url}
               />
             ) : (
-              <CampaignCard
-                showcaseDescription={campaign.showcaseDescription}
-                showcaseImage={campaign.showcaseImage}
-                showcaseTitle={campaign.showcaseTitle}
-                staffPick={campaign.staffPick}
-                url={campaign.url}
-              />
+              <CampaignCard campaign={campaign} />
             )}
           </li>
         );

--- a/resources/assets/components/pages/HomePage/NewHomePage.js
+++ b/resources/assets/components/pages/HomePage/NewHomePage.js
@@ -9,8 +9,10 @@ import * as NewsletterImages from './NewsletterImages';
 import HomePageArticleGallery from './HomePageArticleGallery';
 import SiteFooter from '../../utilities/SiteFooter/SiteFooter';
 import HomePageCampaignGallery from './HomePageCampaignGallery';
+import { pageCardFragment } from '../../utilities/PageCard/PageCard';
 import { campaignCardFragment } from '../../utilities/CampaignCard/CampaignCard';
 import SiteNavigationContainer from '../../SiteNavigation/SiteNavigationContainer';
+import { campaignCardFeaturedFragment } from '../../utilities/CampaignCard/CampaignCardFeatured';
 import {
   contentfulImageUrl,
   isAuthenticated,
@@ -28,21 +30,18 @@ const HOME_PAGE_QUERY = gql`
       }
       campaigns {
         ...CampaignCard
+        ...CampaignCardFeatured
       }
       articles {
-        id
-        showcaseTitle
-        showcaseDescription
-        showcaseImage {
-          url
-        }
-        slug
+        ...PageCard
       }
       additionalContent
     }
   }
 
   ${campaignCardFragment}
+  ${campaignCardFeaturedFragment}
+  ${pageCardFragment}
 `;
 
 const ImpactStatistic = ({ campaignName, impactLabel, impactValue }) => (

--- a/resources/assets/components/pages/HomePage/NewHomePage.js
+++ b/resources/assets/components/pages/HomePage/NewHomePage.js
@@ -8,13 +8,14 @@ import sponsorList from './sponsor-list';
 import * as NewsletterImages from './NewsletterImages';
 import HomePageArticleGallery from './HomePageArticleGallery';
 import SiteFooter from '../../utilities/SiteFooter/SiteFooter';
+import HomePageCampaignGallery from './HomePageCampaignGallery';
+import { campaignCardFragment } from '../../utilities/CampaignCard/CampaignCard';
+import SiteNavigationContainer from '../../SiteNavigation/SiteNavigationContainer';
 import {
   contentfulImageUrl,
   isAuthenticated,
   tailwind,
 } from '../../../helpers';
-import HomePageCampaignGallery from './HomePageCampaignGallery';
-import SiteNavigationContainer from '../../SiteNavigation/SiteNavigationContainer';
 
 const HOME_PAGE_QUERY = gql`
   query HomePageQuery($preview: Boolean!) {
@@ -26,22 +27,7 @@ const HOME_PAGE_QUERY = gql`
         url
       }
       campaigns {
-        ... on Showcasable {
-          showcaseTitle
-          showcaseDescription
-          showcaseImage {
-            url
-          }
-        }
-        ... on CampaignWebsite {
-          id
-          staffPick
-          url
-        }
-        ... on StoryPageWebsite {
-          id
-          url
-        }
+        ...CampaignCard
       }
       articles {
         id
@@ -55,6 +41,8 @@ const HOME_PAGE_QUERY = gql`
       additionalContent
     }
   }
+
+  ${campaignCardFragment}
 `;
 
 const ImpactStatistic = ({ campaignName, impactLabel, impactValue }) => (

--- a/resources/assets/components/utilities/CampaignCard/CampaignCard.js
+++ b/resources/assets/components/utilities/CampaignCard/CampaignCard.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import gql from 'graphql-tag';
-import PropTypes from 'prop-types';
+import { propType } from 'graphql-anywhere';
 
 import { contentfulImageSrcset, contentfulImageUrl } from '../../../helpers';
 
@@ -23,13 +23,15 @@ export const campaignCardFragment = gql`
   }
 `;
 
-const CampaignCard = ({
-  showcaseDescription,
-  showcaseImage,
-  showcaseTitle,
-  staffPick,
-  url,
-}) => {
+const CampaignCard = ({ campaign }) => {
+  const {
+    showcaseDescription,
+    showcaseImage,
+    showcaseTitle,
+    staffPick,
+    url,
+  } = campaign;
+
   const srcset = contentfulImageSrcset(showcaseImage.url, [
     { height: 205, width: 365 },
     { height: 410, width: 730 },
@@ -72,15 +74,7 @@ const CampaignCard = ({
 };
 
 CampaignCard.propTypes = {
-  showcaseDescription: PropTypes.string.isRequired,
-  showcaseImage: PropTypes.object.isRequired,
-  showcaseTitle: PropTypes.string.isRequired,
-  staffPick: PropTypes.bool,
-  url: PropTypes.string.isRequired,
-};
-
-CampaignCard.defaultProps = {
-  staffPick: false,
+  campaign: propType(campaignCardFragment).isRequired,
 };
 
 export default CampaignCard;

--- a/resources/assets/components/utilities/CampaignCard/CampaignCard.js
+++ b/resources/assets/components/utilities/CampaignCard/CampaignCard.js
@@ -1,12 +1,29 @@
 import React from 'react';
+import gql from 'graphql-tag';
 import PropTypes from 'prop-types';
 
-import {
-  contentfulImageSrcset,
-  contentfulImageUrl,
-} from '../../../../../helpers';
+import { contentfulImageSrcset, contentfulImageUrl } from '../../../helpers';
 
-const CampaignGalleryItem = ({
+export const campaignCardFragment = gql`
+  fragment CampaignCard on Showcasable {
+    showcaseTitle
+    showcaseDescription
+    showcaseImage {
+      url
+    }
+    ... on CampaignWebsite {
+      id
+      staffPick
+      url
+    }
+    ... on StoryPageWebsite {
+      id
+      url
+    }
+  }
+`;
+
+const CampaignCard = ({
   showcaseDescription,
   showcaseImage,
   showcaseTitle,
@@ -54,7 +71,7 @@ const CampaignGalleryItem = ({
   );
 };
 
-CampaignGalleryItem.propTypes = {
+CampaignCard.propTypes = {
   showcaseDescription: PropTypes.string.isRequired,
   showcaseImage: PropTypes.object.isRequired,
   showcaseTitle: PropTypes.string.isRequired,
@@ -62,8 +79,8 @@ CampaignGalleryItem.propTypes = {
   url: PropTypes.string.isRequired,
 };
 
-CampaignGalleryItem.defaultProps = {
+CampaignCard.defaultProps = {
   staffPick: false,
 };
 
-export default CampaignGalleryItem;
+export default CampaignCard;

--- a/resources/assets/components/utilities/CampaignCard/CampaignCardFeatured.js
+++ b/resources/assets/components/utilities/CampaignCard/CampaignCardFeatured.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import gql from 'graphql-tag';
 import PropTypes from 'prop-types';
 import { css } from '@emotion/core';
 
@@ -7,6 +8,25 @@ import {
   contentfulImageSrcset,
   tailwind,
 } from '../../../helpers';
+
+export const campaignCardFeaturedFragment = gql`
+  fragment CampaignCardFeatured on Showcasable {
+    showcaseTitle
+    showcaseDescription
+    showcaseImage {
+      url
+    }
+    ... on CampaignWebsite {
+      id
+      staffPick
+      url
+    }
+    ... on StoryPageWebsite {
+      id
+      url
+    }
+  }
+`;
 
 const CampaignCardFeatured = ({
   showcaseDescription,

--- a/resources/assets/components/utilities/CampaignCard/CampaignCardFeatured.js
+++ b/resources/assets/components/utilities/CampaignCard/CampaignCardFeatured.js
@@ -6,9 +6,9 @@ import {
   contentfulImageUrl,
   contentfulImageSrcset,
   tailwind,
-} from '../../../../../helpers';
+} from '../../../helpers';
 
-const CampaignGalleryFeaturedItem = ({
+const CampaignCardFeatured = ({
   showcaseDescription,
   showcaseImage,
   showcaseTitle,
@@ -79,11 +79,11 @@ const CampaignGalleryFeaturedItem = ({
   );
 };
 
-CampaignGalleryFeaturedItem.propTypes = {
+CampaignCardFeatured.propTypes = {
   showcaseDescription: PropTypes.string.isRequired,
   showcaseImage: PropTypes.object.isRequired,
   showcaseTitle: PropTypes.string.isRequired,
   url: PropTypes.string.isRequired,
 };
 
-export default CampaignGalleryFeaturedItem;
+export default CampaignCardFeatured;

--- a/resources/assets/components/utilities/CampaignCard/CampaignCardFeatured.js
+++ b/resources/assets/components/utilities/CampaignCard/CampaignCardFeatured.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import gql from 'graphql-tag';
-import PropTypes from 'prop-types';
 import { css } from '@emotion/core';
+import { propType } from 'graphql-anywhere';
 
 import {
   contentfulImageUrl,
@@ -28,12 +28,9 @@ export const campaignCardFeaturedFragment = gql`
   }
 `;
 
-const CampaignCardFeatured = ({
-  showcaseDescription,
-  showcaseImage,
-  showcaseTitle,
-  url,
-}) => {
+const CampaignCardFeatured = ({ campaign }) => {
+  const { showcaseDescription, showcaseImage, showcaseTitle, url } = campaign;
+
   const tailwindGray = tailwind('colors.gray');
   const tailwindScreens = tailwind('screens');
 
@@ -100,10 +97,7 @@ const CampaignCardFeatured = ({
 };
 
 CampaignCardFeatured.propTypes = {
-  showcaseDescription: PropTypes.string.isRequired,
-  showcaseImage: PropTypes.object.isRequired,
-  showcaseTitle: PropTypes.string.isRequired,
-  url: PropTypes.string.isRequired,
+  campaign: propType(campaignCardFeaturedFragment).isRequired,
 };
 
 export default CampaignCardFeatured;

--- a/resources/assets/components/utilities/PageCard/PageCard.js
+++ b/resources/assets/components/utilities/PageCard/PageCard.js
@@ -1,17 +1,24 @@
 import React from 'react';
-import PropTypes from 'prop-types';
+import gql from 'graphql-tag';
+import { propType } from 'graphql-anywhere';
 
-import {
-  contentfulImageSrcset,
-  contentfulImageUrl,
-} from '../../../../../helpers';
+import { contentfulImageSrcset, contentfulImageUrl } from '../../../helpers';
 
-const PageGalleryItem = ({
-  showcaseDescription,
-  showcaseImage,
-  showcaseTitle,
-  slug,
-}) => {
+export const pageCardFragment = gql`
+  fragment PageCard on Page {
+    id
+    showcaseTitle
+    showcaseDescription
+    showcaseImage {
+      url
+    }
+    slug
+  }
+`;
+
+const PageCard = ({ page }) => {
+  const { showcaseDescription, showcaseImage, showcaseTitle, slug } = page;
+
   const srcset = contentfulImageSrcset(showcaseImage.url, [
     { height: 205, width: 365 },
     { height: 410, width: 730 },
@@ -43,11 +50,8 @@ const PageGalleryItem = ({
   );
 };
 
-PageGalleryItem.propTypes = {
-  showcaseDescription: PropTypes.string.isRequired,
-  showcaseImage: PropTypes.object.isRequired,
-  showcaseTitle: PropTypes.string.isRequired,
-  slug: PropTypes.string.isRequired,
+PageCard.propTypes = {
+  page: propType(pageCardFragment).isRequired,
 };
 
-export default PageGalleryItem;
+export default PageCard;


### PR DESCRIPTION
### What's this PR do?

This pull request renames the Campaign and Page gallery item components to `CampaignCard` and `PageCard` and universalizes them so they can be used more regularly on other pages and outside of galleries.

It also moves the GraphQL queries for what these components need into fragments inline within the component to make it all easier to follow.


### How should this be reviewed?

👀 

### Relevant tickets

References [Pivotal #172181956](https://www.pivotaltracker.com/story/show/172181956).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.