### PR TITLE
Test the Volunteer Credits query and data parsing

### DIFF
--- a/resources/assets/components/pages/AccountPage/Credits/VolunteerCreditsQuery.test.js
+++ b/resources/assets/components/pages/AccountPage/Credits/VolunteerCreditsQuery.test.js
@@ -2,14 +2,11 @@ import React from 'react';
 import { mount } from 'enzyme';
 import { act } from 'react-dom/test-utils';
 import { MockedProvider } from '@apollo/react-testing';
-import { getHumanFriendlyDate } from '../../../../helpers';
 
 import {
   mockPostsResponse,
   mockParsedPostsData,
-} from './volunteer-credits-mock-data.js';
-
-import VolunteerCreditsTable from './VolunteerCreditsTable';
+} from './volunteer-credits-mock-data';
 import VolunteerCreditsQuery, {
   VOLUNTEER_CREDIT_POSTS_QUERY,
 } from './VolunteerCreditsQuery';

--- a/resources/assets/components/pages/AccountPage/Credits/VolunteerCreditsQuery.test.js
+++ b/resources/assets/components/pages/AccountPage/Credits/VolunteerCreditsQuery.test.js
@@ -1,0 +1,66 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import { act } from 'react-dom/test-utils';
+import { MockedProvider } from '@apollo/react-testing';
+import { getHumanFriendlyDate } from '../../../../helpers';
+
+import {
+  mockPostsResponse,
+  mockParsedPostsData,
+} from './volunteer-credits-mock-data.js';
+
+import VolunteerCreditsTable from './VolunteerCreditsTable';
+import VolunteerCreditsQuery, {
+  VOLUNTEER_CREDIT_POSTS_QUERY,
+} from './VolunteerCreditsQuery';
+
+// Mock the VolunteerCreditsTable component to avoid dealing with its nested complexity.
+// (Needs to be in lower-case form re https://git.io/JvbZ6).
+jest.mock('./VolunteerCreditsTable', () => 'volunteer-credits-table');
+
+const MOCK_USER_ID = '123';
+
+// Mock the user ID we fetch from the window.
+global.AUTH = { id: MOCK_USER_ID };
+
+// Mock the GraphQL query and response.
+const mocks = [
+  {
+    request: {
+      query: VOLUNTEER_CREDIT_POSTS_QUERY,
+      variables: {
+        userId: MOCK_USER_ID,
+      },
+    },
+    result: {
+      data: {
+        paginatedPosts: {
+          edges: mockPostsResponse,
+        },
+      },
+    },
+  },
+];
+
+describe('VolunteerCreditsQuery component', () => {
+  const wrapper = mount(
+    <MockedProvider mocks={mocks} addTypename={false}>
+      <VolunteerCreditsQuery />
+    </MockedProvider>,
+  );
+
+  test('it renders the VolunteerCreditsTable with a list of processed posts', async () => {
+    // This pushes us past the 'first tick' over to when the query actually loads.
+    await act(async () => new Promise(resolve => setTimeout(resolve)));
+
+    act(() => {
+      // Update the component state with the retrieved mock reponse data.
+      wrapper.update();
+    });
+
+    expect(wrapper.find('volunteer-credits-table').length).toEqual(1);
+    expect(wrapper.find('volunteer-credits-table').prop('posts')).toEqual(
+      mockParsedPostsData,
+    );
+  });
+});

--- a/resources/assets/components/pages/AccountPage/Credits/volunteer-credits-mock-data.js
+++ b/resources/assets/components/pages/AccountPage/Credits/volunteer-credits-mock-data.js
@@ -1,0 +1,138 @@
+// Mock Action Details:
+const ACTION_ONE = {
+  id: 1,
+  actionLabel: 'Contact a Decision-Maker',
+  timeCommitmentLabel: '3+ hours',
+};
+
+const ACTION_TWO = {
+  id: 2,
+  actionLabel: 'Attend an Event',
+  timeCommitmentLabel: '4+ hours',
+};
+
+const ACTION_THREE = {
+  id: 3,
+  actionLabel: 'Collect Something',
+  timeCommitmentLabel: '30 minutes - 1 hour',
+};
+
+// Mock Campaign Website Showcase:
+const CAMPAIGN_ONE = {
+  showcaseImage: {
+    url: 'https://images.api.info/1',
+    description: 'Cover Photo 1',
+  },
+  showcaseTitle: 'Example Campaign 1',
+  showcaseDescription: 'Example Description 1',
+};
+
+const CAMPAIGN_TWO = {
+  showcaseImage: {
+    url: 'https://images.api.info/2',
+    description: 'Cover Photo 2',
+  },
+  showcaseTitle: 'Example Campaign 2',
+  showcaseDescription: 'Example Description 2',
+};
+
+const CAMPAIGN_THREE = {
+  showcaseImage: {
+    url: 'https://images.api.info/3',
+    description: 'Cover Photo 3',
+  },
+  showcaseTitle: 'Example Campaign 3',
+  showcaseDescription: 'Example Description 3',
+};
+
+// Mock reponse paginatedPost data from GraphQL:
+export const mockPostsResponse = [
+  {
+    node: {
+      id: 1,
+      createdAt: '2020-04-01T18:38:03Z',
+      quantity: null,
+      status: 'PENDING',
+      actionDetails: ACTION_ONE,
+      campaign: {
+        campaignWebsite: CAMPAIGN_ONE,
+      },
+    },
+  },
+  {
+    node: {
+      id: 2,
+      createdAt: '2020-04-01T17:53:40Z',
+      quantity: 1,
+      status: 'PENDING',
+      actionDetails: ACTION_TWO,
+      campaign: {
+        campaignWebsite: CAMPAIGN_TWO,
+      },
+    },
+  },
+  {
+    node: {
+      id: 3,
+      createdAt: '2020-01-06T20:45:21Z',
+      quantity: 1,
+      status: 'PENDING',
+      actionDetails: ACTION_TWO,
+      campaign: {
+        campaignWebsite: CAMPAIGN_TWO,
+      },
+    },
+  },
+  {
+    node: {
+      id: 4,
+      createdAt: '2019-12-10T21:42:24Z',
+      quantity: 90,
+      status: 'PENDING',
+      actionDetails: ACTION_TWO,
+      campaign: {
+        campaignWebsite: CAMPAIGN_TWO,
+      },
+    },
+  },
+  {
+    node: {
+      id: 5,
+      createdAt: '2019-11-21T20:00:13Z',
+      quantity: 1,
+      status: 'ACCEPTED',
+      actionDetails: ACTION_THREE,
+      campaign: {
+        campaignWebsite: CAMPAIGN_THREE,
+      },
+    },
+  },
+];
+
+// Mocked paginatedPost data should be parsed into the following result:
+export const mockParsedPostsData = [
+  {
+    id: 1,
+    campaignWebsite: CAMPAIGN_ONE,
+    actionLabel: ACTION_ONE.actionLabel,
+    dateCompleted: 'April 1st, 2020',
+    volunteerHours: ACTION_ONE.timeCommitmentLabel,
+    pending: true,
+  },
+  {
+    id: 4,
+    campaignWebsite: CAMPAIGN_TWO,
+    actionLabel: ACTION_TWO.actionLabel,
+    dateCompleted: 'December 10th, 2019',
+    volunteerHours: ACTION_TWO.timeCommitmentLabel,
+    pending: true,
+  },
+  {
+    id: 5,
+    campaignWebsite: CAMPAIGN_THREE,
+    actionLabel: ACTION_THREE.actionLabel,
+    dateCompleted: 'November 21st, 2019',
+    volunteerHours: ACTION_THREE.timeCommitmentLabel,
+    pending: false,
+  },
+];


### PR DESCRIPTION
### What's this PR do?

This pull request adds a test to ensure the somewhat complex data-parsing `VolunteerCreditsTableQuery` component passes the correctly parsed list of posts to the `VolunteerCreditsTable`

### How should this be reviewed?
👀 

### Any background context you want to provide?
I spent most of my time wrangling with the [`MockedProvider`](https://www.apollographql.com/docs/react/development-testing/testing/#mockedprovider) which is lame. This isn't exhaustive, but I thought it can at least provide us with some level of reassurance, especially as we iterate on this processing logic. 

A potential refactor you might argue would be prudent -- would be to abstract away the parsing logic from the `VolunteerCreditsTableQuery` as helper methods, and add more compartmentalized unit tests on those! This could be a nice refactor once we add a Cypress integration test following our server-rendering updates in Q2(?)

### Relevant tickets

References [Pivotal #172150775](https://www.pivotaltracker.com/story/show/172150775).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added screenshots of front-end changes on small, medium, and large screens.
- [x] Added appropriate feature/unit tests.
