### PR TITLE
Display Signup Button on Quiz

### DIFF
--- a/resources/assets/components/LedeBanner/templates/HeroTemplate.js
+++ b/resources/assets/components/LedeBanner/templates/HeroTemplate.js
@@ -29,7 +29,6 @@ const HeroTemplate = ({
   content,
   coverImage,
   dashboard,
-  displaySignupButton,
   isAffiliated,
   scholarshipAmount,
   scholarshipCallToAction,
@@ -103,7 +102,7 @@ const HeroTemplate = ({
             </div>
 
             <div className="grid-wide-3/10 secondary">
-              {!isAffiliated && displaySignupButton ? (
+              {!isAffiliated ? (
                 <div className="hero-signup-button">
                   <SignupButtonContainer
                     className="w-full"
@@ -156,7 +155,7 @@ const HeroTemplate = ({
                   : null
               }
             >
-              {!isAffiliated && displaySignupButton ? (
+              {!isAffiliated ? (
                 <div className="pt-6 w-2/3 sm:w-1/2">
                   <SignupButtonContainer
                     className="w-full md:px-2"
@@ -189,7 +188,6 @@ HeroTemplate.propTypes = {
     type: PropTypes.string,
     fields: PropTypes.object,
   }),
-  displaySignupButton: PropTypes.bool,
   isAffiliated: PropTypes.bool,
   scholarshipAmount: PropTypes.number,
   scholarshipCallToAction: PropTypes.string,
@@ -207,7 +205,6 @@ HeroTemplate.defaultProps = {
   numberOfScholarships: 1,
   campaignId: null,
   dashboard: null,
-  displaySignupButton: true,
   isAffiliated: false,
   scholarshipAmount: null,
   scholarshipCallToAction: null,

--- a/resources/assets/components/LedeBanner/templates/MosaicTemplate.js
+++ b/resources/assets/components/LedeBanner/templates/MosaicTemplate.js
@@ -23,7 +23,6 @@ const MosaicTemplate = props => {
     affiliateCreditText,
     affiliateOptInContent,
     affiliateSponsors,
-    displaySignupButton,
     title,
     subtitle,
     blurb,
@@ -41,7 +40,7 @@ const MosaicTemplate = props => {
     )})`,
   };
 
-  const signupButton = displaySignupButton ? (
+  const signupButton = (
     <div className="mosaic-lede-banner__signup">
       {affiliateOptInContent ? (
         <AffiliateOptInToggleContainer
@@ -65,7 +64,7 @@ const MosaicTemplate = props => {
         />
       ) : null}
     </div>
-  ) : null;
+  );
 
   const actionButton = affiliatedActionLink ? (
     <div className="mosaic-lede-banner__signup">
@@ -130,7 +129,6 @@ MosaicTemplate.propTypes = {
     description: PropTypes.string,
     url: PropTypes.string,
   }).isRequired,
-  displaySignupButton: PropTypes.bool,
   isAffiliated: PropTypes.bool.isRequired,
   subtitle: PropTypes.string.isRequired,
   title: PropTypes.string.isRequired,
@@ -143,7 +141,6 @@ MosaicTemplate.defaultProps = {
   affiliateCreditText: undefined,
   affiliateOptInContent: null,
   blurb: null,
-  displaySignupButton: true,
   signupArrowContent: null,
 };
 

--- a/resources/assets/components/pages/CampaignPage/CampaignPage.js
+++ b/resources/assets/components/pages/CampaignPage/CampaignPage.js
@@ -21,10 +21,7 @@ const CampaignPage = props => {
   return (
     <>
       <article className="campaign-page bg-white">
-        <LedeBannerContainer
-          displaySignupButton={Boolean(!entryContent)}
-          isClosed={isCampaignClosed}
-        />
+        <LedeBannerContainer isClosed={isCampaignClosed} />
 
         <div className="clearfix relative">
           {!isCampaignClosed && !entryContent ? (

--- a/resources/assets/components/pages/CampaignPage/CampaignPageContent.js
+++ b/resources/assets/components/pages/CampaignPage/CampaignPageContent.js
@@ -57,8 +57,8 @@ const CampaignPageContent = props => {
                 ImagesBlock: 'grid-wide',
                 PostGalleryBlock: 'grid-wide',
                 PhotoSubmissionBlock: 'grid-wide',
-                SocialDriveBlock: 'grid-wide',
                 QuizBlock: 'grid-wide',
+                SocialDriveBlock: 'grid-wide',
               }}
             />
           ))}

--- a/resources/assets/components/pages/CampaignPage/CampaignPageContent.js
+++ b/resources/assets/components/pages/CampaignPage/CampaignPageContent.js
@@ -58,6 +58,7 @@ const CampaignPageContent = props => {
                 PostGalleryBlock: 'grid-wide',
                 PhotoSubmissionBlock: 'grid-wide',
                 SocialDriveBlock: 'grid-wide',
+                QuizBlock: 'grid-wide',
               }}
             />
           ))}


### PR DESCRIPTION
### What's this PR do?

This pull request removes functionality hiding the signup button from the Hero Template & Scholarship modal on quiz pages.

### How should this be reviewed?
👁 

### Any background context you want to provide?
We introduced this in https://github.com/DoSomething/phoenix-next/pull/977 when we initially moved the quiz into campaigns under the ole Lede Banner umbrella. The request then was to hide the signup button for the user flow. 

We've now graduated to a user flow where we want to surface the signup button, and so, we bid this logic adieu 👋 

I snuck in a quick fix in https://github.com/DoSomething/phoenix-next/commit/303d2cf68b6890fd519b03c5e8c814685491b85c to allow the quiz to span the full `grid-wide` on campaign pages since why the heck not I guess ([Slack](https://dosomething.slack.com/archives/C09ANFQLA/p1586213433096300?thread_ts=1586208677.087900&cid=C09ANFQLA)).

**Before** 
![image](https://user-images.githubusercontent.com/12417657/78722972-8b267f80-78f8-11ea-92cc-843d71a9cd54.png)

**After**
![image](https://user-images.githubusercontent.com/12417657/78722940-7944dc80-78f8-11ea-983b-059cafa22547.png)


### Relevant tickets

References [Pivotal #172206157](https://www.pivotaltracker.com/story/show/172206157).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [x] Added screenshots of front-end changes on small, medium, and large screens.
- [ ] Added appropriate feature/unit tests.
