### PR TITLE
Allow PhotoSubmissionAction on story pages

### DIFF
--- a/cypress/integration/campaign-post.js
+++ b/cypress/integration/campaign-post.js
@@ -104,7 +104,7 @@ describe('Campaign Post', () => {
 
       // Mock the backend response:
       const response = newPhotoPost(campaignId, user);
-      cy.route('POST', CAMPAIGN_POSTS_API, response).as('submitPost');
+      cy.route('POST', POSTS_API, response).as('submitPost');
 
       // Submit the form, and assert we made the API request:
       cy.contains('Submit a new photo').click();

--- a/resources/assets/components/actions/PhotoSubmissionAction/PhotoSubmissionAction.js
+++ b/resources/assets/components/actions/PhotoSubmissionAction/PhotoSubmissionAction.js
@@ -216,15 +216,29 @@ class PhotoSubmissionAction extends PostForm {
       school_id: await this.getUserActionSchoolId(),
     });
 
-    // Send request to store the campaign photo submission post.
-    this.props.storeCampaignPost(this.props.campaignId, {
+    const data = {
       action,
       actionId: this.props.actionId,
       blockId: this.props.id,
       body: formatPostPayload(formFields),
       pageId: this.props.pageId,
+      campaignId: this.props.campaignId,
       type,
-    });
+    };
+
+    // Send request to store the campaign photo submission post.
+    if (this.props.actionId) {
+      this.props.storePost(data);
+    } else {
+      this.props.storeCampaignPost(this.props.campaignId, {
+        action,
+        actionId: this.props.actionId,
+        blockId: this.props.id,
+        body: formatPostPayload(formFields),
+        pageId: this.props.pageId,
+        type,
+      });
+    }
   };
 
   /**
@@ -478,7 +492,7 @@ PhotoSubmissionAction.propTypes = {
   actionId: PropTypes.number,
   affirmationContent: PropTypes.string,
   buttonText: PropTypes.string,
-  campaignId: PropTypes.string.isRequired,
+  campaignId: PropTypes.string,
   captionFieldLabel: PropTypes.string,
   captionFieldPlaceholder: PropTypes.string,
   className: PropTypes.string,
@@ -492,6 +506,7 @@ PhotoSubmissionAction.propTypes = {
   resetPostSubmissionItem: PropTypes.func.isRequired,
   showQuantityField: PropTypes.bool,
   storeCampaignPost: PropTypes.func.isRequired,
+  storePost: PropTypes.func.isRequired,
   submissions: PropTypes.shape({
     isPending: PropTypes.bool,
     items: PropTypes.object,
@@ -507,6 +522,7 @@ PhotoSubmissionAction.defaultProps = {
   affirmationContent:
     "Thanks for joining the movement, and submitting your photo! After we review your submission, we'll add it to the public gallery alongside submissions from all the other members taking action in this campaign.",
   buttonText: 'Submit a new photo',
+  campaignId: null,
   captionFieldLabel: 'Add a title to your photo.',
   captionFieldPlaceholder: '60 characters or less',
   className: null,

--- a/resources/assets/components/actions/PhotoSubmissionAction/PhotoSubmissionAction.js
+++ b/resources/assets/components/actions/PhotoSubmissionAction/PhotoSubmissionAction.js
@@ -308,7 +308,7 @@ class PhotoSubmissionAction extends PostForm {
               title={this.props.title}
             >
               <div className="text-center p-2">
-                <a className="btn" href={this.props.authRegisterUrl}>
+                <a className="button w-full" href={this.props.authRegisterUrl}>
                   Add Photo
                 </a>
               </div>

--- a/resources/assets/components/actions/PhotoSubmissionAction/PhotoSubmissionAction.js
+++ b/resources/assets/components/actions/PhotoSubmissionAction/PhotoSubmissionAction.js
@@ -297,8 +297,9 @@ class PhotoSubmissionAction extends PostForm {
         : null,
     );
 
+    // If we don't have an authenticated user, then this is a story page
     if (!this.props.userId) {
-      // creating account, but not getting redirected back to the page (might be a local vs. real thing, also not happening on campaigns)
+      // add scroll concierge
       return (
         <React.Fragment>
           <div className="clearfix">
@@ -307,9 +308,11 @@ class PhotoSubmissionAction extends PostForm {
               className={classnames('bordered rounded', this.props.className)}
               title={this.props.title}
             >
-              <a id="utility-nav__join" href={this.props.authRegisterUrl}>
-                Add Photo
-              </a>
+              <div className="text-center p-2">
+                <a className="btn" href={this.props.authRegisterUrl}>
+                  Add Photo
+                </a>
+              </div>
             </Card>
           </div>
         </React.Fragment>

--- a/resources/assets/components/actions/PhotoSubmissionAction/PhotoSubmissionAction.js
+++ b/resources/assets/components/actions/PhotoSubmissionAction/PhotoSubmissionAction.js
@@ -297,6 +297,25 @@ class PhotoSubmissionAction extends PostForm {
         : null,
     );
 
+    if (!this.props.userId) {
+      // creating account, but not getting redirected back to the page (might be a local vs. real thing, also not happening on campaigns)
+      return (
+        <React.Fragment>
+          <div className="clearfix">
+            <div className="photo-submission-action" />
+            <Card
+              className={classnames('bordered rounded', this.props.className)}
+              title={this.props.title}
+            >
+              <a id="utility-nav__join" href={this.props.authRegisterUrl}>
+                Add Photo
+              </a>
+            </Card>
+          </div>
+        </React.Fragment>
+      );
+    }
+
     return (
       <React.Fragment>
         <div className="clearfix">

--- a/resources/assets/components/actions/PhotoSubmissionAction/PhotoSubmissionAction.js
+++ b/resources/assets/components/actions/PhotoSubmissionAction/PhotoSubmissionAction.js
@@ -103,15 +103,17 @@ class PhotoSubmissionAction extends PostForm {
    * @return {void}
    */
   componentDidMount() {
-    const request = getUserCampaignSignups(
-      this.props.userId,
-      this.props.campaignId,
-    );
+    if (this.props.campaignId) {
+      const request = getUserCampaignSignups(
+        this.props.userId,
+        this.props.campaignId,
+      );
 
-    // @TODO: handle if errors.
-    request.then(response => {
-      this.handleSignupResponse(response.data[0]);
-    });
+      // @TODO: handle if errors.
+      request.then(response => {
+        this.handleSignupResponse(response.data[0]);
+      });
+    }
   }
 
   /**

--- a/resources/assets/components/actions/PhotoSubmissionAction/PhotoSubmissionAction.js
+++ b/resources/assets/components/actions/PhotoSubmissionAction/PhotoSubmissionAction.js
@@ -299,7 +299,6 @@ class PhotoSubmissionAction extends PostForm {
 
     // If we don't have an authenticated user, then this is a story page
     if (!this.props.userId) {
-      // add scroll concierge
       return (
         <React.Fragment>
           <div className="clearfix">

--- a/resources/assets/components/actions/PhotoSubmissionAction/PhotoSubmissionActionContainer.js
+++ b/resources/assets/components/actions/PhotoSubmissionAction/PhotoSubmissionActionContainer.js
@@ -1,22 +1,31 @@
 import { connect } from 'react-redux';
 
 import { getUserId } from '../../../selectors/user';
+import { getDataForNorthstar } from '../../../selectors';
+import { buildAuthRedirectUrl } from '../../../helpers/auth';
 import PhotoSubmissionAction from './PhotoSubmissionAction';
 import {
   resetPostSubmissionItem,
   storeCampaignPost,
+  storePost,
 } from '../../../actions/post';
 
-const mapStateToProps = state => ({
-  campaignId: state.campaign.campaignId,
-  pageId: state.campaign.id || state.page.id,
-  submissions: state.postSubmissions,
-  userId: getUserId(state),
-});
+const mapStateToProps = state => {
+  const northstarData = getDataForNorthstar(state);
+
+  return {
+    campaignId: state.campaign.campaignId,
+    pageId: state.campaign.id || state.page.id,
+    submissions: state.postSubmissions,
+    userId: getUserId(state),
+    authRegisterUrl: buildAuthRedirectUrl(northstarData),
+  };
+};
 
 const actionCreators = {
   resetPostSubmissionItem,
   storeCampaignPost,
+  storePost,
 };
 
 export default connect(

--- a/resources/assets/components/actions/TextSubmissionAction/TextSubmissionAction.js
+++ b/resources/assets/components/actions/TextSubmissionAction/TextSubmissionAction.js
@@ -112,7 +112,7 @@ class TextSubmissionAction extends PostForm {
     };
 
     // Send request to store the text submission post.
-    // (Use campaign ID independant post method if actionId is provided).
+    // (Use campaign ID independent post method if actionId is provided).
     if (this.props.actionId) {
       this.props.storePost(data);
     } else {


### PR DESCRIPTION
### What's this PR do?

This pull request makes some changes in order to:
1. Let the `PhotoSubmissionAction` work on story pages for authenticated users (I copied how we do this for `TextSubmissionAction`) - which is basically submitting to Rogue using action id rather than campaign id.

2. If a `PhotoSubmissionAction` is on a story page and a user is unauthenticated, they can click an "Add Photo" button (which is basically the same as the "Join Now" button) which will take them through the registration/login flow and bring them back to the story page. They will NOT be scrolled back down to the `PhotoSubmissionAction` when they return to the page NOR will they be signed up for any campaign upon registering. There is no campaign, this is a story page!

BIGGEST CHANGE:
In the `PhotoSubmissionAction`, if we have an action id we now use `storePost` and only fall back on `storeCampaignPost` if we do not have an action id. A cypress test has been updated to reflect this.

Here's what it looks like if you're unauthenticated:
<img width="629" alt="image" src="https://user-images.githubusercontent.com/4240292/78839362-31cc5800-79ad-11ea-9ae0-dbe6e104b549.png">



### How should this be reviewed?

Upon submission, users still get the photo submission affirmation - is that okay?

You can test it out [in the review app on this story page](https://dosomething-phoenix-de-pr-2024.herokuapp.com/us/stories/test-for-photo-uploader). UPDATE: this isn't actually gonna redirect you correctly and I think that is a review app thing, but you'll still be able to log in and submit a photo.

### Any background context you want to provide?

We couldn't do this the same way as text posts because we need you to actually be logged in first!

### Relevant tickets

References [Pivotal #171943340](https://www.pivotaltracker.com/story/show/171943340).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added screenshots of front-end changes on small, medium, and large screens.
- [ ] Added appropriate feature/unit tests.
