### PR TITLE
Fix Pending State in Volunteer Credits Table

### DIFF
--- a/resources/assets/components/pages/AccountPage/Credits/VolunteerCreditsTableRow.js
+++ b/resources/assets/components/pages/AccountPage/Credits/VolunteerCreditsTableRow.js
@@ -46,16 +46,24 @@ PostDetail.propTypes = {
 };
 
 // The certificate PDF Download button with pending/ready state.
-const DownloadButton = ({ pending }) => (
-  <PDFDownloadLink
-    document={<PdfTemplate />}
-    fileName="dosomething-volunteer-credit-certificate.pdf"
-    /* @TODO: Test out using the btn class here instead of the Forge class. */
-    className={classNames('button w-full py-4', { 'is-disabled': pending })}
-  >
-    {pending ? 'Pending' : 'Download'}
-  </PDFDownloadLink>
-);
+const buttonClassNames = 'btn w-full py-4 text-lg';
+const DownloadButton = ({ pending }) =>
+  pending ? (
+    <button type="button" disabled className={buttonClassNames}>
+      Pending
+    </button>
+  ) : (
+    <PDFDownloadLink
+      document={<PdfTemplate />}
+      fileName="dosomething-volunteer-credit-certificate.pdf"
+      className={classNames(
+        buttonClassNames,
+        'hover:bg-blue-300 hover:no-underline hover:text-white',
+      )}
+    >
+      Download
+    </PDFDownloadLink>
+  );
 
 DownloadButton.propTypes = {
   pending: PropTypes.bool,


### PR DESCRIPTION
### What's this PR do?

This pull request updates the download button logic in the Volunteer Credits tables rows to render a disabled button when the certificate is still in pending mode.

It also updates the styling to use our [Tailwind `btn`](https://github.com/DoSomething/phoenix-next/blob/dd4555a41bc8d3d98b81461085bbe16bed439311/resources/assets/scss/base.scss#L19-L21) macro instead of the legacy Forge `button` class per https://github.com/DoSomething/phoenix-next/pull/1992#discussion_r399493383

### How should this be reviewed?
👀 
Everything should look the same visually! You can take a look in the [review app](https://dosomething-phoenix-de-pr-2027.herokuapp.com/us/account/profile/credits).

### Any background context you want to provide?
Since the PDF rendering library outputs an `<a>` tag (what with this being a download link), I figured it'd be nicer to output a disabled button for pending state (which also avoids hacking the `disabled` attributed in browser to prematurely download a certificate 🕵️‍♀️)

### Relevant tickets

References [Pivotal #171729122](https://www.pivotaltracker.com/story/show/171729122).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added screenshots of front-end changes on small, medium, and large screens.
- [ ] Added appropriate feature/unit tests.
