### PR TITLE
Enabling Snowplow link tracking

### DIFF
--- a/resources/assets/components/pages/HomePage/NewHomePage.js
+++ b/resources/assets/components/pages/HomePage/NewHomePage.js
@@ -243,7 +243,6 @@ const NewHomePageTemplate = ({ articles, campaigns, coverImage, title }) => {
                   <a
                     href="/us/about/easy-scholarships"
                     className="font-normal text-blurple-500 hover:text-blurple-300 underline hover:no-underline"
-                    data-label="signup_cta_authorize"
                     data-label="campaign_section_earn_scholarships"
                   >
                     earn scholarships
@@ -256,7 +255,6 @@ const NewHomePageTemplate = ({ articles, campaigns, coverImage, title }) => {
                 <a
                   href="/us/campaigns"
                   className="btn bg-blurple-500 hover:bg-blurple-300 focus:bg-blurple-700 inline-block mt-8 hover:no-underline py-4 px-8 text-lg hover:text-white"
-                  data-label="signup_cta_authorize"
                   data-label="campaign_section_show_more"
                 >
                   See More Campaigns
@@ -366,7 +364,6 @@ const NewHomePageTemplate = ({ articles, campaigns, coverImage, title }) => {
                 <a
                   href="/us/articles"
                   className="btn bg-blurple-500 hover:bg-blurple-300 focus:bg-blurple-700 inline-block mt-8 hover:no-underline py-4 px-8 text-lg hover:text-white"
-                  data-label="signup_cta_authorize"
                   data-label="article_section_show_more"
                 >
                   See More Articles

--- a/resources/assets/components/pages/HomePage/NewHomePage.js
+++ b/resources/assets/components/pages/HomePage/NewHomePage.js
@@ -78,6 +78,7 @@ const NewsletterItem = ({ content, image, link, title }) => (
     <p className="mb-4 flex-grow text-white">{content}</p>
     <a
       className="font-normal text-white hover:text-yellow-300 underline hover:no-underline"
+      data-label={`newsletter_cta_${title.toLowerCase()}`}
       href={link.url}
       rel="noopener noreferrer"
       target="_blank"
@@ -242,6 +243,7 @@ const NewHomePageTemplate = ({ articles, campaigns, coverImage, title }) => {
                   <a
                     href="/us/about/easy-scholarships"
                     className="font-normal text-blurple-500 hover:text-blurple-300 underline hover:no-underline"
+                    data-label="signup_cta_authorize"
                     data-label="campaign_section_earn_scholarships"
                   >
                     earn scholarships
@@ -254,6 +256,7 @@ const NewHomePageTemplate = ({ articles, campaigns, coverImage, title }) => {
                 <a
                   href="/us/campaigns"
                   className="btn bg-blurple-500 hover:bg-blurple-300 focus:bg-blurple-700 inline-block mt-8 hover:no-underline py-4 px-8 text-lg hover:text-white"
+                  data-label="signup_cta_authorize"
                   data-label="campaign_section_show_more"
                 >
                   See More Campaigns
@@ -363,6 +366,7 @@ const NewHomePageTemplate = ({ articles, campaigns, coverImage, title }) => {
                 <a
                   href="/us/articles"
                   className="btn bg-blurple-500 hover:bg-blurple-300 focus:bg-blurple-700 inline-block mt-8 hover:no-underline py-4 px-8 text-lg hover:text-white"
+                  data-label="signup_cta_authorize"
                   data-label="article_section_show_more"
                 >
                   See More Articles
@@ -424,6 +428,7 @@ const NewHomePageTemplate = ({ articles, campaigns, coverImage, title }) => {
                   <a
                     href="/authorize"
                     className="btn bg-blurple-500 hover:bg-blurple-300 inline-block mt-8 xl:m-0 hover:no-underline py-4 px-16 text-lg hover:text-white xl:ml-auto"
+                    data-label="signup_cta_authorize"
                   >
                     Join Now
                   </a>

--- a/resources/assets/components/pages/HomePage/NewHomePage.js
+++ b/resources/assets/components/pages/HomePage/NewHomePage.js
@@ -242,6 +242,7 @@ const NewHomePageTemplate = ({ articles, campaigns, coverImage, title }) => {
                   <a
                     href="/us/about/easy-scholarships"
                     className="font-normal text-blurple-500 hover:text-blurple-300 underline hover:no-underline"
+                    data-label="campaign_section_earn_scholarships"
                   >
                     earn scholarships
                   </a>
@@ -253,6 +254,7 @@ const NewHomePageTemplate = ({ articles, campaigns, coverImage, title }) => {
                 <a
                   href="/us/campaigns"
                   className="btn bg-blurple-500 hover:bg-blurple-300 focus:bg-blurple-700 inline-block mt-8 hover:no-underline py-4 px-8 text-lg hover:text-white"
+                  data-label="campaign_section_show_more"
                 >
                   See More Campaigns
                 </a>
@@ -361,6 +363,7 @@ const NewHomePageTemplate = ({ articles, campaigns, coverImage, title }) => {
                 <a
                   href="/us/articles"
                   className="btn bg-blurple-500 hover:bg-blurple-300 focus:bg-blurple-700 inline-block mt-8 hover:no-underline py-4 px-8 text-lg hover:text-white"
+                  data-label="article_section_show_more"
                 >
                   See More Articles
                 </a>

--- a/resources/assets/helpers/analytics.js
+++ b/resources/assets/helpers/analytics.js
@@ -205,6 +205,41 @@ export function getUtmContext() {
 }
 
 /**
+ * Track link clicks for Snowplow Analytics.
+ *
+ * @param {Object} link
+ * @param {Object} data
+ * @return {void}
+ */
+export function trackAnalyticsLinkClick(link, data = {}) {
+  const context = {
+    referrer: link.baseURI,
+    ...data,
+  };
+
+  const analyticsEvent = [
+    'trackLinkClick',
+    link.href,
+    link.id,
+    [...link.classList],
+    get(link.dataset, 'label', ''),
+    link.text,
+    [
+      {
+        schema: `${window.ENV.PHOENIX_URL}/snowplow_schema.json`,
+        data: {
+          payload: JSON.stringify(withoutValueless(context)),
+        },
+      },
+    ],
+  ];
+
+  analyze('snowplow', analyticsEvent, payload => {
+    window.snowplow(...payload);
+  });
+}
+
+/**
  * Track page views on initial load and for any changes in History interface.
  *
  * @param  {Object} history

--- a/resources/assets/helpers/loggers.js
+++ b/resources/assets/helpers/loggers.js
@@ -127,6 +127,14 @@ export function snowplowLog(data) {
       console.log('User ID:', data[1]);
       break;
 
+    case 'trackLinkClick':
+      console.log('Target URL: ', data[1]);
+      console.log('Target Label: ', data[4]);
+      console.log('Element ID: ', data[2]);
+      console.log('Element Classes: ', data[3]);
+      console.log('Element Content: ', `"${data[5]}"`);
+      break;
+
     case 'trackStructEvent':
       phoenixEventLog({
         eventName: data[4],

--- a/resources/assets/init.js
+++ b/resources/assets/init.js
@@ -43,7 +43,11 @@ import { init as historyInit } from './history';
 import { bindTokenRefreshEvent } from './helpers/auth';
 import { bindFlashMessageEvents } from './helpers/flash-message';
 import { bindAdminDashboardEvents } from './helpers/admin-dashboard';
-import { analyze, trackAnalyticsPageView } from './helpers/analytics';
+import {
+  analyze,
+  trackAnalyticsLinkClick,
+  trackAnalyticsPageView,
+} from './helpers/analytics';
 
 ready(() => {
   // Enable Debug tools.
@@ -98,4 +102,13 @@ ready(() => {
   if (navAppElement) {
     ReactDom.render(<NavApp store={store} history={history} />, navAppElement);
   }
+
+  // Track link clicks for Snowplow analytics.
+  document.body.addEventListener('click', clickEvent => {
+    if (clickEvent.target.tagName.toLowerCase() === 'a') {
+      clickEvent.preventDefault();
+
+      trackAnalyticsLinkClick(clickEvent.target);
+    }
+  });
 });

--- a/resources/assets/init.js
+++ b/resources/assets/init.js
@@ -106,8 +106,6 @@ ready(() => {
   // Track link clicks for Snowplow analytics.
   document.body.addEventListener('click', clickEvent => {
     if (clickEvent.target.tagName.toLowerCase() === 'a') {
-      clickEvent.preventDefault();
-
       trackAnalyticsLinkClick(clickEvent.target);
     }
   });

--- a/resources/assets/init.js
+++ b/resources/assets/init.js
@@ -91,6 +91,13 @@ ready(() => {
     bindAdminDashboardEvents();
   }
 
+  // Track link clicks for Snowplow analytics.
+  document.body.addEventListener('click', clickEvent => {
+    if (clickEvent.target.tagName.toLowerCase() === 'a') {
+      trackAnalyticsLinkClick(clickEvent.target);
+    }
+  });
+
   // Render the application!
   const appElement = document.getElementById('app');
   if (appElement) {
@@ -102,11 +109,4 @@ ready(() => {
   if (navAppElement) {
     ReactDom.render(<NavApp store={store} history={history} />, navAppElement);
   }
-
-  // Track link clicks for Snowplow analytics.
-  document.body.addEventListener('click', clickEvent => {
-    if (clickEvent.target.tagName.toLowerCase() === 'a') {
-      trackAnalyticsLinkClick(clickEvent.target);
-    }
-  });
 });


### PR DESCRIPTION
### What's this PR do?

This pull request enables tracking link clicks in Snowplow using a manual method that is called automatically whenever any link is clicked on a rendered page.

### How should this be reviewed?

👀 

### Any background context you want to provide?

Ooof, here we go...

We initially saw that you could enable link tracking in Snowplow by calling the [`snowplow('enablelinkclicktracking')` method](https://github.com/snowplow/snowplow/wiki/2-Specific-event-tracking-with-the-Javascript-tracker-v2.5#391-enablelinkclicktracking), but that depends on links being present on the page for it to "active" them to track clicks.

However, since our page is rendered with React on the client side, by the time this method is called, there are no links on the page yet. I tried seeing if I could call this method from inside the `NewHomePage` component using a `useEffect()` but didn't seem to work. I then found that there's an additional method that can be called if links are added to a page after the fact, called [`snowplow('refreshLinkClickTracking')`](https://github.com/snowplow/snowplow/wiki/2-Specific-event-tracking-with-the-Javascript-tracker-v2.5#392-refreshlinkclicktracking), and the docs indicate:

> `enableLinkClickTracking` only tracks clicks on links which exist when the page has loaded. If new links can be added to the page after then which you wish to track, just use `refreshLinkClickTracking`. This will add Snowplow click listeners to all links which do not already have them...

This seemed hopeful, but again I tried running it in a `useEffect()` on the component and since these functions run in the background by the Snowplow script, it was hard to tell if they were actually working. Even checking the Network tab in the browser tools wasn't super helpful since links result in full page refreshes and clears out the prior Network tab info.

Lastly, after chatting it over with @DFurnes, we concluded that maybe the best approach would be to handle it ourselves, using a listener on the `body` and relying on _event bubbling_ to find when a link is clicked and then trigger the [`snowplow('trackLinkClick')` method](https://github.com/snowplow/snowplow/wiki/2-Specific-event-tracking-with-the-Javascript-tracker-v2.5#393-tracklinkclick) manually. An added bonus to this approach is that since we can trigger using our `analyze()` wrapper function, we can display the event in the console along with our other analytic events!

This all seemed great until I ran into a couple of frustrating things that stalled my progress for a bit. As it turns out, it was the crappy documentation for the older Snowplow v2.5! So as to not make mistakes, I copy-pasted the example calls from the docs, here:

![image](https://user-images.githubusercontent.com/105849/78930597-60603680-7a72-11ea-99f0-0472c52425e9.png)

The first bug, was that while the method signature shows the first parameter is `targetUrl` (the only required argument), the example entirely misses this, which was a bit confusing.

Along with this, the example also has a typo for the method name; it is `trackLinkCLick ` instead of `trackLinkClick `, which was especially frustrating given the cryptic error that resulted in the console.

To add to the frustration, these mistakes in the documentation were fixed in the [later versions of the docs](https://github.com/snowplow/snowplow/wiki/2-Specific-event-tracking-with-the-Javascript-tracker#393-tracklinkclick), but were never retroactively fixed 😡


### Relevant tickets

References [Pivotal #172202644](https://www.pivotaltracker.com/story/show/172202644).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
