### PR TITLE
Adding Context data to logger.

### DIFF
--- a/resources/assets/helpers/loggers.js
+++ b/resources/assets/helpers/loggers.js
@@ -133,6 +133,7 @@ export function snowplowLog(data) {
       console.log('Element ID: ', data[2]);
       console.log('Element Classes: ', data[3]);
       console.log('Element Content: ', `"${data[5]}"`);
+      console.log('Context: ', JSON.parse(data[6][0].data.payload));
       break;
 
     case 'trackStructEvent':


### PR DESCRIPTION
### What's this PR do?

This pull request adds the `context` data to the logger for Snowplow link click events, which I forgot to add in #2030.

### How should this be reviewed?

👀 
