### PR TITLE
Make sure we have quantity before displaying it in galleries

### DIFF
--- a/resources/assets/components/utilities/PostCard/PostCard.js
+++ b/resources/assets/components/utilities/PostCard/PostCard.js
@@ -21,6 +21,7 @@ export const postCardFragment = gql`
     text
     tags
     impact
+    quantity
     location(format: HUMAN_FORMAT)
     signupId
     createdAt
@@ -104,7 +105,7 @@ const PostCard = ({ post, hideCaption, hideQuantity, hideReactions }) => {
             </p>
           ) : null}
 
-          {post.impact && !hideQuantity ? (
+          {post.quantity && post.impact && !hideQuantity ? (
             <p className="mt-1 text-gray-600 text-sm">{post.impact}</p>
           ) : null}
 


### PR DESCRIPTION
### What's this PR do?

This pull request grabs `quantity` in addition to `impact` in `<PostCard>` so we can check if we have `quantity` AND `impact` (which is like "3 jeans collected") before displaying it so we can avoid displaying things like "null things done."

Before:
<img width="612" alt="Screen Shot 2020-04-13 at 10 22 34 AM" src="https://user-images.githubusercontent.com/4240292/79147347-a837d400-7d78-11ea-8c25-dda44e222fc9.png">

After:
<img width="556" alt="Screen Shot 2020-04-13 at 11 16 19 AM" src="https://user-images.githubusercontent.com/4240292/79147362-ae2db500-7d78-11ea-92ed-f29cf9483d8b.png">


### How should this be reviewed?

Will this ever prevent us from displaying the impact when we might actually want to? Anywhere else I need to add this change? Does this prevent us from displaying `null` and `0`?

### Any background context you want to provide?

We used to just check if we have `impact` but that doesn't save us if the `quantity` is `null`!

### Relevant tickets

References [Pivotal #171901122](https://www.pivotaltracker.com/story/show/171901122).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added screenshots of front-end changes on small, medium, and large screens.
- [ ] Added appropriate feature/unit tests.
