### PR TITLE
Volunteer Credit Certificate Data

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13664,6 +13664,11 @@
         "semver-compare": "^1.0.0"
       }
     },
+    "pluralize": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-8.0.0.tgz",
+      "integrity": "sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA=="
+    },
     "pn": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/pn/-/pn-1.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -112,6 +112,7 @@
     "markdown-it-footnote": "^3.0.2",
     "markdown-it-for-inline": "^0.1.1",
     "node-fetch": "^2.6.0",
+    "pluralize": "^8.0.0",
     "prop-types": "^15.7.2",
     "query-string": "^5.1.1",
     "react": "^16.13.1",

--- a/resources/assets/components/pages/AccountPage/Credits/VolunteerCreditsQuery.js
+++ b/resources/assets/components/pages/AccountPage/Credits/VolunteerCreditsQuery.js
@@ -1,8 +1,8 @@
 import React from 'react';
 import gql from 'graphql-tag';
 import pluralize from 'pluralize';
+import { get, groupBy, last } from 'lodash';
 import { useQuery } from '@apollo/react-hooks';
-import { get, groupBy, last, findLast } from 'lodash';
 
 import { getUserId } from '../../../../helpers/auth';
 import Spinner from '../../../artifacts/Spinner/Spinner';

--- a/resources/assets/components/pages/AccountPage/Credits/VolunteerCreditsQuery.js
+++ b/resources/assets/components/pages/AccountPage/Credits/VolunteerCreditsQuery.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import gql from 'graphql-tag';
-import { groupBy, last } from 'lodash';
 import { useQuery } from '@apollo/react-hooks';
+import { get, groupBy, last, findLast } from 'lodash';
 
 import { getUserId } from '../../../../helpers/auth';
 import Spinner from '../../../artifacts/Spinner/Spinner';
@@ -24,6 +24,7 @@ export const VOLUNTEER_CREDIT_POSTS_QUERY = gql`
           createdAt
           quantity
           status
+          url
           actionDetails {
             id
             actionLabel
@@ -85,6 +86,13 @@ const VolunteerCreditsQuery = () => {
     // The certificate download button will be disabled if there is no 'accepted' post.
     const pending = posts.every(post => post.status === 'PENDING');
 
+    // Find the earliest accepted post and grab it's photo URL.
+    const firstAcceptedPost = findLast(
+      posts,
+      post => post.status === 'ACCEPTED',
+    );
+    const photo = get(firstAcceptedPost, 'url');
+
     return {
       id,
       campaignWebsite,
@@ -92,6 +100,7 @@ const VolunteerCreditsQuery = () => {
       dateCompleted: getHumanFriendlyDate(createdAt),
       volunteerHours: timeCommitmentLabel,
       pending,
+      photo,
     };
   });
 

--- a/resources/assets/components/pages/AccountPage/Credits/VolunteerCreditsQuery.js
+++ b/resources/assets/components/pages/AccountPage/Credits/VolunteerCreditsQuery.js
@@ -91,18 +91,9 @@ const VolunteerCreditsQuery = () => {
 
     const campaignWebsite = lastPost.campaign.campaignWebsite;
 
-    // Find the earliest accepted post and grab it's photo URL.
-    const firstAcceptedPost = findLast(
-      posts,
-      post => post.status === 'ACCEPTED',
-    );
-    const photo = get(firstAcceptedPost, 'url');
-
-    // The certificate download button will be disabled if there is no 'accepted' post.
-    const pending = !firstAcceptedPost;
+    const acceptedPosts = posts.filter(post => post.status === 'ACCEPTED');
 
     // Calculate total quantity of accepted posts.
-    const acceptedPosts = posts.filter(post => post.status === 'ACCEPTED');
     const quantity = acceptedPosts.reduce(
       (totalQuantity, post) => totalQuantity + post.quantity,
       0,
@@ -111,15 +102,22 @@ const VolunteerCreditsQuery = () => {
     // Generate human-friendly impact label based on quantity and action noun + verb.
     const impactLabel = `${pluralize(noun, quantity, true)} ${verb}`;
 
+    // Grab the photo URL of the earliest accepted post.
+    const firstAcceptedPost = last(acceptedPosts);
+    const photo = get(firstAcceptedPost, 'url');
+
+    // The certificate download button will be disabled if there is no 'accepted' post.
+    const pending = !firstAcceptedPost;
+
     return {
       id,
       campaignWebsite,
       actionLabel,
       dateCompleted: getHumanFriendlyDate(createdAt),
       volunteerHours: timeCommitmentLabel,
-      pending,
-      photo,
       impactLabel,
+      photo,
+      pending,
     };
   });
 

--- a/resources/assets/components/pages/AccountPage/Credits/VolunteerCreditsQuery.js
+++ b/resources/assets/components/pages/AccountPage/Credits/VolunteerCreditsQuery.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import gql from 'graphql-tag';
+import pluralize from 'pluralize';
 import { useQuery } from '@apollo/react-hooks';
 import { get, groupBy, last, findLast } from 'lodash';
 
@@ -29,6 +30,8 @@ export const VOLUNTEER_CREDIT_POSTS_QUERY = gql`
             id
             actionLabel
             timeCommitmentLabel
+            noun
+            verb
           }
           campaign {
             campaignWebsite {
@@ -79,7 +82,12 @@ const VolunteerCreditsQuery = () => {
     // We use the ID as the unique 'key' when we map over the formatted post data.
     const { id, createdAt } = lastPost;
 
-    const { timeCommitmentLabel, actionLabel } = lastPost.actionDetails;
+    const {
+      timeCommitmentLabel,
+      actionLabel,
+      noun,
+      verb,
+    } = lastPost.actionDetails;
 
     const campaignWebsite = lastPost.campaign.campaignWebsite;
 
@@ -93,6 +101,16 @@ const VolunteerCreditsQuery = () => {
     // The certificate download button will be disabled if there is no 'accepted' post.
     const pending = !firstAcceptedPost;
 
+    // Calculate total quantity of accepted posts.
+    const acceptedPosts = posts.filter(post => post.status === 'ACCEPTED');
+    const quantity = acceptedPosts.reduce(
+      (totalQuantity, post) => totalQuantity + post.quantity,
+      0,
+    );
+
+    // Generate human-friendly impact label based on quantity and action noun + verb.
+    const impactLabel = `${pluralize(noun, quantity, true)} ${verb}`;
+
     return {
       id,
       campaignWebsite,
@@ -101,6 +119,7 @@ const VolunteerCreditsQuery = () => {
       volunteerHours: timeCommitmentLabel,
       pending,
       photo,
+      impactLabel,
     };
   });
 

--- a/resources/assets/components/pages/AccountPage/Credits/VolunteerCreditsQuery.js
+++ b/resources/assets/components/pages/AccountPage/Credits/VolunteerCreditsQuery.js
@@ -111,6 +111,7 @@ const VolunteerCreditsQuery = () => {
     const acceptedPosts = posts.filter(post => post.status === 'ACCEPTED');
 
     // Calculate total quantity of accepted posts.
+    // @TODO: How do we handle 'null' quantity on a post? Or generally, actions not collecting quantity?
     const quantity = acceptedPosts.reduce(
       (totalQuantity, post) => totalQuantity + post.quantity,
       0,

--- a/resources/assets/components/pages/AccountPage/Credits/VolunteerCreditsQuery.js
+++ b/resources/assets/components/pages/AccountPage/Credits/VolunteerCreditsQuery.js
@@ -83,15 +83,15 @@ const VolunteerCreditsQuery = () => {
 
     const campaignWebsite = lastPost.campaign.campaignWebsite;
 
-    // The certificate download button will be disabled if there is no 'accepted' post.
-    const pending = posts.every(post => post.status === 'PENDING');
-
     // Find the earliest accepted post and grab it's photo URL.
     const firstAcceptedPost = findLast(
       posts,
       post => post.status === 'ACCEPTED',
     );
     const photo = get(firstAcceptedPost, 'url');
+
+    // The certificate download button will be disabled if there is no 'accepted' post.
+    const pending = !firstAcceptedPost;
 
     return {
       id,

--- a/resources/assets/components/pages/AccountPage/Credits/VolunteerCreditsQuery.js
+++ b/resources/assets/components/pages/AccountPage/Credits/VolunteerCreditsQuery.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import gql from 'graphql-tag';
 import pluralize from 'pluralize';
+import PropTypes from 'prop-types';
 import { get, groupBy, last } from 'lodash';
 import { useQuery } from '@apollo/react-hooks';
 
@@ -48,6 +49,22 @@ export const VOLUNTEER_CREDIT_POSTS_QUERY = gql`
     }
   }
 `;
+
+export const postType = PropTypes.shape({
+  id: PropTypes.string.isRequired,
+  campaignWebsite: PropTypes.shape({
+    showcaseImage: PropTypes.shape({
+      url: PropTypes.string.isRequired,
+      description: PropTypes.string,
+    }).isRequired,
+  }).isRequired,
+  actionLabel: PropTypes.string.isRequired,
+  dateCompleted: PropTypes.string.isRequired,
+  volunteerHours: PropTypes.string.isRequired,
+  impactLabel: PropTypes.string.isRequired,
+  photo: PropTypes.string,
+  pending: PropTypes.bool.isRequired,
+});
 
 const VolunteerCreditsQuery = () => {
   const options = { variables: { userId: getUserId() } };

--- a/resources/assets/components/pages/AccountPage/Credits/VolunteerCreditsTable.js
+++ b/resources/assets/components/pages/AccountPage/Credits/VolunteerCreditsTable.js
@@ -39,7 +39,7 @@ const VolunteerCreditsTable = ({ posts }) =>
               }
             `}
           >
-            <VolunteerCreditsTableRow {...post} />
+            <VolunteerCreditsTableRow post={post} />
           </tr>
         ))}
       </tbody>

--- a/resources/assets/components/pages/AccountPage/Credits/VolunteerCreditsTableRow.js
+++ b/resources/assets/components/pages/AccountPage/Credits/VolunteerCreditsTableRow.js
@@ -14,6 +14,7 @@ import {
 
 import { tailwind } from '../../../../helpers';
 import CampaignPreview from './CampaignPreview';
+import { postType } from './VolunteerCreditsQuery';
 
 // PDF template styles.
 const styles = StyleSheet.create({
@@ -47,14 +48,14 @@ PostDetail.propTypes = {
 
 // The certificate PDF Download button with pending/ready state.
 const buttonClassNames = 'btn w-full py-4 text-lg';
-const DownloadButton = ({ pending }) =>
-  pending ? (
+const DownloadButton = ({ post }) =>
+  post.pending ? (
     <button type="button" disabled className={buttonClassNames}>
       Pending
     </button>
   ) : (
     <PDFDownloadLink
-      document={<PdfTemplate />}
+      document={<PdfTemplate post={post} />}
       fileName="dosomething-volunteer-credit-certificate.pdf"
       className={classNames(
         buttonClassNames,
@@ -66,59 +67,49 @@ const DownloadButton = ({ pending }) =>
   );
 
 DownloadButton.propTypes = {
-  pending: PropTypes.bool,
-};
-
-DownloadButton.defaultProps = {
-  pending: false,
+  post: postType.isRequired,
 };
 
 const TableData = tw.td`align-middle p-4 pr-6`;
 
-const VolunteerCreditsTableRow = ({
-  campaignWebsite,
-  actionLabel,
-  dateCompleted,
-  volunteerHours,
-  pending,
-}) => (
-  <Media query={`(min-width: ${tailwind('screens.md')})`}>
-    {matches =>
-      matches ? (
-        <>
+const VolunteerCreditsTableRow = ({ post }) => {
+  const { campaignWebsite, actionLabel, dateCompleted, volunteerHours } = post;
+
+  return (
+    <Media query={`(min-width: ${tailwind('screens.md')})`}>
+      {matches =>
+        matches ? (
+          <>
+            <TableData>
+              <CampaignPreview campaignWebsite={campaignWebsite} />
+            </TableData>
+            <TableData>{actionLabel}</TableData>
+            <TableData>{dateCompleted}</TableData>
+            <TableData>{volunteerHours}</TableData>
+            <TableData>
+              <DownloadButton post={post} />
+            </TableData>
+          </>
+        ) : (
           <TableData>
             <CampaignPreview campaignWebsite={campaignWebsite} />
-          </TableData>
-          <TableData>{actionLabel}</TableData>
-          <TableData>{dateCompleted}</TableData>
-          <TableData>{volunteerHours}</TableData>
-          <TableData>
-            <DownloadButton pending={pending} />
-          </TableData>
-        </>
-      ) : (
-        <TableData>
-          <CampaignPreview campaignWebsite={campaignWebsite} />
 
-          <ul className="py-5">
-            <PostDetail detail="Action Type" value={actionLabel} />
-            <PostDetail detail="Volunteer Hours" value={volunteerHours} />
-            <PostDetail detail="Date Completed" value={dateCompleted} />
-          </ul>
+            <ul className="py-5">
+              <PostDetail detail="Action Type" value={actionLabel} />
+              <PostDetail detail="Volunteer Hours" value={volunteerHours} />
+              <PostDetail detail="Date Completed" value={dateCompleted} />
+            </ul>
 
-          <DownloadButton pending={pending} />
-        </TableData>
-      )
-    }
-  </Media>
-);
+            <DownloadButton post={post} />
+          </TableData>
+        )
+      }
+    </Media>
+  );
+};
 
 VolunteerCreditsTableRow.propTypes = {
-  actionLabel: PropTypes.string.isRequired,
-  campaignWebsite: PropTypes.object.isRequired,
-  dateCompleted: PropTypes.string.isRequired,
-  volunteerHours: PropTypes.string.isRequired,
-  pending: PropTypes.bool.isRequired,
+  post: postType.isRequired,
 };
 
 export default VolunteerCreditsTableRow;

--- a/resources/assets/components/pages/AccountPage/Credits/volunteer-credits-mock-data.js
+++ b/resources/assets/components/pages/AccountPage/Credits/volunteer-credits-mock-data.js
@@ -3,18 +3,24 @@ const ACTION_ONE = {
   id: 1,
   actionLabel: 'Contact a Decision-Maker',
   timeCommitmentLabel: '3+ hours',
+  noun: 'things',
+  verb: 'done',
 };
 
 const ACTION_TWO = {
   id: 2,
   actionLabel: 'Attend an Event',
   timeCommitmentLabel: '4+ hours',
+  noun: 'things',
+  verb: 'done',
 };
 
 const ACTION_THREE = {
   id: 3,
   actionLabel: 'Collect Something',
   timeCommitmentLabel: '30 minutes - 1 hour',
+  noun: 'things',
+  verb: 'done',
 };
 
 // Mock Campaign Website Showcase:
@@ -53,6 +59,8 @@ export const mockPostsResponse = [
       createdAt: '2020-04-01T18:38:03Z',
       quantity: null,
       status: 'PENDING',
+      url: 'images/1',
+      quantity: 1,
       actionDetails: ACTION_ONE,
       campaign: {
         campaignWebsite: CAMPAIGN_ONE,
@@ -65,6 +73,8 @@ export const mockPostsResponse = [
       createdAt: '2020-04-01T17:53:40Z',
       quantity: 1,
       status: 'PENDING',
+      url: 'images/2',
+      quantity: 1,
       actionDetails: ACTION_TWO,
       campaign: {
         campaignWebsite: CAMPAIGN_TWO,
@@ -77,6 +87,8 @@ export const mockPostsResponse = [
       createdAt: '2020-01-06T20:45:21Z',
       quantity: 1,
       status: 'PENDING',
+      url: 'images/3',
+      quantity: 1,
       actionDetails: ACTION_TWO,
       campaign: {
         campaignWebsite: CAMPAIGN_TWO,
@@ -89,6 +101,8 @@ export const mockPostsResponse = [
       createdAt: '2019-12-10T21:42:24Z',
       quantity: 90,
       status: 'PENDING',
+      url: 'images/4',
+      quantity: 1,
       actionDetails: ACTION_TWO,
       campaign: {
         campaignWebsite: CAMPAIGN_TWO,
@@ -101,6 +115,22 @@ export const mockPostsResponse = [
       createdAt: '2019-11-21T20:00:13Z',
       quantity: 1,
       status: 'ACCEPTED',
+      url: 'images/5',
+      quantity: 1,
+      actionDetails: ACTION_THREE,
+      campaign: {
+        campaignWebsite: CAMPAIGN_THREE,
+      },
+    },
+  },
+  {
+    node: {
+      id: 6,
+      createdAt: '2019-11-21T20:00:12Z',
+      quantity: 1,
+      status: 'ACCEPTED',
+      url: 'images/6',
+      quantity: 1,
       actionDetails: ACTION_THREE,
       campaign: {
         campaignWebsite: CAMPAIGN_THREE,
@@ -118,6 +148,8 @@ export const mockParsedPostsData = [
     dateCompleted: 'April 1st, 2020',
     volunteerHours: ACTION_ONE.timeCommitmentLabel,
     pending: true,
+    photo: undefined,
+    impactLabel: '0 things done',
   },
   {
     id: 4,
@@ -126,13 +158,17 @@ export const mockParsedPostsData = [
     dateCompleted: 'December 10th, 2019',
     volunteerHours: ACTION_TWO.timeCommitmentLabel,
     pending: true,
+    photo: undefined,
+    impactLabel: '0 things done',
   },
   {
-    id: 5,
+    id: 6,
     campaignWebsite: CAMPAIGN_THREE,
     actionLabel: ACTION_THREE.actionLabel,
     dateCompleted: 'November 21st, 2019',
     volunteerHours: ACTION_THREE.timeCommitmentLabel,
     pending: false,
+    impactLabel: '2 things done',
+    photo: 'images/6',
   },
 ];

--- a/resources/assets/components/pages/AccountPage/Credits/volunteer-credits-mock-data.js
+++ b/resources/assets/components/pages/AccountPage/Credits/volunteer-credits-mock-data.js
@@ -60,7 +60,6 @@ export const mockPostsResponse = [
       quantity: null,
       status: 'PENDING',
       url: 'images/1',
-      quantity: 1,
       actionDetails: ACTION_ONE,
       campaign: {
         campaignWebsite: CAMPAIGN_ONE,
@@ -74,7 +73,6 @@ export const mockPostsResponse = [
       quantity: 1,
       status: 'PENDING',
       url: 'images/2',
-      quantity: 1,
       actionDetails: ACTION_TWO,
       campaign: {
         campaignWebsite: CAMPAIGN_TWO,
@@ -88,7 +86,6 @@ export const mockPostsResponse = [
       quantity: 1,
       status: 'PENDING',
       url: 'images/3',
-      quantity: 1,
       actionDetails: ACTION_TWO,
       campaign: {
         campaignWebsite: CAMPAIGN_TWO,
@@ -102,7 +99,6 @@ export const mockPostsResponse = [
       quantity: 90,
       status: 'PENDING',
       url: 'images/4',
-      quantity: 1,
       actionDetails: ACTION_TWO,
       campaign: {
         campaignWebsite: CAMPAIGN_TWO,
@@ -116,7 +112,6 @@ export const mockPostsResponse = [
       quantity: 1,
       status: 'ACCEPTED',
       url: 'images/5',
-      quantity: 1,
       actionDetails: ACTION_THREE,
       campaign: {
         campaignWebsite: CAMPAIGN_THREE,
@@ -130,7 +125,6 @@ export const mockPostsResponse = [
       quantity: 1,
       status: 'ACCEPTED',
       url: 'images/6',
-      quantity: 1,
       actionDetails: ACTION_THREE,
       campaign: {
         campaignWebsite: CAMPAIGN_THREE,


### PR DESCRIPTION
### What's this PR do?

This pull request queries and parses out the remaining bits of data needed for the Volunteer Credits Table certificates.

### How should this be reviewed?
This might look like a lot, but it should all be pretty straightforward! I'd recommend a commit-by-commit approach for a digestible review.

### Any background context you want to provide?
You'll notice that we're essentially replicating some logic we've set up [in GraphQL](https://github.com/DoSomething/graphql/blob/ba64e6594745686aae8479962f447ada2bc991e5/src/repositories/rogue.js#L470-L481) to generate the impact label per post. This is because we're in a bit of a unique situation: we want to generate this label based on the _total_ quantity of post impact for _this_ action. 
- Each post contains an impact label specific to that post's own quantity
- The campaign signup contains a total of quantity for _all_ campaign actions' posts.

This could be something we eventually add to GraphQL (maybe a field on the action) but would require more thinking around specifics (particularly how to handle pagination et al. (this overall has similar qualities to [this issue](https://github.com/DoSomething/phoenix-next/pull/1998#discussion_r398806993))) Things we'll hopefully be talking about in later iterations!

Another notable change here, was to add a central prop types definition for this beefy `post` object, so we can pass that around to the various table rows and utility components more seamlessly.

Finally, there's the big open question of what to do about posts with no quantity or actions where we generally don't collect quantity info (which relates to [Pivotal #171901122](https://www.pivotaltracker.com/story/show/171901122)). I left a TODO for now, and will raise this question in Pivotal.

### Relevant tickets

References [Pivotal #172150720](https://www.pivotaltracker.com/story/show/172150720).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added screenshots of front-end changes on small, medium, and large screens.
- [x] Added appropriate feature/unit tests.
