### PR TITLE
Switch feature badge on campaign card to left side.

### DIFF
--- a/resources/assets/components/utilities/CampaignCard/CampaignCard.js
+++ b/resources/assets/components/utilities/CampaignCard/CampaignCard.js
@@ -49,7 +49,7 @@ const CampaignCard = ({ campaign }) => {
 
       <div className="bg-white border-b-2 border-l-2 border-r-2 border-gray-300 border-solid flex flex-col flex-grow p-4 rounded-b">
         {staffPick ? (
-          <div className="absolute bg-purple-500 font-bold px-3 py-1 right-0 text-base text-white top-0 uppercase">
+          <div className="absolute bg-purple-500 font-bold left-0 px-3 py-1 text-base text-white top-0 uppercase">
             Featured
           </div>
         ) : null}


### PR DESCRIPTION
### What's this PR do?

This pull request simply switches the feature badge to the left side on the campaign card.

Before:

![image](https://user-images.githubusercontent.com/105849/79384611-36f15000-7f35-11ea-86c4-7b3ee2a3bb48.png)

After:

![image](https://user-images.githubusercontent.com/105849/79384628-3fe22180-7f35-11ea-8a6a-a3ecf860dbb8.png)


### How should this be reviewed?

👀 

### Relevant tickets

References [Pivotal #172338665](https://www.pivotaltracker.com/story/show/172338665).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.