### PR TITLE
Volunteer Credit Posts Impact Label Update for No-Quantity Actions

### DIFF
--- a/resources/assets/components/pages/AccountPage/Credits/VolunteerCreditsQuery.js
+++ b/resources/assets/components/pages/AccountPage/Credits/VolunteerCreditsQuery.js
@@ -118,7 +118,10 @@ const VolunteerCreditsQuery = () => {
     );
 
     // Generate human-friendly impact label based on quantity and action noun + verb.
-    const impactLabel = `${pluralize(noun, quantity, true)} ${verb}`;
+    // Will be 'null' for actions where we don't collect quantity info, or where total impact tallies to 0.
+    const impactLabel = quantity
+      ? `${pluralize(noun, quantity, true)} ${verb}`
+      : null;
 
     // Grab the photo URL of the earliest accepted post.
     const firstAcceptedPost = last(acceptedPosts);

--- a/resources/assets/components/pages/AccountPage/Credits/volunteer-credits-mock-data.js
+++ b/resources/assets/components/pages/AccountPage/Credits/volunteer-credits-mock-data.js
@@ -143,7 +143,7 @@ export const mockParsedPostsData = [
     volunteerHours: ACTION_ONE.timeCommitmentLabel,
     pending: true,
     photo: undefined,
-    impactLabel: '0 things done',
+    impactLabel: null,
   },
   {
     id: 4,
@@ -153,7 +153,7 @@ export const mockParsedPostsData = [
     volunteerHours: ACTION_TWO.timeCommitmentLabel,
     pending: true,
     photo: undefined,
-    impactLabel: '0 things done',
+    impactLabel: null,
   },
   {
     id: 6,


### PR DESCRIPTION
### What's this PR do?

This pull request ensures we don't generate an 'impact label' for Volunteer Credit table generated posts where we have no impact quantity (social shares, text posts, or specific photo posts).

### How should this be reviewed?
👀 

### Any background context you want to provide?
https://www.pivotaltracker.com/story/show/172150720/comments/213540218
https://github.com/DoSomething/phoenix-next/pull/2037#discussion_r409550907

### Relevant tickets

References [Pivotal #172150720](https://www.pivotaltracker.com/story/show/172150720).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added screenshots of front-end changes on small, medium, and large screens.
- [x] Added appropriate feature/unit tests.
