### PR TITLE
Fix errors caused by multiple queries sharing copy-pasted names.

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,7 +27,7 @@ CONTENTFUL_ENVIRONMENT_ID=dev
 CONTENTFUL_USE_PREVIEW_API=false
 CONTENTFUL_SPACE_ID=
 
-ENGINE_API_KEY=
+APOLLO_KEY=
 GRAPHQL_URL=https://graphql-dev.dosomething.org/graphql
 
 NORTHSTAR_URL=https://identity-dev.dosomething.org

--- a/docs/installation-and-usage/usage.md
+++ b/docs/installation-and-usage/usage.md
@@ -32,10 +32,10 @@ To run JavaScript [Cypress](https://www.cypress.io/) tests locally, run:
 $ npm run cypress
 ```
 
-New GraphQL types, fields, queries, and mutations should be reflected in the root `schema.json` file that is used by our Cypress test suite to mock GraphQL requests. The easiest way to update the schema is by using the [Apollo CLI](https://www.apollographql.com/docs/devtools/cli/):
+New GraphQL types, fields, queries, and mutations should be reflected in the root `schema.json` file that is used by our Cypress test suite to mock GraphQL requests. The easiest way to update the schema is by using the `schema:fetch` command:
 
 ```bash
-$ apollo client:download-schema --endpoint=http://graphql-dev.dosomething.org/graphql schema.json
+$ npm run schema:fetch
 ```
 
 {% hint style="warning" %}

--- a/docs/installation-and-usage/usage.md
+++ b/docs/installation-and-usage/usage.md
@@ -38,17 +38,6 @@ New GraphQL types, fields, queries, and mutations should be reflected in the roo
 $ npm run schema:fetch
 ```
 
-{% hint style="warning" %}
-Note: This command won't work until we remove the duplicate `UserPostsQuery` definitions in the codebase. It fails with this error:
-
-```
- ›   dosomething-graphql-dev-lambda": Error: ️️There are multiple definitions
- ›   for the `UserPostsQuery` operation. Please rename or remove all operations
- ›   with the duplicated name before continuing.
-```
-
-{% endhint %}
-
 ## Code Style
 
 We use [Prettier](https://prettier.io/) to format our code & [ESLint](http://eslint.org/) to catch common mistakes.

--- a/resources/assets/components/actions/PetitionSubmissioncAction/PetitionSubmissionAction.js
+++ b/resources/assets/components/actions/PetitionSubmissioncAction/PetitionSubmissionAction.js
@@ -32,8 +32,8 @@ export const PetitionSubmissionBlockFragment = gql`
   }
 `;
 
-export const USER_POSTS_QUERY = gql`
-  query UserPostsQuery($userId: String!, $actionIds: [Int]!) {
+export const PETITION_SUBMISSION_BLOCK_QUERY = gql`
+  query PetitionSubmissionBlockQuery($userId: String!, $actionIds: [Int]!) {
     posts(userId: $userId, actionIds: $actionIds) {
       text
     }
@@ -134,7 +134,7 @@ class PetitionSubmissionAction extends PostForm {
             context={{ blockId: id }}
           />
           <ApolloQuery
-            query={USER_POSTS_QUERY}
+            query={PETITION_SUBMISSION_BLOCK_QUERY}
             variables={{ userId, actionIds: [actionId] }}
             queryName="userPosts"
             skip={!userId}

--- a/resources/assets/components/actions/PetitionSubmissioncAction/PetitionSubmissionAction.test.js
+++ b/resources/assets/components/actions/PetitionSubmissioncAction/PetitionSubmissionAction.test.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { mount } from 'enzyme';
 import { MockedProvider } from '@apollo/react-testing';
 
-import { USER_POSTS_QUERY } from './PetitionSubmissionAction'; // eslint-disable-line import/no-duplicates
+import { PETITION_SUBMISSION_BLOCK_QUERY } from './PetitionSubmissionAction'; // eslint-disable-line import/no-duplicates
 import PetitionSubmissionAction from './PetitionSubmissionAction'; // eslint-disable-line import/no-duplicates
 import IntersectionObserverMock from '../../../__mocks__/intersectionObserverMock';
 
@@ -11,7 +11,7 @@ global.IntersectionObserver = IntersectionObserverMock;
 const mocks = [
   {
     request: {
-      query: USER_POSTS_QUERY,
+      query: PETITION_SUBMISSION_BLOCK_QUERY,
       variables: {
         userId: '1',
         actionIds: [1],

--- a/resources/assets/components/actions/PostCreatedModal.js
+++ b/resources/assets/components/actions/PostCreatedModal.js
@@ -10,7 +10,7 @@ import Badge from '../pages/AccountPage/Badges/Badge';
 import TextContent from '../utilities/TextContent/TextContent';
 
 const BADGE_QUERY = gql`
-  query UserBadgeQuery($userId: String!) {
+  query PostCreatedModalBadgeQuery($userId: String!) {
     user(id: $userId) {
       id
       hasBadgesFlag: hasFeatureFlag(feature: "badges")
@@ -19,7 +19,7 @@ const BADGE_QUERY = gql`
 `;
 
 const POST_COUNT_BADGE = gql`
-  query PostsCountQuery($userId: String!) {
+  query PostsCreatedModalCountQuery($userId: String!) {
     postsCount(userId: $userId, limit: 4)
   }
 `;

--- a/resources/assets/components/actions/SelectionSubmissionAction/SelectionSubmissionAction.js
+++ b/resources/assets/components/actions/SelectionSubmissionAction/SelectionSubmissionAction.js
@@ -26,8 +26,8 @@ export const SelectionSubmissionBlockFragment = gql`
   }
 `;
 
-const USER_POSTS_QUERY = gql`
-  query UserPostsQuery($userId: String!, $actionIds: [Int]!) {
+const SELECTION_SUBMISSION_BLOCK_QUERY = gql`
+  query SelectionSubmissionBlockQuery($userId: String!, $actionIds: [Int]!) {
     posts(userId: $userId, actionIds: $actionIds) {
       text
     }
@@ -129,7 +129,7 @@ class SelectionSubmissionAction extends PostForm {
         <TextContent className="p-3">{richText}</TextContent>
 
         <Query
-          query={USER_POSTS_QUERY}
+          query={SELECTION_SUBMISSION_BLOCK_QUERY}
           variables={{ userId, actionIds: [actionId] }}
         >
           {({ loading, data }) => {

--- a/schema.json
+++ b/schema.json
@@ -427,12 +427,26 @@
                 "defaultValue": null
               },
               {
-                "name": "status",
-                "description": "The post status to load posts for.",
+                "name": "referrerUserId",
+                "description": "The referring User ID to load posts for.",
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
                   "ofType": null
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "status",
+                "description": "The post statuses to load posts for.",
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "ENUM",
+                    "name": "ReviewStatus",
+                    "ofType": null
+                  }
                 },
                 "defaultValue": null
               },
@@ -476,6 +490,16 @@
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "volunteerCredit",
+                "description": "Filter by the corresponding Action's volunteer credit status",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
                   "ofType": null
                 },
                 "defaultValue": null
@@ -572,12 +596,26 @@
                 "defaultValue": null
               },
               {
-                "name": "status",
-                "description": "The post status to load posts for.",
+                "name": "referrerUserId",
+                "description": "The referring User ID to load posts for.",
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
                   "ofType": null
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "status",
+                "description": "The post statuses to load posts for.",
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "ENUM",
+                    "name": "ReviewStatus",
+                    "ofType": null
+                  }
                 },
                 "defaultValue": null
               },
@@ -621,6 +659,16 @@
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "volunteerCredit",
+                "description": "Filter by the corresponding Action's volunteer credit status",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
                   "ofType": null
                 },
                 "defaultValue": null
@@ -1124,7 +1172,7 @@
               },
               {
                 "name": "campaignId",
-                "description": "# The campaign ID to count posts for.",
+                "description": "The campaign ID to count posts for.",
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -1144,7 +1192,7 @@
               },
               {
                 "name": "referrerUserId",
-                "description": "The referrer user ID to count posts for.",
+                "description": "The referring User ID to count posts for.",
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -1154,7 +1202,7 @@
               },
               {
                 "name": "source",
-                "description": "# The post source to count posts for.",
+                "description": "The post source to count posts for.",
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -1178,7 +1226,7 @@
               },
               {
                 "name": "type",
-                "description": "# The type name to count posts for.",
+                "description": "The type name to count posts for.",
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -1188,7 +1236,7 @@
               },
               {
                 "name": "userId",
-                "description": "# The user ID to count posts for.",
+                "description": "The user ID to count posts for.",
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -1208,7 +1256,7 @@
               },
               {
                 "name": "limit",
-                "description": "# The maximum count to report.",
+                "description": "The maximum count to report.",
                 "type": {
                   "kind": "SCALAR",
                   "name": "Int",
@@ -1411,6 +1459,43 @@
             "deprecationReason": null
           },
           {
+            "name": "pageBySlug",
+            "description": null,
+            "args": [
+              {
+                "name": "slug",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "preview",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                },
+                "defaultValue": "false"
+              }
+            ],
+            "type": {
+              "kind": "OBJECT",
+              "name": "Page",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "campaignWebsiteByCampaignId",
             "description": null,
             "args": [
@@ -1553,6 +1638,66 @@
             "type": {
               "kind": "OBJECT",
               "name": "CompanyPage",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "homePage",
+            "description": null,
+            "args": [
+              {
+                "name": "preview",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                },
+                "defaultValue": "false"
+              }
+            ],
+            "type": {
+              "kind": "OBJECT",
+              "name": "HomePage",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "storyPageWebsite",
+            "description": null,
+            "args": [
+              {
+                "name": "id",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "preview",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                },
+                "defaultValue": "false"
+              }
+            ],
+            "type": {
+              "kind": "OBJECT",
+              "name": "StoryPageWebsite",
               "ofType": null
             },
             "isDeprecated": false,
@@ -2531,11 +2676,35 @@
           },
           {
             "name": "voterRegistrationStatus",
-            "description": "The user's voter registration status, either self-reported or by registering with TurboVote.",
+            "description": "The user's voter registration status, either self-reported or by registering with third-party.",
             "args": [],
             "type": {
               "kind": "ENUM",
               "name": "VoterRegistrationStatus",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "referrerUserId",
+            "description": "The user who referred this user to create an account.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "deletionRequestedAt",
+            "description": "If the user has requested their account to be deleted, this is the time that request occurred.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "DateTime",
               "ofType": null
             },
             "isDeprecated": false,
@@ -2680,6 +2849,22 @@
               "kind": "SCALAR",
               "name": "String",
               "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "causes",
+            "description": "The causes areas this user is interested in.",
+            "args": [],
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "CauseIdentifier",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -2890,12 +3075,6 @@
         "interfaces": null,
         "enumValues": [
           {
-            "name": "REGISTRATION_COMPLETE",
-            "description": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
             "name": "CONFIRMED",
             "description": null,
             "isDeprecated": false,
@@ -2908,7 +3087,49 @@
             "deprecationReason": null
           },
           {
+            "name": "REJECTED",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "REGISTRATION_COMPLETE",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "STEP_1",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "STEP_2",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "STEP_3",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "STEP_4",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "UNCERTAIN",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "UNDER_18",
             "description": null,
             "isDeprecated": false,
             "deprecationReason": null
@@ -2930,6 +3151,89 @@
         "inputFields": null,
         "interfaces": null,
         "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "CauseIdentifier",
+        "description": "The user's choices of cause area preference.",
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "ANIMAL_WELFARE",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "BULLYING",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "EDUCATION",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "ENVIRONMENT",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "GENDER_RIGHTS_EQUALITY",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "HOMELESSNESS_POVERTY",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "IMMIGRATION_REFUGEES",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "LGBTQ_RIGHTS_EQUALITY",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "MENTAL_HEALTH",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "PHYSICAL_HEALTH",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "RACIAL_JUSTICE_EQUITY",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "SEXUAL_HARASSMENT_ASSAULT",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
         "possibleTypes": null
       },
       {
@@ -3156,6 +3460,30 @@
           {
             "name": "source",
             "description": "The source of this post. This is often a Northstar OAuth client.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "details",
+            "description": "Extra information about this post.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "referrerUserId",
+            "description": "The user who referred the post user to create this post.",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -3503,6 +3831,18 @@
           {
             "name": "scholarshipEntry",
             "description": "Does this action count as a scholarship entry?",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "volunteerCredit",
+            "description": "Does this action qualify for volunteer credit?",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -3991,8 +4331,20 @@
             "deprecationReason": null
           },
           {
-            "name": "showcaseTitle",
+            "name": "staffPick",
             "description": "The showcase title (the title field.)",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "showcaseTitle",
+            "description": "Designates if this is a staff pick campaign.",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -4185,6 +4537,11 @@
           {
             "kind": "OBJECT",
             "name": "PersonBlock",
+            "ofType": null
+          },
+          {
+            "kind": "OBJECT",
+            "name": "StoryPageWebsite",
             "ofType": null
           },
           {
@@ -4414,12 +4771,12 @@
           },
           {
             "kind": "OBJECT",
-            "name": "AffirmationBlock",
+            "name": "PersonBlock",
             "ofType": null
           },
           {
             "kind": "OBJECT",
-            "name": "PersonBlock",
+            "name": "AffirmationBlock",
             "ofType": null
           },
           {
@@ -4981,6 +5338,18 @@
             "deprecationReason": null
           },
           {
+            "name": "referrerUserId",
+            "description": "The user who referred the signup user to create this signup.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "updatedAt",
             "description": "The time this signup was last modified.",
             "args": [],
@@ -5061,7 +5430,13 @@
             "deprecationReason": null
           },
           {
-            "name": "REJECTED",
+            "name": "CONFIRMED",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "INELIGIBLE",
             "description": null,
             "isDeprecated": false,
             "deprecationReason": null
@@ -5085,19 +5460,43 @@
             "deprecationReason": null
           },
           {
-            "name": "CONFIRMED",
+            "name": "REJECTED",
             "description": null,
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
-            "name": "INELIGIBLE",
+            "name": "STEP_1",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "STEP_2",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "STEP_3",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "STEP_4",
             "description": null,
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
             "name": "UNCERTAIN",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "UNDER_18",
             "description": null,
             "isDeprecated": false,
             "deprecationReason": null
@@ -6002,6 +6401,22 @@
             "deprecationReason": null
           },
           {
+            "name": "authors",
+            "description": "The authors for this page.",
+            "args": [],
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "PersonBlock",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "content",
             "description": "The content of the page.",
             "args": [],
@@ -6167,6 +6582,244 @@
           {
             "kind": "INTERFACE",
             "name": "Showcasable",
+            "ofType": null
+          }
+        ],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "PersonBlock",
+        "description": null,
+        "fields": [
+          {
+            "name": "name",
+            "description": "Name of the person displayed on the block.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "type",
+            "description": "The person's relationship with the organization: member? employee?",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "active",
+            "description": "The status of the person's relationship with the organization: active? non-active?",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "jobTitle",
+            "description": "Job title of the person.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "email",
+            "description": "The perons's email address.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "twitterId",
+            "description": "The person's Twitter handle.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "photo",
+            "description": "Photo of the person.",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "Asset",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "alternatePhoto",
+            "description": "Alternate Photo of the person.",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "Asset",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "description",
+            "description": "Description of the person.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "showcaseTitle",
+            "description": "The Showcase title (the name field.)",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "showcaseDescription",
+            "description": "The Showcase description ('description' if the person is a board member and 'jobTitle' by default.)",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "showcaseImage",
+            "description": "The Showcase image ('photo' if the person is an advisory board member 'alternatePhoto' by default.)",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "Asset",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "internalTitle",
+            "description": "The internal-facing title for this block.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "id",
+            "description": "The Contentful ID for this entry.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "updatedAt",
+            "description": "The time this entry was last modified.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "DateTime",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "createdAt",
+            "description": "The time when this entry was originally created.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "DateTime",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [
+          {
+            "kind": "INTERFACE",
+            "name": "Showcasable",
+            "ofType": null
+          },
+          {
+            "kind": "INTERFACE",
+            "name": "Block",
             "ofType": null
           }
         ],
@@ -6657,6 +7310,383 @@
         "possibleTypes": null
       },
       {
+        "kind": "OBJECT",
+        "name": "HomePage",
+        "description": null,
+        "fields": [
+          {
+            "name": "internalTitle",
+            "description": "This title is used internally to help find this content.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "title",
+            "description": "The title for the home page.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "subTitle",
+            "description": "The subtitle for the home page.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "coverImage",
+            "description": "Cover image for the home page.",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "Asset",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "campaigns",
+            "description": "Campaigns (campaign and story page entries) rendered as a list on the home page.",
+            "args": [],
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "UNION",
+                "name": "ResourceWebsite",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "articles",
+            "description": "Articles (page entries) rendered as a list on the home page.",
+            "args": [],
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "Page",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "additionalContent",
+            "description": "Any custom overrides for the home page.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "JSON",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "id",
+            "description": "The Contentful ID for this entry.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "updatedAt",
+            "description": "The time this entry was last modified.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "DateTime",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "createdAt",
+            "description": "The time when this entry was originally created.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "DateTime",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "UNION",
+        "name": "ResourceWebsite",
+        "description": "A web-based campaign interface, such as the traditional campaign template or story page.",
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": [
+          {
+            "kind": "OBJECT",
+            "name": "CampaignWebsite",
+            "ofType": null
+          },
+          {
+            "kind": "OBJECT",
+            "name": "StoryPageWebsite",
+            "ofType": null
+          }
+        ]
+      },
+      {
+        "kind": "OBJECT",
+        "name": "StoryPageWebsite",
+        "description": null,
+        "fields": [
+          {
+            "name": "internalTitle",
+            "description": "The internal-facing title for this story campaign.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "slug",
+            "description": "The slug for this story campaign.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "url",
+            "description": "The URL for this story campaign.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "title",
+            "description": "The user-facing title for this story campaign.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "subTitle",
+            "description": "The user-facing subtitle for this story campaign.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "coverImage",
+            "description": "The cover image for this story campaign.",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "Asset",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "blocks",
+            "description": "Blocks rendered following the initial content on the story campaign.",
+            "args": [],
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "INTERFACE",
+                "name": "Block",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "showcaseTitle",
+            "description": "The showcase title (the title field.)",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "showcaseDescription",
+            "description": "The showcase description (the subTitle field.)",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "showcaseImage",
+            "description": "The showcase image (the coverImage field.)",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "Asset",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "id",
+            "description": "The Contentful ID for this entry.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "updatedAt",
+            "description": "The time this entry was last modified.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "DateTime",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "createdAt",
+            "description": "The time when this entry was originally created.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "DateTime",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [
+          {
+            "kind": "INTERFACE",
+            "name": "Showcasable",
+            "ofType": null
+          }
+        ],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
         "kind": "INTERFACE",
         "name": "Broadcast",
         "description": "A DoSomething.org broadcast.",
@@ -6967,6 +7997,68 @@
         "description": "The mutation root of our GraphQL schema. Start here if you want to write data",
         "fields": [
           {
+            "name": "requestDeletion",
+            "description": "Request deletion for the given user account.",
+            "args": [
+              {
+                "name": "id",
+                "description": "The user ID to request deletion for.",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "User",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "undoDeletionRequest",
+            "description": "Request deletion for the given user account.",
+            "args": [
+              {
+                "name": "id",
+                "description": "The user ID whose request we're undoing.",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "User",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "updateEmailSubscriptionTopics",
             "description": "Update the list of newsletters a user is subscribed to.",
             "args": [
@@ -7016,6 +8108,65 @@
             "deprecationReason": null
           },
           {
+            "name": "updateEmailSubscriptionTopic",
+            "description": "Update the user's subscription for a given newsletter.",
+            "args": [
+              {
+                "name": "id",
+                "description": "The user to update.",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "topic",
+                "description": "The newsletter the to update the subscription status of.",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "ENUM",
+                    "name": "EmailSubscriptionTopic",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "subscribed",
+                "description": "The new subscription status.",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "User",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "updateSchoolId",
             "description": "Update the user school id.",
             "args": [
@@ -7040,6 +8191,65 @@
                   "kind": "SCALAR",
                   "name": "String",
                   "ofType": null
+                },
+                "defaultValue": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "User",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "updateCausePreferences",
+            "description": "Update the user's cause interest preferences.",
+            "args": [
+              {
+                "name": "id",
+                "description": "The user to update.",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "cause",
+                "description": "The cause area to update the preference of.",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "ENUM",
+                    "name": "CauseIdentifier",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "interested",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
+                    "ofType": null
+                  }
                 },
                 "defaultValue": null
               }
@@ -8304,244 +9514,6 @@
       },
       {
         "kind": "OBJECT",
-        "name": "PersonBlock",
-        "description": null,
-        "fields": [
-          {
-            "name": "name",
-            "description": "Name of the person displayed on the block.",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "type",
-            "description": "The person's relationship with the organization: member? employee?",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "active",
-            "description": "The status of the person's relationship with the organization: active? non-active?",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "Boolean",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "jobTitle",
-            "description": "Job title of the person.",
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "email",
-            "description": "The perons's email address.",
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "twitterId",
-            "description": "The person's Twitter handle.",
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "photo",
-            "description": "Photo of the person.",
-            "args": [],
-            "type": {
-              "kind": "OBJECT",
-              "name": "Asset",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "alternatePhoto",
-            "description": "Alternate Photo of the person.",
-            "args": [],
-            "type": {
-              "kind": "OBJECT",
-              "name": "Asset",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "description",
-            "description": "Description of the person.",
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "showcaseTitle",
-            "description": "The Showcase title (the name field.)",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "showcaseDescription",
-            "description": "The Showcase description ('description' if the person is a board member and 'jobTitle' by default.)",
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "showcaseImage",
-            "description": "The Showcase image ('photo' if the person is an advisory board member 'alternatePhoto' by default.)",
-            "args": [],
-            "type": {
-              "kind": "OBJECT",
-              "name": "Asset",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "internalTitle",
-            "description": "The internal-facing title for this block.",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "id",
-            "description": "The Contentful ID for this entry.",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "updatedAt",
-            "description": "The time this entry was last modified.",
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "DateTime",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "createdAt",
-            "description": "The time when this entry was originally created.",
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "DateTime",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "inputFields": null,
-        "interfaces": [
-          {
-            "kind": "INTERFACE",
-            "name": "Showcasable",
-            "ofType": null
-          },
-          {
-            "kind": "INTERFACE",
-            "name": "Block",
-            "ofType": null
-          }
-        ],
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "OBJECT",
         "name": "CallToActionBlock",
         "description": null,
         "fields": [
@@ -9491,9 +10463,13 @@
             "description": "The user-facing title for this link block.",
             "args": [],
             "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -9512,12 +10488,16 @@
           },
           {
             "name": "link",
-            "description": "The URL being linked to.",
+            "description": "The URL (or tel: number) being linked to.",
             "args": [],
             "type": {
-              "kind": "SCALAR",
-              "name": "AbsoluteUrl",
-              "ofType": null
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null


### PR DESCRIPTION
### What's this PR do?

This pull request fixes errors in our editor extensions, developer tooling & monitoring systems caused by copy-pasting the same query name into multiple components (like `UserPostsQuery`).

I've also updated documentation on pulling local schema & updated the suggested Apollo environment variable in `.env.example` (since `ENGINE_API_KEY` was [deprecated](https://git.io/JfJEN) in favor of `APOLLO_KEY`).

### How should this be reviewed?

👀

### Any background context you want to provide?

It's really important for each query to uniquely describe the particular usage (a good start is just naming it to match the component), since this is how we track down errors when debugging!

### Relevant tickets

References [Pivotal #172387091](https://www.pivotaltracker.com/story/show/172387091).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added screenshots of front-end changes on small, medium, and large screens.
- [ ] Added appropriate feature/unit tests.
