### PR TITLE
Add tracking to Sitewide Banner

### DIFF
--- a/resources/assets/components/utilities/SitewideBanner/SitewideBannerContent.js
+++ b/resources/assets/components/utilities/SitewideBanner/SitewideBannerContent.js
@@ -2,6 +2,10 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import CloseButton from '../../artifacts/CloseButton/CloseButton';
+import {
+  EVENT_CATEGORIES,
+  trackAnalyticsEvent,
+} from '../../../helpers/analytics';
 
 const SitewideBannerContent = ({
   cta,
@@ -10,6 +14,16 @@ const SitewideBannerContent = ({
   handleComplete,
   link,
 }) => {
+  const handleCompleteWithTracking = () => {
+    handleComplete();
+
+    trackAnalyticsEvent('clicked_call_to_action_sitewide_banner', {
+      action: 'button_clicked',
+      category: EVENT_CATEGORIES.siteAction,
+      label: 'sitewide_banner',
+      context: { contextSource: 'voter_registration' },
+    });
+  };
   return (
     <div className="w-full flex justify-center bg-yellow-500 p-4 z-50">
       <CloseButton
@@ -26,7 +40,7 @@ const SitewideBannerContent = ({
           href={link}
           target="_blank"
           rel="noopener noreferrer"
-          onClick={handleComplete}
+          onClick={handleCompleteWithTracking}
         >
           {cta}
         </a>


### PR DESCRIPTION
### What's this PR do?

This pull request adds a tracking event to the CTA button on the sitewide banner

### How should this be reviewed?

👀 

### Any background context you want to provide?

Already had tracking set up on the dismiss 'x', and wanted follow up the launch of the button with tracking for successful conversion as well. 

### Relevant tickets

References [Pivotal # 172343609](https://www.pivotaltracker.com/story/show/172343609).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added screenshots of front-end changes on small, medium, and large screens.
- [ ] Added appropriate feature/unit tests.
