### PR TITLE
Allow editors to override the action displayed in CampaignInfoBlock

### DIFF
--- a/resources/assets/components/LedeBanner/LedeBannerContainer.js
+++ b/resources/assets/components/LedeBanner/LedeBannerContainer.js
@@ -8,6 +8,11 @@ import { isSignedUp } from '../../selectors/signup';
  * Provide state from the Redux store as props for this component.
  */
 const mapStateToProps = (state, props) => ({
+  actionToDisplay: get(
+    state,
+    'campaign.additionalContent.actionToDisplay',
+    null,
+  ),
   affiliatedActionText: get(
     state,
     'campaign.additionalContent.affiliatedActionText',

--- a/resources/assets/components/LedeBanner/templates/HeroTemplate.js
+++ b/resources/assets/components/LedeBanner/templates/HeroTemplate.js
@@ -21,6 +21,7 @@ import {
 import './hero-lede-banner.scss';
 
 const HeroTemplate = ({
+  actionToDisplay,
   additionalContent,
   affiliateCreditText,
   affiliateSponsors,
@@ -126,6 +127,7 @@ const HeroTemplate = ({
                 scholarshipAmount={scholarshipAmount}
                 scholarshipDeadline={scholarshipDeadline}
                 showModal={() => setShowScholarshipModal(true)}
+                actionToDisplay={actionToDisplay}
               />
             </div>
           </div>
@@ -175,6 +177,7 @@ const HeroTemplate = ({
 };
 
 HeroTemplate.propTypes = {
+  actionToDisplay: PropTypes.number,
   additionalContent: PropTypes.object,
   affiliateCreditText: PropTypes.string,
   affiliateSponsors: PropTypes.arrayOf(PropTypes.object),
@@ -198,6 +201,7 @@ HeroTemplate.propTypes = {
 };
 
 HeroTemplate.defaultProps = {
+  actionToDisplay: null,
   additionalContent: null,
   affiliateCreditText: undefined,
   affiliateSponsors: [],

--- a/resources/assets/components/blocks/CampaignInfoBlock/CampaignInfoBlock.js
+++ b/resources/assets/components/blocks/CampaignInfoBlock/CampaignInfoBlock.js
@@ -22,6 +22,7 @@ const CAMPAIGN_INFO_QUERY = gql`
       endDate
       isOpen
       actions {
+        id
         actionLabel
         timeCommitmentLabel
         scholarshipEntry
@@ -36,6 +37,7 @@ const CampaignInfoBlock = ({
   scholarshipAmount,
   scholarshipDeadline,
   showModal,
+  actionToDisplay,
 }) => (
   <Card className="bordered p-3 rounded campaign-info">
     <Query query={CAMPAIGN_INFO_QUERY} variables={{ campaignId }}>
@@ -54,20 +56,35 @@ const CampaignInfoBlock = ({
           });
         };
 
-        let actionItem = actions.find(
-          action => action.reportback && action.scholarshipEntry,
-        );
+        // Decide which action to display
+        let actionItem;
 
+        if (actionToDisplay) {
+          actionItem = actions.find(action => action.id === actionToDisplay);
+        } else {
+          actionItem = actions.find(
+            action => action.reportback && action.scholarshipEntry,
+          );
+        }
         if (!actionItem) {
           actionItem = actions.find(action => action.reportback);
         }
+
         return (
           <>
-            {!scholarshipAmount ? (
+            {!(
+              scholarshipAmount &&
+              scholarshipDeadline &&
+              isOpen &&
+              actionItem.scholarshipEntry
+            ) ? (
               <h1 className="mb-3 text-lg uppercase">Campaign Info</h1>
             ) : null}
             <dl className="clearfix">
-              {scholarshipAmount && scholarshipDeadline && isOpen ? (
+              {scholarshipAmount &&
+              scholarshipDeadline &&
+              isOpen &&
+              actionItem.scholarshipEntry ? (
                 <React.Fragment>
                   <dt className="campaign-info__scholarship">
                     Win A Scholarship
@@ -118,6 +135,7 @@ const CampaignInfoBlock = ({
 );
 
 CampaignInfoBlock.propTypes = {
+  actionToDisplay: PropTypes.number,
   campaignId: PropTypes.number.isRequired,
   scholarshipAmount: PropTypes.number,
   scholarshipDeadline: PropTypes.string,
@@ -125,6 +143,7 @@ CampaignInfoBlock.propTypes = {
 };
 
 CampaignInfoBlock.defaultProps = {
+  actionToDisplay: null,
   scholarshipAmount: null,
   scholarshipDeadline: null,
   showModal: null,

--- a/resources/assets/components/blocks/CampaignInfoBlock/CampaignInfoBlock.js
+++ b/resources/assets/components/blocks/CampaignInfoBlock/CampaignInfoBlock.js
@@ -73,12 +73,7 @@ const CampaignInfoBlock = ({
         // Decide if we want to display scholarship information
         let showScholarshipInfo = false;
 
-        if (
-          scholarshipAmount &&
-          scholarshipDeadline &&
-          isOpen &&
-          actionItem.scholarshipEntry
-        ) {
+        if (scholarshipAmount && scholarshipDeadline && isOpen) {
           showScholarshipInfo = true;
         }
 

--- a/resources/assets/components/blocks/CampaignInfoBlock/CampaignInfoBlock.js
+++ b/resources/assets/components/blocks/CampaignInfoBlock/CampaignInfoBlock.js
@@ -70,21 +70,25 @@ const CampaignInfoBlock = ({
           actionItem = actions.find(action => action.reportback);
         }
 
+        // Decide if we want to display scholarship information
+        let showScholarshipInfo = false;
+
+        if (
+          scholarshipAmount &&
+          scholarshipDeadline &&
+          isOpen &&
+          actionItem.scholarshipEntry
+        ) {
+          showScholarshipInfo = true;
+        }
+
         return (
           <>
-            {!(
-              scholarshipAmount &&
-              scholarshipDeadline &&
-              isOpen &&
-              actionItem.scholarshipEntry
-            ) ? (
+            {!showScholarshipInfo ? (
               <h1 className="mb-3 text-lg uppercase">Campaign Info</h1>
             ) : null}
             <dl className="clearfix">
-              {scholarshipAmount &&
-              scholarshipDeadline &&
-              isOpen &&
-              actionItem.scholarshipEntry ? (
+              {showScholarshipInfo ? (
                 <React.Fragment>
                   <dt className="campaign-info__scholarship">
                     Win A Scholarship
@@ -108,7 +112,7 @@ const CampaignInfoBlock = ({
                 </React.Fragment>
               ) : null}
 
-              {endDate && !scholarshipAmount ? (
+              {endDate && !showScholarshipInfo ? (
                 <>
                   <dt>Deadline</dt>
                   <dd>{getHumanFriendlyDate(endDate)}</dd>


### PR DESCRIPTION
# What's this PR do?

This pull request allows editors to override the action displayed in `CampaignInfoBlock`. Context on why we want to do that is in the Pivotal card.

Since this is more of a one-off, we are using `additionalContent`. An editor can override the action displayed by including something like: `"actionToDisplay": 3,` in the Additional Content field of a Campaign. Then, the information for that action will be displayed in the `CampaignInfoBlock`.

Before:
<img width="412" alt="Screen Shot 2020-04-22 at 12 15 53 PM" src="https://user-images.githubusercontent.com/4240292/80024198-884c9280-8493-11ea-8177-87d78a9fee0e.png">

After with `"actionToDisplay": 3,`:
<img width="357" alt="Screen Shot 2020-04-22 at 3 06 28 PM" src="https://user-images.githubusercontent.com/4240292/80038715-0d8f7180-84ab-11ea-87a2-fc5a9baeaeb0.png">


### How should this be reviewed?

Did I cover all the cases?

### Any background context you want to provide?

All in the card!

### Relevant tickets

References [Pivotal #172316942](https://www.pivotaltracker.com/story/show/172316942).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added screenshots of front-end changes on small, medium, and large screens.
- [ ] Added appropriate feature/unit tests.
