### PR TITLE
Blurple buttons foreva part trois

### DIFF
--- a/resources/assets/components/pages/AccountPage/Interests/CausePreferenceItem.js
+++ b/resources/assets/components/pages/AccountPage/Interests/CausePreferenceItem.js
@@ -2,8 +2,10 @@ import React from 'react';
 import { get } from 'lodash';
 import gql from 'graphql-tag';
 import PropTypes from 'prop-types';
-import classNames from 'classnames';
 import { useMutation, useQuery } from '@apollo/react-hooks';
+
+import Spinner from '../../../artifacts/Spinner/Spinner';
+import ToggleButton from '../../../utilities/Button/ToggleButton';
 
 const CAUSE_PREFERENCE_QUERY = gql`
   query CausePreferenceQuery($userId: String!) {
@@ -45,35 +47,32 @@ const CausePreferenceItem = ({ cause, description, title }) => {
   const causes = get(data, 'user.causes', []);
 
   return (
-    <div className="border border-solid border-gray-300 p-4 rounded-md flex justify-between">
+    <div className="border border-solid border-gray-300 p-4 rounded-md flex">
       <div className="w-2/3 lg:w-3/4 pr-4">
         <h1 className="text-blurple-500 text-base text-bold">{title}</h1>
+
         <p className="text-sm text-gray-500">{description}</p>
       </div>
+
       <div className="w-1/3 lg:w-1/4">
-        <button
-          type="button"
-          className={classNames(
-            'btn w-full border border-solid border-blurple-500 focus:outline-none',
-            !causes.includes(cause)
-              ? 'bg-blurple-500 text-white hover:bg-blurple-300 focus:bg-blurple-500 focus:text-white'
-              : 'bg-white border text-blurple-500 border-solid hover:border-blurple-300 hover:text-blurple-200 focus:bg-white focus:text-blurple-500',
-          )}
-          onClick={() =>
-            updateInterest({
-              variables: {
-                cause,
-                interested: !causes.includes(cause),
-              },
-            })
-          }
-        >
-          {!loading ? (
-            <>{causes.includes(cause) ? 'Unfollow' : ' Follow '}</>
-          ) : (
-            <div className="spinner" />
-          )}
-        </button>
+        {loading ? (
+          <Spinner className="flex justify-center p-2" />
+        ) : (
+          <ToggleButton
+            activateText="Follow"
+            className="w-full"
+            deactivateText="Unfollow"
+            isToggled={causes.includes(cause)}
+            onClick={() =>
+              updateInterest({
+                variables: {
+                  cause,
+                  interested: !causes.includes(cause),
+                },
+              })
+            }
+          />
+        )}
       </div>
     </div>
   );

--- a/resources/assets/components/pages/AccountPage/Interests/CausePreferenceItem.js
+++ b/resources/assets/components/pages/AccountPage/Interests/CausePreferenceItem.js
@@ -38,7 +38,10 @@ const CausePreferenceItem = ({ cause, description, title }) => {
 
   // Make the initial query to get the user's subscriptions
   const { data, loading, error } = useQuery(CAUSE_PREFERENCE_QUERY, options);
-  const [updateInterest] = useMutation(CAUSE_PREFERENCE_MUTATION, options);
+  const [updateInterest, { loading: modifying }] = useMutation(
+    CAUSE_PREFERENCE_MUTATION,
+    options,
+  );
 
   if (error) {
     return <p>Something went wrong!</p>;
@@ -62,6 +65,7 @@ const CausePreferenceItem = ({ cause, description, title }) => {
             activateText="Follow"
             className="w-full"
             deactivateText="Unfollow"
+            isDisabled={modifying}
             isToggled={causes.includes(cause)}
             onClick={() =>
               updateInterest({

--- a/resources/assets/components/pages/AccountPage/Interests/CausePreferenceItem.js
+++ b/resources/assets/components/pages/AccountPage/Interests/CausePreferenceItem.js
@@ -66,6 +66,7 @@ const CausePreferenceItem = ({ cause, description, title }) => {
             className="w-full"
             deactivateText="Unfollow"
             isDisabled={modifying}
+            isLoading={modifying}
             isToggled={causes.includes(cause)}
             onClick={() =>
               updateInterest({

--- a/resources/assets/components/pages/AccountPage/Interests/CausePreferences.js
+++ b/resources/assets/components/pages/AccountPage/Interests/CausePreferences.js
@@ -63,6 +63,7 @@ const CausePreferences = () => {
     <div className="gallery-grid gallery-grid-duo my-6 -mx-3">
       {Object.keys(causeItems).map(cause => (
         <CausePreferenceItem
+          key={`${cause.toLowerCase()}_item`}
           cause={cause}
           title={causeItems[cause].title}
           description={causeItems[cause].description}

--- a/resources/assets/components/pages/AccountPage/Subscriptions/EmailSubscriptionItem.js
+++ b/resources/assets/components/pages/AccountPage/Subscriptions/EmailSubscriptionItem.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import gql from 'graphql-tag';
 import { useQuery, useMutation } from '@apollo/react-hooks';
 
+import Spinner from '../../../artifacts/Spinner/Spinner';
 import ToggleButton from '../../../utilities/Button/ToggleButton';
 
 const EMAIL_SUBSCRIPTION_QUERY = gql`
@@ -35,17 +36,13 @@ const EmailSubscriptionItem = ({ topic, name, image, description }) => {
 
   // Make the initial query to get the user's subscriptions
   const { data, loading, error } = useQuery(EMAIL_SUBSCRIPTION_QUERY, options);
-  const [updateSubscription] = useMutation(
+  const [updateSubscription, { loading: modifying }] = useMutation(
     EMAIL_SUBSCRIPTION_MUTATION,
     options,
   );
 
   if (error) {
     return <p>Something went wrong!</p>;
-  }
-
-  if (loading) {
-    return <div className="spinner" />;
   }
 
   const topics = data.user.emailSubscriptionTopics;
@@ -64,20 +61,26 @@ const EmailSubscriptionItem = ({ topic, name, image, description }) => {
 
           <p className="flex-grow">{description}</p>
 
-          <ToggleButton
-            activateText="Subscribe"
-            deactivateText="Unsubscribe"
-            isToggled={topics.includes(topic)}
-            className="mt-4"
-            onClick={() =>
-              updateSubscription({
-                variables: {
-                  topic,
-                  subscribed: !topics.includes(topic),
-                },
-              })
-            }
-          />
+          {loading ? (
+            <Spinner className="flex justify-center p-2" />
+          ) : (
+            <ToggleButton
+              activateText="Subscribe"
+              deactivateText="Unsubscribe"
+              isDisabled={modifying}
+              isLoading={modifying}
+              isToggled={topics.includes(topic)}
+              className="mt-4"
+              onClick={() =>
+                updateSubscription({
+                  variables: {
+                    topic,
+                    subscribed: !topics.includes(topic),
+                  },
+                })
+              }
+            />
+          )}
         </div>
       </div>
     </div>

--- a/resources/assets/components/pages/AccountPage/Subscriptions/EmailSubscriptionItem.js
+++ b/resources/assets/components/pages/AccountPage/Subscriptions/EmailSubscriptionItem.js
@@ -53,7 +53,11 @@ const EmailSubscriptionItem = ({ topic, name, image, description }) => {
   return (
     <div className="card rounded border-solid border-2 border-gray-300">
       <div className="flex flex-col h-full">
-        <img style={{ width: '100%' }} src={image} alt="newsletter" />
+        <img
+          style={{ width: '100%' }}
+          src={image}
+          alt={`${name.toLowerCase()} newsletter logo`}
+        />
 
         <div className="p-4 flex flex-col flex-grow">
           <h3 className="text-base">{name}</h3>

--- a/resources/assets/components/pages/AccountPage/Subscriptions/EmailSubscriptionItem.js
+++ b/resources/assets/components/pages/AccountPage/Subscriptions/EmailSubscriptionItem.js
@@ -3,6 +3,8 @@ import PropTypes from 'prop-types';
 import gql from 'graphql-tag';
 import { useQuery, useMutation } from '@apollo/react-hooks';
 
+import ToggleButton from '../../../utilities/Button/ToggleButton';
+
 const EMAIL_SUBSCRIPTION_QUERY = gql`
   query EmailSubscriptionsQuery($userId: String!) {
     user(id: $userId) {
@@ -51,32 +53,28 @@ const EmailSubscriptionItem = ({ topic, name, image, description }) => {
   return (
     <div className="card rounded border-solid border-2 border-gray-300">
       <div className="flex flex-col h-full">
-        <img
-          className="pb-4"
-          style={{ width: '100%' }}
-          src={image}
-          alt="newsletter"
-        />
-        <h3 className="text-base px-4">{name}</h3>
-        <p className="pb-4 px-4 flex-grow">{description}</p>
-        <button
-          type="button"
-          className={
-            !topics.includes(topic)
-              ? 'btn mx-4 mb-4 bg-blurple-500 text-white border border-solid border-blurple-500 hover:bg-blurple-300 focus:bg-blurple-500 focus:text-white focus:outline-none'
-              : 'btn mx-4 mb-4 bg-white text-blurple-500 border border-solid border-blurple-500 hover:border-blurple-300 hover:text-blurple-200 focus:bg-white focus:text-blurple-500 focus:outline-none'
-          }
-          onClick={() =>
-            updateSubscription({
-              variables: {
-                topic,
-                subscribed: !topics.includes(topic),
-              },
-            })
-          }
-        >
-          {topics.includes(topic) ? 'Unsubscribe' : 'Subscribe'}
-        </button>
+        <img style={{ width: '100%' }} src={image} alt="newsletter" />
+
+        <div className="p-4 flex flex-col flex-grow">
+          <h3 className="text-base">{name}</h3>
+
+          <p className="flex-grow">{description}</p>
+
+          <ToggleButton
+            activateText="Subscribe"
+            deactivateText="Unsubscribe"
+            isToggled={topics.includes(topic)}
+            className="mt-4"
+            onClick={() =>
+              updateSubscription({
+                variables: {
+                  topic,
+                  subscribed: !topics.includes(topic),
+                },
+              })
+            }
+          />
+        </div>
       </div>
     </div>
   );

--- a/resources/assets/components/pages/CampaignsPage/FilterNavigation/FilterNavigation.js
+++ b/resources/assets/components/pages/CampaignsPage/FilterNavigation/FilterNavigation.js
@@ -35,8 +35,8 @@ const FilterNavigation = ({ filters, setFilters }) => {
 
   return (
     <div className="md:w-full bg-white">
-      <div className="flex items-center md:w-3/4 mx-auto pt-2 md:pt-0 pb-6 pl-6 md:pl-0">
-        <h2 className="text-gray-600 pr-4 text-base uppercase">Filters</h2>
+      <div className="flex items-center md:w-3/4 mx-auto pt-2 pb-6 pl-6 md:pl-0">
+        <h2 className="mb-0 pr-4 text-gray-600 text-base uppercase">Filters</h2>
 
         {filterCategoryNames.map(name => (
           <SecondaryButton

--- a/resources/assets/components/utilities/Button/PrimaryButton.js
+++ b/resources/assets/components/utilities/Button/PrimaryButton.js
@@ -34,8 +34,7 @@ const PrimaryButton = props => {
     'active:bg-blurple-700 focus:bg-blurple-400 hover:bg-blurple-400',
     'border-2 border-solid active:border-blurple-700 focus:border-blurple-400 hover:border-blurple-400 focus:rounded-none',
     'focus:outline-2 focus:outline-blurple-100 focus:outline-solid',
-    'text-base',
-    'text-white hover:text-white',
+    'text-base text-white hover:text-white',
     className,
   );
 

--- a/resources/assets/components/utilities/Button/SecondaryButton.js
+++ b/resources/assets/components/utilities/Button/SecondaryButton.js
@@ -32,10 +32,9 @@ const SecondaryButton = props => {
   const classes = classnames(
     baseClasses,
     'active:bg-gray-200',
-    'border-2 border-solid active:border-blurple-700 hover:border-blurple-300 focus:rounded-none',
+    'border-2 active:border-blurple-700 hover:border-blurple-300 border-solid focus:rounded-none',
     'focus:outline-2 focus:outline-blurple-100 focus:outline-solid',
-    'text-base',
-    'active:text-blurple-700 hover:text-blurple-300',
+    'text-base active:text-blurple-700 hover:text-blurple-300',
     className,
   );
 

--- a/resources/assets/components/utilities/Button/ToggleButton.js
+++ b/resources/assets/components/utilities/Button/ToggleButton.js
@@ -1,0 +1,67 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import classnames from 'classnames';
+
+import ElementButton from './ElementButton';
+
+const ToggleButton = props => {
+  const {
+    activateText,
+    className,
+    data,
+    deactivateText,
+    isDisabled,
+    onClick,
+    isToggled,
+    type,
+  } = props;
+
+  const activateClasses = classnames(
+    'bg-blurple-500 active:bg-blurple-700 focus:bg-blurple-400 hover:bg-blurple-400',
+    'border-2 border-solid border-blurple-500 active:border-blurple-700 focus:border-blurple-400 hover:border-blurple-400 focus:rounded-none',
+    'focus:outline-2 focus:outline-blurple-100 focus:outline-solid',
+    'text-base text-white hover:text-white',
+    className,
+  );
+
+  const deactivateClasses = classnames(
+    'bg-white active:bg-gray-200',
+    'border-2 border-blurple-500 active:border-blurple-700 hover:border-blurple-300 border-solid focus:rounded-none',
+    'focus:outline-2 focus:outline-blurple-100 focus:outline-solid',
+    'text-base text-blurple-500 active:text-blurple-700 hover:text-blurple-300',
+    className,
+  );
+
+  return (
+    <ElementButton
+      className={isToggled ? deactivateClasses : activateClasses}
+      data={data}
+      isDisabled={isDisabled}
+      onClick={onClick}
+      text={isToggled ? deactivateText : activateText}
+      type={type}
+    />
+  );
+};
+
+ToggleButton.propTypes = {
+  className: PropTypes.string,
+  activateText: PropTypes.string.isRequired,
+  data: PropTypes.object,
+  deactivateText: PropTypes.string.isRequired,
+  isDisabled: PropTypes.bool,
+  isToggled: PropTypes.bool,
+  onClick: PropTypes.func,
+  type: PropTypes.oneOf(['button', 'submit', 'reset']),
+};
+
+ToggleButton.defaultProps = {
+  className: null,
+  data: {},
+  isDisabled: false,
+  isToggled: false,
+  onClick: null,
+  type: 'button',
+};
+
+export default ToggleButton;

--- a/resources/assets/components/utilities/Button/ToggleButton.js
+++ b/resources/assets/components/utilities/Button/ToggleButton.js
@@ -11,8 +11,9 @@ const ToggleButton = props => {
     data,
     deactivateText,
     isDisabled,
-    onClick,
+    isLoading,
     isToggled,
+    onClick,
     type,
   } = props;
 
@@ -22,6 +23,7 @@ const ToggleButton = props => {
     'focus:outline-2 focus:outline-blurple-100 focus:outline-solid',
     'text-base text-white hover:text-white',
     className,
+    { 'is-loading': isLoading },
   );
 
   const deactivateClasses = classnames(
@@ -30,6 +32,7 @@ const ToggleButton = props => {
     'focus:outline-2 focus:outline-blurple-100 focus:outline-solid',
     'text-base text-blurple-500 active:text-blurple-700 hover:text-blurple-300',
     className,
+    { 'is-loading': isLoading },
   );
 
   return (
@@ -50,6 +53,7 @@ ToggleButton.propTypes = {
   data: PropTypes.object,
   deactivateText: PropTypes.string.isRequired,
   isDisabled: PropTypes.bool,
+  isLoading: PropTypes.bool,
   isToggled: PropTypes.bool,
   onClick: PropTypes.func,
   type: PropTypes.oneOf(['button', 'submit', 'reset']),
@@ -59,6 +63,7 @@ ToggleButton.defaultProps = {
   className: null,
   data: {},
   isDisabled: false,
+  isLoading: false,
   isToggled: false,
   onClick: null,
   type: 'button',

--- a/resources/assets/scss/base.scss
+++ b/resources/assets/scss/base.scss
@@ -35,6 +35,10 @@ $forge-path: '../../../node_modules/@dosomething/forge/assets/';
   color: theme('colors.gray.100') !important;
 }
 
+.btn.is-loading:disabled {
+  @apply cursor-wait;
+}
+
 // @TODO:forge-removal Rename this class to "text-field".
 .text-input {
   @apply bg-white p-3 border border-gray-200 border-solid font-source-sans rounded;


### PR DESCRIPTION
### What's this PR do?

This pull request continues the button updates on Phoenix. 

Specifically it adds a new `ToggleButton` that visually looks like a combination of the `PrimaryButton` and `SecondaryButton` (styling is subject to change) but behaves differently; it is meant to be entirely a toggle that "activate" or "deactivates" a setting with a very distinct visual style and language to represent "on" and "off". Example usage would be subscribe/unsubscribe from newsletters or follow/unfollow cause interests.

GIF example for email subscriptions:
![ToggleButton Email Subscriptions](https://user-images.githubusercontent.com/105849/80031530-d5daf680-84b7-11ea-8161-72ad0b528919.gif)

Image example with cause preferences:
![image](https://user-images.githubusercontent.com/105849/80039638-3bce7a80-84c6-11ea-9588-f657d23725cb.png)

The above sections now both utilize the `ToggleButton` and it contains all the expected :hover, :focus, active styles including the different styles based on whether the button is toggled "on" or "off".

### How should this be reviewed?

👀 

### Relevant tickets

References [Pivotal #172184401](https://www.pivotaltracker.com/story/show/172184401).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [x] Added screenshots of front-end changes on small, medium, and large screens.