### PR TITLE
Adds new CallToActionBlock

### DIFF
--- a/app/Entities/Entity.php
+++ b/app/Entities/Entity.php
@@ -79,7 +79,7 @@ class Entity implements ArrayAccess, JsonSerializable
             case 'storyPage':
                 return new TruncatedStoryPage($block->entry);
             default:
-                return ['id' => $block->entry->getId()];
+                return ['id' => $block->entry->getId(), 'type' => $block->getContentType()];
         }
     }
 

--- a/resources/assets/components/ContentfulEntry/ContentfulEntry.js
+++ b/resources/assets/components/ContentfulEntry/ContentfulEntry.js
@@ -9,11 +9,11 @@ import ContentBlock from '../blocks/ContentBlock/ContentBlock';
 import GalleryBlock from '../blocks/GalleryBlock/GalleryBlock';
 import SectionBlock from '../blocks/SectionBlock/SectionBlock';
 import AffirmationContainer from '../Affirmation/AffirmationContainer';
-import CallToActionContainer from '../CallToAction/CallToActionContainer';
 import { parseContentfulType, report, withoutNulls } from '../../helpers';
 import EmbedBlockContainer from '../blocks/EmbedBlock/EmbedBlockContainer';
 import LinkActionContainer from '../actions/LinkAction/LinkActionContainer';
 import LandingPageContainer from '../pages/LandingPage/LandingPageContainer';
+import CallToActionBlock from '../blocks/CallToActionBlock/CallToActionBlock';
 import ShareActionContainer from '../actions/ShareAction/ShareActionContainer';
 import CampaignDashboard from '../utilities/CampaignDashboard/CampaignDashboard';
 import SixpackExperiment from '../utilities/SixpackExperiment/SixpackExperiment';
@@ -65,18 +65,9 @@ class ContentfulEntry extends React.Component {
           />
         );
 
+      case 'callToAction':
       case 'CallToActionBlock':
-        return (
-          <CallToActionContainer
-            actionText={json.actionText}
-            content={json.content}
-            impactPrefix={json.impactPrefix}
-            impactSuffix={json.impactSuffix}
-            impactValue={json.impactValue}
-            visualStyle={json.visualStyle.toLowerCase()}
-            useCampaignTagline={json.useCampaignTagline}
-          />
-        );
+        return <CallToActionBlock {...withoutNulls(json)} />;
 
       // Note: This is loaded via legacy PHP Content API.
       case 'campaignDashboard':

--- a/resources/assets/components/ContentfulEntry/ContentfulEntry.test.js
+++ b/resources/assets/components/ContentfulEntry/ContentfulEntry.test.js
@@ -35,7 +35,7 @@ test('it can display a CTA block', () => {
       }}
     />,
   );
-  expect(wrapper.find('CallToActionContainer')).toHaveLength(1);
+  expect(wrapper.find('CallToActionBlock')).toHaveLength(1);
 });
 
 test('it should display an error for an unknown block type', () => {

--- a/resources/assets/components/blocks/CallToActionBlock/CallToActionBlock.js
+++ b/resources/assets/components/blocks/CallToActionBlock/CallToActionBlock.js
@@ -119,10 +119,13 @@ const CallToActionBlock = ({ id }) => {
         <h3 className="text-m font-source-sans font-bold uppercase">
           {superTitle}
         </h3>
+
         <h2 className="text-4xl font-league-gothic font-bold uppercase">
           {title}
         </h2>
+
         <p className="text-lg pb-4">{content}</p>
+
         <PrimaryButton href={link} text={linkText} />
       </div>
     </div>

--- a/resources/assets/components/blocks/CallToActionBlock/CallToActionBlock.js
+++ b/resources/assets/components/blocks/CallToActionBlock/CallToActionBlock.js
@@ -1,12 +1,12 @@
 import React from 'react';
+import { get } from 'lodash';
 import gql from 'graphql-tag';
 import PropTypes from 'prop-types';
 import { css } from '@emotion/core';
 import { useQuery } from '@apollo/react-hooks';
 
 import { tailwind } from '../../../helpers';
-
-const { get } = require('lodash');
+import Spinner from '../../artifacts/Spinner/Spinner';
 
 const CALL_TO_ACTION_QUERY = gql`
   query CallToActionBlockQuery($id: String!) {
@@ -35,7 +35,7 @@ const CallToActionBlock = ({ id }) => {
   }
 
   if (loading) {
-    return <div className="spinner" />;
+    return <Spinner className="flex justify-center p-2" />;
   }
 
   const {
@@ -113,23 +113,21 @@ const CallToActionBlock = ({ id }) => {
   const alignmentStyles = get(alignmentObject, alignment, 'CENTER');
 
   return (
-    <div css={[templateStyles, alignmentStyles]}>
-      <div className="base-12-grid">
-        <div className="grid-narrow my-8">
-          <h3 className="text-m font-source-sans font-bold uppercase">
-            {superTitle}
-          </h3>
-          <h2 className="text-4xl font-league-gothic font-bold uppercase">
-            {title}
-          </h2>
-          <p className="text-lg pb-4">{content}</p>
-          <a
-            href={link}
-            className="btn bg-blurple-500 text-white text-lg border border-solid border-blurple-500 hover:bg-blurple-300 hover:border-blurple-300 focus:bg-blurple-500 focus:text-white focus:outline-none"
-          >
-            {linkText}
-          </a>
-        </div>
+    <div className="base-12-grid" css={[templateStyles, alignmentStyles]}>
+      <div className="grid-narrow my-8">
+        <h3 className="text-m font-source-sans font-bold uppercase">
+          {superTitle}
+        </h3>
+        <h2 className="text-4xl font-league-gothic font-bold uppercase">
+          {title}
+        </h2>
+        <p className="text-lg pb-4">{content}</p>
+        <a
+          href={link}
+          className="btn bg-blurple-500 text-white text-lg border border-solid border-blurple-500 hover:bg-blurple-300 hover:border-blurple-300 focus:bg-blurple-500 focus:text-white focus:outline-none"
+        >
+          {linkText}
+        </a>
       </div>
     </div>
   );

--- a/resources/assets/components/blocks/CallToActionBlock/CallToActionBlock.js
+++ b/resources/assets/components/blocks/CallToActionBlock/CallToActionBlock.js
@@ -1,0 +1,142 @@
+import React from 'react';
+import gql from 'graphql-tag';
+import PropTypes from 'prop-types';
+import { css } from '@emotion/core';
+import { useQuery } from '@apollo/react-hooks';
+
+import { tailwind } from '../../../helpers';
+
+const { get } = require('lodash');
+
+const CALL_TO_ACTION_QUERY = gql`
+  query CallToActionBlockQuery($id: String!) {
+    block(id: $id) {
+      id
+      ... on CallToActionBlock {
+        superTitle
+        title
+        content
+        linkText
+        link
+        template
+        alignment
+      }
+    }
+  }
+`;
+
+const CallToActionBlock = ({ id }) => {
+  const { data, loading, error } = useQuery(CALL_TO_ACTION_QUERY, {
+    variables: { id },
+  });
+
+  if (error) {
+    return <p>Something went wrong!</p>;
+  }
+
+  if (loading) {
+    return <div className="spinner" />;
+  }
+
+  const {
+    superTitle,
+    title,
+    content,
+    linkText,
+    link,
+    template,
+    alignment,
+  } = data.block;
+
+  const tailwindPurple = tailwind('colors.purple');
+  const tailwindYellow = tailwind('colors.yellow');
+
+  const purpleStyleSet = css`
+    background-color: ${tailwindPurple['700']};
+
+    h2,
+    p {
+      color: white;
+    }
+
+    h3 {
+      color: ${tailwindYellow['500']};
+    }
+  `;
+
+  const yellowStyleSet = css`
+    background-color: ${tailwindYellow['500']};
+
+    h2,
+    h3,
+    p {
+      color: black;
+    }
+  `;
+
+  const voterRegStyleSet = css`
+    background-color: #000047;
+
+    h2 {
+      color: #00ff75;
+    }
+
+    h3 {
+      color: ${tailwindYellow['500']};
+    }
+
+    p {
+      color: white;
+    }
+  `;
+
+  const leftAlignment = css`
+    text-align: left;
+  `;
+
+  const centerAlignment = css`
+    text-align: center;
+  `;
+
+  const styleObject = {
+    PURPLE: purpleStyleSet,
+    YELLOW: yellowStyleSet,
+    VOTER_REGISTRATION: voterRegStyleSet,
+  };
+
+  const alignmentObject = {
+    LEFT: leftAlignment,
+    CENTER: centerAlignment,
+  };
+
+  const templateStyles = get(styleObject, template, 'PURPLE');
+  const alignmentStyles = get(alignmentObject, alignment, 'CENTER');
+
+  return (
+    <div css={[templateStyles, alignmentStyles]}>
+      <div className="base-12-grid">
+        <div className="grid-narrow my-8">
+          <h3 className="text-m font-source-sans font-bold uppercase">
+            {superTitle}
+          </h3>
+          <h2 className="text-4xl font-league-gothic font-bold uppercase">
+            {title}
+          </h2>
+          <p className="text-lg pb-4">{content}</p>
+          <a
+            href={link}
+            className="btn bg-blurple-500 text-white text-lg border border-solid border-blurple-500 hover:bg-blurple-300 hover:border-blurple-300 focus:bg-blurple-500 focus:text-white focus:outline-none"
+          >
+            {linkText}
+          </a>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+CallToActionBlock.propTypes = {
+  id: PropTypes.string.isRequired,
+};
+
+export default CallToActionBlock;

--- a/resources/assets/components/blocks/CallToActionBlock/CallToActionBlock.js
+++ b/resources/assets/components/blocks/CallToActionBlock/CallToActionBlock.js
@@ -7,6 +7,7 @@ import { useQuery } from '@apollo/react-hooks';
 
 import { tailwind } from '../../../helpers';
 import Spinner from '../../artifacts/Spinner/Spinner';
+import PrimaryButton from '../../utilities/Button/PrimaryButton';
 
 const CALL_TO_ACTION_QUERY = gql`
   query CallToActionBlockQuery($id: String!) {
@@ -122,12 +123,7 @@ const CallToActionBlock = ({ id }) => {
           {title}
         </h2>
         <p className="text-lg pb-4">{content}</p>
-        <a
-          href={link}
-          className="btn bg-blurple-500 text-white text-lg border border-solid border-blurple-500 hover:bg-blurple-300 hover:border-blurple-300 focus:bg-blurple-500 focus:text-white focus:outline-none"
-        >
-          {linkText}
-        </a>
+        <PrimaryButton href={link} text={linkText} />
       </div>
     </div>
   );

--- a/resources/assets/components/utilities/ContentfulEntryLoader/ContentfulEntryLoader.js
+++ b/resources/assets/components/utilities/ContentfulEntryLoader/ContentfulEntryLoader.js
@@ -17,7 +17,6 @@ import { LinkBlockFragment } from '../../actions/LinkAction/LinkAction';
 import { AffirmationBlockFragment } from '../../Affirmation/Affirmation';
 import { ImagesBlockFragment } from '../../blocks/ImagesBlock/ImagesBlock';
 import { ShareBlockFragment } from '../../actions/ShareAction/ShareAction';
-import { CallToActionBlockFragment } from '../../CallToAction/CallToAction';
 import { GalleryBlockFragment } from '../../blocks/GalleryBlock/GalleryBlock';
 import { ContentBlockFragment } from '../../blocks/ContentBlock/ContentBlock';
 import { CampaignDashboardFragment } from '../CampaignDashboard/CampaignDashboard';
@@ -69,9 +68,6 @@ const CONTENTFUL_BLOCK_QUERY = gql`
       ... on PostGalleryBlock {
         ...PostGalleryBlockFragment
       }
-      ... on CallToActionBlock {
-        ...CallToActionBlockFragment
-      }
       ... on CampaignDashboard {
         ...CampaignDashboardFragment
       }
@@ -113,7 +109,6 @@ const CONTENTFUL_BLOCK_QUERY = gql`
   ${AffirmationBlockFragment}
   ${SocialDriveBlockFragment}
   ${PostGalleryBlockFragment}
-  ${CallToActionBlockFragment}
   ${CampaignDashboardFragment}
   ${CurrentSchoolBlockFragment}
   ${CampaignUpdateBlockFragment}


### PR DESCRIPTION
### What's this PR do?

This PR refactors the Call to Action block in a number of ways:
- It has a new visual styles and layout, controlled with some new fields on the Content Type
- It bypasses the Contentful Entry Loader and queries graphql for it's content inside the component itself.

#### Things to do before deploy
- Finish migrating new content type to master
- Deploy new GraphQL schema

### How should this be reviewed?

Use the test app or pull down to create new CTA blocks

### Any background context you want to provide?

This is one of three new Contentful blocks in development that will be used for premiere marketing pages

### Relevant tickets

References [Pivotal #172203389](https://www.pivotaltracker.com/n/projects/2328687/stories/172203389).

![Screenshot_2020-04-27 Dave's Test Page](https://user-images.githubusercontent.com/1865372/80390876-0a193300-887b-11ea-8a4c-506c4a6daf1f.jpg)
<img width="1377" alt="Screen Shot 2020-04-27 at 11 35 29 AM" src="https://user-images.githubusercontent.com/1865372/80391076-42b90c80-887b-11ea-859e-f0a0816b8ff9.png">
<img width="1337" alt="Screen Shot 2020-04-27 at 11 35 40 AM" src="https://user-images.githubusercontent.com/1865372/80391087-464c9380-887b-11ea-9950-28bafca27ed0.png">


