### PR TITLE
Fix for filter navigation clear button.

### DIFF
--- a/resources/assets/components/pages/CampaignsPage/CampaignFilters/CauseFilter/CauseFilter.js
+++ b/resources/assets/components/pages/CampaignsPage/CampaignFilters/CauseFilter/CauseFilter.js
@@ -2,53 +2,65 @@ import React from 'react';
 import { get } from 'lodash';
 import PropTypes from 'prop-types';
 
+import ElementButton from '../../../../utilities/Button/ElementButton';
 import {
   EVENT_CATEGORIES,
   trackAnalyticsEvent,
 } from '../../../../../helpers/analytics';
 
-const CauseInput = ({ causeChecked, causeName, causeValue, handleSelect }) => (
-  <label className="flex justify-start pb-2" htmlFor={causeValue}>
+const causeLabels = {
+  'animal-welfare': 'Animal Welfare',
+  bullying: 'Bullying',
+  education: 'Education',
+  environment: 'Environment',
+  'gender-rights': 'Gender Rights & Equality',
+  'homelessness-and-poverty': 'Homelessness & Poverty',
+  immigration: 'Immigration & Refugees',
+  'lgbtq-rights': 'LGBTQ+ Rights & Equality',
+  'mental-health': 'Mental Health',
+  'physical-health': 'Physical Health',
+  'racial-justice': 'Racial Justice & Equity',
+  'sexual-harassment': 'Sexual Harassment & Assault',
+};
+
+/**
+ * Checkbox input component.
+ *
+ * @param {Object}
+ */
+const CauseInput = ({ causeName, causeValue, handleSelect, isChecked }) => (
+  <label className="flex items-start justify-start pb-2" htmlFor={causeValue}>
     <input
-      name={causeValue}
       id={causeValue}
+      checked={isChecked}
+      className="mt-1"
+      name={causeValue}
+      onChange={handleSelect}
       type="checkbox"
       value={causeValue}
-      onClick={handleSelect}
-      defaultChecked={causeChecked}
     />
     <span className="pl-4">{causeName}</span>
   </label>
 );
 
 CauseInput.propTypes = {
-  causeChecked: PropTypes.bool,
+  isChecked: PropTypes.bool,
   causeName: PropTypes.string.isRequired,
   causeValue: PropTypes.string.isRequired,
   handleSelect: PropTypes.func.isRequired,
 };
 
 CauseInput.defaultProps = {
-  causeChecked: false,
+  isChecked: false,
 };
 
+/**
+ * Filter menu form with series of checkbox inputs.
+ *
+ * @param {Object}
+ */
 const CauseFilter = ({ filters, setFilters }) => {
   const causes = get(filters, 'causes', []);
-
-  const causeLabels = {
-    'animal-welfare': 'Animal Welfare',
-    bullying: 'Bullying',
-    education: 'Education',
-    environment: 'Environment',
-    'gender-rights': 'Gender Rights & Equality',
-    'homelessness-and-poverty': 'Homelessness & Poverty',
-    immigration: 'Immigration & Refugees',
-    'lgbtq-rights': 'LGBTQ+ Rights & Equality',
-    'mental-health': 'Mental Health',
-    'physical-health': 'Physical Health',
-    'racial-justice': 'Racial Justice & Equity',
-    'sexual-harassment': 'Sexual Harassment & Assault',
-  };
 
   const handleCauseSelect = event => {
     trackAnalyticsEvent('clicked_filter_options_cause', {
@@ -74,6 +86,7 @@ const CauseFilter = ({ filters, setFilters }) => {
       category: EVENT_CATEGORIES.filter,
       label: 'cause',
     });
+
     if (causes) {
       setFilters({ causes: [] });
     }
@@ -89,19 +102,18 @@ const CauseFilter = ({ filters, setFilters }) => {
               handleSelect={handleCauseSelect}
               causeName={causeLabels[cause]}
               causeValue={cause}
-              causeChecked={causes.includes(cause)}
+              isChecked={causes.includes(cause)}
             />
           );
         })}
       </div>
+
       <div className="w-full flex justify-start py-2 px-4">
-        <button
-          className="pr-6 focus:outline-none"
+        <ElementButton
+          className="font-bold p-2 text-blue-500 hover:text-blue-300"
+          text="clear"
           onClick={clearAllSelected}
-          type="button"
-        >
-          <p className="font-bold text-blue-500">clear</p>
-        </button>
+        />
       </div>
     </form>
   );

--- a/resources/assets/scss/base.scss
+++ b/resources/assets/scss/base.scss
@@ -17,7 +17,7 @@ $forge-path: '../../../node_modules/@dosomething/forge/assets/';
 
 // @TODO:forge-removal Rename this class to "button".
 .btn {
-  @apply cursor-pointer font-bold font-source-sans inline-block no-underline py-3 px-4 rounded text-center text-white outline-none;
+  @apply cursor-pointer font-bold font-source-sans inline-block no-underline py-3 px-4 rounded text-base text-center text-white outline-none;
 }
 
 .btn:active {
@@ -25,7 +25,7 @@ $forge-path: '../../../node_modules/@dosomething/forge/assets/';
 }
 
 .btn:hover {
-  @apply text-white no-underline;
+  @apply cursor-pointer text-white no-underline;
 }
 
 .btn:disabled {


### PR DESCRIPTION
### What's this PR do?

This pull request resolves a bug that was introduced in [#2048](https://github.com/DoSomething/phoenix-next/pull/2048/files#diff-02a27f20fa3f7ba1788718a9c7ebed90R18), which cause the React component to no longer handle the state changes and caused problems with not allowing to clear the checked items when clicking the "clear" button.

In that PR the `checked` attribute was changed to `defaultChecked` to deal with a console error that was popping up. While it resolved the error, that change converted the form from a controlled component to an uncontrolled one.

Resolving this bug simply involved switching back to using `checked` and changing the `onClick` handler to `onChange` which is the handle form inputs are meant to use.

Also took the opportunity for further cleanup and changing the "clear" button to use `ElementButton`!

### How should this be reviewed?

👀 

### Relevant tickets

References [Pivotal #172184401](https://www.pivotaltracker.com/story/show/172184401).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
