### PR TITLE
Changes URL to /my-voter-registration-drive

### DIFF
--- a/resources/assets/components/App.js
+++ b/resources/assets/components/App.js
@@ -82,12 +82,8 @@ const App = ({ store, history }) => {
             />
             <Route path="/us/join" component={BetaReferralPage} />
             <Route
-              path="/us/members/:userId/voter-registration-drive"
-              render={routeProps => (
-                <VoterRegistrationDrivePage
-                  userId={routeProps.match.params.userId}
-                />
-              )}
+              path="/us/my-voter-registration-drive"
+              component={VoterRegistrationDrivePage}
             />
             <Route
               path="/us/refer-friends"

--- a/resources/assets/components/pages/VoterRegistrationDrivePage/VoterRegistrationDrivePage.js
+++ b/resources/assets/components/pages/VoterRegistrationDrivePage/VoterRegistrationDrivePage.js
@@ -6,6 +6,7 @@ import ErrorPage from '../ErrorPage';
 import { query } from '../../../helpers';
 import NotFoundPage from '../NotFoundPage';
 import Placeholder from '../../utilities/Placeholder';
+import VoterRegistrationFaq from './VoterRegistrationFaq';
 import ButtonLink from '../../utilities/ButtonLink/ButtonLink';
 import SiteFooter from '../../utilities/SiteFooter/SiteFooter';
 import ContentBlock from '../../blocks/ContentBlock/ContentBlock';
@@ -107,20 +108,7 @@ const VoterRegistrationDrivePage = () => {
               </ButtonLink>
             </div>
             <div className="pb-6">
-              <h1 className="section-header__title font-normal font-league-gothic uppercase text-4xl -underlined pb-3">
-                Learn The Facts
-              </h1>
-              <ul>
-                {/* These will eventually expand/collapse with more information. */}
-                <li>Does my vote actually matter?</li>
-                <li>Is registering to vote online safe?</li>
-                <li>Am I registered to vote?</li>
-                <li>I’m not 18. Can I still register to vote?</li>
-                <li>Can I register to vote without a driver’s license?</li>
-                <li>How do I vote if I’m at college in a different state?</li>
-                <li>When are my elections?</li>
-                <li>Where can I find more information?</li>
-              </ul>
+              <VoterRegistrationFaq />
             </div>
             <ContentBlock
               superTitle="Step 2"

--- a/resources/assets/components/pages/VoterRegistrationDrivePage/VoterRegistrationDrivePage.js
+++ b/resources/assets/components/pages/VoterRegistrationDrivePage/VoterRegistrationDrivePage.js
@@ -13,9 +13,9 @@ import ContentBlock from '../../blocks/ContentBlock/ContentBlock';
 import CampaignInfoBlock from '../../blocks/CampaignInfoBlock/CampaignInfoBlock';
 import SiteNavigationContainer from '../../SiteNavigation/SiteNavigationContainer';
 
-const VOTER_REGISTRATION_DRIVE_PAGE_USER_QUERY = gql`
-  query VoterRegistrationDrivePageUserQuery($id: String!) {
-    user(id: $id) {
+const VOTER_REGISTRATION_DRIVE_PAGE_REFERRER_USER_QUERY = gql`
+  query VoterRegistrationDrivePageReffererUserQuery($referrerUserId: String!) {
+    user(id: $referrerUserId) {
       id
       firstName
     }
@@ -23,16 +23,16 @@ const VOTER_REGISTRATION_DRIVE_PAGE_USER_QUERY = gql`
 `;
 
 const VoterRegistrationDrivePage = () => {
-  const userId = query('referrer_user_id');
+  const referrerUserId = query('referrer_user_id');
 
-  if (!userId) {
+  if (!referrerUserId) {
     return <NotFoundPage />;
   }
 
   const { loading, error, data } = useQuery(
-    VOTER_REGISTRATION_DRIVE_PAGE_USER_QUERY,
+    VOTER_REGISTRATION_DRIVE_PAGE_REFERRER_USER_QUERY,
     {
-      variables: { id: userId },
+      variables: { referrerUserId },
     },
   );
 
@@ -102,7 +102,7 @@ const VoterRegistrationDrivePage = () => {
             <div className="pb-6">
               {/* We will eventually want to add form fields for email and zip, and send as query parameters to Rock the Vote */}
               <ButtonLink
-                link={`https://register.rockthevote.com/registrants/new?partner=37187&source=user:${userId},source:web,source_details:onlinedrivereferral,referral=true`}
+                link={`https://register.rockthevote.com/registrants/new?partner=37187&source=user:${referrerUserId},source:web,source_details:onlinedrivereferral,referral=true`}
               >
                 Register To Vote
               </ButtonLink>

--- a/resources/assets/components/pages/VoterRegistrationDrivePage/VoterRegistrationDrivePage.js
+++ b/resources/assets/components/pages/VoterRegistrationDrivePage/VoterRegistrationDrivePage.js
@@ -1,9 +1,9 @@
 import React from 'react';
 import gql from 'graphql-tag';
-import PropTypes from 'prop-types';
 import { useQuery } from '@apollo/react-hooks';
 
 import ErrorPage from '../ErrorPage';
+import { query } from '../../../helpers';
 import NotFoundPage from '../NotFoundPage';
 import Placeholder from '../../utilities/Placeholder';
 import ButtonLink from '../../utilities/ButtonLink/ButtonLink';
@@ -21,7 +21,13 @@ const VOTER_REGISTRATION_DRIVE_PAGE_USER_QUERY = gql`
   }
 `;
 
-const VoterRegistrationDrivePage = ({ userId }) => {
+const VoterRegistrationDrivePage = () => {
+  const userId = query('referrer_user_id');
+
+  if (!userId) {
+    return <NotFoundPage />;
+  }
+
   const { loading, error, data } = useQuery(
     VOTER_REGISTRATION_DRIVE_PAGE_USER_QUERY,
     {
@@ -130,10 +136,6 @@ const VoterRegistrationDrivePage = ({ userId }) => {
       <SiteFooter />
     </>
   );
-};
-
-VoterRegistrationDrivePage.propTypes = {
-  userId: PropTypes.string.isRequired,
 };
 
 export default VoterRegistrationDrivePage;

--- a/resources/assets/components/pages/VoterRegistrationDrivePage/VoterRegistrationFaq.js
+++ b/resources/assets/components/pages/VoterRegistrationDrivePage/VoterRegistrationFaq.js
@@ -1,0 +1,22 @@
+import React from 'react';
+
+const VoterRegistrationFaq = () => (
+  <React.Fragment>
+    <h1 className="section-header__title font-normal font-league-gothic uppercase text-4xl -underlined pb-3">
+      Learn The Facts
+    </h1>
+    <ul>
+      {/* These will eventually expand/collapse with more information. */}
+      <li>Does my vote actually matter?</li>
+      <li>Is registering to vote online safe?</li>
+      <li>Am I registered to vote?</li>
+      <li>I’m not 18. Can I still register to vote?</li>
+      <li>Can I register to vote without a driver’s license?</li>
+      <li>How do I vote if I’m at college in a different state?</li>
+      <li>When are my elections?</li>
+      <li>Where can I find more information?</li>
+    </ul>
+  </React.Fragment>
+);
+
+export default VoterRegistrationFaq;

--- a/routes/web.php
+++ b/routes/web.php
@@ -75,6 +75,9 @@ $router->view('us/refer-friends', 'app')
 // Blocks
 $router->view('us/blocks/{id}', 'app');
 
+// Voter Registration Drives
+$router->view('us/my-voter-registration-drive', 'app');
+
 // Pages
 $router->get('us/{slug}', 'PageController@show');
 $router->get('{slug}', function ($slug) {
@@ -89,9 +92,6 @@ $router->view('us/collections/{slug}', 'app');
 
 // Cache
 $router->get('cache/{cacheId}', 'CacheController');
-
-// Voter Registration Drives
-$router->view('us/members/{userId}/voter-registration-drive', 'app');
 
 // Unknown Route Fallback
 // Ensures we run through web middleware when rendering 404 pages.


### PR DESCRIPTION
### What's this PR do?

This pull request changes the URL of the skeleton beta voter registration drive page introduced in #2028 to `/us/my-voter-registration-drive` per request in [Slack thread](https://dosomething.slack.com/archives/CTVPG6L4R/p1587677468112600?thread_ts=1587480084.014100&cid=CTVPG6L4R), checking for a `referrer_user_id` query parameter instead of a route parameter.

Example URL:
```
http://phoenix.test/us/my-voter-registration-drive?referrer_user_id=55767606a59dbf3c7a8b4571
```

### How should this be reviewed?

👀 

### Any background context you want to provide?

Also moves the FAQ section into a different component to make it easier to split out the work amongst the team.

### Relevant tickets

References [Pivotal #]().

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added screenshots of front-end changes on small, medium, and large screens.
- [ ] Added appropriate feature/unit tests.
