### PR TITLE
POC - Volunteer Credit Certificate Download Imperative flow

### DIFF
--- a/resources/assets/components/pages/AccountPage/Credits/CertificateDownloadButton.js
+++ b/resources/assets/components/pages/AccountPage/Credits/CertificateDownloadButton.js
@@ -13,15 +13,19 @@ const CertificateDownloadButton = ({ certificatePost }) => {
     if (!isPdfGenerated) {
       setIsPdfGenerated(true);
 
-      pdf(<CertificateTemplate certificatePost={certificatePost} />)
-        .toBlob()
-        .then(blob => {
-          pdfLink.current.href = URL.createObjectURL(blob);
-          pdfLink.current.click();
-        })
-        .catch(error => {
-          console.error(error);
-        });
+      try {
+        pdf(<CertificateTemplate certificatePost={certificatePost} />)
+          .toBlob()
+          .then(blob => {
+            pdfLink.current.href = URL.createObjectURL(blob);
+            pdfLink.current.click();
+          })
+          .catch(error => {
+            console.error(error);
+          });
+      } catch (error) {
+        console.error(error);
+      }
     }
   };
 

--- a/resources/assets/components/pages/AccountPage/Credits/CertificateDownloadButton.js
+++ b/resources/assets/components/pages/AccountPage/Credits/CertificateDownloadButton.js
@@ -6,19 +6,19 @@ import CertificateTemplate, {
 } from './CertificateTemplate';
 
 const CertificateDownloadButton = ({ certificatePost }) => {
-  const [isPdfGenerated, setIsPdfGenerated] = useState(false);
+  const [hasGeneratedPdf, setHasgeneratedPdf] = useState(false);
   const pdfLink = useRef(null);
 
   const handleClick = () => {
-    if (!isPdfGenerated) {
-      setIsPdfGenerated(true);
-
+    if (!hasGeneratedPdf) {
       try {
         pdf(<CertificateTemplate certificatePost={certificatePost} />)
           .toBlob()
           .then(blob => {
             pdfLink.current.href = URL.createObjectURL(blob);
             pdfLink.current.click();
+
+            setHasgeneratedPdf(true);
           })
           .catch(error => {
             console.error(error);
@@ -46,7 +46,7 @@ const CertificateDownloadButton = ({ certificatePost }) => {
       download="certa.pdf"
       ref={pdfLink}
       className="btn w-full py-4 text-lg bg-blue-500 hover:bg-blue-300"
-      onClick={() => handleClick()}
+      onClick={handleClick}
     >
       Download
     </a>

--- a/resources/assets/components/pages/AccountPage/Credits/CertificateDownloadButton.js
+++ b/resources/assets/components/pages/AccountPage/Credits/CertificateDownloadButton.js
@@ -1,30 +1,48 @@
 import React from 'react';
-import classNames from 'classnames';
-import { PDFDownloadLink } from '@react-pdf/renderer';
+import { pdf } from '@react-pdf/renderer';
 
 import CertificateTemplate, {
   certificatePostType,
 } from './CertificateTemplate';
 
-// The certificate PDF Download button with pending/ready state.
-const buttonClassNames = 'btn w-full py-4 text-lg';
-const CertificateDownloadButton = ({ certificatePost }) =>
-  certificatePost.pending ? (
-    <button type="button" disabled className={buttonClassNames}>
-      Pending
-    </button>
-  ) : (
-    <PDFDownloadLink
-      document={<CertificateTemplate certificatePost={certificatePost} />}
-      fileName="dosomething-volunteer-credit-certificate.pdf"
-      className={classNames(
-        buttonClassNames,
-        'bg-blue-500 hover:bg-blue-300 hover:no-underline hover:text-white',
-      )}
+const CertificateDownloadButton = ({ certificatePost }) => {
+  const handleClick = () => {
+    // Render the certificate template as a PDF in Blob data form.
+    pdf(<CertificateTemplate certificatePost={certificatePost} />)
+      .toBlob()
+      .then(blob => {
+        // Create a phantom <a> tag to download the certificate for the user.
+        const phantomDownloadLink = document.createElement('a');
+        // Assign the generated PDF blob data as the download link.
+        phantomDownloadLink.href = URL.createObjectURL(blob);
+        // Assign the certificate file name.
+        phantomDownloadLink.download =
+          // @TODO: Update filename to include campaign title and exclude 'credit'.
+          'dosomething-volunteer-credit-certificate.pdf';
+
+        // 'Click' the link to trigger the download.
+        phantomDownloadLink.click();
+      })
+      .catch(() => {
+        // Report error, update button error state.
+      });
+  };
+
+  const { pending } = certificatePost;
+
+  // @TODO Handle loading and error state.
+  return (
+    // @TODO: Use one of our in-house button components.
+    <button
+      type="button"
+      disabled={pending}
+      className="btn w-full py-4 text-lg bg-blue-500 hover:bg-blue-300 active:no-outline"
+      onClick={() => !pending && handleClick()}
     >
-      Download
-    </PDFDownloadLink>
+      {pending ? 'Pending' : 'Download'}
+    </button>
   );
+};
 
 CertificateDownloadButton.propTypes = {
   certificatePost: certificatePostType.isRequired,


### PR DESCRIPTION
### What's this PR do?

This pull request utilizes the `react-pdf`  library's [`pdf` function](https://react-pdf.org/advanced#access-blob-data) to imperatively download the PDF certificate upon button click.

### How should this be reviewed?
Do you agree with the logic outlined below, and think this approach makes sense? Point 1 feels stronger to me. But I'm honestly not completely convinced and open to counter thoughts and ditching this approach.

How do you feel about this implementation? Is the code clear and readable?

### Any background context you want to provide?
There are two issues with the current (more straightforward) implementation of the library's [`PDFDownloadLink`](https://react-pdf.org/advanced#download-link) component:
1. It automatically generates the PDF upon initial render as opposed to waiting for you to click the download button. This could cause a VC table with multiple certificates to all to generate PDFs immediately. Not a crisis, but it does seem like an expensive strain just for a page view.
2. Since the flow is so declarative, we cede some control over error handling (we would be yielded an `error` object and could run our reporting before rendering some error state, but this would presumably be before the user even clicks download which feels less logical to me. We would now have a more logical - a. user clicked download b. pdf generation failed - flow)

The downside is that we force ourselves to do some busy work to download the certificate via the phantom `<a>` tag et al. 

But using the `pdf` to imperatively handle the render/download flow allows us to only run this render once the user intends to download the certificate, and _arguably_, handle the reporting & error state more cleanly.

A counter-argument I can think of is that perhaps we'd _rather_ know about any failed PDF generation via analytics, even if it wasn't prompted by a user clicking download. The strain on the browser to 'eager-generate' PDF's is perhaps both worthwhile and not expensive enough to worry about for now.

### Relevant tickets

References [Pivotal #172439408](https://www.pivotaltracker.com/story/show/172439408).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added screenshots of front-end changes on small, medium, and large screens.
- [ ] Added appropriate feature/unit tests.
