### PR TITLE
Volunteer Certificate Download Button - Full state flow

### DIFF
--- a/resources/assets/components/pages/AccountPage/Credits/CertificateDownloadButton.js
+++ b/resources/assets/components/pages/AccountPage/Credits/CertificateDownloadButton.js
@@ -16,7 +16,13 @@ const CertificateDownloadButton = ({ certificatePost }) => {
   );
 
   // Dynamically toggles the button text to 'loading' while we're in loading state.
-  useEffect(() => setButtonText(loading ? 'loading' : 'download'), [loading]);
+  useEffect(() => {
+    if (certificatePost.pending) {
+      return;
+    }
+
+    setButtonText(loading ? 'loading' : 'download');
+  }, [loading]);
 
   /**
    * Handle PDF rendering errors.

--- a/resources/assets/components/pages/AccountPage/Credits/CertificateDownloadButton.js
+++ b/resources/assets/components/pages/AccountPage/Credits/CertificateDownloadButton.js
@@ -18,9 +18,8 @@ const CertificateDownloadButton = ({ certificatePost }) => {
    * @param {Error} err
    */
   const handleError = err => {
-    // We're no longer loading.
     setLoading(false);
-    // Update the local error state.
+
     setError(err);
     // @TODO: Track analytics. Report error to NR.
     console.error(err);
@@ -47,9 +46,6 @@ const CertificateDownloadButton = ({ certificatePost }) => {
             // @TODO: Update filename per https://www.pivotaltracker.com/story/show/172439408/comments/213717690.
             phantomLink.download = 'certificate.pdf';
 
-
-            // All set! We pass along the link so that on the initial process we can click the
-            // link directly without referring to the local link in state which saves asynchronously.
             resolve(phantomLink);
           })
           // Catch any errors from the PDF data -> blob conversion.
@@ -65,7 +61,7 @@ const CertificateDownloadButton = ({ certificatePost }) => {
    *
    */
   const handleClick = () => {
-    // If we've already generated a pdfLink, we can simply 'click' it to download the pdf.
+    // If we've already generated a pdfLink, simply 'click' it to download the PDF.
     if (pdfLink) {
       pdfLink.click();
       return;

--- a/resources/assets/components/pages/AccountPage/Credits/CertificateDownloadButton.js
+++ b/resources/assets/components/pages/AccountPage/Credits/CertificateDownloadButton.js
@@ -9,12 +9,12 @@ import CertificateTemplate, {
 } from './CertificateTemplate';
 
 const CertificateDownloadButton = ({ certificatePost }) => {
-  const [error, setError] = useState(null);
   const [loading, setLoading] = useState(false);
   const [pdfLink, setPdfLink] = useState(null);
   const [buttonText, setButtonText] = useState(
     certificatePost.pending ? 'pending' : 'download',
   );
+  const [generatePdfError, setGeneratePdfError] = useState(null);
 
   // Dynamically toggles the button text to 'loading' while we're in loading state.
   useEffect(() => {
@@ -28,14 +28,14 @@ const CertificateDownloadButton = ({ certificatePost }) => {
   /**
    * Handle PDF rendering errors.
    *
-   * @param {Error} err
+   * @param {Error} error
    */
-  const handleError = err => {
+  const handleError = error => {
     setLoading(false);
 
-    setError(err);
+    setGeneratePdfError(error);
     // @TODO: Track analytics. Report error to NR.
-    console.error(err);
+    console.error(error);
   };
 
   /**
@@ -64,8 +64,8 @@ const CertificateDownloadButton = ({ certificatePost }) => {
           // Catch any errors from the PDF data -> blob conversion.
           .catch(reject);
         // Catch any errors from the initial PDF render.
-      } catch (err) {
-        reject(err);
+      } catch (error) {
+        reject(error);
       }
     });
 
@@ -95,8 +95,8 @@ const CertificateDownloadButton = ({ certificatePost }) => {
       .catch(handleError);
   };
 
-  if (error) {
-    return <ErrorBlock error={error} />;
+  if (generatePdfError) {
+    return <ErrorBlock error={generatePdfError} />;
   }
 
   return (

--- a/resources/assets/components/pages/AccountPage/Credits/CertificateDownloadButton.js
+++ b/resources/assets/components/pages/AccountPage/Credits/CertificateDownloadButton.js
@@ -45,7 +45,6 @@ const CertificateDownloadButton = ({ certificatePost }) => {
             // Create a 'phantom' link so we can download the PDF on the user's behalf.
             const phantomLink = document.createElement('a');
 
-            // Clicking the link will now download the pdf automatically.
             phantomLink.href = URL.createObjectURL(blob);
             // Assign the PDF filename.
             // @TODO: Update filename per https://www.pivotaltracker.com/story/show/172439408/comments/213717690.

--- a/resources/assets/components/pages/AccountPage/Credits/CertificateDownloadButton.js
+++ b/resources/assets/components/pages/AccountPage/Credits/CertificateDownloadButton.js
@@ -54,7 +54,6 @@ const CertificateDownloadButton = ({ certificatePost }) => {
             // Save this download link in state so we can just 'click' it again if necessary.
             setPdfLink(phantomLink);
 
-            // Cool, we're no longer loading.
             setLoading(false);
 
             // All set! We pass along the link so that on the initial process we can click the

--- a/resources/assets/components/pages/AccountPage/Credits/CertificateDownloadButton.js
+++ b/resources/assets/components/pages/AccountPage/Credits/CertificateDownloadButton.js
@@ -103,7 +103,7 @@ const CertificateDownloadButton = ({ certificatePost }) => {
     <ElementButton
       type="button"
       className={classNames('w-full py-4 text-lg capitalize', {
-        'bg-blue-500 hover:bg-blue-300': !certificatePost.pending,
+        'bg-blurple-500 hover:bg-blurple-300': !certificatePost.pending,
       })}
       isDisabled={certificatePost.pending || loading}
       isLoading={loading}

--- a/resources/assets/components/pages/AccountPage/Credits/CertificateDownloadButton.js
+++ b/resources/assets/components/pages/AccountPage/Credits/CertificateDownloadButton.js
@@ -40,7 +40,6 @@ const CertificateDownloadButton = ({ certificatePost }) => {
       try {
         // Render the PDF template.
         pdf(<CertificateTemplate certificatePost={certificatePost} />)
-          // Convert the data to a Blob object.
           .toBlob()
           .then(blob => {
             // Create a 'phantom' link so we can download the PDF on the user's behalf.

--- a/resources/assets/components/pages/AccountPage/Credits/CertificateDownloadButton.js
+++ b/resources/assets/components/pages/AccountPage/Credits/CertificateDownloadButton.js
@@ -1,55 +1,124 @@
-import React, { useRef, useState } from 'react';
+import classNames from 'classnames';
+import React, { useState } from 'react';
 import { pdf } from '@react-pdf/renderer';
 
+import ErrorBlock from '../../../blocks/ErrorBlock/ErrorBlock';
 import CertificateTemplate, {
   certificatePostType,
 } from './CertificateTemplate';
 
 const CertificateDownloadButton = ({ certificatePost }) => {
-  const [hasGeneratedPdf, setHasgeneratedPdf] = useState(false);
-  const pdfLink = useRef(null);
+  const [error, setError] = useState(null);
+  const [loading, setLoading] = useState(false);
+  const [pdfLink, setPdfLink] = useState(null);
 
-  const handleClick = () => {
-    if (!hasGeneratedPdf) {
-      try {
-        pdf(<CertificateTemplate certificatePost={certificatePost} />)
-          .toBlob()
-          .then(blob => {
-            pdfLink.current.href = URL.createObjectURL(blob);
-            pdfLink.current.click();
-
-            setHasgeneratedPdf(true);
-          })
-          .catch(error => {
-            console.error(error);
-          });
-      } catch (error) {
-        console.error(error);
-      }
-    }
+  /**
+   * Handle PDF rendering errors.
+   *
+   * @param {Error} err
+   */
+  const handleError = err => {
+    // We're no longer loading.
+    setLoading(false);
+    // Update the local error state.
+    setError(err);
+    // @TODO: Track analytics. Report error to NR.
+    console.error(err);
   };
 
-  if (certificatePost.pending) {
-    return (
-      <button type="button" disabled className="btn w-full py-4 text-lg">
-        Pending
-      </button>
-    );
+  /**
+   * Generate the certificate PDF data, and build a phantom download link.
+   *
+   * @return {Promise|Undefined}
+   */
+  const generatePdfLink = () =>
+    new Promise(resolve => {
+      // We'll be 'loading' until the PDF link is generated.
+      setLoading(true);
+
+      // Playing it safe to catch any errors caused by the initial PDF rendering step.
+      try {
+        // Render the PDF template.
+        pdf(<CertificateTemplate certificatePost={certificatePost} />)
+          // Convert the data to a Blob object.
+          .toBlob()
+          .then(blob => {
+            // Create a 'phantom' link so we can download the PDF on the user's behalf.
+            const phantomLink = document.createElement('a');
+
+            // Convert the PDF Blob to a URL and assign it as the link's href.
+            // Clicking the link will now download the pdf automatically.
+            phantomLink.href = URL.createObjectURL(blob);
+            // Assign the PDF filename.
+            // @TODO: Update filename per https://www.pivotaltracker.com/story/show/172439408/comments/213717690.
+            phantomLink.download = 'certificate.pdf';
+
+            // Save this download link in state so we can just 'click' it again if necessary.
+            setPdfLink(phantomLink);
+
+            // Cool, we're no longer loading.
+            setLoading(false);
+
+            // All set! We pass along the link so that on the initial process we can click the
+            // link directly without referring to the local link in state which saves asynchronously.
+            resolve(phantomLink);
+          })
+          // Catch any errors from the PDF data -> blob conversion.
+          .catch(err => handleError(err));
+        // Catch any errors from the initial PDF render.
+      } catch (err) {
+        handleError(err);
+      }
+    });
+
+  /**
+   * Handle click events on the download button.
+   *
+   */
+  const handleClick = () => {
+    // If we've already generated a pdfLink, we can simply 'click' it to download the pdf.
+    if (pdfLink) {
+      pdfLink.click();
+      return;
+    }
+
+    // generate the phantom PDF link, and 'click' it to download the pdf!
+    generatePdfLink().then(link => link.click());
+  };
+
+  /**
+   * Generate button text per PDF status.
+   *
+   */
+  const buttonText = () => {
+    if (certificatePost.pending) {
+      return 'Pending';
+    }
+
+    if (loading) {
+      return 'Loading';
+    }
+
+    return 'Download';
+  };
+
+  if (error) {
+    return <ErrorBlock error={error} />;
   }
 
-  // @TODO Handle loading and error state.
   return (
-    // eslint-disable-next-line jsx-a11y/anchor-is-valid
-    <a
-      role="link"
-      tabIndex="0"
-      download="certa.pdf"
-      ref={pdfLink}
-      className="btn w-full py-4 text-lg bg-blue-500 hover:bg-blue-300"
-      onClick={handleClick}
+    <button
+      type="button"
+      className={classNames('btn w-full py-4 text-lg', {
+        'bg-blue-500 hover:bg-blue-300': !certificatePost.pending,
+        'is-loading': loading,
+      })}
+      disabled={certificatePost.pending || loading}
+      // If a sneaky user removes the 'disabled' attribute we don't want to trigger the PDF download.
+      onClick={() => !certificatePost.pending && handleClick()}
     >
-      Download
-    </a>
+      {buttonText()}
+    </button>
   );
 };
 

--- a/resources/assets/components/pages/AccountPage/Credits/CertificateDownloadButton.js
+++ b/resources/assets/components/pages/AccountPage/Credits/CertificateDownloadButton.js
@@ -45,7 +45,6 @@ const CertificateDownloadButton = ({ certificatePost }) => {
             // Create a 'phantom' link so we can download the PDF on the user's behalf.
             const phantomLink = document.createElement('a');
 
-            // Convert the PDF Blob to a URL and assign it as the link's href.
             // Clicking the link will now download the pdf automatically.
             phantomLink.href = URL.createObjectURL(blob);
             // Assign the PDF filename.

--- a/resources/assets/components/pages/AccountPage/Credits/CertificateDownloadButton.js
+++ b/resources/assets/components/pages/AccountPage/Credits/CertificateDownloadButton.js
@@ -3,6 +3,7 @@ import { pdf } from '@react-pdf/renderer';
 import React, { useState, useEffect } from 'react';
 
 import ErrorBlock from '../../../blocks/ErrorBlock/ErrorBlock';
+import ElementButton from '../../../utilities/Button/ElementButton';
 import CertificateTemplate, {
   certificatePostType,
 } from './CertificateTemplate';
@@ -99,18 +100,17 @@ const CertificateDownloadButton = ({ certificatePost }) => {
   }
 
   return (
-    <button
+    <ElementButton
       type="button"
-      className={classNames('btn w-full py-4 text-lg capitalize', {
+      className={classNames('w-full py-4 text-lg capitalize', {
         'bg-blue-500 hover:bg-blue-300': !certificatePost.pending,
-        'is-loading': loading,
       })}
-      disabled={certificatePost.pending || loading}
+      isDisabled={certificatePost.pending || loading}
+      isLoading={loading}
       // If a sneaky user removes the 'disabled' attribute we don't want to trigger the PDF download.
       onClick={() => !certificatePost.pending && handleClick()}
-    >
-      {buttonText}
-    </button>
+      text={buttonText}
+    />
   );
 };
 

--- a/resources/assets/components/pages/AccountPage/Credits/CertificateDownloadButton.js
+++ b/resources/assets/components/pages/AccountPage/Credits/CertificateDownloadButton.js
@@ -1,6 +1,6 @@
 import classNames from 'classnames';
-import React, { useState } from 'react';
 import { pdf } from '@react-pdf/renderer';
+import React, { useState, useEffect } from 'react';
 
 import ErrorBlock from '../../../blocks/ErrorBlock/ErrorBlock';
 import CertificateTemplate, {
@@ -11,6 +11,12 @@ const CertificateDownloadButton = ({ certificatePost }) => {
   const [error, setError] = useState(null);
   const [loading, setLoading] = useState(false);
   const [pdfLink, setPdfLink] = useState(null);
+  const [buttonText, setButtonText] = useState(
+    certificatePost.pending ? 'pending' : 'download',
+  );
+
+  // Dynamically toggles the button text to 'loading' while we're in loading state.
+  useEffect(() => setButtonText(loading ? 'loading' : 'download'), [loading]);
 
   /**
    * Handle PDF rendering errors.
@@ -82,22 +88,6 @@ const CertificateDownloadButton = ({ certificatePost }) => {
       .catch(handleError);
   };
 
-  /**
-   * Generate button text per PDF status.
-   *
-   */
-  const buttonText = () => {
-    if (certificatePost.pending) {
-      return 'Pending';
-    }
-
-    if (loading) {
-      return 'Loading';
-    }
-
-    return 'Download';
-  };
-
   if (error) {
     return <ErrorBlock error={error} />;
   }
@@ -105,7 +95,7 @@ const CertificateDownloadButton = ({ certificatePost }) => {
   return (
     <button
       type="button"
-      className={classNames('btn w-full py-4 text-lg', {
+      className={classNames('btn w-full py-4 text-lg capitalize', {
         'bg-blue-500 hover:bg-blue-300': !certificatePost.pending,
         'is-loading': loading,
       })}
@@ -113,7 +103,7 @@ const CertificateDownloadButton = ({ certificatePost }) => {
       // If a sneaky user removes the 'disabled' attribute we don't want to trigger the PDF download.
       onClick={() => !certificatePost.pending && handleClick()}
     >
-      {buttonText()}
+      {buttonText}
     </button>
   );
 };

--- a/resources/assets/components/utilities/Button/ElementButton.js
+++ b/resources/assets/components/utilities/Button/ElementButton.js
@@ -14,13 +14,14 @@ const ElementButton = ({
   className,
   data,
   isDisabled,
+  isLoading,
   onClick,
   text,
   type,
 }) => {
   return (
     <button
-      className={classnames('btn', className)}
+      className={classnames('btn', className, { 'is-loading': isLoading })}
       disabled={isDisabled}
       onClick={onClick}
       type={type}
@@ -35,6 +36,7 @@ ElementButton.propTypes = {
   className: PropTypes.string,
   data: PropTypes.object,
   isDisabled: PropTypes.bool,
+  isLoading: PropTypes.bool,
   onClick: PropTypes.func,
   text: PropTypes.string.isRequired,
   type: PropTypes.oneOf(['button', 'submit', 'reset']),
@@ -44,6 +46,7 @@ ElementButton.defaultProps = {
   className: null,
   data: {},
   isDisabled: false,
+  isLoading: false,
   onClick: null,
   type: 'button',
 };


### PR DESCRIPTION
### What's this PR do?

This pull request updates the `CertificateDownloadButton` to include the complete experience across success, loading, and error states.

### How should this be reviewed?
Hopefully, the comments help! I also hope this intimidating component actually proves to be deceptively simple.

Do you agree with my rationale outlined below?

Does the Error state make sense here? (Rendering an `ErrorBlock` in place of the button.

The review app is failing to build or release upon various tries. I _think_ it's a Heroku issue 🤔 
GIF of the download flow: https://github.com/DoSomething/phoenix-next/pull/2067#issuecomment-620666574

### Any background context you want to provide?
Some context per #2063:

We opted to include a more imperative PDF rendering / download logic flow so that we have more control of the logic, and error handling than the simple download link the library provides.

We wanted to avoid using a phantom `<a>` tag to download the PDF since that increases complexity.

Our compromise was manipulating an existing `<a>` tag 'download button'.

I found while attempting to introduce error and loading state into the component, that the complexity inherently grew to the extent that it felt OK to use the 'phantom' link to avoid a dizzying amount of DOM manipulation to keep an `<a>` tag rendering properly in the DOM across the various states.

In summary: my assessment is that the complexity inherent in the endeavor of a (well relatively) rich PDF downloading experience necessitates a complex component.

That being said I tried to break things down as elegantly as I could! But you'll be the judge of that, oh esteemed reviewer.

### Relevant tickets

References [Pivotal #172439408](https://www.pivotaltracker.com/story/show/172439408).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added screenshots of front-end changes on small, medium, and large screens.
- [ ] Added appropriate feature/unit tests.
