### PR TITLE
Improve error handling & reporting.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2729,7 +2729,7 @@
     "@types/zen-observable": {
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/@types/zen-observable/-/zen-observable-0.8.0.tgz",
-      "integrity": "sha1-i2OrfxqlMhJIqtWsiQpIVlbc6k0="
+      "integrity": "sha512-te5lMAWii1uEJ4FwLjzdlbw3+n0FZNOvFXHxQDKeT0dilh7HOzdMzV2TrJVUzq8ep7J4Na8OUYPRLSQkJHAlrg=="
     },
     "@webassemblyjs/ast": {
       "version": "1.9.0",
@@ -2926,7 +2926,7 @@
     "@xtuc/ieee754": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
-      "integrity": "sha1-7vAUoxRa5Hehy8AM0eVSM23Ot5A=",
+      "integrity": "sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==",
       "dev": true
     },
     "@xtuc/long": {
@@ -3549,7 +3549,7 @@
     "apollo-link-persisted-queries": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/apollo-link-persisted-queries/-/apollo-link-persisted-queries-0.2.2.tgz",
-      "integrity": "sha1-FWWXyyWbe7Vs9Olnp74DEpVPRZE=",
+      "integrity": "sha512-YL7XBu/5QsSbbYaWUXgm87T2Hn/2AQZk5Wr8CLXGDr3Wl3E/TRhBhKgQQTly9xhaTi7jgBO+AeIyTH5wCBHA9w==",
       "requires": {
         "apollo-link": "^1.2.1",
         "hash.js": "^1.1.3"
@@ -3768,7 +3768,7 @@
     "asn1.js": {
       "version": "4.10.1",
       "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.10.1.tgz",
-      "integrity": "sha1-ucK/WAXx5kqt7tbfOiv6+1pz9aA=",
+      "integrity": "sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==",
       "dev": true,
       "requires": {
         "bn.js": "^4.0.0",
@@ -4308,7 +4308,7 @@
     "bn.js": {
       "version": "4.11.8",
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
-      "integrity": "sha1-LN4J617jQfSEdGuwMJsyU7GxRC8=",
+      "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==",
       "dev": true
     },
     "body-parser": {
@@ -4436,7 +4436,7 @@
     "browserify-aes": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
-      "integrity": "sha1-Mmc0ZC9APavDADIJhTu3CtQo70g=",
+      "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
       "dev": true,
       "requires": {
         "buffer-xor": "^1.0.3",
@@ -4450,7 +4450,7 @@
     "browserify-cipher": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.1.tgz",
-      "integrity": "sha1-jWR0wbhwv9q807z8wZNKEOlPFfA=",
+      "integrity": "sha512-sPhkz0ARKbf4rRQt2hTpAHqn47X3llLkUGn+xEJzLjwY8LRs2p0v7ljvI5EyoRO/mexrNunNECisZs+gw2zz1w==",
       "dev": true,
       "requires": {
         "browserify-aes": "^1.0.4",
@@ -4461,7 +4461,7 @@
     "browserify-des": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.2.tgz",
-      "integrity": "sha1-OvTx9Zg5QDVy8cZiBDdfen9wPpw=",
+      "integrity": "sha512-BioO1xf3hFwz4kc6iBhI3ieDFompMhrMlnDFC4/0/vd5MokpuAc3R+LYbwTA9A5Yc9pq9UYPqffKpW2ObuwX5A==",
       "dev": true,
       "requires": {
         "cipher-base": "^1.0.1",
@@ -4515,7 +4515,7 @@
     "browserify-zlib": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.2.0.tgz",
-      "integrity": "sha1-KGlFnZqjviRf6P4sofRuLn9U1z8=",
+      "integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
       "dev": true,
       "requires": {
         "pako": "~1.0.5"
@@ -4890,7 +4890,7 @@
     "cipher-base": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
-      "integrity": "sha1-h2Dk7MJy9MNjUy+SbYdKriwTl94=",
+      "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
       "dev": true,
       "requires": {
         "inherits": "^2.0.1",
@@ -5400,7 +5400,7 @@
     "copy-concurrently": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/copy-concurrently/-/copy-concurrently-1.0.5.tgz",
-      "integrity": "sha1-kilzmMrjSTf8r9bsgTnBgFHwteA=",
+      "integrity": "sha512-f2domd9fsVDFtaFcbaRZuYXwtdmnzqbADSwhSWYxYB/Q8zsdUUFMXVRwXGDMWmbEzAn1kdRrtI1T/KTFOL4X2A==",
       "dev": true,
       "requires": {
         "aproba": "^1.1.1",
@@ -5465,7 +5465,7 @@
     "create-ecdh": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.3.tgz",
-      "integrity": "sha1-yREbbzMEXEaX8UR4f5JUzcd8Rf8=",
+      "integrity": "sha512-GbEHQPMOswGpKXM9kCWVrremUcBmjteUaQ01T9rkKCPDXfUHX0IoP9LpHYo2NPFampa4e+/pFDc3jQdxrxQLaw==",
       "dev": true,
       "requires": {
         "bn.js": "^4.1.0",
@@ -5534,7 +5534,7 @@
     "create-hash": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
-      "integrity": "sha1-iJB4rxGmN1a8+1m9IhmWvjqe8ZY=",
+      "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
       "dev": true,
       "requires": {
         "cipher-base": "^1.0.1",
@@ -5547,7 +5547,7 @@
     "create-hmac": {
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
-      "integrity": "sha1-aRcMeLOrlXFHsriwRXLkfq0iQ/8=",
+      "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
       "dev": true,
       "requires": {
         "cipher-base": "^1.0.3",
@@ -5588,7 +5588,7 @@
     "crypto-browserify": {
       "version": "3.12.0",
       "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.12.0.tgz",
-      "integrity": "sha1-OWz58xN/A+S45TLFj2mCVOAPgOw=",
+      "integrity": "sha512-fz4spIh+znjO2VjL+IdhEpRJ3YN6sMzITSBijk6FK2UvTqruSQW+/cCZTSNsMiZNvUeq0CqurF+dAbyiGOY6Wg==",
       "dev": true,
       "requires": {
         "browserify-cipher": "^1.0.0",
@@ -6415,7 +6415,7 @@
     "diffie-hellman": {
       "version": "5.0.3",
       "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
-      "integrity": "sha1-QOjumPVaIUlgcUaSHGPhrl89KHU=",
+      "integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
       "dev": true,
       "requires": {
         "bn.js": "^4.1.0",
@@ -6468,7 +6468,7 @@
     "domain-browser": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.2.0.tgz",
-      "integrity": "sha1-PTH1AZGmdJ3RN1p/Ui6CPULlTto=",
+      "integrity": "sha512-jnjyiM6eRyZl2H+W8Q/zLMA481hzi0eszAaBUzIVnmYVDBbnLxVNnfu1HgEBvCbL+71FrxMl3E6lpKH7Ge3OXA==",
       "dev": true
     },
     "domelementtype": {
@@ -7309,7 +7309,7 @@
     "evp_bytestokey": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
-      "integrity": "sha1-f8vbGY3HGVlDLv4ThCaE4FJaywI=",
+      "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
       "dev": true,
       "requires": {
         "md5.js": "^1.3.4",
@@ -11807,7 +11807,7 @@
     "md5.js": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
-      "integrity": "sha1-tdB7jjIW4+J81yjXL3DR5qNCAF8=",
+      "integrity": "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==",
       "dev": true,
       "requires": {
         "hash-base": "^3.0.0",
@@ -12012,7 +12012,7 @@
     "miller-rabin": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.1.tgz",
-      "integrity": "sha1-8IA1HIZbDcViqEYpZtqlNUPHik0=",
+      "integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
       "dev": true,
       "requires": {
         "bn.js": "^4.0.0",
@@ -12105,7 +12105,7 @@
     "mississippi": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/mississippi/-/mississippi-3.0.0.tgz",
-      "integrity": "sha1-6goykfl+C16HdrNj1fChLZTGcCI=",
+      "integrity": "sha512-x471SsVjUtBRtcvd4BzKE9kFC+/2TeWgKCgw0bZcw1b9l2X3QX5vCWgF+KaZaYm87Ss//rHnWryupDrgLvmSkA==",
       "dev": true,
       "requires": {
         "concat-stream": "^1.5.0",
@@ -13544,7 +13544,7 @@
     "pbkdf2": {
       "version": "3.0.17",
       "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.17.tgz",
-      "integrity": "sha1-l2wgZTBhexTrsyEUI597CTNuk6Y=",
+      "integrity": "sha512-U/il5MsrZp7mGg3mSQfn742na2T+1/vHDCG5/iTI3X9MKUuYUZVLQhyRsg06mCgDBTd57TxzgZt7P+fYfjRLtA==",
       "dev": true,
       "requires": {
         "create-hash": "^1.1.2",
@@ -14159,7 +14159,7 @@
     "public-encrypt": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.3.tgz",
-      "integrity": "sha1-T8ydd6B+SLp1J+fL4N4z0HATMeA=",
+      "integrity": "sha512-zVpa8oKZSz5bTMTFClc1fQOnyyEzpl5ozpi1B5YcvBrdohMjH2rfsBtyXcuNuwjsDIXmBYlF2N5FlJYhR29t8Q==",
       "dev": true,
       "requires": {
         "bn.js": "^4.1.0",
@@ -14173,7 +14173,7 @@
     "pump": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
-      "integrity": "sha1-tKIRaBW94vTh6mAjVOjHVWUQemQ=",
+      "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
       "requires": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
@@ -14182,7 +14182,7 @@
     "pumpify": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/pumpify/-/pumpify-1.5.1.tgz",
-      "integrity": "sha1-NlE74karJ1cLGjdKXOJ4v9dDcM4=",
+      "integrity": "sha512-oClZI37HvuUJJxSKKrC17bZ9Cu0ZYhEAGPsPUy9KlMUmv9dKX2o77RUmq7f3XjIxbwyGwYzbzQ1L2Ks8sIradQ==",
       "dev": true,
       "requires": {
         "duplexify": "^3.6.0",
@@ -14193,7 +14193,7 @@
         "pump": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
-          "integrity": "sha1-Ejma3W5M91Jtlzy8i1zi4pCLOQk=",
+          "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
           "dev": true,
           "requires": {
             "end-of-stream": "^1.1.0",
@@ -14285,7 +14285,7 @@
     "randomfill": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/randomfill/-/randomfill-1.0.4.tgz",
-      "integrity": "sha1-ySGW/IarQr6YPxvzF3giSTHWFFg=",
+      "integrity": "sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==",
       "dev": true,
       "requires": {
         "randombytes": "^2.0.5",
@@ -14384,6 +14384,11 @@
         "prop-types": "^15.6.2",
         "scheduler": "^0.19.1"
       }
+    },
+    "react-error-boundary": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/react-error-boundary/-/react-error-boundary-1.2.5.tgz",
+      "integrity": "sha512-5CPSeLJA2igJNppAgFRwnTL9aK3ojenk65enNzhVyoxYNbHpIJXnChUO7+4vPhkncRA9wvQMXq6Azp2XeXd+iQ=="
     },
     "react-input-autosize": {
       "version": "2.2.2",
@@ -15078,7 +15083,7 @@
     "ripemd160": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz",
-      "integrity": "sha1-ocGm9iR1FXe6XQeRTLyShQWFiQw=",
+      "integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
       "dev": true,
       "requires": {
         "hash-base": "^3.0.0",
@@ -15381,7 +15386,7 @@
     "sha.js": {
       "version": "2.4.11",
       "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
-      "integrity": "sha1-N6XPC4HsvGlD3hCbopYNGyZYSuc=",
+      "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
       "dev": true,
       "requires": {
         "inherits": "^2.0.1",
@@ -15744,7 +15749,7 @@
     "ssri": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.1.tgz",
-      "integrity": "sha1-KjxBso3UW2K2Nnbst0ABJlrp7dg=",
+      "integrity": "sha512-3Wge10hNcT1Kur4PDFwEieXSCMCJs/7WvSACcrMYrNp+b8kDL1/0wJch5Ni2WrtwEa2IO8OsVfeKIciKCDx/QA==",
       "dev": true,
       "requires": {
         "figgy-pudding": "^3.5.1"
@@ -15817,7 +15822,7 @@
     "stream-each": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/stream-each/-/stream-each-1.2.3.tgz",
-      "integrity": "sha1-6+J6DDibBPvMIzZClS4Qcxr6m64=",
+      "integrity": "sha512-vlMC2f8I2u/bZGqkdfLQW/13Zihpej/7PmSiMQsbYddxuTsJp8vRe2x2FvVExZg7FaOds43ROAuFJwPR4MTZLw==",
       "dev": true,
       "requires": {
         "end-of-stream": "^1.1.0",
@@ -15827,7 +15832,7 @@
     "stream-http": {
       "version": "2.8.3",
       "resolved": "https://registry.npmjs.org/stream-http/-/stream-http-2.8.3.tgz",
-      "integrity": "sha1-stJCRpKIpaJ+xP6JM6z2I95lFPw=",
+      "integrity": "sha512-+TSkfINHDo4J+ZobQLWiMouQYB+UVYFttRA94FpEzzJ7ZdqcL4uUUQ7WkdkI4DSozGmgBUE/a47L+38PenXhUw==",
       "dev": true,
       "requires": {
         "builtin-status-codes": "^3.0.0",
@@ -16309,7 +16314,7 @@
     "through2": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
-      "integrity": "sha1-AcHjnrMdB8t9A6lqcIIyYLIxMs0=",
+      "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
       "dev": true,
       "requires": {
         "readable-stream": "~2.3.6",
@@ -16712,7 +16717,7 @@
     "unique-filename": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-1.1.1.tgz",
-      "integrity": "sha1-HWl2k2mtoFgxA6HmrodoG1ZXMjA=",
+      "integrity": "sha512-Vmp0jIp2ln35UTXuryvjzkjGdRyf9b2lTXuSYUiPmzRcl3FDtYqAwOnTJkAngD9SWhnoJzDbTKwaOrZ+STtxNQ==",
       "dev": true,
       "requires": {
         "unique-slug": "^2.0.0"

--- a/package.json
+++ b/package.json
@@ -119,6 +119,7 @@
     "react-addons-update": "^15.6.2",
     "react-apollo": "^3.1.3",
     "react-dom": "^16.13.1",
+    "react-error-boundary": "^1.2.5",
     "react-intersection-observer": "^8.25.2",
     "react-loadable": "^5.4.0",
     "react-media": "^1.10.0",

--- a/resources/assets/components/App.js
+++ b/resources/assets/components/App.js
@@ -1,11 +1,13 @@
 import React from 'react';
 import { get } from 'lodash';
 import PropTypes from 'prop-types';
-import { Provider } from 'react-redux';
+import ErrorBoundary from 'react-error-boundary';
 import { ApolloProvider } from '@apollo/react-common';
+import { Provider as ReduxProvider } from 'react-redux';
 import { Router, Route, Switch } from 'react-router-dom';
 
 import graphqlClient from '../graphql';
+import ErrorPage from './pages/ErrorPage';
 import { initializeStore } from '../store/store';
 import HomePage from './pages/HomePage/HomePage';
 import Modal from './utilities/Modal/Modal';
@@ -32,96 +34,98 @@ const App = ({ store, history }) => {
   initializeStore(store);
 
   return (
-    <Provider store={store}>
-      {featureFlag('sitewide_cta_banner') ? (
-        <DismissableElement
-          name="sitewide_banner_call_to_action"
-          daysToReRender={7}
-          context={{ contextSource: 'voter_registration' }}
-          render={(handleClose, handleComplete) => (
-            <SitewideBanner
-              cta="Get Started"
-              description="Make your voice heard. Register to vote in less than 2 minutes."
-              handleClose={handleClose}
-              handleComplete={handleComplete}
-              link={buildVoterRegUrl('web', 'hellobar')}
-            />
-          )}
-        />
-      ) : null}
-      <ApolloProvider client={graphqlClient(env('GRAPHQL_URL'))}>
-        {featureFlag('sitewide_nps_survey') &&
-        window.location.pathname !== '/us' ? (
-          <TrafficDistribution percentage={5} feature="nps_survey">
-            <DismissableElement
-              name="nps_survey"
-              render={(handleClose, handleComplete) => (
-                <DelayedElement delay={30}>
-                  <Modal onClose={handleClose} trackingId="SURVEY_MODAL">
-                    <TypeFormEmbed
-                      displayType="modal"
-                      typeformUrl="https://dosomething.typeform.com/to/Bvcwvm"
-                      queryParameters={{
-                        northstar_id: get(window.AUTH, 'id', null),
-                        url: window.location.pathname,
-                      }}
-                      onSubmit={handleComplete}
-                    />
-                  </Modal>
-                </DelayedElement>
-              )}
-            />
-          </TrafficDistribution>
+    <ReduxProvider store={store}>
+      <ErrorBoundary FallbackComponent={ErrorPage}>
+        {featureFlag('sitewide_cta_banner') ? (
+          <DismissableElement
+            name="sitewide_banner_call_to_action"
+            daysToReRender={7}
+            context={{ contextSource: 'voter_registration' }}
+            render={(handleClose, handleComplete) => (
+              <SitewideBanner
+                cta="Get Started"
+                description="Make your voice heard. Register to vote in less than 2 minutes."
+                handleClose={handleClose}
+                handleComplete={handleComplete}
+                link={buildVoterRegUrl('web', 'hellobar')}
+              />
+            )}
+          />
         ) : null}
-        <Router history={history}>
-          <Switch>
-            <Route
-              exact
-              path="/us"
-              component={featureFlag('new_homepage') ? NewHomePage : HomePage}
-            />
-            <Route path="/us/account" component={AccountContainer} />
-            <Route path="/us/blocks/:id" component={BlockPage} />
-            {featureFlag('dynamic_explore_campaigns') ? (
+        <ApolloProvider client={graphqlClient(env('GRAPHQL_URL'))}>
+          {featureFlag('sitewide_nps_survey') &&
+          window.location.pathname !== '/us' ? (
+            <TrafficDistribution percentage={5} feature="nps_survey">
+              <DismissableElement
+                name="nps_survey"
+                render={(handleClose, handleComplete) => (
+                  <DelayedElement delay={30}>
+                    <Modal onClose={handleClose} trackingId="SURVEY_MODAL">
+                      <TypeFormEmbed
+                        displayType="modal"
+                        typeformUrl="https://dosomething.typeform.com/to/Bvcwvm"
+                        queryParameters={{
+                          northstar_id: get(window.AUTH, 'id', null),
+                          url: window.location.pathname,
+                        }}
+                        onSubmit={handleComplete}
+                      />
+                    </Modal>
+                  </DelayedElement>
+                )}
+              />
+            </TrafficDistribution>
+          ) : null}
+          <Router history={history}>
+            <Switch>
               <Route
                 exact
-                path="/us/campaigns"
-                component={CampaignsIndexPage}
+                path="/us"
+                component={featureFlag('new_homepage') ? NewHomePage : HomePage}
               />
-            ) : null}
-            <Route path="/us/campaigns/:slug" component={CampaignContainer} />
-            <Route
-              path="/us/causes/:slug"
-              render={routeProps => (
-                <CausePage slug={routeProps.match.params.slug} />
-              )}
-            />
-            <Route
-              path="/us/collections/:slug"
-              render={routeProps => (
-                <CollectionPage slug={routeProps.match.params.slug} />
-              )}
-            />
-            <Route
-              path="/us/about/:slug"
-              render={routeProps => (
-                <CompanyPage slug={routeProps.match.params.slug} />
-              )}
-            />
-            <Route path="/us/join" component={BetaReferralPage} />
-            <Route
-              path="/us/my-voter-registration-drive"
-              component={BetaVoterRegistrationDrivePage}
-            />
-            <Route
-              path="/us/refer-friends"
-              component={AlphaReferralPageContainer}
-            />
-            <Route path="/us/:slug" component={PageDispatcherContainer} />
-          </Switch>
-        </Router>
-      </ApolloProvider>
-    </Provider>
+              <Route path="/us/account" component={AccountContainer} />
+              <Route path="/us/blocks/:id" component={BlockPage} />
+              {featureFlag('dynamic_explore_campaigns') ? (
+                <Route
+                  exact
+                  path="/us/campaigns"
+                  component={CampaignsIndexPage}
+                />
+              ) : null}
+              <Route path="/us/campaigns/:slug" component={CampaignContainer} />
+              <Route
+                path="/us/causes/:slug"
+                render={routeProps => (
+                  <CausePage slug={routeProps.match.params.slug} />
+                )}
+              />
+              <Route
+                path="/us/collections/:slug"
+                render={routeProps => (
+                  <CollectionPage slug={routeProps.match.params.slug} />
+                )}
+              />
+              <Route
+                path="/us/about/:slug"
+                render={routeProps => (
+                  <CompanyPage slug={routeProps.match.params.slug} />
+                )}
+              />
+              <Route path="/us/join" component={BetaReferralPage} />
+              <Route
+                path="/us/my-voter-registration-drive"
+                component={BetaVoterRegistrationDrivePage}
+              />
+              <Route
+                path="/us/refer-friends"
+                component={AlphaReferralPageContainer}
+              />
+              <Route path="/us/:slug" component={PageDispatcherContainer} />
+            </Switch>
+          </Router>
+        </ApolloProvider>
+      </ErrorBoundary>
+    </ReduxProvider>
   );
 };
 

--- a/resources/assets/components/blocks/ErrorBlock/ErrorBlock.js
+++ b/resources/assets/components/blocks/ErrorBlock/ErrorBlock.js
@@ -4,9 +4,7 @@ import PropTypes from 'prop-types';
 import errorIcon from './error_icon.svg';
 import { report } from '../../../helpers';
 import Card from '../../utilities/Card/Card';
-import { HELP_REQUEST_LINK } from '../../../constants';
-
-const DEBUGGING = process.env.NODE_ENV !== 'production';
+import ErrorDetails from '../../utilities/ErrorDetails';
 
 const ErrorBlock = ({ error }) => {
   // Print error to console & report to New Relic:
@@ -16,14 +14,11 @@ const ErrorBlock = ({ error }) => {
     <Card className="rounded bordered p-3">
       <img src={errorIcon} alt="Error" className="mx-auto my-8" />
       <p className="text-center my-4">
-        <strong>Something went wrong!</strong> Try refreshing the page or{' '}
-        <a href={HELP_REQUEST_LINK}>reach out</a> to us.
+        <strong>Something went wrong!</strong> Try refreshing the page - it may
+        work the second time. If not, we&apos;ve already noted the problem &amp;
+        will try to fix it as soon as possible.
       </p>
-      {DEBUGGING && error ? (
-        <p className="color-error text-center my-4">
-          <code>{JSON.stringify(error)}</code>
-        </p>
-      ) : null}
+      <ErrorDetails error={error} />
     </Card>
   );
 };

--- a/resources/assets/components/blocks/ErrorBlock/ErrorBlock.js
+++ b/resources/assets/components/blocks/ErrorBlock/ErrorBlock.js
@@ -8,7 +8,7 @@ import ErrorDetails from '../../utilities/ErrorDetails';
 
 const ErrorBlock = ({ error }) => {
   // Print error to console & report to New Relic:
-  useEffect(() => report(error), []);
+  useEffect(() => report(error), [error]);
 
   return (
     <Card className="rounded bordered p-3">

--- a/resources/assets/components/blocks/ErrorBlock/ErrorBlock.js
+++ b/resources/assets/components/blocks/ErrorBlock/ErrorBlock.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
 
 import errorIcon from './error_icon.svg';
@@ -10,10 +10,7 @@ const DEBUGGING = process.env.NODE_ENV !== 'production';
 
 const ErrorBlock = ({ error }) => {
   // Print error to console & report to New Relic:
-  if (error) {
-    console.error(`[ErrorBlock] ${error}`);
-    report(error);
-  }
+  useEffect(() => report(error), []);
 
   return (
     <Card className="rounded bordered p-3">

--- a/resources/assets/components/pages/ErrorPage.js
+++ b/resources/assets/components/pages/ErrorPage.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
 
 import { report } from '../../helpers';
@@ -10,10 +10,7 @@ const DEBUGGING = process.env.NODE_ENV !== 'production';
 
 const ErrorPage = ({ error }) => {
   // Print error to console & report to New Relic:
-  if (error) {
-    console.error(`[ErrorPage] ${error}`);
-    report(error);
-  }
+  useEffect(() => report(error), []);
 
   return (
     <>

--- a/resources/assets/components/pages/ErrorPage.js
+++ b/resources/assets/components/pages/ErrorPage.js
@@ -8,7 +8,7 @@ import SiteNavigationContainer from '../SiteNavigation/SiteNavigationContainer';
 
 const ErrorPage = ({ error }) => {
   // Print error to console & report to New Relic:
-  useEffect(() => report(error), []);
+  useEffect(() => report(error), [error]);
 
   return (
     <>

--- a/resources/assets/components/pages/ErrorPage.js
+++ b/resources/assets/components/pages/ErrorPage.js
@@ -2,11 +2,9 @@ import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
 
 import { report } from '../../helpers';
-import { HELP_REQUEST_LINK } from '../../constants';
+import ErrorDetails from '../utilities/ErrorDetails';
 import SiteFooter from '../utilities/SiteFooter/SiteFooter';
 import SiteNavigationContainer from '../SiteNavigation/SiteNavigationContainer';
-
-const DEBUGGING = process.env.NODE_ENV !== 'production';
 
 const ErrorPage = ({ error }) => {
   // Print error to console & report to New Relic:
@@ -35,21 +33,7 @@ const ErrorPage = ({ error }) => {
             movement of 5 million young people making an impact in their
             communities.
           </p>
-          <p className="text-sm text-gray-800 m-0">
-            If you continue to run into problems, contact our{' '}
-            <a
-              href={HELP_REQUEST_LINK}
-              className="font-semibold text-gray-800 hover:text-gray-400 underline"
-            >
-              support squad
-            </a>
-            !
-          </p>
-          {DEBUGGING && error ? (
-            <p className="color-error text-center my-4">
-              <code>{JSON.stringify(error)}</code>
-            </p>
-          ) : null}
+          <ErrorDetails error={error} />
         </article>
       </main>
 

--- a/resources/assets/components/pages/PageQuery.js
+++ b/resources/assets/components/pages/PageQuery.js
@@ -20,7 +20,7 @@ const PageQuery = ({ query, variables, children }) => {
   }
 
   if (error) {
-    return <ErrorPage />;
+    return <ErrorPage error={error} />;
   }
 
   if (!data.page) {

--- a/resources/assets/components/utilities/ErrorDetails.js
+++ b/resources/assets/components/utilities/ErrorDetails.js
@@ -5,12 +5,12 @@ import { makeUrl } from '../../helpers';
 import { HELP_REQUEST_LINK } from '../../constants';
 
 const ErrorDetails = ({ error }) => {
-  const context = `${+new Date()}, ${window.AUTH ? window.AUTH.id : 'N/A'}`;
+  const context = `${+new Date()}, ID: ${window.AUTH ? window.AUTH.id : 'N/A'}`;
 
   let message = error;
   if (error instanceof Error) {
     const trace = error.stack.toString().split(/\r\n|\n/)[0];
-    message = `${error.message} ${trace}, ${context}`;
+    message = `${error.message} ${trace}`;
   }
 
   const technicalDetails = `${message}, ${context}`;

--- a/resources/assets/components/utilities/ErrorDetails.js
+++ b/resources/assets/components/utilities/ErrorDetails.js
@@ -1,0 +1,47 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import { makeUrl } from '../../helpers';
+import { HELP_REQUEST_LINK } from '../../constants';
+
+const ErrorDetails = ({ error }) => {
+  const context = `${+new Date()}, ${window.AUTH ? window.AUTH.id : 'N/A'}`;
+
+  let message = error;
+  if (error instanceof Error) {
+    const trace = error.stack.toString().split(/\r\n|\n/)[0];
+    message = `${error.message} ${trace}, ${context}`;
+  }
+
+  const technicalDetails = `${message}, ${context}`;
+
+  return (
+    <>
+      <p className="text-sm text-gray-800 text-center m-0">
+        If you continue to run into problems, contact our{' '}
+        <a
+          href={makeUrl(HELP_REQUEST_LINK, { technicalDetails })}
+          className="font-semibold text-gray-800 hover:text-gray-600 underline"
+        >
+          support squad
+        </a>
+        !
+      </p>
+      {error ? (
+        <p className="text-sm text-gray-500 text-center my-4 leading-normal">
+          <strong>Technical Details:</strong> {technicalDetails}
+        </p>
+      ) : null}
+    </>
+  );
+};
+
+ErrorDetails.propTypes = {
+  error: PropTypes.oneOfType([PropTypes.object, PropTypes.string]),
+};
+
+ErrorDetails.defaultProps = {
+  error: 'Unknown Error',
+};
+
+export default ErrorDetails;

--- a/resources/assets/helpers/index.js
+++ b/resources/assets/helpers/index.js
@@ -870,15 +870,30 @@ export function parseContentfulType(json, defaultType) {
 /**
  * Report a caught error to New Relic.
  *
- * @param {Error}  error
+ * @param {Error|string}  error
  * @param {Object} customAttributes
  */
 export function report(error, customAttributes = null) {
+  let errorInstance;
+
+  // Print to the console for devs:
+  console.error(`[report] ${error}`);
+
+  // If we're not running New Relic here, don't report:
   if (!window.newrelic) {
     return;
   }
 
-  window.newrelic.noticeError(error, customAttributes);
+  // New Relic's 'noticeError' expects an Error instance:
+  if (isString(error)) {
+    errorInstance = new Error(error);
+  }
+
+  if (isNull(error)) {
+    errorInstance = new Error('Unknown error');
+  }
+
+  window.newrelic.noticeError(errorInstance, customAttributes);
 }
 
 /*


### PR DESCRIPTION
### What's this PR do?

This pull request makes a few improvements to how we report errors to users:

⚠️ Makes sure we report string errors to New Relic. The [`newrelic.noticeError`](https://docs.newrelic.com/docs/browser/new-relic-browser/browser-agent-spa-api/notice-error) API expects an `Error`, and sometimes we'll pass a string (say from a GraphQL issue). This ensures those non-traditional errors appear in Error Analytics too. ad67c39

🔂 Makes sure we don't report errors multiple times if the app re-renders. aec837f

ℹ️ Includes technical details in user-facing errors (so that they're visible in screenshots we get in Zendesk tickets). Bonus: the "support squad" link auto-fills on the linked helpdesk form! 3ad35a6

🔲 Adds a root-level error boundary, so any uncaught errors will show our ErrorPage. [e0173cd](https://github.com/DoSomething/phoenix-next/commit/e0173cdada439a66d204908683f1cba11814047e?w=1)

### How should this be reviewed?

It's probably easiest to review commit-by-commit for context.

### Any background context you want to provide?

Here's how the root-level `ErrorPage` (for uncaught errors) now looks. This will allow us to see the error message, first line of the stack trace, timestamp (for correlating to server logs), and user ID (again, for correlating to server-side logs if they're logged in):

![Screen Shot 2020-04-27 at 2 27 34 PM](https://user-images.githubusercontent.com/583202/80417700-27162c00-88a4-11ea-9fbd-a2d084c9dc79.png)

And the updated ErrorBlock, for individual component errors:

![Screen Shot 2020-04-27 at 2 27 55 PM](https://user-images.githubusercontent.com/583202/80417748-3d23ec80-88a4-11ea-81a4-f4a01f35eb87.png)

In both cases, these will pre-fill the ticket body on the "New Request" page using this snippet that I added into the Zendesk template (see `templates/new_request_page.hbs` on [Zendesk](https://help.dosomething.org/theming/workbench)):

```js
<script type="text/javascript">
$(document).ready(function() {
  // Don't bother autofilling for old browsers.
  if (!window.URLSearchParams) {
    return;
  }

  const urlParams = new URLSearchParams(window.location.search);
  const technicalDetails = urlParams.get('technicalDetails');
  if (technicalDetails) {
    $('#request_description').val('\n\n--------\nTechnical Details:\n' + technicalDetails);
  }
});
</script>
```

### Relevant tickets

References [Pivotal #172384322](https://www.pivotaltracker.com/story/show/172384322).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [x] Added screenshots of front-end changes on ~small, medium, and~ large screens.
- [ ] Added appropriate feature/unit tests.
