### PR TITLE
Small updates to homepage.

### DIFF
--- a/resources/assets/components/pages/HomePage/NewHomePage.js
+++ b/resources/assets/components/pages/HomePage/NewHomePage.js
@@ -268,7 +268,7 @@ const NewHomePageTemplate = ({ articles, campaigns, coverImage, title }) => {
                   />
                 </h2>
 
-                <p className="mb-6 lg:mb-8 text-lg">
+                <p className="mb-3 text-lg">
                   Choose a campaign below to make an impact and enter for a
                   chance to{' '}
                   <a
@@ -278,7 +278,11 @@ const NewHomePageTemplate = ({ articles, campaigns, coverImage, title }) => {
                   >
                     earn scholarships
                   </a>
-                  . (Talk about a win-win.)
+                  .
+                </p>
+
+                <p className="mb-6 lg:mb-8 mt-0 text-lg">
+                  (Talk about a win-win.)
                 </p>
 
                 {/*

--- a/resources/assets/components/pages/HomePage/sponsor-list.js
+++ b/resources/assets/components/pages/HomePage/sponsor-list.js
@@ -94,6 +94,16 @@ const sponsorList = [
     image:
       'https://images.ctfassets.net/81iqaqpfd8fy/nqrXUW4560jS9sCU3nLqo/bbf4cd2cd75fbacc058198a9d8c5bb13/HSBC_Bank_Dark.png',
   },
+  {
+    name: "Harry's",
+    image:
+      'https://images.ctfassets.net/81iqaqpfd8fy/CZzZhXTkyXnUW66YS2Lmp/37e5fcd1ae9b0d3752c19d16867f8681/HarrysBW.png',
+  },
+  {
+    name: 'Hollister',
+    image:
+      'https://images.ctfassets.net/81iqaqpfd8fy/l1Z2GocsPmamhjYlAb111/4c7e9664a5621b160aa74131064d6b97/Hollister_Logo_Dark.png',
+  },
 ];
 
 export default sponsorList;

--- a/resources/assets/components/utilities/CampaignCard/CampaignCard.js
+++ b/resources/assets/components/utilities/CampaignCard/CampaignCard.js
@@ -36,6 +36,7 @@ const CampaignCard = ({ campaign }) => {
   const srcset = contentfulImageSrcset(showcaseImage.url, [
     { height: 205, width: 365 },
     { height: 410, width: 730 },
+    { height: 820, width: 1460 },
   ]);
 
   return (

--- a/resources/assets/components/utilities/CampaignCard/CampaignCardFeatured.js
+++ b/resources/assets/components/utilities/CampaignCard/CampaignCardFeatured.js
@@ -38,6 +38,8 @@ const CampaignCardFeatured = ({ campaign }) => {
   const srcset = contentfulImageSrcset(showcaseImage.url, [
     { height: 205, width: 365 },
     { height: 410, width: 730 },
+    { height: 820, width: 1460 },
+    { height: 1100, width: 1960 },
   ]);
 
   return (

--- a/resources/assets/components/utilities/PageCard/PageCard.js
+++ b/resources/assets/components/utilities/PageCard/PageCard.js
@@ -22,6 +22,7 @@ const PageCard = ({ page }) => {
   const srcset = contentfulImageSrcset(showcaseImage.url, [
     { height: 205, width: 365 },
     { height: 410, width: 730 },
+    { height: 820, width: 1460 },
   ]);
 
   return (


### PR DESCRIPTION
### What's this PR do?

This pull request includes a few tweaks for the homepage and beyond™!

- Updates the campaign section section text to split out the "(Talk about a win-win.)" as a separate paragraph since it was breaking weird on medium-ish screen sizes.
- Adds 2 additional sponsor logos.
- Includes additional `srcset` sizes to help with how images are rendered for campaign and page cards on retina displays.

### How should this be reviewed?

👀 

### Relevant tickets

References [Pivotal #172488236](https://www.pivotaltracker.com/story/show/172488236).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.