### PR TITLE
Have action id override apply to scholarship modal

### DIFF
--- a/resources/assets/components/LedeBanner/LedeBannerContainer.js
+++ b/resources/assets/components/LedeBanner/LedeBannerContainer.js
@@ -8,9 +8,9 @@ import { isSignedUp } from '../../selectors/signup';
  * Provide state from the Redux store as props for this component.
  */
 const mapStateToProps = (state, props) => ({
-  actionToDisplay: get(
+  actionIdToDisplay: get(
     state,
-    'campaign.additionalContent.actionToDisplay',
+    'campaign.additionalContent.actionIdToDisplay',
     null,
   ),
   affiliatedActionText: get(

--- a/resources/assets/components/LedeBanner/templates/HeroTemplate.js
+++ b/resources/assets/components/LedeBanner/templates/HeroTemplate.js
@@ -20,7 +20,7 @@ import {
 import './hero-lede-banner.scss';
 
 const HeroTemplate = ({
-  actionToDisplay,
+  actionIdToDisplay,
   additionalContent,
   affiliateCreditText,
   affiliateSponsors,
@@ -111,7 +111,7 @@ const HeroTemplate = ({
                 scholarshipAmount={scholarshipAmount}
                 scholarshipDeadline={scholarshipDeadline}
                 showModal={() => setShowScholarshipModal(true)}
-                actionToDisplay={actionToDisplay}
+                actionIdToDisplay={actionIdToDisplay}
               />
             </div>
           </div>
@@ -128,7 +128,7 @@ const HeroTemplate = ({
             trackingId="SCHOLARSHIP_MODAL"
           >
             <ScholarshipInfoBlock
-              actionToDisplay={actionToDisplay}
+              actionIdToDisplay={actionIdToDisplay}
               affiliateSponsors={affiliateSponsors}
               campaignId={numCampaignId}
               scholarshipAmount={scholarshipAmount}
@@ -162,7 +162,7 @@ const HeroTemplate = ({
 };
 
 HeroTemplate.propTypes = {
-  actionToDisplay: PropTypes.number,
+  actionIdToDisplay: PropTypes.number,
   additionalContent: PropTypes.object,
   affiliateCreditText: PropTypes.string,
   affiliateSponsors: PropTypes.arrayOf(PropTypes.object),
@@ -186,7 +186,7 @@ HeroTemplate.propTypes = {
 };
 
 HeroTemplate.defaultProps = {
-  actionToDisplay: null,
+  actionIdToDisplay: null,
   additionalContent: null,
   affiliateCreditText: undefined,
   affiliateSponsors: [],

--- a/resources/assets/components/LedeBanner/templates/HeroTemplate.js
+++ b/resources/assets/components/LedeBanner/templates/HeroTemplate.js
@@ -128,6 +128,7 @@ const HeroTemplate = ({
             trackingId="SCHOLARSHIP_MODAL"
           >
             <ScholarshipInfoBlock
+              actionToDisplay={actionToDisplay}
               affiliateSponsors={affiliateSponsors}
               campaignId={numCampaignId}
               scholarshipAmount={scholarshipAmount}

--- a/resources/assets/components/blocks/CampaignInfoBlock/CampaignInfoBlock.js
+++ b/resources/assets/components/blocks/CampaignInfoBlock/CampaignInfoBlock.js
@@ -38,7 +38,7 @@ const CampaignInfoBlock = ({
   scholarshipAmount,
   scholarshipDeadline,
   showModal,
-  actionToDisplay,
+  actionIdToDisplay,
 }) => (
   <Card className="bordered p-3 rounded campaign-info">
     <Query query={CAMPAIGN_INFO_QUERY} variables={{ campaignId }}>
@@ -60,8 +60,8 @@ const CampaignInfoBlock = ({
         // Decide which action to display
         let actionItem;
 
-        if (actionToDisplay) {
-          actionItem = actions.find(action => action.id === actionToDisplay);
+        if (actionIdToDisplay) {
+          actionItem = actions.find(action => action.id === actionIdToDisplay);
         } else {
           actionItem = actions.find(
             action => action.reportback && action.scholarshipEntry,
@@ -137,7 +137,7 @@ const CampaignInfoBlock = ({
 );
 
 CampaignInfoBlock.propTypes = {
-  actionToDisplay: PropTypes.number,
+  actionIdToDisplay: PropTypes.number,
   campaignId: PropTypes.number.isRequired,
   hideScholarshipDetails: PropTypes.bool,
   scholarshipAmount: PropTypes.number,
@@ -146,8 +146,12 @@ CampaignInfoBlock.propTypes = {
 };
 
 CampaignInfoBlock.defaultProps = {
+<<<<<<< HEAD
   actionToDisplay: null,
   hideScholarshipDetails: false,
+=======
+  actionIdToDisplay: null,
+>>>>>>> Rename "actionToDisplay" to "actionIdToDisplay"
   scholarshipAmount: null,
   scholarshipDeadline: null,
   showModal: null,

--- a/resources/assets/components/blocks/CampaignInfoBlock/CampaignInfoBlock.js
+++ b/resources/assets/components/blocks/CampaignInfoBlock/CampaignInfoBlock.js
@@ -146,12 +146,8 @@ CampaignInfoBlock.propTypes = {
 };
 
 CampaignInfoBlock.defaultProps = {
-<<<<<<< HEAD
-  actionToDisplay: null,
-  hideScholarshipDetails: false,
-=======
   actionIdToDisplay: null,
->>>>>>> Rename "actionToDisplay" to "actionIdToDisplay"
+  hideScholarshipDetails: false,
   scholarshipAmount: null,
   scholarshipDeadline: null,
   showModal: null,

--- a/resources/assets/components/blocks/ScholarshipInfoBlock/ScholarshipInfoBlock.js
+++ b/resources/assets/components/blocks/ScholarshipInfoBlock/ScholarshipInfoBlock.js
@@ -48,7 +48,7 @@ const SCHOLARSHIP_INFO_QUERY = gql`
 `;
 
 const ScholarshipInfoBlock = ({
-  actionToDisplay,
+  actionIdToDisplay,
   affiliateSponsors,
   campaignId,
   children,
@@ -101,8 +101,8 @@ const ScholarshipInfoBlock = ({
   // Decide which action to display
   let actionItem;
 
-  if (actionToDisplay) {
-    actionItem = actions.find(action => action.id === actionToDisplay);
+  if (actionIdToDisplay) {
+    actionItem = actions.find(action => action.id === actionIdToDisplay);
   } else {
     actionItem = actions.find(
       action => action.scholarshipEntry && action.reportback,
@@ -285,7 +285,7 @@ const ScholarshipInfoBlock = ({
 };
 
 ScholarshipInfoBlock.propTypes = {
-  actionToDisplay: PropTypes.number,
+  actionIdToDisplay: PropTypes.number,
   affiliateSponsors: PropTypes.arrayOf(PropTypes.object),
   campaignId: PropTypes.number,
   children: PropTypes.object,
@@ -298,7 +298,7 @@ ScholarshipInfoBlock.propTypes = {
 };
 
 ScholarshipInfoBlock.defaultProps = {
-  actionToDisplay: null,
+  actionIdToDisplay: null,
   affiliateSponsors: [],
   campaignId: null,
   children: null,

--- a/resources/assets/components/blocks/ScholarshipInfoBlock/ScholarshipInfoBlock.js
+++ b/resources/assets/components/blocks/ScholarshipInfoBlock/ScholarshipInfoBlock.js
@@ -34,6 +34,7 @@ const SCHOLARSHIP_AFFILIATE_QUERY = gql`
 const SCHOLARSHIP_INFO_QUERY = gql`
   query ScholarshipInfoQuery($campaignId: Int!) {
     actions(campaignId: $campaignId) {
+      id
       actionLabel
       scholarshipEntry
       reportback
@@ -47,6 +48,7 @@ const SCHOLARSHIP_INFO_QUERY = gql`
 `;
 
 const ScholarshipInfoBlock = ({
+  actionToDisplay,
   affiliateSponsors,
   campaignId,
   children,
@@ -95,9 +97,18 @@ const ScholarshipInfoBlock = ({
   const affiliateTitle = get(data, 'affiliate.title');
   const endDate = get(scholarshipData, 'campaign.endDate');
   const actions = get(scholarshipData, 'actions', []);
-  const actionItem = actions.find(
-    action => action.scholarshipEntry && action.reportback,
-  );
+
+  // Decide which action to display
+  let actionItem;
+
+  if (actionToDisplay) {
+    actionItem = actions.find(action => action.id === actionToDisplay);
+  } else {
+    actionItem = actions.find(
+      action => action.scholarshipEntry && action.reportback,
+    );
+  }
+
   const actionType = get(actionItem, 'actionLabel', '');
   if (error || scholarshipError) {
     console.error(`[ErrorBlock] ${error}`);
@@ -274,6 +285,7 @@ const ScholarshipInfoBlock = ({
 };
 
 ScholarshipInfoBlock.propTypes = {
+  actionToDisplay: PropTypes.number,
   affiliateSponsors: PropTypes.arrayOf(PropTypes.object),
   campaignId: PropTypes.number,
   children: PropTypes.object,
@@ -286,6 +298,7 @@ ScholarshipInfoBlock.propTypes = {
 };
 
 ScholarshipInfoBlock.defaultProps = {
+  actionToDisplay: null,
   affiliateSponsors: [],
   campaignId: null,
   children: null,


### PR DESCRIPTION
### What's this PR do?

This pull request builds on the work from https://github.com/DoSomething/phoenix-next/pull/2052 so that if an editor has added an action id override to be displayed in the `CampaignInfoBlock`, it will carry over to the `ScholarshipInfoBlock` as well!

Before this change (note that action type is DIFFERENT in the `CampaignInfoBlock` and `ScholarshipInfoBlock`):
![before](https://user-images.githubusercontent.com/4240292/80633347-74fa7380-8a0d-11ea-8ca0-e066dd84b1c3.gif)


After the change (note that action type is THE SAME in the `CampaignInfoBlock` and `ScholarshipInfoBlock`): 
![after](https://user-images.githubusercontent.com/4240292/80633422-9ce9d700-8a0d-11ea-991a-d22e5dfd2e62.gif)


### How should this be reviewed?

Does the logic around choosing the action still make sense?

### Any background context you want to provide?

See the pivotal card! Basically, this is our workaround to better support multiple actions in this area.

### Relevant tickets

References [Pivotal #172316942](https://www.pivotaltracker.com/story/show/172316942).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added screenshots of front-end changes on small, medium, and large screens.
- [ ] Added appropriate feature/unit tests.
