### PR TITLE
Fixes Beta OVRD page on dev

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -36,6 +36,7 @@
   - [Affiliate Opt In](development/features/affiliate-opt-in.md)
   - [Affiliate Scholarship Block](development/features/affiliate-scholarship-block.md)
   - [Analytics Waypoint](development/features/analytics-waypoint.md)
+  - [Voter Registration](development/features/voter-registration.md)
   - [Refer A Friend](development/features/referral-pages.md)
   - [Zendesk Form](development/features/zendesk-form.md)
 - [Contentful](development/contentful/README.md)

--- a/docs/development/features/voter-registration.md
+++ b/docs/development/features/voter-registration.md
@@ -1,0 +1,45 @@
+# Voter Registration
+
+## Overview
+
+We partner with [Rock The Vote](https://www.rockthevote.org) to register young people to vote on behalf of DoSomething.org, by redirecting to them to the Rock The Vote (RTV) registration website and appending our partner ID: `https://register.rockthevote.com/registrants/new?partner=37187`
+
+Our importer app, [Chompy](https://www.github.com/dosomething/chompy) downloads all voter registrations created with our partner ID, and imports them as `voter-reg` posts by posting to the Rogue API. See [import docs](https://github.com/DoSomething/chompy/blob/master/docs/imports/rock-the-vote.md).
+
+## Voting Portal
+
+We host our voting portal, [vote.dosomething.org](https://vote.dosomething.org) on Instapage. It prompts user for their email and zip, and redirects them to the Rock The Vote registration URL with our partner ID, pre-populating the email and zip submitted from the form.
+
+TODO: Link to doc about why we host on Instapage / Phoenix limitations
+
+## Voter Registration Action
+
+The `VoterRegistrationAction` content type can be used to display a call to action button that redirects a user to our vote.dosomething.org portal.
+
+## Online Registration Drives
+
+The call to action in the [Ready, Set, Vote campaign](https://www.dosomething.org/us/campaigns/online-registration-drive/) asks a member (the alpha) to get their friends to register to vote, by providing them with a custom URL to their own Online Voter Registration Drive (OVRD) that they can share with their friends (the betas).
+
+### Current version
+
+The campaign action page (aka the alpha page) uses a `SocialDriveAction` to customize the query parameters of the beta page -- which is hosted on our Instapage voting portal at https://vote.dosomething.org/member-drives.
+
+An example complete custom link for an alpha with user ID 58e68d5da0bfad4c3b4cd722 will look like:
+
+```
+https://vote.dosomething.org/member-drive?userId=58e68d5da0bfad4c3b4cd722&r=user:58e68d5da0bfad4c3b4cd722,source:web,source_details:onlinedrivereferral,referral=true
+```
+
+### Upcoming version
+
+In May 2020, we will release updated versions of both the alpha and beta OVRD pages.
+
+The OVRD (Ready Set Vote) campaign action page will still be used as the alpha page, except we render a hardcoded template instead of the Contentful blocks field. This is hardcoded because it displays one-off features, such as a list of the beta's that the alpha has gotten to register to vote via their OVRD, that we don't need to make re-usable by other campaigns or pages at this time.
+
+We'll host the beta page internally in Phoenix instead of Instapage, at path `/us/my-voter-registration-drive?referrer_user_id=58e68d5da0bfad4c3b4cd722` (where the `referrer_user_id` is our alpha's user ID).
+
+This beta page is a hardcoded template, but shares some components with the OVRD campaign template, like its `CoverImage` and scholarship information. The OVRD campaign's contentful ID, `3pwxnRZxociqMaQCMcGOyc`, is the same in all of our `dev`, `qa` and `production` spaces. Usually this isn't the case -- our Contentful ID's don't match between our `dev` and `production` spaces -- but this entry was created before we introduced different Contentful environments to our Phoenix space. Because of this, we're able to hardcode this Contentful ID to use in both `dev` and `production` environments.
+
+## Tracking Source
+
+TODO: Document how the `r` query parameter is used by the Chompy import.

--- a/resources/assets/components/pages/VoterRegistrationDrivePage/Beta/BetaPage.js
+++ b/resources/assets/components/pages/VoterRegistrationDrivePage/Beta/BetaPage.js
@@ -61,7 +61,7 @@ const BetaVoterRegistrationDrivePage = () => {
   }
 
   if (error) {
-    return <ErrorPage />;
+    return <ErrorPage error={error} />;
   }
 
   if (!data.user) {

--- a/resources/assets/components/pages/VoterRegistrationDrivePage/Beta/BetaPage.js
+++ b/resources/assets/components/pages/VoterRegistrationDrivePage/Beta/BetaPage.js
@@ -4,7 +4,7 @@ import { useQuery } from 'react-apollo';
 
 import Faq from './Faq';
 import ErrorPage from '../../ErrorPage';
-import { query } from '../../../../helpers';
+import { isDevEnvironment, query } from '../../../../helpers';
 import NotFoundPage from '../../NotFoundPage';
 import Placeholder from '../../../utilities/Placeholder';
 import ButtonLink from '../../../utilities/ButtonLink/ButtonLink';
@@ -15,23 +15,20 @@ import CampaignInfoBlock from '../../../blocks/CampaignInfoBlock/CampaignInfoBlo
 import SiteNavigationContainer from '../../../SiteNavigation/SiteNavigationContainer';
 
 const BETA_VOTER_REGISTRATION_DRIVE_PAGE_QUERY = gql`
-  query VoterRegistrationDrivePageReffererUserQuery(
+  query BetaVoterRegistrationDrivePageQuery(
     $referrerUserId: String!
-    $voterRegistrationDriveCampaignId: Int!
+    $voterRegistrationDriveCampaignWebsiteId: String!
   ) {
     user(id: $referrerUserId) {
       id
       firstName
     }
 
-    campaign(id: $voterRegistrationDriveCampaignId) {
-      id
-      campaignWebsite {
-        title
-        coverImage {
-          url
-          description
-        }
+    campaignWebsite(id: $voterRegistrationDriveCampaignWebsiteId) {
+      title
+      coverImage {
+        url
+        description
       }
     }
   }
@@ -39,8 +36,11 @@ const BETA_VOTER_REGISTRATION_DRIVE_PAGE_QUERY = gql`
 
 const BetaVoterRegistrationDrivePage = () => {
   const referrerUserId = query('referrer_user_id');
-  const voterRegistrationDriveCampaignId =
-    process.env.NODE_ENV === 'production' ? 9054 : 9004;
+  /**
+   * The CampaignWebsite ID is the same across all Contentful environments for OVRD.
+   * @see /docs/development/features/voter-registration
+   */
+  const voterRegistrationDriveCampaignWebsiteId = '3pwxnRZxociqMaQCMcGOyc';
 
   if (!referrerUserId) {
     return <NotFoundPage />;
@@ -51,7 +51,7 @@ const BetaVoterRegistrationDrivePage = () => {
     {
       variables: {
         referrerUserId,
-        voterRegistrationDriveCampaignId,
+        voterRegistrationDriveCampaignWebsiteId,
       },
     },
   );
@@ -69,18 +69,17 @@ const BetaVoterRegistrationDrivePage = () => {
   }
 
   const { firstName } = data.user;
-  const { coverImage, title } = data.campaign.campaignWebsite;
+  const { coverImage, title } = data.campaignWebsite;
+
   /**
-   * Because this component isn't associated with a campaign Contentful entry, we don't have a
-   * scholarship amount or deadline to pull from. We may need to hardcode a Contentful ID, or keep
-   * this hardcoded -- but we will eventually need to figure out how to display the modal to show
-   * additional scholarship information.
+   * TODO: Add campaignId, scholarshipAmount, and scholarshipDeadline as available properties
+   * to our CampaignWebsite type in GraphQL to avoid hardcoding.
    *
-   * 04/28/20 - keeping the scholarship info hard coded for v1 and hiding details link
+   * For now, we're hiding the scholarship details.
    */
   const campaignInfoBlock = (
     <CampaignInfoBlock
-      campaignId={voterRegistrationDriveCampaignId}
+      campaignId={isDevEnvironment ? 9035 : 9054}
       hideScholarshipDetails
       scholarshipAmount={1500}
       scholarshipDeadline="2020-04-30"

--- a/resources/assets/helpers/index.js
+++ b/resources/assets/helpers/index.js
@@ -206,6 +206,15 @@ export function isAuthenticated() {
 }
 
 /**
+ * Check to see if running in a development enviroment.
+ *
+ * @return {Boolean}
+ */
+export function isDevEnvironment() {
+  return ['local', 'development'].includes(get(window.ENV, 'APP_ENV', 'local'));
+}
+
+/**
  * Check to see if user is a DS.org staffer.
  *
  * @return {Boolean}


### PR DESCRIPTION
### What's this PR do?

The dev beta OVRD page is currently displaying an ErrorPage with  `TypeError: Cannot read property 'campaignWebsite' of null` per changes in #2062 

* https://dev.dosomething.org/us/my-voter-registration-drive?referrer_user_id=55767606a59dbf3c7a8b4571

This pull request fixes a mistake I made in #2028, where I was inspecting `process.env.NODE_ENV` to determine whether we're using a dev environment. I was following by example over [here](https://github.com/DoSomething/phoenix-next/blob/0b1534db613cdfd65d702eec2097a7bb5a531c10/resources/assets/store/store.js#L24). 

I see a few other examples where we're checking for the `window.ENV.APP_ENV`, which could have been the fix for the [broken dev beta page](https://github.com/DoSomething/phoenix-next/pull/2062#issuecomment-620860305)- but thought it'd be useful to add a new helper, `isDevEnvironment` to determine whether we're in a dev environment, where all of our Contentful, Action, User, Everything ID's don't match QA / production.

Then, in looking to fix the broken beta OVRD page, I noticed a happy coincidence that the Contentful ID is the same in dev and non-dev environments for our OVRD campaign because it's such an old school entry. And figured this was a good PR to additionally start some documentation on all things old and new OVRD.

### How should this be reviewed?

Verify the review app's beta page loads correctly:

* https://dosomething-phoenix-de-pr-2080.herokuapp.com/us/my-voter-registration-drive?referrer_user_id=55767606a59dbf3c7a8b4571


### Any background context you want to provide?

I created a new dev Rogue campaign with ID 9035 called Test Voter Registration Campaign, so it'll be much easier to create our own test actions and not worry about reusing a campaign that any other dev Contentful entries might be referencing. I changed our dev OVRD campaign to use this campaign ID instead of 9004 (which is used by multiple dev Contentful entries)

### Relevant tickets

References [Pivotal #172439286](https://www.pivotaltracker.com/story/show/172439286).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [x] Documentation added for new features/changed endpoints.
- [ ] Added screenshots of front-end changes on small, medium, and large screens.
- [ ] Added appropriate feature/unit tests.
