### PR TITLE
Change "Web Magazine" to "Articles" in footer

### DIFF
--- a/resources/assets/components/utilities/SiteFooter/SiteFooter.js
+++ b/resources/assets/components/utilities/SiteFooter/SiteFooter.js
@@ -86,7 +86,7 @@ const SiteFooter = () => (
             <a href="/us/about/our-press">Press</a>
           </li>
           <li>
-            <a href="https://lets.dosomething.org/">Web Magazine</a>
+            <a href="https://lets.dosomething.org/">Articles</a>
           </li>
           <li>
             <a href="/us/about/contact-us">Contact Us</a>

--- a/resources/views/partials/footer.blade.php
+++ b/resources/views/partials/footer.blade.php
@@ -32,7 +32,7 @@
           <li><a href="{{ config('app.url') }}/us/about/our-people">Our Team</a></li>
           <li><a href="{{ config('app.url') }}/us/about/our-financials">Our Financials</a></li>
           <li><a href="{{ config('app.url') }}/us/about/our-press">Press</a></li>
-          <li><a href="https://lets.dosomething.org/">Web Magazine</a></li>
+          <li><a href="https://lets.dosomething.org/">Articles</a></li>
           <li><a href="{{ config('app.url') }}/us/about/contact-us">Contact Us</a></li>
          </ul>
     </div>


### PR DESCRIPTION
### What's this PR do?

This pull request changes the text of the link that used to be "Web Magazine" to "Articles" in the footer!

<img width="203" alt="image" src="https://user-images.githubusercontent.com/4240292/80845098-1c69d880-8bbd-11ea-94b7-93b398788d2a.png">


### How should this be reviewed?

Anywhere else this update needs to be made?

### Any background context you want to provide?

Nope!

### Relevant tickets

References [Pivotal #172387347](https://www.pivotaltracker.com/story/show/172387347).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added screenshots of front-end changes on small, medium, and large screens.
- [ ] Added appropriate feature/unit tests.
