### PR TITLE
Button updates and sitewide banner update

### DIFF
--- a/resources/assets/components/pages/CampaignsPage/FilterNavigation/FilterNavigation.js
+++ b/resources/assets/components/pages/CampaignsPage/FilterNavigation/FilterNavigation.js
@@ -40,12 +40,12 @@ const FilterNavigation = ({ filters, setFilters }) => {
 
         {filterCategoryNames.map(name => (
           <SecondaryButton
-            key={`${name}_button`}
+            attributes={{ 'data-filter': name }}
             className="mr-8"
-            data={{ 'data-filter': name }}
+            isActive={activeFilter === name}
+            key={`${name}_button`}
             onClick={handleMenuToggle}
             text={startCase(name)}
-            isActive={activeFilter === name}
           />
         ))}
       </div>

--- a/resources/assets/components/pages/HomePage/NewHomePage.js
+++ b/resources/assets/components/pages/HomePage/NewHomePage.js
@@ -307,8 +307,8 @@ const NewHomePageTemplate = ({ articles, campaigns, coverImage, title }) => {
                 <HomePageCampaignGallery campaigns={campaigns} />
 
                 <PrimaryButton
+                  attributes={{ 'data-label': 'campaign_section_show_more' }}
                   className="mt-8 py-4 px-8 text-lg"
-                  data={{ 'data-label': 'campaign_section_show_more' }}
                   href="/us/campaigns"
                   text="See More Campaigns"
                 />
@@ -412,8 +412,8 @@ const NewHomePageTemplate = ({ articles, campaigns, coverImage, title }) => {
                 <HomePageArticleGallery articles={articles} />
 
                 <PrimaryButton
+                  attributes={{ 'data-label': 'article_section_show_more' }}
                   className="mt-8 py-4 px-8 text-lg"
-                  data={{ 'data-label': 'article_section_show_more' }}
                   href="https://lets.dosomething.org/"
                   text="See More Articles"
                 />
@@ -472,8 +472,8 @@ const NewHomePageTemplate = ({ articles, campaigns, coverImage, title }) => {
 
                 <div className="flex-grow">
                   <PrimaryButton
+                    attributes={{ 'data-label': 'signup_cta_authorize' }}
                     className="mt-8 xl:m-0 py-4 px-16 text-lg xl:ml-auto"
-                    data={{ 'data-label': 'signup_cta_authorize' }}
                     href="/authorize"
                     text="Join Now"
                   />

--- a/resources/assets/components/utilities/Button/ElementButton.js
+++ b/resources/assets/components/utilities/Button/ElementButton.js
@@ -11,8 +11,8 @@ import classnames from 'classnames';
  * @param {Object} props
  */
 const ElementButton = ({
+  attributes,
   className,
-  data,
   isDisabled,
   isLoading,
   onClick,
@@ -25,7 +25,7 @@ const ElementButton = ({
       disabled={isDisabled}
       onClick={onClick}
       type={type}
-      {...data}
+      {...attributes}
     >
       {text}
     </button>
@@ -33,8 +33,8 @@ const ElementButton = ({
 };
 
 ElementButton.propTypes = {
+  attributes: PropTypes.object,
   className: PropTypes.string,
-  data: PropTypes.object,
   isDisabled: PropTypes.bool,
   isLoading: PropTypes.bool,
   onClick: PropTypes.func,
@@ -43,8 +43,8 @@ ElementButton.propTypes = {
 };
 
 ElementButton.defaultProps = {
+  attributes: {},
   className: null,
-  data: {},
   isDisabled: false,
   isLoading: false,
   onClick: null,

--- a/resources/assets/components/utilities/Button/LinkButton.js
+++ b/resources/assets/components/utilities/Button/LinkButton.js
@@ -8,28 +8,28 @@ import classnames from 'classnames';
  *
  * @param {Object} props
  */
-const LinkButton = ({ className, data, href, onClick, text }) => (
+const LinkButton = ({ attributes, className, href, onClick, text }) => (
   <a
     className={classnames('btn', className)}
     href={href}
     onClick={onClick}
-    {...data}
+    {...attributes}
   >
     {text}
   </a>
 );
 
 LinkButton.propTypes = {
+  attributes: PropTypes.object,
   className: PropTypes.string,
-  data: PropTypes.object,
   href: PropTypes.string.isRequired,
   onClick: PropTypes.func,
   text: PropTypes.string.isRequired,
 };
 
 LinkButton.defaultProps = {
+  attributes: {},
   className: null,
-  data: {},
   onClick: null,
 };
 

--- a/resources/assets/components/utilities/Button/PrimaryButton.js
+++ b/resources/assets/components/utilities/Button/PrimaryButton.js
@@ -15,8 +15,8 @@ import ElementButton from './ElementButton';
  */
 const PrimaryButton = props => {
   const {
+    attributes,
     className,
-    data,
     href,
     isActive,
     isDisabled,
@@ -41,14 +41,20 @@ const PrimaryButton = props => {
 
   if (href) {
     return (
-      <LinkButton className={classes} data={data} href={href} text={text} />
+      <LinkButton
+        attributes={attributes}
+        className={classes}
+        href={href}
+        onClick={onClick}
+        text={text}
+      />
     );
   }
 
   return (
     <ElementButton
+      attributes={attributes}
       className={classes}
-      data={data}
       isDisabled={isDisabled}
       isLoading={isLoading}
       onClick={onClick}
@@ -59,8 +65,8 @@ const PrimaryButton = props => {
 };
 
 PrimaryButton.propTypes = {
+  attributes: PropTypes.object,
   className: PropTypes.string,
-  data: PropTypes.object,
   href: PropTypes.string,
   isActive: PropTypes.bool,
   isDisabled: PropTypes.bool,
@@ -71,8 +77,8 @@ PrimaryButton.propTypes = {
 };
 
 PrimaryButton.defaultProps = {
+  attributes: {},
   className: null,
-  data: {},
   href: null,
   isActive: false,
   isDisabled: false,

--- a/resources/assets/components/utilities/Button/SecondaryButton.js
+++ b/resources/assets/components/utilities/Button/SecondaryButton.js
@@ -15,8 +15,8 @@ import ElementButton from './ElementButton';
  */
 const SecondaryButton = props => {
   const {
+    attributes,
     className,
-    data,
     href,
     isActive,
     isDisabled,
@@ -40,14 +40,20 @@ const SecondaryButton = props => {
 
   if (href) {
     return (
-      <LinkButton className={classes} data={data} href={href} text={text} />
+      <LinkButton
+        attributes={attributes}
+        className={classes}
+        href={href}
+        onClick={onClick}
+        text={text}
+      />
     );
   }
 
   return (
     <ElementButton
+      attributes={attributes}
       className={classes}
-      data={data}
       isDisabled={isDisabled}
       onClick={onClick}
       text={text}
@@ -57,8 +63,8 @@ const SecondaryButton = props => {
 };
 
 SecondaryButton.propTypes = {
+  attributes: PropTypes.object,
   className: PropTypes.string,
-  data: PropTypes.object,
   href: PropTypes.string,
   isActive: PropTypes.bool,
   isDisabled: PropTypes.bool,
@@ -68,8 +74,8 @@ SecondaryButton.propTypes = {
 };
 
 SecondaryButton.defaultProps = {
+  attributes: {},
   className: null,
-  data: {},
   href: null,
   isActive: false,
   isDisabled: false,

--- a/resources/assets/components/utilities/Button/ToggleButton.js
+++ b/resources/assets/components/utilities/Button/ToggleButton.js
@@ -6,9 +6,9 @@ import ElementButton from './ElementButton';
 
 const ToggleButton = props => {
   const {
+    attributes,
     activateText,
     className,
-    data,
     deactivateText,
     isDisabled,
     isLoading,
@@ -37,8 +37,8 @@ const ToggleButton = props => {
 
   return (
     <ElementButton
+      attributes={attributes}
       className={isToggled ? deactivateClasses : activateClasses}
-      data={data}
       isDisabled={isDisabled}
       onClick={onClick}
       text={isToggled ? deactivateText : activateText}
@@ -48,9 +48,9 @@ const ToggleButton = props => {
 };
 
 ToggleButton.propTypes = {
-  className: PropTypes.string,
   activateText: PropTypes.string.isRequired,
-  data: PropTypes.object,
+  attributes: PropTypes.object,
+  className: PropTypes.string,
   deactivateText: PropTypes.string.isRequired,
   isDisabled: PropTypes.bool,
   isLoading: PropTypes.bool,
@@ -60,8 +60,8 @@ ToggleButton.propTypes = {
 };
 
 ToggleButton.defaultProps = {
+  attributes: {},
   className: null,
-  data: {},
   isDisabled: false,
   isLoading: false,
   isToggled: false,

--- a/resources/assets/components/utilities/SitewideBanner/SitewideBannerContent.js
+++ b/resources/assets/components/utilities/SitewideBanner/SitewideBannerContent.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
+import PrimaryButton from '../Button/PrimaryButton';
 import CloseButton from '../../artifacts/CloseButton/CloseButton';
 import {
   EVENT_CATEGORIES,
@@ -25,25 +26,25 @@ const SitewideBannerContent = ({
     });
   };
   return (
-    <div className="w-full flex justify-center bg-yellow-500 p-4 z-50">
+    <div className="w-full md:flex md:justify-center bg-yellow-500 p-8 pb-4 sm:px-10 z-50">
       <CloseButton
         callback={handleClose}
-        className="block absolute right-0 top-0 pt-4 md:pt-2 pr-6 md:pr-2"
+        className="block absolute right-0 top-0 p-4"
         size="14px"
       />
-      <div className="flex flex-wrap justify-center items-center">
-        <h1 className="text-center text-base m-4 md:mx-6 md:my-2">
+      <div className="md:flex items-center text-center">
+        {/* m-4 md:mx-6 md:my-2 */}
+        <h1 className="mb-4 md:mb-0 md:mr-4 text-center text-base">
           {description}
         </h1>
-        <a
-          className="py-2 px-4 hover:bg-blurple-300 hover:text-white hover:no-underline border border-solid-blurple rounded-md bg-blurple-500 text-white uppercase"
+
+        <PrimaryButton
+          attributes={{ rel: 'noopener noreferrer', target: '_blank' }}
+          className="py-2 px-4"
           href={link}
-          target="_blank"
-          rel="noopener noreferrer"
           onClick={handleCompleteWithTracking}
-        >
-          {cta}
-        </a>
+          text={cta}
+        />
       </div>
     </div>
   );

--- a/resources/assets/components/utilities/SitewideBanner/SitewideBannerContent.js
+++ b/resources/assets/components/utilities/SitewideBanner/SitewideBannerContent.js
@@ -33,7 +33,6 @@ const SitewideBannerContent = ({
         size="14px"
       />
       <div className="md:flex items-center text-center">
-        {/* m-4 md:mx-6 md:my-2 */}
         <h1 className="mb-4 md:mb-0 md:mr-4 text-center text-base">
           {description}
         </h1>

--- a/resources/views/search/results.blade.php
+++ b/resources/views/search/results.blade.php
@@ -26,7 +26,7 @@
                         ])
                         <input class="border-none leading-none pl-10 text-input w-full" name="query" type="text" value="{{ $query }}">
                     </div>
-                    <input class="btn" type="submit" value="Search">
+                    <input class="btn bg-blurple-500 hover:bg-blurple-400" type="submit" value="Search">
                 </form>
 
                 @if(! empty($campaigns))


### PR DESCRIPTION
### What's this PR do?

This pull request further updates buttons and our new components.

It renames the `data` prop to `attributes` to indicate that other attributes apart from `data-*` attributes can be passed to our new button components. This was necessary to allow passing other attributes like the `target` and `rel` attributes in link buttons, without needing to resort to creating new props for each possible attribute, which would be daunting.

This PR also updates the button in the `SitewideBannerContent` component. While updating it, I also took the liberty to address the close button size and tweak a bit of the styles.

### How should this be reviewed?

Does this `attributes` prop make sense?

### Relevant tickets

References [Pivotal #172184401](https://www.pivotaltracker.com/story/show/172184401).
References [Pivotal #172413748](https://www.pivotaltracker.com/story/show/172413748).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.