### PR TITLE
Volunteer Credit Data in Campaign Info Bar

### DIFF
--- a/cypress/integration/hero-campaign-signup.js
+++ b/cypress/integration/hero-campaign-signup.js
@@ -89,6 +89,58 @@ describe('Hero Template Landing Page', () => {
     cy.contains('Win A Scholarship');
   });
 
+  describe('Landing Page Displays the Volunteer Credit value', () => {
+    it('Displays Yes when the action earns volunteer credit', () => {
+      cy.mockGraphqlOp('CampaignInfoQuery', {
+        campaign: (root, { campaignId }) => ({
+          id: campaignId,
+          actions: () => [
+            {
+              actionLabel: 'Share Something',
+              timeCommitmentLabel: '1 hour',
+              scholarshipEntry: false,
+              reportback: true,
+              volunteerCredit: true,
+            },
+          ],
+        }),
+      });
+
+      // Visit the campaign pitch page:
+      cy.withFeatureFlags({ volunteer_credits: true })
+        .withState(exampleCampaign)
+        .visit('/us/campaigns/test-example-campaign');
+
+      cy.contains('Volunteer Credit');
+      cy.get('[data-test=volunteer-credit-value]').contains('Yes');
+    });
+
+    it('Displays No when the action does not earn volunteer credit', () => {
+      cy.mockGraphqlOp('CampaignInfoQuery', {
+        campaign: (root, { campaignId }) => ({
+          id: campaignId,
+          actions: () => [
+            {
+              actionLabel: 'Share Something',
+              timeCommitmentLabel: '1 hour',
+              scholarshipEntry: false,
+              reportback: true,
+              volunteerCredit: false,
+            },
+          ],
+        }),
+      });
+
+      // Visit the campaign pitch page:
+      cy.withFeatureFlags({ volunteer_credits: true })
+        .withState(exampleCampaign)
+        .visit('/us/campaigns/test-example-campaign');
+
+      cy.contains('Volunteer Credit');
+      cy.get('[data-test=volunteer-credit-value]').contains('No');
+    });
+  });
+
   it('Create signup, as an anonymous user', () => {
     const user = userFactory();
 

--- a/resources/assets/components/blocks/CampaignInfoBlock/CampaignInfoBlock.js
+++ b/resources/assets/components/blocks/CampaignInfoBlock/CampaignInfoBlock.js
@@ -86,7 +86,7 @@ const CampaignInfoBlock = ({
             ) : null}
             <dl className="clearfix">
               {showScholarshipInfo ? (
-                <React.Fragment>
+                <>
                   <dt className="campaign-info__scholarship">
                     Win A Scholarship
                   </dt>
@@ -108,7 +108,7 @@ const CampaignInfoBlock = ({
                     </div>
                   ) : null}
                   <hr className="clear-both pb-3 border-gray-300" />
-                </React.Fragment>
+                </>
               ) : null}
 
               {endDate && !showScholarshipInfo ? (
@@ -118,24 +118,24 @@ const CampaignInfoBlock = ({
                 </>
               ) : null}
               {actionItem && actionItem.timeCommitmentLabel ? (
-                <React.Fragment>
+                <>
                   <dt>Time</dt>
                   <dd>{actionItem.timeCommitmentLabel}</dd>
-                </React.Fragment>
+                </>
               ) : null}
               {actionItem && actionItem.actionLabel ? (
-                <React.Fragment>
+                <>
                   <dt>Action Type</dt>
                   <dd>{actionItem.actionLabel}</dd>
-                </React.Fragment>
+                </>
               ) : null}
               {featureFlag('volunteer_credits') && actionItem ? (
-                <React.Fragment>
+                <>
                   <dt>Volunteer Credit</dt>
                   <dd data-test="volunteer-credit-value">
                     {actionItem.volunteerCredit ? 'Yes' : 'No'}
                   </dd>
-                </React.Fragment>
+                </>
               ) : null}
             </dl>
           </>

--- a/resources/assets/components/blocks/CampaignInfoBlock/CampaignInfoBlock.js
+++ b/resources/assets/components/blocks/CampaignInfoBlock/CampaignInfoBlock.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 
 import Query from '../../Query';
 import Card from '../../utilities/Card/Card';
-import { getHumanFriendlyDate } from '../../../helpers';
+import { featureFlag, getHumanFriendlyDate } from '../../../helpers';
 import {
   EVENT_CATEGORIES,
   trackAnalyticsEvent,
@@ -27,6 +27,7 @@ const CAMPAIGN_INFO_QUERY = gql`
         timeCommitmentLabel
         scholarshipEntry
         reportback
+        volunteerCredit
       }
     }
   }
@@ -126,6 +127,14 @@ const CampaignInfoBlock = ({
                 <React.Fragment>
                   <dt>Action Type</dt>
                   <dd>{actionItem.actionLabel}</dd>
+                </React.Fragment>
+              ) : null}
+              {featureFlag('volunteer_credits') && actionItem ? (
+                <React.Fragment>
+                  <dt>Volunteer Credit</dt>
+                  <dd data-test="volunteer-credit-value">
+                    {actionItem.volunteerCredit ? 'Yes' : 'No'}
+                  </dd>
                 </React.Fragment>
               ) : null}
             </dl>


### PR DESCRIPTION
### What's this PR do?

This pull request adds a (feature-flagged for when VC goes live) row displaying Volunteer Credit qualifying info in the Campaign Info Bar

### How should this be reviewed?
👀 

### Relevant tickets

References [Pivotal #171729143](https://www.pivotaltracker.com/story/show/171729143).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [x] Added screenshots of front-end changes on small, medium, and large screens.
- [x] Added appropriate feature/unit tests.

![Screenshot_2020-05-01  Test  Teens for Jeans](https://user-images.githubusercontent.com/12417657/80976255-35f36600-8df1-11ea-9518-458cd6eb8ac5.png)

- [Large](https://user-images.githubusercontent.com/12417657/80976267-37bd2980-8df1-11ea-9bf0-9985411607c2.png)
- [Medium](https://user-images.githubusercontent.com/12417657/80976264-37249300-8df1-11ea-8bb4-c4e399b6cba0.png)
- [Small](https://user-images.githubusercontent.com/12417657/80976260-368bfc80-8df1-11ea-99a7-3fa5b7a73ba7.png)

