### PR TITLE
Display total accepted quantity sum on Alpha OVRD page

### DIFF
--- a/cypress/integration/alpha-voter-registration-drive-page.js
+++ b/cypress/integration/alpha-voter-registration-drive-page.js
@@ -37,7 +37,7 @@ describe('Alpha Voter Registration Drive Page', () => {
       'have.length',
       0,
     );
-    cy.get('[data-test=accepted-posts-count]').should('have.length', 0);
+    cy.get('[data-test=total-accepted-quantity]').should('have.length', 0);
     cy.get(
       `[data-contentful-id=${legacyVoterRegistrationDriveActionPageBlockId}]`,
     ).should('have.length', 1);
@@ -54,7 +54,7 @@ describe('Alpha Voter Registration Drive Page', () => {
       'have.length',
       1,
     );
-    cy.get('[data-test=accepted-posts-count]').should('have.length', 1);
+    cy.get('[data-test=total-accepted-quantity]').should('have.length', 1);
     cy.get(
       `[data-contentful-id=${legacyVoterRegistrationDriveActionPageBlockId}]`,
     ).should('have.length', 0);
@@ -129,33 +129,33 @@ describe('Alpha Voter Registration Drive Page', () => {
     cy.get('[data-test=additional-referrals-count]').contains('+ 2 more');
   });
 
-  it('Renders count of approved posts when less than 50', () => {
+  it('Renders sum of quantity if approved posts query returns results', () => {
     const user = userFactory();
     const actionId = faker.random.number();
 
-    cy.mockGraphqlOp('UserAcceptedPostsCountForAction', {
-      postsCount: (root, { userId, actionId }) => 11,
+    cy.mockGraphqlOp('UserAcceptedPostsForAction', {
+      posts: [{ quantity: 10 }, { quantity: 20 }, { quantity: 30 }],
     });
 
     cy.withFeatureFlags({
       voter_reg_alpha_page: true,
     }).authVisitCampaignWithSignup(user, exampleVoterRegistrationDriveCampaign);
 
-    cy.get('[data-test=accepted-posts-count-amount]').contains(11);
+    cy.get('[data-test=total-accepted-quantity-value]').contains('60');
   });
 
-  it('Renders 50+ approved posts when count is 51', () => {
+  it('Renders 0 if approved posts query does not return any results', () => {
     const user = userFactory();
     const actionId = faker.random.number();
 
-    cy.mockGraphqlOp('UserAcceptedPostsCountForAction', {
-      postsCount: (root, { userId, actionId }) => 51,
+    cy.mockGraphqlOp('UserAcceptedPostsForAction', {
+      posts: [],
     });
 
     cy.withFeatureFlags({
       voter_reg_alpha_page: true,
     }).authVisitCampaignWithSignup(user, exampleVoterRegistrationDriveCampaign);
 
-    cy.get('[data-test=accepted-posts-count-amount]').contains('50+');
+    cy.get('[data-test=total-accepted-quantity-value]').contains('0');
   });
 });

--- a/resources/assets/components/actions/SocialDriveAction/SocialDriveAction.js
+++ b/resources/assets/components/actions/SocialDriveAction/SocialDriveAction.js
@@ -9,7 +9,7 @@ import linkIcon from './linkIcon.svg';
 import Card from '../../utilities/Card/Card';
 import Embed from '../../utilities/Embed/Embed';
 import { postRequest } from '../../../helpers/api';
-import AcceptedPostsCount from './AcceptedPostsCount';
+import TotalAcceptedQuantity from './TotalAcceptedQuantity';
 import VoterRegistrationDriveInfo from './VoterRegistrationDriveInfo';
 import { dynamicString, withoutTokens } from '../../../helpers';
 import SocialShareTray from '../../utilities/SocialShareTray/SocialShareTray';
@@ -142,7 +142,7 @@ class SocialDriveAction extends React.Component {
         ) : null}
 
         {actionId ? (
-          <AcceptedPostsCount userId={userId} actionId={actionId} />
+          <TotalAcceptedQuantity userId={userId} actionId={actionId} />
         ) : null}
       </div>
     );

--- a/resources/assets/components/actions/SocialDriveAction/TotalAcceptedQuantity.js
+++ b/resources/assets/components/actions/SocialDriveAction/TotalAcceptedQuantity.js
@@ -1,25 +1,23 @@
 import React from 'react';
 import gql from 'graphql-tag';
+import { sumBy } from 'lodash';
 import PropTypes from 'prop-types';
 
 import Query from '../../Query';
 import Card from '../../utilities/Card/Card';
 
-const USER_ACCEPTED_POSTS_COUNT_FOR_ACTION_QUERY = gql`
-  query UserAcceptedPostsCountForAction($userId: String!, $actionId: Int!) {
-    postsCount(
-      userId: $userId
-      actionIds: [$actionId]
-      status: [ACCEPTED]
-      limit: 51
-    )
+const USER_ACCEPTED_POSTS_FOR_ACTION_QUERY = gql`
+  query UserAcceptedPostsForAction($userId: String!, $actionId: Int!) {
+    posts(userId: $userId, actionIds: [$actionId], status: [ACCEPTED]) {
+      quantity
+    }
   }
 `;
 
-const AcceptedPostsCount = ({ actionId, userId }) => {
+const TotalAcceptedQuantity = ({ actionId, userId }) => {
   return (
     <div
-      data-test="accepted-posts-count"
+      data-test="total-accepted-quantity"
       className="mt-6 lg:w-1/3 lg:pl-3 lg:mt-0"
     >
       <Card className="bordered rounded" title="More info">
@@ -28,12 +26,12 @@ const AcceptedPostsCount = ({ actionId, userId }) => {
             Total scholarship entries
           </span>
           <Query
-            query={USER_ACCEPTED_POSTS_COUNT_FOR_ACTION_QUERY}
+            query={USER_ACCEPTED_POSTS_FOR_ACTION_QUERY}
             variables={{ actionId, userId }}
           >
             {data => (
-              <h1 data-test="accepted-posts-count-amount">
-                {data.postsCount === 51 ? '50+' : data.postsCount}
+              <h1 data-test="total-accepted-quantity-value">
+                {sumBy(data.posts, post => post.quantity)}
               </h1>
             )}
           </Query>
@@ -43,9 +41,9 @@ const AcceptedPostsCount = ({ actionId, userId }) => {
   );
 };
 
-AcceptedPostsCount.propTypes = {
+TotalAcceptedQuantity.propTypes = {
   actionId: PropTypes.number.isRequired,
   userId: PropTypes.string.isRequired,
 };
 
-export default AcceptedPostsCount;
+export default TotalAcceptedQuantity;


### PR DESCRIPTION
### What's this PR do?

This pull request updates the Alpha OVRD page to display the sum quantity of all accepted posts for the OVRD Photo Submission Action, fixing a requirements miscommunication in [#172423982](https://www.pivotaltracker.com/story/show/172423982/comments/213986646).

This action asks users to upload a screenshot of sharing their OVRD link -- the total # of scholarship entries corresponds to the number of times they shared (the quantity) vs the number of posts created (what this component was initially displaying)


### How should this be reviewed?

I did create an [accompanying photo upload page in our dev Contentful environment,](https://dev.dosomething.org/us/campaigns/online-registration-drive/submit-photo) so this is easy to manually test by uploading a photo post, approving it in Rogue, and then refreshing the alpha OVRD page to view the updated total quantity.

### Any background context you want to provide?

🧷 

### Relevant tickets

References [Pivotal #172423982](https://www.pivotaltracker.com/story/show/172423982).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added screenshots of front-end changes on small, medium, and large screens.
- [x] Added appropriate feature/unit tests.
