### PR TITLE
Landing Page Content Whitespace Fix

### DIFF
--- a/resources/assets/components/pages/LandingPage/LandingPage.js
+++ b/resources/assets/components/pages/LandingPage/LandingPage.js
@@ -83,15 +83,17 @@ const LandingPage = props => {
         </>
       ) : (
         <>
-          <div className="bg-white">
-            <div className="md:w-3/4 mx-auto py-6 px-3 pitch-landing-page">
-              <div className="campaign-page__content clearfix">
-                <div className="primary">
-                  {content ? <TextContent>{content}</TextContent> : null}
+          {content ? (
+            <div className="bg-white">
+              <div className="md:w-3/4 mx-auto py-6 px-3 pitch-landing-page">
+                <div className="campaign-page__content clearfix">
+                  <div className="primary">
+                    <TextContent>{content}</TextContent>
+                  </div>
                 </div>
               </div>
             </div>
-          </div>
+          ) : null}
           <CampaignInfoBarContainer />
         </>
       )}


### PR DESCRIPTION
### What's this PR do?

This pull request updates to only display the Landing Page if there's content to display, otherwise, we render the container which causes some extra whitespace.

### How should this be reviewed?
👀 


### Relevant tickets

References [Pivotal #172411046](https://www.pivotaltracker.com/story/show/172411046).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [x] Added screenshots of front-end changes on small, medium, and large screens.
- [ ] Added appropriate feature/unit tests.

Before:
![image](https://user-images.githubusercontent.com/12417657/80989119-7c9d8c00-8e02-11ea-9caa-489d2c5b24a9.png)


After:
![image](https://user-images.githubusercontent.com/12417657/80989159-88894e00-8e02-11ea-99d9-492ef4cef394.png)

