### PR TITLE
Volunteer Credits - Website Data Filter

### DIFF
--- a/resources/assets/components/pages/AccountPage/Credits/VolunteerCreditsQuery.js
+++ b/resources/assets/components/pages/AccountPage/Credits/VolunteerCreditsQuery.js
@@ -85,58 +85,61 @@ const VolunteerCreditsQuery = () => {
 
   // Next, we parse out the specific data points we'll want from the larger
   // group of action posts generally, and from certain posts specifically.
-  const formattedPostData = Object.values(postsGroupedByAction).map(posts => {
-    // We need the last post since it has the earliest 'createdAt' date.
-    // We'll also use it to retrieve some other common post metadata.
-    const lastPost = last(posts);
+  const formattedPostData = Object.values(postsGroupedByAction)
+    .map(posts => {
+      // We need the last post since it has the earliest 'createdAt' date.
+      // We'll also use it to retrieve some other common post metadata.
+      const lastPost = last(posts);
 
-    // We use the ID as the unique 'key' when we map over the formatted post data.
-    const { createdAt } = lastPost;
+      // We use the ID as the unique 'key' when we map over the formatted post data.
+      const { createdAt } = lastPost;
 
-    const {
-      id,
-      timeCommitmentLabel,
-      actionLabel,
-      noun,
-      verb,
-    } = lastPost.actionDetails;
+      const {
+        id,
+        timeCommitmentLabel,
+        actionLabel,
+        noun,
+        verb,
+      } = lastPost.actionDetails;
 
-    const campaignWebsite = lastPost.campaign.campaignWebsite;
+      const campaignWebsite = lastPost.campaign.campaignWebsite;
 
-    const acceptedPosts = posts.filter(post => post.status === 'ACCEPTED');
+      const acceptedPosts = posts.filter(post => post.status === 'ACCEPTED');
 
-    // Calculate total quantity of accepted posts.
-    // @TODO: How do we handle 'null' quantity on a post? Or generally, actions not collecting quantity?
-    const quantity = acceptedPosts.reduce(
-      (totalQuantity, post) => totalQuantity + post.quantity,
-      0,
-    );
+      // Calculate total quantity of accepted posts.
+      // @TODO: How do we handle 'null' quantity on a post? Or generally, actions not collecting quantity?
+      const quantity = acceptedPosts.reduce(
+        (totalQuantity, post) => totalQuantity + post.quantity,
+        0,
+      );
 
-    // Generate human-friendly impact label based on quantity and action noun + verb.
-    // Will be 'null' for actions where we don't collect quantity info, or where total impact tallies to 0.
-    const impactLabel = quantity
-      ? `${pluralize(noun, quantity, true)} ${verb}`
-      : null;
+      // Generate human-friendly impact label based on quantity and action noun + verb.
+      // Will be 'null' for actions where we don't collect quantity info, or where total impact tallies to 0.
+      const impactLabel = quantity
+        ? `${pluralize(noun, quantity, true)} ${verb}`
+        : null;
 
-    // Grab the photo URL of the earliest accepted post.
-    const firstAcceptedPost = last(acceptedPosts);
-    const photo = get(firstAcceptedPost, 'url');
+      // Grab the photo URL of the earliest accepted post.
+      const firstAcceptedPost = last(acceptedPosts);
+      const photo = get(firstAcceptedPost, 'url');
 
-    // The certificate download button will be disabled if there is no 'accepted' post.
-    const pending = !firstAcceptedPost;
+      // The certificate download button will be disabled if there is no 'accepted' post.
+      const pending = !firstAcceptedPost;
 
-    return {
-      actionId: id,
-      campaignWebsite,
-      actionLabel,
-      dateCompleted: getHumanFriendlyDate(createdAt),
-      volunteerHours: timeCommitmentLabel,
-      impactLabel,
-      photo,
-      pending,
-      user: data.user,
-    };
-  });
+      return {
+        actionId: id,
+        campaignWebsite,
+        actionLabel,
+        dateCompleted: getHumanFriendlyDate(createdAt),
+        volunteerHours: timeCommitmentLabel,
+        impactLabel,
+        photo,
+        pending,
+        user: data.user,
+      };
+    })
+    // The certificates & display table won't function without campaign website data.
+    .filter(post => post.campaignWebsite);
 
   return <VolunteerCreditsTable certificatePosts={formattedPostData} />;
 };

--- a/resources/assets/components/pages/AccountPage/Credits/volunteer-credits-mock-data.js
+++ b/resources/assets/components/pages/AccountPage/Credits/volunteer-credits-mock-data.js
@@ -23,6 +23,14 @@ const ACTION_THREE = {
   verb: 'done',
 };
 
+const ACTION_FOUR = {
+  id: 4,
+  actionLabel: 'Sit Around',
+  timeCommitmentLabel: '0 time',
+  noun: 'nothing',
+  verb: 'done',
+};
+
 const AFFILIATE_SPONSORS = [
   {
     logo: {
@@ -139,6 +147,19 @@ export const mockPostsResponse = [
       actionDetails: ACTION_THREE,
       campaign: {
         campaignWebsite: CAMPAIGN_THREE,
+      },
+    },
+  },
+  {
+    node: {
+      id: 7,
+      createdAt: '2019-11-22',
+      quantity: 1,
+      status: 'ACCEPTED',
+      url: 'images/7',
+      actionDetails: ACTION_FOUR,
+      campaign: {
+        campaignWebsite: null,
       },
     },
   },


### PR DESCRIPTION
### What's this PR do?

This pull request filters aways posts without an overlying attached Campaign Website. 

### How should this be reviewed?
Does this filter make sense?

### Any background context you want to provide?
If we trigger Volunteer Credit on an action who's overlying campaign has no Campaign Website attached, we'd want those filtered out since the table & certificate wouldn't make much sense without it. (This also related to [this issue here](https://www.pivotaltracker.com/story/show/172023457/comments/213974808) with invalid `contentfulCampaignId`s on Rogue campaigns)

### Relevant tickets

References [Pivotal #]().

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added screenshots of front-end changes on small, medium, and large screens.
- [x] Added appropriate feature/unit tests.
