### PR TITLE
Volunteer Credits - Hide Empty Impact

### DIFF
--- a/resources/assets/components/pages/AccountPage/Credits/CertificateTemplate.js
+++ b/resources/assets/components/pages/AccountPage/Credits/CertificateTemplate.js
@@ -211,10 +211,12 @@ const CertificateTemplate = ({ certificatePost }) => {
                   </View>
                 </View>
 
-                <View style={{ marginTop: 10 }}>
-                  <Text style={styles.postDetailsTitle}>Impact</Text>
-                  <Text>{certificatePost.impactLabel}</Text>
-                </View>
+                {certificatePost.impactLabel ? (
+                  <View style={{ marginTop: 10 }}>
+                    <Text style={styles.postDetailsTitle}>Impact</Text>
+                    <Text>{certificatePost.impactLabel}</Text>
+                  </View>
+                ) : null}
               </View>
             </View>
           </View>

--- a/resources/assets/components/pages/AccountPage/Credits/VolunteerCreditsQuery.js
+++ b/resources/assets/components/pages/AccountPage/Credits/VolunteerCreditsQuery.js
@@ -91,7 +91,6 @@ const VolunteerCreditsQuery = () => {
       // We'll also use it to retrieve some other common post metadata.
       const lastPost = last(posts);
 
-      // We use the ID as the unique 'key' when we map over the formatted post data.
       const { actionDetails, createdAt } = lastPost;
 
       const {

--- a/resources/assets/components/pages/AccountPage/Credits/VolunteerCreditsQuery.js
+++ b/resources/assets/components/pages/AccountPage/Credits/VolunteerCreditsQuery.js
@@ -105,8 +105,7 @@ const VolunteerCreditsQuery = () => {
 
       const acceptedPosts = posts.filter(post => post.status === 'ACCEPTED');
 
-      // Calculate total quantity of accepted posts.
-      // @TODO: How do we handle 'null' quantity on a post? Or generally, actions not collecting quantity?
+      // Calculate total quantity from all accepted posts.
       const quantity = acceptedPosts.reduce(
         (totalQuantity, post) => totalQuantity + post.quantity,
         0,

--- a/resources/assets/components/pages/AccountPage/Credits/VolunteerCreditsQuery.js
+++ b/resources/assets/components/pages/AccountPage/Credits/VolunteerCreditsQuery.js
@@ -92,7 +92,7 @@ const VolunteerCreditsQuery = () => {
       const lastPost = last(posts);
 
       // We use the ID as the unique 'key' when we map over the formatted post data.
-      const { createdAt } = lastPost;
+      const { actionDetails, createdAt } = lastPost;
 
       const {
         id,
@@ -100,7 +100,7 @@ const VolunteerCreditsQuery = () => {
         actionLabel,
         noun,
         verb,
-      } = lastPost.actionDetails;
+      } = actionDetails;
 
       const campaignWebsite = lastPost.campaign.campaignWebsite;
 


### PR DESCRIPTION
### What's this PR do?

This pull request hides the 'Impact' field on Volunteer Credit certificates where the post did not collect impact (or 'quantity').

Also a touch of light pretty trivial misc.

### How should this be reviewed?
👀 

### Any background context you want to provide?
This will ensure that on posts where we do not collect the `quantity` from the user (e.g. on Contentful Photo Submission Actions, editors can toggle the quantity field to be hidden, which would mean posts would have a `null` quantity.), or for whatever reason if a post has `0` quantity (some legacy database campaigns appear stuck with this.) we won't display a sad-looking "Impact" section on the certificate.

Before (don't mind the borked logo, I'm working on that in a follow-up!):
![image](https://user-images.githubusercontent.com/12417657/81110698-e6dd2c00-8ee9-11ea-8d07-55f7e0a26ec2.png)

After:
![image](https://user-images.githubusercontent.com/12417657/81112271-62d87380-8eec-11ea-8a47-122d94da7bad.png)

