### PR TITLE
Volunteer Credit Certificate -  Sponsor Logo Updates

### DIFF
--- a/resources/assets/components/pages/AccountPage/Credits/CertificateTemplate.js
+++ b/resources/assets/components/pages/AccountPage/Credits/CertificateTemplate.js
@@ -117,10 +117,9 @@ const CertificateTemplate = ({ certificatePost }) => {
 
             {sponsorLogo ? (
               <View style={styles.flex}>
-                <View style={{ alignSelf: 'center' }}>
+                <View style={{ alignSelf: 'center', marginLeft: 20 }}>
                   <Text
                     style={{
-                      paddingLeft: 20,
                       fontWeight: 'bold',
                       fontSize: 24,
                     }}
@@ -128,11 +127,10 @@ const CertificateTemplate = ({ certificatePost }) => {
                     &#43;
                   </Text>
                 </View>
-                <View>
+                <View style={{ alignSelf: 'center', marginLeft: 20 }}>
                   <Image
                     src={sponsorLogo}
                     style={{
-                      marginLeft: 20,
                       height: 55,
                       width: 65,
                     }}

--- a/resources/assets/components/pages/AccountPage/Credits/CertificateTemplate.js
+++ b/resources/assets/components/pages/AccountPage/Credits/CertificateTemplate.js
@@ -131,7 +131,6 @@ const CertificateTemplate = ({ certificatePost }) => {
                   <Image
                     src={sponsorLogo}
                     style={{
-                      height: 55,
                       width: 65,
                     }}
                   />

--- a/resources/assets/components/pages/AccountPage/Credits/CertificateTemplate.js
+++ b/resources/assets/components/pages/AccountPage/Credits/CertificateTemplate.js
@@ -111,8 +111,8 @@ const CertificateTemplate = ({ certificatePost }) => {
           <View
             style={[styles.flex, { justifyContent: 'center', marginTop: 30 }]}
           >
-              <Image src={doSomethingLogo} style={{ height: 55, width: 65 }} />
             <View style={{ alignSelf: 'center' }}>
+              <Image src={doSomethingLogo} style={{ width: 65 }} />
             </View>
 
             {sponsorLogo ? (

--- a/resources/assets/components/pages/AccountPage/Credits/CertificateTemplate.js
+++ b/resources/assets/components/pages/AccountPage/Credits/CertificateTemplate.js
@@ -111,8 +111,8 @@ const CertificateTemplate = ({ certificatePost }) => {
           <View
             style={[styles.flex, { justifyContent: 'center', marginTop: 30 }]}
           >
-            <View>
               <Image src={doSomethingLogo} style={{ height: 55, width: 65 }} />
+            <View style={{ alignSelf: 'center' }}>
             </View>
 
             {sponsorLogo ? (

--- a/resources/assets/components/pages/AccountPage/Credits/CertificateTemplate.js
+++ b/resources/assets/components/pages/AccountPage/Credits/CertificateTemplate.js
@@ -131,7 +131,7 @@ const CertificateTemplate = ({ certificatePost }) => {
                   <Image
                     src={sponsorLogo}
                     style={{
-                      width: 65,
+                      width: 75,
                     }}
                   />
                 </View>

--- a/resources/assets/components/pages/AccountPage/Credits/CertificateTemplate.js
+++ b/resources/assets/components/pages/AccountPage/Credits/CertificateTemplate.js
@@ -171,7 +171,7 @@ const CertificateTemplate = ({ certificatePost }) => {
           >
             <Image
               style={{
-                width: '24%',
+                width: '25%',
                 borderRight: `2 solid ${colors.lightBlue}`,
               }}
               src={certificatePost.photo}

--- a/resources/assets/components/pages/AccountPage/Credits/CertificateTemplate.js
+++ b/resources/assets/components/pages/AccountPage/Credits/CertificateTemplate.js
@@ -109,7 +109,7 @@ const CertificateTemplate = ({ certificatePost }) => {
           }}
         >
           <View
-            style={[styles.flex, { justifyContent: 'center', marginTop: 30 }]}
+            style={[styles.flex, { justifyContent: 'center', marginTop: 20 }]}
           >
             <View style={{ alignSelf: 'center' }}>
               <Image src={doSomethingLogo} style={{ width: 65 }} />

--- a/resources/assets/components/pages/AccountPage/Credits/CertificateTemplate.js
+++ b/resources/assets/components/pages/AccountPage/Credits/CertificateTemplate.js
@@ -131,7 +131,8 @@ const CertificateTemplate = ({ certificatePost }) => {
                   <Image
                     src={sponsorLogo}
                     style={{
-                      width: 75,
+                      maxWidth: 70,
+                      maxHeight: 65,
                     }}
                   />
                 </View>


### PR DESCRIPTION
### What's this PR do?

This pull request spruces up the sponsor logo placement alongside the DS Logo in the certificate.

### How should this be reviewed?
does this styling make sense? I've attached certificates with a sampling of our recent affiliates to test:
[blue-shield.pdf](https://github.com/DoSomething/phoenix-next/files/4587282/blue-shield.pdf)
[chevrolet.pdf](https://github.com/DoSomething/phoenix-next/files/4587283/chevrolet.pdf)
[cotton.pdf](https://github.com/DoSomething/phoenix-next/files/4587284/cotton.pdf)
[cvs.pdf](https://github.com/DoSomething/phoenix-next/files/4587285/cvs.pdf)
[harry's.pdf](https://github.com/DoSomething/phoenix-next/files/4587286/harry.s.pdf)
[hsbc.pdf](https://github.com/DoSomething/phoenix-next/files/4587287/hsbc.pdf)
[MLB.pdf](https://github.com/DoSomething/phoenix-next/files/4587288/MLB.pdf)
[toyota.pdf](https://github.com/DoSomething/phoenix-next/files/4587289/toyota.pdf)

### Any background context you want to provide?
I procrastinated on more exhaustively testing the sponsor logos until in the screenshots for https://github.com/DoSomething/phoenix-next/pull/2100 it hit me in the face.

We're essentially being a bit more particular about margin placement and such generally, and specifically giving the sponsor logo a bit more generous spacing since they tend to be much wider and more rectangular. Our DS Logo is in a comfortable place because it's pretty square and well cropped.
