### PR TITLE
Volunteer Certificate - Campaign CTA font-size adjustment

### DIFF
--- a/resources/assets/components/pages/AccountPage/Credits/CertificateTemplate.js
+++ b/resources/assets/components/pages/AccountPage/Credits/CertificateTemplate.js
@@ -94,6 +94,17 @@ const CertificateTemplate = ({ certificatePost }) => {
     'logo.url',
   );
 
+  const showcaseDescriptionLength =
+    certificatePost.campaignWebsite.showcaseDescription.length;
+
+  let showcaseDescriptionFontSize = 15;
+
+  if (showcaseDescriptionLength > 200) {
+    showcaseDescriptionFontSize = 11;
+  } else if (showcaseDescriptionLength > 100) {
+    showcaseDescriptionFontSize = 13;
+  }
+
   return (
     <Document>
       <Page
@@ -189,8 +200,13 @@ const CertificateTemplate = ({ certificatePost }) => {
                 {certificatePost.campaignWebsite.showcaseTitle}
               </Text>
 
-              {/* @TODO adjust font size if character count is greater then 100 */}
-              <Text style={{ fontStyle: 'italic' }}>
+              <Text
+                style={{
+                  fontStyle: 'italic',
+                  paddingRight: 5,
+                  fontSize: showcaseDescriptionFontSize,
+                }}
+              >
                 {certificatePost.campaignWebsite.showcaseDescription}
               </Text>
 


### PR DESCRIPTION
### What's this PR do?

This pull request dynamically adjusts the Campaign CTA (Campaign Website Showcase Description) font size based on the character length.

### How should this be reviewed?
Do you think this logic makes sense? Is it clear? Is this all much too much?
Here are a few different variations:
[50-chars.pdf](https://github.com/DoSomething/phoenix-next/files/4587848/50-chars.pdf)
[100-chars.pdf](https://github.com/DoSomething/phoenix-next/files/4587849/100-chars.pdf)
[150-chars.pdf](https://github.com/DoSomething/phoenix-next/files/4587850/150-chars.pdf)
[200-chars.pdf](https://github.com/DoSomething/phoenix-next/files/4587852/200-chars.pdf)
[250-chars.pdf](https://github.com/DoSomething/phoenix-next/files/4587854/250-chars.pdf)


### Any background context you want to provide?
The Campaign CTA field is a [Short Text field](https://github.com/DoSomething/phoenix-next/blob/8721b2ffd4f4d5c1796e746b47c3da9b70e937b1/contentful/content-types/campaign.js#L52) (`Symbol`), which [Contentful limits](https://www.contentful.com/developers/docs/concepts/data-model/#fields) to 256 characters. Most of our campaign CTA's seem to be under 100 characters, so this is a bit edge case-y admittedly.