### PR TITLE
Temporarily removes FAQ block from Alpha OVRD page

### DIFF
--- a/cypress/integration/beta-voter-registration-drive-page.js
+++ b/cypress/integration/beta-voter-registration-drive-page.js
@@ -45,7 +45,7 @@ describe('Beta Voter Registration Drive (OVRD) Page', () => {
     cy.visit(betaPagePath);
 
     cy.get('[data-test=not-found-page]').should('have.length', 1);
-    cy.get('[data-test=alpha-voter-registration-drive-page]').should(
+    cy.get('[data-test=beta-voter-registration-drive-page]').should(
       'have.length',
       0,
     );
@@ -62,7 +62,7 @@ describe('Beta Voter Registration Drive (OVRD) Page', () => {
     cy.visit(getBetaPagePathForUser(user));
 
     cy.get('[data-test=not-found-page]').should('have.length', 1);
-    cy.get('[data-test=alpha-voter-registration-drive-page]').should(
+    cy.get('[data-test=beta-voter-registration-drive-page]').should(
       'have.length',
       0,
     );

--- a/resources/assets/components/pages/VoterRegistrationDrivePage/Alpha/AlphaPage.js
+++ b/resources/assets/components/pages/VoterRegistrationDrivePage/Alpha/AlphaPage.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import { faq, shareLink } from './config';
+import { shareLink } from './config';
 import VoterRegistrationReferrals from './VoterRegistrationReferrals/VoterRegistrationReferrals';
 import ContentfulEntryLoader from '../../../utilities/ContentfulEntryLoader/ContentfulEntryLoader';
 import SocialDriveActionContainer from '../../../actions/SocialDriveAction/SocialDriveActionContainer';
@@ -24,10 +24,6 @@ const AlphaPage = ({ userId }) => (
         hidePageViews
       />
     </div>
-    <ContentfulEntryLoader
-      id={faq.contentBlockId}
-      className="grid-wide clearfix wrapper pb-3"
-    />
   </div>
 );
 

--- a/resources/assets/components/pages/VoterRegistrationDrivePage/Alpha/config.js
+++ b/resources/assets/components/pages/VoterRegistrationDrivePage/Alpha/config.js
@@ -1,5 +1,7 @@
 import { isDevEnvironment } from '../../../../helpers';
 
+// Note: We're not using FAQ block yet, exists as a separate campaign page.
+// @see https://dosomething.slack.com/archives/CTVPG6L4R/p1588785224363300?thread_ts=1588722526.354200&cid=CTVPG6L4R
 export const faq = {
   // ContentBlock used for FAQ section.
   contentBlockId: isDevEnvironment()


### PR DESCRIPTION
### What's this PR do?

This pull request removes the FAQ block for now, since it will continue to exist as a campaign page (https://qa.dosomething.org/us/campaigns/online-registration-drive/faq).

Also fixes copy/paste errors I made in #1682 

### How should this be reviewed?

👀 

### Any background context you want to provide?

🚂 

