### PR TITLE
New script for updating LinkActions to CTA Blocks

### DIFF
--- a/contentful/management-api-scripts/2020_05_06_migrate_cta_blocks.js
+++ b/contentful/management-api-scripts/2020_05_06_migrate_cta_blocks.js
@@ -1,0 +1,112 @@
+/* eslint-disable no-restricted-syntax, no-await-in-loop, no-continue */
+
+const { contentManagementClient } = require('./contentManagementClient');
+const {
+  createLogger,
+  getField,
+  withFields,
+  linkReference,
+  constants,
+  sleep,
+} = require('./helpers');
+
+const { LOCALE } = constants;
+
+const logger = createLogger('migrate_cta_blocks');
+
+contentManagementClient.init(async environment => {
+  logger.info(
+    `Running 'migrate_cta_blocks', using Contentful's '${environment.sys.id}' environment.`,
+  );
+  logger.info('Kicking things off in 5 seconds...');
+
+  await sleep(5000);
+
+  const blocks = await environment.getEntries({
+    content_type: 'linkAction',
+    'fields.template': 'cta',
+  });
+
+  for (let i = 0; i < blocks.items.length; i += 1) {
+    const linkAction = blocks.items[i];
+
+    // Find all Entries which link to the CTA-type LinkAction.
+    const linkedEntries = await environment.getEntries({
+      links_to_entry: linkAction.sys.id,
+    });
+
+    const internalTitle = getField(linkAction, 'internalTitle');
+    logger.info(
+      `\n\nProcessing ${linkedEntries.items.length} links to "${internalTitle}".`,
+    );
+
+    // Archive things that aren't linked
+    if (linkedEntries.items.length === 0) {
+      logger.info(`⇢ Archiving '${internalTitle}', not linked anywhere.`);
+      linkAction.archive();
+      continue;
+    }
+
+    // Make the new CTA block
+    const ctaBlock = await environment.createEntry(
+      'callToAction',
+      withFields({
+        internalTitle,
+        content: getField(linkAction, 'content'),
+        linkText: getField(linkAction, 'buttonText'),
+        link: getField(linkAction, 'link'),
+        template: 'Purple',
+        alignment: 'Center',
+      }),
+    );
+
+    // Publish new block
+    await ctaBlock.publish();
+
+    // Loop through and get all places where the old block is linked
+    for (let j = 0; j < linkedEntries.items.length; j += 1) {
+      const page = linkedEntries.items[j];
+      const pageTitle = getField(page, 'internalTitle');
+      const id = page.sys.id;
+
+      // Skip archived pages
+      const isPageArchived = await page.isArchived();
+      if (isPageArchived) {
+        logger.info(`⇢ Skipping '${id}', archived.`);
+        continue;
+      }
+
+      // Replace old entity with new one
+      const linkActionIndex = page.fields.blocks[LOCALE].findIndex(
+        block => block.sys.id === linkAction.sys.id,
+      );
+      const newIndex = linkReference(ctaBlock.sys.id);
+      page.fields.blocks[LOCALE].splice(linkActionIndex, 1, newIndex);
+
+      // Make sure that we don't publish an unpublished campaign by mistake:
+      const wasPublished = await page.isPublished();
+      const updatedPage = await page.update();
+
+      if (!updatedPage) {
+        logger.error(`→ Could not update reference for "${pageTitle}".`);
+        continue;
+      }
+
+      if (!wasPublished) {
+        logger.warn(`→ Needs review: ${updatedPage.sys.id}`);
+        continue;
+      }
+
+      const publishedPage = await updatedPage.publish();
+
+      if (publishedPage) {
+        logger.info(
+          `✔ Published "${pageTitle}": https://qa.dosomething.org/us/campaigns/${publishedPage.fields.slug[LOCALE]}`,
+        );
+      }
+    }
+
+    // Archive old LinkActions
+    linkAction.archive();
+  }
+});

--- a/contentful/management-api-scripts/2020_05_06_migrate_cta_blocks.js
+++ b/contentful/management-api-scripts/2020_05_06_migrate_cta_blocks.js
@@ -119,14 +119,5 @@ contentManagementClient.init(async environment => {
         );
       }
     }
-
-    // Archive old LinkActions
-    logger.info(`⇢ Deleting '${internalTitle}'...`);
-    if (linkAction.isPublished) {
-      await linkAction.unpublish();
-      logger.info(`⇢ Unpublished LinkAction...`);
-    }
-    await linkAction.archive();
-    logger.info(`✔ Archived successfully`);
   }
 });

--- a/contentful/management-api-scripts/2020_05_06_migrate_cta_blocks.js
+++ b/contentful/management-api-scripts/2020_05_06_migrate_cta_blocks.js
@@ -25,6 +25,7 @@ contentManagementClient.init(async environment => {
   const blocks = await environment.getEntries({
     content_type: 'linkAction',
     'fields.template': 'cta',
+    limit: 1000,
   });
 
   logger.info(`Found ${blocks.items.length} Link Actions with CTA template`);
@@ -49,10 +50,8 @@ contentManagementClient.init(async environment => {
         await linkAction.unpublish();
         logger.info(`⇢ Unpublished LinkAction...`);
       }
-      if (await !linkAction.isArchived) {
-        await linkAction.archive();
-        logger.info(`⇢ Archived successfully`);
-      }
+      await linkAction.archive();
+      logger.info(`⇢ Archived successfully`);
       continue;
     }
 
@@ -121,14 +120,13 @@ contentManagementClient.init(async environment => {
       }
     }
 
-    // // Archive old LinkActions
-    if ((await linkAction.isPublished) && (await !linkAction.isArchived)) {
+    // Archive old LinkActions
+    logger.info(`⇢ Deleting '${internalTitle}'...`);
+    if (linkAction.isPublished) {
       await linkAction.unpublish();
       logger.info(`⇢ Unpublished LinkAction...`);
     }
-    if (await !linkAction.isArchived) {
-      await linkAction.archive();
-      logger.info(`⇢ Archived successfully`);
-    }
+    await linkAction.archive();
+    logger.info(`✔ Archived successfully`);
   }
 });


### PR DESCRIPTION
### What's this PR do?

This is a script that will convert all Link Action entries with template type of `CTA` to a new CTA block, moving over all relevant information and links.

### How should this be reviewed?

> "Give it a look see, i don't know" - David Furnes

### Any background context you want to provide?

This is the second half of using the new CTA blocks, not just on story pages, but everywhere on site. See [this PR](https://github.com/DoSomething/phoenix-next/pull/2104). For information about contentful-management see [documentation](https://contentful.github.io/contentful-management.js/contentful-management/1.3.0/typedef/index.html#static-typedef-Entry).

### Relevant tickets

References [Pivotal #169758942](https://www.pivotaltracker.com/n/projects/2328687/stories/169758942).