### PR TITLE
Modify isDevEnvironment helper to default to false if window.ENV.APP_ENV not found

### DIFF
--- a/resources/assets/helpers/index.js
+++ b/resources/assets/helpers/index.js
@@ -211,7 +211,9 @@ export function isAuthenticated() {
  * @return {Boolean}
  */
 export function isDevEnvironment() {
-  return ['local', 'development'].includes(get(window.ENV, 'APP_ENV', 'local'));
+  return ['local', 'development'].includes(
+    get(window.ENV, 'APP_ENV', 'production'),
+  );
 }
 
 /**


### PR DESCRIPTION
### What's this PR do?

This pull request modifies the `isDevEnvironment` helper introduced in #2080 to default to `false` if we can't find a `window.ENV.APP_ENV` -- so we err on the side assuming we should use the production Contentful ID's in the OVRD pages, vs dev ones.

### How should this be reviewed?

👀 

### Any background context you want to provide?

I thought the NotFound blocks on the OVRD pages would only happen to devs who may be switching environments within the same browser session, but [Diana saw one when testing on QA](https://dosomething.slack.com/archives/CTVPG6L4R/p1588792379380400?thread_ts=1588722526.354200&cid=CTVPG6L4R). Defaulting to displaying the production Contentful ID's feels like a safe move here, we don't want to rely on real users hard refreshing in order to view content.

### Relevant tickets

References [Pivotal #172439286](https://www.pivotaltracker.com/story/show/172439286/comments/214013911).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added screenshots of front-end changes on small, medium, and large screens.
- [ ] Added appropriate feature/unit tests.
