### PR TITLE
Button color override.

### DIFF
--- a/resources/assets/scss/base.scss
+++ b/resources/assets/scss/base.scss
@@ -46,6 +46,23 @@ a > * {
   @apply cursor-wait;
 }
 
+// @TODO: remove ".button" rules once all buttons in Phoenix have switched to the new button components.
+.button {
+  background: theme('colors.blurple.500');
+}
+
+.button:active {
+  background: theme('colors.blurple.700');
+}
+
+.button:focus {
+  background: theme('colors.blurple.400');
+}
+
+.button:hover {
+  background: theme('colors.blurple.400');
+}
+
 // @TODO:forge-removal Rename this class to "text-field".
 .text-input {
   @apply bg-white p-3 border border-gray-200 border-solid font-source-sans rounded;


### PR DESCRIPTION
### What's this PR do?

This pull request simply adds a few style overrides to the old `.button` class to ensure that the buttons using old button components match the color of the new button components. 

We don't want to get a mish-mosh of colored buttons on a single page potentially using different components, as we transition buttons on the site to use the new button components!

### How should this be reviewed?

👀 

### Relevant tickets

References [Pivotal #172184401](https://www.pivotaltracker.com/story/show/172184401).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
