### PR TITLE
Fix intermittent NotFound errors on OVRD pages

### DIFF
--- a/resources/assets/components/pages/VoterRegistrationDrivePage/Alpha/AlphaPage.js
+++ b/resources/assets/components/pages/VoterRegistrationDrivePage/Alpha/AlphaPage.js
@@ -9,7 +9,7 @@ import SocialDriveActionContainer from '../../../actions/SocialDriveAction/Socia
 
 const AlphaPage = ({ userId }) => {
   const config = isDevEnvironment()
-    ? gqlVariables.dev
+    ? gqlVariables.development
     : gqlVariables.production;
 
   return (

--- a/resources/assets/components/pages/VoterRegistrationDrivePage/Alpha/AlphaPage.js
+++ b/resources/assets/components/pages/VoterRegistrationDrivePage/Alpha/AlphaPage.js
@@ -1,31 +1,37 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import { shareLink } from './config';
+import { gqlVariables } from './config';
+import { isDevEnvironment } from '../../../../helpers';
 import VoterRegistrationReferrals from './VoterRegistrationReferrals/VoterRegistrationReferrals';
 import ContentfulEntryLoader from '../../../utilities/ContentfulEntryLoader/ContentfulEntryLoader';
 import SocialDriveActionContainer from '../../../actions/SocialDriveAction/SocialDriveActionContainer';
 
-const AlphaPage = ({ userId }) => (
-  <div
-    className="base-12-grid clear-both py-3 md:py-6"
-    data-test="alpha-voter-registration-drive-page"
-  >
-    <VoterRegistrationReferrals referrerUserId={userId} />
-    <ContentfulEntryLoader
-      id={shareLink.contentBlockId}
-      className="grid-wide clearfix wrapper pb-3"
-    />
-    <div className="grid-wide">
-      <SocialDriveActionContainer
-        link={`https://vote.dosomething.org/member-drive?userId=${userId}&r=user:${userId},source:web,source_details:onlinedrivereferral,referral=true`}
-        fullWidth
-        actionId={shareLink.actionId}
-        hidePageViews
+const AlphaPage = ({ userId }) => {
+  const config = isDevEnvironment()
+    ? gqlVariables.dev
+    : gqlVariables.production;
+
+  return (
+    <div
+      className="base-12-grid clear-both py-3 md:py-6"
+      data-test="alpha-voter-registration-drive-page"
+    >
+      <VoterRegistrationReferrals referrerUserId={userId} />
+      <ContentfulEntryLoader
+        id={config.shareLink.contentBlockId}
+        className="grid-wide clearfix wrapper pb-3"
       />
+      <div className="grid-wide">
+        <SocialDriveActionContainer
+          link={`https://vote.dosomething.org/member-drive?userId=${userId}&r=user:${userId},source:web,source_details:onlinedrivereferral,referral=true`}
+          actionId={config.shareLink.actionId}
+          hidePageViews
+        />
+      </div>
     </div>
-  </div>
-);
+  );
+};
 
 AlphaPage.propTypes = {
   userId: PropTypes.string.isRequired,

--- a/resources/assets/components/pages/VoterRegistrationDrivePage/Alpha/config.js
+++ b/resources/assets/components/pages/VoterRegistrationDrivePage/Alpha/config.js
@@ -9,7 +9,7 @@ export const gqlVariables = {
       contentBlockId: '3fj7mXlyrcJZ3mUKXqco1R',
     },
   },
-  dev: {
+  development: {
     faq: {
       contentBlockId: '6H22Y1wmICy05pM9twIGGR',
     },

--- a/resources/assets/components/pages/VoterRegistrationDrivePage/Alpha/config.js
+++ b/resources/assets/components/pages/VoterRegistrationDrivePage/Alpha/config.js
@@ -1,21 +1,22 @@
-import { isDevEnvironment } from '../../../../helpers';
-
-// Note: We're not using FAQ block yet, exists as a separate campaign page.
-// @see https://dosomething.slack.com/archives/CTVPG6L4R/p1588785224363300?thread_ts=1588722526.354200&cid=CTVPG6L4R
-export const faq = {
-  // ContentBlock used for FAQ section.
-  contentBlockId: isDevEnvironment()
-    ? '6H22Y1wmICy05pM9twIGGR'
-    : '1nLV3YUhLzJdlcGrd2Mq9N',
-};
-
-export const shareLink = {
-  // Used to count total number of scholarship entries.
-  actionId: isDevEnvironment() ? 27 : 1025,
-  // ContentBlock that appears above the SocialDriveAction.
-  contentBlockId: isDevEnvironment()
-    ? '1xcG1CTinKwn3Iyxtcc0f4'
-    : '3fj7mXlyrcJZ3mUKXqco1R',
+export const gqlVariables = {
+  production: {
+    faq: {
+      contentBlockId: '1nLV3YUhLzJdlcGrd2Mq9N',
+    },
+    shareLink: {
+      actionId: 1025,
+      contentBlockId: '3fj7mXlyrcJZ3mUKXqco1R',
+    },
+  },
+  dev: {
+    faq: {
+      contentBlockId: '6H22Y1wmICy05pM9twIGGR',
+    },
+    shareLink: {
+      actionId: 1025,
+      contentBlockId: '1xcG1CTinKwn3Iyxtcc0f4',
+    },
+  },
 };
 
 // Options to use for customizing the SocialDriveAction share link (not implemented yet).

--- a/resources/assets/components/pages/VoterRegistrationDrivePage/Alpha/config.js
+++ b/resources/assets/components/pages/VoterRegistrationDrivePage/Alpha/config.js
@@ -1,3 +1,4 @@
+// Values for GraphQL queries.
 export const gqlVariables = {
   production: {
     faq: {

--- a/resources/assets/components/pages/VoterRegistrationDrivePage/Alpha/config.js
+++ b/resources/assets/components/pages/VoterRegistrationDrivePage/Alpha/config.js
@@ -14,7 +14,7 @@ export const gqlVariables = {
       contentBlockId: '6H22Y1wmICy05pM9twIGGR',
     },
     shareLink: {
-      actionId: 1025,
+      actionId: 27,
       contentBlockId: '1xcG1CTinKwn3Iyxtcc0f4',
     },
   },

--- a/resources/assets/components/pages/VoterRegistrationDrivePage/Beta/BetaPage.js
+++ b/resources/assets/components/pages/VoterRegistrationDrivePage/Beta/BetaPage.js
@@ -2,14 +2,10 @@ import React, { useState } from 'react';
 import gql from 'graphql-tag';
 import { useQuery } from 'react-apollo';
 
-import {
-  faq,
-  registerToVote,
-  voterRegistrationDriveCampaignLink,
-} from './config';
+import { gqlVariables } from './config';
 import ErrorPage from '../../ErrorPage';
 import HeroSection from './HeroSection';
-import { query } from '../../../../helpers';
+import { isDevEnvironment, query } from '../../../../helpers';
 import NotFoundPage from '../../NotFoundPage';
 import Modal from '../../../utilities/Modal/Modal';
 import Placeholder from '../../../utilities/Placeholder';
@@ -46,13 +42,17 @@ const BETA_VOTER_REGISTRATION_DRIVE_PAGE_QUERY = gql`
 
 const BetaVoterRegistrationDrivePage = () => {
   const referrerUserId = query('referrer_user_id');
+
+  const config = isDevEnvironment()
+    ? gqlVariables.dev
+    : gqlVariables.production;
   /**
    * The CampaignWebsite ID is the same across all Contentful environments for OVRD.
    * @see /docs/development/features/voter-registration
    */
   const voterRegistrationDriveCampaignWebsiteId = '3pwxnRZxociqMaQCMcGOyc';
-  const [showScholarshipModal, setShowScholarshipModal] = useState(false);
 
+  const [showScholarshipModal, setShowScholarshipModal] = useState(false);
   const modalToggle = () => setShowScholarshipModal(true);
 
   if (!referrerUserId) {
@@ -100,7 +100,7 @@ const BetaVoterRegistrationDrivePage = () => {
         <div className="bg-white">
           <div className="md:w-3/4 mx-auto py-6 px-3 pitch-landing-page">
             <ContentfulEntryLoader
-              id={registerToVote.contentBlockId}
+              id={config.startVoterRegistration.contentBlockId}
               className="grid-wide clearfix wrapper pb-3"
             />
             <div className="pb-6">
@@ -110,11 +110,11 @@ const BetaVoterRegistrationDrivePage = () => {
               />
             </div>
             <ContentfulEntryLoader
-              id={faq.contentBlockId}
+              id={config.faq.contentBlockId}
               className="grid-wide clearfix wrapper pb-3"
             />
             <ContentfulEntryLoader
-              id={voterRegistrationDriveCampaignLink.contentBlockId}
+              id={config.joinCampaign.contentBlockId}
               className="grid-wide clearfix wrapper pb-3"
             />
             <ButtonLink link="/us/campaigns/online-registration-drive">

--- a/resources/assets/components/pages/VoterRegistrationDrivePage/Beta/BetaPage.js
+++ b/resources/assets/components/pages/VoterRegistrationDrivePage/Beta/BetaPage.js
@@ -27,15 +27,16 @@ const BETA_VOTER_REGISTRATION_DRIVE_PAGE_QUERY = gql`
     }
 
     campaignWebsite(id: $voterRegistrationDriveCampaignWebsiteId) {
+      additionalContent
       campaignId
-      title
       coverImage {
-        url
         description
+        url
       }
       scholarshipAmount
       scholarshipDeadline
-      additionalContent
+      title
+      url
     }
   }
 `;
@@ -86,6 +87,7 @@ const BetaVoterRegistrationDrivePage = () => {
     campaignId,
     scholarshipAmount,
     scholarshipDeadline,
+    url,
   } = data.campaignWebsite;
 
   return (
@@ -117,9 +119,7 @@ const BetaVoterRegistrationDrivePage = () => {
               id={config.joinCampaign.contentBlockId}
               className="grid-wide clearfix wrapper pb-3"
             />
-            <ButtonLink link="/us/campaigns/online-registration-drive">
-              Get Started
-            </ButtonLink>
+            <ButtonLink link={url}>Get Started</ButtonLink>
           </div>
         </div>
         {showScholarshipModal ? (

--- a/resources/assets/components/pages/VoterRegistrationDrivePage/Beta/BetaPage.js
+++ b/resources/assets/components/pages/VoterRegistrationDrivePage/Beta/BetaPage.js
@@ -45,7 +45,7 @@ const BetaVoterRegistrationDrivePage = () => {
   const referrerUserId = query('referrer_user_id');
 
   const config = isDevEnvironment()
-    ? gqlVariables.dev
+    ? gqlVariables.development
     : gqlVariables.production;
   /**
    * The CampaignWebsite ID is the same across all Contentful environments for OVRD.

--- a/resources/assets/components/pages/VoterRegistrationDrivePage/Beta/config.js
+++ b/resources/assets/components/pages/VoterRegistrationDrivePage/Beta/config.js
@@ -1,24 +1,27 @@
-import { isDevEnvironment } from '../../../../helpers';
-
-export const faq = {
-  // ContentBlock used for FAQ section.
-  contentBlockId: isDevEnvironment()
-    ? '3cXc0RPMVNeE4surEqFujL'
-    : '4yP8BdIdiGU0qwZaFyzmsm',
-};
-
-export const registerToVote = {
-  // ContentBlock used for step to start voter registration.
-  contentBlockId: isDevEnvironment()
-    ? 'bt0jUBYJaKoi1oab25Wmx'
-    : '2d2i2M3yn4RB9pZYVzQxGm',
-};
-
-export const voterRegistrationDriveCampaignLink = {
-  // ContentBlock used for step to join the voter registration drive campaign (become an alpha).
-  contentBlockId: isDevEnvironment()
-    ? '3p2qz2JPCvgVitgRVBoMFz'
-    : '30rCn63G1rnpzojCXC9PmF',
+// Values for GraphQL queries.
+export const gqlVariables = {
+  production: {
+    faq: {
+      contentBlockId: '4yP8BdIdiGU0qwZaFyzmsm',
+    },
+    startVoterRegistration: {
+      contentBlockId: '2d2i2M3yn4RB9pZYVzQxGm',
+    },
+    joinCampaign: {
+      contentBlockId: '30rCn63G1rnpzojCXC9PmF',
+    },
+  },
+  dev: {
+    faq: {
+      contentBlockId: '3cXc0RPMVNeE4surEqFujL',
+    },
+    startVoterRegistration: {
+      contentBlockId: 'bt0jUBYJaKoi1oab25Wmx',
+    },
+    joinCampaign: {
+      contentBlockId: '3p2qz2JPCvgVitgRVBoMFz',
+    },
+  },
 };
 
 /**

--- a/resources/assets/components/pages/VoterRegistrationDrivePage/Beta/config.js
+++ b/resources/assets/components/pages/VoterRegistrationDrivePage/Beta/config.js
@@ -11,7 +11,7 @@ export const gqlVariables = {
       contentBlockId: '30rCn63G1rnpzojCXC9PmF',
     },
   },
-  dev: {
+  development: {
     faq: {
       contentBlockId: '3cXc0RPMVNeE4surEqFujL',
     },


### PR DESCRIPTION
### What's this PR do?

This pull request refactors the OVRD pages to check for `window.ENV.APP_ENV` via the  `isDevEnvironment` helper while rendering each component, moving it out of the config per @mendelB's suggestion in https://github.com/DoSomething/phoenix-next/pull/2108#issuecomment-625292928.  

Also pulls the OVRD campaign's URL from GraphQL instead of hardcoding the path.

### How should this be reviewed?

I'll add the review app to Aurora and share some links to 👀 the NotFound blocks shouldn't appear.

### Any background context you want to provide?

@mendelB is a genius. Also - this makes the configs wayyy easier to read, which is a fun quick win ⚾ 

### Relevant tickets

References https://github.com/DoSomething/phoenix-next/pull/2108#issuecomment-625286346

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added screenshots of front-end changes on small, medium, and large screens.
- [ ] Added appropriate feature/unit tests.
