### PR TITLE
Adds markdown-it-collapsible

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11783,6 +11783,11 @@
       "resolved": "https://registry.npmjs.org/markdown-it-anchor/-/markdown-it-anchor-5.2.5.tgz",
       "integrity": "sha512-xLIjLQmtym3QpoY9llBgApknl7pxAcN3WDRc2d3rwpl+/YvDZHPmKscGs+L6E05xf2KrCXPBvosWt7MZukwSpQ=="
     },
+    "markdown-it-collapsible": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/markdown-it-collapsible/-/markdown-it-collapsible-1.0.0.tgz",
+      "integrity": "sha512-WRkgDH66GNxkdkZGEyW/0VnsEtOzxZuQCAY1e5FjVYACAhMtDNleZs1Y7NZSj5Pn3yksQ6SrgPkEwQW2IFGAQw=="
+    },
     "markdown-it-footnote": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/markdown-it-footnote/-/markdown-it-footnote-3.0.2.tgz",

--- a/package.json
+++ b/package.json
@@ -109,6 +109,7 @@
     "lodash-es": "^4.17.15",
     "markdown-it": "^8.4.0",
     "markdown-it-anchor": "^5.2.5",
+    "markdown-it-collapsible": "^1.0.0",
     "markdown-it-footnote": "^3.0.2",
     "markdown-it-for-inline": "^0.1.1",
     "node-fetch": "^2.6.0",

--- a/resources/assets/components/utilities/TextContent/markdown.scss
+++ b/resources/assets/components/utilities/TextContent/markdown.scss
@@ -154,5 +154,5 @@ details > *:not(summary) {
 
 summary {
   @apply font-bold;
-  font-size: 18px;
+  font-size: inherit;
 }

--- a/resources/assets/components/utilities/TextContent/markdown.scss
+++ b/resources/assets/components/utilities/TextContent/markdown.scss
@@ -143,3 +143,16 @@
     overflow-wrap: break-word;
   }
 }
+
+details {
+  @apply pb-3;
+}
+
+details > *:not(summary) {
+  @apply pt-5;
+}
+
+summary {
+  @apply font-bold;
+  font-size: 18px;
+}

--- a/resources/assets/components/utilities/TextContent/markdown.scss
+++ b/resources/assets/components/utilities/TextContent/markdown.scss
@@ -133,6 +133,19 @@
     margin: 60px auto;
     width: 33.333333333%;
   }
+
+  details {
+    @apply pb-3;
+  }
+
+  details > *:not(summary) {
+    @apply pt-5;
+  }
+
+  summary {
+    @apply font-bold;
+    font-size: inherit;
+  }
 }
 
 .footnotes {
@@ -142,17 +155,4 @@
     color: theme('colors.gray.600');
     overflow-wrap: break-word;
   }
-}
-
-details {
-  @apply pb-3;
-}
-
-details > *:not(summary) {
-  @apply pt-5;
-}
-
-summary {
-  @apply font-bold;
-  font-size: inherit;
 }

--- a/resources/assets/helpers/text.js
+++ b/resources/assets/helpers/text.js
@@ -1,12 +1,12 @@
 import React from 'react';
-import { get, isArray, isString, kebabCase } from 'lodash';
 import classnames from 'classnames';
 import MarkdownIt from 'markdown-it';
 import iterator from 'markdown-it-for-inline';
 import markdownItAnchor from 'markdown-it-anchor';
+import markdownItFootnote from 'markdown-it-footnote';
+import { get, isArray, isString, kebabCase } from 'lodash';
 import markdownItCollapsible from 'markdown-it-collapsible';
 import { BLOCKS, INLINES } from '@contentful/rich-text-types';
-import markdownItFootnote from 'markdown-it-footnote';
 import { documentToReactComponents } from '@contentful/rich-text-react-renderer';
 
 import { contentfulImageUrl, isExternal } from '.';

--- a/resources/assets/helpers/text.js
+++ b/resources/assets/helpers/text.js
@@ -4,6 +4,7 @@ import classnames from 'classnames';
 import MarkdownIt from 'markdown-it';
 import iterator from 'markdown-it-for-inline';
 import markdownItAnchor from 'markdown-it-anchor';
+import markdownItCollapsible from 'markdown-it-collapsible';
 import { BLOCKS, INLINES } from '@contentful/rich-text-types';
 import markdownItFootnote from 'markdown-it-footnote';
 import { documentToReactComponents } from '@contentful/rich-text-react-renderer';
@@ -76,6 +77,9 @@ function getMarkdownItInstance() {
 
   // Add linkable anchors to heading elements:
   markdownIt.use(markdownItAnchor, { slugify });
+
+  // Supports <details> and <summary> HTML elements via syntax: https://git.io/JfcPL
+  markdownIt.use(markdownItCollapsible);
 
   // We use 'markdown-it-for-inline' to make a simple overrides: https://git.io/Jv714
   // This rule transforms Markdown links to open in a new tab if external:

--- a/resources/assets/scss/base.scss
+++ b/resources/assets/scss/base.scss
@@ -106,6 +106,18 @@ a > * {
   border-radius: 0;
 }
 
+details {
+  @apply pb-3;
+}
+
+summary {
+  @apply font-bold;
+}
+
+details > *:not(summary) {
+  padding-top: 1.25em;
+}
+
 /*
 |-------------------------------------------------------------------------------
 | START: DEPRECATION WARNING!!

--- a/resources/assets/scss/base.scss
+++ b/resources/assets/scss/base.scss
@@ -106,18 +106,6 @@ a > * {
   border-radius: 0;
 }
 
-details {
-  @apply pb-3;
-}
-
-summary {
-  @apply font-bold;
-}
-
-details > *:not(summary) {
-  padding-top: 1.25em;
-}
-
 /*
 |-------------------------------------------------------------------------------
 | START: DEPRECATION WARNING!!


### PR DESCRIPTION
### What's this PR do?

This pull request adds the [`markdown-it-collapsible`](https://www.npmjs.com/package/markdown-it-collapsible) plugin to render `<summary>` and `<details>` HTML5 tags using syntax:
```
+++ Click me!
Hidden text
+++
```

Here's some example content:

```
+++ Does my vote _actually_ matter?

Yes, it definitely does! There are countless elections that have been decided by only a few votes. For example, a state election in 2017 was tied, so the winner was selected by drawing names out of a hat. Literally. In a 2014 election in Louisiana, one race was decided by just 1%. Who pushed the winner over the top? Young people, who supported that candidate more than any other group. 

+++

+++I'm not 18, but I will be by Election Day. Can I still register to vote?

It depends on your state. In most states, YES. In all but a few states, you can register to vote if you’ll be 18 by Election Day. In the following states, you can only register if your 18th birthday is within a certain number of days or months before Election Day.

+++

+++ When are my elections?

There are hundreds of local elections in each state. Luckily, our friends at Rock the Vote can send you reminders about when elections are coming up in your state or city.

+++
```

And its rendered result, with the third item expanded:

<img width="759" alt="Screen Shot 2020-05-08 at 9 06 31 AM" src="https://user-images.githubusercontent.com/1236811/81424720-3d758080-910b-11ea-89ec-9846d3d5c88f.png">

### How should this be reviewed?

With a grain of 🧂 and ideally some guidance on the best way to style these new `<summary>` and `<details>` tags and the additional background context I want to provide.


### Any background context you want to provide?

Where should the styles go? Also how should we handle the custom carat image our [designs](https://share.goabstract.com/99a2866c-437b-4d78-9799-d74cc91ba4e9) require? 


Closed:
<img width="384" alt="Screen Shot 2020-05-08 at 9 11 12 AM" src="https://user-images.githubusercontent.com/1236811/81425164-e623e000-910b-11ea-8b3b-54edd0b21703.png">

Open:
<img width="384" alt="Screen Shot 2020-05-08 at 9 09 07 AM" src="https://user-images.githubusercontent.com/1236811/81424984-9b09cd00-910b-11ea-8c7a-652a0ba044e0.png">


### Relevant tickets

References [Pivotal #172087924](https://www.pivotaltracker.com/story/show/172087924).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added screenshots of front-end changes on small, medium, and large screens.
- [ ] Added appropriate feature/unit tests.
