### PR TITLE
Test the Volunteer Certificate PDF Download Flow

### DIFF
--- a/resources/assets/components/pages/AccountPage/Credits/CertificateDownloadButton.test.js
+++ b/resources/assets/components/pages/AccountPage/Credits/CertificateDownloadButton.test.js
@@ -1,0 +1,98 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import { act } from 'react-dom/test-utils';
+import * as reactPdfMock from '@react-pdf/renderer';
+
+import CertificateDownloadButton from './CertificateDownloadButton';
+import { mockParsedPostsData } from './volunteer-credits-mock-data';
+
+jest.mock('./CertificateTemplate');
+jest.mock('../../../../helpers/analytics');
+jest.mock('../../../blocks/ErrorBlock/ErrorBlock', () => 'mock-error-block');
+
+global.URL.createObjectURL = jest.fn();
+
+// Mocks the react-pdf 'pdf' method which we use to generate the PDF.
+reactPdfMock.pdf = jest.fn(() => ({
+  toBlob: () => Promise.resolve(new Blob()),
+}));
+
+describe('CertificateDownloadButton component', () => {
+  describe('With a pending post', () => {
+    const wrapper = mount(
+      <CertificateDownloadButton certificatePost={mockParsedPostsData[0]} />,
+    );
+
+    it('renders a disabled, "pending" button', () => {
+      const button = wrapper.find('button');
+
+      expect(button.length).toEqual(1);
+      expect(button.text()).toEqual('pending');
+      expect(button.prop('disabled')).toBe(true);
+    });
+  });
+
+  describe('With an accepted post', () => {
+    describe('A successful PDF download flow', () => {
+      const wrapper = mount(
+        <CertificateDownloadButton certificatePost={mockParsedPostsData[2]} />,
+      );
+
+      const button = wrapper.find('button');
+
+      it('renders a "download" button', () => {
+        expect(button.length).toEqual(1);
+        expect(button.text()).toEqual('download');
+      });
+
+      it('switches to "loading" when clicked, and generates the PDF', async () => {
+        button.simulate('click');
+
+        expect(button.text()).toEqual('loading');
+
+        // 'Wait' for the PDF to download.
+        await act(async () => {});
+
+        expect(reactPdfMock.pdf).toHaveBeenCalled();
+      });
+
+      it('switches back to "download" and doesn\'t generate the PDF again', () => {
+        expect(button.text()).toEqual('download');
+
+        // Click the button a second time.
+        button.simulate('click');
+
+        // We should not have invoked the libraries 'pdf' method again.
+        expect(reactPdfMock.pdf).toHaveBeenCalledTimes(0);
+        // We shoud not switch to "loading" state again.
+        expect(button.text()).toEqual('download');
+      });
+    });
+
+    describe('An unsuccessful PDF download flow', () => {
+      it('renders an error block when the PDF download fails', async () => {
+        const wrapper = mount(
+          <CertificateDownloadButton
+            certificatePost={mockParsedPostsData[2]}
+          />,
+        );
+
+        const button = wrapper.find('button');
+
+        // Mock an error during the PDF generation.
+        reactPdfMock.pdf = jest.fn(() => {
+          throw new Error();
+        });
+
+        button.simulate('click');
+
+        // 'Wait' for the PDF to generate (and fail).
+        await act(async () => {});
+
+        wrapper.update();
+
+        expect(wrapper.find('mock-error-block').length).toEqual(1);
+      });
+    });
+  });
+});


### PR DESCRIPTION
### What's this PR do?

This pull request adds some Jest tests for the `CertificateDownloadButton` component across the core Volunteer Certificate PDF download flow.

### How should this be reviewed?
This hopefully should be pretty readable. There's a touch of Jest magic here and there to mock library functions and await async promise resolution, but altogether should be straightforward. (lol I wish the implementation was too 😵)

### Any background context you want to provide?
The part I found most challenging was mocking the react-pdf libraries `pdf` function (to avoid actually rendering a PDF in the tests, and to allow mocking an error flow.) I ended up following the [advice here](https://stackoverflow.com/a/51223001/5657278) to mock a named export function and it seemed to do the trick!

### Relevant tickets

References [Pivotal #172439425](https://www.pivotaltracker.com/story/show/172439425).
