### PR TITLE
Retire Legacy Landing Page

### DIFF
--- a/app/Entities/Campaign.php
+++ b/app/Entities/Campaign.php
@@ -104,7 +104,6 @@ class Campaign extends Entity implements JsonSerializable
             'id' => $this->entry->getId(),
             'campaignId' => $this->legacyCampaignId,
             'type' => $this->entry->getContentType()->getId(),
-            'template' => 'mosaic',
             'title' => $this->title,
             'slug' => $this->slug,
             'metadata' => $this->metadata ? new Metadata($this->metadata->entry) : null,

--- a/contentful/content-types/campaign.js
+++ b/contentful/content-types/campaign.js
@@ -106,33 +106,6 @@ module.exports = function(migration) {
     .linkType('Entry');
 
   campaign
-    .createField('template')
-    .name('Template')
-    .type('Array')
-    .localized(false)
-    .required(false)
-    .validations([
-      {
-        size: {
-          max: 1,
-        },
-
-        message: 'Only choose one template.',
-      },
-    ])
-    .disabled(true)
-    .omitted(false)
-    .items({
-      type: 'Symbol',
-
-      validations: [
-        {
-          in: ['legacy', 'mosaic'],
-        },
-      ],
-    });
-
-  campaign
     .createField('endDate')
     .name('End Date')
     .type('Date')

--- a/docs/development/content-types/landing-page.md
+++ b/docs/development/content-types/landing-page.md
@@ -16,4 +16,4 @@ Any heading-1's will be styled as [Section Header titles](https://github.com/DoS
 
 - **Content** : A Rich Text field, which can embed `contentBlock`, `imagesBlock`, and `linkAction` entries.
 
-- **Additional Content** : The legacy campaign template uses this field to display Landing Page content, expecting a `legacyTemplateContent` property.
+- **Additional Content** : No additional content fields are currently formally supported. This can be used for feature flagging and experimental fields.

--- a/resources/assets/components/CampaignPageNavigation/CampaignPageNavigation.js
+++ b/resources/assets/components/CampaignPageNavigation/CampaignPageNavigation.js
@@ -10,13 +10,8 @@ const CampaignPageNavigation = ({
   campaignSlug,
   isAffiliated,
   isCampaignClosed,
-  isLegacyTemplate,
   pages,
 }) => {
-  if (isLegacyTemplate) {
-    return null;
-  }
-
   const linkablePages = pages
     .filter(page => page.type === 'page')
     // @TODO: we want to eventually remove the need for hideFromNavigation field
@@ -44,7 +39,6 @@ CampaignPageNavigation.propTypes = {
   campaignSlug: PropTypes.string.isRequired,
   isAffiliated: PropTypes.bool.isRequired,
   isCampaignClosed: PropTypes.bool.isRequired,
-  isLegacyTemplate: PropTypes.bool.isRequired,
   pages: PropTypes.arrayOf(
     PropTypes.shape({
       fields: PropTypes.object,

--- a/resources/assets/components/CampaignPageNavigation/CampaignPageNavigationContainer.js
+++ b/resources/assets/components/CampaignPageNavigation/CampaignPageNavigationContainer.js
@@ -8,7 +8,6 @@ import CampaignPageNavigation from './CampaignPageNavigation';
 const mapStateToProps = state => ({
   isAffiliated: isSignedUp(state),
   isCampaignClosed: isCampaignClosed(state.campaign.endDate),
-  isLegacyTemplate: Boolean(state.campaign.template === 'legacy'),
   pages: state.campaign.pages,
   campaignSlug: state.campaign.slug,
 });

--- a/resources/assets/components/LedeBanner/LedeBanner.js
+++ b/resources/assets/components/LedeBanner/LedeBanner.js
@@ -1,25 +1,7 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
-import MosaicTemplate from './templates/MosaicTemplate';
 import HeroTemplate from './templates/HeroTemplate';
 
-const LedeBanner = props => {
-  const { featureFlagUseLegacyTemplate } = props;
-
-  return featureFlagUseLegacyTemplate ? (
-    <MosaicTemplate {...props} />
-  ) : (
-    <HeroTemplate {...props} />
-  );
-};
-
-LedeBanner.propTypes = {
-  featureFlagUseLegacyTemplate: PropTypes.bool,
-};
-
-LedeBanner.defaultProps = {
-  featureFlagUseLegacyTemplate: false,
-};
+const LedeBanner = props => <HeroTemplate {...props} />;
 
 export default LedeBanner;

--- a/resources/assets/components/LedeBanner/LedeBannerContainer.js
+++ b/resources/assets/components/LedeBanner/LedeBannerContainer.js
@@ -43,10 +43,6 @@ const mapStateToProps = (state, props) => ({
   content: state.campaign.blurb,
   dashboard: state.campaign.dashboard,
   endDate: state.campaign.endDate,
-  featureFlagUseLegacyTemplate: get(
-    state,
-    'campaign.additionalContent.featureFlagUseLegacyTemplate',
-  ),
   isAffiliated: isSignedUp(state),
   scholarshipAmount: state.campaign.scholarshipAmount,
   scholarshipCallToAction: state.campaign.scholarshipCallToAction,

--- a/resources/assets/components/pages/LandingPage/LandingPage.js
+++ b/resources/assets/components/pages/LandingPage/LandingPage.js
@@ -5,31 +5,13 @@ import tw from 'twin.macro';
 import PropTypes from 'prop-types';
 import { css } from '@emotion/core';
 
-import Card from '../../utilities/Card/Card';
+import { tailwind } from '../../../helpers';
 import TextContent from '../../utilities/TextContent/TextContent';
 import LedeBannerContainer from '../../LedeBanner/LedeBannerContainer';
-import { getScholarshipAffiliateLabel, tailwind } from '../../../helpers';
-import CallToActionContainer from '../../CallToAction/CallToActionContainer';
 import CampaignInfoBarContainer from '../../CampaignInfoBar/CampaignInfoBarContainer';
-import AffiliateScholarshipBlockQuery from '../../blocks/AffiliateScholarshipBlock/AffiliateScholarshipBlockQuery';
 
 const LandingPage = props => {
-  const {
-    additionalContent,
-    campaignId,
-    content,
-    isCampaignClosed,
-    featureFlagUseLegacyTemplate,
-    scholarshipAmount,
-    scholarshipDeadline,
-    sidebarCTA,
-    signupArrowContent,
-    tagline,
-  } = props;
-  const scholarshipAffiliateLabel = getScholarshipAffiliateLabel();
-  const displayAffiliateScholarshipBlock =
-    scholarshipAffiliateLabel && scholarshipAmount && scholarshipDeadline;
-
+  const { content, isCampaignClosed } = props;
   // @TODO: Implement this as a custom (rich text) renderer per https://git.io/JfGlf.
   const landingPageHeadingOneStyle = css`
     h1 {
@@ -42,107 +24,34 @@ const LandingPage = props => {
   `;
 
   return (
-    <React.Fragment>
-      <LedeBannerContainer
-        isClosed={isCampaignClosed}
-        signupArrowContent={signupArrowContent}
-      />
-      {featureFlagUseLegacyTemplate ? (
-        <>
-          <div className="bg-white">
-            <div className="md:w-3/4 mx-auto py-6 px-3 pitch-landing-page">
-              <div className="campaign-page__content clearfix">
-                <div className="primary">
-                  {displayAffiliateScholarshipBlock ? (
-                    <AffiliateScholarshipBlockQuery
-                      campaignId={Number(campaignId)}
-                      utmLabel={scholarshipAffiliateLabel.toLowerCase()}
-                      scholarshipAmount={scholarshipAmount}
-                      scholarshipDeadline={scholarshipDeadline}
-                      className="mb-6"
-                    />
-                  ) : null}
+    <>
+      <LedeBannerContainer isClosed={isCampaignClosed} />
 
-                  {additionalContent.legacyTemplateContent ? (
-                    <TextContent>
-                      {additionalContent.legacyTemplateContent}
-                    </TextContent>
-                  ) : null}
-                </div>
-                <div className="secondary">
-                  <Card title={sidebarCTA.title} className="rounded bordered">
-                    <TextContent className="p-3">
-                      {sidebarCTA.content}
-                    </TextContent>
-                  </Card>
-                </div>
+      {content ? (
+        <div className="bg-white">
+          <div className="md:w-3/4 mx-auto py-6 px-3 pitch-landing-page">
+            <div className="campaign-page__content clearfix">
+              <div className="primary" css={landingPageHeadingOneStyle}>
+                <TextContent>{content}</TextContent>
               </div>
             </div>
           </div>
+        </div>
+      ) : null}
 
-          <CallToActionContainer
-            className="bg-gray-100-important border-t border-solid border-gray-300 font-bold px-3 md:px-6 py-6 text-base md:text-lg"
-            content={tagline}
-          />
-
-          <CampaignInfoBarContainer />
-
-          <div className="info-bar bg-gray-700">
-            <div className="wrapper">
-              A DoSomething.org campaign. Join millions of young people
-              transforming their communities. Let&#39;s Do This!
-            </div>
-          </div>
-        </>
-      ) : (
-        <>
-          {content ? (
-            <div className="bg-white">
-              <div className="md:w-3/4 mx-auto py-6 px-3 pitch-landing-page">
-                <div className="campaign-page__content clearfix">
-                  <div className="primary" css={landingPageHeadingOneStyle}>
-                    <TextContent>{content}</TextContent>
-                  </div>
-                </div>
-              </div>
-            </div>
-          ) : null}
-          <CampaignInfoBarContainer />
-        </>
-      )}
-    </React.Fragment>
+      <CampaignInfoBarContainer />
+    </>
   );
 };
 
 LandingPage.propTypes = {
-  additionalContent: PropTypes.object,
-  campaignId: PropTypes.string.isRequired,
   content: PropTypes.object,
-  featureFlagUseLegacyTemplate: PropTypes.bool,
   isCampaignClosed: PropTypes.bool,
-  scholarshipAmount: PropTypes.number,
-  scholarshipDeadline: PropTypes.string,
-  sidebarCTA: PropTypes.shape({
-    title: PropTypes.string,
-    content: PropTypes.string,
-  }),
-  signupArrowContent: PropTypes.string,
-  tagline: PropTypes.string,
 };
 
 LandingPage.defaultProps = {
-  additionalContent: null,
   content: null,
-  featureFlagUseLegacyTemplate: false,
   isCampaignClosed: false,
-  scholarshipAmount: null,
-  scholarshipDeadline: null,
-  sidebarCTA: {
-    title: 'what you get',
-    content: '*You could win a $5,000 dollar scholarship!*',
-  },
-  signupArrowContent: null,
-  tagline: 'Ready to start?',
 };
 
 export default LandingPage;

--- a/resources/assets/components/pages/LandingPage/LandingPageContainer.js
+++ b/resources/assets/components/pages/LandingPage/LandingPageContainer.js
@@ -1,4 +1,4 @@
-import { first, get } from 'lodash';
+import { get } from 'lodash';
 import { connect } from 'react-redux';
 
 import LandingPage from './LandingPage';
@@ -12,27 +12,10 @@ const mapStateToProps = (state, ownProps) => {
   // or a landingPage content type, the ownProps is structured a bit
   // differently. Revise once all landing pages use landingPage type.
   const landingPage = get(ownProps, 'landingPage.fields', ownProps);
-  // We use the first block in the landing page sidebar as the sidebar CTA.
-  const sidebarCTA = get(first(landingPage.sidebar), 'fields');
 
   return {
-    additionalContent: landingPage.additionalContent,
-    campaignId: state.campaign.campaignId,
     content: landingPage.content,
-    featureFlagUseLegacyTemplate: get(
-      state,
-      'campaign.additionalContent.featureFlagUseLegacyTemplate',
-    ),
     isCampaignClosed: isCampaignClosed(state.campaign.endDate),
-    scholarshipAmount: state.campaign.scholarshipAmount,
-    scholarshipDeadline: state.campaign.scholarshipDeadline,
-    sidebarCTA,
-    signupArrowContent: get(
-      state.campaign.additionalContent,
-      'signupArrowContent',
-      null,
-    ),
-    tagline: get(state.campaign.additionalContent, 'tagline'),
   };
 };
 


### PR DESCRIPTION
### What's this PR do?

This pull request formally deprecates the Legacy Landing Page (which employed the `MosaicTemplate` from the `LedeBanner`) and it's accompanied logic.

It also removes the deprecated Campaign `template` field.

This opens us up to some exciting 🗑️and restructuring in follow-up work to come! (Keeping this PR contained to just retiring the rendering functionality. But will follow up with trashing legacy components and restructuring and simplifying some of the Landing Page / Lede Banner logic.)

### How should this be reviewed?
Perhaps see if you happen to spy anything being trashed that shouldn't be, but this should all be straightforward!

### Any background context you want to provide?
We've ported over all lingering campaigns activating the `featureFlagUseLegacyTemplate` to the new Landing Page & `HeroTemplate` ([Pivotal #170879500](https://www.pivotaltracker.com/story/show/170879500)).

### Relevant tickets

References [Pivotal #171776980](https://www.pivotaltracker.com/story/show/171776980).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added screenshots of front-end changes on small, medium, and large screens.
- [ ] Added appropriate feature/unit tests.
