### PR TITLE
Display personalized message using selected causes

### DIFF
--- a/cypress/integration/beta-voter-registration-drive-page.js
+++ b/cypress/integration/beta-voter-registration-drive-page.js
@@ -186,7 +186,7 @@ describe('Beta Voter Registration Drive (OVRD) Page', () => {
     cy.get(
       '[data-test=beta-voter-registration-drive-page-quote-text]',
     ).contains(
-      'Voting is important for young people because we can effect change on issues we care about most like , COVID-19 relief and climate change.',
+      'Voting is important for young people because we can effect change on issues we care about most like COVID-19 relief and climate change.',
     );
     cy.get(
       '[data-test=beta-voter-registration-drive-page-quote-byline]',
@@ -210,7 +210,7 @@ describe('Beta Voter Registration Drive (OVRD) Page', () => {
     cy.get(
       '[data-test=beta-voter-registration-drive-page-quote-text]',
     ).contains(
-      'Voting is important for young people because we can effect change on issues we care about most like , COVID-19 relief, student debt, mental health, gun violence and climate change.',
+      'Voting is important for young people because we can effect change on issues we care about most like COVID-19 relief,student debt,mental health,gun violence, and climate change.',
     );
     cy.get(
       '[data-test=beta-voter-registration-drive-page-quote-byline]',

--- a/cypress/integration/beta-voter-registration-drive-page.js
+++ b/cypress/integration/beta-voter-registration-drive-page.js
@@ -204,13 +204,13 @@ describe('Beta Voter Registration Drive (OVRD) Page', () => {
     cy.visit(
       `${getBetaPagePathForUser(
         user,
-      )}&voting-reasons=covid-relief,student-debt,mental-health,gun-violence,climate-change`,
+      )}&voting-reasons=covid-relief,climate-change,healthcare`,
     );
 
     cy.get(
       '[data-test=beta-voter-registration-drive-page-quote-text]',
     ).contains(
-      'Voting is important for young people because we can effect change on issues we care about most like COVID-19 relief, student debt, mental health, gun violence, and climate change.',
+      'Voting is important for young people because we can effect change on issues we care about most like COVID-19 relief, climate change, and healthcare.',
     );
     cy.get(
       '[data-test=beta-voter-registration-drive-page-quote-byline]',

--- a/cypress/integration/beta-voter-registration-drive-page.js
+++ b/cypress/integration/beta-voter-registration-drive-page.js
@@ -204,13 +204,13 @@ describe('Beta Voter Registration Drive (OVRD) Page', () => {
     cy.visit(
       `${getBetaPagePathForUser(
         user,
-      )}&voting-reasons=covid-relief,climate-change,healthcare`,
+      )}&voting-reasons=mental-health,climate-change,healthcare,covid-relief`,
     );
 
     cy.get(
       '[data-test=beta-voter-registration-drive-page-quote-text]',
     ).contains(
-      'Voting is important for young people because we can effect change on issues we care about most like COVID-19 relief, climate change, and healthcare.',
+      'Voting is important for young people because we can effect change on issues we care about most like mental health, climate change, healthcare, and COVID-19 relief',
     );
     cy.get(
       '[data-test=beta-voter-registration-drive-page-quote-byline]',

--- a/cypress/integration/beta-voter-registration-drive-page.js
+++ b/cypress/integration/beta-voter-registration-drive-page.js
@@ -210,7 +210,7 @@ describe('Beta Voter Registration Drive (OVRD) Page', () => {
     cy.get(
       '[data-test=beta-voter-registration-drive-page-quote-text]',
     ).contains(
-      'Voting is important for young people because we can effect change on issues we care about most like COVID-19 relief,student debt,mental health,gun violence, and climate change.',
+      'Voting is important for young people because we can effect change on issues we care about most like COVID-19 relief, student debt, mental health, gun violence, and climate change.',
     );
     cy.get(
       '[data-test=beta-voter-registration-drive-page-quote-byline]',

--- a/cypress/integration/beta-voter-registration-drive-page.js
+++ b/cypress/integration/beta-voter-registration-drive-page.js
@@ -149,6 +149,74 @@ describe('Beta Voter Registration Drive (OVRD) Page', () => {
     ).contains(`- ${user.firstName}`);
   });
 
+  it('Beta OVRD quote displays one cause query when found in voting-options query', () => {
+    const user = userFactory();
+
+    cy.mockGraphqlOp('BetaVoterRegistrationDrivePageQuery', {
+      user,
+      campaignWebsite,
+    });
+
+    cy.visit(`${getBetaPagePathForUser(user)}&voting-reasons=student-debt`);
+
+    cy.get(
+      '[data-test=beta-voter-registration-drive-page-quote-text]',
+    ).contains(
+      'Voting is important for young people because we can effect change on issues we care about most like student debt.',
+    );
+    cy.get(
+      '[data-test=beta-voter-registration-drive-page-quote-byline]',
+    ).contains(`- ${user.firstName}`);
+  });
+
+  it('Beta OVRD quote displays two causes when found in voting-options query', () => {
+    const user = userFactory();
+
+    cy.mockGraphqlOp('BetaVoterRegistrationDrivePageQuery', {
+      user,
+      campaignWebsite,
+    });
+
+    cy.visit(
+      `${getBetaPagePathForUser(
+        user,
+      )}&voting-reasons=covid-relief,climate-change`,
+    );
+
+    cy.get(
+      '[data-test=beta-voter-registration-drive-page-quote-text]',
+    ).contains(
+      'Voting is important for young people because we can effect change on issues we care about most like , COVID-19 relief and climate change.',
+    );
+    cy.get(
+      '[data-test=beta-voter-registration-drive-page-quote-byline]',
+    ).contains(`- ${user.firstName}`);
+  });
+
+  it('Beta OVRD quote displays three or more causes when found in voting-options query', () => {
+    const user = userFactory();
+
+    cy.mockGraphqlOp('BetaVoterRegistrationDrivePageQuery', {
+      user,
+      campaignWebsite,
+    });
+
+    cy.visit(
+      `${getBetaPagePathForUser(
+        user,
+      )}&voting-reasons=covid-relief,student-debt,mental-health,gun-violence,climate-change`,
+    );
+
+    cy.get(
+      '[data-test=beta-voter-registration-drive-page-quote-text]',
+    ).contains(
+      'Voting is important for young people because we can effect change on issues we care about most like , COVID-19 relief, student debt, mental health, gun violence and climate change.',
+    );
+    cy.get(
+      '[data-test=beta-voter-registration-drive-page-quote-byline]',
+    ).contains(`- ${user.firstName}`);
+  });
+
   it('Beta OVRD HeroSection displays scholarship info in blurb', () => {
     const user = userFactory();
 

--- a/resources/assets/components/pages/VoterRegistrationDrivePage/Beta/HeroSection.js
+++ b/resources/assets/components/pages/VoterRegistrationDrivePage/Beta/HeroSection.js
@@ -24,22 +24,18 @@ const HeroSection = ({ user, campaignInfo, modalToggle }) => {
 
   const formatQuote = () => {
     const votingReasonsQuery = query('voting-reasons');
+
     if (!votingReasonsQuery) {
       return null;
     }
+
     const votingReasonsValues = votingReasonsQuery.split(',');
 
     if (votingReasonsValues.length === 1) {
       return ` like ${votingReasons[votingReasonsValues[0]]}`;
     }
 
-    if (votingReasonsValues.length === 2) {
-      return ` like ${votingReasons[votingReasonsValues[0]]} and ${
-        votingReasons[votingReasonsValues[1]]
-      }`;
-    }
-
-    if (votingReasonsValues.length > 2) {
+    if (votingReasonsValues.length > 1) {
       let result = '';
 
       votingReasonsValues.forEach((value, index) => {
@@ -49,6 +45,7 @@ const HeroSection = ({ user, campaignInfo, modalToggle }) => {
           result = `${result}, ${votingReasons[value]}`;
         }
       });
+
       return ` like ${result}`;
     }
 

--- a/resources/assets/components/pages/VoterRegistrationDrivePage/Beta/HeroSection.js
+++ b/resources/assets/components/pages/VoterRegistrationDrivePage/Beta/HeroSection.js
@@ -1,8 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-
+import QueryString from 'query-string';
 import CoverImage from '../../../utilities/CoverImage/CoverImage';
 import CampaignInfoBlock from '../../../blocks/CampaignInfoBlock/CampaignInfoBlock';
+import votingReasons from '../../../pages/VoterRegistrationDrivePage/Beta/config';
 
 const HeroSection = ({ user, campaignInfo, modalToggle }) => {
   const { firstName } = user;
@@ -18,6 +19,13 @@ const HeroSection = ({ user, campaignInfo, modalToggle }) => {
    * TODO: Check for a voting-reasons query parameter, and render values in quote if present.
    * @see https://www.pivotaltracker.com/story/show/172087475
    */
+
+  QueryString.parse(location.search);
+  /*
+Query url
+check for votingReasons
+append to p tag
+*/
   return (
     <div className="hero-landing-page">
       <CoverImage

--- a/resources/assets/components/pages/VoterRegistrationDrivePage/Beta/HeroSection.js
+++ b/resources/assets/components/pages/VoterRegistrationDrivePage/Beta/HeroSection.js
@@ -35,17 +35,23 @@ const HeroSection = ({ user, campaignInfo, modalToggle }) => {
       return ` like ${votingReasons[votingReasonsValues[0]]}`;
     }
 
-    if (votingReasonsValues.length > 1) {
+    if (votingReasonsValues.length === 2) {
+      return ` like ${votingReasons[votingReasonsValues[0]]} and ${
+        votingReasons[votingReasonsValues[1]]
+      }`;
+    }
+
+    if (votingReasonsValues.length > 2) {
       let result = '';
 
       votingReasonsValues.forEach((value, index) => {
         if (index === votingReasonsValues.length - 1) {
           result = `${result} and ${votingReasons[value]}`;
         } else {
-          result = `${result}, ${votingReasons[value]}`;
+          result = `${result}${votingReasons[value]},`;
         }
       });
-
+      console.log('result:', result);
       return ` like ${result}`;
     }
 

--- a/resources/assets/components/pages/VoterRegistrationDrivePage/Beta/HeroSection.js
+++ b/resources/assets/components/pages/VoterRegistrationDrivePage/Beta/HeroSection.js
@@ -48,11 +48,11 @@ const HeroSection = ({ user, campaignInfo, modalToggle }) => {
         if (index === votingReasonsValues.length - 1) {
           result = `${result} and ${votingReasons[value]}`;
         } else {
-          result = `${result}${votingReasons[value]},`;
+          result = `${result}${votingReasons[value]}, `;
         }
       });
 
-      return ` like ${result}`;
+      return ` like  ${result}`;
     }
 
     return ' ';

--- a/resources/assets/components/pages/VoterRegistrationDrivePage/Beta/HeroSection.js
+++ b/resources/assets/components/pages/VoterRegistrationDrivePage/Beta/HeroSection.js
@@ -21,7 +21,7 @@ const HeroSection = ({ user, campaignInfo, modalToggle }) => {
    */
 
   const formatEndofBetaCauseSentence = () => {
-    let userCauses = query('voting-reasons').split(',');
+    const userCauses = query('voting-reasons').split(', ');
 
     if (userCauses && userCauses.length) {
       userCauses
@@ -35,7 +35,7 @@ const HeroSection = ({ user, campaignInfo, modalToggle }) => {
         .slice(0, -2);
       return `like ${userCauses}`;
     }
-    return;
+    return '';
   };
 
   return (

--- a/resources/assets/components/pages/VoterRegistrationDrivePage/Beta/HeroSection.js
+++ b/resources/assets/components/pages/VoterRegistrationDrivePage/Beta/HeroSection.js
@@ -1,9 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import QueryString from 'query-string';
+
+import { query } from '../../../../helpers';
 import CoverImage from '../../../utilities/CoverImage/CoverImage';
 import CampaignInfoBlock from '../../../blocks/CampaignInfoBlock/CampaignInfoBlock';
-import votingReasons from '../../../pages/VoterRegistrationDrivePage/Beta/config';
 
 const HeroSection = ({ user, campaignInfo, modalToggle }) => {
   const { firstName } = user;
@@ -20,12 +20,24 @@ const HeroSection = ({ user, campaignInfo, modalToggle }) => {
    * @see https://www.pivotaltracker.com/story/show/172087475
    */
 
-  QueryString.parse(location.search);
-  /*
-Query url
-check for votingReasons
-append to p tag
-*/
+  const formatEndofBetaCauseSentence = () => {
+    let userCauses = query('voting-reasons').split(',');
+
+    if (userCauses && userCauses.length) {
+      userCauses
+        .reduce((accumulator, currentCause, idx) => {
+          return (
+            accumulator +
+            currentCause +
+            (idx === userCauses.length - 2 ? 'and' : ', ')
+          );
+        }, '')
+        .slice(0, -2);
+      return `like ${userCauses}`;
+    }
+    return;
+  };
+
   return (
     <div className="hero-landing-page">
       <CoverImage
@@ -46,7 +58,8 @@ append to p tag
             <blockquote>
               <p data-test="beta-voter-registration-drive-page-quote-text">
                 Voting is important for young people because we can effect
-                change on issues we care about most.
+                change on issues we care about most{' '}
+                {formatEndofBetaCauseSentence()}.
               </p>
               <p data-test="beta-voter-registration-drive-page-quote-byline">
                 - {firstName}

--- a/resources/assets/components/pages/VoterRegistrationDrivePage/Beta/HeroSection.js
+++ b/resources/assets/components/pages/VoterRegistrationDrivePage/Beta/HeroSection.js
@@ -46,13 +46,13 @@ const HeroSection = ({ user, campaignInfo, modalToggle }) => {
 
       votingReasonsValues.forEach((value, index) => {
         if (index === votingReasonsValues.length - 1) {
-          result = `${result} and ${votingReasons[value]}`;
+          result = `${result}and ${votingReasons[value]}`;
         } else {
           result = `${result}${votingReasons[value]}, `;
         }
       });
 
-      return ` like  ${result}`;
+      return ` like ${result}`;
     }
 
     return ' ';
@@ -78,8 +78,7 @@ const HeroSection = ({ user, campaignInfo, modalToggle }) => {
             <blockquote>
               <p data-test="beta-voter-registration-drive-page-quote-text">
                 Voting is important for young people because we can effect
-                change on issues we care about most
-                {formatQuote()}.
+                change on issues we care about most{formatQuote()}.
               </p>
               <p data-test="beta-voter-registration-drive-page-quote-byline">
                 - {firstName}

--- a/resources/assets/components/pages/VoterRegistrationDrivePage/Beta/HeroSection.js
+++ b/resources/assets/components/pages/VoterRegistrationDrivePage/Beta/HeroSection.js
@@ -51,7 +51,7 @@ const HeroSection = ({ user, campaignInfo, modalToggle }) => {
           result = `${result}${votingReasons[value]},`;
         }
       });
-      console.log('result:', result);
+
       return ` like ${result}`;
     }
 

--- a/resources/assets/components/pages/VoterRegistrationDrivePage/Beta/HeroSection.js
+++ b/resources/assets/components/pages/VoterRegistrationDrivePage/Beta/HeroSection.js
@@ -23,30 +23,36 @@ const HeroSection = ({ user, campaignInfo, modalToggle }) => {
    */
 
   const formatQuote = () => {
-    let result = [];
-    let lastCause;
-    const votingReasonValues = query('voting-reasons').split(',');
+    const votingReasonsQuery = query('voting-reasons');
+    if (!votingReasonsQuery) {
+      return null;
+    }
+    const votingReasonsValues = votingReasonsQuery.split(',');
 
-    if (votingReasonValues.length === 1) {
-      return ` like ${votingReasons[votingReasonValues[0]]}`;
+    if (votingReasonsValues.length === 1) {
+      return ` like ${votingReasons[votingReasonsValues[0]]}`;
     }
 
-    if (votingReasonValues.length === 2) {
-      return ` like ${votingReasons[votingReasonValues[0]]} and ${
-        votingReasons[votingReasonValues[1]]
+    if (votingReasonsValues.length === 2) {
+      return ` like ${votingReasons[votingReasonsValues[0]]} and ${
+        votingReasons[votingReasonsValues[1]]
       }`;
     }
 
-    if (votingReasonValues.length >= 2) {
-      votingReasonValues.forEach(cause => {
-        result.push(votingReasons[cause]);
+    if (votingReasonsValues.length > 2) {
+      let result = '';
+
+      votingReasonsValues.forEach((value, index) => {
+        if (index === votingReasonsValues.length - 1) {
+          result = `${result} and ${votingReasons[value]}`;
+        } else {
+          result = `${result}, ${votingReasons[value]}`;
+        }
       });
-      lastCause = result[result.length - 1];
-      result = result.slice(0, -1);
-      result.join(', ');
-      return ` like ${result} and ${lastCause}`;
+      return ` like ${result}`;
     }
-    return;
+
+    return ' ';
   };
 
   return (

--- a/resources/assets/components/pages/VoterRegistrationDrivePage/Beta/HeroSection.js
+++ b/resources/assets/components/pages/VoterRegistrationDrivePage/Beta/HeroSection.js
@@ -58,7 +58,7 @@ const HeroSection = ({ user, campaignInfo, modalToggle }) => {
             <blockquote>
               <p data-test="beta-voter-registration-drive-page-quote-text">
                 Voting is important for young people because we can effect
-                change on issues we care about most{' '}
+                change on issues we care about most
                 {formatEndofBetaCauseSentence()}.
               </p>
               <p data-test="beta-voter-registration-drive-page-quote-byline">

--- a/resources/assets/components/pages/VoterRegistrationDrivePage/Beta/HeroSection.js
+++ b/resources/assets/components/pages/VoterRegistrationDrivePage/Beta/HeroSection.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import { query } from '../../../../helpers';
+import { votingReasons } from './config';
 import CoverImage from '../../../utilities/CoverImage/CoverImage';
 import CampaignInfoBlock from '../../../blocks/CampaignInfoBlock/CampaignInfoBlock';
 
@@ -20,20 +21,29 @@ const HeroSection = ({ user, campaignInfo, modalToggle }) => {
    * @see https://www.pivotaltracker.com/story/show/172087475
    */
 
-  const formatEndofBetaCauseSentence = () => {
-    const userCauses = query('voting-reasons').split(', ');
+  const formatEndOfBetaCauseSentence = () => {
+    let result = [];
+    let lastCause;
+    const userCauses = query('voting-reasons').split(',');
 
-    if (userCauses && userCauses.length) {
-      userCauses
-        .reduce((accumulator, currentCause, idx) => {
-          return (
-            accumulator +
-            currentCause +
-            (idx === userCauses.length - 2 ? 'and' : ', ')
-          );
-        }, '')
-        .slice(0, -2);
-      return `like ${userCauses}`;
+    if (userCauses.length === 1) {
+      return ` like ${votingReasons[userCauses[0]]}`;
+    }
+
+    if (userCauses.length === 2) {
+      return ` like ${votingReasons[userCauses[0]]} and ${
+        votingReasons[userCauses[1]]
+      }`;
+    }
+
+    if (userCauses.length >= 2) {
+      userCauses.forEach(cause => {
+        result.push(votingReasons[cause]);
+      });
+      lastCause = result[result.length - 1];
+      result = result.slice(0, -1);
+      result.join(', ');
+      return ` like ${result} and ${lastCause}`;
     }
     return '';
   };
@@ -59,7 +69,7 @@ const HeroSection = ({ user, campaignInfo, modalToggle }) => {
               <p data-test="beta-voter-registration-drive-page-quote-text">
                 Voting is important for young people because we can effect
                 change on issues we care about most
-                {formatEndofBetaCauseSentence()}.
+                {formatEndOfBetaCauseSentence()}.
               </p>
               <p data-test="beta-voter-registration-drive-page-quote-byline">
                 - {firstName}

--- a/resources/assets/components/pages/VoterRegistrationDrivePage/Beta/HeroSection.js
+++ b/resources/assets/components/pages/VoterRegistrationDrivePage/Beta/HeroSection.js
@@ -1,8 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import { query } from '../../../../helpers';
 import { votingReasons } from './config';
+import { query } from '../../../../helpers';
 import CoverImage from '../../../utilities/CoverImage/CoverImage';
 import CampaignInfoBlock from '../../../blocks/CampaignInfoBlock/CampaignInfoBlock';
 
@@ -17,27 +17,28 @@ const HeroSection = ({ user, campaignInfo, modalToggle }) => {
   } = campaignInfo;
 
   /**
-   * TODO: Check for a voting-reasons query parameter, and render values in quote if present.
-   * @see https://www.pivotaltracker.com/story/show/172087475
+   * Query url for voting-reasons param.
+   *
+   * @return {String}
    */
 
-  const formatEndOfBetaCauseSentence = () => {
+  const formatQuote = () => {
     let result = [];
     let lastCause;
-    const userCauses = query('voting-reasons').split(',');
+    const votingReasonValues = query('voting-reasons').split(',');
 
-    if (userCauses.length === 1) {
-      return ` like ${votingReasons[userCauses[0]]}`;
+    if (votingReasonValues.length === 1) {
+      return ` like ${votingReasons[votingReasonValues[0]]}`;
     }
 
-    if (userCauses.length === 2) {
-      return ` like ${votingReasons[userCauses[0]]} and ${
-        votingReasons[userCauses[1]]
+    if (votingReasonValues.length === 2) {
+      return ` like ${votingReasons[votingReasonValues[0]]} and ${
+        votingReasons[votingReasonValues[1]]
       }`;
     }
 
-    if (userCauses.length >= 2) {
-      userCauses.forEach(cause => {
+    if (votingReasonValues.length >= 2) {
+      votingReasonValues.forEach(cause => {
         result.push(votingReasons[cause]);
       });
       lastCause = result[result.length - 1];
@@ -45,7 +46,7 @@ const HeroSection = ({ user, campaignInfo, modalToggle }) => {
       result.join(', ');
       return ` like ${result} and ${lastCause}`;
     }
-    return '';
+    return;
   };
 
   return (
@@ -69,7 +70,7 @@ const HeroSection = ({ user, campaignInfo, modalToggle }) => {
               <p data-test="beta-voter-registration-drive-page-quote-text">
                 Voting is important for young people because we can effect
                 change on issues we care about most
-                {formatEndOfBetaCauseSentence()}.
+                {formatQuote()}.
               </p>
               <p data-test="beta-voter-registration-drive-page-quote-byline">
                 - {firstName}


### PR DESCRIPTION
### What's this PR do?

This pull request...
Adds a personalized message to the beta's page with the causes the alpha selects 
"Voting is important for young people because we can affect change on issues we care about most like [cause 1], [cause 2], and [cause 3]."
' - [Alpha's First Name]

### How should this be reviewed?

*
<img width="419" alt="Screen Shot 2020-05-12 at 6 26 45 PM" src="https://user-images.githubusercontent.com/20409413/81752005-9718da80-947e-11ea-9808-2032a1bfca5f.png">
<img width="405" alt="Screen Shot 2020-05-12 at 6 27 07 PM" src="https://user-images.githubusercontent.com/20409413/81752006-9718da80-947e-11ea-9f5a-55338a42257a.png">
<img width="414" alt="Screen Shot 2020-05-12 at 6 27 21 PM" src="https://user-images.githubusercontent.com/20409413/81752007-9718da80-947e-11ea-9a46-6d316db56155.png">
<img width="407" alt="Screen Shot 2020-05-12 at 6 27 30 PM" src="https://user-images.githubusercontent.com/20409413/81752009-97b17100-947e-11ea-8a13-e209cbcb1562.png">



...

### Any background context you want to provide?
This PR isn't finished, just want to receive feedback before proceeding with writing cypress test 
...

### Relevant tickets
References [Pivotal #](https://www.pivotaltracker.com/n/projects/2417735/stories/172087475).

### Checklist

- [x ] This PR has been added to the relevant Pivotal card.
- [ ] Added screenshots of front-end changes on small, medium, and large screens.
- [ ] Added appropriate feature/unit tests.
