### PR TITLE
Add trackingId to affirmation modal

### DIFF
--- a/resources/assets/components/Campaign/CampaignRoute/CampaignRoute.js
+++ b/resources/assets/components/Campaign/CampaignRoute/CampaignRoute.js
@@ -34,7 +34,10 @@ const CampaignRoute = props => {
   return (
     <>
       {shouldShowAffirmation ? (
-        <Modal onClose={clickedHideAffirmation}>
+        <Modal
+          onClose={clickedHideAffirmation}
+          trackingId="SIGNUP_AFFIRMATION_MODAL"
+        >
           <PostSignupModal
             affirmation={affirmation || undefined}
             onClose={clickedHideAffirmation}


### PR DESCRIPTION
### What's this PR do?

This pull request adds a `trackingId` to the affirmation modal (aka `<PostSignupModal>`) which is only rendered in one place, `CampaignRoute.js`.

### How should this be reviewed?

Is this where this should be and what it should be called?

### Any background context you want to provide?

We want to be able to better track when this modal opens to try to figure out what's going on with a bug where it doesn't show up sometimes.

### Relevant tickets

References [Pivotal #172157205](https://www.pivotaltracker.com/story/show/172157205).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added screenshots of front-end changes on small, medium, and large screens.
- [ ] Added appropriate feature/unit tests.
