### PR TITLE
Contentful Script to remove signupArrowContent field from campaigns

### DIFF
--- a/contentful/management-api-scripts/2020_05_11_remove_signup_arrow_content_field_from_campaigns.js
+++ b/contentful/management-api-scripts/2020_05_11_remove_signup_arrow_content_field_from_campaigns.js
@@ -1,0 +1,86 @@
+const { omit } = require('lodash');
+
+const { contentManagementClient } = require('./contentManagementClient');
+const {
+  constants,
+  createLogger,
+  getField,
+  processEntries,
+  sleep,
+  withFields,
+} = require('./helpers');
+
+const { LOCALE } = constants;
+
+const logger = createLogger('remove_signup_arrow_content_field_from_campaigns');
+
+const removeSignupArrowContentField = async (environment, campaignEntry) => {
+  const campaignInternalTitle = getField(campaignEntry, 'internalTitle');
+  const campaignAdditionalContent = getField(
+    campaignEntry,
+    'additionalContent',
+  );
+
+  if (
+    !campaignAdditionalContent ||
+    !campaignAdditionalContent.signupArrowContent
+  ) {
+    return;
+  }
+
+  logger.info(`\n\nProcessing ${campaignInternalTitle}.`);
+
+  const isArchived = await campaignEntry.isArchived();
+
+  if (isArchived) {
+    logger.info(`→ Skipping archived campaign ${campaignInternalTitle}.`);
+    return;
+  }
+
+  campaignEntry.fields.additionalContent[LOCALE] = omit(
+    campaignAdditionalContent,
+    'signupArrowContent',
+  );
+
+  const updatedCampaign = await campaignEntry.update();
+
+  if (!updatedCampaign) {
+    logger.info(`☓ Unable to update ${campaignInternalTitle}.`);
+    return;
+  }
+
+  // Make sure that we don't publish an unpublished campaign by mistake:
+  const wasPublished = await campaignEntry.isPublished();
+
+  if (!wasPublished) {
+    logger.warn(`→ Needs review: ${campaignEntry.sys.id}`);
+    return;
+  }
+
+  publishedUpdatedCampaign = await updatedCampaign.publish();
+
+  if (!publishedUpdatedCampaign) {
+    logger.info(`☓ Unable to publish updated ${campaignInternalTitle}.`);
+    return;
+  }
+
+  logger.info(`✔ Published updated ${campaignInternalTitle}.`);
+
+  await sleep(500);
+};
+
+contentManagementClient.init(async (environment, args) => {
+  logger.info(
+    `Running 'remove_signup_arrow_content_field_from_campaigns', using Contentful's '${environment.sys.id}' environment.`,
+  );
+  logger.info('Kicking things off in 5 seconds...');
+
+  await sleep(5000);
+
+  await processEntries(
+    environment,
+    args,
+    'campaign',
+    removeSignupArrowContentField,
+  );
+});


### PR DESCRIPTION
### What's this PR do?

This pull request adds a Contentful Management API script to remove all the deprecated `additionalContent.SignupArrowContent` fields from campaigns.

### How should this be reviewed?
👀 
https://dosomething.gitbook.io/phoenix-documentation/development/contentful/content-management-api-scripts

### Any background context you want to provide?
We've deprecated the legacy template in #2123 which means this feature is 👋 

I did think twice before writing this script. But I felt like
1. A looooot of campaigns had this field (we used this on most database campaigns)
2. We've got some remnant `additionalContent` fields which both clutter and confuse. So this felt like the right move

Side tangent but it's lame that most of the busy work on these scripts tends to be taking care of updating/publishing/archiving which feel automatable? It felt particularly lame on this script since we're actually doing so little, but it still feels like a ton of work. Food for thought. (Maybe another ole helper method if we see this continuing to happen?)

### Relevant tickets

References [Pivotal #171776980](https://www.pivotaltracker.com/story/show/171776980).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added screenshots of front-end changes on small, medium, and large screens.
- [ ] Added appropriate feature/unit tests.
