### PR TITLE
Adds tests for appending voting-reasons query parameter

### DIFF
--- a/cypress/integration/alpha-voter-registration-drive-page.js
+++ b/cypress/integration/alpha-voter-registration-drive-page.js
@@ -170,4 +170,34 @@ describe('Alpha Voter Registration Drive (OVRD) Page', () => {
     cy.get('[data-test=voting-reasons-query-options]').should('have.length', 1);
     cy.get('[data-test=social-share-tray-title]').should('have.length', 0);
   });
+
+  it('Alpha OVRD page appends voting-reasons query parameter to SocialDriveAction link when checking options', () => {
+    const user = userFactory();
+    const longUrl = `${PHOENIX_URL}/us/my-voter-registration-drive?referrer_user_id=${user.id}`;
+
+    cy.withFeatureFlags({
+      voter_reg_beta_page: true,
+    }).authVisitCampaignWithSignup(user, exampleVoterRegistrationDriveCampaign);
+
+    cy.get('#mental-health').check();
+    cy.get('.link-bar input').should(
+      'contain.value',
+      `${longUrl}&voting-reasons=mental-health`,
+    );
+
+    cy.get('#student-debt').check();
+    cy.get('.link-bar input').should(
+      'contain.value',
+      `${longUrl}&voting-reasons=mental-health,student-debt`,
+    );
+
+    cy.get('#student-debt').check();
+    cy.get('.link-bar input').should(
+      'contain.value',
+      `${longUrl}&voting-reasons=mental-health`,
+    );
+
+    cy.get('#mental-health').check();
+    cy.get('.link-bar input').should('contain.value', longUrl);
+  });
 });

--- a/cypress/integration/alpha-voter-registration-drive-page.js
+++ b/cypress/integration/alpha-voter-registration-drive-page.js
@@ -150,6 +150,9 @@ describe('Alpha Voter Registration Drive (OVRD) Page', () => {
       `https://vote.dosomething.org/member-drive?userId=${user.id}&r=user:${user.id},source:web,source_details:onlinedrivereferral,referral=true`,
     );
     cy.get('[data-test=voting-reasons-query-options]').should('have.length', 0);
+    cy.get('[data-test=social-share-tray-title]').contains(
+      'Share on Social Media',
+    );
   });
 
   it('Alpha OVRD page SocialDriveAction links to internal beta page when beta page feature enabled', () => {
@@ -165,5 +168,6 @@ describe('Alpha Voter Registration Drive (OVRD) Page', () => {
       `${PHOENIX_URL}/us/my-voter-registration-drive?referrer_user_id=${user.id}`,
     );
     cy.get('[data-test=voting-reasons-query-options]').should('have.length', 1);
+    cy.get('[data-test=social-share-tray-title]').should('have.length', 0);
   });
 });

--- a/cypress/integration/alpha-voter-registration-drive-page.js
+++ b/cypress/integration/alpha-voter-registration-drive-page.js
@@ -33,6 +33,13 @@ describe('Alpha Voter Registration Drive (OVRD) Page', () => {
         content: faker.lorem.sentence(),
       },
     });
+    // Mock a Bertly API error to ensure the longUrl will appear in the input field.
+    cy.route({
+      method: 'POST',
+      url: '/api/v2/links',
+      status: 503,
+      response: {},
+    });
   });
 
   it('The blocks field of the Alpha OVRD action page is not displayed', () => {

--- a/resources/assets/components/actions/SocialDriveAction/SocialDriveAction.js
+++ b/resources/assets/components/actions/SocialDriveAction/SocialDriveAction.js
@@ -197,7 +197,7 @@ class SocialDriveAction extends React.Component {
             <SocialShareTray
               shareLink={shortUrl}
               trackLink={link}
-              title={queryOptions ? null : `Share on Social Media`}
+              title={queryOptions ? null : 'Share on Social Media'}
               responsive
             />
           </Card>

--- a/resources/assets/components/actions/SocialDriveAction/SocialDriveAction.js
+++ b/resources/assets/components/actions/SocialDriveAction/SocialDriveAction.js
@@ -197,7 +197,7 @@ class SocialDriveAction extends React.Component {
             <SocialShareTray
               shareLink={shortUrl}
               trackLink={link}
-              title="Share on Social Media"
+              title={queryOptions ? null : `Share on Social Media`}
               responsive
             />
           </Card>

--- a/resources/assets/components/utilities/SocialShareTray/SocialShareTray.js
+++ b/resources/assets/components/utilities/SocialShareTray/SocialShareTray.js
@@ -141,7 +141,14 @@ class SocialShareTray extends React.Component {
     const trackLink = this.props.trackLink || this.props.shareLink;
     return (
       <div className="social-share-tray p-3 text-center">
-        {title ? <p className="title uppercase font-bold">{title}</p> : null}
+        {title ? (
+          <p
+            data-test="social-share-tray-title"
+            className="title uppercase font-bold"
+          >
+            {title}
+          </p>
+        ) : null}
 
         <div className={classNames('share-buttons', { responsive })}>
           {platforms.includes('facebook') ? (


### PR DESCRIPTION
### What's this PR do?

This pull request adds a Cypress test to verify the `voting-reasons` query parameter is modified as expected when checking the various voting reasons on the Alpha OVRD page, when the beta page feature is enabled.

It also hides the title on the `SocialShareTray` per the [designs](https://app.abstract.com/projects/fadf0790-f1f9-11e6-9a30-b54ba7e8e705/branches/a02a32be-978a-44ec-a73f-006d65a9744f/commits/aa7a98c0565956ad6218cb2aa2ee07a1cd564407/files/05f5faae-3c13-4947-b624-f9e0ea97822c/layers/F351BB85-358D-4FCB-B292-4061730A368F?collectionId=72c40c1f-06db-4544-8724-69c62d9224e3&collectionLayerId=b704e1c8-4783-4aac-bc33-46a53f857a15).

### How should this be reviewed?

👀 

### Any background context you want to provide?

Speaking of the design - this holds off on making the last changes that would require a bit more work:

* The "Copy Link" button should be blurple BG with white text, and the link icon should be white
* The `SocialShareTray` elements should be left aligned instead of centered

Because neither of these elements use Tailwind, this feels like a pretty substantial lift. Going to check in on whether these are launch blocking items. 

*Desired styles:*

<img width="450" alt="Screen Shot 2020-05-12 at 4 44 04 PM" src="https://user-images.githubusercontent.com/1236811/81756189-e277bc80-946f-11ea-9c5c-166b0a8ea480.png">


*Current styles (per this PR):*

<img width="450" alt="Screen Shot 2020-05-12 at 4 46 17 PM" src="https://user-images.githubusercontent.com/1236811/81756268-236fd100-9470-11ea-9288-b819407c8438.png">


### Relevant tickets

References [Pivotal #172419329](https://www.pivotaltracker.com/story/show/172419329).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [x] Added screenshots of front-end changes on small, medium, and large screens.
- [x] Added appropriate feature/unit tests.
