### PR TITLE
Voting reasons cleanup on OVRD pages

### DIFF
--- a/cypress/integration/alpha-voter-registration-drive-page.js
+++ b/cypress/integration/alpha-voter-registration-drive-page.js
@@ -195,7 +195,7 @@ describe('Alpha Voter Registration Drive (OVRD) Page', () => {
     cy.get('#student-debt').check();
     cy.get('.link-bar input').should(
       'contain.value',
-      `${longUrl}&voting-reasons=mental-health,student-debt`,
+      `${longUrl}&voting-reasons=mental-health%2Cstudent-debt`,
     );
 
     cy.get('#student-debt').check();

--- a/cypress/integration/beta-voter-registration-drive-page.js
+++ b/cypress/integration/beta-voter-registration-drive-page.js
@@ -127,9 +127,7 @@ describe('Beta Voter Registration Drive (OVRD) Page', () => {
     cy.contains(`April 25th, 2022`);
   });
 
-  // Eventually the quote will change if a voting-options query parameter exists.
-  // @see https://www.pivotaltracker.com/story/show/172087475
-  it('Beta OVRD quote displays default if no voting-options query parameter found', () => {
+  it('Beta OVRD quote displays default if no voting-reasons query parameter found', () => {
     const user = userFactory();
 
     cy.mockGraphqlOp('BetaVoterRegistrationDrivePageQuery', {
@@ -149,7 +147,7 @@ describe('Beta Voter Registration Drive (OVRD) Page', () => {
     ).contains(`- ${user.firstName}`);
   });
 
-  it('Beta OVRD quote displays one cause query when found in voting-options query', () => {
+  it('Beta OVRD quote displays one voting reason when found in voting-reasons query', () => {
     const user = userFactory();
 
     cy.mockGraphqlOp('BetaVoterRegistrationDrivePageQuery', {
@@ -169,7 +167,7 @@ describe('Beta Voter Registration Drive (OVRD) Page', () => {
     ).contains(`- ${user.firstName}`);
   });
 
-  it('Beta OVRD quote displays two causes when found in voting-options query', () => {
+  it('Beta OVRD quote displays two voting reasons when found in voting-reasons query', () => {
     const user = userFactory();
 
     cy.mockGraphqlOp('BetaVoterRegistrationDrivePageQuery', {
@@ -193,7 +191,7 @@ describe('Beta Voter Registration Drive (OVRD) Page', () => {
     ).contains(`- ${user.firstName}`);
   });
 
-  it('Beta OVRD quote displays three or more causes when found in voting-options query', () => {
+  it('Beta OVRD quote displays three or more voting reasons when found in voting-reasons query', () => {
     const user = userFactory();
 
     cy.mockGraphqlOp('BetaVoterRegistrationDrivePageQuery', {

--- a/resources/assets/components/actions/SocialDriveAction/SocialDriveAction.js
+++ b/resources/assets/components/actions/SocialDriveAction/SocialDriveAction.js
@@ -2,6 +2,7 @@
 
 import React from 'react';
 import gql from 'graphql-tag';
+import { debounce } from 'lodash';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
@@ -36,6 +37,12 @@ class SocialDriveAction extends React.Component {
     };
 
     this.linkInput = React.createRef();
+
+    /**
+     * Debounce the API request to shorten our long URL.
+     * @see https://gist.github.com/simonw/c29de00c20fde731243cbac8568a3d7f
+     */
+    this.getShortUrl = debounce(this.getShortUrl, 300);
   }
 
   componentDidMount() {

--- a/resources/assets/components/actions/SocialDriveAction/SocialDriveAction.js
+++ b/resources/assets/components/actions/SocialDriveAction/SocialDriveAction.js
@@ -10,7 +10,7 @@ import Card from '../../utilities/Card/Card';
 import Embed from '../../utilities/Embed/Embed';
 import { postRequest } from '../../../helpers/api';
 import TotalAcceptedQuantity from './TotalAcceptedQuantity';
-import { dynamicString, withoutTokens } from '../../../helpers';
+import { appendToQuery, dynamicString, withoutTokens } from '../../../helpers';
 import SocialShareTray from '../../utilities/SocialShareTray/SocialShareTray';
 import {
   EVENT_CATEGORIES,
@@ -51,22 +51,15 @@ class SocialDriveAction extends React.Component {
   /**
    * Replaces any userId tokens, and appends query string if given.
    *
-   * @param String queryStr
+   * @param Object query
    * @return String
    */
-  getLongUrl(queryStr) {
-    let result = dynamicString(this.props.link, { userId: this.props.userId });
+  getLongUrl(query) {
+    const result = dynamicString(this.props.link, {
+      userId: this.props.userId,
+    });
 
-    if (queryStr) {
-      // Append the queryStr to our current result.
-      // @TODO: Refactor to use appendToQuery helper.
-      // @see https://github.com/DoSomething/phoenix-next/pull/2114#discussion_r422352265
-      result = `${result}${
-        this.props.link.includes('?') ? '&' : '?'
-      }${queryStr}`;
-    }
-
-    return result;
+    return query ? appendToQuery(query, result).href : result;
   }
 
   /**

--- a/resources/assets/components/pages/VoterRegistrationDrivePage/Alpha/VotingReasonsQueryOptions.js
+++ b/resources/assets/components/pages/VoterRegistrationDrivePage/Alpha/VotingReasonsQueryOptions.js
@@ -10,7 +10,7 @@ const VotingReasonsQueryOptions = ({ onChange }) => {
   useEffect(() => {
     onChange(
       selectedVotingReasons.length
-        ? `voting-reasons=${selectedVotingReasons.join(',')}`
+        ? { 'voting-reasons': selectedVotingReasons.join(',') }
         : null,
     );
   }, [selectedVotingReasons]);


### PR DESCRIPTION
### What's this PR do?

This pull request fixes the TODO from https://github.com/DoSomething/phoenix-next/pull/2114#discussion_r422352265 by  using `appendToQuery` to construct URL's based on selected voting reasons on the OVRD alpha page.

It also debounces the API requests to shorten the URL's to avoid overloading Bertly (if a user continuously checks and unchecks voting reasons options, we wait 3 seconds until making our API request vs making an API request per every check or uncheck).

### How should this be reviewed?

👀 

I'll add the review app to our dev Aurora should you feel inclined to manually test -- verify that your beta page URL updates accordingly per selecting different voting reasons.

### Any background context you want to provide?

Now that #2126 is merged, once this is merged we should be ready to QA both the alpha and beta OVRD pages per selecting voting reasons. The remaining design tasks outlined in #2130 are not required for launch (per [Slack thread](https://dosomething.slack.com/archives/CTVPG6L4R/p1589393372082300))

### Relevant tickets

References [Pivotal #172419329](https://www.pivotaltracker.com/story/show/172419329).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added screenshots of front-end changes on small, medium, and large screens.
- [ ] Added appropriate feature/unit tests.
