### PR TITLE
Starts on QuizResultPage feature

### DIFF
--- a/config/features.php
+++ b/config/features.php
@@ -17,6 +17,7 @@ return [
     'dynamic_explore_campaigns' => env('DS_ENABLE_DYNAMIC_CAMPAIGNS_PAGE', false),
     'volunteer_credits' => env('DS_ENABLE_VOLUNTEER_CREDITS', false),
     'cause_preferences' => env('DS_ENABLE_CAUSE_INTERESTS_PAGE', false),
+    'quiz_result_page' =>  env('DS_ENABLE_QUIZ_RESULT_PAGE', false),
     'sitewide_nps_survey' => env('DS_ENABLE_SITEWIDE_NPS_SURVEY', false),
     'snapchat_button' => env('DS_ENABLE_SNAPCHAT', false),
     'voter_reg_beta_page' => env('DS_ENABLE_VOTER_REG_BETA_PAGE', false),

--- a/docs/development/features/voter-registration.md
+++ b/docs/development/features/voter-registration.md
@@ -100,13 +100,9 @@ Ungated: `/us/campaigns/ready-vote/quiz/ready` - user can take quiz but must sig
 
 ### Quiz Result Page
 
-We're working on a new release to redirect users to a new `QuizResultPage` component after completing the quiz if the `DS_ENABLE_QUIZ_RESULT_PAGE` configuration variable is set to `true`.
+We're working on a new release to redirect users to `/us/quiz-results/:id` to view their quiz result if the `DS_ENABLE_QUIZ_RESULT_PAGE` configuration variable is set to `true`.
 
-```
-/us/quiz-results/:id
-```
-
-The page expects the `:id` route parameter to be the ID of one of the Link Action entries referenced by the Quiz's `resultBlocks` multi-value reference field.
+The page displays a new `QuizResultPage` component, and expects the `:id` route parameter to be the ID of one of the Link Action entries referenced by the Quiz's `resultBlocks` multi-value reference field.
 
 The `QuizResultPage` displays a static `GalleryBlock` for all of the different result ID's.
 

--- a/docs/development/features/voter-registration.md
+++ b/docs/development/features/voter-registration.md
@@ -102,14 +102,29 @@ The 2020 version will redirect users to a `QuizResultPage` after completing the 
 /us/quiz-results/:id
 ```
 
-The `:id` route parameter corresponds to the Contentful entry containing the quiz result content. Please only edit the quiz entries that link to these entries only if necessary, as they are configured delicately by manually entering JSON.
+The `:id` route parameter corresponds to the Contentful `LinkBlock` entry containing the quiz result content. Please only edit the quiz entries that link to these entries only if necessary, as they are configured delicately by manually entering JSON.
 
-**Dev**:
+**Production**
 
 Quiz results:
 
-| id                     | type      | internalTitle    | title |
-| ---------------------- | --------- | ---------------- | ----- |
-| 347iYsbykgQe6KqeGceMUk | LinkBlock | Super Motivated  |       |
-| 1lvJHhlJqQSgKgwIwUymQ8 | LinkBlock | Social Voter     |       |
-| 2KfkCOTi7u4CqAyyCuGyci | LinkBlock | Election Dabbler |       |
+| id                     | title               | internalTitle      | assetId                |
+| ---------------------- | ------------------- | ------------------ | ---------------------- |
+| p7hqjSP4Y1U6ad0UDz4iS  | Shell-tered Voter   | Vote By Mail       | 49Y4ucuGbJbgZL7IDDfxG0 |
+| 1giTEF3B2hO2CyccmhlVDm | Hare Who Dares      | In-Person Voting   | 2f2kgaHl9w5VtdswKkaBWT |
+| 21PDBge2bKCTWMe5f9eo1H | Sloth At a Loss     | Unsure of Voting   | 1YomtHAeqXJ3qbjQNgsM0v |
+| 14KfeAs265httjNMf1jwTw | Moral Support Panda | Ineligible to Vote | 3WjT0QGNnJEPPz2yMd3inj |
+
+Gallery Block: 78WaGsvDEzAxnreEvNx3Za
+
+**Dev**
+
+Quiz results:
+
+| id                     | title               | internalTitle    | assetId                |
+| ---------------------- | ------------------- | ---------------- | ---------------------- |
+| 347iYsbykgQe6KqeGceMUk | Moral Support Panda | Super Motivated  | 6J13jUL4YGGC1fyYMNEfbc |
+| 1lvJHhlJqQSgKgwIwUymQ8 | Shell-tered Voter   | Social Voter     | 3iLKsRlFQ1k9ddQbRb3RN8 |
+| 2KfkCOTi7u4CqAyyCuGyci | Hare Who Dares      | Election Dabbler | 3uB88eZmTNEaoFxV9pZ8hX |
+
+Gallery Block: 2VGFq3XBcqCfKOA8mC5mP4

--- a/docs/development/features/voter-registration.md
+++ b/docs/development/features/voter-registration.md
@@ -87,3 +87,29 @@ Content:
 ## Tracking Source
 
 TODO: Document how the `r` query parameter is used by the Chompy import.
+
+## Quiz
+
+Our Voter Registration Quiz campaign uses the legacy Quiz content type, which has been deprecated for Typeform except for this one warrior entry, living at path:
+
+```
+/us/campaigns/ready-vote/ready
+```
+
+The 2020 version will redirect users to a `QuizResultPage` after completing the quiz if the `DS_ENABLE_QUIZ_RESULT_PAGE` configuration variable is set to `true`.
+
+```
+/us/quiz-results/:id
+```
+
+The `:id` route parameter corresponds to the Contentful entry containing the quiz result content. Please only edit the quiz entries that link to these entries only if necessary, as they are configured delicately by manually entering JSON.
+
+**Dev**:
+
+Quiz results:
+
+| id                     | type      | internalTitle    | title |
+| ---------------------- | --------- | ---------------- | ----- |
+| 347iYsbykgQe6KqeGceMUk | LinkBlock | Super Motivated  |       |
+| 1lvJHhlJqQSgKgwIwUymQ8 | LinkBlock | Social Voter     |       |
+| 2KfkCOTi7u4CqAyyCuGyci | LinkBlock | Election Dabbler |       |

--- a/docs/development/features/voter-registration.md
+++ b/docs/development/features/voter-registration.md
@@ -98,10 +98,6 @@ Gated: `/us/campaigns/ready-vote` - user must signup to take the quiz from the a
 
 Ungated: `/us/campaigns/ready-vote/quiz/ready` - user can take quiz but must signup to see their result
 
-```
-
-```
-
 ### Quiz Result Page
 
 We're working on a new release to redirect users to a new `QuizResultPage` component after completing the quiz if the `DS_ENABLE_QUIZ_RESULT_PAGE` configuration variable is set to `true`.

--- a/docs/development/features/voter-registration.md
+++ b/docs/development/features/voter-registration.md
@@ -92,22 +92,14 @@ TODO: Document how the `r` query parameter is used by the Chompy import.
 
 ### Voter Registration Quiz Campaign
 
-Our Voter Registration Quiz campaign uses the legacy Quiz content type, which has been deprecated for Typeform except for this one warrior entry, living on all environments under a Voter Registration Quiz campaign, at path:
+Our Voter Registration Quiz campaign uses the legacy Quiz content type, which has been deprecated for Typeform except for this one warrior entry, living on all environments under a Voter Registration Quiz campaign, with two entry points:
+
+Gated: `/us/campaigns/ready-vote` - user must signup to take the quiz from the action page
+
+Ungated: `/us/campaigns/ready-vote/quiz/ready` - user can take quiz but must signup to see their result
 
 ```
-/us/campaigns/ready-vote
-```
 
-When users visit the campaign URL, they are prompted to signup from the landing page, and are then redirected to the action page to take the quiz:
-
-```
-/us/campaigns/action
-```
-
-There is also a version of the landing page that allows an anonymous user to take the quiz, and then authenticate in order to see their result:
-
-```
-/us/campaigns/ready-vote/quiz/ready
 ```
 
 ### Quiz Result Page
@@ -146,6 +138,12 @@ Quiz Results:
 | 347iYsbykgQe6KqeGceMUk | Moral Support Panda | Super Motivated  | 6J13jUL4YGGC1fyYMNEfbc |
 | 1lvJHhlJqQSgKgwIwUymQ8 | Shell-tered Voter   | Social Voter     | 3iLKsRlFQ1k9ddQbRb3RN8 |
 | 2KfkCOTi7u4CqAyyCuGyci | Hare Who Dares      | Election Dabbler | 3uB88eZmTNEaoFxV9pZ8hX |
+
+**Related links**
+
+- [User Flows For Voting Quiz](https://docs.google.com/spreadsheets/d/10uIZNghJTMKWR0lk5_y-q9-NwabDKYyrf8Vxlj17S9c/edit#gid=1453114542)
+
+- [Quiz documentation](https://github.com/DoSomething/phoenix-next/blob/8b5a97fdd973c8eb925191f78b36c2f676d2707a/docs/content-publishing/quiz.md) - This was removed in [#1369](https://github.com/DoSomething/phoenix-next/pull/1369) when we moved editorial guides into the Campaign Playbook.
 
 **Notes**
 

--- a/docs/development/features/voter-registration.md
+++ b/docs/development/features/voter-registration.md
@@ -102,7 +102,7 @@ The 2020 version will redirect users to a `QuizResultPage` after completing the 
 /us/quiz-results/:id
 ```
 
-The `:id` route parameter corresponds to the Contentful `LinkBlock` entry containing the quiz result content. Please only edit the quiz entries that link to these entries only if necessary, as they are configured delicately by manually entering JSON.
+The page expects the `:id` route parameter to be the ID of one of the Link Action entries referenced by the Quiz's `resultBlocks` multi-value reference field. Please avoid editing the Quiz entries if possible, as they are delicately configured (deleting one of the `LinkAction` entries referenced by the `resultBlocks` field would not be pretty).
 
 **Production**
 

--- a/docs/development/features/voter-registration.md
+++ b/docs/development/features/voter-registration.md
@@ -90,7 +90,7 @@ TODO: Document how the `r` query parameter is used by the Chompy import.
 
 ## Quiz
 
-Our Voter Registration Quiz campaign uses the legacy Quiz content type, which has been deprecated for Typeform except for this one warrior entry, living at path:
+Our Voter Registration Quiz campaign uses the legacy Quiz content type, which has been deprecated for Typeform except for this one warrior entry, living on all environments at the path:
 
 ```
 /us/campaigns/ready-vote/ready
@@ -102,7 +102,7 @@ The 2020 version will redirect users to a `QuizResultPage` after completing the 
 /us/quiz-results/:id
 ```
 
-The page expects the `:id` route parameter to be the ID of one of the Link Action entries referenced by the Quiz's `resultBlocks` multi-value reference field. Please avoid editing the Quiz entries if possible, as they are delicately configured (deleting one of the `LinkAction` entries referenced by the `resultBlocks` field would not be pretty).
+The page expects the `:id` route parameter to be the ID of one of the Link Action entries referenced by the Quiz's `resultBlocks` multi-value reference field. Please avoid editing the Quiz entries if possible, as [they are delicately configured](https://github.com/DoSomething/phoenix-next/blob/8b5a97fdd973c8eb925191f78b36c2f676d2707a/docs/content-publishing/quiz.md#adding-available-choices-for-question) (deleting one of the `LinkAction` entries referenced by the `resultBlocks` field would not be pretty).
 
 **Production**
 

--- a/docs/development/features/voter-registration.md
+++ b/docs/development/features/voter-registration.md
@@ -90,13 +90,13 @@ TODO: Document how the `r` query parameter is used by the Chompy import.
 
 ## Quiz
 
-### Voter Registration Quiz Campaign
+### Voting Quiz Campaign
 
-Our Voter Registration Quiz campaign uses the legacy Quiz content type, which has been deprecated for Typeform except for this one warrior entry, living on all environments under a Voter Registration Quiz campaign, with two entry points:
+Our Voting Quiz campaign (`/us/campaigns/ready-vote`) uses the legacy Quiz content type, which has been deprecated for Typeform except for this one warrior entry. It has two entry points:
 
-Gated: `/us/campaigns/ready-vote` - user must signup to take the quiz from the action page
+- Gated: `/us/campaigns/ready-vote` - user must signup to take the quiz from the action page
 
-Ungated: `/us/campaigns/ready-vote/quiz/ready` - user can take quiz but must signup to see their result
+- Ungated: `/us/campaigns/ready-vote/quiz/ready` - user can take quiz but must signup to see their result
 
 ### Quiz Result Page
 

--- a/docs/development/features/voter-registration.md
+++ b/docs/development/features/voter-registration.md
@@ -90,23 +90,43 @@ TODO: Document how the `r` query parameter is used by the Chompy import.
 
 ## Quiz
 
-Our Voter Registration Quiz campaign uses the legacy Quiz content type, which has been deprecated for Typeform except for this one warrior entry, living on all environments at the path:
+### Voter Registration Quiz Campaign
+
+Our Voter Registration Quiz campaign uses the legacy Quiz content type, which has been deprecated for Typeform except for this one warrior entry, living on all environments under a Voter Registration Quiz campaign, at path:
 
 ```
-/us/campaigns/ready-vote/ready
+/us/campaigns/ready-vote
 ```
 
-The 2020 version will redirect users to a `QuizResultPage` after completing the quiz if the `DS_ENABLE_QUIZ_RESULT_PAGE` configuration variable is set to `true`.
+When users visit the campaign URL, they are prompted to signup from the landing page, and are then redirected to the action page to take the quiz:
+
+```
+/us/campaigns/action
+```
+
+There is also a version of the landing page that allows an anonymous user to take the quiz, and then authenticate in order to see their result:
+
+```
+/us/campaigns/ready-vote/quiz/ready
+```
+
+### Quiz Result Page
+
+We're working on a new release to redirect users to a new `QuizResultPage` component after completing the quiz if the `DS_ENABLE_QUIZ_RESULT_PAGE` configuration variable is set to `true`.
 
 ```
 /us/quiz-results/:id
 ```
 
-The page expects the `:id` route parameter to be the ID of one of the Link Action entries referenced by the Quiz's `resultBlocks` multi-value reference field. Please avoid editing the Quiz entries if possible, as [they are delicately configured](https://github.com/DoSomething/phoenix-next/blob/8b5a97fdd973c8eb925191f78b36c2f676d2707a/docs/content-publishing/quiz.md#adding-available-choices-for-question) (deleting one of the `LinkAction` entries referenced by the `resultBlocks` field would not be pretty).
+The page expects the `:id` route parameter to be the ID of one of the Link Action entries referenced by the Quiz's `resultBlocks` multi-value reference field.
+
+The `QuizResultPage` displays a static `GalleryBlock` for all of the different result ID's.
 
 **Production**
 
-Quiz results:
+Gallery Block: 78WaGsvDEzAxnreEvNx3Za
+
+Quiz Results:
 
 | id                     | title               | internalTitle      | assetId                |
 | ---------------------- | ------------------- | ------------------ | ---------------------- |
@@ -115,11 +135,11 @@ Quiz results:
 | 21PDBge2bKCTWMe5f9eo1H | Sloth At a Loss     | Unsure of Voting   | 1YomtHAeqXJ3qbjQNgsM0v |
 | 14KfeAs265httjNMf1jwTw | Moral Support Panda | Ineligible to Vote | 3WjT0QGNnJEPPz2yMd3inj |
 
-Gallery Block: 78WaGsvDEzAxnreEvNx3Za
-
 **Dev**
 
-Quiz results:
+Gallery Block: 2VGFq3XBcqCfKOA8mC5mP4
+
+Quiz Results:
 
 | id                     | title               | internalTitle    | assetId                |
 | ---------------------- | ------------------- | ---------------- | ---------------------- |
@@ -127,4 +147,6 @@ Quiz results:
 | 1lvJHhlJqQSgKgwIwUymQ8 | Shell-tered Voter   | Social Voter     | 3iLKsRlFQ1k9ddQbRb3RN8 |
 | 2KfkCOTi7u4CqAyyCuGyci | Hare Who Dares      | Election Dabbler | 3uB88eZmTNEaoFxV9pZ8hX |
 
-Gallery Block: 2VGFq3XBcqCfKOA8mC5mP4
+**Notes**
+
+- Please avoid editing the Quiz entries if possible, as [they are delicately configured](https://github.com/DoSomething/phoenix-next/blob/8b5a97fdd973c8eb925191f78b36c2f676d2707a/docs/content-publishing/quiz.md#adding-available-choices-for-question) (deleting one of the `LinkAction` entries referenced by the `resultBlocks` field would not be pretty).

--- a/resources/assets/components/App.js
+++ b/resources/assets/components/App.js
@@ -19,6 +19,7 @@ import CampaignContainer from './Campaign/CampaignContainer';
 import { env, featureFlag, buildVoterRegUrl } from '../helpers';
 import BetaReferralPage from './pages/ReferralPage/Beta/BetaPage';
 import CollectionPage from './pages/CollectionPage/CollectionPage';
+import QuizResultPage from './pages/QuizResultPage/QuizResultPage';
 import TypeFormEmbed from './utilities/TypeFormEmbed/TypeFormEmbed';
 import DelayedElement from './utilities/DelayedElement/DelayedElement';
 import SitewideBanner from './utilities/SitewideBanner/SitewideBanner';
@@ -119,6 +120,8 @@ const App = ({ store, history }) => {
               />
 
               <Route path="/us/join" component={BetaReferralPage} />
+
+              <Route path="/us/quiz-results/:id" component={QuizResultPage} />
 
               <Route
                 path="/us/my-voter-registration-drive"

--- a/resources/assets/components/App.js
+++ b/resources/assets/components/App.js
@@ -121,7 +121,12 @@ const App = ({ store, history }) => {
 
               <Route path="/us/join" component={BetaReferralPage} />
 
-              <Route path="/us/quiz-results/:id" component={QuizResultPage} />
+              <Route
+                path="/us/quiz-results/:id"
+                render={routeProps => (
+                  <QuizResultPage id={routeProps.match.params.id} />
+                )}
+              />
 
               <Route
                 path="/us/my-voter-registration-drive"

--- a/resources/assets/components/Quiz/QuizResult.js
+++ b/resources/assets/components/Quiz/QuizResult.js
@@ -1,8 +1,10 @@
 import gql from 'graphql-tag';
 import PropTypes from 'prop-types';
 import React, { useEffect } from 'react';
+import { Redirect } from 'react-router-dom';
 import { useMutation } from '@apollo/react-hooks';
 
+import { featureFlag } from '../../helpers';
 import { isAuthenticated } from '../../helpers/auth';
 import ContentfulEntryLoader from '../utilities/ContentfulEntryLoader/ContentfulEntryLoader';
 
@@ -27,7 +29,11 @@ const QuizResult = ({ id, campaignId }) => {
     }
   }, [id]);
 
-  return <ContentfulEntryLoader id={id} />;
+  return featureFlag('quiz_result_page') ? (
+    <Redirect to={`/us/quiz-results/${id}`} />
+  ) : (
+    <ContentfulEntryLoader id={id} />
+  );
 };
 
 QuizResult.propTypes = {

--- a/resources/assets/components/pages/QuizResultPage/QuizResultPage.js
+++ b/resources/assets/components/pages/QuizResultPage/QuizResultPage.js
@@ -5,7 +5,7 @@ import SiteFooter from '../../utilities/SiteFooter/SiteFooter';
 import TextContent from '../../utilities/TextContent/TextContent';
 import SiteNavigationContainer from '../../SiteNavigation/SiteNavigationContainer';
 
-const QuizResultPage = () => {
+const QuizResultPage = ({ id }) => {
   return (
     <>
       <SiteNavigationContainer />
@@ -20,7 +20,7 @@ const QuizResultPage = () => {
               <h2 className="my-3 uppercase color-white text-lg">Subtitle</h2>
 
               <h1 className="my-3 font-normal font-league-gothic color-white uppercase">
-                Title
+                {id}
               </h1>
 
               <TextContent className="text-white">Description</TextContent>
@@ -37,11 +37,7 @@ const QuizResultPage = () => {
 };
 
 QuizResultPage.propTypes = {
-  id: PropTypes.string,
-};
-
-QuizResultPage.propTypes = {
-  id: null,
+  id: PropTypes.string.isRequired,
 };
 
 export default QuizResultPage;

--- a/resources/assets/components/pages/QuizResultPage/QuizResultPage.js
+++ b/resources/assets/components/pages/QuizResultPage/QuizResultPage.js
@@ -1,16 +1,20 @@
 import React from 'react';
+import { get } from 'lodash';
 import gql from 'graphql-tag';
 import PropTypes from 'prop-types';
 import { useQuery } from 'react-apollo';
 
 import ErrorPage from '../ErrorPage';
+import { gqlVariables } from './config';
 import NotFoundPage from '../NotFoundPage';
+import { isDevEnvironment } from '../../../helpers';
 import Placeholder from '../../utilities/Placeholder';
 import SiteFooter from '../../utilities/SiteFooter/SiteFooter';
 import TextContent from '../../utilities/TextContent/TextContent';
 import { LinkBlockFragment } from '../../actions/LinkAction/LinkAction';
-import { ShareBlockFragment } from '../../actions/ShareAction/ShareAction';
+import ContentfulAsset from '../../utilities/ContentfulAsset/ContentfulAsset';
 import SiteNavigationContainer from '../../SiteNavigation/SiteNavigationContainer';
+import ContentfulEntryLoader from '../../utilities/ContentfulEntryLoader/ContentfulEntryLoader';
 
 const QUIZ_RESULT_PAGE_QUERY = gql`
   query QuizResultPageQuery($id: String!) {
@@ -19,14 +23,10 @@ const QUIZ_RESULT_PAGE_QUERY = gql`
       ... on LinkBlock {
         ...LinkBlockFragment
       }
-      ... on ShareBlock {
-        ...ShareBlockFragment
-      }
     }
   }
 
   ${LinkBlockFragment}
-  ${ShareBlockFragment}
 `;
 
 const QuizResultPage = ({ id }) => {
@@ -46,7 +46,11 @@ const QuizResultPage = ({ id }) => {
     return <NotFoundPage id={id} />;
   }
 
-  const { title, content } = data.block;
+  const config = isDevEnvironment()
+    ? gqlVariables.development
+    : gqlVariables.production;
+  const { linkBlockTitle, content } = data.block;
+  const assetId = get(config, `results.${id}.assetId`, null);
 
   return (
     <>
@@ -60,12 +64,19 @@ const QuizResultPage = ({ id }) => {
           >
             <div className="my-6 grid-full">
               <h1 className="my-3 font-normal font-league-gothic color-white uppercase">
-                {title}
+                {linkBlockTitle}
               </h1>
+              {assetId ? (
+                <ContentfulAsset id={assetId} width={400} height={300} />
+              ) : null}
             </div>
           </header>
           <div className="bg-white base-12-grid py-3 md:py-6">
             <TextContent className="grid-full">{content}</TextContent>
+            <ContentfulEntryLoader
+              id={config.galleryBlockId}
+              className="grid-full"
+            />
           </div>
         </article>
       </main>

--- a/resources/assets/components/pages/QuizResultPage/QuizResultPage.js
+++ b/resources/assets/components/pages/QuizResultPage/QuizResultPage.js
@@ -1,11 +1,53 @@
 import React from 'react';
+import gql from 'graphql-tag';
 import PropTypes from 'prop-types';
+import { useQuery } from 'react-apollo';
 
+import ErrorPage from '../ErrorPage';
+import NotFoundPage from '../NotFoundPage';
+import Placeholder from '../../utilities/Placeholder';
 import SiteFooter from '../../utilities/SiteFooter/SiteFooter';
 import TextContent from '../../utilities/TextContent/TextContent';
+import { LinkBlockFragment } from '../../actions/LinkAction/LinkAction';
+import { ShareBlockFragment } from '../../actions/ShareAction/ShareAction';
 import SiteNavigationContainer from '../../SiteNavigation/SiteNavigationContainer';
 
+const QUIZ_RESULT_PAGE_QUERY = gql`
+  query QuizResultPageQuery($id: String!) {
+    block(id: $id) {
+      id
+      ... on LinkBlock {
+        ...LinkBlockFragment
+      }
+      ... on ShareBlock {
+        ...ShareBlockFragment
+      }
+    }
+  }
+
+  ${LinkBlockFragment}
+  ${ShareBlockFragment}
+`;
+
 const QuizResultPage = ({ id }) => {
+  const { loading, error, data } = useQuery(QUIZ_RESULT_PAGE_QUERY, {
+    variables: { id },
+  });
+
+  if (loading) {
+    return <Placeholder />;
+  }
+
+  if (error) {
+    return <ErrorPage error={error} />;
+  }
+
+  if (!data.block) {
+    return <NotFoundPage id={id} />;
+  }
+
+  const { title, content } = data.block;
+
   return (
     <>
       <SiteNavigationContainer />
@@ -16,18 +58,15 @@ const QuizResultPage = ({ id }) => {
             role="banner"
             className="base-12-grid py-3 md:py-6 bg-blurple-500"
           >
-            <div className="my-6">
-              <h2 className="my-3 uppercase color-white text-lg">Subtitle</h2>
-
+            <div className="my-6 grid-full">
               <h1 className="my-3 font-normal font-league-gothic color-white uppercase">
-                {id}
+                {title}
               </h1>
-
-              <TextContent className="text-white">Description</TextContent>
             </div>
           </header>
-
-          <TextContent className="base-12-grid py-3 md:py-6">Hello</TextContent>
+          <div className="bg-white base-12-grid py-3 md:py-6">
+            <TextContent className="grid-full">{content}</TextContent>
+          </div>
         </article>
       </main>
 

--- a/resources/assets/components/pages/QuizResultPage/QuizResultPage.js
+++ b/resources/assets/components/pages/QuizResultPage/QuizResultPage.js
@@ -1,0 +1,47 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import SiteFooter from '../../utilities/SiteFooter/SiteFooter';
+import TextContent from '../../utilities/TextContent/TextContent';
+import SiteNavigationContainer from '../../SiteNavigation/SiteNavigationContainer';
+
+const QuizResultPage = () => {
+  return (
+    <>
+      <SiteNavigationContainer />
+
+      <main>
+        <article className="quiz-result-page">
+          <header
+            role="banner"
+            className="base-12-grid py-3 md:py-6 bg-blurple-500"
+          >
+            <div className="my-6">
+              <h2 className="my-3 uppercase color-white text-lg">Subtitle</h2>
+
+              <h1 className="my-3 font-normal font-league-gothic color-white uppercase">
+                Title
+              </h1>
+
+              <TextContent className="text-white">Description</TextContent>
+            </div>
+          </header>
+
+          <TextContent className="base-12-grid py-3 md:py-6">Hello</TextContent>
+        </article>
+      </main>
+
+      <SiteFooter />
+    </>
+  );
+};
+
+QuizResultPage.propTypes = {
+  id: PropTypes.string,
+};
+
+QuizResultPage.propTypes = {
+  id: null,
+};
+
+export default QuizResultPage;

--- a/resources/assets/components/pages/QuizResultPage/config.js
+++ b/resources/assets/components/pages/QuizResultPage/config.js
@@ -1,0 +1,45 @@
+export const gqlVariables = {
+  production: {
+    galleryBlockId: '78WaGsvDEzAxnreEvNx3Za',
+    results: {
+      // Vote by mail / Turtle
+      p7hqjSP4Y1U6ad0UDz4iS: {
+        assetId: '49Y4ucuGbJbgZL7IDDfxG0',
+      },
+      // In-person voting / Rabbit
+      '1giTEF3B2hO2CyccmhlVDm': {
+        assetId: '2f2kgaHl9w5VtdswKkaBWT',
+      },
+      // Unsure of voting / Slothie Boi
+      '21PDBge2bKCTWMe5f9eo1H': {
+        assetId: '1YomtHAeqXJ3qbjQNgsM0v',
+      },
+      // Ineligible to vote / Panda
+      '14KfeAs265httjNMf1jwTw': {
+        assetId: '3WjT0QGNnJEPPz2yMd3inj',
+      },
+    },
+  },
+  development: {
+    galleryBlockId: '2VGFq3XBcqCfKOA8mC5mP4',
+    results: {
+      // Super Motivated
+      '347iYsbykgQe6KqeGceMUk': {
+        // Panda
+        assetId: '6J13jUL4YGGC1fyYMNEfbc',
+      },
+      // Social Voter
+      '1lvJHhlJqQSgKgwIwUymQ8': {
+        // Turtle:
+        assetId: '3iLKsRlFQ1k9ddQbRb3RN8',
+      },
+      // Election Dabbler
+      '2KfkCOTi7u4CqAyyCuGyci': {
+        // Rabbit:
+        assetId: '3uB88eZmTNEaoFxV9pZ8hX',
+      },
+    },
+  },
+};
+
+export { gqlVariables as default };

--- a/routes/web.php
+++ b/routes/web.php
@@ -78,6 +78,9 @@ $router->view('us/blocks/{id}', 'app');
 // Voter Registration Drives
 $router->view('us/my-voter-registration-drive', 'app');
 
+// Quiz Results
+$router->view('us/quiz-results/{id}', 'app');
+
 // Pages
 $router->get('us/{slug}', 'PageController@show');
 $router->get('{slug}', function ($slug) {


### PR DESCRIPTION
### What's this PR do?

This pull request adds a new site path, `/us/quiz-results/:id`, and displays a new `QuizResultPage` component. It also adds a new `quiz_result_page` feature flag, which when enabled -- redirects a user to the respective quiz result page after completing the quiz. 

### How should this be reviewed?

The `QuizResultPage` is minimally styled and will be polished up in future PR's, so not looking for feedback there. I'm looking for feedback to whether the docs make this hopefully easy for any dev to get a feel for how this feature works and contribute to the quiz result pages (without needing to know the nuts and bolts of how quizzes work)

Here are some example pages from the review app:
* https://dosomething-phoenix-de-pr-2136.herokuapp.com/us/quiz-results/347iYsbykgQe6KqeGceMUk
* https://dosomething-phoenix-de-pr-2136.herokuapp.com/us/quiz-results/1lvJHhlJqQSgKgwIwUymQ8

### Any background context you want to provide?

* I decided to define the Asset to display in the banner within a config file vs adding a new field to the `LinkAction` type, which would only be used for this one instance. It felt leaner vs figuring out what to name the field when it's only used for this single Quiz Result template (and possibly never again after this year's election) and then requiring corresponding changes to GraphQL, the `LinkAction` GraphQL fragment, etc. I manually added 3 of the assets into our dev environment so we can build against the same images we want to display in production.

* I spent a good amount of time trying to write a Cypress test to mock displaying a quiz block, hoping to test the redirect based on feature flag. I was copying by example from other Cypress tests, but the Quiz Block kept returning ` Technical Details: GraphQL error: Please return a __typename in "Block" Error: GraphQL error: Please return a __typename in "Block", 1589419807481, ID: 5ebc9f1d3b32bf55b2c8994`.  I tried both visiting the quiz at `/us/blocks/:id` and also created a example fixture of the quiz campaign, but both approaches resulted in that error within the quiz block.



### Relevant tickets

References [Pivotal #172752983](https://www.pivotaltracker.com/story/show/172752983).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [x] Documentation added for new features/changed endpoints.
- [ ] Added screenshots of front-end changes on small, medium, and large screens.
- [ ] Added appropriate feature/unit tests.
