### PR TITLE
Adds placeholder content for QuizResultPage

### DIFF
--- a/cypress/fixtures/graphql.js
+++ b/cypress/fixtures/graphql.js
@@ -113,6 +113,10 @@ export const mocks = {
     id: args.id,
     __typename: args.__typename || blocks[args.id],
   }),
+  LinkBlock: args => ({
+    title: args.title || faker.lorem.title(),
+    content: args.content || faker.lorem.paragraphs(),
+  }),
   // By default, we'll assume most optional block fields aren't set so
   // that they can just use the defaults in the component itself:
   TextSubmissionBlock: () => ({

--- a/cypress/integration/quiz-result-page.js
+++ b/cypress/integration/quiz-result-page.js
@@ -1,0 +1,62 @@
+/// <reference types="Cypress" />
+
+import faker from 'faker';
+
+const quizResultPagePath = '/us/quiz-results/';
+const quizResultId = '347iYsbykgQe6KqeGceMUk';
+
+/**
+ * @param String id
+ * @param Boolean preview
+ * @return String
+ */
+function getQuizResultPath(id) {
+  return `/us/quiz-results/${id}`;
+}
+
+const linkBlock = {
+  id: quizResultId,
+  __typename: 'LinkBlock',
+  title: faker.company.bsBuzz(),
+  content: faker.lorem.sentence(),
+};
+
+describe('Quiz Result Page', () => {
+  beforeEach(() => cy.configureMocks());
+
+  it('Renders NotFound if GraphQL query does not return a block', () => {
+    cy.mockGraphqlOp('QuizResultPageQuery', {
+      block: null,
+    });
+
+    cy.visit(getQuizResultPath('55767606a59dbf3c7a8b4571'));
+
+    cy.get('[data-test=not-found-page]').should('have.length', 1);
+    cy.get('[data-test=quiz-result-page]').should('have.length', 0);
+  });
+
+  it('Renders placeholder content if preview query is not passed', () => {
+    cy.mockGraphqlOp('QuizResultPageQuery', {
+      block: linkBlock,
+    });
+
+    cy.visit(getQuizResultPath(quizResultId));
+
+    cy.get('[data-test=quiz-result-page]').should('have.length', 1);
+    cy.get('h1').should('contain', linkBlock.title);
+    cy.get('[data-test=quiz-result-page-content]').contains(
+      'Saepe cupiditate non. Facere velit vitae corporis.',
+    );
+  });
+
+  it('Renders GraphQL content if preview query parameter is passed', () => {
+    cy.mockGraphqlOp('QuizResultPageQuery', {
+      block: linkBlock,
+    });
+
+    cy.visit(`${getQuizResultPath(quizResultId)}?preview=true`);
+
+    cy.get('h1').should('contain', linkBlock.title);
+    cy.get('[data-test=quiz-result-page-content]').contains(linkBlock.content);
+  });
+});

--- a/docs/development/features/voter-registration.md
+++ b/docs/development/features/voter-registration.md
@@ -139,4 +139,11 @@ Quiz Results:
 
 **Notes**
 
+- While we're still developing this component, we're displaying placeholder copy for the Link Action content unless a `preview=true` query parameter is present. Examples:
+
+  - Placeholder content = https://qa.dosomething.org/us/quiz-results/p7hqjSP4Y1U6ad0UDz4iS
+  - Live content - https://qa.dosomething.org/us/quiz-results/p7hqjSP4Y1U6ad0UDz4iS?preview=true
+
+This is because the current content in Contentful for our result entries contains the banner image inline (so they are displayed twice, once within the header and a second time within the copy). When we're ready to go live, we'll have the campaigns team edit the content and remove the requirement to include the `preview` query.
+
 - Please avoid editing the Quiz entries if possible, as [they are delicately configured](https://github.com/DoSomething/phoenix-next/blob/8b5a97fdd973c8eb925191f78b36c2f676d2707a/docs/content-publishing/quiz.md#adding-available-choices-for-question) (deleting one of the `LinkAction` entries referenced by the `resultBlocks` field would not be pretty).

--- a/resources/assets/components/pages/QuizResultPage/QuizResultPage.js
+++ b/resources/assets/components/pages/QuizResultPage/QuizResultPage.js
@@ -59,7 +59,7 @@ const QuizResultPage = ({ id }) => {
       <SiteNavigationContainer />
 
       <main>
-        <article className="quiz-result-page">
+        <article data-test="quiz-result-page">
           <header
             role="banner"
             className="base-12-grid py-3 md:py-6 bg-blurple-500"
@@ -73,7 +73,10 @@ const QuizResultPage = ({ id }) => {
               ) : null}
             </div>
           </header>
-          <div className="bg-white base-12-grid py-3 md:py-6">
+          <div
+            data-test="quiz-result-page-content"
+            className="bg-white base-12-grid py-3 md:py-6"
+          >
             <TextContent className="grid-full">{content}</TextContent>
             <ContentfulEntryLoader
               id={config.galleryBlockId}

--- a/resources/assets/components/pages/QuizResultPage/QuizResultPage.js
+++ b/resources/assets/components/pages/QuizResultPage/QuizResultPage.js
@@ -5,10 +5,10 @@ import PropTypes from 'prop-types';
 import { useQuery } from 'react-apollo';
 
 import ErrorPage from '../ErrorPage';
-import { gqlVariables } from './config';
+import { gqlVariables, placeholderContent } from './config';
 import NotFoundPage from '../NotFoundPage';
-import { isDevEnvironment } from '../../../helpers';
 import Placeholder from '../../utilities/Placeholder';
+import { isDevEnvironment, query } from '../../../helpers';
 import SiteFooter from '../../utilities/SiteFooter/SiteFooter';
 import TextContent from '../../utilities/TextContent/TextContent';
 import { LinkBlockFragment } from '../../actions/LinkAction/LinkAction';
@@ -49,8 +49,10 @@ const QuizResultPage = ({ id }) => {
   const config = isDevEnvironment()
     ? gqlVariables.development
     : gqlVariables.production;
-  const { linkBlockTitle, content } = data.block;
+  const { linkBlockTitle } = data.block;
   const assetId = get(config, `results.${id}.assetId`, null);
+  // Use placeholder for development until we're ready to enable Quiz Result Page feature.
+  const content = query('preview') ? data.block.content : placeholderContent;
 
   return (
     <>

--- a/resources/assets/components/pages/QuizResultPage/config.js
+++ b/resources/assets/components/pages/QuizResultPage/config.js
@@ -42,4 +42,5 @@ export const gqlVariables = {
   },
 };
 
-export { gqlVariables as default };
+export const placeholderContent =
+  'Saepe cupiditate non. Facere velit vitae corporis. Voluptatum illo inventore quasi earum. Necessitatibus odio nam. Repudiandae commodi fugit. Placeat consequuntur autem dignissimos ducimus excepturi quis neque. Qui maiores voluptas illum et est laborum quia veniam. Dicta quia quas impedit. Laborum id eius molestias eveniet temporibus. Rerum tempora id eos officiis omnis nam. Eveniet quod quam et hic eligendi ab et. Tempora qui consequatur dolor laudantium voluptate magnam soluta. Eaque saepe quisquam similique voluptatum error.';

--- a/resources/assets/components/pages/QuizResultPage/config.js
+++ b/resources/assets/components/pages/QuizResultPage/config.js
@@ -42,5 +42,9 @@ export const gqlVariables = {
   },
 };
 
-export const placeholderContent =
-  'Saepe cupiditate non. Facere velit vitae corporis. Voluptatum illo inventore quasi earum. Necessitatibus odio nam. Repudiandae commodi fugit. Placeat consequuntur autem dignissimos ducimus excepturi quis neque. Qui maiores voluptas illum et est laborum quia veniam. Dicta quia quas impedit. Laborum id eius molestias eveniet temporibus. Rerum tempora id eos officiis omnis nam. Eveniet quod quam et hic eligendi ab et. Tempora qui consequatur dolor laudantium voluptate magnam soluta. Eaque saepe quisquam similique voluptatum error.';
+export const placeholderContent = `Saepe cupiditate non. Facere velit vitae corporis. Voluptatum illo inventore quasi earum.
+
+  **Necessitatibus odio nam.** Repudiandae commodi fugit. Placeat consequuntur autem dignissimos ducimus excepturi quis neque. Qui maiores voluptas illum et est laborum quia veniam. 
+
+  Dicta quia quas impedit. Laborum id eius molestias eveniet temporibus. Rerum tempora id eos officiis omnis nam. Eveniet quod quam et hic eligendi ab et. Tempora qui consequatur dolor laudantium voluptate magnam soluta. Eaque saepe quisquam similique voluptatum error.
+`;


### PR DESCRIPTION
### What's this PR do?

This pull request will display placeholder content on the `QuizResultPage`, unless a `preview` query parameter is set, e.g. `/quiz-results/p7hqjSP4Y1U6ad0UDz4iS?preview=true`. 

We'll need this to test our work against QA reliably, because our current production content for the voting quiz results contains markup to display the banner image -- so it gets displayed twice. Example: https://qa.dosomething.org/us/quiz-results/p7hqjSP4Y1U6ad0UDz4iS

Once this feature is ready to go live, we can edit our production content to remove the image - as well as removing the placeholder copy, and just displaying the GraphQL content by default.

It also starts on some baseline tests for the new `QuizResultPage` component, added in #2136 

### How should this be reviewed?

Verify expected behavior:

* By default, we show placeholder content: https://dosomething-phoenix-de-pr-2139.herokuapp.com/us/quiz-results/347iYsbykgQe6KqeGceMUk

* We show GraphQL content when `preview` query is set: https://dosomething-phoenix-de-pr-2139.herokuapp.com/us/quiz-results/347iYsbykgQe6KqeGceMUk?preview=true

### Any background context you want to provide?

When I started on these tests, I was getting the same  `Please return a __typename in "Block"` error that I got in https://github.com/DoSomething/phoenix-next/pull/2136#issuecomment-628667720, when I tried to add coverage for visiting a quiz -- either by visiting the quiz campaigns' action page, or the BlockPage (`/us/blocks/:id`)

With @mendelB's clue around not "defining the ...on LinkBlock or whatever for the nested block fields" - it got me thinking about the GraphQL fixtures we have, and adding a `LinkBlock` in there fixed the GraphQL query.

I kept adding more types to try to get the `ContentfulBlockQuery` to properly mock the Quiz Result Page's `GalleryBlock` -- but still kept seeing the `Please return a __typename in "Block`. error. I can push up that commit in a different branch, wanted to keep this branch in a good place to review/merge.
 
### Relevant tickets

References [Pivotal #172752983](https://www.pivotaltracker.com/story/show/172752983).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added screenshots of front-end changes on small, medium, and large screens.
- [x] Added appropriate feature/unit tests.
