### PR TITLE
No Landing Page? No Problem! (Fix Missing Landing Page Bug)

### DIFF
--- a/docs/development/content-types/campaign.md
+++ b/docs/development/content-types/campaign.md
@@ -14,7 +14,7 @@ Configures a [campaign](https://github.com/DoSomething/rogue/blob/master/docs/en
 
 - **Blurb** : Long text displayed in the LedeBanner.
 
-- **Landing Page** : Reference to a [Landing Page](development/content-types/landing-page.md) or Sixpack Experiment entry, displayed when the current user has not signed up for the campaign.
+- **Landing Page** : Reference to a [Landing Page](development/content-types/landing-page.md) or Sixpack Experiment entry ([currently broken](https://www.pivotaltracker.com/n/projects/2401401/stories/170964251)), displayed when the current user has not signed up for the campaign.
 
 - **Additional Content** : A JSON field, which may contain the following properties:
 

--- a/resources/assets/components/Campaign/CampaignRoute/CampaignRoute.js
+++ b/resources/assets/components/Campaign/CampaignRoute/CampaignRoute.js
@@ -9,6 +9,7 @@ import NotFound from '../../NotFound';
 import Modal from '../../utilities/Modal/Modal';
 import { isCampaignClosed } from '../../../helpers';
 import BlockPage from '../../pages/BlockPage/BlockPage';
+import LandingPage from '../../pages/LandingPage/LandingPage';
 import ContentfulEntry from '../../ContentfulEntry/ContentfulEntry';
 import PostSignupModal from '../../pages/PostSignupModal/PostSignupModal';
 import CampaignClosedPage from '../../pages/CampaignPage/CampaignClosedPage';
@@ -84,14 +85,10 @@ const CampaignRoute = props => {
               );
             }
 
-            if (!props.landingPage) {
-              return <NotFound />;
-            }
-
-            // This could be a Landing Page or a Sixpack Experiment.
-            // (Sixpack experiments are actually _not_ supported ATM:
-            // https://www.pivotaltracker.com/n/projects/2401401/stories/170964251).
-            return <ContentfulEntry json={props.landingPage} />;
+            return (
+              // @TODO: Add support for SixpackExperiment components (https://bit.ly/2T99sUl).
+              <LandingPage content={get(props.landingPage, 'fields.content')} />
+            );
           }}
         />
 

--- a/resources/assets/components/Campaign/CampaignRoute/CampaignRoute.js
+++ b/resources/assets/components/Campaign/CampaignRoute/CampaignRoute.js
@@ -5,12 +5,10 @@ import PropTypes from 'prop-types';
 import ReactRouterPropTypes from 'react-router-prop-types';
 import { Switch, Route, Redirect } from 'react-router-dom';
 
-import NotFound from '../../NotFound';
 import Modal from '../../utilities/Modal/Modal';
 import { isCampaignClosed } from '../../../helpers';
 import BlockPage from '../../pages/BlockPage/BlockPage';
 import LandingPage from '../../pages/LandingPage/LandingPage';
-import ContentfulEntry from '../../ContentfulEntry/ContentfulEntry';
 import PostSignupModal from '../../pages/PostSignupModal/PostSignupModal';
 import CampaignClosedPage from '../../pages/CampaignPage/CampaignClosedPage';
 import CampaignPageContainer from '../../pages/CampaignPage/CampaignPageContainer';


### PR DESCRIPTION
### What's this PR do?

This pull request fixes a bug in our rendering logic wherein we'd render a (rather shoddy looking) `NotFound` component if an open campaign didn't contain a Landing Page reference (for unaffiliated users).

### How should this be reviewed?
👀 

### Any background context you want to provide?
I was noodling over the best way to handle a [`SixpackExperiment` reference](https://github.com/DoSomething/phoenix-next/blob/2523855fbed2eaaea74fb5553fb6110187ed796b/contentful/content-types/campaign.js#L230), but then decided to formally remove that support for now since it's quite quite broken as it stands, and [we've deprioritized](https://www.pivotaltracker.com/n/projects/2401401/stories/170964251) re-adding support. 

I had an idea or two for refactoring the Landing Page to include a child `LandingPageContent` component (like we do [for campaign pages](https://github.com/DoSomething/phoenix-next/blob/2523855fbed2eaaea74fb5553fb6110187ed796b/resources/assets/components/pages/CampaignPage/CampaignPage.js)), this would allow us to handle both cases in neatly encapsulated fashion. But that can be addressed apart from this.

I'm going to go ahead and disable `SixpackExperiment` as a Landing Page reference on Contentful to avoid confusion and further breakage. (I'll leave a note in the story to flip it back on once we fix).

Pending #2143 I'll add a test to cover no landing page reference. (And try and consolidate the `campaign-signup` & `campaign-signup-hero` tests since they should be united at last).

Before 🤒
![image](https://user-images.githubusercontent.com/12417657/82085588-47732280-96bb-11ea-8c6c-1eb80046b672.png)

After:
![image](https://user-images.githubusercontent.com/12417657/82085737-725d7680-96bb-11ea-8002-df4d73741497.png)


### Relevant tickets

References [Pivotal #171776980](https://www.pivotaltracker.com/story/show/171776980).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added screenshots of front-end changes on small, medium, and large screens.
- [ ] Added appropriate feature/unit tests.
