### PR TITLE
Fix for broken Ghost Inspector test.

### DIFF
--- a/resources/assets/components/actions/PhotoSubmissionAction/PhotoSubmissionAction.js
+++ b/resources/assets/components/actions/PhotoSubmissionAction/PhotoSubmissionAction.js
@@ -393,7 +393,10 @@ class PhotoSubmissionAction extends PostForm {
                                 total items
                               </span>
 
-                              <span className="block font-league-gothic leading-none text-4xl">
+                              <span
+                                className="block font-league-gothic leading-none text-4xl"
+                                data-testid="quantity-total"
+                              >
                                 {quantity}
                               </span>
                             </div>


### PR DESCRIPTION
### What's this PR do?

This pull request adds a `data-testid` in the photo submission action to make it easier to query this particular item in Ghost Inspector. In #2132, I removed the named classes in favor of using Tailwind utility classes and turns out a test in GI depended on it.

Best to be using `data-testid` anyway for testing purposes!

### How should this be reviewed?

👀 

### Any background context you want to provide?

The [Testing Library framework](https://testing-library.com/docs/dom-testing-library/api-queries#bytestid) has built in support for querying test IDs as data attributes that are named as `data-testid`, which is slightly different from our current `data-test`. I think it makes sense to switch to this library's recommendation since it has the same support for Cypress tests, etc.

I suspect this would mean updating the [Communal Docs](https://github.com/DoSomething/communal-docs/tree/master/Contributing#data-attributes) to follow the Testing Library's naming scheme.