### PR TITLE
Deprecate Legacy Affiliate Logo Override for Hero Template

### DIFF
--- a/resources/assets/components/LedeBanner/templates/HeroTemplate.js
+++ b/resources/assets/components/LedeBanner/templates/HeroTemplate.js
@@ -1,5 +1,4 @@
 import React, { useState, useEffect } from 'react';
-import { get } from 'lodash';
 import PropTypes from 'prop-types';
 
 import Modal from '../../utilities/Modal/Modal';
@@ -21,7 +20,6 @@ import './hero-lede-banner.scss';
 
 const HeroTemplate = ({
   actionIdToDisplay,
-  additionalContent,
   affiliateCreditText,
   affiliateSponsors,
   affiliateOptInContent,
@@ -72,13 +70,7 @@ const HeroTemplate = ({
               {affiliateSponsors.length ? (
                 <AffiliatePromotion
                   className="mt-3"
-                  imgUrl={
-                    get(
-                      additionalContent,
-                      'campaignSponsorLogoAlternativeUrl',
-                      null,
-                    ) || affiliateSponsors[0].fields.logo.url
-                  }
+                  imgUrl={affiliateSponsors[0].fields.logo.url}
                   text={affiliateCreditText}
                   textClassName="text-gray-600"
                   title={affiliateSponsors[0].fields.logo.title}
@@ -166,7 +158,6 @@ const HeroTemplate = ({
 
 HeroTemplate.propTypes = {
   actionIdToDisplay: PropTypes.number,
-  additionalContent: PropTypes.object,
   affiliateCreditText: PropTypes.string,
   affiliateSponsors: PropTypes.arrayOf(PropTypes.object),
   affiliateOptInContent: PropTypes.object,
@@ -190,7 +181,6 @@ HeroTemplate.propTypes = {
 
 HeroTemplate.defaultProps = {
   actionIdToDisplay: null,
-  additionalContent: null,
   affiliateCreditText: undefined,
   affiliateSponsors: [],
   affiliateOptInContent: null,

--- a/resources/assets/components/LedeBanner/templates/HeroTemplate.js
+++ b/resources/assets/components/LedeBanner/templates/HeroTemplate.js
@@ -1,5 +1,5 @@
-import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
+import React, { useState, useEffect } from 'react';
 
 import Modal from '../../utilities/Modal/Modal';
 import ContentfulEntry from '../../ContentfulEntry';


### PR DESCRIPTION
### What's this PR do?

This pull request removes an outdated override we had in place during the transition to the now formalized Hero Template.

### How should this be reviewed?
👀 

### Any background context you want to provide?
We added this in #1510, but we no longer need it! There was one living instance of this in place in Contentful which I deleted (and fixed the logo which was still a white one which was invisible on the Hero Template).

(In fact, this was no longer functional since we weren't passing through the `additionalContent` from the container anymore).

### Relevant tickets

References [Pivotal #171776980](https://www.pivotaltracker.com/story/show/171776980).

