### PR TITLE
Cypress beta url refactor

### DIFF
--- a/cypress/integration/beta-voter-registration-drive-page.js
+++ b/cypress/integration/beta-voter-registration-drive-page.js
@@ -289,6 +289,10 @@ describe('Beta Voter Registration Drive (OVRD) Page', () => {
 
     cy.get('[data-id=voter-registration-email-field]').type('text@test.com');
     cy.get('[data-id=voter-registration-zip-field]').type('12345');
+    cy.get('[data-id=voter-registration-sourceDetails').type(
+      `user:${user.id},source:web,source_details:onlinedrivereferral,referral=true`,
+      { force: true },
+    );
 
     cy.get('[data-test=voter-registration-submit-button]').should('be.enabled');
   });

--- a/cypress/integration/beta-voter-registration-drive-page.js
+++ b/cypress/integration/beta-voter-registration-drive-page.js
@@ -289,9 +289,9 @@ describe('Beta Voter Registration Drive (OVRD) Page', () => {
 
     cy.get('[data-id=voter-registration-email-field]').type('text@test.com');
     cy.get('[data-id=voter-registration-zip-field]').type('12345');
-    cy.get('[data-id=voter-registration-sourceDetails').type(
+    cy.get('[data-id=voter-registration-source-details]').should(
+      'have.value',
       `user:${user.id},source:web,source_details:onlinedrivereferral,referral=true`,
-      { force: true },
     );
 
     cy.get('[data-test=voter-registration-submit-button]').should('be.enabled');

--- a/resources/assets/components/pages/VoterRegistrationDrivePage/Beta/StartVoterRegistrationForm.js
+++ b/resources/assets/components/pages/VoterRegistrationDrivePage/Beta/StartVoterRegistrationForm.js
@@ -51,7 +51,7 @@ const StartVoterRegistrationForm = ({ campaignId, referrerUserId }) => {
             type="hidden"
             name="source"
             value={urlSourceDetails}
-            data-id="voter-registration-sourceDetails"
+            data-id="voter-registration-source-details"
           />
 
           <div className="form-item stretched">

--- a/resources/assets/components/pages/VoterRegistrationDrivePage/Beta/StartVoterRegistrationForm.js
+++ b/resources/assets/components/pages/VoterRegistrationDrivePage/Beta/StartVoterRegistrationForm.js
@@ -47,7 +47,12 @@ const StartVoterRegistrationForm = ({ campaignId, referrerUserId }) => {
         >
           <input type="hidden" name="partner" value="37187" />
 
-          <input type="hidden" name="source" value={urlSourceDetails} />
+          <input
+            type="hidden"
+            name="source"
+            value={urlSourceDetails}
+            data-id="voter-registration-sourceDetails"
+          />
 
           <div className="form-item stretched">
             <label htmlFor="email" className="font-bold">


### PR DESCRIPTION
### What's this PR do?

This pull request adds a cypress test to @lindsayrmaher [PR ](https://github.com/DoSomething/phoenix-next/pull/2141) refractor work for the beta form,
with this test we account for coverage on the expected URL we'll redirect a user to.


### How should this be reviewed?

...

### Any background context you want to provide?
With the suggestions from various conversations in [slack](https://dosomething.slack.com/archives/CTVPG6L4R/p1589575301148900) and [PR's](https://github.com/DoSomething/phoenix-next/pull/2141), this appears to be a reasonable solution to best the URL on the beta page and the coming work for the quiz page since the URL will be slightly different. 
...

### Relevant tickets

References [Pivotal #](https://www.pivotaltracker.com/n/projects/2417735/stories/172829662).

### Checklist

- [ x ] This PR has been added to the relevant Pivotal card.
- [ x ] Added appropriate feature/unit tests.
