### PR TITLE
Deprecate 'Disable Signup' Experimental Feature

### DIFF
--- a/resources/assets/components/SignupButton/SignupButton.js
+++ b/resources/assets/components/SignupButton/SignupButton.js
@@ -14,7 +14,6 @@ const SignupButton = props => {
     campaignTitle,
     className,
     contextSource,
-    disableSignup,
     endDate,
     pageId,
     storeCampaignSignup,
@@ -56,11 +55,6 @@ const SignupButton = props => {
     });
   };
 
-  // Have signups been disabled for this campaign?
-  if (disableSignup) {
-    return null;
-  }
-
   // In descending priority: button-specific text prop,
   // campaign action text override, or standard "Take Action" copy.
   const buttonCopy = text || campaignActionText;
@@ -81,7 +75,6 @@ SignupButton.propTypes = {
   campaignTitle: PropTypes.string,
   className: PropTypes.string,
   contextSource: PropTypes.string,
-  disableSignup: PropTypes.bool,
   endDate: PropTypes.string,
   pageId: PropTypes.string.isRequired,
   storeCampaignSignup: PropTypes.func.isRequired,
@@ -94,7 +87,6 @@ SignupButton.defaultProps = {
   campaignTitle: null,
   className: null,
   contextSource: null,
-  disableSignup: false,
   endDate: null,
   text: null,
 };

--- a/resources/assets/components/SignupButton/SignupButton.test.js
+++ b/resources/assets/components/SignupButton/SignupButton.test.js
@@ -18,12 +18,6 @@ describe('The SignupButton component', () => {
     expect(wrapper.find('PrimaryButton')).toHaveLength(1);
   });
 
-  it("doesn't render the Button if the signup is disabled", () => {
-    const wrapper = mount(<SignupButton {...props} disableSignup />);
-
-    expect(wrapper.find('PrimaryButton')).toHaveLength(0);
-  });
-
   it('invokes the storeCampaignSignup function when the button is clicked', () => {
     const wrapper = mount(<SignupButton {...props} />);
 

--- a/resources/assets/components/SignupButton/SignupButtonContainer.js
+++ b/resources/assets/components/SignupButton/SignupButtonContainer.js
@@ -14,7 +14,6 @@ const mapStateToProps = state => ({
   campaignTitle: state.campaign.title,
   endDate: state.campaign.endDate,
   pageId: state.campaign.id || state.page.id,
-  disableSignup: get(state.campaign, 'additionalContent.disableSignup', false),
 });
 
 /**

--- a/resources/assets/components/SignupButton/SignupButtonContainer.js
+++ b/resources/assets/components/SignupButton/SignupButtonContainer.js
@@ -1,5 +1,4 @@
 import { connect } from 'react-redux';
-import { get } from 'lodash';
 
 import SignupButton from './SignupButton';
 import { storeCampaignSignup } from '../../actions/signup';


### PR DESCRIPTION
### What's this PR do?

This pull request deprecates an informal feature we deployed for a one-off [campaign](https://app.contentful.com/spaces/81iqaqpfd8fy/entries/2dyuYzsu0Y88CmC0AeU8S8) to withhold the Signup button.

### How should this be reviewed?
👀 

Any objections? I feel like this is just clutter in the codebase since we're not using it anywhere, it's not documented, and we really employed this as a one-off experiment feature way back in https://github.com/DoSomething/phoenix-next/pull/798.

### Any background context you want to provide?
I'm working on cleaning out legacy landing page `additionalContent` fields and this popped up.

### Relevant tickets

References [Pivotal #171776980](https://www.pivotaltracker.com/story/show/171776980).
