### PR TITLE
Renamed data attribute

### DIFF
--- a/cypress/integration/beta-voter-registration-drive-page.js
+++ b/cypress/integration/beta-voter-registration-drive-page.js
@@ -289,7 +289,7 @@ describe('Beta Voter Registration Drive (OVRD) Page', () => {
 
     cy.get('[data-id=voter-registration-email-field]').type('text@test.com');
     cy.get('[data-id=voter-registration-zip-field]').type('12345');
-    cy.get('[data-id=voter-registration-source-details]').should(
+    cy.get('[data-testid=voter-registration-source-details]').should(
       'have.value',
       `user:${user.id},source:web,source_details:onlinedrivereferral,referral=true`,
     );

--- a/cypress/integration/beta-voter-registration-drive-page.js
+++ b/cypress/integration/beta-voter-registration-drive-page.js
@@ -287,8 +287,10 @@ describe('Beta Voter Registration Drive (OVRD) Page', () => {
 
     cy.visit(getBetaPagePathForUser(user));
 
-    cy.get('[data-id=voter-registration-email-field]').type('text@test.com');
-    cy.get('[data-id=voter-registration-zip-field]').type('12345');
+    cy.get('[data-testid=voter-registration-email-field]').type(
+      'text@test.com',
+    );
+    cy.get('[data-testid=voter-registration-zip-field]').type('12345');
     cy.get('[data-testid=voter-registration-source-details]').should(
       'have.value',
       `user:${user.id},source:web,source_details:onlinedrivereferral,referral=true`,

--- a/resources/assets/components/pages/VoterRegistrationDrivePage/Beta/StartVoterRegistrationForm.js
+++ b/resources/assets/components/pages/VoterRegistrationDrivePage/Beta/StartVoterRegistrationForm.js
@@ -64,7 +64,7 @@ const StartVoterRegistrationForm = ({ campaignId, referrerUserId }) => {
                 name="email_address"
                 value={email}
                 onChange={handleChange}
-                data-id="voter-registration-email-field"
+                data-testid="voter-registration-email-field"
               />
             </label>
           </div>
@@ -80,7 +80,7 @@ const StartVoterRegistrationForm = ({ campaignId, referrerUserId }) => {
                 onChange={handleChange}
                 required
                 pattern="^\s*?\d{5}(?:[-\s]\d{4})?\s*?$"
-                data-id="voter-registration-zip-field"
+                data-testid="voter-registration-zip-field"
               />
             </label>
           </div>

--- a/resources/assets/components/pages/VoterRegistrationDrivePage/Beta/StartVoterRegistrationForm.js
+++ b/resources/assets/components/pages/VoterRegistrationDrivePage/Beta/StartVoterRegistrationForm.js
@@ -51,7 +51,7 @@ const StartVoterRegistrationForm = ({ campaignId, referrerUserId }) => {
             type="hidden"
             name="source"
             value={urlSourceDetails}
-            data-id="voter-registration-source-details"
+            data-testid="voter-registration-source-details"
           />
 
           <div className="form-item stretched">


### PR DESCRIPTION
### What's this PR do?

This pull request makes a change to the data attribute being called for testing in [PR](https://github.com/DoSomething/phoenix-next/pull/2151) to `data-testid` being used [here](https://github.com/DoSomething/communal-docs/tree/master/Contributing#tests) for testing.

### How should this be reviewed?

...

### Any background context you want to provide?

...

### Relevant tickets

References [Pivotal #]().

### Checklist

- [ x ] This PR has been added to the relevant Pivotal card.
- [ x ] Added appropriate feature/unit tests.
