### PR TITLE
Script to Remove Deprecated Campaign Additional Content Fields

### DIFF
--- a/contentful/management-api-scripts/2020_05_18_remove_deprecated_campaign_additional_content_fields.js
+++ b/contentful/management-api-scripts/2020_05_18_remove_deprecated_campaign_additional_content_fields.js
@@ -1,0 +1,123 @@
+const { omit } = require('lodash');
+
+const { contentManagementClient } = require('./contentManagementClient');
+const {
+  constants,
+  createLogger,
+  getField,
+  processEntries,
+  sleep,
+  withFields,
+} = require('./helpers');
+
+const { LOCALE } = constants;
+
+const logger = createLogger(
+  'remove_deprecated_campaign_additional_content_fields',
+);
+
+const deprecatedAdditionalContentFields = [
+  'campaignLead',
+  'sixpackSourceActionText',
+  'themeColor',
+  'enableBackgroundTest',
+  'featureFlags',
+  'NumberOfScholarships',
+  'reverseActivityFeedOrder',
+  'displayAffilitateOptOut',
+  'reportbackAffirmation',
+  'affiliateOption',
+  'verb',
+  'noun',
+  'tagline',
+  'smsShareConfirmationActionText',
+  'smsShareConfirmationActionLink',
+  'smsShareConfirmation',
+  'referralRB',
+  'sourceActionText',
+];
+
+const removeDeprecatedAdditionalContentFields = async (
+  environment,
+  campaignEntry,
+) => {
+  const campaignInternalTitle = getField(campaignEntry, 'internalTitle');
+  const campaignAdditionalContent = getField(
+    campaignEntry,
+    'additionalContent',
+  );
+
+  if (!campaignAdditionalContent) {
+    return;
+  }
+
+  const containsDeprecatedField = Object.keys(campaignAdditionalContent).some(
+    key => deprecatedAdditionalContentFields.includes(key),
+  );
+
+  if (!containsDeprecatedField) {
+    return;
+  }
+
+  logger.info(`\n\nProcessing ${campaignInternalTitle}.`);
+
+  const isArchived = await campaignEntry.isArchived();
+
+  if (isArchived) {
+    logger.info(`→ Skipping archived campaign ${campaignInternalTitle}.`);
+    return;
+  }
+
+  const withoutDeprecatedFields = omit(
+    campaignAdditionalContent,
+    deprecatedAdditionalContentFields,
+  );
+
+  campaignEntry.fields.additionalContent[LOCALE] = Object.keys(
+    withoutDeprecatedFields,
+  ).length
+    ? withoutDeprecatedFields
+    : null;
+
+  const updatedCampaign = await campaignEntry.update();
+
+  if (!updatedCampaign) {
+    logger.info(`☓ Unable to update ${campaignInternalTitle}.`);
+    return;
+  }
+
+  // Make sure that we don't publish an unpublished campaign by mistake:
+  const wasPublished = await campaignEntry.isPublished();
+
+  if (!wasPublished) {
+    logger.warn(`→ Needs review: ${campaignEntry.sys.id}`);
+    return;
+  }
+
+  publishedUpdatedCampaign = await updatedCampaign.publish();
+
+  if (!publishedUpdatedCampaign) {
+    logger.info(`☓ Unable to publish updated ${campaignInternalTitle}.`);
+    return;
+  }
+
+  logger.info(`✔ Published updated ${campaignInternalTitle}.`);
+
+  await sleep(200);
+};
+
+contentManagementClient.init(async (environment, args) => {
+  logger.info(
+    `Running 'remove_deprecated_campaign_additional_content_fields', using Contentful's '${environment.sys.id}' environment.`,
+  );
+  logger.info('Kicking things off in 5 seconds...');
+
+  await sleep(5000);
+
+  await processEntries(
+    environment,
+    args,
+    'campaign',
+    removeDeprecatedAdditionalContentFields,
+  );
+});

--- a/cypress/fixtures/contentful/exampleVoterRegistrationDriveCampaign.js
+++ b/cypress/fixtures/contentful/exampleVoterRegistrationDriveCampaign.js
@@ -128,14 +128,6 @@ export default {
       },
     },
     socialOverride: null,
-    additionalContent: {
-      referralRB: true,
-      sourceActionText: {
-        niche: 'Apply Now!',
-        partner: 'Apply Now!',
-      },
-      signupArrowContent: 'Win a $5,000 Scholarship',
-    },
     allowExperiments: true,
     actionText: 'Join Us',
     staffPick: true,


### PR DESCRIPTION
### What's this PR do?

This pull request adds a Contentful Management API script to remove deprecated `additionalContent` fields from Campaigns

### How should this be reviewed?
I searched through the codebase to confirm the deprecation of these fields, but if any from the list alarm you, pls give a shout!

### Any background context you want to provide?
A number of these relate to the legacy landing page\s. I figured if we're retiring those we may as well tackle these other lingering fields.

We should probably get into the habit of cleaning these up as we retire the features from the codebase 👼 

### Relevant tickets

References [Pivotal #171776980](https://www.pivotaltracker.com/story/show/171776980).
