### PR TITLE
Rename LedeBanner to CampaignBanner & deprecate 'templates'

### DIFF
--- a/docs/development/content-types/campaign.md
+++ b/docs/development/content-types/campaign.md
@@ -12,7 +12,7 @@ Configures a [campaign](https://github.com/DoSomething/rogue/blob/master/docs/en
 
 - **Display Referral Page** : Whether to display the [Referral Page Banner](development/features/referral-pages.md) in the signup Affirmation.
 
-- **Blurb** : Long text displayed in the LedeBanner.
+- **Blurb** : Long text displayed in the CampaignBanner.
 
 - **Landing Page** : Reference to a [Landing Page](development/content-types/landing-page.md) or Sixpack Experiment entry ([currently broken](https://www.pivotaltracker.com/n/projects/2401401/stories/170964251)), displayed when the current user has not signed up for the campaign.
 

--- a/resources/assets/components/CampaignBanner/CampaignBanner.js
+++ b/resources/assets/components/CampaignBanner/CampaignBanner.js
@@ -1,24 +1,24 @@
 import PropTypes from 'prop-types';
 import React, { useState, useEffect } from 'react';
 
-import Modal from '../../utilities/Modal/Modal';
-import ContentfulEntry from '../../ContentfulEntry';
-import CoverImage from '../../utilities/CoverImage/CoverImage';
-import TextContent from '../../utilities/TextContent/TextContent';
-import { SCHOLARSHIP_SIGNUP_BUTTON_TEXT } from '../../../constants';
-import SignupButtonContainer from '../../SignupButton/SignupButtonContainer';
-import CampaignInfoBlock from '../../blocks/CampaignInfoBlock/CampaignInfoBlock';
-import AffiliatePromotion from '../../utilities/AffiliatePromotion/AffiliatePromotion';
-import ScholarshipInfoBlock from '../../blocks/ScholarshipInfoBlock/ScholarshipInfoBlock';
-import AffiliateOptInToggleContainer from '../../AffiliateOptInToggle/AffiliateOptInToggleContainer';
+import Modal from '../utilities/Modal/Modal';
+import ContentfulEntry from '../ContentfulEntry';
+import CoverImage from '../utilities/CoverImage/CoverImage';
+import TextContent from '../utilities/TextContent/TextContent';
+import { SCHOLARSHIP_SIGNUP_BUTTON_TEXT } from '../../constants';
+import SignupButtonContainer from '../SignupButton/SignupButtonContainer';
+import CampaignInfoBlock from '../blocks/CampaignInfoBlock/CampaignInfoBlock';
+import AffiliatePromotion from '../utilities/AffiliatePromotion/AffiliatePromotion';
+import ScholarshipInfoBlock from '../blocks/ScholarshipInfoBlock/ScholarshipInfoBlock';
+import AffiliateOptInToggleContainer from '../AffiliateOptInToggle/AffiliateOptInToggleContainer';
 import {
   isScholarshipAffiliateReferral,
   getScholarshipAffiliateLabel,
-} from '../../../helpers';
+} from '../../helpers';
 
-import './hero-lede-banner.scss';
+import './campaign-banner.scss';
 
-const HeroTemplate = ({
+const CampaignBanner = ({
   actionIdToDisplay,
   affiliateCreditText,
   affiliateSponsors,
@@ -156,7 +156,7 @@ const HeroTemplate = ({
   );
 };
 
-HeroTemplate.propTypes = {
+CampaignBanner.propTypes = {
   actionIdToDisplay: PropTypes.number,
   affiliateCreditText: PropTypes.string,
   affiliateSponsors: PropTypes.arrayOf(PropTypes.object),
@@ -179,7 +179,7 @@ HeroTemplate.propTypes = {
   title: PropTypes.string.isRequired,
 };
 
-HeroTemplate.defaultProps = {
+CampaignBanner.defaultProps = {
   actionIdToDisplay: null,
   affiliateCreditText: undefined,
   affiliateSponsors: [],
@@ -194,4 +194,4 @@ HeroTemplate.defaultProps = {
   scholarshipDescription: null,
 };
 
-export default HeroTemplate;
+export default CampaignBanner;

--- a/resources/assets/components/CampaignBanner/CampaignBannerContainer.js
+++ b/resources/assets/components/CampaignBanner/CampaignBannerContainer.js
@@ -1,7 +1,7 @@
 import get from 'lodash/get';
 import { connect } from 'react-redux';
 
-import LedeBanner from './LedeBanner';
+import CampaignBanner from './CampaignBanner';
 import { isSignedUp } from '../../selectors/signup';
 
 /**
@@ -40,4 +40,4 @@ const mapStateToProps = (state, props) => ({
 });
 
 // Export the container component.
-export default connect(mapStateToProps)(LedeBanner);
+export default connect(mapStateToProps)(CampaignBanner);

--- a/resources/assets/components/CampaignBanner/campaign-banner.scss
+++ b/resources/assets/components/CampaignBanner/campaign-banner.scss
@@ -1,4 +1,4 @@
-@import '../../../scss/next-toolbox.scss';
+@import '../../scss/next-toolbox.scss';
 
 .hero-landing-page {
   .cover-image {

--- a/resources/assets/components/LedeBanner/LedeBanner.js
+++ b/resources/assets/components/LedeBanner/LedeBanner.js
@@ -1,7 +1,0 @@
-import React from 'react';
-
-import HeroTemplate from './templates/HeroTemplate';
-
-const LedeBanner = props => <HeroTemplate {...props} />;
-
-export default LedeBanner;

--- a/resources/assets/components/pages/CampaignPage/CampaignClosedPage.js
+++ b/resources/assets/components/pages/CampaignPage/CampaignClosedPage.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import LedeBannerContainer from '../../LedeBanner/LedeBannerContainer';
+import CampaignBannerContainer from '../../CampaignBanner/CampaignBannerContainer';
 import CampaignInfoBarContainer from '../../CampaignInfoBar/CampaignInfoBarContainer';
 import { getHumanFriendlyDate } from '../../../helpers';
 
@@ -11,7 +11,7 @@ const CampaignClosedPage = props => {
   return (
     <>
       <article className="campaign-closed-page pb-6">
-        <LedeBannerContainer />
+        <CampaignBannerContainer />
 
         <div className="md:w-3/4 mx-auto my-6 px-3">
           <h1>Great work!</h1>

--- a/resources/assets/components/pages/CampaignPage/CampaignPage.js
+++ b/resources/assets/components/pages/CampaignPage/CampaignPage.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 
 import CampaignPageContent from './CampaignPageContent';
 import { CallToActionContainer } from '../../CallToAction';
-import LedeBannerContainer from '../../LedeBanner/LedeBannerContainer';
+import CampaignBannerContainer from '../../CampaignBanner/CampaignBannerContainer';
 import CampaignInfoBarContainer from '../../CampaignInfoBar/CampaignInfoBarContainer';
 import ContentfulEntryLoader from '../../utilities/ContentfulEntryLoader/ContentfulEntryLoader';
 import CampaignPageNavigationContainer from '../../CampaignPageNavigation/CampaignPageNavigationContainer';
@@ -14,7 +14,7 @@ const CampaignPage = props => {
   return (
     <>
       <article className="campaign-page bg-white">
-        <LedeBannerContainer />
+        <CampaignBannerContainer />
 
         <div className="clearfix relative">
           {quizEntry ? (

--- a/resources/assets/components/pages/LandingPage/LandingPage.js
+++ b/resources/assets/components/pages/LandingPage/LandingPage.js
@@ -7,7 +7,7 @@ import { css } from '@emotion/core';
 
 import { tailwind } from '../../../helpers';
 import TextContent from '../../utilities/TextContent/TextContent';
-import LedeBannerContainer from '../../LedeBanner/LedeBannerContainer';
+import CampaignBannerContainer from '../../CampaignBanner/CampaignBannerContainer';
 import CampaignInfoBarContainer from '../../CampaignInfoBar/CampaignInfoBarContainer';
 
 // @TODO: Implement this as a custom (rich text) renderer per https://git.io/JfGlf.
@@ -23,7 +23,7 @@ const landingPageHeadingOneStyle = css`
 
 const LandingPage = ({ content }) => (
   <>
-    <LedeBannerContainer />
+    <CampaignBannerContainer />
 
     {content ? (
       <div


### PR DESCRIPTION
### What's this PR do?

This pull request replaces the `LedeBanner` with a new `CampaignBanner` with no templates structure since we've settled on the one!

### How should this be reviewed?
Naming sound good? I did not change _anything_ besides for the name and structure. You'll notice some fun class names used for styling, and I'm hoping to replace those with Tailwind, and some extracted utilities in a follow-up PR to address the TODO here.

### Any background context you want to provide?
Now that we've gotten rid of the Mosaic Template in #2140 we're free to formalize the Hero Template!

(See [this thread](https://dosomething.slack.com/archives/CUQMU4Q6B/p1589569201008200) in Slack)

### Relevant tickets

References [Pivotal #171776980](https://www.pivotaltracker.com/story/show/171776980).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [x] Documentation added for new features/changed endpoints.
- [ ] Added screenshots of front-end changes on small, medium, and large screens. - _no visual changes!_
- [ ] Added appropriate feature/unit tests. _- updating tests in follow-up!_
