### PR TITLE
Adds documentation for voter registration tracking source

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -24,6 +24,7 @@
   - [Page](development/content-types/page.md)
   - [Selection Submission Action](development/content-types/selection-submission-action.md)
   - [Social Drive Action](development/content-types/social-drive-action.md)
+  - [Voter Registration Action](development/content-types/voter-registration-action.md)
 - [Features](development/features/README.md)
   - [Affiliate Opt In](development/features/affiliate-opt-in.md)
   - [Affiliate Scholarship Block](development/features/affiliate-scholarship-block.md)

--- a/docs/development/content-types/voter-registration-action.md
+++ b/docs/development/content-types/voter-registration-action.md
@@ -1,0 +1,13 @@
+# Voter Registration Action
+
+The Voter Registration Action content type renders a visual component which prompts DoSomething.org members to register to vote by linking to an external voter registration partner.
+
+![Voter Registration Action component](../../.gitbook/assets/voter-registration-action-component.png)
+
+## Usage Instructions
+
+When creating a new _Voter Registration Action_ on Contentful, an editor is required to enter a `link` field -- which is the full URL where the member should be directed to upon clicking on the button to start their registration.
+
+- For current entries, this will always be set to a URL in our [vote.dosomething.org Voting Portal]
+
+- For older entries, this may be set to a TurboVote URL, our [previous external voter registration partner before Rock The Vote](https://github.com/DoSomething/chompy/tree/master/docs/imports#rock-the-vote).

--- a/docs/development/content-types/voter-registration-action.md
+++ b/docs/development/content-types/voter-registration-action.md
@@ -8,6 +8,6 @@ The Voter Registration Action content type renders a visual component which prom
 
 When creating a new _Voter Registration Action_ on Contentful, an editor is required to enter a `link` field -- which is the full URL where the member should be directed to upon clicking on the button to start their registration.
 
-- For current entries, this will always be set to a URL in our [vote.dosomething.org Voting Portal]
+- For current entries, this will always be set to a URL in our [vote.dosomething.org Voting Portal](development/features/voter-registration.md#voting-portal)
 
 - For older entries, this may be set to a TurboVote URL, our [previous external voter registration partner before Rock The Vote](https://github.com/DoSomething/chompy/tree/master/docs/imports#rock-the-vote).

--- a/docs/development/features/sitewide-banner.md
+++ b/docs/development/features/sitewide-banner.md
@@ -6,7 +6,7 @@ This is a banner feature that is displayed site wide when turned on. In the past
 
 We use this feature to display important info to our users in a prominent banner across the top of the site. It is currently hardcoded to link to our [voter registration portal](/development/features/voter-registration.md#voting-portal).
 
-The `SitewideBanner` can be used in conjunction with a `DissmissableElement` or other wrapper components.
+The `SitewideBanner` can be used in conjunction with a `DismissableElement` or other wrapper components.
 
 ## Suppressing from Pages
 

--- a/docs/development/features/sitewide-banner.md
+++ b/docs/development/features/sitewide-banner.md
@@ -4,7 +4,9 @@
 
 This is a banner feature that is displayed site wide when turned on. In the past, we partnered with a 3rd party service to achieve this (HelloBar), but ran into some unforeseen and hard to troubleshoot bugs. And so, HowdyBar was born!
 
-Use this feature to display important info to our users in a prominent banner across the top of the site. This can be used in conjunction with a `DissmissableElement` or other wrapper components.
+We use this feature to display important info to our users in a prominent banner across the top of the site. It is currently hardcoded to link to our [voter registration portal](/development/features/voter-registration.md#voting-portal).
+
+The `SitewideBanner` can be used in conjunction with a `DissmissableElement` or other wrapper components.
 
 ## Suppressing from Pages
 

--- a/docs/development/features/voter-registration.md
+++ b/docs/development/features/voter-registration.md
@@ -28,9 +28,13 @@ This tracking source value is saved within the serialized `details` field of the
 
 - `user` - This is the Northstar user ID of either the authenticated user registering to vote, or the referring alpha user for a beta registration, when the `referral` key is present.
 
-- `source` - This is similar to a `utm_source`. Example values: `web`, `sms`, `email`
+- `source` - This is similar to a `utm_source`.
 
-- `source_detail` - This is similar to a `utm_campaign`. Example values: `hellobar`, `broadcastID_4YOiqwTVOOVklZFARAFd4h`, `VoterRegQuiz_completed_votebymail`, `onlinedrivereferral`
+  - Examples: `web`, `sms`, `email`
+
+- `source_detail` - This is similar to a `utm_campaign`.
+
+  - Example values: `hellobar`, `broadcastID_4YOiqwTVOOVklZFARAFd4h`, `VoterRegQuiz_completed_votebymail`, `onlinedrivereferral`
 
 - `referral` - If this is set, the `user` parameter should be used as the `referrer_user_id` on the `voter-reg` post.
 

--- a/docs/development/features/voter-registration.md
+++ b/docs/development/features/voter-registration.md
@@ -2,7 +2,13 @@
 
 ## Overview
 
-We partner with [Rock The Vote](https://www.rockthevote.org) to register young people to vote on behalf of DoSomething.org, by redirecting to them to the Rock The Vote (RTV) registration website and appending our partner ID: `https://register.rockthevote.com/registrants/new?partner=37187`
+We partner with [Rock The Vote](https://www.rockthevote.org) to register young people to vote on behalf of DoSomething.org, by redirecting to them to the Rock The Vote (RTV) registration website and appending our partner ID: `https://register.rockthevote.com/registrants/new?partner=37187`.
+
+We're able to pre-populate the user's email address and zip via `email_address` and `home_zip_code` query parameters, which we often include when redirecting an authenticated user on the web, e.g:
+
+```
+https://register.rockthevote.com.rockthevote.com/registrants/new?partner=37187&source=user:58e68d5da0bfad4c3b4cd722,source:web,source_details:onlinedrivereferral,referral=true&email_address=aschachter@dosomething.org&home_zip_code=94116
+```
 
 ## Import
 
@@ -13,6 +19,12 @@ Our importer app, [Chompy](https://www.github.com/dosomething/chompy) downloads 
 When we redirect to the RTV registration form, we include a `source` query parameter. Per the [RTV docs](https://www.rockthevote.org/programs-and-partner-resources/tech-for-civic-engagement/partner-ovr-tool-faqs/partner-ovr-tool-faqs/), a source parameter is used to:
 
 > track the success of various campaigns, affiliates, social media posts, and more using just one tool.
+
+We pass a `source` query parameter that contains multiple properties, comma separated by `key:value` substrings. Example:
+
+```
+https://register.rockthevote.com.rockthevote.com/registrants/new?partner=37187&source=user:58e68d5da0bfad4c3b4cd722,source:web,source_details:onlinedrivereferral,referral=true&email_address=aschachter@dosomething.org&home_zip_code=94116
+```
 
 ## Voting Portal
 

--- a/docs/development/features/voter-registration.md
+++ b/docs/development/features/voter-registration.md
@@ -64,7 +64,7 @@ The [`VoterRegistrationAction` content type](development/content-types/voter-reg
 
 ## Start Voter Registration Form
 
-The `StartVoterRegistrationForm` component displays form fields for email and zip, and redirects a user directly to the RTV registration site upon submitting. It's currently hardcoded on the OVRD [alpha page](#alpha-page) and [Quiz Result page](#quiz-result-page).
+The `StartVoterRegistrationForm` component displays form fields for email and zip, and redirects a user directly to the RTV registration site upon submitting. It's currently hardcoded on the [OVRD alpha page](#alpha-page) and [Quiz Result page](#quiz-result-page).
 
 ## Online Drives
 
@@ -160,12 +160,12 @@ Gallery Block: 78WaGsvDEzAxnreEvNx3Za
 
 Quiz Results:
 
-| id                     | title               | internalTitle      | assetId                |
-| ---------------------- | ------------------- | ------------------ | ---------------------- |
-| p7hqjSP4Y1U6ad0UDz4iS  | Shell-tered Voter   | Vote By Mail       | 49Y4ucuGbJbgZL7IDDfxG0 |
-| 1giTEF3B2hO2CyccmhlVDm | Hare Who Dares      | In-Person Voting   | 2f2kgaHl9w5VtdswKkaBWT |
-| 21PDBge2bKCTWMe5f9eo1H | Sloth At a Loss     | Unsure of Voting   | 1YomtHAeqXJ3qbjQNgsM0v |
-| 14KfeAs265httjNMf1jwTw | Moral Support Panda | Ineligible to Vote | 3WjT0QGNnJEPPz2yMd3inj |
+| id                                                                                           | title               | internalTitle      | assetId                |
+| -------------------------------------------------------------------------------------------- | ------------------- | ------------------ | ---------------------- |
+| [p7hqjSP4Y1U6ad0UDz4iS](https://www.dosomething.org/us/quiz/results/p7hqjSP4Y1U6ad0UDz4iS)   | Shell-tered Voter   | Vote By Mail       | 49Y4ucuGbJbgZL7IDDfxG0 |
+| [1giTEF3B2hO2CyccmhlVDm](https://www.dosomething.org/us/quiz/results/1giTEF3B2hO2CyccmhlVDm) | Hare Who Dares      | In-Person Voting   | 2f2kgaHl9w5VtdswKkaBWT |
+| [21PDBge2bKCTWMe5f9eo1H](https://www.dosomething.org/us/quiz/results/21PDBge2bKCTWMe5f9eo1H) | Sloth At a Loss     | Unsure of Voting   | 1YomtHAeqXJ3qbjQNgsM0v |
+| [14KfeAs265httjNMf1jwTw](https://www.dosomething.org/us/quiz/results/14KfeAs265httjNMf1jwTw) | Moral Support Panda | Ineligible to Vote | 3WjT0QGNnJEPPz2yMd3inj |
 
 **Dev:**
 

--- a/docs/development/features/voter-registration.md
+++ b/docs/development/features/voter-registration.md
@@ -8,7 +8,7 @@ We're able to pre-populate the user's email address and zip via `email_address` 
 
 Example:
 
-`https://register.rockthevote.com.rockthevote.com/registrants/new?partner=37187&source=user:58e68d5da0bfad4c3b4cd722,source:web,source_details:onlinedrivereferral,referral=true&email_address=aschachter@dosomething.org&home_zip_code=94116`
+> https://register.rockthevote.com.rockthevote.com/registrants/new?partner=37187&source=user:58e68d5da0bfad4c3b4cd722,source:web,source_details:onlinedrivereferral,referral=true&email_address=aschachter@dosomething.org&home_zip_code=94116
 
 ## Import
 

--- a/docs/development/features/voter-registration.md
+++ b/docs/development/features/voter-registration.md
@@ -8,7 +8,7 @@ We're able to pre-populate the user's email address and zip via `email_address` 
 
 Example:
 
-> https://register.rockthevote.com.rockthevote.com/registrants/new?partner=37187&source=user:58e68d5da0bfad4c3b4cd722,source:web,source_details:onlinedrivereferral,referral=true&email_address=aschachter@dosomething.org&home_zip_code=94116
+> https://register.rockthevote.com.rockthevote.com/registrants/new?partner=37187&source=user:58e68d5da0bfad4c3b4cd722,source:web,source_details:onlinedrivereferral,referral=true&email_address=puppet.sloth@dosomething.org&home_zip_code=94116
 
 ## Import
 

--- a/docs/development/features/voter-registration.md
+++ b/docs/development/features/voter-registration.md
@@ -162,10 +162,10 @@ Quiz Results:
 
 | id                                                                                           | title               | internalTitle      | assetId                |
 | -------------------------------------------------------------------------------------------- | ------------------- | ------------------ | ---------------------- |
-| [p7hqjSP4Y1U6ad0UDz4iS](https://www.dosomething.org/us/quiz/results/p7hqjSP4Y1U6ad0UDz4iS)   | Shell-tered Voter   | Vote By Mail       | 49Y4ucuGbJbgZL7IDDfxG0 |
-| [1giTEF3B2hO2CyccmhlVDm](https://www.dosomething.org/us/quiz/results/1giTEF3B2hO2CyccmhlVDm) | Hare Who Dares      | In-Person Voting   | 2f2kgaHl9w5VtdswKkaBWT |
-| [21PDBge2bKCTWMe5f9eo1H](https://www.dosomething.org/us/quiz/results/21PDBge2bKCTWMe5f9eo1H) | Sloth At a Loss     | Unsure of Voting   | 1YomtHAeqXJ3qbjQNgsM0v |
-| [14KfeAs265httjNMf1jwTw](https://www.dosomething.org/us/quiz/results/14KfeAs265httjNMf1jwTw) | Moral Support Panda | Ineligible to Vote | 3WjT0QGNnJEPPz2yMd3inj |
+| [p7hqjSP4Y1U6ad0UDz4iS](https://www.dosomething.org/us/quiz-results/p7hqjSP4Y1U6ad0UDz4iS)   | Shell-tered Voter   | Vote By Mail       | 49Y4ucuGbJbgZL7IDDfxG0 |
+| [1giTEF3B2hO2CyccmhlVDm](https://www.dosomething.org/us/quiz-results/1giTEF3B2hO2CyccmhlVDm) | Hare Who Dares      | In-Person Voting   | 2f2kgaHl9w5VtdswKkaBWT |
+| [21PDBge2bKCTWMe5f9eo1H](https://www.dosomething.org/us/quiz-results/21PDBge2bKCTWMe5f9eo1H) | Sloth At a Loss     | Unsure of Voting   | 1YomtHAeqXJ3qbjQNgsM0v |
+| [14KfeAs265httjNMf1jwTw](https://www.dosomething.org/us/quiz-results/14KfeAs265httjNMf1jwTw) | Moral Support Panda | Ineligible to Vote | 3WjT0QGNnJEPPz2yMd3inj |
 
 **Dev:**
 
@@ -173,11 +173,11 @@ Gallery Block: 2VGFq3XBcqCfKOA8mC5mP4
 
 Quiz Results:
 
-| id                     | title               | internalTitle    | assetId                |
-| ---------------------- | ------------------- | ---------------- | ---------------------- |
-| 347iYsbykgQe6KqeGceMUk | Moral Support Panda | Super Motivated  | 6J13jUL4YGGC1fyYMNEfbc |
-| 1lvJHhlJqQSgKgwIwUymQ8 | Shell-tered Voter   | Social Voter     | 3iLKsRlFQ1k9ddQbRb3RN8 |
-| 2KfkCOTi7u4CqAyyCuGyci | Hare Who Dares      | Election Dabbler | 3uB88eZmTNEaoFxV9pZ8hX |
+| id                                                                                           | title               | internalTitle    | assetId                |
+| -------------------------------------------------------------------------------------------- | ------------------- | ---------------- | ---------------------- |
+| [347iYsbykgQe6KqeGceMUk](https://dev.dosomething.org/us/quiz-results/347iYsbykgQe6KqeGceMUk) | Moral Support Panda | Super Motivated  | 6J13jUL4YGGC1fyYMNEfbc |
+| [1lvJHhlJqQSgKgwIwUymQ8](https://dev.dosomething.org/us/quiz-results/1lvJHhlJqQSgKgwIwUymQ8) | Shell-tered Voter   | Social Voter     | 3iLKsRlFQ1k9ddQbRb3RN8 |
+| [2KfkCOTi7u4CqAyyCuGyci](https://dev.dosomething.org/us/quiz-results/2KfkCOTi7u4CqAyyCuGyci) | Hare Who Dares      | Election Dabbler | 3uB88eZmTNEaoFxV9pZ8hX |
 
 **Related links:**
 

--- a/docs/development/features/voter-registration.md
+++ b/docs/development/features/voter-registration.md
@@ -50,13 +50,17 @@ Example:
 
 ### Influencers
 
-We host customized voter registration drives for influencers on our Instapage, by creating pages like https://vote.dosomething.org/NoorAldayeh on Instapage and including a relevant tracking source:
+We host customized voter registration drives for influencers on our Instapage, by creating pages like https://vote.dosomething.org/NoorAldayeh on Instapage and passing a relevant tracking source when redirecting to the RTV registration site:
 
 > source:influencer,source_details:noor_aldayeh
 
 ## Voter Registration Action
 
-The `VoterRegistrationAction` content type can be used to display a call to action button that redirects a user to our vote.dosomething.org portal.
+The [`VoterRegistrationAction` content type](development/content-types/voter-registration-action.md) can be used to display a call to action button that redirects a user to our vote.dosomething.org portal.
+
+## Start Voter Registration Form
+
+The `StartVoterRegistrationForm` component displays form fields for email and zip, and redirects a user directly to the RTV registration site upon submitting. It's currently hardcoded on the OVRD [alpha page](#alpha-page) and [Quiz Result page](#quiz-result-page).
 
 ## Online Drives
 

--- a/docs/development/features/voter-registration.md
+++ b/docs/development/features/voter-registration.md
@@ -46,7 +46,7 @@ This tracking source value is saved within the serialized `details` field of the
 
 We host our voting portal, [vote.dosomething.org](https://vote.dosomething.org) on Instapage. It displays a form that prompts for email and zip, and redirects them to the Rock The Vote registration URL with our partner ID, pre-populating the email and zip submitted from the form.
 
-When constructing a URL for the voting portal, we pass along the tracking source via a `r` query parameter, which will be passed as a `source` parameter when the email/zip form is submitted and the user is redirected to the RTV registration site.
+When constructing a URL for the voting portal, we include the tracking source via a `r` query parameter, which is then added as a `source` parameter when redirecting the user to the RTV registration site after they enter their email and zip (handled via JS on Instapage).
 
 Example:
 

--- a/docs/development/features/voter-registration.md
+++ b/docs/development/features/voter-registration.md
@@ -36,13 +36,19 @@ This tracking source value is saved within the serialized `details` field of the
 
 ## Voting Portal
 
-We host our voting portal, [vote.dosomething.org](https://vote.dosomething.org) on Instapage. It prompts user for their email and zip, and redirects them to the Rock The Vote registration URL with our partner ID, pre-populating the email and zip submitted from the form.
+We host our voting portal, [vote.dosomething.org](https://vote.dosomething.org) on Instapage. It displays a form that prompts for email and zip, and redirects them to the Rock The Vote registration URL with our partner ID, pre-populating the email and zip submitted from the form.
 
 When constructing a URL for the voting portal, we pass along the tracking source via a `r` query parameter, which will be passed as a `source` parameter when the email/zip form is submitted and the user is redirected to the RTV registration site.
 
 Example:
 
 > vote.dosomething.org/covid19?r=campaignID:8017,campaignRunID:8022,source:web,source_details:VoterRegQuiz_completed_notsure
+
+### Influencers
+
+We host customized voter registration drives for influencers on our Instapage, by creating pages like https://vote.dosomething.org/NoorAldayeh on Instapage and including a relevant tracking source:
+
+> source:influencer,source_details:noor_aldayeh
 
 ## Voter Registration Action
 
@@ -112,7 +118,11 @@ Content:
 
 **Notes:**
 
-- The initial version of OVRD beta page was hosted on Instapage - https://vote.dosomething.org/member-drives. Example URL: `https://vote.dosomething.org/member-drive?userId=${referrerUserId}&r=user:${referrerUserId},source:web,source_details:onlinedrivereferral,referral=true`. This page had inline JS that would query Northstar to find a user's first name based on the `userId` query parameter passed.
+The initial version of OVRD beta page was hosted on Instapage - https://vote.dosomething.org/member-drives. Example URL:
+
+> vote.dosomething.org/member-drive?userId=${referrerUserId}&r=user:${referrerUserId},source:web,source_details:onlinedrivereferral,referral=true
+
+This page had inline JS that would query Northstar to find a user's first name based on the `userId` query parameter passed.
 
 ## Quiz
 

--- a/docs/development/features/voter-registration.md
+++ b/docs/development/features/voter-registration.md
@@ -4,11 +4,11 @@
 
 We partner with [Rock The Vote](https://www.rockthevote.org) to register young people to vote on behalf of DoSomething.org, by redirecting to them to the Rock The Vote (RTV) registration website and appending our partner ID: `https://register.rockthevote.com/registrants/new?partner=37187`.
 
-We're able to pre-populate the user's email address and zip via `email_address` and `home_zip_code` query parameters, which we often include when redirecting an authenticated user on the web, e.g:
+We're able to pre-populate the user's email address and zip via `email_address` and `home_zip_code` query parameters, which we often include when redirecting an authenticated user on the web.
 
-```
-https://register.rockthevote.com.rockthevote.com/registrants/new?partner=37187&source=user:58e68d5da0bfad4c3b4cd722,source:web,source_details:onlinedrivereferral,referral=true&email_address=aschachter@dosomething.org&home_zip_code=94116
-```
+Example:
+
+`https://register.rockthevote.com.rockthevote.com/registrants/new?partner=37187&source=user:58e68d5da0bfad4c3b4cd722,source:web,source_details:onlinedrivereferral,referral=true&email_address=aschachter@dosomething.org&home_zip_code=94116`
 
 ## Import
 

--- a/docs/development/features/voter-registration.md
+++ b/docs/development/features/voter-registration.md
@@ -20,11 +20,11 @@ When we redirect to the RTV registration form, we include a `source` query param
 
 > track the success of various campaigns, affiliates, social media posts, and more using just one tool.
 
-We pass a `source` query parameter that contains multiple properties, comma separated by `key:value` substrings. Example:
+When we download the RTV reports, each registration contains the `source` query parameter that was present when the user began their registration. We construct the value to pass for the `source` by comma-separating `key:value` substrings. Example:
 
 > user:5547be89469c64ec7d8b518d,source:web,source_details:VoterRegQuiz_completed_notsure
 
-The following parameters can be passed:
+The tracking source value is saved within the serialized `details` field of the `voter-reg` post. The following key/values are parsed from the tracking source value, used either by the Chompy import or Looker:
 
 - `user` - This is the Northstar user ID of either the authenticated user registering to vote, or the referring user, if the `referral` key is present
 
@@ -39,6 +39,12 @@ The following parameters can be passed:
 ## Voting Portal
 
 We host our voting portal, [vote.dosomething.org](https://vote.dosomething.org) on Instapage. It prompts user for their email and zip, and redirects them to the Rock The Vote registration URL with our partner ID, pre-populating the email and zip submitted from the form.
+
+When constructing a URL for the voting portal, we pass along the tracking source via a `r` query parameter -- which will be passed as a `source` parameter when the email/zip form is submitted and the user is redirected to the RTV registration site.
+
+Example:
+
+> vote.dosomething.org/covid19?r=campaignID:8017,campaignRunID:8022,source:web,source_details:VoterRegQuiz_completed_notsure
 
 ## Voter Registration Action
 

--- a/docs/development/features/voter-registration.md
+++ b/docs/development/features/voter-registration.md
@@ -4,11 +4,11 @@
 
 We partner with [Rock The Vote](https://www.rockthevote.org) to register young people to vote on behalf of DoSomething.org, by redirecting to them to the Rock The Vote (RTV) registration website and appending our partner ID: `https://register.rockthevote.com/registrants/new?partner=37187`.
 
-We're able to pre-populate the user's email address and zip via `email_address` and `home_zip_code` query parameters, which we often include when redirecting an authenticated user on the web.
+We can pre-populate the voter registration email address and zip via `email_address` and `home_zip_code` query parameters, which we often include when redirecting an authenticated user on the web.
 
 Example:
 
-> https://register.rockthevote.com.rockthevote.com/registrants/new?partner=37187&source=user:58e68d5da0bfad4c3b4cd722,source:web,source_details:onlinedrivereferral,referral=true&email_address=puppet.sloth@dosomething.org&home_zip_code=94116
+> register.rockthevote.com.rockthevote.com/registrants/new?partner=37187&source=user:58e68d5da0bfad4c3b4cd722,source:web,source_details:onlinedrivereferral,referral=true&email_address=puppet.sloth@dosomething.org&home_zip_code=94116
 
 ## Import
 
@@ -22,8 +22,18 @@ When we redirect to the RTV registration form, we include a `source` query param
 
 We pass a `source` query parameter that contains multiple properties, comma separated by `key:value` substrings. Example:
 
-```
-https://register.rockthevote.com.rockthevote.com/registrants/new?partner=37187&source=user:58e68d5da0bfad4c3b4cd722,source:web,source_details:onlinedrivereferral,referral=true&email_address=aschachter@dosomething.org&home_zip_code=94116
+> user:5547be89469c64ec7d8b518d,source:web,source_details:VoterRegQuiz_completed_notsure
+
+The following parameters can be passed:
+
+- `user` - This is the Northstar user ID of either the authenticated user registering to vote, or the referring user, if the `referral` key is present
+
+- `source` - This is similar to a `utm_source`. Example values: `web`, `sms`, `email`
+
+- `source_detail` - This is similar to a `utm_campaign`. Example values: `hellobar`, `broadcastID_4YOiqwTVOOVklZFARAFd4h`, `VoterRegQuiz_completed_votebymail`, `onlinedrivereferral`
+
+- `referral` - If this is set, the `user` parameter should be used as the `referrer_user_id` on the `voter-reg` post.
+
 ```
 
 ## Voting Portal
@@ -159,3 +169,4 @@ Quiz Results:
 This is because the current content in Contentful for our result entries contains the banner image inline (so they are displayed twice, once within the header and a second time within the copy). When we're ready to go live, we'll have the campaigns team edit the content and remove the requirement to include the `preview` query.
 
 - Please avoid editing the Quiz entries if possible, as [they are delicately configured](https://github.com/DoSomething/phoenix-next/blob/8b5a97fdd973c8eb925191f78b36c2f676d2707a/docs/content-publishing/quiz.md#adding-available-choices-for-question) (deleting one of the `LinkAction` entries referenced by the `resultBlocks` field would not be pretty).
+```

--- a/docs/development/features/voter-registration.md
+++ b/docs/development/features/voter-registration.md
@@ -4,7 +4,15 @@
 
 We partner with [Rock The Vote](https://www.rockthevote.org) to register young people to vote on behalf of DoSomething.org, by redirecting to them to the Rock The Vote (RTV) registration website and appending our partner ID: `https://register.rockthevote.com/registrants/new?partner=37187`
 
-Our importer app, [Chompy](https://www.github.com/dosomething/chompy) downloads all voter registrations created with our partner ID, and imports them as `voter-reg` posts by posting to the Rogue API. See [import docs](https://github.com/DoSomething/chompy/blob/master/docs/imports/rock-the-vote.md).
+## Import
+
+Our importer app, [Chompy](https://www.github.com/dosomething/chompy) downloads all voter registrations created with our partner ID, and imports them as `voter-reg` posts by posting to the Rogue API. See [import docs](https://github.com/DoSomething/chompy/blob/master/docs/imports#rock-the-vote).
+
+### Tracking Source
+
+When we redirect to the RTV registration form, we include a `source` query parameter. Per the [RTV docs](https://www.rockthevote.org/programs-and-partner-resources/tech-for-civic-engagement/partner-ovr-tool-faqs/partner-ovr-tool-faqs/), a source parameter is used to:
+
+> track the success of various campaigns, affiliates, social media posts, and more using just one tool.
 
 ## Voting Portal
 
@@ -79,10 +87,6 @@ Content:
 ### Notes
 
 - The initial version of beta page was on Instapage - https://vote.dosomething.org/member-drives. Example URL: `https://vote.dosomething.org/member-drive?userId=${referrerUserId}&r=user:${referrerUserId},source:web,source_details:onlinedrivereferral,referral=true`
-
-## Tracking Source
-
-TODO: Document how the `r` query parameter is used by the Chompy import.
 
 ## Quiz
 

--- a/docs/development/features/voter-registration.md
+++ b/docs/development/features/voter-registration.md
@@ -34,7 +34,7 @@ This tracking source value is saved within the serialized `details` field of the
 
 - `source_detail` - This is similar to a `utm_campaign`.
 
-  - Example values: `hellobar`, `broadcastID_4YOiqwTVOOVklZFARAFd4h`, `VoterRegQuiz_completed_votebymail`, `onlinedrivereferral`
+  - Examples: `hellobar`, `broadcastID_4YOiqwTVOOVklZFARAFd4h`, `VoterRegQuiz_completed_votebymail`, `onlinedrivereferral`
 
 - `referral` - If this is set, the `user` parameter should be used as the `referrer_user_id` on the `voter-reg` post.
 

--- a/docs/development/features/voter-registration.md
+++ b/docs/development/features/voter-registration.md
@@ -68,7 +68,7 @@ A `clicked_voter_registration_action` analytics event is fired when the user cli
 
 The `StartVoterRegistrationForm` component displays form fields for email and zip, and redirects a user directly to the RTV registration site upon submitting. It's currently hardcoded on the [OVRD alpha page](#alpha-page) and [Quiz Result page](#quiz-result-page).
 
-A `clicked_voter_registration_action` analytics event is fired when the user clicks on the CTA to continue their voter registration on the RTV registration site.
+A `clicked_voter_registration_action` analytics event is fired when the user submits the form to continue their voter registration on the RTV registration site.
 
 ## Online Drives
 

--- a/docs/development/features/voter-registration.md
+++ b/docs/development/features/voter-registration.md
@@ -38,6 +38,10 @@ This tracking source value is saved within the serialized `details` field of the
 
 - `referral` - If this is set, the `user` parameter should be used as the `referrer_user_id` on the `voter-reg` post.
 
+**Notes**
+
+- Some older voter registration URLs may contain `campaignID` and `campaignRunID` keys within their tracking source. These have long been deprecated by the import: when we first started on voter registration, we used multiple campaigns. The import would update the `campaignID` and `campaignRunID` values on the `voter-reg` post if present within the tracking source. See [#171090116](https://www.pivotaltracker.com/story/show/171090116) for details.
+
 ## Voting Portal
 
 We host our voting portal, [vote.dosomething.org](https://vote.dosomething.org) on Instapage. It displays a form that prompts for email and zip, and redirects them to the Rock The Vote registration URL with our partner ID, pre-populating the email and zip submitted from the form.

--- a/docs/development/features/voter-registration.md
+++ b/docs/development/features/voter-registration.md
@@ -62,9 +62,13 @@ We host customized voter registration drives for influencers on our Instapage, b
 
 The [`VoterRegistrationAction` content type](development/content-types/voter-registration-action.md) can be used to display a call to action button that redirects a user to our vote.dosomething.org portal.
 
+A `clicked_voter_registration_action` analytics event is fired when the user clicks on the CTA to visit the voter registration portal.
+
 ## Start Voter Registration Form
 
 The `StartVoterRegistrationForm` component displays form fields for email and zip, and redirects a user directly to the RTV registration site upon submitting. It's currently hardcoded on the [OVRD alpha page](#alpha-page) and [Quiz Result page](#quiz-result-page).
+
+A `clicked_voter_registration_action` analytics event is fired when the user clicks on the CTA to continue their voter registration on the RTV registration site.
 
 ## Online Drives
 

--- a/docs/development/features/voter-registration.md
+++ b/docs/development/features/voter-registration.md
@@ -34,7 +34,7 @@ This tracking source value is saved within the serialized `details` field of the
 
 - `source_detail` - This is similar to a `utm_campaign`.
 
-  - Examples: `hellobar`, `broadcastID_4YOiqwTVOOVklZFARAFd4h`, `VoterRegQuiz_completed_votebymail`, `onlinedrivereferral`
+  - Examples: [`hellobar`](<(development/features/sitewide-banner.md)>), `broadcastID_4YOiqwTVOOVklZFARAFd4h`, `VoterRegQuiz_completed_votebymail`, `onlinedrivereferral`
 
 - `referral` - If this is set, the `user` parameter should be used as the `referrer_user_id` on the `voter-reg` post.
 

--- a/docs/development/features/voter-registration.md
+++ b/docs/development/features/voter-registration.md
@@ -110,9 +110,9 @@ Content:
 - [FAQ ContentBlock](https://app.contentful.com/spaces/81iqaqpfd8fy/environments/dev/entries/3cXc0RPMVNeE4surEqFujL) - 3cXc0RPMVNeE4surEqFujL
 - [OVRD Campaign Link ContentBlock](https://app.contentful.com/spaces/81iqaqpfd8fy/environments/dev/entries/3p2qz2JPCvgVitgRVBoMFz) - 3p2qz2JPCvgVitgRVBoMFz
 
-### Notes
+**Notes:**
 
-- The initial version of beta page was on Instapage - https://vote.dosomething.org/member-drives. Example URL: `https://vote.dosomething.org/member-drive?userId=${referrerUserId}&r=user:${referrerUserId},source:web,source_details:onlinedrivereferral,referral=true`
+- The initial version of OVRD beta page was hosted on Instapage - https://vote.dosomething.org/member-drives. Example URL: `https://vote.dosomething.org/member-drive?userId=${referrerUserId}&r=user:${referrerUserId},source:web,source_details:onlinedrivereferral,referral=true`. This page had inline JS that would query Northstar to find a user's first name based on the `userId` query parameter passed.
 
 ## Quiz
 
@@ -132,7 +132,7 @@ The page displays a new `QuizResultPage` component, and expects the `:id` route 
 
 The `QuizResultPage` displays a static `GalleryBlock` for all of the different result ID's.
 
-**Production**
+**Production:**
 
 Gallery Block: 78WaGsvDEzAxnreEvNx3Za
 
@@ -145,7 +145,7 @@ Quiz Results:
 | 21PDBge2bKCTWMe5f9eo1H | Sloth At a Loss     | Unsure of Voting   | 1YomtHAeqXJ3qbjQNgsM0v |
 | 14KfeAs265httjNMf1jwTw | Moral Support Panda | Ineligible to Vote | 3WjT0QGNnJEPPz2yMd3inj |
 
-**Dev**
+**Dev:**
 
 Gallery Block: 2VGFq3XBcqCfKOA8mC5mP4
 
@@ -157,13 +157,13 @@ Quiz Results:
 | 1lvJHhlJqQSgKgwIwUymQ8 | Shell-tered Voter   | Social Voter     | 3iLKsRlFQ1k9ddQbRb3RN8 |
 | 2KfkCOTi7u4CqAyyCuGyci | Hare Who Dares      | Election Dabbler | 3uB88eZmTNEaoFxV9pZ8hX |
 
-**Related links**
+**Related links:**
 
 - [User Flows For Voting Quiz](https://docs.google.com/spreadsheets/d/10uIZNghJTMKWR0lk5_y-q9-NwabDKYyrf8Vxlj17S9c/edit#gid=1453114542)
 
 - [Quiz documentation](https://github.com/DoSomething/phoenix-next/blob/8b5a97fdd973c8eb925191f78b36c2f676d2707a/docs/content-publishing/quiz.md) - This was removed in [#1369](https://github.com/DoSomething/phoenix-next/pull/1369) when we moved editorial guides into the Campaign Playbook.
 
-**Notes**
+**Notes:**
 
 - While we're still developing this component, we're displaying placeholder copy for the Link Action content unless a `preview=true` query parameter is present. Examples:
 
@@ -173,7 +173,3 @@ Quiz Results:
 This is because the current content in Contentful for our result entries contains the banner image inline (so they are displayed twice, once within the header and a second time within the copy). When we're ready to go live, we'll have the campaigns team edit the content and remove the requirement to include the `preview` query.
 
 - Please avoid editing the Quiz entries if possible, as [they are delicately configured](https://github.com/DoSomething/phoenix-next/blob/8b5a97fdd973c8eb925191f78b36c2f676d2707a/docs/content-publishing/quiz.md#adding-available-choices-for-question) (deleting one of the `LinkAction` entries referenced by the `resultBlocks` field would not be pretty).
-
-```
-
-```

--- a/docs/development/features/voter-registration.md
+++ b/docs/development/features/voter-registration.md
@@ -2,17 +2,17 @@
 
 ## Overview
 
-We partner with [Rock The Vote](https://www.rockthevote.org) to register young people to vote on behalf of DoSomething.org, by redirecting to them to the Rock The Vote (RTV) registration website and appending our partner ID: `https://register.rockthevote.com/registrants/new?partner=37187`.
+We partner with [Rock The Vote](https://www.rockthevote.org) to register young people to vote on behalf of DoSomething.org, by redirecting to them to the Rock The Vote (RTV) registration website and appending our partner ID:
 
-We can pre-populate the voter registration email address and zip via `email_address` and `home_zip_code` query parameters, which we often include when redirecting an authenticated user on the web.
+> register.rockthevote.com/registrants/new?partner=37187
 
-Example:
+We can pre-populate the voter registration email address and zip via `email_address` and `home_zip_code` query parameters, which we often include when redirecting an authenticated user on the web:
 
-> register.rockthevote.com.rockthevote.com/registrants/new?partner=37187&source=user:58e68d5da0bfad4c3b4cd722,source:web,source_details:onlinedrivereferral,referral=true&email_address=puppet.sloth@dosomething.org&home_zip_code=94116
+> rockthevote.com/registrants/new?partner=37187&source=user:58e68d5da0bfad4c3b4cd722,source:web,source_details:onlinedrivereferral,referral=true&email_address=puppet.sloth@dosomething.org&home_zip_code=94116
 
 ## Import
 
-Our importer app, [Chompy](https://www.github.com/dosomething/chompy) downloads all voter registrations created with our partner ID, and imports them as `voter-reg` posts by posting to the Rogue API. See [import docs](https://github.com/DoSomething/chompy/blob/master/docs/imports#rock-the-vote).
+Our importer app, [Chompy](https://www.github.com/dosomething/chompy) downloads all voter registrations created with our partner ID, and imports them as `voter-reg` posts by posting to the Rogue API. See [import docs](https://github.com/DoSomething/chompy/blob/master/docs/imports#rock-the-vote) for details.
 
 ### Tracking Source
 
@@ -20,13 +20,13 @@ When we redirect to the RTV registration form, we include a `source` query param
 
 > track the success of various campaigns, affiliates, social media posts, and more using just one tool.
 
-When we download the RTV reports, each registration contains the `source` query parameter that was present when the user began their registration. We construct the value to pass for the `source` by comma-separating `key:value` substrings. Example:
+When we download the RTV reports, each registration contains the `source` query parameter that was present when the user began their registration. The expected values to pass for the `source` are comma-separated `key:value` substrings:
 
 > user:5547be89469c64ec7d8b518d,source:web,source_details:VoterRegQuiz_completed_notsure
 
-The tracking source value is saved within the serialized `details` field of the `voter-reg` post. The following key/values are parsed from the tracking source value, used either by the Chompy import or Looker:
+This tracking source value is saved within the serialized `details` field of the `voter-reg` post, and is utilized by both the Chompy import and Looker:
 
-- `user` - This is the Northstar user ID of either the authenticated user registering to vote, or the referring user, if the `referral` key is present
+- `user` - This is the Northstar user ID of either the authenticated user registering to vote, or the referring alpha user for a beta registration, when the `referral` key is present.
 
 - `source` - This is similar to a `utm_source`. Example values: `web`, `sms`, `email`
 
@@ -34,13 +34,11 @@ The tracking source value is saved within the serialized `details` field of the 
 
 - `referral` - If this is set, the `user` parameter should be used as the `referrer_user_id` on the `voter-reg` post.
 
-```
-
 ## Voting Portal
 
 We host our voting portal, [vote.dosomething.org](https://vote.dosomething.org) on Instapage. It prompts user for their email and zip, and redirects them to the Rock The Vote registration URL with our partner ID, pre-populating the email and zip submitted from the form.
 
-When constructing a URL for the voting portal, we pass along the tracking source via a `r` query parameter -- which will be passed as a `source` parameter when the email/zip form is submitted and the user is redirected to the RTV registration site.
+When constructing a URL for the voting portal, we pass along the tracking source via a `r` query parameter, which will be passed as a `source` parameter when the email/zip form is submitted and the user is redirected to the RTV registration site.
 
 Example:
 
@@ -50,7 +48,7 @@ Example:
 
 The `VoterRegistrationAction` content type can be used to display a call to action button that redirects a user to our vote.dosomething.org portal.
 
-## Online Registration Drives
+## Online Drives
 
 The call to action in the [Ready, Set, Vote campaign](https://www.dosomething.org/us/campaigns/online-registration-drive/) asks a member (the alpha) to get their friends to register to vote, by providing them with a custom URL to their own Online Voter Registration Drive (OVRD) that they can share with their friends (the betas).
 
@@ -175,4 +173,7 @@ Quiz Results:
 This is because the current content in Contentful for our result entries contains the banner image inline (so they are displayed twice, once within the header and a second time within the copy). When we're ready to go live, we'll have the campaigns team edit the content and remove the requirement to include the `preview` query.
 
 - Please avoid editing the Quiz entries if possible, as [they are delicately configured](https://github.com/DoSomething/phoenix-next/blob/8b5a97fdd973c8eb925191f78b36c2f676d2707a/docs/content-publishing/quiz.md#adding-available-choices-for-question) (deleting one of the `LinkAction` entries referenced by the `resultBlocks` field would not be pretty).
+
+```
+
 ```


### PR DESCRIPTION
### What's this PR do?

This pull request fixes the TODO of adding details on the `source` parameter we send along to the Rock The Vote registration site, and how it's used by the Chompy import. It also adds some additional information, in attempt to remove it out of brain and into written words:

* Restores docs for the `VoterRegistrationAction`, removed in #1369. Adds context to why we may see Turbovote links here

* Adds section for a `StartVoterRegistrationForm`

* Adds details about the voting portal's `r` query parameter, and influencer pages

* Specifies the `SitewideBanner` is currently hardcoded to link to the voting portal

### How should this be reviewed?

One of my favorite features of Gitbook is that this can be previewed on the site: https://app.gitbook.com/@dosomething/s/phoenix-documentation/v/docs%2Ftracking-source/development/features/voter-registration#voter-registration-action

👀 📖 

### Any background context you want to provide?

Next up, updating  Chompy docs. Example -- [this section on OVRD](https://github.com/DoSomething/chompy/tree/master/docs/imports#online-drives) can now just link out to these docs.

### Relevant tickets

* [Pivotal #172635133](https://www.pivotaltracker.com/story/show/172635133)
* https://github.com/DoSomething/phoenix-next/pull/2164#discussion_r428714489

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.