### PR TITLE
Helpers Docs & Refer Friends Helpers Categorization 

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -46,6 +46,7 @@
 - [Contentful](development/contentful/README.md)
   - [Workflow](development/contentful/workflow.md)
   - [Content Management API Scripts](development/contentful/content-management-api-scripts.md)
+- [Helpers](development/helpers/README.md)
 
 ## Phoenix API
 

--- a/docs/development/helpers/README.md
+++ b/docs/development/helpers/README.md
@@ -13,7 +13,7 @@ We also have a large amount of miscellaneous or otherwise uncategorized methods 
 
 ##### Using/Creating Helper Methods
 
-When a piece of repeatable contained logic (e.g. [a method](https://github.com/DoSomething/phoenix-next/blob/4a5f24f5832d701c586f7b06db4483e4b0256676/resources/assets/helpers/index.js#L425-L433) to generate a user friendly representation of a Contentful Date), our rule of thumb is to first peruse our suite of helpers to see if this functionality already exists as a method (or if our logic can at least utilize an existing one). Otherwise, if a new helper method is necessary (such as when this logic has already been applied elsewhere and can be abstracted), add the new helper method to the appropriate categorized file, or create a new category file (`helpers/[new-category].js`).
+When building a piece of repeatable contained logic (e.g. [a method](https://github.com/DoSomething/phoenix-next/blob/4a5f24f5832d701c586f7b06db4483e4b0256676/resources/assets/helpers/index.js#L425-L433) to generate a user friendly representation of a Contentful Date), our rule of thumb is to first peruse our suite of helpers to see if this functionality already exists as a method (or if our logic can at least _utilize_ an existing helper). Otherwise, if a new helper method is necessary (such as when this logic has already been applied elsewhere and can be abstracted), add the new helper method to the appropriate categorized file, or create a new category file (`helpers/[new-category].js`).
 
 ## Clean up
 

--- a/docs/development/helpers/README.md
+++ b/docs/development/helpers/README.md
@@ -11,7 +11,7 @@ We organize our helpers in filenames with logical categories. E.g. methods relat
 
 We also have a large amount of miscellaneous or otherwise uncategorized methods within the main `helpers/index.js` file.
 
-##### Rule of thumb
+##### Using/Creating Helper Methods
 
 When thinking about building, or building a piece of repeatable contained logic (e.g. [a method](https://github.com/DoSomething/phoenix-next/blob/4a5f24f5832d701c586f7b06db4483e4b0256676/resources/assets/helpers/index.js#L425-L433) to generate a user friendly representation of a Contentful Date) our rule of thumb is to first peruse our suite of helpers to see if this functionality already exists as a method (or if our logic can at least utilize an existing one). Otherwise, if a new helper method if necessary, or if this logic has already been applied elsewhere and can be abstracted, add the new helper method to the appropriate categorized file, or create a new category file (`helpers/[new-category].js`).
 

--- a/docs/development/helpers/README.md
+++ b/docs/development/helpers/README.md
@@ -1,0 +1,24 @@
+# Helper methods
+
+We have two suites of helper methods in the Phoenix codebase.
+
+1. PHP helper methods globally available on the backend PHP application in [app/helpers.php](https://github.com/DoSomething/phoenix-next/blob/4a5f24f5832d701c586f7b06db4483e4b0256676/app/helpers.php)
+2. JS helper methods which can be imported from anywhere in our front-end React application in the [resources/assets/helpers](https://github.com/DoSomething/phoenix-next/blob/4a5f24f5832d701c586f7b06db4483e4b0256676/resources/assets/helpers) directory
+
+## JS Helper Methods
+
+We organize our helpers in filenames with logical categories. E.g. methods related to user & authentication information in `helpers/auth`.
+
+We also have a large amount of miscellaneous or otherwise uncategorized methods within the main `helpers/index.js` file.
+
+##### Rule of thumb
+
+When thinking about building, or building a piece of repeatable contained logic (e.g. [a method](https://github.com/DoSomething/phoenix-next/blob/4a5f24f5832d701c586f7b06db4483e4b0256676/resources/assets/helpers/index.js#L425-L433) to generate a user friendly representation of a Contentful Date) our rule of thumb is to first peruse our suite of helpers to see if this functionality already exists as a method (or if our logic can at least utilize an existing one). Otherwise, if a new helper method if necessary, or if this logic has already been applied elsewhere and can be abstracted, add the new helper method to the appropriate categorized file, or create a new category file (`helpers/[new-category].js`).
+
+## Clean up
+
+Many helper methods remain uncategorized in the main `helpers/index.js` file, if using an existing helper that looks like it can fit in an existing category -- feel free to move it in! If you notice a new logical grouping forming or already existing -- feel free to port them over to the new categorized file!
+
+## Tests (I don't [Jest](https://jestjs.io/))
+
+We're missing tests on many of our existing helper functions. If utilizing an existing helper method - or certainly if adding a new one - we recommend creating an accompanying set of tests. This would either go in the main `helpers/test.js` file for methods in the main `helpers/index.js` file, or in a `helpers/[category-name].test.js` file. (If one doesn't already exist, please feel free to backfill!)

--- a/docs/development/helpers/README.md
+++ b/docs/development/helpers/README.md
@@ -13,7 +13,7 @@ We also have a large amount of miscellaneous or otherwise uncategorized methods 
 
 ##### Using/Creating Helper Methods
 
-When thinking about building, or building a piece of repeatable contained logic (e.g. [a method](https://github.com/DoSomething/phoenix-next/blob/4a5f24f5832d701c586f7b06db4483e4b0256676/resources/assets/helpers/index.js#L425-L433) to generate a user friendly representation of a Contentful Date) our rule of thumb is to first peruse our suite of helpers to see if this functionality already exists as a method (or if our logic can at least utilize an existing one). Otherwise, if a new helper method if necessary, or if this logic has already been applied elsewhere and can be abstracted, add the new helper method to the appropriate categorized file, or create a new category file (`helpers/[new-category].js`).
+When a piece of repeatable contained logic (e.g. [a method](https://github.com/DoSomething/phoenix-next/blob/4a5f24f5832d701c586f7b06db4483e4b0256676/resources/assets/helpers/index.js#L425-L433) to generate a user friendly representation of a Contentful Date), our rule of thumb is to first peruse our suite of helpers to see if this functionality already exists as a method (or if our logic can at least utilize an existing one). Otherwise, if a new helper method is necessary (such as when this logic has already been applied elsewhere and can be abstracted), add the new helper method to the appropriate categorized file, or create a new category file (`helpers/[new-category].js`).
 
 ## Clean up
 

--- a/docs/installation-and-usage/usage.md
+++ b/docs/installation-and-usage/usage.md
@@ -51,6 +51,10 @@ They run in the following scenarios:
 
 We use [StyleCI](https://styleci.io/repos/75642790) service to lint our PHP code when a new pull request is made for the respository.
 
+## Helper Methods
+
+[See here](../developments/helpers/README.md) for some information on developing with our suite of helper methods.
+
 ## Services
 
 There are a couple of other third-party services that you will want access to for development:

--- a/resources/assets/components/pages/ReferralPage/Alpha/AlphaPage.js
+++ b/resources/assets/components/pages/ReferralPage/Alpha/AlphaPage.js
@@ -1,9 +1,9 @@
 import React from 'react';
 
 import ErrorPage from '../../ErrorPage';
-import { getReferFriendsLink } from '../../../../helpers';
 import ArticleHeader from '../../../utilities/ArticleHeader';
 import SiteFooter from '../../../utilities/SiteFooter/SiteFooter';
+import { getReferFriendsLink } from '../../../../helpers/refer-friends';
 import SiteNavigationContainer from '../../../SiteNavigation/SiteNavigationContainer';
 import SocialDriveActionContainer from '../../../actions/SocialDriveAction/SocialDriveActionContainer';
 

--- a/resources/assets/components/pages/ReferralPage/Alpha/AlphaPage.test.js
+++ b/resources/assets/components/pages/ReferralPage/Alpha/AlphaPage.test.js
@@ -2,11 +2,13 @@ import React from 'react';
 import { shallow } from 'enzyme';
 
 import AlphaPage from './AlphaPage';
-import * as helpers from '../../../../helpers';
+import * as referFriendsHelpers from '../../../../helpers/refer-friends';
 
 describe('AlphaPage component', () => {
   test('is rendered as an ErrorPage if referral link is not generated', () => {
-    helpers.getReferFriendsLink = jest.fn().mockReturnValue(undefined);
+    referFriendsHelpers.getReferFriendsLink = jest
+      .fn()
+      .mockReturnValue(undefined);
 
     const wrapper = shallow(<AlphaPage />);
 
@@ -14,7 +16,7 @@ describe('AlphaPage component', () => {
   });
 
   test('is rendered with a main.alpha-referral-page if referral link is generated', () => {
-    helpers.getReferFriendsLink = jest
+    referFriendsHelpers.getReferFriendsLink = jest
       .fn()
       .mockReturnValue('http://refer.friends');
 

--- a/resources/assets/components/pages/ReferralPage/Beta/BetaPage.js
+++ b/resources/assets/components/pages/ReferralPage/Beta/BetaPage.js
@@ -3,10 +3,11 @@ import gql from 'graphql-tag';
 
 import Query from '../../../Query';
 import ErrorPage from '../../ErrorPage';
+import { query } from '../../../../helpers';
 import MoneyHandImage from './money-hand.svg';
 import CampaignLink from './BetaPageCampaignLink';
 import ArticleHeader from '../../../utilities/ArticleHeader';
-import { getReferralCampaignId, query } from '../../../../helpers';
+import { getReferralCampaignId } from '../../../../helpers/refer-friends';
 
 const REFERRAL_PAGE_USER = gql`
   query ReferralPageUserQuery($id: String!) {

--- a/resources/assets/helpers/index.js
+++ b/resources/assets/helpers/index.js
@@ -21,7 +21,6 @@ import {
 import { getUserId } from './auth';
 import Debug from '../services/Debug';
 import Sixpack from '../services/Sixpack';
-import { PHOENIX_URL } from '../constants';
 import tailwindVariables from '../../../tailwind.variables';
 import { EVENT_CATEGORIES, trackAnalyticsEvent } from './analytics';
 
@@ -562,31 +561,6 @@ export function query(key, url = window.location) {
   const search = queryString.parse(url.search);
 
   return search[key];
-}
-
-/**
- * Get referral campaign ID for refer-a-friend share URL.
- *
- * @return {string}
- */
-export function getReferralCampaignId() {
-  return query('campaign_id');
-}
-
-/**
- * Get refer-a-friend share URL.
- *
- * @return {String|Undefined}
- */
-export function getReferFriendsLink() {
-  const userId = getUserId();
-  const referralCampaignId = getReferralCampaignId();
-
-  if (!userId || !referralCampaignId) {
-    return undefined;
-  }
-
-  return `${PHOENIX_URL}/us/join?user_id=${userId}&campaign_id=${referralCampaignId}`;
 }
 
 /**

--- a/resources/assets/helpers/refer-friends.js
+++ b/resources/assets/helpers/refer-friends.js
@@ -1,0 +1,28 @@
+import { query } from './index';
+import { getUserId } from './auth';
+import { PHOENIX_URL } from '../constants';
+
+/**
+ * Get referral campaign ID for refer-a-friend share URL.
+ *
+ * @return {string}
+ */
+export function getReferralCampaignId() {
+  return query('campaign_id');
+}
+
+/**
+ * Get refer-a-friend share URL.
+ *
+ * @return {String|Undefined}
+ */
+export function getReferFriendsLink() {
+  const userId = getUserId();
+  const referralCampaignId = getReferralCampaignId();
+
+  if (!userId || !referralCampaignId) {
+    return undefined;
+  }
+
+  return `${PHOENIX_URL}/us/join?user_id=${userId}&campaign_id=${referralCampaignId}`;
+}

--- a/resources/assets/helpers/refer-friends.test.js
+++ b/resources/assets/helpers/refer-friends.test.js
@@ -1,0 +1,36 @@
+import { PHOENIX_URL } from '../constants';
+import { getReferFriendsLink } from './refer-friends';
+
+describe('getReferFriendsLink', () => {
+  const userId = '123';
+  const referralCampaignId = '456';
+
+  window.jsdom.reconfigure({
+    url: `http://phoenix.test/join?campaign_id=${referralCampaignId}`,
+  });
+
+  global.AUTH = { id: userId };
+
+  /** @test */
+  it('returns referral link when user is autenticated & campaign ID query param is present', () => {
+    expect(getReferFriendsLink()).toEqual(
+      `${PHOENIX_URL}/us/join?user_id=${userId}&campaign_id=${referralCampaignId}`,
+    );
+  });
+
+  /** @test */
+  it('returns undefined if there is no user ID', () => {
+    global.AUTH = {};
+
+    expect(getReferFriendsLink()).toEqual(undefined);
+  });
+
+  /** @test */
+  it('returns undefined if there is no campaign ID query param', () => {
+    window.jsdom.reconfigure({
+      url: `http://phoenix.test/join`,
+    });
+
+    expect(getReferFriendsLink()).toEqual(undefined);
+  });
+});

--- a/resources/assets/helpers/test.js
+++ b/resources/assets/helpers/test.js
@@ -1,4 +1,3 @@
-import { PHOENIX_URL } from '../constants';
 import {
   makeHash,
   modifiers,
@@ -6,7 +5,6 @@ import {
   makeShareLink,
   dynamicString,
   contentfulImageUrl,
-  getReferFriendsLink,
 } from './index';
 
 /**
@@ -153,38 +151,4 @@ test('pluralizes words', () => {
   expect(pluralize(0, 'item', 'items')).toEqual('items');
   expect(pluralize(1, 'item', 'items')).toEqual('item');
   expect(pluralize(2, 'item', 'items')).toEqual('items');
-});
-
-describe('getReferFriendsLink', () => {
-  const userId = '123';
-  const referralCampaignId = '456';
-
-  window.jsdom.reconfigure({
-    url: `http://phoenix.test/join?campaign_id=${referralCampaignId}`,
-  });
-
-  global.AUTH = { id: userId };
-
-  /** @test */
-  it('returns referral link when user is autenticated & campaign ID query param is present', () => {
-    expect(getReferFriendsLink()).toEqual(
-      `${PHOENIX_URL}/us/join?user_id=${userId}&campaign_id=${referralCampaignId}`,
-    );
-  });
-
-  /** @test */
-  it('returns undefined if there is no user ID', () => {
-    global.AUTH = {};
-
-    expect(getReferFriendsLink()).toEqual(undefined);
-  });
-
-  /** @test */
-  it('returns undefined if there is no campaign ID query param', () => {
-    window.jsdom.reconfigure({
-      url: `http://phoenix.test/join`,
-    });
-
-    expect(getReferFriendsLink()).toEqual(undefined);
-  });
 });


### PR DESCRIPTION
### What's this PR do?

This pull request starts adding some documentation on our helper methods per some _helpful_ (oy) feedback from @aaronschachter https://github.com/DoSomething/phoenix-next/pull/2168#discussion_r430559146 and categorizes the RAF helpers into their own file.

### How should this be reviewed?
You can preview this in [Gitbooks directly](https://dosomething.gitbook.io/phoenix-documentation/v/docs%2Fbegin-helper-docs/development/helpers)

How's clarity? Do you think this covers the essential gist? Would this be useful if I was a new developer in the codebase wondering about helper methods?

### Any background context you want to provide?
In https://github.com/DoSomething/phoenix-next/pull/2168#discussion_r430559146 (in case you're too lazy to just read it, for shame!) two problems were noted:
1. That we often don't categorize helper methods, with `helpers/index.js` thus being pretty cluttered thus diminishing helper discoverability
2. We don't have any existing documentation 

Hopefully this helps start to solve 2 while laying some groundwork and guidance for 1.