### PR TITLE
Update Profile Page Subscription Copy 

### DIFF
--- a/resources/assets/components/pages/AccountPage/Subscriptions/EmailSubscriptionItem.js
+++ b/resources/assets/components/pages/AccountPage/Subscriptions/EmailSubscriptionItem.js
@@ -31,7 +31,13 @@ const EMAIL_SUBSCRIPTION_MUTATION = gql`
     }
   }
 `;
-const EmailSubscriptionItem = ({ topic, name, image, description }) => {
+const EmailSubscriptionItem = ({
+  topic,
+  name,
+  image,
+  description,
+  descriptionHeader,
+}) => {
   const options = { variables: { userId: window.AUTH.id } };
 
   // Make the initial query to get the user's subscriptions
@@ -58,6 +64,9 @@ const EmailSubscriptionItem = ({ topic, name, image, description }) => {
 
         <div className="p-4 flex flex-col flex-grow">
           <h3 className="text-base">{name}</h3>
+
+          <h4 className="text-base italic">{descriptionHeader}</h4>
+          <br />
 
           <p className="flex-grow">{description}</p>
 
@@ -92,6 +101,7 @@ EmailSubscriptionItem.propTypes = {
   name: PropTypes.string.isRequired,
   image: PropTypes.string.isRequired,
   description: PropTypes.string.isRequired,
+  descriptionHeader: PropTypes.string.isRequired,
 };
 
 export default EmailSubscriptionItem;

--- a/resources/assets/components/pages/AccountPage/Subscriptions/EmailSubscriptions.js
+++ b/resources/assets/components/pages/AccountPage/Subscriptions/EmailSubscriptions.js
@@ -10,24 +10,28 @@ const EmailSubscriptions = () => (
       topic="COMMUNITY"
       name="What You're Doing"
       image={NewsletterImages.CommunityNewsletter}
+      descriptionHeader="Sent every Tuesday"
       description="A roundup of photos, writing, and stories of impact from the DoSomething community and members like you."
     />
     <EmailSubscriptionItem
       topic="NEWS"
       name="The Breakdown"
       image={NewsletterImages.NewsNewsletter}
+      descriptionHeader="Sent every Wednesday"
       description="Don’t just read the news…*change* the news. Our current events newsletter has headlines, along with immediate ways to impact them."
     />
     <EmailSubscriptionItem
       topic="LIFESTYLE"
       name="The Boost"
       image={NewsletterImages.LifestyleNewsletter}
+      descriptionHeader="Sent every Thursday"
       description="Stories of incredible young people, actionable how-tos, inspirational playlists, and other content to live your best life and help others do the same."
     />
     <EmailSubscriptionItem
       topic="SCHOLARSHIPS"
       name="Pays to Do Good"
       image={NewsletterImages.ScholarshipNewsletter}
+      descriptionHeader="Sent monthly every first Friday"
       description="Alerts on new ways to earn scholarships by doing social good, plus announcements of scholarship winners."
     />
   </div>


### PR DESCRIPTION
### What's this PR do?

This pull request edits the copy for the user profile subscriptions: **WYD, Pays to Do Good, The Breakdown and The boost.** I had to add a new prop called `descriptionHeader `to the `EmailSubscriptionItem` component to separate the new italicized header for example "_Sent every Wednesday ..._" See image:

![image](https://user-images.githubusercontent.com/18747117/82962094-349b0080-9f8d-11ea-8c39-17df0466ec02.png)


### How should this be reviewed?

👀


### Relevant tickets

References [Pivotal #172726904](https://www.pivotaltracker.com/story/show/172726904).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added screenshots of front-end changes on small, medium, and large screens.
- [ ] Added appropriate feature/unit tests.
