### PR TITLE
Campaign Info Bar - Zendesk Form Bug

### DIFF
--- a/resources/assets/components/CampaignInfoBar/CampaignInfoBar.js
+++ b/resources/assets/components/CampaignInfoBar/CampaignInfoBar.js
@@ -11,7 +11,7 @@ const CampaignInfoBar = ({
   affiliateCreditText,
   affiliateSponsors,
   affiliatePartners,
-  campaignTitle,
+  pageTitle,
   contactEmail,
 }) => {
   const [showZendeskModal, setShowZendeskModal] = useState(false);
@@ -45,7 +45,7 @@ const CampaignInfoBar = ({
           ) : (
             <a
               href={encodeURI(
-                `mailto:${contactEmail}?subject=Question About ${campaignTitle}`,
+                `mailto:${contactEmail}?subject=Question About ${pageTitle}`,
               )}
             >
               Email Us
@@ -61,7 +61,7 @@ CampaignInfoBar.propTypes = {
   affiliateCreditText: PropTypes.string,
   affiliateSponsors: PropTypes.arrayOf(PropTypes.object),
   affiliatePartners: PropTypes.arrayOf(PropTypes.object),
-  campaignTitle: PropTypes.string,
+  pageTitle: PropTypes.string.isRequired,
   contactEmail: PropTypes.string,
 };
 
@@ -69,7 +69,6 @@ CampaignInfoBar.defaultProps = {
   affiliateCreditText: undefined,
   affiliateSponsors: [],
   affiliatePartners: [],
-  campaignTitle: 'Campaign',
   contactEmail: 'campaignhelp@dosomething.org',
 };
 

--- a/resources/assets/components/CampaignInfoBar/CampaignInfoBar.js
+++ b/resources/assets/components/CampaignInfoBar/CampaignInfoBar.js
@@ -33,7 +33,7 @@ const CampaignInfoBar = ({
 
         <div className="info-bar__secondary">
           Questions?{' '}
-          {/*The Zendesk form will only work for authenticated users on a campaign page. */}
+          {/* The Zendesk form will only work for authenticated users on a campaign page. */}
           {isAuthenticated() && getCampaign() ? (
             <button
               type="button"

--- a/resources/assets/components/CampaignInfoBar/CampaignInfoBar.js
+++ b/resources/assets/components/CampaignInfoBar/CampaignInfoBar.js
@@ -3,6 +3,7 @@ import React, { useState } from 'react';
 
 import Modal from '../utilities/Modal/Modal';
 import { isAuthenticated } from '../../helpers/auth';
+import { getCampaign } from '../../helpers/campaign';
 import AffiliateCredits from '../utilities/AffiliateCredits/AffiliateCredits';
 import ZendeskFormContainer from '../utilities/ZendeskForm/ZendeskFormContainer';
 
@@ -32,7 +33,8 @@ const CampaignInfoBar = ({
 
         <div className="info-bar__secondary">
           Questions?{' '}
-          {isAuthenticated() ? (
+          {/*The Zendesk form will only work for authenticated users on a campaign page. */}
+          {isAuthenticated() && getCampaign() ? (
             <button
               type="button"
               className="underline"

--- a/resources/assets/components/CampaignInfoBar/CampaignInfoBarContainer.js
+++ b/resources/assets/components/CampaignInfoBar/CampaignInfoBarContainer.js
@@ -13,7 +13,7 @@ const mapStateToProps = state => {
     affiliateSponsors: state.campaign.affiliateSponsors,
     affiliatePartners: state.campaign.affiliatePartners,
     contactEmail: get(state, 'campaign.campaignLead.fields.email', undefined),
-    campaignTitle: get(state, 'campaign.title'),
+    campaignTitle: get(state, 'campaign.title', 'Campaign'),
   };
 };
 

--- a/resources/assets/components/pages/StoryPage/StoryPage.js
+++ b/resources/assets/components/pages/StoryPage/StoryPage.js
@@ -5,10 +5,10 @@ import PropTypes from 'prop-types';
 
 import ContentfulEntry from '../../ContentfulEntry';
 import SiteFooter from '../../utilities/SiteFooter/SiteFooter';
+import CampaignInfoBar from '../../CampaignInfoBar/CampaignInfoBar';
 import { contentfulImageUrl, withoutNulls } from '../../../helpers';
 import SocialShareTray from '../../utilities/SocialShareTray/SocialShareTray';
 import SiteNavigationContainer from '../../SiteNavigation/SiteNavigationContainer';
-import CampaignInfoBarContainer from '../../CampaignInfoBar/CampaignInfoBarContainer';
 
 import './story-page.scss';
 
@@ -66,7 +66,7 @@ const StoryPage = props => {
           ))}
         </article>
 
-        <CampaignInfoBarContainer />
+        <CampaignInfoBar pageTitle={title} />
       </main>
 
       <SiteFooter />

--- a/resources/assets/helpers/campaign.js
+++ b/resources/assets/helpers/campaign.js
@@ -1,4 +1,5 @@
 import { join } from 'path';
+import get from 'lodash/get';
 
 /**
  * Prepare a campaign subpage's slug.
@@ -16,5 +17,12 @@ export function prepareCampaignPageSlug(campaignSlug, pageSlug) {
 
   return join('/us/campaigns', pageSlug);
 }
+
+/**
+ * Get the Campaign.
+ *
+ * @return {String|Undefined}
+ */
+export const getCampaign = () => get(window.STATE, 'campaign');
 
 export default null;


### PR DESCRIPTION
### What's this PR do?

This pull request ensures we don't render a `ZendeskForm` from the `CampaignInfoBar` on _non_ campaign pages where the form wouldn't work. 

- https://github.com/DoSomething/phoenix-next/commit/c558ecd376fba08527b6d891f8877bce0a6133ba adds a helper to allow us to obtain the campaign from window.STATE (and avoid a Redux selector). This will help us determine if we're on a campaign page (and hopefully be useful otherwise for obtaining campaign data without redux).
- https://github.com/DoSomething/phoenix-next/commit/9e071c0dc9ae02e02ccab563ee5ca7f3df514dc7 will ensure we're on a campaign page before rendering the `ZendeskForm` in the `CampaignInfoBar`, using the helper.
- https://github.com/DoSomething/phoenix-next/commit/9ccac5d58883ce848f116f84514f5a4c0294e11a uses a `pageTitle` prop instead of `campaignTitle` to assign into the help email `mailto` link's subject line. (Since we're using this on Story Pages this seems logical and hopefully more clear). We adjust the logic to make it a required prop since we shouldn't default to `'Campaign'` anymore as the subject.
- https://github.com/DoSomething/phoenix-next/commit/ef90904f991dafa6d9fe2f5737a1b332e6c80f16 pass a `pageTitle` to the `CampaignInfoBar` directly. We don't need the container since that's campaign specific.

### How should this be reviewed?
commit-by-commit! Hopefully this all makes simple logical sense.

### Any background context you want to provide?
We're seeing the help link fail for auth'd users on Story Pages due to an unrelated bug to be fixed in a follow-up PR. This will avoid that bug in the first place since it would only occur on non campaign pages that render the `ZendeskForm`.

### Relevant tickets

References [Pivotal #173063909](https://www.pivotaltracker.com/story/show/173063909).
