### PR TITLE
Adds migration for new voter registration content types

### DIFF
--- a/contentful/content-types/voterRegistrationDriveAction.js
+++ b/contentful/content-types/voterRegistrationDriveAction.js
@@ -1,0 +1,105 @@
+module.exports = function(migration) {
+  const voterRegistrationDriveAction = migration
+    .createContentType('voterRegistrationDriveAction')
+    .name('Voter Registration Drive Action')
+    .description('A Social Drive Action for voter registration drives.')
+    .displayField('internalTitle');
+
+  voterRegistrationDriveAction
+    .createField('internalTitle')
+    .name('Internal Title')
+    .type('Symbol')
+    .localized(false)
+    .required(true)
+    .validations([
+      {
+        unique: true,
+      },
+    ])
+    .disabled(false)
+    .omitted(false);
+
+  voterRegistrationDriveAction
+    .createField('title')
+    .name('Title')
+    .type('Symbol')
+    .localized(false)
+    .required(false)
+    .validations([])
+    .disabled(false)
+    .omitted(false);
+  voterRegistrationDriveAction
+    .createField('description')
+    .name('Description')
+    .type('Text')
+    .localized(false)
+    .required(false)
+    .validations([])
+    .disabled(false)
+    .omitted(false);
+
+  voterRegistrationDriveAction
+    .createField('approvedPostCountActionId')
+    .name('Approved Post Count Action ID')
+    .type('Integer')
+    .localized(false)
+    .required(false)
+    .validations([
+      {
+        range: {
+          min: 1,
+          max: null,
+        },
+      },
+    ])
+    .disabled(false)
+    .omitted(false);
+
+  voterRegistrationDriveAction
+    .createField('approvedPostCountLabel')
+    .name('Approved Post Count Label')
+    .type('Symbol')
+    .localized(false)
+    .required(false)
+    .validations([])
+    .disabled(false)
+    .omitted(false);
+  voterRegistrationDriveAction.changeFieldControl(
+    'internalTitle',
+    'builtin',
+    'singleLine',
+    {},
+  );
+  voterRegistrationDriveAction.changeFieldControl(
+    'title',
+    'builtin',
+    'singleLine',
+    {},
+  );
+  voterRegistrationDriveAction.changeFieldControl(
+    'description',
+    'builtin',
+    'markdown',
+    {},
+  );
+
+  voterRegistrationDriveAction.changeFieldControl(
+    'approvedPostCountActionId',
+    'builtin',
+    'numberEditor',
+    {
+      helpText:
+        "If set, the count of current user's approved posts for this action will appear in the sidebar.",
+    },
+  );
+
+  voterRegistrationDriveAction.changeFieldControl(
+    'approvedPostCountLabel',
+    'builtin',
+    'singleLine',
+    {
+      helpText:
+        'Label text for the approved post count action, if set. Defaults to "Total scholarship entries" if blank.',
+    },
+  );
+};

--- a/contentful/content-types/voterRegistrationReferralsBlock.js
+++ b/contentful/content-types/voterRegistrationReferralsBlock.js
@@ -1,0 +1,45 @@
+module.exports = function(migration) {
+  const voterRegistrationReferralsBlock = migration
+    .createContentType('voterRegistrationReferralsBlock')
+    .name('Voter Registration Referrals Block')
+    .description(
+      "Displays current user's number of completed voter registration referrals.",
+    )
+    .displayField('internalTitle');
+
+  voterRegistrationReferralsBlock
+    .createField('internalTitle')
+    .name('Internal Title')
+    .type('Symbol')
+    .localized(false)
+    .required(true)
+    .validations([
+      {
+        unique: true,
+      },
+    ])
+    .disabled(false)
+    .omitted(false);
+
+  voterRegistrationReferralsBlock
+    .createField('title')
+    .name('Title')
+    .type('Symbol')
+    .localized(false)
+    .required(false)
+    .validations([])
+    .disabled(false)
+    .omitted(false);
+  voterRegistrationReferralsBlock.changeFieldControl(
+    'internalTitle',
+    'builtin',
+    'singleLine',
+    {},
+  );
+  voterRegistrationReferralsBlock.changeFieldControl(
+    'title',
+    'builtin',
+    'singleLine',
+    {},
+  );
+};


### PR DESCRIPTION
### What's this PR do?

This pull request adds migrations for two new content types I've added into our dev Contentful space:

* `voterRegistrationDriveAction`: to be used for rendering a `VoterRegistrationDriveAction` component (introduced in #2176), with fields

    * Internal title
    * Title (e.g. "Share with your friends")
    * Description (e.g. "Urge your friend to vote based on the causes you care about most. The causes you choose will be mentioned on your custom page.")
    * Approved Post Count Action ID
    * Approved Post Count Label

* `voterRegistrationReferralsBlock`: to be used for rendering a `VoterRegistrationReferralsBlock` component (introduced in #2172)

   * Internal title
    * Title (e.g. "Get 3 friends to register!")


### How should this be reviewed?

👀 

### Any background context you want to provide?

Once merged, I'll use the CLI to run this migration on our `qa` and `master` spaces per [docs](https://dosomething.gitbook.io/phoenix-documentation/development/contentful/workflow#5-upon-merge-apply-changes-to-contentful-qa-and-master).

Then next up will be adding these new types to GraphQL.

### Relevant tickets

References [Pivotal #173019820](https://www.pivotaltracker.com/story/show/173019820), [#173019860](https://www.pivotaltracker.com/story/show/173019860)

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added screenshots of front-end changes on small, medium, and large screens.
- [ ] Added appropriate feature/unit tests.
