### PR TITLE
Swap cyberbullying for covid in top searches

### DIFF
--- a/resources/assets/components/SiteNavigation/SiteNavigation.js
+++ b/resources/assets/components/SiteNavigation/SiteNavigation.js
@@ -666,18 +666,17 @@ class SiteNavigation extends React.Component {
 
                         <li>
                           <a
-                            href="/us/facts/11-facts-about-cyber-bullying"
+                            href="us/collections/corona-virus-campaigns"
                             onClick={() =>
                               this.analyzeEvent({
-                                name:
-                                  'clicked_subnav_link_cyberbullying_top_search',
+                                name: 'clicked_subnav_link_covid_top_search',
                                 action: 'link_clicked',
                                 category: EVENT_CATEGORIES.navigation,
-                                label: 'cyberbullying_top_search',
+                                label: 'covid_top_search',
                               })
                             }
                           >
-                            cyberbullying
+                            covid
                           </a>
                         </li>
 


### PR DESCRIPTION
### What's this PR do?

This pull request removes cyberbullying from the top searches and replaces it with covid and links to our covid collection page.

It looks like this now:

<img width="650" alt="Screen Shot 2020-05-28 at 3 48 24 PM" src="https://user-images.githubusercontent.com/4240292/83201801-27038900-a0fb-11ea-9b90-92ec42259d2e.png">

And here are the analytics that happen when you click on it:

<img width="511" alt="Screen Shot 2020-05-28 at 3 49 42 PM" src="https://user-images.githubusercontent.com/4240292/83201821-3256b480-a0fb-11ea-9021-0f93e2ba7dd3.png">


### How should this be reviewed?

Did I miss anywhere else that we need to switch cyberbullying with covid?

### Any background context you want to provide?

Nope!

### Relevant tickets

References [Pivotal #172697584](https://www.pivotaltracker.com/story/show/172697584).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added screenshots of front-end changes on small, medium, and large screens.
- [ ] Added appropriate feature/unit tests.
