### PR TITLE
Make the buttons work and bring the dollars signs back.

### DIFF
--- a/resources/assets/components/blocks/GalleryBlock/GalleryBlock.js
+++ b/resources/assets/components/blocks/GalleryBlock/GalleryBlock.js
@@ -36,6 +36,10 @@ export const GalleryBlockFragment = gql`
         scholarshipAmount
         scholarshipDeadline
         slug
+        path
+      }
+      ... on StoryPageWebsite {
+        path
       }
       ... on Page {
         slug

--- a/resources/assets/components/utilities/ScholarshipCard/ScholarshipCard.js
+++ b/resources/assets/components/utilities/ScholarshipCard/ScholarshipCard.js
@@ -22,11 +22,11 @@ export const scholarshipCardFragment = gql`
       scholarshipAmount
       scholarshipDeadline
       staffPick
-      url
+      path
     }
     ... on StoryPageWebsite {
       id
-      url
+      path
     }
   }
 `;
@@ -40,7 +40,7 @@ const ScholarshipCard = ({ campaign }) => {
     scholarshipDeadline,
     showcaseImage,
     staffPick,
-    url,
+    path,
   } = campaign;
 
   const srcset = contentfulImageSrcset(showcaseImage.url, [
@@ -51,7 +51,7 @@ const ScholarshipCard = ({ campaign }) => {
 
   return (
     <article className="flex flex-col h-full relative text-left">
-      <a className="block cursor-pointer" href={url}>
+      <a className="block cursor-pointer" href={path}>
         <img
           alt={showcaseImage.description || `Cover photo for ${showcaseTitle}`}
           srcSet={srcset}
@@ -69,7 +69,7 @@ const ScholarshipCard = ({ campaign }) => {
         <h1 className="font-bold mb-2 text-base">
           <a
             className="text-blurple-500 hover:text-blurple-300 cursor-pointer"
-            href={url}
+            href={path}
           >
             {showcaseTitle}
           </a>
@@ -80,7 +80,9 @@ const ScholarshipCard = ({ campaign }) => {
           <div className="float-left pr-8">
             <h4 className="font-bold uppercase text-gray-600">Amount</h4>
             <p className="">
-              {scholarshipAmount ? scholarshipAmount.toLocaleString() : 'N/A'}
+              {scholarshipAmount
+                ? `$${scholarshipAmount.toLocaleString()}`
+                : 'N/A'}
             </p>
           </div>
           <div className="float-left pr-8">
@@ -93,7 +95,7 @@ const ScholarshipCard = ({ campaign }) => {
           </div>
         </div>
 
-        <SecondaryButton className="w-full" href={url} text="Apply Now" />
+        <SecondaryButton className="w-full" href={path} text="Apply Now" />
       </div>
     </article>
   );


### PR DESCRIPTION
### What's this PR do?

This pull request fixes a couple small bugs from the scholarship gallery:
- The dollar signs are back in front of scholarship amounts
- Fixed the graphql query so block paths can actually make the buttons work

### How should this be reviewed?

👀 

### Relevant tickets

References [Pivotal #172203401](https://www.pivotaltracker.com/story/show/172203401).


<img width="544" alt="Screen Shot 2020-05-29 at 10 48 27 AM" src="https://user-images.githubusercontent.com/1865372/83273136-240ba580-a19a-11ea-9375-14534faf3e57.png">
