### PR TITLE
Add larger text for hero image

### DIFF
--- a/resources/assets/components/pages/QuizResultPage/QuizResultPage.js
+++ b/resources/assets/components/pages/QuizResultPage/QuizResultPage.js
@@ -68,7 +68,7 @@ const QuizResultPage = ({ id }) => {
               </div>
               <div className="md:w-3/4">
                 <h1 className=" font-normal font-league-gothic color-white uppercase leading-10">
-                  <span className="border-b-4 border-solid border-yellow-400 inline-block">
+                  <span className="border-b-4 border-solid border-yellow-400 inline-block text-4xl">
                     {linkBlockTitle}
                   </span>
                 </h1>

--- a/resources/assets/components/pages/QuizResultPage/QuizResultPage.js
+++ b/resources/assets/components/pages/QuizResultPage/QuizResultPage.js
@@ -61,12 +61,12 @@ const QuizResultPage = ({ id }) => {
 
       <main>
         <article data-testid="quiz-result-page">
-          <header role="banner" className="base-12-grid bg-blurple-500">
-            <div className="col-span-3 bg-bottom md:col-start-2">
+          <header role="banner" className="base-12-grid bg-blurple-500 py-3">
+            <div className="col-span-4 md:col-span-3 bg-bottom md:col-start-2">
               {assetId ? <ContentfulAsset id={assetId} width={375} /> : null}
             </div>
-            <div className="col-span-7 md:my-auto">
-              <h1 className=" font-normal font-league-gothic color-white uppercase">
+            <div className="col-span-4 md:col-span-7 md:my-auto">
+              <h1 className="font-normal font-league-gothic color-white uppercase">
                 <span className="border-b-4 border-solid border-yellow-400 inline-block text-4xl">
                   {linkBlockTitle}
                 </span>

--- a/resources/assets/components/pages/QuizResultPage/QuizResultPage.js
+++ b/resources/assets/components/pages/QuizResultPage/QuizResultPage.js
@@ -61,20 +61,18 @@ const QuizResultPage = ({ id }) => {
 
       <main>
         <article data-testid="quiz-result-page">
-          <header role="banner" className="bg-blurple-500">
-            <div className="md:flex my-auto p-8">
-              <div className="md:w-1/4 flex-grow md:flex-col bg-bottom ">
-                {assetId ? <ContentfulAsset id={assetId} width={375} /> : null}
-              </div>
-              <div className="md:w-3/4">
-                <h1 className=" font-normal font-league-gothic color-white uppercase leading-10">
-                  <span className="border-b-4 border-solid border-yellow-400 inline-block text-4xl">
-                    {linkBlockTitle}
-                  </span>
-                </h1>
-                <div className="color-white">
-                  <TextContent>{data.block.content}</TextContent>
-                </div>
+          <header role="banner" className="base-12-grid bg-blurple-500">
+            <div className="col-span-3 bg-bottom md:col-start-2">
+              {assetId ? <ContentfulAsset id={assetId} width={375} /> : null}
+            </div>
+            <div className="col-span-7 md:my-auto">
+              <h1 className=" font-normal font-league-gothic color-white uppercase">
+                <span className="border-b-4 border-solid border-yellow-400 inline-block text-4xl">
+                  {linkBlockTitle}
+                </span>
+              </h1>
+              <div className="color-white">
+                <TextContent>{data.block.content}</TextContent>
               </div>
             </div>
           </header>


### PR DESCRIPTION
### What's this PR do?

This pull request...
Tweak width and removes flexbox within the hero image. This fix aligns with this [PR #](https://github.com/DoSomething/phoenix-next/pull/2163#issuecomment-634286246)

### How should this be reviewed?
⚒️ 
...

### Any background context you want to provide?
[Slack conversation](https://dosomething.slack.com/archives/CTVPG6L4R/p1590692814220100)
...

### Relevant tickets
Additional fix for towards this [Pivotal ticket](https://www.pivotaltracker.com/n/projects/2417735/stories/172823028).

### Checklist

- [ x ] This PR has been added to the relevant Pivotal card.
- [ x ] Added screenshots of front-end changes on small, medium, and large screens.

<img width="1436" alt="Screen Shot 2020-05-29 at 12 38 17 PM" src="https://user-images.githubusercontent.com/20409413/83283710-a2237880-a1a9-11ea-96fc-86f18b1a391c.png">
<img width="182" alt="Screen Shot 2020-05-29 at 12 38 48 PM" src="https://user-images.githubusercontent.com/20409413/83283720-a64f9600-a1a9-11ea-91d3-08ce6d6d439b.png">
<img width="184" alt="Screen Shot 2020-05-29 at 12 39 10 PM" src="https://user-images.githubusercontent.com/20409413/83283727-a8195980-a1a9-11ea-9c8a-86b127f2ccb8.png">
