### PR TITLE
Update Contentful workflow docs

### DIFF
--- a/docs/development/contentful/workflow.md
+++ b/docs/development/contentful/workflow.md
@@ -61,7 +61,7 @@ For updates to existing Content types, make the corresponding changes via the Co
 For brand new Content types, it’s easiest to run the CLI [migration](https://github.com/contentful/contentful-cli/tree/master/docs/space/import) command to add new content types to the `qa` and `master` environments:
 
 ```bash
-$ contentful space migration --s $SPACE_ID --e qa --content-file contentful/content-types/currentSchoolBlock.js
+$ contentful space migration --s $SPACE_ID --e qa contentful/content-types/currentSchoolBlock.js
 ```
 
 Upon success, you'll see:

--- a/docs/development/contentful/workflow.md
+++ b/docs/development/contentful/workflow.md
@@ -35,7 +35,7 @@ $ contentful space generate migration -s $SPACE_ID -e dev -c currentSchoolBlock 
 Upon success, you'll see:
 
 ```bash
-$ contentful space generate migration -s $SPACE_ID -e dev -c galleryBlock -f contentful/content-types/currentSchoolBlock.js
+$ contentful space generate migration -s $SPACE_ID -e dev -c currentSchoolBlock -f contentful/content-types/currentSchoolBlock.js
 
 Fetching content model
 Creating migration for content type: 'currentSchoolBlock'


### PR DESCRIPTION
### What's this PR do?

This pull request tweaks two documentation items around migrating and importing Contentful content types, which I've revisited to import the new types added in #2179.

### How should this be reviewed?

:eyes:

### Any background context you want to provide?

I am really not sure why the `--content-file` parameter isn't working for me, but the command as per these docs (and the Contentful docs it links to) was returning the `help` menu, and prompted me to `Please provide the file containing the migration script.` 🤷‍♂️ 

### Relevant tickets

References [Pivotal #173019820](https://www.pivotaltracker.com/story/show/173019820), [#173019860](https://www.pivotaltracker.com/story/show/173019860)

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added screenshots of front-end changes on small, medium, and large screens.
- [ ] Added appropriate feature/unit tests.
