### PR TITLE
Updating the SiteWide Banner to exclude Quiz Results pages

### DIFF
--- a/cypress/integration/sitewide-banner.js
+++ b/cypress/integration/sitewide-banner.js
@@ -60,6 +60,29 @@ describe('Site Wide Banner', () => {
   });
 
   /** @test */
+  it('The Site Wide Banner is not displayed on voter registration quiz results page', () => {
+    const quizResultId = 'p7hqjSP4Y1U6ad0UDz4iS';
+
+    const linkBlock = {
+      id: quizResultId,
+      __typename: 'LinkBlock',
+      title: faker.company.bsBuzz(),
+      content: faker.lorem.sentence(),
+    };
+
+    cy.mockGraphqlOp('QuizResultPageQuery', {
+      block: linkBlock,
+    });
+
+    cy.visit(`/us/quiz-results/${quizResultId}`);
+
+    cy.get('#banner-portal > .wrapper > [data-test=site-wide-banner]').should(
+      'have.length',
+      0,
+    );
+  });
+
+  /** @test */
   it('The Site Wide Banner CTA URL is correct for an unauthenticated user', () => {
     cy.anonVisitCampaign(exampleCampaign);
 

--- a/docs/development/features/sitewide-banner.md
+++ b/docs/development/features/sitewide-banner.md
@@ -13,3 +13,10 @@ The `SitewideBanner` can be used in conjunction with a `DismissableElement` or o
 In certain cases, you may want to hide the sitewide banner on specific pages of the site. If that's the case, you'll simply need to add the URL path as a _string_ to `components/utilities/SiteWideBanner/config`
 
 Before the banner renders on the page, we check the config for any pages that should be suppressed.
+
+If you want to suppress the banner from a page that may have multiple sub paths but share the same base path, you'll need to add a `*` to the end of the pathname.
+
+### Pathnames Currently Excluded:
+
+- `/us/my-voter-registration-drive`
+- `/us/quiz-results/*`

--- a/resources/assets/components/utilities/SitewideBanner/SitewideBanner.js
+++ b/resources/assets/components/utilities/SitewideBanner/SitewideBanner.js
@@ -4,21 +4,17 @@ import React, { useRef, useEffect } from 'react';
 import excludedPaths from './config';
 import SitewideBannerContent from './SitewideBannerContent';
 
-const checkExcludedPathname = pathname => {
-  for (let i = 0; i < excludedPaths.length; i += 1) {
-    if (excludedPaths[i] === pathname) {
-      return true;
+const isExcludedPath = pathname => {
+  return excludedPaths.find(excludedPath => {
+    if (excludedPath.includes('*')) {
+      return (
+        pathname.includes(excludedPath.slice(0, -1)) &&
+        pathname.length > excludedPath.length
+      );
     }
-    if (excludedPaths[i].includes('*')) {
-      if (
-        pathname.includes(excludedPaths[i].slice(0, -1)) &&
-        pathname.length > excludedPaths[i].length
-      ) {
-        return true;
-      }
-    }
-  }
-  return false;
+
+    return excludedPath === pathname;
+  });
 };
 
 const SitewideBanner = props => {
@@ -39,7 +35,7 @@ const SitewideBanner = props => {
 
   const target = usePortal('banner-portal');
 
-  return !checkExcludedPathname(window.location.pathname)
+  return !isExcludedPath(window.location.pathname)
     ? createPortal(children, target)
     : null;
 };

--- a/resources/assets/components/utilities/SitewideBanner/SitewideBanner.js
+++ b/resources/assets/components/utilities/SitewideBanner/SitewideBanner.js
@@ -10,7 +10,10 @@ const checkExcludedPathname = pathname => {
       return true;
     }
     if (excludedPaths[i].includes('*')) {
-      if (pathname.includes('/us/quiz-results/')) {
+      if (
+        pathname.includes(excludedPaths[i].slice(0, -1)) &&
+        pathname.length > excludedPaths[i].length
+      ) {
         return true;
       }
     }

--- a/resources/assets/components/utilities/SitewideBanner/SitewideBanner.js
+++ b/resources/assets/components/utilities/SitewideBanner/SitewideBanner.js
@@ -4,6 +4,20 @@ import React, { useRef, useEffect } from 'react';
 import excludedPaths from './config';
 import SitewideBannerContent from './SitewideBannerContent';
 
+const checkExcludedPathname = pathname => {
+  for (let i = 0; i < excludedPaths.length; i += 1) {
+    if (excludedPaths[i] === pathname) {
+      return true;
+    }
+    if (excludedPaths[i].includes('*')) {
+      if (pathname.includes('/us/quiz-results/')) {
+        return true;
+      }
+    }
+  }
+  return false;
+};
+
 const SitewideBanner = props => {
   const usePortal = id => {
     const rootElem = useRef(document.createElement('div'));
@@ -22,7 +36,7 @@ const SitewideBanner = props => {
 
   const target = usePortal('banner-portal');
 
-  return !excludedPaths.includes(window.location.pathname)
+  return !checkExcludedPathname(window.location.pathname)
     ? createPortal(children, target)
     : null;
 };

--- a/resources/assets/components/utilities/SitewideBanner/config.js
+++ b/resources/assets/components/utilities/SitewideBanner/config.js
@@ -1,3 +1,3 @@
-const excludedPaths = ['/us/my-voter-registration-drive'];
+const excludedPaths = ['/us/my-voter-registration-drive', '/us/quiz-results/*'];
 
 export { excludedPaths as default };


### PR DESCRIPTION
### What's this PR do?

This pull request adds a helper function to check our pathnames that shouldn't display the howdyBar 🤠 

### How should this be reviewed?

Could the helper be refactored in anyway? I tried to keep it succinct but i didn't know how to avoid da loop and the if statements.

### Any background context you want to provide?

We want to exclude the howdyBar from all 4 quiz results pages, so we need to be able to check for the pathname without the quiz ID.

### Relevant tickets

References [Pivotal # 172898540](https://www.pivotaltracker.com/story/show/172898540).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added screenshots of front-end changes on small, medium, and large screens.
- [ ] Added appropriate feature/unit tests.
