### PR TITLE
Add additionalContent field to Collection Page Content Type

### DIFF
--- a/contentful/content-types/collection-page.js
+++ b/contentful/content-types/collection-page.js
@@ -203,6 +203,16 @@ module.exports = function(migration) {
     .disabled(false)
     .omitted(false);
 
+  collectionPage
+    .createField('additionalContent')
+    .name('Additional Content')
+    .type('Object')
+    .localized(false)
+    .required(false)
+    .validations([])
+    .disabled(false)
+    .omitted(false);
+
   collectionPage.changeFieldControl('internalTitle', 'builtin', 'singleLine', {
     helpText:
       'This title is used internally to help find this content. It will not be displayed anywhere on the rendered web page.',
@@ -267,4 +277,11 @@ module.exports = function(migration) {
     helpText:
       'The core content for this collection page, sits below the banner, optimally a collection of galleries e.g. campaigns & articles related to this topic.',
   });
+
+  collectionPage.changeFieldControl(
+    'additionalContent',
+    'builtin',
+    'objectEditor',
+    {},
+  );
 };


### PR DESCRIPTION
### What's this PR do?

This pull request adds an `additionalContent` JSON field to the Collection Page content type by generating a new migration file from Contentful into the collection-page migration script.

### How should this be reviewed?
👀 

### Any background context you want to provide?
We're going to be supporting the (still somewhat informal) `stats` property a la Cause Pages

### Relevant tickets

References [Pivotal #172697820](https://www.pivotaltracker.com/story/show/172697820).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints. - _not yet_
