### PR TITLE
Support additionalContent Stats in Collection Page

### DIFF
--- a/resources/assets/components/pages/CollectionPage/CollectionPage.js
+++ b/resources/assets/components/pages/CollectionPage/CollectionPage.js
@@ -28,6 +28,7 @@ export const COLLECTION_PAGE_QUERY = gql`
         }
       }
       content
+      additionalContent
     }
   }
 `;
@@ -40,7 +41,10 @@ const CollectionPageTemplate = ({
   affiliatePrefix,
   affiliates,
   content,
+  additionalContent,
 }) => {
+  const { stats, statsBackgroundColor } = additionalContent || {};
+
   return (
     <>
       <SiteNavigationContainer />
@@ -55,6 +59,8 @@ const CollectionPageTemplate = ({
               description,
               affiliates,
               affiliatePrefix,
+              stats,
+              statsBackgroundColor,
             })}
           />
 
@@ -86,11 +92,16 @@ CollectionPageTemplate.propTypes = {
   affiliatePrefix: PropTypes.string,
   affiliates: PropTypes.arrayOf(PropTypes.object),
   content: PropTypes.object.isRequired,
+  additionalContent: PropTypes.shape({
+    stats: PropTypes.array,
+    statsBackgroundColor: PropTypes.string,
+  }),
 };
 
 CollectionPageTemplate.defaultProps = {
   affiliatePrefix: null,
   affiliates: null,
+  additionalContent: {},
 };
 
 const CollectionPage = ({ slug }) => (

--- a/schema.json
+++ b/schema.json
@@ -7392,6 +7392,18 @@
             "deprecationReason": null
           },
           {
+            "name": "additionalContent",
+            "description": "Any custom overrides for this collection page.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "JSON",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "id",
             "description": "The Contentful ID for this entry.",
             "args": [],


### PR DESCRIPTION
### What's this PR do?

This pull request adds `additionalContent` to the list of Collection Page fields per #2191 and https://github.com/DoSomething/graphql/pull/236 to allow assigning 'Stats' to a Collection Page banner.

### How should this be reviewed?
👀

### Any background context you want to provide?
I'm going to add a backlog cleanup card to consolidate the Collection/Cause pages a bit more, add documentation to the collection page, and some more tests. (I'm already quite overtime due to all the cleanup for this simple feature 😬)

### Relevant tickets

References [Pivotal #172697820](https://www.pivotaltracker.com/story/show/172697820).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [x] Added screenshots of front-end changes on small, medium, and large screens.
- [ ] Added appropriate feature/unit tests.


![image](https://user-images.githubusercontent.com/12417657/83646747-154e3580-a582-11ea-90a8-e7bdccc943da.png)

- [Medium](https://user-images.githubusercontent.com/12417657/83646789-26974200-a582-11ea-9710-93436b507a58.png)

- [Small](https://user-images.githubusercontent.com/12417657/83646828-30b94080-a582-11ea-9be6-64d6cabfc180.png)
