### PR TITLE
Refactor BaseFigure out of Voter Registration Referrals Block

### DIFF
--- a/cypress/integration/voter-registration-referrals-block.js
+++ b/cypress/integration/voter-registration-referrals-block.js
@@ -55,10 +55,10 @@ describe('Voter Registration Referrals Block', () => {
 
     cy.get('[data-test=referral-list-item-completed]').should('have.length', 2);
     cy.nth('[data-test=referral-list-item-completed]', 0).within(() => {
-      cy.get('.figure__body').contains('Jesus Q.');
+      cy.findByTestId('referral-list-item-label').contains('Jesus Q.');
     });
     cy.nth('[data-test=referral-list-item-completed]', 1).within(() => {
-      cy.get('.figure__body').contains('Walter S.');
+      cy.findByTestId('referral-list-item-label').contains('Walter S.');
     });
     cy.get('[data-test=referral-list-item-empty]').should('have.length', 1);
     cy.get('[data-test=additional-referrals-count]').should('have.length', 0);
@@ -84,10 +84,10 @@ describe('Voter Registration Referrals Block', () => {
       cy.get('p').contains('Sarah C.');
     });
     cy.nth('[data-test=referral-list-item-completed]', 1).within(() => {
-      cy.get('.figure__body').contains('Kyle R.');
+      cy.findByTestId('referral-list-item-label').contains('Kyle R.');
     });
     cy.nth('[data-test=referral-list-item-completed]', 2).within(() => {
-      cy.get('.figure__body').contains('John C.');
+      cy.findByTestId('referral-list-item-label').contains('John C.');
     });
     cy.get('[data-test=referral-list-item-empty]').should('have.length', 0);
     cy.get('[data-test=additional-referrals-count]').contains('+ 2 more');

--- a/resources/assets/components/blocks/VoterRegistrationReferralsBlock/VoterRegistrationReferralsBlock.js
+++ b/resources/assets/components/blocks/VoterRegistrationReferralsBlock/VoterRegistrationReferralsBlock.js
@@ -60,7 +60,7 @@ const VoterRegistrationReferralsBlock = ({ title }) => (
               {numberOfReferrals > 3 ? (
                 <div
                   data-test="additional-referrals-count"
-                  className="text-center md:text-left md:pt-16 font-bold uppercase text-gray-600"
+                  className="text-center md:text-left pt-8 md:pt-16 font-bold uppercase text-gray-600"
                 >
                   {`+ ${numberOfReferrals - 3} more`}
                 </div>

--- a/resources/assets/components/blocks/VoterRegistrationReferralsBlock/VoterRegistrationReferralsList.js
+++ b/resources/assets/components/blocks/VoterRegistrationReferralsBlock/VoterRegistrationReferralsList.js
@@ -13,7 +13,7 @@ const VoterRegistrationReferralsList = ({ referralPosts }) => {
    */
   for (let i = 0; i < 3; i += 1) {
     items.push(
-      <li key={i} className="flex-grow md:float-left md:pr-6">
+      <li key={i} className="md:pr-6">
         <VoterRegistrationReferralsListItem
           label={get(referralPosts[i], 'user.displayName')}
         />
@@ -26,7 +26,7 @@ const VoterRegistrationReferralsList = ({ referralPosts }) => {
    * component within our VoterRegistrationReferralsListItem doesn't align left.
    * @see https://www.pivotaltracker.com/n/projects/2441250/stories/172608156
    */
-  return <ul className="flex md:clearfix">{items}</ul>;
+  return <ul className="flex justify-around">{items}</ul>;
 };
 
 VoterRegistrationReferralsList.propTypes = {

--- a/resources/assets/components/blocks/VoterRegistrationReferralsBlock/VoterRegistrationReferralsList.js
+++ b/resources/assets/components/blocks/VoterRegistrationReferralsBlock/VoterRegistrationReferralsList.js
@@ -21,11 +21,6 @@ const VoterRegistrationReferralsList = ({ referralPosts }) => {
     );
   }
 
-  /**
-   * We're using clearfix and float-left for non-small screens instead of flex, because the Figure
-   * component within our VoterRegistrationReferralsListItem doesn't align left.
-   * @see https://www.pivotaltracker.com/n/projects/2441250/stories/172608156
-   */
   return <ul className="flex justify-around">{items}</ul>;
 };
 

--- a/resources/assets/components/blocks/VoterRegistrationReferralsBlock/VoterRegistrationReferralsListItem.js
+++ b/resources/assets/components/blocks/VoterRegistrationReferralsBlock/VoterRegistrationReferralsListItem.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import { BaseFigure } from '../../utilities/Figure/Figure';
 import EmptyRegistrationImage from './empty-registration.svg';
 import CompletedRegistrationImage from './completed-registration.svg';
 
@@ -9,18 +8,19 @@ const VoterRegistrationReferralsListItem = props => {
   const { label } = props;
   const isEmpty = label === '???';
 
-  const media = (
-    <img
-      src={!isEmpty ? CompletedRegistrationImage : EmptyRegistrationImage}
-      alt={!isEmpty ? 'Completed voter registration icon' : 'Empty circle icon'}
-    />
-  );
-
   return (
-    <div data-test={`referral-list-item-${!isEmpty ? 'completed' : 'empty'}`}>
-      <BaseFigure media={media} size="medium">
-        <p className={isEmpty ? 'text-gray-500' : null}>{label}</p>
-      </BaseFigure>
+    <div
+      data-test={`referral-list-item-${!isEmpty ? 'completed' : 'empty'}`}
+      className="text-center w-20 xs:w-24 sm:w-32 md:w-40"
+    >
+      <img
+        className="mb-3"
+        src={!isEmpty ? CompletedRegistrationImage : EmptyRegistrationImage}
+        alt={
+          !isEmpty ? 'Completed voter registration icon' : 'Empty circle icon'
+        }
+      />
+      <p className={isEmpty ? 'text-gray-500' : null}>{label}</p>
     </div>
   );
 };

--- a/resources/assets/components/blocks/VoterRegistrationReferralsBlock/VoterRegistrationReferralsListItem.js
+++ b/resources/assets/components/blocks/VoterRegistrationReferralsBlock/VoterRegistrationReferralsListItem.js
@@ -10,6 +10,7 @@ const VoterRegistrationReferralsListItem = props => {
 
   return (
     <div
+      /* @TODO: Update to data-testid. */
       data-test={`referral-list-item-${!isEmpty ? 'completed' : 'empty'}`}
       className="text-center w-20 xs:w-24 sm:w-32 md:w-40"
     >

--- a/resources/assets/components/blocks/VoterRegistrationReferralsBlock/VoterRegistrationReferralsListItem.js
+++ b/resources/assets/components/blocks/VoterRegistrationReferralsBlock/VoterRegistrationReferralsListItem.js
@@ -20,7 +20,12 @@ const VoterRegistrationReferralsListItem = props => {
           !isEmpty ? 'Completed voter registration icon' : 'Empty circle icon'
         }
       />
-      <p className={isEmpty ? 'text-gray-500' : null}>{label}</p>
+      <p
+        data-testid="referral-list-item-label"
+        className={isEmpty ? 'text-gray-500' : null}
+      >
+        {label}
+      </p>
     </div>
   );
 };

--- a/resources/assets/components/pages/CampaignPage/CampaignPageContent.js
+++ b/resources/assets/components/pages/CampaignPage/CampaignPageContent.js
@@ -63,6 +63,7 @@ const CampaignPageContent = props => {
                 QuizBlock: 'grid-wide',
                 SocialDriveBlock: 'grid-wide',
                 VoterRegistrationDriveBlock: 'grid-wide',
+                VoterRegistrationReferralsBlock: 'grid-wide',
               }}
             />
           ))}


### PR DESCRIPTION
### What's this PR do?

This pull request replaces the `BaseFigure` in our `VoterRegistrationReferralsBlock` component with inline Tailwind classes.

### How should this be reviewed?
Makes sense? Looks good?

### Any background context you want to provide?
The `BaseFigure` was giving us all sort of headaches (See [Pivotal #172608156](https://www.pivotaltracker.com/n/projects/2441250/stories/172608156)). Toward the effort of potentially extracting this gallery to be used for the RAF tab ([Pivotal #172748788](https://www.pivotaltracker.com/story/show/172748788)), this felt like a good time to try and wrangle out the `BaseFigure`. This allowed removing some float logic in the parent `<div>`s

For the most part, what we were getting from BaseFigure seemed to be 
- centered text for the label (replaced with `text-center`)
- margin-spaced-out nodes (replaced with `justify-around` for auto spacing)
- widths on the nodes themselves (replaced with the series of `w-x` on each item)

I also added a few extra breakpoint width adjustments for the nodes so they'll take up a bit more space on the in-between breakpoints & added a custom `grid-wide` class for when this component is rendered on campaign pages.

### Relevant tickets

References [Pivotal #172748788](https://www.pivotaltracker.com/story/show/172748788).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [x] Added screenshots of front-end changes on small, medium, and large screens.
- [x] Added appropriate feature/unit tests.

![Kapture 2020-06-03 at 14 15 47](https://user-images.githubusercontent.com/12417657/83672752-c665c780-a5a4-11ea-8b95-b3625d89750e.gif)

- [Large](https://user-images.githubusercontent.com/12417657/83672857-f6ad6600-a5a4-11ea-8877-781b5b6583ca.png)
- [Medium](https://user-images.githubusercontent.com/12417657/83672914-0cbb2680-a5a5-11ea-9969-5b4652636d21.png)
- [Small](https://user-images.githubusercontent.com/12417657/83672965-2197ba00-a5a5-11ea-9e6f-99937f33d4ba.png)


