### PR TITLE
Adds the Quiz Campaign pathname to list that suppresses the HowdyBar

### DIFF
--- a/docs/development/features/sitewide-banner.md
+++ b/docs/development/features/sitewide-banner.md
@@ -18,5 +18,6 @@ If you want to suppress the banner from a page that may have multiple sub paths 
 
 ### Pathnames Currently Excluded:
 
+- `/us/campaigns/ready-vote*`
 - `/us/my-voter-registration-drive`
 - `/us/quiz-results/*`

--- a/resources/assets/components/utilities/SitewideBanner/SitewideBanner.js
+++ b/resources/assets/components/utilities/SitewideBanner/SitewideBanner.js
@@ -7,9 +7,10 @@ import SitewideBannerContent from './SitewideBannerContent';
 const isExcludedPath = pathname => {
   return excludedPaths.find(excludedPath => {
     if (excludedPath.includes('*')) {
+      const pathWithoutAsterisk = excludedPath.slice(0, -1);
       return (
         pathname.includes(excludedPath.slice(0, -1)) &&
-        pathname.length > excludedPath.length
+        pathname.length >= pathWithoutAsterisk.length
       );
     }
 

--- a/resources/assets/components/utilities/SitewideBanner/SitewideBanner.js
+++ b/resources/assets/components/utilities/SitewideBanner/SitewideBanner.js
@@ -8,9 +8,10 @@ const isExcludedPath = pathname => {
   return excludedPaths.find(excludedPath => {
     if (excludedPath.includes('*')) {
       const pathWithoutAsterisk = excludedPath.slice(0, -1);
+
       return (
-        pathname.includes(excludedPath.slice(0, -1)) &&
-        pathname.length >= pathWithoutAsterisk.length
+        pathname.includes(pathWithoutAsterisk) &&
+        pathname.length > pathWithoutAsterisk.length
       );
     }
 

--- a/resources/assets/components/utilities/SitewideBanner/config.js
+++ b/resources/assets/components/utilities/SitewideBanner/config.js
@@ -1,5 +1,6 @@
 const excludedPaths = [
-  '/us/campaigns/ready-vote*',
+  '/us/campaigns/ready-vote',
+  '/us/campaigns/ready-vote/*',
   '/us/my-voter-registration-drive',
   '/us/quiz-results/*',
 ];

--- a/resources/assets/components/utilities/SitewideBanner/config.js
+++ b/resources/assets/components/utilities/SitewideBanner/config.js
@@ -1,3 +1,7 @@
-const excludedPaths = ['/us/my-voter-registration-drive', '/us/quiz-results/*'];
+const excludedPaths = [
+  '/us/campaigns/ready-vote*',
+  '/us/my-voter-registration-drive',
+  '/us/quiz-results/*',
+];
 
 export { excludedPaths as default };


### PR DESCRIPTION
### What's this PR do?

This pull request suppresses the sitewide banner from the quiz in general, rather than just from the quiz results page. 

### How should this be reviewed?

👀 

### Any background context you want to provide?

Having issues with the way the react Router redirect method is interacting with the React portal that's created for the sitewide banner and when it checked the pathnames on redirects!

### Relevant tickets

References [Pivotal # 172898540](https://www.pivotaltracker.com/story/show/172898540).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [x] Documentation added for new features/changed endpoints.
- [ ] Added screenshots of front-end changes on small, medium, and large screens.
- [ ] Added appropriate feature/unit tests.
