### PR TITLE
Generalize the Voter Registration Referrals Gallery List/Items

### DIFF
--- a/cypress/integration/voter-registration-referrals-block.js
+++ b/cypress/integration/voter-registration-referrals-block.js
@@ -39,9 +39,9 @@ describe('Voter Registration Referrals Block', () => {
 
     cy.authVisitBlockPermalink(user, blockId);
 
-    cy.get('[data-test=referral-list-item-empty]').should('have.length', 3);
-    cy.get('[data-test=referral-list-item-completed]').should('have.length', 0);
-    cy.get('[data-test=additional-referrals-count]').should('have.length', 0);
+    cy.findAllByTestId('referral-list-item-empty').should('have.length', 3);
+    cy.findAllByTestId('referral-list-item-completed').should('have.length', 0);
+    cy.findByTestId('additional-referrals-count').should('have.length', 0);
   });
 
   it('Displays 2 completed icons if user has 2 referrals', () => {
@@ -53,15 +53,15 @@ describe('Voter Registration Referrals Block', () => {
 
     cy.authVisitBlockPermalink(user, blockId);
 
-    cy.get('[data-test=referral-list-item-completed]').should('have.length', 2);
-    cy.nth('[data-test=referral-list-item-completed]', 0).within(() => {
+    cy.findAllByTestId('referral-list-item-completed').should('have.length', 2);
+    cy.nth('[data-testid=referral-list-item-completed]', 0).within(() => {
       cy.findByTestId('referral-list-item-label').contains('Jesus Q.');
     });
-    cy.nth('[data-test=referral-list-item-completed]', 1).within(() => {
+    cy.nth('[data-testid=referral-list-item-completed]', 1).within(() => {
       cy.findByTestId('referral-list-item-label').contains('Walter S.');
     });
-    cy.get('[data-test=referral-list-item-empty]').should('have.length', 1);
-    cy.get('[data-test=additional-referrals-count]').should('have.length', 0);
+    cy.findAllByTestId('referral-list-item-empty').should('have.length', 1);
+    cy.findByTestId('additional-referrals-count').should('have.length', 0);
   });
 
   it('Displays 3 completed icons and additional count if user has 5 referrals', () => {
@@ -79,17 +79,17 @@ describe('Voter Registration Referrals Block', () => {
 
     cy.authVisitBlockPermalink(user, blockId);
 
-    cy.get('[data-test=referral-list-item-completed]').should('have.length', 3);
-    cy.nth('[data-test=referral-list-item-completed]', 0).within(() => {
-      cy.get('p').contains('Sarah C.');
+    cy.findAllByTestId('referral-list-item-completed').should('have.length', 3);
+    cy.nth('[data-testid=referral-list-item-completed]', 0).within(() => {
+      cy.findByTestId('referral-list-item-label').contains('Sarah C.');
     });
-    cy.nth('[data-test=referral-list-item-completed]', 1).within(() => {
+    cy.nth('[data-testid=referral-list-item-completed]', 1).within(() => {
       cy.findByTestId('referral-list-item-label').contains('Kyle R.');
     });
-    cy.nth('[data-test=referral-list-item-completed]', 2).within(() => {
+    cy.nth('[data-testid=referral-list-item-completed]', 2).within(() => {
       cy.findByTestId('referral-list-item-label').contains('John C.');
     });
-    cy.get('[data-test=referral-list-item-empty]').should('have.length', 0);
-    cy.get('[data-test=additional-referrals-count]').contains('+ 2 more');
+    cy.findAllByTestId('referral-list-item-empty').should('have.length', 0);
+    cy.findByTestId('additional-referrals-count').contains('+ 2 more');
   });
 });

--- a/resources/assets/components/blocks/VoterRegistrationReferralsBlock/VoterRegistrationReferralsBlock.js
+++ b/resources/assets/components/blocks/VoterRegistrationReferralsBlock/VoterRegistrationReferralsBlock.js
@@ -65,7 +65,7 @@ const VoterRegistrationReferralsBlock = ({ title }) => (
               />
               {numberOfReferrals > 3 ? (
                 <div
-                  data-test="additional-referrals-count"
+                  data-testid="additional-referrals-count"
                   className="text-center md:text-left pt-8 md:pt-16 font-bold uppercase text-gray-600"
                 >
                   {`+ ${numberOfReferrals - 3} more`}

--- a/resources/assets/components/blocks/VoterRegistrationReferralsBlock/VoterRegistrationReferralsBlock.js
+++ b/resources/assets/components/blocks/VoterRegistrationReferralsBlock/VoterRegistrationReferralsBlock.js
@@ -5,6 +5,8 @@ import PropTypes from 'prop-types';
 
 import Query from '../../Query';
 import { getUserId } from '../../../helpers/auth';
+import EmptyRegistrationImage from './empty-registration.svg';
+import CompletedRegistrationImage from './completed-registration.svg';
 import SectionHeader from '../../utilities/SectionHeader/SectionHeader';
 import VoterRegistrationReferralsList from './VoterRegistrationReferralsList';
 
@@ -56,7 +58,11 @@ const VoterRegistrationReferralsBlock = ({ title }) => (
               </div>
             )}
             <div className="md:flex">
-              <VoterRegistrationReferralsList referralPosts={data.posts} />
+              <VoterRegistrationReferralsList
+                referralPosts={data.posts}
+                referralIcon={CompletedRegistrationImage}
+                placeholderIcon={EmptyRegistrationImage}
+              />
               {numberOfReferrals > 3 ? (
                 <div
                   data-test="additional-referrals-count"

--- a/resources/assets/components/blocks/VoterRegistrationReferralsBlock/VoterRegistrationReferralsList.js
+++ b/resources/assets/components/blocks/VoterRegistrationReferralsBlock/VoterRegistrationReferralsList.js
@@ -2,11 +2,9 @@ import React from 'react';
 import { get } from 'lodash';
 import PropTypes from 'prop-types';
 
-import EmptyRegistrationImage from './empty-registration.svg';
-import CompletedRegistrationImage from './completed-registration.svg';
 import VoterRegistrationReferralsListItem from './VoterRegistrationReferralsListItem';
 
-const VoterRegistrationReferralsList = ({ referralPosts }) => {
+const VoterRegistrationReferralsList = props => {
   const items = [];
 
   /**
@@ -17,9 +15,9 @@ const VoterRegistrationReferralsList = ({ referralPosts }) => {
     items.push(
       <li key={i} className="md:pr-6">
         <VoterRegistrationReferralsListItem
-          label={get(referralPosts[i], 'user.displayName')}
-          referralIcon={CompletedRegistrationImage}
-          placeholderIcon={EmptyRegistrationImage}
+          label={get(props.referralPosts[i], 'user.displayName')}
+          referralIcon={props.referralIcon}
+          placeholderIcon={props.placeholderIcon}
         />
       </li>,
     );
@@ -29,6 +27,8 @@ const VoterRegistrationReferralsList = ({ referralPosts }) => {
 };
 
 VoterRegistrationReferralsList.propTypes = {
+  placeholderIcon: PropTypes.string.isRequired,
+  referralIcon: PropTypes.string.isRequired,
   referralPosts: PropTypes.arrayOf(PropTypes.object).isRequired,
 };
 

--- a/resources/assets/components/blocks/VoterRegistrationReferralsBlock/VoterRegistrationReferralsList.js
+++ b/resources/assets/components/blocks/VoterRegistrationReferralsBlock/VoterRegistrationReferralsList.js
@@ -2,6 +2,8 @@ import React from 'react';
 import { get } from 'lodash';
 import PropTypes from 'prop-types';
 
+import EmptyRegistrationImage from './empty-registration.svg';
+import CompletedRegistrationImage from './completed-registration.svg';
 import VoterRegistrationReferralsListItem from './VoterRegistrationReferralsListItem';
 
 const VoterRegistrationReferralsList = ({ referralPosts }) => {
@@ -16,6 +18,8 @@ const VoterRegistrationReferralsList = ({ referralPosts }) => {
       <li key={i} className="md:pr-6">
         <VoterRegistrationReferralsListItem
           label={get(referralPosts[i], 'user.displayName')}
+          referralIcon={CompletedRegistrationImage}
+          placeholderIcon={EmptyRegistrationImage}
         />
       </li>,
     );

--- a/resources/assets/components/blocks/VoterRegistrationReferralsBlock/VoterRegistrationReferralsListItem.js
+++ b/resources/assets/components/blocks/VoterRegistrationReferralsBlock/VoterRegistrationReferralsListItem.js
@@ -1,11 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import EmptyRegistrationImage from './empty-registration.svg';
-import CompletedRegistrationImage from './completed-registration.svg';
-
 const VoterRegistrationReferralsListItem = props => {
-  const { label } = props;
+  const { label, placeholderIcon, referralIcon } = props;
   const isEmpty = label === '???';
 
   return (
@@ -16,10 +13,8 @@ const VoterRegistrationReferralsListItem = props => {
     >
       <img
         className="mb-3"
-        src={!isEmpty ? CompletedRegistrationImage : EmptyRegistrationImage}
-        alt={
-          !isEmpty ? 'Completed voter registration icon' : 'Empty circle icon'
-        }
+        src={!isEmpty ? referralIcon : placeholderIcon}
+        alt={!isEmpty ? 'Completed referral icon' : 'Empty icon'}
       />
       <p
         data-testid="referral-list-item-label"
@@ -33,6 +28,8 @@ const VoterRegistrationReferralsListItem = props => {
 
 VoterRegistrationReferralsListItem.propTypes = {
   label: PropTypes.string,
+  placeholderIcon: PropTypes.string.isRequired,
+  referralIcon: PropTypes.string.isRequired,
 };
 
 VoterRegistrationReferralsListItem.defaultProps = {

--- a/resources/assets/components/blocks/VoterRegistrationReferralsBlock/VoterRegistrationReferralsListItem.js
+++ b/resources/assets/components/blocks/VoterRegistrationReferralsBlock/VoterRegistrationReferralsListItem.js
@@ -7,8 +7,7 @@ const VoterRegistrationReferralsListItem = props => {
 
   return (
     <div
-      /* @TODO: Update to data-testid. */
-      data-test={`referral-list-item-${!isEmpty ? 'completed' : 'empty'}`}
+      data-testid={`referral-list-item-${!isEmpty ? 'completed' : 'empty'}`}
       className="text-center w-20 xs:w-24 sm:w-32 md:w-40"
     >
       <img


### PR DESCRIPTION
### What's this PR do?

This pull request lifts the 'completed' & 'empty' referral icons as props into the parent VR referrals gallery so that the referrals list and list items can re be-used generally.

It also updates some `data-test`s to `data-testids` per https://github.com/DoSomething/phoenix-next/pull/2196#discussion_r434777874

### How should this be reviewed?
You can commit-by-commit this but it's pretty straightforward altogether. No visual changes but once the review app build you can check out /us/campaigns/online-registration-drive to make sure the gallery still works.

### Any background context you want to provide?
This brings us one step closer to being able to borrow this for the RAF referrals gallery. The next step is seeing if it's feasible to generalize the gallery block itself which I think _will_ be possible to at least some capacity (not like the content type and associated block, but some of the internal logic), or otherwise, to move these out into utility components.

### Relevant tickets

References [Pivotal #172748788](https://www.pivotaltracker.com/story/show/172748788).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [x] Added appropriate feature/unit tests.
