### PR TITLE
Analytics on "add photo" button on story pages

### DIFF
--- a/resources/assets/components/actions/PhotoSubmissionAction/PhotoSubmissionAction.js
+++ b/resources/assets/components/actions/PhotoSubmissionAction/PhotoSubmissionAction.js
@@ -25,7 +25,6 @@ import {
 } from '../../../helpers/forms';
 import {
   EVENT_CATEGORIES,
-  getUtmContext,
   getPageContext,
   trackAnalyticsEvent,
 } from '../../../helpers/analytics';

--- a/resources/assets/components/actions/PhotoSubmissionAction/PhotoSubmissionAction.js
+++ b/resources/assets/components/actions/PhotoSubmissionAction/PhotoSubmissionAction.js
@@ -326,7 +326,6 @@ class PhotoSubmissionAction extends PostForm {
                       label: 'block_auth',
                       context: {
                         ...getPageContext(),
-                        ...getUtmContext(),
                         referrer: document.referrer,
                       },
                     })

--- a/resources/assets/components/actions/PhotoSubmissionAction/PhotoSubmissionAction.js
+++ b/resources/assets/components/actions/PhotoSubmissionAction/PhotoSubmissionAction.js
@@ -23,6 +23,12 @@ import {
   getFieldErrors,
   formatPostPayload,
 } from '../../../helpers/forms';
+import {
+  EVENT_CATEGORIES,
+  getUtmContext,
+  getPageContext,
+  trackAnalyticsEvent,
+} from '../../../helpers/analytics';
 
 import './photo-submission-action.scss';
 
@@ -313,6 +319,18 @@ class PhotoSubmissionAction extends PostForm {
                   className="block text-lg w-full"
                   href={this.props.authRegisterUrl}
                   text="Add Photo"
+                  onClick={() =>
+                    trackAnalyticsEvent('phoenix_clicked_button_log_in', {
+                      action: 'button_clicked',
+                      category: EVENT_CATEGORIES.authentication,
+                      label: 'block_auth',
+                      context: {
+                        ...getPageContext(),
+                        ...getUtmContext(),
+                        referrer: document.referrer,
+                      },
+                    })
+                  }
                 />
               </div>
             </Card>

--- a/resources/assets/components/actions/PhotoSubmissionAction/PhotoSubmissionAction.js
+++ b/resources/assets/components/actions/PhotoSubmissionAction/PhotoSubmissionAction.js
@@ -565,7 +565,7 @@ PhotoSubmissionAction.propTypes = {
     items: PropTypes.object,
   }).isRequired,
   title: PropTypes.string,
-  userId: PropTypes.string.isRequired,
+  userId: PropTypes.string,
   whyParticipatedFieldLabel: PropTypes.string,
   whyParticipatedFieldPlaceholder: PropTypes.string,
 };
@@ -587,6 +587,7 @@ PhotoSubmissionAction.defaultProps = {
   quantityFieldPlaceholder: 'Quantity # (e.g. 300)',
   showQuantityField: true,
   title: 'Submit your photo',
+  userId: null,
   whyParticipatedFieldLabel: 'Why is this campaign important to you?',
   whyParticipatedFieldPlaceholder:
     "No need to write an essay, but we'd love to see why this matters to you!",

--- a/resources/assets/components/actions/PhotoSubmissionAction/PhotoSubmissionAction.js
+++ b/resources/assets/components/actions/PhotoSubmissionAction/PhotoSubmissionAction.js
@@ -325,7 +325,6 @@ class PhotoSubmissionAction extends PostForm {
                       label: 'block_auth',
                       context: {
                         ...getPageContext(),
-                        referrer: document.referrer,
                       },
                     })
                   }


### PR DESCRIPTION
### What's this PR do?

This pull request adds some analytics! When there is a PhotoSubmissionAction on a story page and the user is unauthenticated, we show an "Add Photo" button instead of the uploader (really this would happen _any_ place that an unauthenticated user encounters a PhotoSubmissionAction, but a story page is the only place that could happen). We'll now track analytics on that "Add Photo" button.

ALSO I did some cleaning. I was getting a warning that `userId` was `null` but required in PhotoSubmissionAction so I added a default prop of `null` for `userId` and made it not required.

New events:
<img width="509" alt="Screen Shot 2020-06-04 at 9 34 23 AM" src="https://user-images.githubusercontent.com/4240292/83786850-d4205900-a647-11ea-80bf-711e51806b4e.png">

Existing event:
<img width="512" alt="Screen Shot 2020-06-04 at 9 34 43 AM" src="https://user-images.githubusercontent.com/4240292/83786873-db476700-a647-11ea-8b4d-4732cd8348c9.png">

### How should this be reviewed?

Does the event look right? Any flags about not requiring `userId`?

### Any background context you want to provide?

Nope!

### Relevant tickets

References [Pivotal #172384668](https://www.pivotaltracker.com/story/show/172384668).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added screenshots of front-end changes on small, medium, and large screens.
- [ ] Added appropriate feature/unit tests.
