### PR TITLE
Globally Unsubscribe from Emails on Phoenix

### DIFF
--- a/resources/assets/components/pages/AccountPage/Subscriptions/CancelEmailSubscription.js
+++ b/resources/assets/components/pages/AccountPage/Subscriptions/CancelEmailSubscription.js
@@ -2,7 +2,8 @@ import React from 'react';
 import gql from 'graphql-tag';
 import { useQuery, useMutation } from '@apollo/react-hooks';
 
-import LinkButton from '.../utilities/Button/LinkButton';
+import LinkButton from '../../../utilities/Button/LinkButton';
+import Spinner from '../../../artifacts/Spinner/Spinner';
 
 const EMAIL_SUBSCRIPTION_STATUS = gql`
   query EmailSubscriptionStatus($userId: String!) {
@@ -39,26 +40,28 @@ const CancelEmailSubscription = () => {
     return <p>Something went wrong!</p>;
   }
 
+  if (loading) {
+    return Spinner;
+  }
   return (
     <div>
-      <p>
-        "Need a break?
-        <LinkButton
-          attributes={attributes}
-          className={classes}
-          href=""
-          onClick={() =>
-            updateEmailSubscriptionStatus({
-              variables: {
-                userId,
-                subscribed: false,
-              },
-            })
-          }
-          text="Unsubscribe"
-        />
-        from all newsletters and account notification emails"
-      </p>
+      {data.user.EMAIL_SUBSCRIPTION_STATUS === true ? (
+        <p>
+          Need a break?
+          <LinkButton
+            onClick={() =>
+              updateEmailSubscriptionStatus({
+                variables: {
+                  userId,
+                  subscribed: false,
+                },
+              })
+            }
+            text="Unsubscribe"
+          />
+          from all newsletters and account notification emails
+        </p>
+      ) : null}
     </div>
   );
 };

--- a/resources/assets/components/pages/AccountPage/Subscriptions/CancelEmailSubscription.js
+++ b/resources/assets/components/pages/AccountPage/Subscriptions/CancelEmailSubscription.js
@@ -1,0 +1,52 @@
+import React from 'react';
+import gql from 'graphql-tag';
+import { useQuery, useMutation } from '@apollo/react-hooks';
+
+import LinkButton from '.../utilities/Button/LinkButton';
+
+const EMAIL_SUBSCRIPTION_STATUS = gql`
+  query EmailSubscriptionStatus($userId: String!) {
+    user(id: $userId) {
+      id
+      emailSubscriptionStatus
+    }
+  }
+`;
+const EMAIL_SUBSCRIPTION_STATUS_MUTATION = gql`
+  mutation EmailSubscriptionStatus(
+    $userId: String!
+    $emailSubscriptionStatus: Boolean!
+  ) {
+    updateEmailSubscriptionStatus(
+      id: $userId
+      emailSubscriptionStatus: $emailSubscriptionStatus
+    ) {
+      id
+      emailSubscriptionStatus
+    }
+  }
+`;
+const CancelEmailSubscription = () => {
+  const options = { variables: { userId: window.ondurationchange.id } };
+
+  const { data, loading, error } = useQuery(EMAIL_SUBSCRIPTION_STATUS, options);
+  const [updateEmailSubscriptionStatus, { loading: modifying }] = useMutation(
+    EMAIL_SUBSCRIPTION_STATUS_MUTATION,
+    options,
+  );
+
+  if (error) {
+    return <p>Something went wrong!</p>;
+  }
+
+  return (
+    <div>
+      <p>
+        "Need a break? Unsubscribe <LinkButton /> from all newsletters and
+        account notification emails"
+      </p>
+    </div>
+  );
+};
+
+export default CancelEmailSubscription;

--- a/resources/assets/components/pages/AccountPage/Subscriptions/CancelEmailSubscription.js
+++ b/resources/assets/components/pages/AccountPage/Subscriptions/CancelEmailSubscription.js
@@ -1,8 +1,8 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import gql from 'graphql-tag';
 import { useQuery, useMutation } from '@apollo/react-hooks';
 
-import LinkButton from '../../../utilities/Button/LinkButton';
 import Spinner from '../../../artifacts/Spinner/Spinner';
 
 const EMAIL_SUBSCRIPTION_STATUS = gql`
@@ -27,11 +27,12 @@ const EMAIL_SUBSCRIPTION_STATUS_MUTATION = gql`
     }
   }
 `;
-const CancelEmailSubscription = () => {
-  const options = { variables: { userId: window.ondurationchange.id } };
+const CancelEmailSubscription = props => {
+  const userId = props.user.id;
+  const options = { variables: { userId } };
 
   const { data, loading, error } = useQuery(EMAIL_SUBSCRIPTION_STATUS, options);
-  const updateEmailSubscriptionStatus = useMutation(
+  const [updateEmailSubscriptionStatus] = useMutation(
     EMAIL_SUBSCRIPTION_STATUS_MUTATION,
     options,
   );
@@ -45,25 +46,34 @@ const CancelEmailSubscription = () => {
   }
   return (
     <div>
-      {data.user.EMAIL_SUBSCRIPTION_STATUS === true ? (
+      {data.user.emailSubscriptionStatus ? (
         <p>
           Need a break?
-          <LinkButton
+          <button
+            className="px-1 text-blue-500 pb-4"
+            type="button"
             onClick={() =>
               updateEmailSubscriptionStatus({
                 variables: {
                   userId,
-                  subscribed: false,
+                  emailSubscriptionStatus: false,
                 },
               })
             }
-            text="Unsubscribe"
-          />
-          from all newsletters and account notification emails
+          >
+            Unsubscribe
+          </button>
+          from all newsletters and account notification emails.
         </p>
       ) : null}
     </div>
   );
+};
+
+CancelEmailSubscription.propTypes = {
+  user: PropTypes.shape({
+    id: PropTypes.string,
+  }).isRequired,
 };
 
 export default CancelEmailSubscription;

--- a/resources/assets/components/pages/AccountPage/Subscriptions/CancelEmailSubscription.js
+++ b/resources/assets/components/pages/AccountPage/Subscriptions/CancelEmailSubscription.js
@@ -44,6 +44,7 @@ const CancelEmailSubscription = props => {
   if (loading) {
     return <Spinner />;
   }
+
   return (
     <div>
       {data.user.emailSubscriptionStatus ? (
@@ -55,7 +56,6 @@ const CancelEmailSubscription = props => {
             onClick={() =>
               updateEmailSubscriptionStatus({
                 variables: {
-                  userId,
                   emailSubscriptionStatus: false,
                 },
                 refetchQueries: ['EmailSubscriptionsQuery'],

--- a/resources/assets/components/pages/AccountPage/Subscriptions/CancelEmailSubscription.js
+++ b/resources/assets/components/pages/AccountPage/Subscriptions/CancelEmailSubscription.js
@@ -30,7 +30,7 @@ const CancelEmailSubscription = () => {
   const options = { variables: { userId: window.ondurationchange.id } };
 
   const { data, loading, error } = useQuery(EMAIL_SUBSCRIPTION_STATUS, options);
-  const [updateEmailSubscriptionStatus, { loading: modifying }] = useMutation(
+  const updateEmailSubscriptionStatus = useMutation(
     EMAIL_SUBSCRIPTION_STATUS_MUTATION,
     options,
   );
@@ -42,8 +42,22 @@ const CancelEmailSubscription = () => {
   return (
     <div>
       <p>
-        "Need a break? Unsubscribe <LinkButton /> from all newsletters and
-        account notification emails"
+        "Need a break?
+        <LinkButton
+          attributes={attributes}
+          className={classes}
+          href=""
+          onClick={() =>
+            updateEmailSubscriptionStatus({
+              variables: {
+                userId,
+                subscribed: false,
+              },
+            })
+          }
+          text="Unsubscribe"
+        />
+        from all newsletters and account notification emails"
       </p>
     </div>
   );

--- a/resources/assets/components/pages/AccountPage/Subscriptions/CancelEmailSubscription.js
+++ b/resources/assets/components/pages/AccountPage/Subscriptions/CancelEmailSubscription.js
@@ -42,7 +42,7 @@ const CancelEmailSubscription = props => {
   }
 
   if (loading) {
-    return Spinner;
+    return <Spinner />;
   }
   return (
     <div>
@@ -58,6 +58,7 @@ const CancelEmailSubscription = props => {
                   userId,
                   emailSubscriptionStatus: false,
                 },
+                refetchQueries: ['EmailSubscriptionsQuery'],
               })
             }
           >

--- a/resources/assets/components/pages/AccountPage/Subscriptions/EmailSubscriptionItem.js
+++ b/resources/assets/components/pages/AccountPage/Subscriptions/EmailSubscriptionItem.js
@@ -85,6 +85,7 @@ const EmailSubscriptionItem = ({
                   variables: {
                     topic,
                     subscribed: !topics.includes(topic),
+                    refetchQueries: ['EmailSubscriptionStatus'],
                   },
                 })
               }

--- a/resources/assets/components/pages/AccountPage/Subscriptions/Subscriptions.js
+++ b/resources/assets/components/pages/AccountPage/Subscriptions/Subscriptions.js
@@ -13,7 +13,9 @@ const Subscriptions = props => (
     </p>
 
     <EmailSubscriptions {...props} />
-    <CancelEmailSubscription userId={props.user.userId} />
+    <div>
+      <CancelEmailSubscription {...props} />
+    </div>
   </div>
 );
 

--- a/resources/assets/components/pages/AccountPage/Subscriptions/Subscriptions.js
+++ b/resources/assets/components/pages/AccountPage/Subscriptions/Subscriptions.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import EmailSubscriptions from './EmailSubscriptions';
+import CancelEmailSubscription from './CancelEmailSubscription';
 
 const Subscriptions = props => (
   <div className="grid-wide">
@@ -12,6 +13,7 @@ const Subscriptions = props => (
     </p>
 
     <EmailSubscriptions {...props} />
+    <CancelEmailSubscription userId={props.user.userId} />
   </div>
 );
 


### PR DESCRIPTION
### What's this PR do?

This pull request sets up the interface for a user to globally unsubscribe from all emails and notifications 

### How should this be reviewed?
This is a draft but some questions as I am working on this:
How's the naming of the component? Does everything make logical sense? 

### Any background context you want to provide?

This is part 2 of the gql work done for global unsubscribe [here](https://github.com/DoSomething/graphql/pull/225) 

**Update**
I also added a custom getter method in northstar [here](https://github.com/DoSomething/northstar/pull/1029)(suggested by @mendelB 🙌🏽) to fix a bug that triggers when the unsubscribe link is clicked by the user. With both of these changes, a user should now be able to re-subscribe after unsubscribing without issue.

### Relevant tickets

References [Pivotal #172444740](https://www.pivotaltracker.com/story/show/172444740).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added screenshots of front-end changes on small, medium, and large screens.
- [ ] Added appropriate feature/unit tests.
