### PR TITLE
Extract VR Referrals Gallery to Utility component

### DIFF
--- a/resources/assets/components/blocks/VoterRegistrationReferralsBlock/VoterRegistrationReferralsBlock.js
+++ b/resources/assets/components/blocks/VoterRegistrationReferralsBlock/VoterRegistrationReferralsBlock.js
@@ -8,7 +8,7 @@ import { getUserId } from '../../../helpers/auth';
 import EmptyRegistrationImage from './empty-registration.svg';
 import CompletedRegistrationImage from './completed-registration.svg';
 import SectionHeader from '../../utilities/SectionHeader/SectionHeader';
-import VoterRegistrationReferralsList from './VoterRegistrationReferralsList';
+import ReferralsList from '../../utilities/ReferralsGallery/ReferralsList';
 
 export const VoterRegistrationReferralsBlockFragment = gql`
   fragment VoterRegistrationReferralsBlockFragment on VoterRegistrationReferralsBlock {
@@ -58,7 +58,7 @@ const VoterRegistrationReferralsBlock = ({ title }) => (
               </div>
             )}
             <div className="md:flex">
-              <VoterRegistrationReferralsList
+              <ReferralsList
                 referralPosts={data.posts}
                 referralIcon={CompletedRegistrationImage}
                 placeholderIcon={EmptyRegistrationImage}

--- a/resources/assets/components/blocks/VoterRegistrationReferralsBlock/VoterRegistrationReferralsBlock.js
+++ b/resources/assets/components/blocks/VoterRegistrationReferralsBlock/VoterRegistrationReferralsBlock.js
@@ -59,7 +59,7 @@ const VoterRegistrationReferralsBlock = ({ title }) => (
             )}
 
             <ReferralsGallery
-              referralPosts={data.posts}
+              referrals={data.posts.map(post => post.user)}
               referralIcon={CompletedRegistrationImage}
               placeholderIcon={EmptyRegistrationImage}
             />

--- a/resources/assets/components/blocks/VoterRegistrationReferralsBlock/VoterRegistrationReferralsBlock.js
+++ b/resources/assets/components/blocks/VoterRegistrationReferralsBlock/VoterRegistrationReferralsBlock.js
@@ -8,7 +8,7 @@ import { getUserId } from '../../../helpers/auth';
 import EmptyRegistrationImage from './empty-registration.svg';
 import CompletedRegistrationImage from './completed-registration.svg';
 import SectionHeader from '../../utilities/SectionHeader/SectionHeader';
-import ReferralsList from '../../utilities/ReferralsGallery/ReferralsList';
+import ReferralsGallery from '../../utilities/ReferralsGallery/ReferralsGallery';
 
 export const VoterRegistrationReferralsBlockFragment = gql`
   fragment VoterRegistrationReferralsBlockFragment on VoterRegistrationReferralsBlock {
@@ -57,21 +57,12 @@ const VoterRegistrationReferralsBlock = ({ title }) => (
                 get started!
               </div>
             )}
-            <div className="md:flex">
-              <ReferralsList
-                referralPosts={data.posts}
-                referralIcon={CompletedRegistrationImage}
-                placeholderIcon={EmptyRegistrationImage}
-              />
-              {numberOfReferrals > 3 ? (
-                <div
-                  data-testid="additional-referrals-count"
-                  className="text-center md:text-left pt-8 md:pt-16 font-bold uppercase text-gray-600"
-                >
-                  {`+ ${numberOfReferrals - 3} more`}
-                </div>
-              ) : null}
-            </div>
+
+            <ReferralsGallery
+              referralPosts={data.posts}
+              referralIcon={CompletedRegistrationImage}
+              placeholderIcon={EmptyRegistrationImage}
+            />
           </>
         );
       }}

--- a/resources/assets/components/utilities/ReferralsGallery/ReferralsGallery.js
+++ b/resources/assets/components/utilities/ReferralsGallery/ReferralsGallery.js
@@ -1,0 +1,36 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import ReferralsList from './ReferralsList';
+
+const ReferralsGallery = ({ referralPosts, placeholderIcon, referralIcon }) => (
+  <div className="md:flex" data-testid="referrals-gallery">
+    <ReferralsList
+      referralPosts={referralPosts}
+      referralIcon={referralIcon}
+      placeholderIcon={placeholderIcon}
+    />
+    {referralPosts.length > 3 ? (
+      <div
+        data-testid="additional-referrals-count"
+        className="text-center md:text-left pt-8 md:pt-16 font-bold uppercase text-gray-600"
+      >
+        {`+ ${referralPosts.length - 3} more`}
+      </div>
+    ) : null}
+  </div>
+);
+
+ReferralsGallery.propTypes = {
+  referralPosts: PropTypes.arrayOf(
+    PropTypes.shape({
+      user: PropTypes.shape({
+        displayName: PropTypes.string.isRequired,
+      }).isRequired,
+    }),
+  ).isRequired,
+  placeholderIcon: PropTypes.string.isRequired,
+  referralIcon: PropTypes.string.isRequired,
+};
+
+export default ReferralsGallery;

--- a/resources/assets/components/utilities/ReferralsGallery/ReferralsGallery.js
+++ b/resources/assets/components/utilities/ReferralsGallery/ReferralsGallery.js
@@ -3,31 +3,27 @@ import PropTypes from 'prop-types';
 
 import ReferralsList from './ReferralsList';
 
-const ReferralsGallery = ({ referralPosts, placeholderIcon, referralIcon }) => (
+const ReferralsGallery = ({ referrals, placeholderIcon, referralIcon }) => (
   <div className="md:flex" data-testid="referrals-gallery">
     <ReferralsList
-      referralPosts={referralPosts}
+      referrals={referrals}
       referralIcon={referralIcon}
       placeholderIcon={placeholderIcon}
     />
-    {referralPosts.length > 3 ? (
+    {referrals.length > 3 ? (
       <div
         data-testid="additional-referrals-count"
         className="text-center md:text-left pt-8 md:pt-16 font-bold uppercase text-gray-600"
       >
-        {`+ ${referralPosts.length - 3} more`}
+        {`+ ${referrals.length - 3} more`}
       </div>
     ) : null}
   </div>
 );
 
 ReferralsGallery.propTypes = {
-  referralPosts: PropTypes.arrayOf(
-    PropTypes.shape({
-      user: PropTypes.shape({
-        displayName: PropTypes.string.isRequired,
-      }).isRequired,
-    }),
+  referrals: PropTypes.arrayOf(
+    PropTypes.shape({ displayName: PropTypes.string.isRequired }),
   ).isRequired,
   placeholderIcon: PropTypes.string.isRequired,
   referralIcon: PropTypes.string.isRequired,

--- a/resources/assets/components/utilities/ReferralsGallery/ReferralsGallery.test.js
+++ b/resources/assets/components/utilities/ReferralsGallery/ReferralsGallery.test.js
@@ -1,0 +1,83 @@
+import faker from 'faker';
+import { render, screen, within } from '@testing-library/react';
+
+import ReferralsGallery from './ReferralsGallery';
+
+const renderReferralsGallery = posts =>
+  render(
+    <ReferralsGallery
+      referralPosts={posts}
+      placeholderIcon={faker.image.dataUri()}
+      referralIcon={faker.image.dataUri()}
+    />,
+  );
+
+describe('ReferralGallery component', () => {
+  /** @test */
+  it('Displays three empty icons if there are no referrals', async () => {
+    renderReferralsGallery([]);
+
+    expect(screen.getAllByTestId('referral-list-item-empty')).toHaveLength(3);
+    expect(screen.queryByTestId('referral-list-item-completed')).toBeNull();
+    expect(screen.queryByTestId('additional-referrals-count')).toBeNull();
+  });
+
+  /** @test */
+  it('Displays 2 completed icons there are 2 referrals', () => {
+    renderReferralsGallery([
+      { user: { displayName: 'Jesus Q.' } },
+      { user: { displayName: 'Walter S.' } },
+    ]);
+
+    const referralItems = screen.getAllByTestId('referral-list-item-completed');
+
+    expect(referralItems).toHaveLength(2);
+
+    expect(
+      within(referralItems[0]).getByTestId('referral-list-item-label')
+        .textContent,
+    ).toBe('Jesus Q.');
+
+    expect(
+      within(referralItems[1]).getByTestId('referral-list-item-label')
+        .textContent,
+    ).toBe('Walter S.');
+
+    expect(screen.getAllByTestId('referral-list-item-empty')).toHaveLength(1);
+    expect(screen.queryByTestId('additional-referrals-count')).toBeNull();
+  });
+
+  /** @test */
+  it('Displays 3 completed icons and additional count if user has 5 referrals', () => {
+    renderReferralsGallery([
+      { user: { displayName: 'Sarah C.' } },
+      { user: { displayName: 'Kyle R.' } },
+      { user: { displayName: 'John C.' } },
+      { user: { displayName: 'Miles D.' } },
+      { user: { displayName: 'Tarissa D.' } },
+    ]);
+
+    const referralItems = screen.getAllByTestId('referral-list-item-completed');
+    expect(referralItems).toHaveLength(3);
+
+    expect(
+      within(referralItems[0]).getByTestId('referral-list-item-label')
+        .textContent,
+    ).toBe('Sarah C.');
+
+    expect(
+      within(referralItems[1]).getByTestId('referral-list-item-label')
+        .textContent,
+    ).toBe('Kyle R.');
+
+    expect(
+      within(referralItems[2]).getByTestId('referral-list-item-label')
+        .textContent,
+    ).toBe('John C.');
+
+    expect(screen.queryByTestId('referral-list-item-empty')).toBeNull();
+    expect(screen.getByTestId('additional-referrals-count').textContent).toBe(
+      '+ 2 more',
+    );
+  });
+});

--- a/resources/assets/components/utilities/ReferralsGallery/ReferralsGallery.test.js
+++ b/resources/assets/components/utilities/ReferralsGallery/ReferralsGallery.test.js
@@ -1,4 +1,5 @@
 import faker from 'faker';
+import React from 'react';
 import { render, screen, within } from '@testing-library/react';
 
 import ReferralsGallery from './ReferralsGallery';

--- a/resources/assets/components/utilities/ReferralsGallery/ReferralsGallery.test.js
+++ b/resources/assets/components/utilities/ReferralsGallery/ReferralsGallery.test.js
@@ -3,10 +3,10 @@ import { render, screen, within } from '@testing-library/react';
 
 import ReferralsGallery from './ReferralsGallery';
 
-const renderReferralsGallery = posts =>
+const renderReferralsGallery = referrals =>
   render(
     <ReferralsGallery
-      referralPosts={posts}
+      referrals={referrals}
       placeholderIcon={faker.image.dataUri()}
       referralIcon={faker.image.dataUri()}
     />,
@@ -25,8 +25,8 @@ describe('ReferralGallery component', () => {
   /** @test */
   it('Displays 2 completed icons there are 2 referrals', () => {
     renderReferralsGallery([
-      { user: { displayName: 'Jesus Q.' } },
-      { user: { displayName: 'Walter S.' } },
+      { displayName: 'Jesus Q.' },
+      { displayName: 'Walter S.' },
     ]);
 
     const referralItems = screen.getAllByTestId('referral-list-item-completed');
@@ -50,11 +50,11 @@ describe('ReferralGallery component', () => {
   /** @test */
   it('Displays 3 completed icons and additional count if user has 5 referrals', () => {
     renderReferralsGallery([
-      { user: { displayName: 'Sarah C.' } },
-      { user: { displayName: 'Kyle R.' } },
-      { user: { displayName: 'John C.' } },
-      { user: { displayName: 'Miles D.' } },
-      { user: { displayName: 'Tarissa D.' } },
+      { displayName: 'Sarah C.' },
+      { displayName: 'Kyle R.' },
+      { displayName: 'John C.' },
+      { displayName: 'Miles D.' },
+      { displayName: 'Tarissa D.' },
     ]);
 
     const referralItems = screen.getAllByTestId('referral-list-item-completed');

--- a/resources/assets/components/utilities/ReferralsGallery/ReferralsList.js
+++ b/resources/assets/components/utilities/ReferralsGallery/ReferralsList.js
@@ -2,9 +2,9 @@ import React from 'react';
 import { get } from 'lodash';
 import PropTypes from 'prop-types';
 
-import VoterRegistrationReferralsListItem from './VoterRegistrationReferralsListItem';
+import ReferralsListItem from './ReferralsListItem';
 
-const VoterRegistrationReferralsList = props => {
+const ReferralsList = props => {
   const items = [];
 
   /**
@@ -14,7 +14,7 @@ const VoterRegistrationReferralsList = props => {
   for (let i = 0; i < 3; i += 1) {
     items.push(
       <li key={i} className="md:pr-6">
-        <VoterRegistrationReferralsListItem
+        <ReferralsListItem
           label={get(props.referralPosts[i], 'user.displayName')}
           referralIcon={props.referralIcon}
           placeholderIcon={props.placeholderIcon}
@@ -26,10 +26,10 @@ const VoterRegistrationReferralsList = props => {
   return <ul className="flex justify-around">{items}</ul>;
 };
 
-VoterRegistrationReferralsList.propTypes = {
+ReferralsList.propTypes = {
   placeholderIcon: PropTypes.string.isRequired,
   referralIcon: PropTypes.string.isRequired,
   referralPosts: PropTypes.arrayOf(PropTypes.object).isRequired,
 };
 
-export default VoterRegistrationReferralsList;
+export default ReferralsList;

--- a/resources/assets/components/utilities/ReferralsGallery/ReferralsList.js
+++ b/resources/assets/components/utilities/ReferralsGallery/ReferralsList.js
@@ -15,7 +15,7 @@ const ReferralsList = props => {
     items.push(
       <li key={i} className="md:pr-6">
         <ReferralsListItem
-          label={get(props.referralPosts[i], 'user.displayName')}
+          label={get(props.referrals[i], 'displayName')}
           referralIcon={props.referralIcon}
           placeholderIcon={props.placeholderIcon}
         />
@@ -29,7 +29,7 @@ const ReferralsList = props => {
 ReferralsList.propTypes = {
   placeholderIcon: PropTypes.string.isRequired,
   referralIcon: PropTypes.string.isRequired,
-  referralPosts: PropTypes.arrayOf(PropTypes.object).isRequired,
+  referrals: PropTypes.arrayOf(PropTypes.object).isRequired,
 };
 
 export default ReferralsList;

--- a/resources/assets/components/utilities/ReferralsGallery/ReferralsListItem.js
+++ b/resources/assets/components/utilities/ReferralsGallery/ReferralsListItem.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-const VoterRegistrationReferralsListItem = props => {
+const ReferralsListItem = props => {
   const { label, placeholderIcon, referralIcon } = props;
   const isEmpty = label === '???';
 
@@ -25,14 +25,14 @@ const VoterRegistrationReferralsListItem = props => {
   );
 };
 
-VoterRegistrationReferralsListItem.propTypes = {
+ReferralsListItem.propTypes = {
   label: PropTypes.string,
   placeholderIcon: PropTypes.string.isRequired,
   referralIcon: PropTypes.string.isRequired,
 };
 
-VoterRegistrationReferralsListItem.defaultProps = {
+ReferralsListItem.defaultProps = {
   label: '???',
 };
 
-export default VoterRegistrationReferralsListItem;
+export default ReferralsListItem;


### PR DESCRIPTION
### What's this PR do?

This pull request - on the heels of #2196 & #2198  - extracts the VR Referrals gallery markup & utility components into a general `ReferralsGallery` utility component.

The big change is that we now expect `referrals` (a list of users) instead of `posts` with nested users. This ensures this can work with posts _or_ signups (RAF will be tracking signup referrals).

It also adds the tests we have implemented in the Cypress `voter-registration-referrals-block.js` suite in a local React Testing Library file (so that we'll have coverage for the RAF implementation as well... I wasn't particularly sure this was explicitly needed, but it felt a bit more central now that it's a general utility).

### How should this be reviewed?
👀  Not much craziness here


### Any background context you want to provide?
We'll be using this utility for the RAF referrals gallery!

### Relevant tickets

References [Pivotal #172748788](https://www.pivotaltracker.com/story/show/172748788).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints. - _I'll try and throw some documentation for this new utility in a follow-up_
- [x] Added appropriate feature/unit tests.
