### PR TITLE
Don't include "phoenix" in event name twice

### DIFF
--- a/resources/assets/components/actions/PhotoSubmissionAction/PhotoSubmissionAction.js
+++ b/resources/assets/components/actions/PhotoSubmissionAction/PhotoSubmissionAction.js
@@ -319,7 +319,7 @@ class PhotoSubmissionAction extends PostForm {
                   href={this.props.authRegisterUrl}
                   text="Add Photo"
                   onClick={() =>
-                    trackAnalyticsEvent('phoenix_clicked_button_log_in', {
+                    trackAnalyticsEvent('clicked_button_log_in', {
                       action: 'button_clicked',
                       category: EVENT_CATEGORIES.authentication,
                       label: 'block_auth',


### PR DESCRIPTION
### What's this PR do?

This pull request fixes https://github.com/DoSomething/phoenix-next/pull/2199! We don't need to include `phoenix_` in the event name because that automatically gets prepended to the event name, so it was getting duplicated!

### How should this be reviewed?

Does this look right?
<img width="516" alt="Pasted Image at 2020_06_04_15_06 pm" src="https://user-images.githubusercontent.com/4240292/83815860-faf58400-a675-11ea-8f37-d4da277686af.png">


### Any background context you want to provide?

Nope!

### Relevant tickets

References [Pivotal #172384668](https://www.pivotaltracker.com/story/show/172384668).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added screenshots of front-end changes on small, medium, and large screens.
- [ ] Added appropriate feature/unit tests.
