### PR TITLE
Wider Grid Span on Account RAF Signups Gallery

### DIFF
--- a/resources/assets/components/pages/AccountPage/ReferFriends/ReferFriendsTab.js
+++ b/resources/assets/components/pages/AccountPage/ReferFriends/ReferFriendsTab.js
@@ -5,20 +5,26 @@ import SectionHeader from '../../../utilities/SectionHeader/SectionHeader';
 import SocialDriveActionContainer from '../../../actions/SocialDriveAction/SocialDriveActionContainer';
 
 const ReferFriendsTab = () => (
-  <div className="col-span-4 md:col-span-8 lg:col-start-2 lg:col-span-7 xxl:col-start-2 xxl:col-span-6">
-    {/* @TODO Update all reward related copy once we have the updates from product. */}
-    <SectionHeader underlined title="Enter to Win A $10 Gift Card" />
+  <>
+    <div className="col-span-4 md:col-span-8 lg:col-start-2 lg:col-span-7 xxl:col-start-2 xxl:col-span-6">
+      {/* @TODO Update all reward related copy once we have the updates from product. */}
+      <SectionHeader underlined title="Enter to Win A $10 Gift Card" />
 
-    <SocialDriveActionContainer
-      shareCardTitle="Refer a friend"
-      shareCardDescription="When your friend signs up for their first DoSomething campaign, you’ll both enter to win a $10 gift card! Every 2 weeks, there will be 25 winners. The more friends you refer, the more chances you have to win. (Psst...there’s no limit on how many you can refer!)"
-      /* @TODO use refer-friends link generator helper once we establish a default campaign in https://bit.ly/3c9L7nT */
-      link="https://dosomething.org/us/campaigns/senior-homies"
-      fullWidth
-    />
+      <SocialDriveActionContainer
+        shareCardTitle="Refer a friend"
+        shareCardDescription="When your friend signs up for their first DoSomething campaign, you’ll both enter to win a $10 gift card! Every 2 weeks, there will be 25 winners. The more friends you refer, the more chances you have to win. (Psst...there’s no limit on how many you can refer!)"
+        /* @TODO use refer-friends link generator helper once we establish a default campaign in https://bit.ly/3c9L7nT */
+        link="https://dosomething.org/us/campaigns/senior-homies"
+        fullWidth
+      />
 
-    <SignupReferralsGallery />
-  </div>
+      <SignupReferralsGallery />
+    </div>
+
+    <div className="col-span-4 md:col-span-8 lg:col-start-2 lg:col-span-11 xxl:col-start-2 xxl:col-span-10">
+      <SignupReferralsGallery />
+    </div>
+  </>
 );
 
 export default ReferFriendsTab;


### PR DESCRIPTION
### What's this PR do?

This pull request is a quick follow up to #2205 & #2204 to allow the RAF signups gallery on the account RAF tab to span across the wider grid per [the designs](https://app.abstract.com/projects/fadf0790-f1f9-11e6-9a30-b54ba7e8e705/branches/0202c111-a203-4c78-aa62-6ba16905afbc/commits/438f77bd2783a573c4329b92c23d5819f9a6a826/files/05f5faae-3c13-4947-b624-f9e0ea97822c/layers/D4E08BCE-D4F3-4959-BDB7-5ECD13125D9C?collectionId=507c3689-9b8b-4af5-b698-d5c2112c07f6&collectionLayerId=c1ac3608-6da5-4269-bc5e-ae58229f4b55). 

### How should this be reviewed?
I mistakenly left this change out of #2205 but the screenshots there reflect this styling. 

The grid for the Social Share Action might end up having the same span in a future update, once we add the info bar.

I think we're making progress towards being able to abstract some Grid utility components, but I _think_ it might be wiser to wait for some more implementation of Tailwind grids & [Pivotal #172820107](https://www.pivotaltracker.com/story/show/172820107).

https://user-images.githubusercontent.com/12417657/84167132-d74e8700-aa43-11ea-87dc-af9926ff8742.gif

### Relevant tickets

References [Pivotal #172748788](https://www.pivotaltracker.com/story/show/172748788).
