### PR TITLE
Referrals Gallery Update - referrals Prop to referralLabels

### DIFF
--- a/resources/assets/components/blocks/VoterRegistrationReferralsBlock/VoterRegistrationReferralsBlock.js
+++ b/resources/assets/components/blocks/VoterRegistrationReferralsBlock/VoterRegistrationReferralsBlock.js
@@ -59,7 +59,9 @@ const VoterRegistrationReferralsBlock = ({ title }) => (
             )}
 
             <ReferralsGallery
-              referrals={data.posts.map(post => post.user)}
+              referralLabels={data.posts.map(
+                referral => referral.user.displayName,
+              )}
               referralIcon={CompletedRegistrationImage}
               placeholderIcon={EmptyRegistrationImage}
             />

--- a/resources/assets/components/pages/AccountPage/ReferFriends/ReferFriendsTab.js
+++ b/resources/assets/components/pages/AccountPage/ReferFriends/ReferFriendsTab.js
@@ -17,8 +17,6 @@ const ReferFriendsTab = () => (
         link="https://dosomething.org/us/campaigns/senior-homies"
         fullWidth
       />
-
-      <SignupReferralsGallery />
     </div>
 
     <div className="col-span-4 md:col-span-8 lg:col-start-2 lg:col-span-11 xxl:col-start-2 xxl:col-span-10">

--- a/resources/assets/components/pages/AccountPage/ReferFriends/SignupReferralsGallery.js
+++ b/resources/assets/components/pages/AccountPage/ReferFriends/SignupReferralsGallery.js
@@ -45,7 +45,9 @@ const SignupReferralsGallery = () => (
             <ReferralsGallery
               referralIcon={CompletedReferralIcon}
               placeholderIcon={EmptyReferralIcon}
-              referrals={data.signups.map(signup => signup.user)}
+              referralLabels={data.signups.map(
+                signup => signup.user.displayName,
+              )}
             />
           </>
         );

--- a/resources/assets/components/utilities/ReferralsGallery/ReferralsGallery.js
+++ b/resources/assets/components/utilities/ReferralsGallery/ReferralsGallery.js
@@ -4,7 +4,11 @@ import React, { useState } from 'react';
 
 import ReferralsList from './ReferralsList';
 
-const ReferralsGallery = ({ referrals, placeholderIcon, referralIcon }) => {
+const ReferralsGallery = ({
+  referralLabels,
+  placeholderIcon,
+  referralIcon,
+}) => {
   const [isExpanded, setIsExpanded] = useState(false);
 
   return (
@@ -14,11 +18,11 @@ const ReferralsGallery = ({ referrals, placeholderIcon, referralIcon }) => {
     >
       <ReferralsList
         expanded={isExpanded}
-        referrals={referrals}
+        referralLabels={referralLabels}
         referralIcon={referralIcon}
         placeholderIcon={placeholderIcon}
       />
-      {referrals.length > 3 ? (
+      {referralLabels.length > 3 ? (
         <div
           className={classNames('text-center pt-6', {
             'md:pl-6 md:self-center md:pt-0': !isExpanded,
@@ -30,7 +34,9 @@ const ReferralsGallery = ({ referrals, placeholderIcon, referralIcon }) => {
             className="font-bold uppercase text-blurple-500 underline"
             onClick={() => setIsExpanded(!isExpanded)}
           >
-            {!isExpanded ? `+ ${referrals.length - 3} more` : '- show less'}
+            {!isExpanded
+              ? `+ ${referralLabels.length - 3} more`
+              : '- show less'}
           </button>
         </div>
       ) : null}
@@ -39,9 +45,7 @@ const ReferralsGallery = ({ referrals, placeholderIcon, referralIcon }) => {
 };
 
 ReferralsGallery.propTypes = {
-  referrals: PropTypes.arrayOf(
-    PropTypes.shape({ displayName: PropTypes.string.isRequired }),
-  ).isRequired,
+  referralLabels: PropTypes.arrayOf(PropTypes.string).isRequired,
   placeholderIcon: PropTypes.string.isRequired,
   referralIcon: PropTypes.string.isRequired,
 };

--- a/resources/assets/components/utilities/ReferralsGallery/ReferralsGallery.test.js
+++ b/resources/assets/components/utilities/ReferralsGallery/ReferralsGallery.test.js
@@ -4,10 +4,10 @@ import { fireEvent, render, screen, within } from '@testing-library/react';
 
 import ReferralsGallery from './ReferralsGallery';
 
-const renderReferralsGallery = referrals =>
+const renderReferralsGallery = referralLabels =>
   render(
     <ReferralsGallery
-      referrals={referrals}
+      referralLabels={referralLabels}
       placeholderIcon={faker.image.dataUri()}
       referralIcon={faker.image.dataUri()}
     />,
@@ -25,10 +25,7 @@ describe('ReferralGallery component', () => {
 
   /** @test */
   it('Displays 2 completed icons there are 2 referrals', () => {
-    renderReferralsGallery([
-      { displayName: 'Jesus Q.' },
-      { displayName: 'Walter S.' },
-    ]);
+    renderReferralsGallery(['Jesus Q.', 'Walter S.']);
 
     const referralItems = screen.getAllByTestId('referral-list-item-completed');
 
@@ -51,11 +48,11 @@ describe('ReferralGallery component', () => {
   /** @test */
   it('Displays 3 completed icons and additional count if user has 5 referrals', () => {
     renderReferralsGallery([
-      { displayName: 'Sarah C.' },
-      { displayName: 'Kyle R.' },
-      { displayName: 'John C.' },
-      { displayName: 'Miles D.' },
-      { displayName: 'Tarissa D.' },
+      'Sarah C.',
+      'Kyle R.',
+      'John C.',
+      'Miles D.',
+      'Tarissa D.',
     ]);
 
     const referralItems = screen.getAllByTestId('referral-list-item-completed');
@@ -85,11 +82,11 @@ describe('ReferralGallery component', () => {
   /** @test */
   it('Expands/collapses the gallery when the additional count link is clicked', () => {
     renderReferralsGallery([
-      { displayName: 'Sarah C.' },
-      { displayName: 'Kyle R.' },
-      { displayName: 'John C.' },
-      { displayName: 'Miles D.' },
-      { displayName: 'Tarissa D.' },
+      'Sarah C.',
+      'Kyle R.',
+      'John C.',
+      'Miles D.',
+      'Tarissa D.',
     ]);
 
     fireEvent.click(screen.getByTestId('additional-referrals-count'));

--- a/resources/assets/components/utilities/ReferralsGallery/ReferralsList.js
+++ b/resources/assets/components/utilities/ReferralsGallery/ReferralsList.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import { get } from 'lodash';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
@@ -9,7 +8,7 @@ const ReferralsList = ({
   expanded,
   placeholderIcon,
   referralIcon,
-  referrals,
+  referralLabels,
 }) => {
   const items = [];
 
@@ -19,11 +18,11 @@ const ReferralsList = ({
    *
    * If the gallery is expanded - which implies that we have more than three referrals - we'll simply display them all.
    */
-  for (let i = 0; i < (expanded ? referrals.length : 3); i += 1) {
+  for (let i = 0; i < (expanded ? referralLabels.length : 3); i += 1) {
     items.push(
       <li key={i} className={classNames({ 'md:w-40': !expanded })}>
         <ReferralsListItem
-          label={get(referrals[i], 'displayName')}
+          label={referralLabels[i]}
           referralIcon={referralIcon}
           placeholderIcon={placeholderIcon}
         />
@@ -46,7 +45,7 @@ ReferralsList.propTypes = {
   expanded: PropTypes.bool,
   placeholderIcon: PropTypes.string.isRequired,
   referralIcon: PropTypes.string.isRequired,
-  referrals: PropTypes.arrayOf(PropTypes.object).isRequired,
+  referralLabels: PropTypes.arrayOf(PropTypes.string).isRequired,
 };
 
 ReferralsList.defaultProps = {


### PR DESCRIPTION
### What's this PR do?

This pull request updates the `ReferralsGallery` `referrals` prop to be `referralLabels` -- from a list of user objects containing a `displayName` (which makes assumptions about the data source), to an agnostic list of label Strings. 

https://github.com/DoSomething/phoenix-next/pull/2207/commits/4d64de0ddb1681661a8e7fdc43ae4260728b55c1 addresses a phantom Signup Referrals Gallery that got left in via merge conflict resolution in #2205 

### How should this be reviewed?
👀 No visual changes!

### Any background context you want to provide?
This addresses feedback in https://github.com/DoSomething/phoenix-next/pull/2202#discussion_r436056696


### Relevant tickets

References [Pivotal #172748788](https://www.pivotaltracker.com/story/show/172748788).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [x] Added appropriate feature/unit tests.
