### PR TITLE
Bug Fix - Empty Icons on Voter Registration Referrals Gallery not expanding

### DIFF
--- a/resources/assets/components/blocks/VoterRegistrationReferralsBlock/empty-registration.svg
+++ b/resources/assets/components/blocks/VoterRegistrationReferralsBlock/empty-registration.svg
@@ -1,1 +1,3 @@
-<svg width="150" height="150" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><defs><circle id="a" cx="75" cy="75" r="75"/></defs><use fill="#CBD5E0" xlink:href="#a" fill-rule="evenodd"/></svg>
+<svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+  <circle cx="50" cy="50" r="50" fill="#CBD5E0" />
+</svg>


### PR DESCRIPTION
### What's this PR do?

This pull request fixes a visual bug flagged by @aaronschachter wherein at certain viewports whence the referral icons should implicitly expand responsively to fill their respective grid columns, the empty icon would not causing some visual funkiness:

![image](https://user-images.githubusercontent.com/12417657/84198676-e3e9d400-aa71-11ea-8981-fbba48ac428b.png)


This seems to be because the SVG is encoded with a static height & width.

We update to implement the classic SVG `circle` from our friends at [Mozilla](https://developer.mozilla.org/en-US/docs/Web/SVG/Element/circle), and it expands handsomely!

![Kapture 2020-06-09 at 16 51 53](https://user-images.githubusercontent.com/12417657/84198441-8fdeef80-aa71-11ea-8ff1-817b4f4b89b8.gif)


### How should this be reviewed?
I've never SVG'd before and my math knowledge consists of `Math.max`, so lemme know if anything looks off to you!

### Relevant tickets
[Slack](https://dosomething.slack.com/archives/CUQMU4Q6B/p1591734402066000?thread_ts=1591734016.064700&cid=CUQMU4Q6B)