### PR TITLE
Signup Referrals Gallery Don't Display Duplicate User Referrals

### DIFF
--- a/resources/assets/components/pages/AccountPage/ReferFriends/SignupReferralsGallery.js
+++ b/resources/assets/components/pages/AccountPage/ReferFriends/SignupReferralsGallery.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import gql from 'graphql-tag';
-import pluralize from 'pluralize';
 import { groupBy } from 'lodash';
+import pluralize from 'pluralize';
 
 import Query from '../../../Query';
 import { getUserId } from '../../../../helpers/auth';

--- a/resources/assets/components/pages/AccountPage/ReferFriends/SignupReferralsGallery.js
+++ b/resources/assets/components/pages/AccountPage/ReferFriends/SignupReferralsGallery.js
@@ -9,11 +9,12 @@ import CompletedReferralIcon from './completed-referral.svg';
 import SectionHeader from '../../../utilities/SectionHeader/SectionHeader';
 import ReferralsGallery from '../../../utilities/ReferralsGallery/ReferralsGallery';
 
-const SIGNUP_REFERRALS_QUERY = gql`
+export const SIGNUP_REFERRALS_QUERY = gql`
   query SignupReferrals($referrerUserId: String!) {
     signups(referrerUserId: $referrerUserId) {
       id
       user {
+        id
         displayName
       }
     }

--- a/resources/assets/components/pages/AccountPage/ReferFriends/SignupReferralsGallery.js
+++ b/resources/assets/components/pages/AccountPage/ReferFriends/SignupReferralsGallery.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import gql from 'graphql-tag';
 import pluralize from 'pluralize';
-import groupBy from 'lodash/groupBy';
+import { groupBy } from 'lodash';
 
 import Query from '../../../Query';
 import { getUserId } from '../../../../helpers/auth';

--- a/resources/assets/components/pages/AccountPage/ReferFriends/SignupReferralsGallery.js
+++ b/resources/assets/components/pages/AccountPage/ReferFriends/SignupReferralsGallery.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import gql from 'graphql-tag';
-import { groupBy } from 'lodash';
+import { uniqBy } from 'lodash';
 import pluralize from 'pluralize';
 
 import Query from '../../../Query';
@@ -14,8 +14,8 @@ export const SIGNUP_REFERRALS_QUERY = gql`
   query SignupReferrals($referrerUserId: String!) {
     signups(referrerUserId: $referrerUserId) {
       id
+      userId
       user {
-        id
         displayName
       }
     }
@@ -31,16 +31,9 @@ const SignupReferralsGallery = () => (
       variables={{ referrerUserId: getUserId() }}
     >
       {data => {
-        /**
-         *`We group the signups by User ID to avoid passing duplicate referrals (multiple referral signups
-         * from the same user) to the referrals gallery.
-         */
-        const referralsGroupedByUserId = groupBy(
-          data.signups,
-          signup => signup.user.id,
-        );
-        const referralLabels = Object.values(referralsGroupedByUserId).map(
-          signups => signups[0].user.displayName,
+        // Avoid passing duplicate referrals (multiple referral signups from the same user) to the referrals gallery.
+        const referralLabels = uniqBy(data.signups, 'userId').map(
+          signup => signup.user.displayName,
         );
         const numberOfReferrals = referralLabels.length;
 

--- a/resources/assets/components/pages/AccountPage/ReferFriends/SignupReferralsGallery.js
+++ b/resources/assets/components/pages/AccountPage/ReferFriends/SignupReferralsGallery.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import gql from 'graphql-tag';
 import pluralize from 'pluralize';
+import groupBy from 'lodash/groupBy';
 
 import Query from '../../../Query';
 import { getUserId } from '../../../../helpers/auth';
@@ -30,7 +31,18 @@ const SignupReferralsGallery = () => (
       variables={{ referrerUserId: getUserId() }}
     >
       {data => {
-        const numberOfReferrals = data.signups.length;
+        /**
+         *`We group the signups by User ID to avoid passing duplicate referrals (multiple referral signups
+         * from the same user) to the referrals gallery.
+         */
+        const referralsGroupedByUserId = groupBy(
+          data.signups,
+          signup => signup.user.id,
+        );
+        const referralLabels = Object.values(referralsGroupedByUserId).map(
+          signups => signups[0].user.displayName,
+        );
+        const numberOfReferrals = referralLabels.length;
 
         return (
           <>
@@ -46,9 +58,7 @@ const SignupReferralsGallery = () => (
             <ReferralsGallery
               referralIcon={CompletedReferralIcon}
               placeholderIcon={EmptyReferralIcon}
-              referralLabels={data.signups.map(
-                signup => signup.user.displayName,
-              )}
+              referralLabels={referralLabels}
             />
           </>
         );

--- a/resources/assets/components/pages/AccountPage/ReferFriends/SignupReferralsGallery.test.js
+++ b/resources/assets/components/pages/AccountPage/ReferFriends/SignupReferralsGallery.test.js
@@ -67,6 +67,7 @@ describe('SignupReferralsGallery component', () => {
     );
 
     // This pushes us past the 'first tick' over to when the GraphQL query actually loads.
+    // @TODO: Simplify to use 'waitfor' once jsdom issues are resolved per https://git.io/JfdEd.
     await act(async () => new Promise(resolve => setTimeout(resolve)));
 
     // This user has two referred signups, but we should only see them once in the gallery.

--- a/resources/assets/components/pages/AccountPage/ReferFriends/SignupReferralsGallery.test.js
+++ b/resources/assets/components/pages/AccountPage/ReferFriends/SignupReferralsGallery.test.js
@@ -1,0 +1,76 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import { act } from 'react-dom/test-utils';
+import { MockedProvider } from '@apollo/react-testing';
+import { fireEvent, render, screen, within } from '@testing-library/react';
+
+import SignupReferralsGallery, {
+  SIGNUP_REFERRALS_QUERY,
+} from './SignupReferralsGallery';
+
+const MOCK_USER_ID = '123';
+
+// Mock the user ID we fetch from the window.
+global.AUTH = { id: MOCK_USER_ID };
+
+// Mock the GraphQL query and response.
+const mocks = [
+  {
+    request: {
+      query: SIGNUP_REFERRALS_QUERY,
+      variables: {
+        referrerUserId: MOCK_USER_ID,
+      },
+    },
+    result: {
+      data: {
+        signups: [
+          // There are two signups from the same user.
+          {
+            id: 1100,
+            user: {
+              id: '55767606a59dbf3c7a8b4571',
+              displayName: 'Aaron S.',
+              __typename: 'User',
+            },
+            __typename: 'Signup',
+          },
+          {
+            id: 589,
+            user: {
+              id: '55767606a59dbf3c7a8b4571',
+              displayName: 'Aaron S.',
+              __typename: 'User',
+            },
+            __typename: 'Signup',
+          },
+          {
+            id: 992,
+            user: {
+              id: '5589c991a59dbfa93d8b45ae',
+              displayName: 'Chloe L.',
+              __typename: 'User',
+            },
+            __typename: 'Signup',
+          },
+        ],
+      },
+    },
+  },
+];
+
+describe('SignupReferralsGallery component', () => {
+  test('it passes a unique list of referred users to the Referrals Gallery', async () => {
+    render(
+      <MockedProvider mocks={mocks} addTypename={false}>
+        <SignupReferralsGallery />
+      </MockedProvider>,
+    );
+
+    // This pushes us past the 'first tick' over to when the GraphQL query actually loads.
+    await act(async () => new Promise(resolve => setTimeout(resolve)));
+
+    // This user has two referred signups, but we should only see them once in the gallery.
+    expect(screen.getAllByText('Aaron S.').length).toBe(1);
+  });
+});

--- a/resources/assets/components/pages/AccountPage/ReferFriends/SignupReferralsGallery.test.js
+++ b/resources/assets/components/pages/AccountPage/ReferFriends/SignupReferralsGallery.test.js
@@ -27,8 +27,8 @@ const mocks = [
           // There are two signups from the same user.
           {
             id: 1100,
+            userId: '55767606a59dbf3c7a8b4571',
             user: {
-              id: '55767606a59dbf3c7a8b4571',
               displayName: 'Aaron S.',
               __typename: 'User',
             },
@@ -36,8 +36,8 @@ const mocks = [
           },
           {
             id: 589,
+            userId: '55767606a59dbf3c7a8b4571',
             user: {
-              id: '55767606a59dbf3c7a8b4571',
               displayName: 'Aaron S.',
               __typename: 'User',
             },
@@ -45,8 +45,8 @@ const mocks = [
           },
           {
             id: 992,
+            userId: '5589c991a59dbfa93d8b45ae',
             user: {
-              id: '5589c991a59dbfa93d8b45ae',
               displayName: 'Chloe L.',
               __typename: 'User',
             },

--- a/resources/assets/components/pages/AccountPage/ReferFriends/SignupReferralsGallery.test.js
+++ b/resources/assets/components/pages/AccountPage/ReferFriends/SignupReferralsGallery.test.js
@@ -1,8 +1,7 @@
 import React from 'react';
-import { mount } from 'enzyme';
 import { act } from 'react-dom/test-utils';
 import { MockedProvider } from '@apollo/react-testing';
-import { fireEvent, render, screen, within } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 
 import SignupReferralsGallery, {
   SIGNUP_REFERRALS_QUERY,


### PR DESCRIPTION
### What's this PR do?

This pull request ensures that the `SignupReferralsGallery` 'uniques' the list of referred users to ensure that we don't render the same user twice in the gallery.

### How should this be reviewed?
Does the grouping/uniqueness logic make sense? Is it readable? How's the test?

### Any background context you want to provide?
Hypothetically, a referred user could signup for multiple campaigns via the same referrer. This would cause our request for all the current user's referral signups, to return the same parent referred user _twice_ (which would naively be passed along to the gallery twice).

Instead, we group the signups by their nested `user.id` (the unique identifier of the signup's parent user (multiple users could have the same `displayName`)), and parse out the user per these grouped signups.

Now, as indicated above, this does _not_ preclude referred user's A and B who both have the same "Jen N." `displayName`, which would then indeed appear twice in the gallery.

Could we move this logic into an e.g. `uniqueUserSignupReferrals` GraphQL query? I feel like that _could_ be neat but didn't feel like that was in scope here.

### Relevant tickets

References [Pivotal #172748788](https://www.pivotaltracker.com/story/show/172748788/comments/215135677).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints. _no documentation yet on the new RAF features_
- [ ] Added screenshots of front-end changes on small, medium, and large screens. _no visual changes really, just imagine the duplicate user node disappearing from the gallery 🎊_
- [x] Added appropriate feature/unit tests.
