### PR TITLE
Groups Voter Registration Drive Action - Part 1/2

### DIFF
--- a/cypress/integration/voter-registration-drive-action.js
+++ b/cypress/integration/voter-registration-drive-action.js
@@ -4,6 +4,7 @@ import faker from 'faker';
 
 import { userFactory } from '../fixtures/user';
 import { PHOENIX_URL } from '../../resources/assets/constants';
+import exampleCampaign from '../fixtures/contentful/exampleCampaign';
 
 const blockId = '7un2ZfYO3mrpARy6ZzaUZC';
 
@@ -47,8 +48,11 @@ describe('Voter Registration Drive Action', () => {
     cy.mockGraphqlOp('UserAcceptedPostsForAction', {
       posts: [{ quantity: 10 }, { quantity: 20 }, { quantity: 30 }],
     });
+    cy.mockGraphqlOp('CampaignSignup', {
+      signups: [{ id: 11122019, group: null }],
+    });
 
-    cy.authVisitBlockPermalink(user, blockId);
+    cy.authVisitBlockPermalink(user, blockId, exampleCampaign);
 
     cy.get('[data-test=total-accepted-quantity-value]').contains('60');
   });
@@ -59,8 +63,11 @@ describe('Voter Registration Drive Action', () => {
     cy.mockGraphqlOp('UserAcceptedPostsForAction', {
       posts: [],
     });
+    cy.mockGraphqlOp('CampaignSignup', {
+      signups: [{ id: 11122019, group: null }],
+    });
 
-    cy.authVisitBlockPermalink(user, blockId);
+    cy.authVisitBlockPermalink(user, blockId, exampleCampaign);
 
     cy.get('[data-test=total-accepted-quantity-value]').contains('0');
   });
@@ -68,7 +75,11 @@ describe('Voter Registration Drive Action', () => {
   it('Links to /us/my-voter-registration-drive', () => {
     const user = userFactory();
 
-    cy.authVisitBlockPermalink(user, blockId);
+    cy.mockGraphqlOp('CampaignSignup', {
+      signups: [{ id: 11122019, group: null }],
+    });
+
+    cy.authVisitBlockPermalink(user, blockId, exampleCampaign);
 
     cy.get('.social-drive-action h1').contains(
       contentfulBlockQueryResult.block.title,
@@ -88,7 +99,11 @@ describe('Voter Registration Drive Action', () => {
     const user = userFactory();
     const longUrl = `${PHOENIX_URL}/us/my-voter-registration-drive?referrer_user_id=${user.id}`;
 
-    cy.authVisitBlockPermalink(user, blockId);
+    cy.mockGraphqlOp('CampaignSignup', {
+      signups: [{ id: 11122019, group: null }],
+    });
+
+    cy.authVisitBlockPermalink(user, blockId, exampleCampaign);
 
     cy.get('#mental-health').check();
     cy.get('.link-bar input').should(

--- a/cypress/integration/voter-registration-drive-action.js
+++ b/cypress/integration/voter-registration-drive-action.js
@@ -49,7 +49,7 @@ describe('Voter Registration Drive Action', () => {
       posts: [{ quantity: 10 }, { quantity: 20 }, { quantity: 30 }],
     });
     cy.mockGraphqlOp('CampaignSignup', {
-      signups: [{ id: 11122019, group: null }],
+      signups: [{ id: 11122016, group: null }],
     });
 
     cy.authVisitBlockPermalink(user, blockId, exampleCampaign);
@@ -64,7 +64,7 @@ describe('Voter Registration Drive Action', () => {
       posts: [],
     });
     cy.mockGraphqlOp('CampaignSignup', {
-      signups: [{ id: 11122019, group: null }],
+      signups: [{ id: 11122016, group: null }],
     });
 
     cy.authVisitBlockPermalink(user, blockId, exampleCampaign);
@@ -76,7 +76,7 @@ describe('Voter Registration Drive Action', () => {
     const user = userFactory();
 
     cy.mockGraphqlOp('CampaignSignup', {
-      signups: [{ id: 11122019, group: null }],
+      signups: [{ id: 11122016, group: null }],
     });
 
     cy.authVisitBlockPermalink(user, blockId, exampleCampaign);
@@ -99,7 +99,7 @@ describe('Voter Registration Drive Action', () => {
     const user = userFactory();
 
     cy.mockGraphqlOp('CampaignSignup', {
-      signups: [{ id: 11122019, group: { id: 7 } }],
+      signups: [{ id: 11122016, group: { id: 7 } }],
     });
 
     cy.authVisitBlockPermalink(user, blockId, exampleCampaign);
@@ -123,7 +123,7 @@ describe('Voter Registration Drive Action', () => {
     const longUrl = `${PHOENIX_URL}/us/my-voter-registration-drive?referrer_user_id=${user.id}`;
 
     cy.mockGraphqlOp('CampaignSignup', {
-      signups: [{ id: 11122019, group: null }],
+      signups: [{ id: 11122016, group: null }],
     });
 
     cy.authVisitBlockPermalink(user, blockId, exampleCampaign);

--- a/cypress/integration/voter-registration-drive-action.js
+++ b/cypress/integration/voter-registration-drive-action.js
@@ -72,7 +72,7 @@ describe('Voter Registration Drive Action', () => {
     cy.get('[data-test=total-accepted-quantity-value]').contains('0');
   });
 
-  it('Links to /us/my-voter-registration-drive', () => {
+  it('Links to /us/my-voter-registration-drive with referrer_user_id query', () => {
     const user = userFactory();
 
     cy.mockGraphqlOp('CampaignSignup', {
@@ -90,6 +90,29 @@ describe('Voter Registration Drive Action', () => {
     cy.get('.link-bar input').should(
       'contain.value',
       `${PHOENIX_URL}/us/my-voter-registration-drive?referrer_user_id=${user.id}`,
+    );
+    cy.get('[data-test=voting-reasons-query-options]').should('have.length', 1);
+    cy.get('[data-test=social-share-tray-title]').should('have.length', 0);
+  });
+
+  it('Appends group_id query to link if signed up with group', () => {
+    const user = userFactory();
+
+    cy.mockGraphqlOp('CampaignSignup', {
+      signups: [{ id: 11122019, group: { id: 7 } }],
+    });
+
+    cy.authVisitBlockPermalink(user, blockId, exampleCampaign);
+
+    cy.get('.social-drive-action h1').contains(
+      contentfulBlockQueryResult.block.title,
+    );
+    cy.get('.social-drive-action').contains(
+      contentfulBlockQueryResult.block.description,
+    );
+    cy.get('.link-bar input').should(
+      'contain.value',
+      `${PHOENIX_URL}/us/my-voter-registration-drive?group_id=7&referrer_user_id=${user.id}`,
     );
     cy.get('[data-test=voting-reasons-query-options]').should('have.length', 1);
     cy.get('[data-test=social-share-tray-title]').should('have.length', 0);

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -204,6 +204,18 @@ Cypress.Commands.add('authVisitCampaignWithoutSignup', function(
  *
  * @param {Object} state
  */
-Cypress.Commands.add('authVisitBlockPermalink', function(user, blockId) {
-  cy.login(user).visit(`us/blocks/${blockId}`);
+Cypress.Commands.add('authVisitBlockPermalink', function(
+  user,
+  blockId,
+  contentfulCampaign,
+) {
+  const path = `us/blocks/${blockId}`;
+
+  if (contentfulCampaign) {
+    cy.login(user)
+      .withState(contentfulCampaign)
+      .visit(path);
+  }
+
+  cy.login(user).visit(path);
 });

--- a/docs/development/features/voter-registration.md
+++ b/docs/development/features/voter-registration.md
@@ -28,6 +28,8 @@ This tracking source value is saved within the serialized `details` field of the
 
 - `user` - This is the Northstar user ID of either the authenticated user registering to vote, or the referring alpha user for a beta registration, when the `referral` key is present.
 
+- `group_id` - This is the Rogue group ID stored on the campaign signup, if user is sharing their link from a group OVRD campaign (docs coming soon).
+
 - `source` - This is similar to a `utm_source`.
 
   - Examples: `web`, `sms`, `email`

--- a/resources/assets/components/actions/VoterRegistrationDriveAction/VoterRegistrationDriveAction.js
+++ b/resources/assets/components/actions/VoterRegistrationDriveAction/VoterRegistrationDriveAction.js
@@ -7,7 +7,10 @@ import QueryOptions from './QueryOptions';
 import { PHOENIX_URL } from '../../../constants';
 import { appendToQuery } from '../../../helpers';
 import { getUserId } from '../../../helpers/auth';
-import { getCampaign } from '../../../helpers/campaign';
+import {
+  CAMPAIGN_SIGNUP_QUERY,
+  getCampaignSignupQueryVariables,
+} from '../../../helpers/campaign';
 import SocialDriveActionContainer from '../SocialDriveAction/SocialDriveActionContainer';
 import Placeholder from '../../utilities/Placeholder';
 import ErrorBlock from '../../blocks/ErrorBlock/ErrorBlock';
@@ -21,27 +24,14 @@ export const VoterRegistrationDriveBlockFragment = gql`
   }
 `;
 
-const CAMPAIGN_SIGNUP_QUERY = gql`
-  query CampaignSignup($userId: String!, $campaignId: String!) {
-    signups(userId: $userId, campaignId: $campaignId) {
-      id
-      group {
-        id
-      }
-    }
-  }
-`;
-
 const VoterRegistrationDriveAction = ({
   approvedPostCountActionId,
   approvedPostCountLabel,
   description,
   title,
 }) => {
-  const userId = getUserId();
-
   const { loading, error, data } = useQuery(CAMPAIGN_SIGNUP_QUERY, {
-    variables: { userId, campaignId: getCampaign().campaignId },
+    variables: getCampaignSignupQueryVariables(),
   });
 
   if (loading) {
@@ -53,7 +43,7 @@ const VoterRegistrationDriveAction = ({
   }
 
   const signup = data.signups[0];
-  const queryParams = { referrer_user_id: userId };
+  const queryParams = { referrer_user_id: getUserId() };
 
   if (signup.group) {
     queryParams.group_id = signup.group.id;

--- a/resources/assets/components/actions/VoterRegistrationDriveAction/VoterRegistrationDriveAction.js
+++ b/resources/assets/components/actions/VoterRegistrationDriveAction/VoterRegistrationDriveAction.js
@@ -1,11 +1,19 @@
 import React from 'react';
 import gql from 'graphql-tag';
 import PropTypes from 'prop-types';
+import { useQuery } from '@apollo/react-hooks';
 
 import QueryOptions from './QueryOptions';
 import { PHOENIX_URL } from '../../../constants';
+import { appendToQuery } from '../../../helpers';
 import { getUserId } from '../../../helpers/auth';
+import {
+  campaignSignupGqlQuery,
+  getCampaignSignupGqlQueryVariables,
+} from '../../../helpers/campaign';
 import SocialDriveActionContainer from '../SocialDriveAction/SocialDriveActionContainer';
+import Placeholder from '../../utilities/Placeholder';
+import ErrorBlock from '../../blocks/ErrorBlock/ErrorBlock';
 
 export const VoterRegistrationDriveBlockFragment = gql`
   fragment VoterRegistrationDriveBlockFragment on VoterRegistrationDriveBlock {
@@ -21,18 +29,47 @@ const VoterRegistrationDriveAction = ({
   approvedPostCountLabel,
   description,
   title,
-}) => (
-  <SocialDriveActionContainer
-    approvedPostCountActionId={approvedPostCountActionId}
-    approvedPostCountLabel={
-      approvedPostCountLabel || 'Total scholarship entries'
-    }
-    link={`${PHOENIX_URL}/us/my-voter-registration-drive?referrer_user_id=${getUserId()}`}
-    queryOptions={<QueryOptions />}
-    shareCardDescription={description}
-    shareCardTitle={title}
-  />
-);
+}) => {
+  const { loading, error, data } = useQuery(campaignSignupGqlQuery, {
+    variables: getCampaignSignupGqlQueryVariables(),
+  });
+
+  if (loading) {
+    return <Placeholder />;
+  }
+
+  if (error) {
+    return <ErrorBlock error={error} />;
+  }
+
+  const signup = data.signups[0];
+
+  const queryParams = {
+    referrer_user_id: getUserId(),
+  };
+
+  if (signup.group) {
+    queryParams.group_id = signup.group.id;
+  }
+
+  return (
+    <SocialDriveActionContainer
+      approvedPostCountActionId={approvedPostCountActionId}
+      approvedPostCountLabel={
+        approvedPostCountLabel || 'Total scholarship entries'
+      }
+      link={
+        appendToQuery(
+          queryParams,
+          `${PHOENIX_URL}/us/my-voter-registration-drive`,
+        ).href
+      }
+      queryOptions={<QueryOptions />}
+      shareCardDescription={description}
+      shareCardTitle={title}
+    />
+  );
+};
 
 VoterRegistrationDriveAction.propTypes = {
   approvedPostCountActionId: PropTypes.number,

--- a/resources/assets/components/actions/VoterRegistrationDriveAction/VoterRegistrationDriveAction.js
+++ b/resources/assets/components/actions/VoterRegistrationDriveAction/VoterRegistrationDriveAction.js
@@ -7,10 +7,7 @@ import QueryOptions from './QueryOptions';
 import { PHOENIX_URL } from '../../../constants';
 import { appendToQuery } from '../../../helpers';
 import { getUserId } from '../../../helpers/auth';
-import {
-  CAMPAIGN_SIGNUP_QUERY,
-  getCampaignSignupQueryVariables,
-} from '../../../helpers/campaign';
+import { getCampaign } from '../../../helpers/campaign';
 import SocialDriveActionContainer from '../SocialDriveAction/SocialDriveActionContainer';
 import Placeholder from '../../utilities/Placeholder';
 import ErrorBlock from '../../blocks/ErrorBlock/ErrorBlock';
@@ -24,14 +21,27 @@ export const VoterRegistrationDriveBlockFragment = gql`
   }
 `;
 
+const CAMPAIGN_SIGNUP_QUERY = gql`
+  query CampaignSignup($userId: String!, $campaignId: String!) {
+    signups(userId: $userId, campaignId: $campaignId) {
+      id
+      group {
+        id
+      }
+    }
+  }
+`;
+
 const VoterRegistrationDriveAction = ({
   approvedPostCountActionId,
   approvedPostCountLabel,
   description,
   title,
 }) => {
+  const userId = getUserId();
+
   const { loading, error, data } = useQuery(CAMPAIGN_SIGNUP_QUERY, {
-    variables: getCampaignSignupQueryVariables(),
+    variables: { userId, campaignId: getCampaign().campaignId },
   });
 
   if (loading) {
@@ -43,7 +53,7 @@ const VoterRegistrationDriveAction = ({
   }
 
   const signup = data.signups[0];
-  const queryParams = { referrer_user_id: getUserId() };
+  const queryParams = { referrer_user_id: userId };
 
   if (signup.group) {
     queryParams.group_id = signup.group.id;

--- a/resources/assets/components/actions/VoterRegistrationDriveAction/VoterRegistrationDriveAction.js
+++ b/resources/assets/components/actions/VoterRegistrationDriveAction/VoterRegistrationDriveAction.js
@@ -8,8 +8,8 @@ import { PHOENIX_URL } from '../../../constants';
 import { appendToQuery } from '../../../helpers';
 import { getUserId } from '../../../helpers/auth';
 import {
-  campaignSignupGqlQuery,
-  getCampaignSignupGqlQueryVariables,
+  CAMPAIGN_SIGNUP_QUERY,
+  getCampaignSignupQueryVariables,
 } from '../../../helpers/campaign';
 import SocialDriveActionContainer from '../SocialDriveAction/SocialDriveActionContainer';
 import Placeholder from '../../utilities/Placeholder';
@@ -30,8 +30,8 @@ const VoterRegistrationDriveAction = ({
   description,
   title,
 }) => {
-  const { loading, error, data } = useQuery(campaignSignupGqlQuery, {
-    variables: getCampaignSignupGqlQueryVariables(),
+  const { loading, error, data } = useQuery(CAMPAIGN_SIGNUP_QUERY, {
+    variables: getCampaignSignupQueryVariables(),
   });
 
   if (loading) {

--- a/resources/assets/components/actions/VoterRegistrationDriveAction/VoterRegistrationDriveAction.js
+++ b/resources/assets/components/actions/VoterRegistrationDriveAction/VoterRegistrationDriveAction.js
@@ -43,10 +43,7 @@ const VoterRegistrationDriveAction = ({
   }
 
   const signup = data.signups[0];
-
-  const queryParams = {
-    referrer_user_id: getUserId(),
-  };
+  const queryParams = { referrer_user_id: getUserId() };
 
   if (signup.group) {
     queryParams.group_id = signup.group.id;

--- a/resources/assets/components/actions/VoterRegistrationDriveAction/VoterRegistrationDriveAction.js
+++ b/resources/assets/components/actions/VoterRegistrationDriveAction/VoterRegistrationDriveAction.js
@@ -3,17 +3,17 @@ import gql from 'graphql-tag';
 import PropTypes from 'prop-types';
 import { useQuery } from '@apollo/react-hooks';
 
-import QueryOptions from './QueryOptions';
-import { PHOENIX_URL } from '../../../constants';
-import { appendToQuery } from '../../../helpers';
-import { getUserId } from '../../../helpers/auth';
 import {
   CAMPAIGN_SIGNUP_QUERY,
   getCampaignSignupQueryVariables,
 } from '../../../helpers/campaign';
-import SocialDriveActionContainer from '../SocialDriveAction/SocialDriveActionContainer';
+import QueryOptions from './QueryOptions';
+import { PHOENIX_URL } from '../../../constants';
+import { appendToQuery } from '../../../helpers';
+import { getUserId } from '../../../helpers/auth';
 import Placeholder from '../../utilities/Placeholder';
 import ErrorBlock from '../../blocks/ErrorBlock/ErrorBlock';
+import SocialDriveActionContainer from '../SocialDriveAction/SocialDriveActionContainer';
 
 export const VoterRegistrationDriveBlockFragment = gql`
   fragment VoterRegistrationDriveBlockFragment on VoterRegistrationDriveBlock {

--- a/resources/assets/components/blocks/VoterRegistrationReferralsBlock/VoterRegistrationReferralsBlock.js
+++ b/resources/assets/components/blocks/VoterRegistrationReferralsBlock/VoterRegistrationReferralsBlock.js
@@ -2,18 +2,11 @@ import React from 'react';
 import gql from 'graphql-tag';
 import pluralize from 'pluralize';
 import PropTypes from 'prop-types';
-import { useQuery } from '@apollo/react-hooks';
 
 import Query from '../../Query';
-import {
-  CAMPAIGN_SIGNUP_QUERY,
-  getCampaignSignupQueryVariables,
-} from '../../../helpers/campaign';
 import { getUserId } from '../../../helpers/auth';
 import EmptyRegistrationImage from './empty-registration.svg';
 import CompletedRegistrationImage from './completed-registration.svg';
-import Placeholder from '../../utilities/Placeholder';
-import ErrorBlock from '../ErrorBlock/ErrorBlock';
 import SectionHeader from '../../utilities/SectionHeader/SectionHeader';
 import ReferralsGallery from '../../utilities/ReferralsGallery/ReferralsGallery';
 
@@ -38,63 +31,46 @@ const VOTER_REGISTRATION_REFERRALS_QUERY = gql`
   }
 `;
 
-const VoterRegistrationReferralsBlock = ({ title }) => {
-  const { loading, error, data } = useQuery(CAMPAIGN_SIGNUP_QUERY, {
-    variables: getCampaignSignupQueryVariables(),
-  });
+const VoterRegistrationReferralsBlock = ({ title }) => (
+  <div className="grid-wide clearfix wrapper pb-6">
+    {title ? <SectionHeader underlined title={title} /> : null}
+    <Query
+      query={VOTER_REGISTRATION_REFERRALS_QUERY}
+      variables={{ referrerUserId: getUserId() }}
+    >
+      {data => {
+        const numberOfReferrals = data.posts.length;
 
-  if (loading) {
-    return <Placeholder />;
-  }
+        return (
+          <>
+            {numberOfReferrals ? (
+              <div className="pb-3 md:pb-6">
+                You have registered{' '}
+                <strong>
+                  {numberOfReferrals} {pluralize('person', numberOfReferrals)}
+                </strong>{' '}
+                so far.
+              </div>
+            ) : (
+              <div className="pb-3 md:pb-6">
+                You haven’t helped anyone register to vote yet. Scroll down to
+                get started!
+              </div>
+            )}
 
-  if (error) {
-    return <ErrorBlock error={error} />;
-  }
-
-  const signup = data.signups[0];
-  console.log(signup);
-
-  return (
-    <div className="grid-wide clearfix wrapper pb-6">
-      {title ? <SectionHeader underlined title={title} /> : null}
-      <Query
-        query={VOTER_REGISTRATION_REFERRALS_QUERY}
-        variables={{ referrerUserId: getUserId() }}
-      >
-        {data => {
-          const numberOfReferrals = data.posts.length;
-
-          return (
-            <>
-              {numberOfReferrals ? (
-                <div className="pb-3 md:pb-6">
-                  You have registered{' '}
-                  <strong>
-                    {numberOfReferrals} {pluralize('person', numberOfReferrals)}
-                  </strong>{' '}
-                  so far.
-                </div>
-              ) : (
-                <div className="pb-3 md:pb-6">
-                  You haven’t helped anyone register to vote yet. Scroll down to
-                  get started!
-                </div>
+            <ReferralsGallery
+              referralLabels={data.posts.map(
+                referral => referral.user.displayName,
               )}
-
-              <ReferralsGallery
-                referralLabels={data.posts.map(
-                  referral => referral.user.displayName,
-                )}
-                referralIcon={CompletedRegistrationImage}
-                placeholderIcon={EmptyRegistrationImage}
-              />
-            </>
-          );
-        }}
-      </Query>
-    </div>
-  );
-};
+              referralIcon={CompletedRegistrationImage}
+              placeholderIcon={EmptyRegistrationImage}
+            />
+          </>
+        );
+      }}
+    </Query>
+  </div>
+);
 
 VoterRegistrationReferralsBlock.propTypes = {
   title: PropTypes.string,

--- a/resources/assets/helpers/campaign.js
+++ b/resources/assets/helpers/campaign.js
@@ -1,5 +1,9 @@
 import { join } from 'path';
 import get from 'lodash/get';
+import gql from 'graphql-tag';
+import { useQuery } from '@apollo/react-hooks';
+
+import { getUserId } from './auth';
 
 /**
  * Prepare a campaign subpage's slug.
@@ -49,6 +53,25 @@ export function getCampaignFaqPath() {
 
   // If found, return fully formed path to the FAQ page.
   return faqSlug ? `/us/campaigns/${faqSlug}` : undefined;
+}
+
+export const campaignSignupGqlQuery = gql`
+  query CampaignSignup($userId: String!, $campaignId: String!) {
+    signups(userId: $userId, campaignId: $campaignId) {
+      id
+      group {
+        id
+        name
+      }
+    }
+  }
+`;
+
+export function getCampaignSignupGqlQueryVariables() {
+  return {
+    userId: getUserId(),
+    campaignId: getCampaign().campaignId,
+  };
 }
 
 export default null;

--- a/resources/assets/helpers/campaign.js
+++ b/resources/assets/helpers/campaign.js
@@ -54,7 +54,7 @@ export function getCampaignFaqPath() {
   return faqSlug ? `/us/campaigns/${faqSlug}` : undefined;
 }
 
-export const campaignSignupGqlQuery = gql`
+export const CAMPAIGN_SIGNUP_QUERY = gql`
   query CampaignSignup($userId: String!, $campaignId: String!) {
     signups(userId: $userId, campaignId: $campaignId) {
       id
@@ -66,7 +66,7 @@ export const campaignSignupGqlQuery = gql`
   }
 `;
 
-export function getCampaignSignupGqlQueryVariables() {
+export function getCampaignSignupQueryVariables() {
   return {
     userId: getUserId(),
     campaignId: getCampaign().campaignId,

--- a/resources/assets/helpers/campaign.js
+++ b/resources/assets/helpers/campaign.js
@@ -1,5 +1,8 @@
 import { join } from 'path';
 import get from 'lodash/get';
+import gql from 'graphql-tag';
+
+import { getUserId } from './auth';
 
 /**
  * Prepare a campaign subpage's slug.
@@ -49,6 +52,27 @@ export function getCampaignFaqPath() {
 
   // If found, return fully formed path to the FAQ page.
   return faqSlug ? `/us/campaigns/${faqSlug}` : undefined;
+}
+
+export const CAMPAIGN_SIGNUP_QUERY = gql`
+  query CampaignSignup($userId: String!, $campaignId: String!) {
+    signups(userId: $userId, campaignId: $campaignId) {
+      id
+      group {
+        id
+      }
+    }
+  }
+`;
+
+/**
+ * @return {Object}
+ */
+export function getCampaignSignupQueryVariables() {
+  return {
+    userId: getUserId(),
+    campaignId: getCampaign().campaignId,
+  };
 }
 
 export default null;

--- a/resources/assets/helpers/campaign.js
+++ b/resources/assets/helpers/campaign.js
@@ -1,8 +1,5 @@
 import { join } from 'path';
 import get from 'lodash/get';
-import gql from 'graphql-tag';
-
-import { getUserId } from './auth';
 
 /**
  * Prepare a campaign subpage's slug.
@@ -52,25 +49,6 @@ export function getCampaignFaqPath() {
 
   // If found, return fully formed path to the FAQ page.
   return faqSlug ? `/us/campaigns/${faqSlug}` : undefined;
-}
-
-export const CAMPAIGN_SIGNUP_QUERY = gql`
-  query CampaignSignup($userId: String!, $campaignId: String!) {
-    signups(userId: $userId, campaignId: $campaignId) {
-      id
-      group {
-        id
-        name
-      }
-    }
-  }
-`;
-
-export function getCampaignSignupQueryVariables() {
-  return {
-    userId: getUserId(),
-    campaignId: getCampaign().campaignId,
-  };
 }
 
 export default null;

--- a/resources/assets/helpers/campaign.js
+++ b/resources/assets/helpers/campaign.js
@@ -1,7 +1,6 @@
 import { join } from 'path';
 import get from 'lodash/get';
 import gql from 'graphql-tag';
-import { useQuery } from '@apollo/react-hooks';
 
 import { getUserId } from './auth';
 

--- a/schema.json
+++ b/schema.json
@@ -534,6 +534,16 @@
                 "defaultValue": null
               },
               {
+                "name": "groupId",
+                "description": "The user activity group ID to load posts for.",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null
+              },
+              {
                 "name": "status",
                 "description": "The post statuses to load posts for.",
                 "type": {
@@ -698,6 +708,16 @@
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "groupId",
+                "description": "The user activity group ID to load posts for.",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
                   "ofType": null
                 },
                 "defaultValue": null
@@ -3631,6 +3651,30 @@
             "deprecationReason": null
           },
           {
+            "name": "groupId",
+            "description": "The associated user activity group ID for this post.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "group",
+            "description": "The associated user activity group for this post.",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "Group",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "quantity",
             "description": "The number of items added or removed in this post.",
             "args": [],
@@ -5760,11 +5804,23 @@
           },
           {
             "name": "groupId",
-            "description": "The associated user activity group for this signup.",
+            "description": "The associated user activity group ID for this signup.",
             "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "Int",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "group",
+            "description": "The associated user activity group for this signup.",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "Group",
               "ofType": null
             },
             "isDeprecated": false,
@@ -5825,6 +5881,180 @@
             "type": {
               "kind": "OBJECT",
               "name": "User",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "Group",
+        "description": "A user activity group.",
+        "fields": [
+          {
+            "name": "id",
+            "description": "The unique ID for this group.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "groupTypeId",
+            "description": "The group type ID this group belongs to.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "groupType",
+            "description": "The group type this group belongs to.",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "GroupType",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "name",
+            "description": "The group name.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "goal",
+            "description": "The group goal.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "updatedAt",
+            "description": "The time this group was last modified.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "DateTime",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "createdAt",
+            "description": "The time when this group was originally created.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "DateTime",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "GroupType",
+        "description": "A type of user activity group.",
+        "fields": [
+          {
+            "name": "id",
+            "description": "The unique ID for this group type.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "name",
+            "description": "The name of the group type.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "updatedAt",
+            "description": "The time this group type was last modified.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "DateTime",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "createdAt",
+            "description": "The time when this group type was originally created.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "DateTime",
               "ofType": null
             },
             "isDeprecated": false,
@@ -6437,180 +6667,6 @@
                 "name": "Boolean",
                 "ofType": null
               }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "inputFields": null,
-        "interfaces": [],
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "OBJECT",
-        "name": "Group",
-        "description": "A user activity group.",
-        "fields": [
-          {
-            "name": "id",
-            "description": "The unique ID for this group.",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "Int",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "groupTypeId",
-            "description": "The group type ID this group belongs to.",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "Int",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "groupType",
-            "description": "The group type this group belongs to.",
-            "args": [],
-            "type": {
-              "kind": "OBJECT",
-              "name": "GroupType",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "name",
-            "description": "The group name.",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "goal",
-            "description": "The group goal.",
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "updatedAt",
-            "description": "The time this group was last modified.",
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "DateTime",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "createdAt",
-            "description": "The time when this group was originally created.",
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "DateTime",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "inputFields": null,
-        "interfaces": [],
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "OBJECT",
-        "name": "GroupType",
-        "description": "A type of user activity group.",
-        "fields": [
-          {
-            "name": "id",
-            "description": "The unique ID for this group type.",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "Int",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "name",
-            "description": "The name of the group type.",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "updatedAt",
-            "description": "The time this group type was last modified.",
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "DateTime",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "createdAt",
-            "description": "The time when this group type was originally created.",
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "DateTime",
-              "ofType": null
             },
             "isDeprecated": false,
             "deprecationReason": null


### PR DESCRIPTION
### What's this PR do?

This pull request modifies the `VoterRegistrationDriveAction` component to query GraphQL for the signup of the campaign that the alpha user is viewing a `VoterRegistrationDriveAction` from. If the signup contains a `group`, a `group_id` query parameter should be added to their OVRD page's share link. Example:

```
/us/my-voter-registration-drive?group_id=7&referrer_user_id=5547be89469c64ec7d8b518d
```

Part 2 will entail appending a `group_id` key/value to the RTV tracking source if found on a OVRD page, so it eventually makes its way onto the voter-reg post's `group_id` field when imported (refs https://github.com/DoSomething/chompy/pull/176)

### How should this be reviewed?

Is this readable, maintainable, and does it make sense? I'll add the review app for this PR into Aurora, and provide links to manually test and spot check that a `group_id` is present if joining a group upon signup.

### Any background context you want to provide?

Created new additions in the `campaign` helper because we'll eventually need to query for a signup from the `VoterRegistrationReferralsBlock` as well, as we'll need to display different data and template if the user is viewing a `VoterRegistrationReferralsBlock` from a groups campaign.

Holding off on too many changes for now to help keep this reviewable (at least half of the changes in this PR are updates to the `schema.json` we used for testing, per GraphQL changes in https://github.com/DoSomething/graphql/pull/244)

### Relevant tickets

References [Pivotal #173019820](https://www.pivotaltracker.com/story/show/173019820).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added screenshots of front-end changes on small, medium, and large screens.
- [x] Added appropriate feature/unit tests.
