### PR TITLE
Removing unnecesary br tag.

### DIFF
--- a/resources/assets/components/pages/AccountPage/Subscriptions/EmailSubscriptionItem.js
+++ b/resources/assets/components/pages/AccountPage/Subscriptions/EmailSubscriptionItem.js
@@ -63,10 +63,9 @@ const EmailSubscriptionItem = ({
         />
 
         <div className="p-4 flex flex-col flex-grow">
-          <h3 className="text-base">{name}</h3>
+          <h3 className="mb-1 text-base">{name}</h3>
 
-          <h4 className="text-base italic">{descriptionHeader}</h4>
-          <br />
+          <h4 className="italic mb-6 text-base">{descriptionHeader}</h4>
 
           <p className="flex-grow">{description}</p>
 


### PR DESCRIPTION
### What's this PR do?

This pull request removes the use of a `<br />` tag which should be reserved for use in limited scenarios where you want to force a carriage return on some content entry. In this scenario adding a simple margin class to achieve the desired bottom spacing is more appropriate and make it easier to adjust in the future.

### How should this be reviewed?

👀 

### Any background context you want to provide?

Quick fix from https://github.com/DoSomething/phoenix-next/pull/2171
