### PR TITLE
Group Voter Registration Referrals

### DIFF
--- a/cypress/fixtures/group.js
+++ b/cypress/fixtures/group.js
@@ -1,0 +1,18 @@
+import faker from 'faker';
+
+export const groupTypeFactory = () => ({
+  id: faker.random.number(),
+  name: faker.company.companyName(),
+});
+
+export const groupFactory = () => {
+  const groupType = groupTypeFactory();
+
+  return {
+    id: faker.random.number(),
+    name: `${faker.address.city()} Office`,
+    goal: faker.random.number(),
+    groupTypeId: groupType.id,
+    groupType,
+  };
+};

--- a/cypress/integration/voter-registration-drive-action.js
+++ b/cypress/integration/voter-registration-drive-action.js
@@ -48,7 +48,7 @@ describe('Voter Registration Drive Action', () => {
     cy.mockGraphqlOp('UserAcceptedPostsForAction', {
       posts: [{ quantity: 10 }, { quantity: 20 }, { quantity: 30 }],
     });
-    cy.mockGraphqlOp('CampaignSignup', {
+    cy.mockGraphqlOp('CampaignSignupQuery', {
       signups: [{ id: 11122016, group: null }],
     });
 
@@ -63,7 +63,7 @@ describe('Voter Registration Drive Action', () => {
     cy.mockGraphqlOp('UserAcceptedPostsForAction', {
       posts: [],
     });
-    cy.mockGraphqlOp('CampaignSignup', {
+    cy.mockGraphqlOp('CampaignSignupQuery', {
       signups: [{ id: 11122016, group: null }],
     });
 
@@ -75,7 +75,7 @@ describe('Voter Registration Drive Action', () => {
   it('Links to /us/my-voter-registration-drive with referrer_user_id query', () => {
     const user = userFactory();
 
-    cy.mockGraphqlOp('CampaignSignup', {
+    cy.mockGraphqlOp('CampaignSignupQuery', {
       signups: [{ id: 11122016, group: null }],
     });
 
@@ -98,7 +98,7 @@ describe('Voter Registration Drive Action', () => {
   it('Appends group_id query to link if signed up with group', () => {
     const user = userFactory();
 
-    cy.mockGraphqlOp('CampaignSignup', {
+    cy.mockGraphqlOp('CampaignSignupQuery', {
       signups: [{ id: 11122016, group: { id: 7 } }],
     });
 
@@ -122,7 +122,7 @@ describe('Voter Registration Drive Action', () => {
     const user = userFactory();
     const longUrl = `${PHOENIX_URL}/us/my-voter-registration-drive?referrer_user_id=${user.id}`;
 
-    cy.mockGraphqlOp('CampaignSignup', {
+    cy.mockGraphqlOp('CampaignSignupQuery', {
       signups: [{ id: 11122016, group: null }],
     });
 

--- a/cypress/integration/voter-registration-referrals-block.js
+++ b/cypress/integration/voter-registration-referrals-block.js
@@ -44,6 +44,9 @@ describe('Voter Registration Referrals Block', () => {
 
     cy.authVisitBlockPermalink(user, blockId, exampleCampaign);
 
+    cy.get('.section-header__title').contains(
+      contentfulBlockQueryResult.block.title,
+    );
     cy.findAllByTestId('referral-list-item-empty').should('have.length', 3);
     cy.findAllByTestId('referral-list-item-completed').should('have.length', 0);
     cy.findByTestId('additional-referrals-count').should('have.length', 0);
@@ -124,8 +127,10 @@ describe('Voter Registration Referrals Block', () => {
 
     cy.authVisitBlockPermalink(user, blockId, exampleCampaign);
 
+    cy.get('.section-header__title').contains(
+      `${group.groupType.name}: ${group.name}`,
+    );
     cy.findAllByTestId('group-goal').contains(group.goal);
-
     cy.findAllByTestId('group-total').contains(5);
     cy.findAllByTestId('individual-total').contains(5);
   });

--- a/cypress/integration/voter-registration-referrals-block.js
+++ b/cypress/integration/voter-registration-referrals-block.js
@@ -112,22 +112,22 @@ describe('Voter Registration Referrals Block', () => {
       signups: [{ id: 11122016, group }],
     });
     cy.mockGraphqlOp('GroupVoterRegistrationReferralsQuery', {
-      groupReferrals: () => [
+      // TODO: How can we mock aliases, to test against the two different queries?
+      posts: [
         fakePost('Sarah C.'),
         fakePost('Kyle R.'),
         fakePost('John C.'),
         fakePost('Miles D.'),
         fakePost('Tarissa D.'),
       ],
-      individualReferrals: () => [fakePost('Sarah C.')],
     });
 
     cy.authVisitBlockPermalink(user, blockId, exampleCampaign);
 
     cy.findAllByTestId('group-goal').contains(group.goal);
-    // TODO: This should be 5. Is it possible to mock aliased queries?
-    // cy.findAllByTestId('group-total').contains(5);
-    // cy.findAllByTestId('individual-total').contains(1);
+
+    cy.findAllByTestId('group-total').contains(5);
+    cy.findAllByTestId('individual-total').contains(5);
   });
 
   it('Group displays group goal as 50 if not set on group', () => {

--- a/cypress/integration/voter-registration-referrals-block.js
+++ b/cypress/integration/voter-registration-referrals-block.js
@@ -1,6 +1,7 @@
 import faker from 'faker';
 
 import { userFactory } from '../fixtures/user';
+import exampleCampaign from '../fixtures/contentful/exampleCampaign';
 
 const blockId = '5APr82PRUm6WHtHF8cwa7K';
 
@@ -33,11 +34,14 @@ describe('Voter Registration Referrals Block', () => {
   it('Displays three empty icons if user has no referrals', () => {
     const user = userFactory();
 
-    cy.mockGraphqlOp('VoterRegistrationReferrals', {
+    cy.mockGraphqlOp('CampaignSignup', {
+      signups: [{ id: 11122016, group: null }],
+    });
+    cy.mockGraphqlOp('IndividualVoterRegistrationReferrals', {
       posts: [],
     });
 
-    cy.authVisitBlockPermalink(user, blockId);
+    cy.authVisitBlockPermalink(user, blockId, exampleCampaign);
 
     cy.findAllByTestId('referral-list-item-empty').should('have.length', 3);
     cy.findAllByTestId('referral-list-item-completed').should('have.length', 0);
@@ -47,11 +51,14 @@ describe('Voter Registration Referrals Block', () => {
   it('Displays 2 completed icons if user has 2 referrals', () => {
     const user = userFactory();
 
-    cy.mockGraphqlOp('VoterRegistrationReferrals', {
+    cy.mockGraphqlOp('CampaignSignup', {
+      signups: [{ id: 11122016, group: null }],
+    });
+    cy.mockGraphqlOp('IndividualVoterRegistrationReferrals', {
       posts: [fakePost('Jesus Q.'), fakePost('Walter S.')],
     });
 
-    cy.authVisitBlockPermalink(user, blockId);
+    cy.authVisitBlockPermalink(user, blockId, exampleCampaign);
 
     cy.findAllByTestId('referral-list-item-completed').should('have.length', 2);
     cy.nth('[data-testid=referral-list-item-completed]', 0).within(() => {
@@ -67,7 +74,10 @@ describe('Voter Registration Referrals Block', () => {
   it('Displays 3 completed icons and additional count if user has 5 referrals', () => {
     const user = userFactory();
 
-    cy.mockGraphqlOp('VoterRegistrationReferrals', {
+    cy.mockGraphqlOp('CampaignSignup', {
+      signups: [{ id: 11122016, group: null }],
+    });
+    cy.mockGraphqlOp('IndividualVoterRegistrationReferrals', {
       posts: [
         fakePost('Sarah C.'),
         fakePost('Kyle R.'),
@@ -77,7 +87,7 @@ describe('Voter Registration Referrals Block', () => {
       ],
     });
 
-    cy.authVisitBlockPermalink(user, blockId);
+    cy.authVisitBlockPermalink(user, blockId, exampleCampaign);
 
     cy.findAllByTestId('referral-list-item-completed').should('have.length', 3);
     cy.nth('[data-testid=referral-list-item-completed]', 0).within(() => {

--- a/cypress/integration/voter-registration-referrals-block.js
+++ b/cypress/integration/voter-registration-referrals-block.js
@@ -38,7 +38,7 @@ describe('Voter Registration Referrals Block', () => {
     cy.mockGraphqlOp('CampaignSignup', {
       signups: [{ id: 11122016, group: null }],
     });
-    cy.mockGraphqlOp('IndividualVoterRegistrationReferrals', {
+    cy.mockGraphqlOp('IndividualVoterRegistrationReferralsQuery', {
       posts: [],
     });
 
@@ -55,7 +55,7 @@ describe('Voter Registration Referrals Block', () => {
     cy.mockGraphqlOp('CampaignSignup', {
       signups: [{ id: 11122016, group: null }],
     });
-    cy.mockGraphqlOp('IndividualVoterRegistrationReferrals', {
+    cy.mockGraphqlOp('IndividualVoterRegistrationReferralsQuery', {
       posts: [fakePost('Jesus Q.'), fakePost('Walter S.')],
     });
 
@@ -78,7 +78,7 @@ describe('Voter Registration Referrals Block', () => {
     cy.mockGraphqlOp('CampaignSignup', {
       signups: [{ id: 11122016, group: null }],
     });
-    cy.mockGraphqlOp('IndividualVoterRegistrationReferrals', {
+    cy.mockGraphqlOp('IndividualVoterRegistrationReferralsQuery', {
       posts: [
         fakePost('Sarah C.'),
         fakePost('Kyle R.'),
@@ -111,23 +111,23 @@ describe('Voter Registration Referrals Block', () => {
     cy.mockGraphqlOp('CampaignSignup', {
       signups: [{ id: 11122016, group }],
     });
-    cy.mockGraphqlOp('GroupVoterRegistrationReferrals', {
-      posts: [
+    cy.mockGraphqlOp('GroupVoterRegistrationReferralsQuery', {
+      groupReferrals: () => [
         fakePost('Sarah C.'),
         fakePost('Kyle R.'),
         fakePost('John C.'),
         fakePost('Miles D.'),
         fakePost('Tarissa D.'),
       ],
-      posts: [fakePost('Sarah C.')],
+      individualReferrals: () => [fakePost('Sarah C.')],
     });
 
     cy.authVisitBlockPermalink(user, blockId, exampleCampaign);
 
     cy.findAllByTestId('group-goal').contains(group.goal);
     // TODO: This should be 5. Is it possible to mock aliased queries?
-    cy.findAllByTestId('group-total').contains(1);
-    cy.findAllByTestId('individual-total').contains(1);
+    // cy.findAllByTestId('group-total').contains(5);
+    // cy.findAllByTestId('individual-total').contains(1);
   });
 
   it('Group displays group goal as 50 if not set on group', () => {
@@ -138,15 +138,15 @@ describe('Voter Registration Referrals Block', () => {
     cy.mockGraphqlOp('CampaignSignup', {
       signups: [{ id: 11122016, group }],
     });
-    cy.mockGraphqlOp('GroupVoterRegistrationReferrals', {
-      posts: [],
+    // TODO: Fix me (same as test above).
+    cy.mockGraphqlOp('GroupVoterRegistrationReferralsQuery', {
       posts: [],
     });
 
     cy.authVisitBlockPermalink(user, blockId, exampleCampaign);
 
     cy.findAllByTestId('group-goal').contains(50);
-    //cy.findAllByTestId('group-total').contains(0);
-    //cy.findAllByTestId('individual-total').contains(0);
+    cy.findAllByTestId('group-total').contains(0);
+    cy.findAllByTestId('individual-total').contains(0);
   });
 });

--- a/cypress/integration/voter-registration-referrals-block.js
+++ b/cypress/integration/voter-registration-referrals-block.js
@@ -35,7 +35,7 @@ describe('Voter Registration Referrals Block', () => {
   it('Individual displays three empty icons if user has no referrals', () => {
     const user = userFactory();
 
-    cy.mockGraphqlOp('CampaignSignup', {
+    cy.mockGraphqlOp('CampaignSignupQuery', {
       signups: [{ id: 11122016, group: null }],
     });
     cy.mockGraphqlOp('IndividualVoterRegistrationReferralsQuery', {
@@ -52,7 +52,7 @@ describe('Voter Registration Referrals Block', () => {
   it('Individual displays 2 completed icons if user has 2 referrals', () => {
     const user = userFactory();
 
-    cy.mockGraphqlOp('CampaignSignup', {
+    cy.mockGraphqlOp('CampaignSignupQuery', {
       signups: [{ id: 11122016, group: null }],
     });
     cy.mockGraphqlOp('IndividualVoterRegistrationReferralsQuery', {
@@ -75,7 +75,7 @@ describe('Voter Registration Referrals Block', () => {
   it('Individual displays 3 completed icons and additional count if user has 5 referrals', () => {
     const user = userFactory();
 
-    cy.mockGraphqlOp('CampaignSignup', {
+    cy.mockGraphqlOp('CampaignSignupQuery', {
       signups: [{ id: 11122016, group: null }],
     });
     cy.mockGraphqlOp('IndividualVoterRegistrationReferralsQuery', {
@@ -108,7 +108,7 @@ describe('Voter Registration Referrals Block', () => {
     const user = userFactory();
     const group = groupFactory();
 
-    cy.mockGraphqlOp('CampaignSignup', {
+    cy.mockGraphqlOp('CampaignSignupQuery', {
       signups: [{ id: 11122016, group }],
     });
     cy.mockGraphqlOp('GroupVoterRegistrationReferralsQuery', {
@@ -135,7 +135,7 @@ describe('Voter Registration Referrals Block', () => {
     const group = groupFactory();
     group.goal = null;
 
-    cy.mockGraphqlOp('CampaignSignup', {
+    cy.mockGraphqlOp('CampaignSignupQuery', {
       signups: [{ id: 11122016, group }],
     });
     // TODO: Fix me (same as test above).

--- a/resources/assets/components/blocks/VoterRegistrationReferralsBlock/VoterRegistrationReferralsBlock.js
+++ b/resources/assets/components/blocks/VoterRegistrationReferralsBlock/VoterRegistrationReferralsBlock.js
@@ -22,13 +22,15 @@ const VoterRegistrationReferralsBlock = ({ title }) => (
       query={CAMPAIGN_SIGNUP_QUERY}
       variables={getCampaignSignupQueryVariables()}
     >
-      {data =>
-        data.signups[0] && data.signups[0].group ? (
-          <GroupTemplate group={data.signups[0].group} />
+      {data => {
+        const signup = data.signups[0];
+
+        return signup && signup.group ? (
+          <GroupTemplate group={signup.group} />
         ) : (
           <IndividualTemplate title={title} />
-        )
-      }
+        );
+      }}
     </Query>
   </div>
 );

--- a/resources/assets/components/blocks/VoterRegistrationReferralsBlock/VoterRegistrationReferralsBlock.js
+++ b/resources/assets/components/blocks/VoterRegistrationReferralsBlock/VoterRegistrationReferralsBlock.js
@@ -1,16 +1,14 @@
 import React from 'react';
 import gql from 'graphql-tag';
 import PropTypes from 'prop-types';
-import { useQuery } from '@apollo/react-hooks';
 
+import Query from '../../Query';
 import {
   CAMPAIGN_SIGNUP_QUERY,
   getCampaignSignupQueryVariables,
 } from '../../../helpers/campaign';
 import GroupTemplate from './templates/Group';
 import IndividualTemplate from './templates/Individual';
-import Placeholder from '../../utilities/Placeholder';
-import ErrorBlock from '../ErrorBlock/ErrorBlock';
 
 export const VoterRegistrationReferralsBlockFragment = gql`
   fragment VoterRegistrationReferralsBlockFragment on VoterRegistrationReferralsBlock {
@@ -18,31 +16,22 @@ export const VoterRegistrationReferralsBlockFragment = gql`
   }
 `;
 
-const VoterRegistrationReferralsBlock = ({ title }) => {
-  const { loading, error, data } = useQuery(CAMPAIGN_SIGNUP_QUERY, {
-    variables: getCampaignSignupQueryVariables(),
-  });
-
-  if (loading) {
-    return <Placeholder />;
-  }
-
-  if (error) {
-    return <ErrorBlock error={error} />;
-  }
-
-  const signup = data.signups[0];
-
-  return (
-    <div className="grid-wide clearfix wrapper pb-6">
-      {signup.group ? (
-        <GroupTemplate group={signup.group} />
-      ) : (
-        <IndividualTemplate title={title} />
-      )}
-    </div>
-  );
-};
+const VoterRegistrationReferralsBlock = ({ title }) => (
+  <div className="grid-wide clearfix wrapper pb-6">
+    <Query
+      query={CAMPAIGN_SIGNUP_QUERY}
+      variables={getCampaignSignupQueryVariables()}
+    >
+      {data =>
+        data.signups[0] && data.signups[0].group ? (
+          <GroupTemplate group={data.signups[0].group} />
+        ) : (
+          <IndividualTemplate title={title} />
+        )
+      }
+    </Query>
+  </div>
+);
 
 VoterRegistrationReferralsBlock.propTypes = {
   title: PropTypes.string,

--- a/resources/assets/components/blocks/VoterRegistrationReferralsBlock/VoterRegistrationReferralsBlock.js
+++ b/resources/assets/components/blocks/VoterRegistrationReferralsBlock/VoterRegistrationReferralsBlock.js
@@ -1,14 +1,16 @@
 import React from 'react';
 import gql from 'graphql-tag';
-import pluralize from 'pluralize';
 import PropTypes from 'prop-types';
+import { useQuery } from '@apollo/react-hooks';
 
-import Query from '../../Query';
-import { getUserId } from '../../../helpers/auth';
-import EmptyRegistrationImage from './empty-registration.svg';
-import CompletedRegistrationImage from './completed-registration.svg';
-import SectionHeader from '../../utilities/SectionHeader/SectionHeader';
-import ReferralsGallery from '../../utilities/ReferralsGallery/ReferralsGallery';
+import {
+  CAMPAIGN_SIGNUP_QUERY,
+  getCampaignSignupQueryVariables,
+} from '../../../helpers/campaign';
+import GroupTemplate from './templates/Group';
+import IndividualTemplate from './templates/Individual';
+import Placeholder from '../../utilities/Placeholder';
+import ErrorBlock from '../ErrorBlock/ErrorBlock';
 
 export const VoterRegistrationReferralsBlockFragment = gql`
   fragment VoterRegistrationReferralsBlockFragment on VoterRegistrationReferralsBlock {
@@ -16,61 +18,31 @@ export const VoterRegistrationReferralsBlockFragment = gql`
   }
 `;
 
-const VOTER_REGISTRATION_REFERRALS_QUERY = gql`
-  query VoterRegistrationReferrals($referrerUserId: String!) {
-    posts(
-      referrerUserId: $referrerUserId
-      type: "voter-reg"
-      status: [REGISTER_FORM, REGISTER_OVR]
-    ) {
-      id
-      user {
-        displayName
-      }
-    }
+const VoterRegistrationReferralsBlock = ({ title }) => {
+  const { loading, error, data } = useQuery(CAMPAIGN_SIGNUP_QUERY, {
+    variables: getCampaignSignupQueryVariables(),
+  });
+
+  if (loading) {
+    return <Placeholder />;
   }
-`;
 
-const VoterRegistrationReferralsBlock = ({ title }) => (
-  <div className="grid-wide clearfix wrapper pb-6">
-    {title ? <SectionHeader underlined title={title} /> : null}
-    <Query
-      query={VOTER_REGISTRATION_REFERRALS_QUERY}
-      variables={{ referrerUserId: getUserId() }}
-    >
-      {data => {
-        const numberOfReferrals = data.posts.length;
+  if (error) {
+    return <ErrorBlock error={error} />;
+  }
 
-        return (
-          <>
-            {numberOfReferrals ? (
-              <div className="pb-3 md:pb-6">
-                You have registered{' '}
-                <strong>
-                  {numberOfReferrals} {pluralize('person', numberOfReferrals)}
-                </strong>{' '}
-                so far.
-              </div>
-            ) : (
-              <div className="pb-3 md:pb-6">
-                You haven’t helped anyone register to vote yet. Scroll down to
-                get started!
-              </div>
-            )}
+  const signup = data.signups[0];
 
-            <ReferralsGallery
-              referralLabels={data.posts.map(
-                referral => referral.user.displayName,
-              )}
-              referralIcon={CompletedRegistrationImage}
-              placeholderIcon={EmptyRegistrationImage}
-            />
-          </>
-        );
-      }}
-    </Query>
-  </div>
-);
+  return (
+    <div className="grid-wide clearfix wrapper pb-6">
+      {signup.group ? (
+        <GroupTemplate group={signup.group} />
+      ) : (
+        <IndividualTemplate title={title} />
+      )}
+    </div>
+  );
+};
 
 VoterRegistrationReferralsBlock.propTypes = {
   title: PropTypes.string,

--- a/resources/assets/components/blocks/VoterRegistrationReferralsBlock/templates/Group.js
+++ b/resources/assets/components/blocks/VoterRegistrationReferralsBlock/templates/Group.js
@@ -3,11 +3,22 @@ import PropTypes from 'prop-types';
 
 import SectionHeader from '../../../utilities/SectionHeader/SectionHeader';
 
+const StatBlock = ({ label, amount }) => (
+  <div className="pt-3">
+    <span className="font-bold uppercase text-gray-600">{label}</span>
+    <h1 className="font-normal font-league-gothic text-3xl">{amount}</h1>
+  </div>
+);
+
 const GroupTemplate = ({ group }) => {
   return (
     <>
       <SectionHeader title={`${group.groupType.name}: ${group.name}`} />
       <p>Track how many people you and your group register to vote!</p>
+      <StatBlock
+        label="Your Group's Registration Goal"
+        amount={group.goal || 50}
+      />
     </>
   );
 };

--- a/resources/assets/components/blocks/VoterRegistrationReferralsBlock/templates/Group.js
+++ b/resources/assets/components/blocks/VoterRegistrationReferralsBlock/templates/Group.js
@@ -1,7 +1,32 @@
 import React from 'react';
+import gql from 'graphql-tag';
 import PropTypes from 'prop-types';
 
+import Query from '../../../Query';
+import { getUserId } from '../../../../helpers/auth';
 import SectionHeader from '../../../utilities/SectionHeader/SectionHeader';
+
+const GROUP_VOTER_REGISTRATION_REFERRALS_QUERY = gql`
+  query GroupVoterRegistrationReferrals(
+    $groupId: Int!
+    $referrerUserId: String!
+  ) {
+    individualReferrals: posts(
+      referrerUserId: $referrerUserId
+      type: "voter-reg"
+      status: [REGISTER_FORM, REGISTER_OVR]
+    ) {
+      id
+    }
+    groupReferrals: posts(
+      groupId: $groupId
+      type: "voter-reg"
+      status: [REGISTER_FORM, REGISTER_OVR]
+    ) {
+      id
+    }
+  }
+`;
 
 const StatBlock = ({ label, amount }) => (
   <div className="pt-3">
@@ -15,10 +40,27 @@ const GroupTemplate = ({ group }) => {
     <>
       <SectionHeader title={`${group.groupType.name}: ${group.name}`} />
       <p>Track how many people you and your group register to vote!</p>
-      <StatBlock
-        label="Your Group's Registration Goal"
-        amount={group.goal || 50}
-      />
+      <Query
+        query={GROUP_VOTER_REGISTRATION_REFERRALS_QUERY}
+        variables={{ groupId: group.id, referrerUserId: getUserId() }}
+      >
+        {data => (
+          <>
+            <StatBlock
+              label="Your group’s registration goal"
+              amount={group.goal || 50}
+            />
+            <StatBlock
+              label="People your group has registered"
+              amount={data.groupReferrals.length}
+            />
+            <StatBlock
+              label="People you have registered"
+              amount={data.individualReferrals.length}
+            />
+          </>
+        )}
+      </Query>
     </>
   );
 };

--- a/resources/assets/components/blocks/VoterRegistrationReferralsBlock/templates/Group.js
+++ b/resources/assets/components/blocks/VoterRegistrationReferralsBlock/templates/Group.js
@@ -7,7 +7,7 @@ import { getUserId } from '../../../../helpers/auth';
 import SectionHeader from '../../../utilities/SectionHeader/SectionHeader';
 
 const GROUP_VOTER_REGISTRATION_REFERRALS_QUERY = gql`
-  query GroupVoterRegistrationReferrals(
+  query GroupVoterRegistrationReferralsQuery(
     $groupId: Int!
     $referrerUserId: String!
   ) {

--- a/resources/assets/components/blocks/VoterRegistrationReferralsBlock/templates/Group.js
+++ b/resources/assets/components/blocks/VoterRegistrationReferralsBlock/templates/Group.js
@@ -28,16 +28,22 @@ const GROUP_VOTER_REGISTRATION_REFERRALS_QUERY = gql`
   }
 `;
 
-const StatBlock = ({ label, amount }) => (
+const StatBlock = ({ amount, label, testId }) => (
   <div className="pt-3">
     <span className="font-bold uppercase text-gray-600">{label}</span>
-    <h1 className="font-normal font-league-gothic text-3xl">{amount}</h1>
+    <h1
+      data-testid={testId}
+      className="font-normal font-league-gothic text-3xl"
+    >
+      {amount}
+    </h1>
   </div>
 );
 
 StatBlock.propTypes = {
-  label: PropTypes.string.isRequired,
   amount: PropTypes.number.isRequired,
+  label: PropTypes.string.isRequired,
+  testId: PropTypes.string.isRequired,
 };
 
 const GroupTemplate = ({ group }) => {
@@ -52,16 +58,19 @@ const GroupTemplate = ({ group }) => {
         {data => (
           <>
             <StatBlock
-              label="Your group’s registration goal"
               amount={group.goal || 50}
+              label="Your group’s registration goal"
+              testId="group-goal"
             />
             <StatBlock
-              label="People your group has registered"
               amount={data.groupReferrals.length}
+              label="People your group has registered"
+              testId="group-total"
             />
             <StatBlock
-              label="People you have registered"
               amount={data.individualReferrals.length}
+              label="People you have registered"
+              testId="individual-total"
             />
           </>
         )}

--- a/resources/assets/components/blocks/VoterRegistrationReferralsBlock/templates/Group.js
+++ b/resources/assets/components/blocks/VoterRegistrationReferralsBlock/templates/Group.js
@@ -35,6 +35,11 @@ const StatBlock = ({ label, amount }) => (
   </div>
 );
 
+StatBlock.propTypes = {
+  label: PropTypes.string.isRequired,
+  amount: PropTypes.number.isRequired,
+};
+
 const GroupTemplate = ({ group }) => {
   return (
     <>

--- a/resources/assets/components/blocks/VoterRegistrationReferralsBlock/templates/Group.js
+++ b/resources/assets/components/blocks/VoterRegistrationReferralsBlock/templates/Group.js
@@ -1,0 +1,19 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import SectionHeader from '../../../utilities/SectionHeader/SectionHeader';
+
+const GroupTemplate = ({ group }) => {
+  return (
+    <>
+      <SectionHeader title={`${group.groupType.name}: ${group.name}`} />
+      <p>Track how many people you and your group register to vote!</p>
+    </>
+  );
+};
+
+GroupTemplate.propTypes = {
+  group: PropTypes.object.isRequired,
+};
+
+export default GroupTemplate;

--- a/resources/assets/components/blocks/VoterRegistrationReferralsBlock/templates/Group.js
+++ b/resources/assets/components/blocks/VoterRegistrationReferralsBlock/templates/Group.js
@@ -11,15 +11,15 @@ const GROUP_VOTER_REGISTRATION_REFERRALS_QUERY = gql`
     $groupId: Int!
     $referrerUserId: String!
   ) {
-    individualReferrals: posts(
-      referrerUserId: $referrerUserId
+    groupReferrals: posts(
+      groupId: $groupId
       type: "voter-reg"
       status: [REGISTER_FORM, REGISTER_OVR]
     ) {
       id
     }
-    groupReferrals: posts(
-      groupId: $groupId
+    individualReferrals: posts(
+      referrerUserId: $referrerUserId
       type: "voter-reg"
       status: [REGISTER_FORM, REGISTER_OVR]
     ) {

--- a/resources/assets/components/blocks/VoterRegistrationReferralsBlock/templates/Individual.js
+++ b/resources/assets/components/blocks/VoterRegistrationReferralsBlock/templates/Individual.js
@@ -11,7 +11,7 @@ import SectionHeader from '../../../utilities/SectionHeader/SectionHeader';
 import ReferralsGallery from '../../../utilities/ReferralsGallery/ReferralsGallery';
 
 const INDIVIDUAL_VOTER_REGISTRATION_REFERRALS_QUERY = gql`
-  query IndividualVoterRegistrationReferrals($referrerUserId: String!) {
+  query IndividualVoterRegistrationReferralsQuery($referrerUserId: String!) {
     posts(
       referrerUserId: $referrerUserId
       type: "voter-reg"

--- a/resources/assets/components/blocks/VoterRegistrationReferralsBlock/templates/Individual.js
+++ b/resources/assets/components/blocks/VoterRegistrationReferralsBlock/templates/Individual.js
@@ -1,0 +1,77 @@
+import React from 'react';
+import gql from 'graphql-tag';
+import pluralize from 'pluralize';
+import PropTypes from 'prop-types';
+
+import Query from '../../../Query';
+import { getUserId } from '../../../../helpers/auth';
+import EmptyRegistrationImage from '../empty-registration.svg';
+import CompletedRegistrationImage from '../completed-registration.svg';
+import SectionHeader from '../../../utilities/SectionHeader/SectionHeader';
+import ReferralsGallery from '../../../utilities/ReferralsGallery/ReferralsGallery';
+
+const INDIVIDUAL_VOTER_REGISTRATION_REFERRALS_QUERY = gql`
+  query VoterRegistrationReferrals($referrerUserId: String!) {
+    posts(
+      referrerUserId: $referrerUserId
+      type: "voter-reg"
+      status: [REGISTER_FORM, REGISTER_OVR]
+    ) {
+      id
+      user {
+        displayName
+      }
+    }
+  }
+`;
+
+const IndividualTemplate = ({ title }) => (
+  <>
+    {title ? <SectionHeader underlined title={title} /> : null}
+    <Query
+      query={INDIVIDUAL_VOTER_REGISTRATION_REFERRALS_QUERY}
+      variables={{ referrerUserId: getUserId() }}
+    >
+      {data => {
+        const numberOfReferrals = data.posts.length;
+
+        return (
+          <>
+            {numberOfReferrals ? (
+              <div className="pb-3 md:pb-6">
+                You have registered{' '}
+                <strong>
+                  {numberOfReferrals} {pluralize('person', numberOfReferrals)}
+                </strong>{' '}
+                so far.
+              </div>
+            ) : (
+              <div className="pb-3 md:pb-6">
+                You haven’t helped anyone register to vote yet. Scroll down to
+                get started!
+              </div>
+            )}
+
+            <ReferralsGallery
+              referralLabels={data.posts.map(
+                referral => referral.user.displayName,
+              )}
+              referralIcon={CompletedRegistrationImage}
+              placeholderIcon={EmptyRegistrationImage}
+            />
+          </>
+        );
+      }}
+    </Query>
+  </>
+);
+
+IndividualTemplate.propTypes = {
+  title: PropTypes.string,
+};
+
+IndividualTemplate.defaultProps = {
+  title: null,
+};
+
+export default IndividualTemplate;

--- a/resources/assets/components/blocks/VoterRegistrationReferralsBlock/templates/Individual.js
+++ b/resources/assets/components/blocks/VoterRegistrationReferralsBlock/templates/Individual.js
@@ -11,7 +11,7 @@ import SectionHeader from '../../../utilities/SectionHeader/SectionHeader';
 import ReferralsGallery from '../../../utilities/ReferralsGallery/ReferralsGallery';
 
 const INDIVIDUAL_VOTER_REGISTRATION_REFERRALS_QUERY = gql`
-  query VoterRegistrationReferrals($referrerUserId: String!) {
+  query IndividualVoterRegistrationReferrals($referrerUserId: String!) {
     posts(
       referrerUserId: $referrerUserId
       type: "voter-reg"

--- a/resources/assets/helpers/campaign.js
+++ b/resources/assets/helpers/campaign.js
@@ -60,6 +60,7 @@ export const CAMPAIGN_SIGNUP_QUERY = gql`
       id
       group {
         id
+        goal
         name
         groupTypeId
         groupType {

--- a/resources/assets/helpers/campaign.js
+++ b/resources/assets/helpers/campaign.js
@@ -60,6 +60,11 @@ export const CAMPAIGN_SIGNUP_QUERY = gql`
       id
       group {
         id
+        name
+        groupTypeId
+        groupType {
+          name
+        }
       }
     }
   }

--- a/resources/assets/helpers/campaign.js
+++ b/resources/assets/helpers/campaign.js
@@ -55,7 +55,7 @@ export function getCampaignFaqPath() {
 }
 
 export const CAMPAIGN_SIGNUP_QUERY = gql`
-  query CampaignSignup($userId: String!, $campaignId: String!) {
+  query CampaignSignupQuery($userId: String!, $campaignId: String!) {
     signups(userId: $userId, campaignId: $campaignId) {
       id
       group {


### PR DESCRIPTION
### What's this PR do?

This pull request splits the `VoterRegistrationReferralsBlock` into 2 templates: 

* `Individual` - this is the current view, used on a campaign that doesn't require joining a group upon signup

* `Group` - this will be the view if used on a campaign that does require joining a group upon signup. It makes an additional `posts` query to find all completed voter registrations for a group, and modifies the individual's count to avoid joining on users to get their display name (we only need the count)

<img width="500" alt="Screen Shot 2020-06-10 at 10 28 53 PM" src="https://user-images.githubusercontent.com/1236811/84422374-c895da80-abd1-11ea-9efb-f19bfe6e47f3.png">

### How should this be reviewed?

* 👀 
 * I'll add this review app into Aurora, it'd be helpful to manually test that the Group template is displayed when joining a group upon signup, similar to #2213 

### Any background context you want to provide?

* I ran into trouble trying to get the aliased `posts` queries mocking correctly, so left them as TODOs. I do wonder about adding helper queries into GraphQL, like `voterRegistrationReferralsByGroup` and `voterRegistrationReferralsByReferrer`, as this logic gets duplicated over on https://github.com/DoSomething/rogue/pull/1043. This would be an easy solve for the aliases in Cypress (because we wouldn't need them)

* I'm realizing quite a bit of the voter registration components are missing the 'Query` suffix that a lot of our other gql queries use in the name. Can fix those up in future PR's.

### Relevant tickets

References [Pivotal #173019860](https://www.pivotaltracker.com/story/show/173019860).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added screenshots of front-end changes on small, medium, and large screens.
- [x] Added appropriate feature/unit tests.
