### PR TITLE
Groups Voter Registration Drive Action - Part 2/2

### DIFF
--- a/cypress/integration/voter-registration-drive-page.js
+++ b/cypress/integration/voter-registration-drive-page.js
@@ -97,7 +97,7 @@ describe('Voter Registration Drive (OVRD) Page', () => {
     );
   });
 
-  it('OVRD page displays voter-registration-drive-page component if group is found', () => {
+  it('OVRD page displays expected component if group is found', () => {
     const user = userFactory();
 
     cy.mockGraphqlOp('VoterRegistrationDrivePageQuery', {
@@ -131,6 +131,16 @@ describe('Voter Registration Drive (OVRD) Page', () => {
     cy.get('[data-test=voter-registration-drive-page]').should(
       'have.length',
       1,
+    );
+    cy.get('head meta[property="og:title"]').should(
+      'have.attr',
+      'content',
+      'Register to vote with me!',
+    );
+    cy.get('head meta[property="og:description"]').should(
+      'have.attr',
+      'content',
+      "You can register to vote online... literally right now! It's fast, easy, and requires only basic information like your street address. Let's Do This!",
     );
     cy.findByTestId('campaign-header-subtitle').contains(
       `${user.firstName} wants you to register to vote!`,
@@ -313,30 +323,6 @@ describe('Voter Registration Drive (OVRD) Page', () => {
     cy.findByTestId('voter-registration-tracking-source').should(
       'have.value',
       `user:${user.id},source:web,source_details:onlinedrivereferral,group_id=${group.id},referral=true`,
-    );
-  });
-
-  /** @test */
-  it('OVRD <meta> tag has a title and description', () => {
-    const user = userFactory();
-
-    cy.mockGraphqlOp('VoterRegistrationDrivePageQuery', {
-      user,
-      campaignWebsite,
-      group,
-    });
-
-    cy.visit(getOvrdPagePathForUser(user, group));
-
-    cy.get('head meta[property="og:title"]').should(
-      'have.attr',
-      'content',
-      'Register to vote with me!',
-    );
-    cy.get('head meta[property="og:description"]').should(
-      'have.attr',
-      'content',
-      "You can register to vote online... literally right now! It's fast, easy, and requires only basic information like your street address. Let's Do This!",
     );
   });
 });

--- a/cypress/integration/voter-registration-drive-page.js
+++ b/cypress/integration/voter-registration-drive-page.js
@@ -114,6 +114,9 @@ describe('Voter Registration Drive (OVRD) Page', () => {
     cy.findByTestId('voter-registration-form-card').findByText(
       'Register online to vote',
     );
+    cy.get('[data-test=visit-voter-registration-campaign-button]')
+      .should('have.length', 1)
+      .should('have.attr', 'href', mockUrl);
   });
 
   /** @test */
@@ -198,23 +201,6 @@ describe('Voter Registration Drive (OVRD) Page', () => {
     cy.get('[data-test=voter-registration-drive-page-quote-byline]').contains(
       `- ${user.firstName}`,
     );
-  });
-
-  /** @test */
-  it('OVRD displays campaign href, expects href to match GraphQL URL returned from query', () => {
-    const user = userFactory();
-
-    cy.mockGraphqlOp('VoterRegistrationDrivePageQuery', {
-      user,
-      campaignWebsite,
-    });
-
-    cy.visit(getOvrdPagePathForUser(user));
-
-    // Assert button href is present and contains correct url:
-    cy.get('[data-test=visit-voter-registration-campaign-button]')
-      .should('have.length', 1)
-      .should('have.attr', 'href', mockUrl);
   });
 
   /** @test */

--- a/cypress/integration/voter-registration-drive-page.js
+++ b/cypress/integration/voter-registration-drive-page.js
@@ -24,11 +24,14 @@ const group = {
 };
 
 /**
- * @param Object user
- * @return String
+ * @param {Object} user
+ * @param {Object} group
+ * @return {String}
  */
-function getOvrdPagePathForUser(user) {
-  return `${ovrdPathPage}?referrer_user_id=${user.id}`;
+function getOvrdPagePathForUser(user, group) {
+  return `${ovrdPathPage}?referrer_user_id=${user.id}${
+    group ? `&group_id=${group.id}` : ''
+  }`;
 }
 
 describe('Voter Registration Drive (OVRD) Page', () => {
@@ -64,6 +67,7 @@ describe('Voter Registration Drive (OVRD) Page', () => {
     cy.mockGraphqlOp('VoterRegistrationDrivePageQuery', {
       user: null,
       campaignWebsite,
+      group: null,
     });
 
     cy.visit(getOvrdPagePathForUser(user));
@@ -75,6 +79,42 @@ describe('Voter Registration Drive (OVRD) Page', () => {
     );
   });
 
+  it('OVRD page displays NotFoundPage if group is not found', () => {
+    const user = userFactory();
+
+    cy.mockGraphqlOp('VoterRegistrationDrivePageQuery', {
+      user,
+      campaignWebsite,
+      group: null,
+    });
+
+    cy.visit(getOvrdPagePathForUser(user, group));
+
+    cy.findByTestId('not-found-page').should('have.length', 1);
+    cy.get('[data-test=voter-registration-drive-page]').should(
+      'have.length',
+      0,
+    );
+  });
+
+  it('OVRD page displays voter-registration-drive-page component if group is found', () => {
+    const user = userFactory();
+
+    cy.mockGraphqlOp('VoterRegistrationDrivePageQuery', {
+      user,
+      campaignWebsite,
+      group,
+    });
+
+    cy.visit(getOvrdPagePathForUser(user, group));
+
+    cy.findByTestId('not-found-page').should('have.length', 0);
+    cy.get('[data-test=voter-registration-drive-page]').should(
+      'have.length',
+      1,
+    );
+  });
+
   /** @test */
   it('OVRD banner displays expected info if referrer user found', () => {
     const user = userFactory();
@@ -82,6 +122,7 @@ describe('Voter Registration Drive (OVRD) Page', () => {
     cy.mockGraphqlOp('VoterRegistrationDrivePageQuery', {
       user,
       campaignWebsite,
+      group: null,
     });
 
     cy.visit(getOvrdPagePathForUser(user));
@@ -126,6 +167,7 @@ describe('Voter Registration Drive (OVRD) Page', () => {
     cy.mockGraphqlOp('VoterRegistrationDrivePageQuery', {
       user,
       campaignWebsite,
+      group: null,
     });
 
     cy.visit(getOvrdPagePathForUser(user));
@@ -145,6 +187,7 @@ describe('Voter Registration Drive (OVRD) Page', () => {
     cy.mockGraphqlOp('VoterRegistrationDrivePageQuery', {
       user,
       campaignWebsite,
+      group: null,
     });
 
     cy.visit(`${getOvrdPagePathForUser(user)}&voting-reasons=student-debt`);
@@ -164,6 +207,7 @@ describe('Voter Registration Drive (OVRD) Page', () => {
     cy.mockGraphqlOp('VoterRegistrationDrivePageQuery', {
       user,
       campaignWebsite,
+      group: null,
     });
 
     cy.visit(
@@ -187,6 +231,7 @@ describe('Voter Registration Drive (OVRD) Page', () => {
     cy.mockGraphqlOp('VoterRegistrationDrivePageQuery', {
       user,
       campaignWebsite,
+      group: null,
     });
 
     cy.visit(
@@ -210,6 +255,7 @@ describe('Voter Registration Drive (OVRD) Page', () => {
     cy.mockGraphqlOp('VoterRegistrationDrivePageQuery', {
       user,
       campaignWebsite,
+      group: null,
     });
 
     cy.visit(getOvrdPagePathForUser(user));
@@ -224,6 +270,7 @@ describe('Voter Registration Drive (OVRD) Page', () => {
     cy.mockGraphqlOp('VoterRegistrationDrivePageQuery', {
       user,
       campaignWebsite,
+      group: null,
     });
 
     cy.visit(getOvrdPagePathForUser(user));
@@ -240,6 +287,7 @@ describe('Voter Registration Drive (OVRD) Page', () => {
     cy.mockGraphqlOp('VoterRegistrationDrivePageQuery', {
       user,
       campaignWebsite,
+      group: null,
     });
 
     cy.visit(getOvrdPagePathForUser(user));
@@ -260,7 +308,7 @@ describe('Voter Registration Drive (OVRD) Page', () => {
       group,
     });
 
-    cy.visit(`${getOvrdPagePathForUser(user)}&group_id=${group.id}`);
+    cy.visit(getOvrdPagePathForUser(user, group));
 
     cy.findByTestId('voter-registration-tracking-source').should(
       'have.value',
@@ -270,6 +318,16 @@ describe('Voter Registration Drive (OVRD) Page', () => {
 
   /** @test */
   it('OVRD <meta> tag has a title and description', () => {
+    const user = userFactory();
+
+    cy.mockGraphqlOp('VoterRegistrationDrivePageQuery', {
+      user,
+      campaignWebsite,
+      group,
+    });
+
+    cy.visit(getOvrdPagePathForUser(user, group));
+
     cy.get('head meta[property="og:title"]').should(
       'have.attr',
       'content',

--- a/cypress/integration/voter-registration-drive-page.js
+++ b/cypress/integration/voter-registration-drive-page.js
@@ -19,6 +19,9 @@ const campaignWebsite = {
   additionalContent: null,
   url: mockUrl,
 };
+const group = {
+  id: faker.random.number(),
+};
 
 /**
  * @param Object user
@@ -73,24 +76,7 @@ describe('Voter Registration Drive (OVRD) Page', () => {
   });
 
   /** @test */
-  it('OVRD banner displays a cover image', () => {
-    const user = userFactory();
-
-    cy.mockGraphqlOp('VoterRegistrationDrivePageQuery', {
-      user,
-      campaignWebsite,
-    });
-
-    cy.visit(getOvrdPagePathForUser(user));
-
-    cy.get('[data-test=voter-registration-drive-page-cover-image]').should(
-      'have.length',
-      1,
-    );
-  });
-
-  /** @test */
-  it('OVRD banner displays referrer first name if referrer user found', () => {
+  it('OVRD banner displays expected info if referrer user found', () => {
     const user = userFactory();
 
     cy.mockGraphqlOp('VoterRegistrationDrivePageQuery', {
@@ -108,19 +94,10 @@ describe('Voter Registration Drive (OVRD) Page', () => {
     cy.findByTestId('campaign-header-subtitle').contains(
       `${user.firstName} wants you to register to vote!`,
     );
-  });
-
-  /** @test */
-  it('OVRD banner displays scholarship info if it is provided', () => {
-    const user = userFactory();
-
-    cy.mockGraphqlOp('VoterRegistrationDrivePageQuery', {
-      user,
-      campaignWebsite,
-    });
-
-    cy.visit(getOvrdPagePathForUser(user));
-
+    cy.get('[data-test=voter-registration-drive-page-cover-image]').should(
+      'have.length',
+      1,
+    );
     cy.get(
       '[data-test=voter-registration-drive-page-campaign-info-block]',
     ).should('have.length', 1);
@@ -132,6 +109,10 @@ describe('Voter Registration Drive (OVRD) Page', () => {
     cy.contains(`April 25th, 2022`);
     cy.get('[data-test=voter-registration-drive-page-blurb]').contains(
       `150,000+ young people have registered to vote via DoSomething. After you register, share with your friends to enter to win a $1,500 scholarship!`,
+    );
+    cy.findByTestId('voter-registration-form-card').should('have.length', 1);
+    cy.findByTestId('voter-registration-form-card').findByText(
+      'Register online to vote',
     );
   });
 
@@ -237,24 +218,7 @@ describe('Voter Registration Drive (OVRD) Page', () => {
   });
 
   /** @test */
-  it('OVRD Step One register to vote section displays as expected', () => {
-    const user = userFactory();
-
-    cy.mockGraphqlOp('VoterRegistrationDrivePageQuery', {
-      user,
-      campaignWebsite,
-    });
-
-    cy.visit(getOvrdPagePathForUser(user));
-
-    cy.findByTestId('voter-registration-form-card').should('have.length', 1);
-    cy.findByTestId('voter-registration-form-card').findByText(
-      'Register online to vote',
-    );
-  });
-
-  /** @test */
-  it('OVRD Step One register to vote section button is disabled when form is empty', () => {
+  it('OVRD Start VR Form button is disabled when form is empty', () => {
     const user = userFactory();
 
     cy.mockGraphqlOp('VoterRegistrationDrivePageQuery', {
@@ -268,7 +232,7 @@ describe('Voter Registration Drive (OVRD) Page', () => {
   });
 
   /** @test */
-  it('OVRD Step One register to vote section button is enabled when form is filled in', () => {
+  it('OVRD Start VR Form button is enabled when form is filled in', () => {
     const user = userFactory();
 
     cy.mockGraphqlOp('VoterRegistrationDrivePageQuery', {
@@ -280,12 +244,42 @@ describe('Voter Registration Drive (OVRD) Page', () => {
 
     cy.findByTestId('voter-registration-email-field').type('text@test.com');
     cy.findByTestId('voter-registration-zip-field').type('12345');
+    cy.findByTestId('voter-registration-submit-button').should('be.enabled');
+  });
+
+  /** @test */
+  it('OVRD Start VR Form tracking source contains user and referral key values', () => {
+    const user = userFactory();
+
+    cy.mockGraphqlOp('VoterRegistrationDrivePageQuery', {
+      user,
+      campaignWebsite,
+    });
+
+    cy.visit(getOvrdPagePathForUser(user));
+
     cy.findByTestId('voter-registration-tracking-source').should(
       'have.value',
       `user:${user.id},source:web,source_details:onlinedrivereferral,referral=true`,
     );
+  });
 
-    cy.findByTestId('voter-registration-submit-button').should('be.enabled');
+  /** @test */
+  it('OVRD Start VR Form tracking source contains group_id key value if valid group_id', () => {
+    const user = userFactory();
+
+    cy.mockGraphqlOp('VoterRegistrationDrivePageQuery', {
+      user,
+      campaignWebsite,
+      group,
+    });
+
+    cy.visit(`${getOvrdPagePathForUser(user)}&group_id=${group.id}`);
+
+    cy.findByTestId('voter-registration-tracking-source').should(
+      'have.value',
+      `user:${user.id},source:web,source_details:onlinedrivereferral,group_id=${group.id},referral=true`,
+    );
   });
 
   /** @test */

--- a/cypress/integration/voter-registration-drive-page.js
+++ b/cypress/integration/voter-registration-drive-page.js
@@ -235,7 +235,7 @@ describe('Voter Registration Drive (OVRD) Page', () => {
   });
 
   /** @test */
-  it('OVRD quote displays three or more voting reasons when found in voting-reasons query', () => {
+  it('OVRD quote joins voting reasons with comma when 3 or more found in voting-reasons query', () => {
     const user = userFactory();
 
     cy.mockGraphqlOp('VoterRegistrationDrivePageQuery', {
@@ -259,7 +259,7 @@ describe('Voter Registration Drive (OVRD) Page', () => {
   });
 
   /** @test */
-  it('OVRD Start VR Form button is disabled when form is empty', () => {
+  it('OVRD Start VR Form button is disabled when form is empty, and enabled when completed', () => {
     const user = userFactory();
 
     cy.mockGraphqlOp('VoterRegistrationDrivePageQuery', {
@@ -271,20 +271,6 @@ describe('Voter Registration Drive (OVRD) Page', () => {
     cy.visit(getOvrdPagePathForUser(user));
 
     cy.findByTestId('voter-registration-submit-button').should('be.disabled');
-  });
-
-  /** @test */
-  it('OVRD Start VR Form button is enabled when form is filled in', () => {
-    const user = userFactory();
-
-    cy.mockGraphqlOp('VoterRegistrationDrivePageQuery', {
-      user,
-      campaignWebsite,
-      group: null,
-    });
-
-    cy.visit(getOvrdPagePathForUser(user));
-
     cy.findByTestId('voter-registration-email-field').type('text@test.com');
     cy.findByTestId('voter-registration-zip-field').type('12345');
     cy.findByTestId('voter-registration-submit-button').should('be.enabled');

--- a/cypress/integration/voter-registration-drive-page.js
+++ b/cypress/integration/voter-registration-drive-page.js
@@ -73,7 +73,7 @@ describe('Voter Registration Drive (OVRD) Page', () => {
   });
 
   /** @test */
-  it('OVRD HeroSection displays a cover image', () => {
+  it('OVRD banner displays a cover image', () => {
     const user = userFactory();
 
     cy.mockGraphqlOp('VoterRegistrationDrivePageQuery', {
@@ -90,7 +90,7 @@ describe('Voter Registration Drive (OVRD) Page', () => {
   });
 
   /** @test */
-  it('OVRD HeroSection displays referrer first name if referrer user found', () => {
+  it('OVRD banner displays referrer first name if referrer user found', () => {
     const user = userFactory();
 
     cy.mockGraphqlOp('VoterRegistrationDrivePageQuery', {
@@ -111,7 +111,7 @@ describe('Voter Registration Drive (OVRD) Page', () => {
   });
 
   /** @test */
-  it('OVRD HeroSection displays scholarhship info if it is provided', () => {
+  it('OVRD banner displays scholarship info if it is provided', () => {
     const user = userFactory();
 
     cy.mockGraphqlOp('VoterRegistrationDrivePageQuery', {
@@ -130,6 +130,9 @@ describe('Voter Registration Drive (OVRD) Page', () => {
     ).contains(`$1,500`);
     cy.contains('button', 'View Scholarship Details');
     cy.contains(`April 25th, 2022`);
+    cy.get('[data-test=voter-registration-drive-page-blurb]').contains(
+      `150,000+ young people have registered to vote via DoSomething. After you register, share with your friends to enter to win a $1,500 scholarship!`,
+    );
   });
 
   /** @test */
@@ -213,22 +216,6 @@ describe('Voter Registration Drive (OVRD) Page', () => {
     );
     cy.get('[data-test=voter-registration-drive-page-quote-byline]').contains(
       `- ${user.firstName}`,
-    );
-  });
-
-  /** @test */
-  it('OVRD HeroSection displays scholarship info in blurb', () => {
-    const user = userFactory();
-
-    cy.mockGraphqlOp('VoterRegistrationDrivePageQuery', {
-      user,
-      campaignWebsite,
-    });
-
-    cy.visit(getOvrdPagePathForUser(user));
-
-    cy.get('[data-test=voter-registration-drive-page-blurb]').contains(
-      `150,000+ young people have registered to vote via DoSomething. After you register, share with your friends to enter to win a $1,500 scholarship!`,
     );
   });
 

--- a/resources/assets/components/pages/VoterRegistrationDrivePage/VoterRegistrationDrivePage.js
+++ b/resources/assets/components/pages/VoterRegistrationDrivePage/VoterRegistrationDrivePage.js
@@ -20,6 +20,7 @@ const VOTER_REGISTRATION_DRIVE_PAGE_QUERY = gql`
   query VoterRegistrationDrivePageQuery(
     $referrerUserId: String!
     $voterRegistrationDriveCampaignWebsiteId: String!
+    $groupId: Int!
   ) {
     user(id: $referrerUserId) {
       id
@@ -38,11 +39,17 @@ const VOTER_REGISTRATION_DRIVE_PAGE_QUERY = gql`
       title
       url
     }
+
+    group(id: $groupId) {
+      id
+      name
+    }
   }
 `;
 
 const VoterRegistrationDrivePage = () => {
   const referrerUserId = query('referrer_user_id');
+  const groupId = query('group_id');
 
   const config = isDevEnvironment()
     ? gqlVariables.development
@@ -67,6 +74,8 @@ const VoterRegistrationDrivePage = () => {
       variables: {
         referrerUserId,
         voterRegistrationDriveCampaignWebsiteId,
+        // This is a hack to avoid passing a null groupId, which is required for the query.
+        groupId: Number(groupId) || 0,
       },
     },
   );
@@ -81,6 +90,10 @@ const VoterRegistrationDrivePage = () => {
 
   if (!data.user) {
     return <NotFoundPage id={referrerUserId} />;
+  }
+
+  if (groupId && !data.group) {
+    return <NotFoundPage id={groupId} />;
   }
 
   const {
@@ -111,6 +124,7 @@ const VoterRegistrationDrivePage = () => {
                 campaignId={campaignId}
                 className="md:w-3/5"
                 contextSource="beta-voter-registration-drive-page"
+                groupId={groupId}
                 referrerUserId={referrerUserId}
                 sourceDetail="onlinedrivereferral"
               />

--- a/resources/assets/components/pages/VoterRegistrationDrivePage/VoterRegistrationDrivePage.js
+++ b/resources/assets/components/pages/VoterRegistrationDrivePage/VoterRegistrationDrivePage.js
@@ -49,7 +49,7 @@ const VOTER_REGISTRATION_DRIVE_PAGE_QUERY = gql`
 
 const VoterRegistrationDrivePage = () => {
   const referrerUserId = query('referrer_user_id');
-  const groupId = query('group_id');
+  const groupId = Number(query('group_id'));
 
   const config = isDevEnvironment()
     ? gqlVariables.development
@@ -75,7 +75,7 @@ const VoterRegistrationDrivePage = () => {
         referrerUserId,
         voterRegistrationDriveCampaignWebsiteId,
         // This is a hack to avoid passing a null groupId, which is required for the query.
-        groupId: Number(groupId) || 0,
+        groupId: groupId || 0,
       },
     },
   );
@@ -93,7 +93,7 @@ const VoterRegistrationDrivePage = () => {
   }
 
   if (groupId && !data.group) {
-    return <NotFoundPage id={groupId} />;
+    return <NotFoundPage id={`${groupId}`} />;
   }
 
   const {

--- a/resources/assets/components/pages/VoterRegistrationDrivePage/VoterRegistrationDrivePage.js
+++ b/resources/assets/components/pages/VoterRegistrationDrivePage/VoterRegistrationDrivePage.js
@@ -93,7 +93,7 @@ const VoterRegistrationDrivePage = () => {
   }
 
   if (groupId && !data.group) {
-    return <NotFoundPage id={`${groupId}`} />;
+    return <NotFoundPage id={query('group_id')} />;
   }
 
   const {

--- a/resources/assets/components/utilities/StartVoterRegistrationForm/StartVoterRegistrationForm.js
+++ b/resources/assets/components/utilities/StartVoterRegistrationForm/StartVoterRegistrationForm.js
@@ -14,6 +14,7 @@ const StartVoterRegistrationForm = ({
   campaignId,
   className,
   contextSource,
+  groupId,
   referrerUserId,
   sourceDetail,
 }) => {
@@ -23,6 +24,7 @@ const StartVoterRegistrationForm = ({
   const trackingSource = getVoterRegistrationTrackingSource(
     sourceDetail,
     referrerUserId,
+    groupId,
   );
   const isDisabled = !zip || !email;
 
@@ -113,6 +115,7 @@ StartVoterRegistrationForm.propTypes = {
   campaignId: PropTypes.number,
   className: PropTypes.string,
   contextSource: PropTypes.string.isRequired,
+  groupId: PropTypes.number,
   referrerUserId: PropTypes.string,
   sourceDetail: PropTypes.string.isRequired,
 };
@@ -120,6 +123,7 @@ StartVoterRegistrationForm.propTypes = {
 StartVoterRegistrationForm.defaultProps = {
   campaignId: null,
   className: null,
+  groupId: null,
   referrerUserId: null,
 };
 

--- a/resources/assets/helpers/index.js
+++ b/resources/assets/helpers/index.js
@@ -1026,15 +1026,19 @@ export function getMillisecondsFromDays(days) {
 /**
  * Build UTMs for Voter Registration URLs
  *
- * @param {String} referrerUserId
  * @param {String} sourceDetails
+ * @param {String} referrerUserId
+ * @param {Number} groupId
+ * @return {String}
  */
-
 export function getVoterRegistrationTrackingSource(
   sourceDetails,
-  referrerUserId = '',
+  referrerUserId,
+  groupId,
 ) {
-  const result = `source:web,source_details:${sourceDetails}`;
+  const result = `source:web,source_details:${sourceDetails}${
+    groupId ? `,group_id=${groupId}` : null
+  }`;
 
   if (referrerUserId) {
     return `user:${referrerUserId},${result},referral=true`;

--- a/resources/assets/helpers/index.js
+++ b/resources/assets/helpers/index.js
@@ -1024,7 +1024,8 @@ export function getMillisecondsFromDays(days) {
 }
 
 /**
- * Build UTMs for Voter Registration URLs
+ * Returns tracking source query value to send for Voter Registration URLs.
+ * @see /docs/development/features/voter-registration#tracking-source
  *
  * @param {String} sourceDetails
  * @param {String} referrerUserId

--- a/resources/assets/helpers/index.js
+++ b/resources/assets/helpers/index.js
@@ -1037,7 +1037,7 @@ export function getVoterRegistrationTrackingSource(
   groupId,
 ) {
   const result = `source:web,source_details:${sourceDetails}${
-    groupId ? `,group_id=${groupId}` : null
+    groupId ? `,group_id=${groupId}` : ''
   }`;
 
   if (referrerUserId) {


### PR DESCRIPTION
### What's this PR do?

This pull request continues #2213 to include a `group_id` key/value in the RTV tracking source if a valid `group_id` query parameter is found on an OVRD page. 

This example URL:
```
/us/my-voter-registration-drive?group_id=4&referrer_user_id=55767606a59dbf3c7a8b4571`
```
will pass the tracking source:
```
user:55767606a59dbf3c7a8b4571,source:web,source_details:onlinedrivereferral,group_id=4,referral=true
```

which will end up in a voter-reg post imported with a `group_id` value of 4 per https://github.com/DoSomething/chompy/pull/176.

If a `group_id` query parameter is passed and there is no group found, the OVRD page will display a `NotFoundPage`. This is because the Chompy request to the Rogue `POST /posts` API endpoint would fail with a `foreign key constraint fails` error -- refs https://github.com/DoSomething/rogue/pull/1042#discussion_r437736621.

### How should this be reviewed?

👀 

### Any background context you want to provide?

This PR also consolidates a few of the OVRD page Cypress tests that visit a valid OVRD page and test for expected content into a single "View expected info" test. This makes it a little quicker to run all of the tests, because there's less of them -- and I think helps keep the file a bit more maintainable.

### Relevant tickets

Finishes [Pivotal #173019820](https://www.pivotaltracker.com/story/show/173019820).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added screenshots of front-end changes on small, medium, and large screens.
- [x] Added appropriate feature/unit tests.
