### PR TITLE
Add group type to query for campaigns

### DIFF
--- a/cypress/fixtures/graphql.js
+++ b/cypress/fixtures/graphql.js
@@ -107,7 +107,6 @@ export const mocks = {
   Campaign: () => ({
     endDate: () => addMonths(new Date(), 1).toISOString(),
     isOpen: true,
-    groupTypeId: null,
   }),
   // For blocks, we'll either use the provided '__typename' from the operation
   // mock, or we'll use our hardcoded IDs, above (for PHP interoperability).

--- a/cypress/fixtures/graphql.js
+++ b/cypress/fixtures/graphql.js
@@ -107,6 +107,7 @@ export const mocks = {
   Campaign: () => ({
     endDate: () => addMonths(new Date(), 1).toISOString(),
     isOpen: true,
+    groupTypeId: null,
   }),
   // For blocks, we'll either use the provided '__typename' from the operation
   // mock, or we'll use our hardcoded IDs, above (for PHP interoperability).

--- a/cypress/integration/campaign-signup.js
+++ b/cypress/integration/campaign-signup.js
@@ -21,6 +21,13 @@ describe('Campaign Signup', () => {
   it('Create signup, as an anonymous user', () => {
     const user = userFactory();
 
+    cy.mockGraphqlOp('CampaignBannerQuery', {
+      campaign: {
+        id: campaignId,
+        groupTypeId: null,
+      },
+    });
+
     // Visit the campaign landing page:
     cy.anonVisitCampaign(exampleCampaign);
 
@@ -47,7 +54,12 @@ describe('Campaign Signup', () => {
   /** @test */
   it('Create signup, as an authenticated user', () => {
     const user = userFactory();
-
+    cy.mockGraphqlOp('CampaignBannerQuery', {
+      campaign: {
+        id: campaignId,
+        groupTypeId: null,
+      },
+    });
     // Log in & visit the campaign landing page:
     cy.authVisitCampaignWithoutSignup(user, exampleCampaign);
 
@@ -72,7 +84,12 @@ describe('Campaign Signup', () => {
     /** @test */
     it('Display Referral Page Banner CTA in affirmation for configured campaign & feature flagged user', () => {
       const user = userFactory();
-
+      cy.mockGraphqlOp('CampaignBannerQuery', {
+        campaign: {
+          id: campaignId,
+          groupTypeId: null,
+        },
+      });
       // Log in & visit the campaign pitch page:
       cy.authVisitCampaignWithoutSignup(user, exampleReferralCampaign);
 
@@ -98,6 +115,13 @@ describe('Campaign Signup', () => {
     /** @test */
     it("Doesn't display Referral Page Banner CTA in affirmation for non configured campaign", () => {
       const user = userFactory();
+
+      cy.mockGraphqlOp('CampaignBannerQuery', {
+        campaign: {
+          id: campaignId,
+          groupTypeId: null,
+        },
+      });
 
       // Log in & visit the campaign pitch page:
       cy.authVisitCampaignWithoutSignup(user, exampleCampaign);
@@ -141,6 +165,13 @@ describe('Campaign Signup', () => {
 
   /** @test */
   it('Visits a campaign page from scholarship partner, as an unauthenticated user', () => {
+    cy.mockGraphqlOp('CampaignBannerQuery', {
+      campaign: {
+        id: campaignId,
+        groupTypeId: null,
+      },
+    });
+
     // Visit the campaign pitch page
     cy.withState(exampleCampaign).visit(
       '/us/campaigns/test-example-campaign?utm_campaign=fastweb&utm_source=scholarship',

--- a/cypress/integration/campaign-signup.js
+++ b/cypress/integration/campaign-signup.js
@@ -163,10 +163,15 @@ describe('Campaign Signup', () => {
       ],
     });
 
+    cy.mockGraphqlOp('CampaignBannerQuery', {
+      campaign: {
+        id: campaignId,
+        groupTypeId: 1,
+      },
+    });
+
     // Visit the campaign pitch page
-    cy.withState(exampleCampaign).visit(
-      '/us/campaigns/test-example-campaign?group_type_id=1',
-    );
+    cy.withState(exampleCampaign).visit('/us/campaigns/test-example-campaign');
 
     cy.findByTestId('join-group-signup-form').should('have.length', 1);
     cy.findByTestId('campaign-banner-signup-button').contains(

--- a/resources/assets/components/CampaignBanner/CampaignBanner.js
+++ b/resources/assets/components/CampaignBanner/CampaignBanner.js
@@ -184,12 +184,16 @@ const CampaignBanner = ({
                   !campaignGroupTypeId ? 'w-2/3 sm:w-1/2' : null
                 }`}
               >
-                <SignupButtonContainer
-                  campaignGroupTypeId={campaignGroupTypeId}
-                  className="w-full md:px-2"
-                  text={SCHOLARSHIP_SIGNUP_BUTTON_TEXT}
-                  contextSource="scholarship_modal"
-                />
+                {!loading ? (
+                  <SignupButtonContainer
+                    campaignGroupTypeId={campaignGroupTypeId}
+                    className="w-full md:px-2"
+                    text={SCHOLARSHIP_SIGNUP_BUTTON_TEXT}
+                    contextSource="scholarship_modal"
+                  />
+                ) : (
+                  <Placeholder />
+                )}
               </div>
             ) : null}
           </ScholarshipInfoBlock>

--- a/schema.json
+++ b/schema.json
@@ -232,6 +232,16 @@
                 "defaultValue": null
               },
               {
+                "name": "groupTypeId",
+                "description": "Only return campaigns containing this group type id.",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null
+              },
+              {
                 "name": "orderBy",
                 "description": "How to order the results (e.g. 'id,desc').",
                 "type": {
@@ -309,6 +319,16 @@
                     "name": "String",
                     "ofType": null
                   }
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "groupTypeId",
+                "description": "Only return campaigns containing this group type id.",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
                 },
                 "defaultValue": null
               },
@@ -4336,6 +4356,18 @@
             "type": {
               "kind": "SCALAR",
               "name": "DateTime",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "groupTypeId",
+            "description": "The group type id associated with this campaign.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
               "ofType": null
             },
             "isDeprecated": false,


### PR DESCRIPTION
### What's this PR do?

This pull request removes the check for a query parameter defining a `group_type_id` and adds the `groupTypeId` to a query to graphql.

### How should this be reviewed?

👀 

### Any background context you want to provide?

The query was a hack approach until the graphql was finalized.

### Relevant tickets

References [Pivotal # 172541970](https://www.pivotaltracker.com/story/show/172541970).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added screenshots of front-end changes on small, medium, and large screens.
- [ ] Added appropriate feature/unit tests.
