### PR TITLE
QuizResultPage content changes

### DIFF
--- a/cypress/integration/quiz-result-page.js
+++ b/cypress/integration/quiz-result-page.js
@@ -4,8 +4,7 @@ import faker from 'faker';
 
 import { userFactory } from '../fixtures/user';
 
-const quizResultId = 'p7hqjSP4Y1U6ad0UDz4iS';
-const ineligibleQuizResultId = '14KfeAs265httjNMf1jwTw';
+const quizResultId = '347iYsbykgQe6KqeGceMUk';
 
 /**
  * @param String id
@@ -57,7 +56,7 @@ describe('Quiz Result Page', () => {
       block: linkBlock,
     });
 
-    cy.visit(getQuizResultPath(ineligibleQuizResultId));
+    cy.visit(getQuizResultPath('2KfkCOTi7u4CqAyyCuGyci'));
 
     cy.findByTestId('quiz-result-page').should('have.length', 1);
     cy.findByTestId('voter-registration-form-card').should('have.length', 0);
@@ -74,7 +73,7 @@ describe('Quiz Result Page', () => {
     cy.findByTestId('quiz-result-page').should('have.length', 1);
     cy.findByTestId('voter-registration-tracking-source').should(
       'have.value',
-      'source:web,source_details:VoterRegQuiz_completed_votebymail',
+      'source:web,source_details:VoterRegQuiz_completed_notsure',
     );
   });
 
@@ -92,7 +91,7 @@ describe('Quiz Result Page', () => {
     cy.findByTestId('quiz-result-page').should('have.length', 1);
     cy.findByTestId('voter-registration-tracking-source').should(
       'have.value',
-      `user:${user.id},source:web,source_details:VoterRegQuiz_completed_votebymail`,
+      `user:${user.id},source:web,source_details:VoterRegQuiz_completed_notsure`,
     );
   });
 });

--- a/cypress/support/index.js
+++ b/cypress/support/index.js
@@ -13,6 +13,7 @@ Cypress.on('window:before:load', window => {
 
   // Custom ENV variables for the testing environment.
   window.ENV = {
+    APP_ENV: 'development',
     FEATURE_FLAGS: {
       nps_survey: false,
     },

--- a/resources/assets/components/pages/QuizResultPage/QuizResultPage.js
+++ b/resources/assets/components/pages/QuizResultPage/QuizResultPage.js
@@ -6,7 +6,7 @@ import { useQuery } from 'react-apollo';
 
 import ErrorPage from '../ErrorPage';
 import triangle from './triangle.svg';
-import { gqlVariables } from './config';
+import gqlVariables from './config';
 import NotFoundPage from '../NotFoundPage';
 import { isDevEnvironment } from '../../../helpers';
 import Placeholder from '../../utilities/Placeholder';

--- a/resources/assets/components/pages/QuizResultPage/QuizResultPage.js
+++ b/resources/assets/components/pages/QuizResultPage/QuizResultPage.js
@@ -93,9 +93,9 @@ const QuizResultPage = ({ id }) => {
                 </h1>
 
                 <p className="mb-3 text-lg text-center">
-                  Paying attention to how our government is handling the
-                  COVID-19 outbreak? Your vote is your way of making an impact
-                  on the decisions our government makes.
+                  75% of young people say that the most important thing we can
+                  do to fight for racial justice is vote. Your vote is your way
+                  of making an impact on the decisions our government makes.
                 </p>
                 <p className="mb-6 text-lg text-center">
                   Take 2 minutes and register online now with your state.

--- a/resources/assets/components/pages/QuizResultPage/config.js
+++ b/resources/assets/components/pages/QuizResultPage/config.js
@@ -4,7 +4,7 @@
  */
 const sourceDetailPrefix = 'VoterRegQuiz_completed_';
 
-export const gqlVariables = {
+const gqlVariables = {
   production: {
     galleryBlockId: '78WaGsvDEzAxnreEvNx3Za',
     results: {
@@ -61,9 +61,4 @@ export const gqlVariables = {
   },
 };
 
-export const placeholderContent = `Saepe cupiditate non. Facere velit vitae corporis. Voluptatum illo inventore quasi earum.
-
-  **Necessitatibus odio nam.** Repudiandae commodi fugit. Placeat consequuntur autem dignissimos ducimus excepturi quis neque. Qui maiores voluptas illum et est laborum quia veniam. 
-
-  Dicta quia quas impedit. Laborum id eius molestias eveniet temporibus. Rerum tempora id eos officiis omnis nam. Eveniet quod quam et hic eligendi ab et. Tempora qui consequatur dolor laudantium voluptate magnam soluta. Eaque saepe quisquam similique voluptatum error.
-`;
+export { gqlVariables as default };

--- a/resources/assets/components/pages/QuizResultPage/config.js
+++ b/resources/assets/components/pages/QuizResultPage/config.js
@@ -51,11 +51,15 @@ const gqlVariables = {
         assetId: '3iLKsRlFQ1k9ddQbRb3RN8',
         sourceDetail: `${sourceDetailPrefix}votebymail`,
       },
-      // Election Dabbler
+      /**
+       * This quiz result is intentionally missing a sourceDetail for sake of testing.
+       * A previous iteration of the quiz had one result where we didn't want to display the start
+       * voter registration form (for users who are ineligible to vote), so we didn't include a
+       * sourceDetail.
+       */
       '2KfkCOTi7u4CqAyyCuGyci': {
         // Rabbit:
         assetId: '3uB88eZmTNEaoFxV9pZ8hX',
-        sourceDetail: `${sourceDetailPrefix}inperson`,
       },
     },
   },

--- a/resources/assets/components/pages/QuizResultPage/config.js
+++ b/resources/assets/components/pages/QuizResultPage/config.js
@@ -26,6 +26,8 @@ export const gqlVariables = {
       // Ineligible to vote / Panda
       '14KfeAs265httjNMf1jwTw': {
         assetId: '3WjT0QGNnJEPPz2yMd3inj',
+        // @see https://dosomething.slack.com/archives/CTVPG6L4R/p1592329248450700?thread_ts=1592328663.448100&cid=CTVPG6L4R
+        sourceDetail: `${sourceDetailPrefix}housing`,
       },
     },
   },


### PR DESCRIPTION
### What's this PR do?

* Displays a `StartVoterRegistrationForm` on result `14KfeAs265httjNMf1jwTw`, by passing a source detail - [Slack thread](https://dosomething.slack.com/archives/CTVPG6L4R/p1592328663448100)

* Updates hardcoded copy per [Slack thread](https://dosomething.slack.com/archives/CTVPG6L4R/p1592335113465000)

* Cleanup unused `placeholderContent` config -- this was deprecated in #2174 

### How should this be reviewed?

👀 

### Any background context you want to provide?

This PR also modifies our mock Cypress `APP_URL` to be set to `development`, so we can test with dev quiz result ID's (and remove a source detail for sake of testing, without breaking anything in production)

### Relevant tickets

See linked Slack threads per description.

### Checklist

- [x] Added appropriate feature/unit tests.
