### PR TITLE
Errors or Error Messages In All Error Blocks/Pages

### DIFF
--- a/resources/assets/components/ContentfulEntry/ContentfulEntry.js
+++ b/resources/assets/components/ContentfulEntry/ContentfulEntry.js
@@ -35,18 +35,18 @@ const DEFAULT_BLOCK = { fields: { type: null } };
 
 class ContentfulEntry extends React.Component {
   state = {
-    hasError: false,
+    error: null,
   };
 
   componentDidCatch(error) {
-    this.setState({ hasError: true });
+    this.setState({ error });
     report(error);
   }
 
   render() {
     // Did we hit an error? :(
-    if (this.state.hasError) {
-      return <ErrorBlock />;
+    if (this.state.error) {
+      return <ErrorBlock error={this.state.error} />;
     }
 
     // Otherwise, find the corresponding component & render it!

--- a/resources/assets/components/PaginatedQuery.js
+++ b/resources/assets/components/PaginatedQuery.js
@@ -23,7 +23,7 @@ const PaginatedQuery = ({ query, queryName, variables, count, children }) => (
 
       if (result.error) {
         console.error(`${queryName} ERROR: ${result.error}`);
-        return <ErrorBlock />;
+        return <ErrorBlock error={result.error} />;
       }
 
       return children({

--- a/resources/assets/components/blocks/EmbedBlock/EmbedBlock.js
+++ b/resources/assets/components/blocks/EmbedBlock/EmbedBlock.js
@@ -34,7 +34,11 @@ const EmbedBlock = props => {
       return <CartoTemplate {...props} />;
 
     default:
-      return <ErrorBlock />;
+      return (
+        <ErrorBlock
+          error={`Embed Block URL contains a non permitted hostname. Hostname: ${hostname}`}
+        />
+      );
   }
 };
 

--- a/resources/assets/components/blocks/ErrorBlock/ErrorBlock.js
+++ b/resources/assets/components/blocks/ErrorBlock/ErrorBlock.js
@@ -1,5 +1,5 @@
-import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
+import React, { useEffect } from 'react';
 
 import errorIcon from './error_icon.svg';
 import { report } from '../../../helpers';
@@ -24,11 +24,7 @@ const ErrorBlock = ({ error }) => {
 };
 
 ErrorBlock.propTypes = {
-  error: PropTypes.oneOfType([PropTypes.object, PropTypes.string]),
-};
-
-ErrorBlock.defaultProps = {
-  error: null,
+  error: PropTypes.oneOfType([PropTypes.object, PropTypes.string]).isRequired,
 };
 
 export default ErrorBlock;

--- a/resources/assets/components/pages/AccountPage/Account/AccountQuery.js
+++ b/resources/assets/components/pages/AccountPage/Account/AccountQuery.js
@@ -33,7 +33,7 @@ const AccountQuery = ({ userId }) => {
   }
 
   if (error) {
-    return <ErrorPage />;
+    return <ErrorPage error={error} />;
   }
 
   if (!data.user) {

--- a/resources/assets/components/pages/ErrorPage.js
+++ b/resources/assets/components/pages/ErrorPage.js
@@ -1,5 +1,5 @@
-import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
+import React, { useEffect } from 'react';
 
 import { report } from '../../helpers';
 import ErrorDetails from '../utilities/ErrorDetails';
@@ -43,11 +43,7 @@ const ErrorPage = ({ error }) => {
 };
 
 ErrorPage.propTypes = {
-  error: PropTypes.oneOfType([PropTypes.object, PropTypes.string]),
-};
-
-ErrorPage.defaultProps = {
-  error: null,
+  error: PropTypes.oneOfType([PropTypes.object, PropTypes.string]).isRequired,
 };
 
 export default ErrorPage;

--- a/resources/assets/components/pages/ReferralPage/Alpha/AlphaPage.js
+++ b/resources/assets/components/pages/ReferralPage/Alpha/AlphaPage.js
@@ -57,7 +57,7 @@ const AlphaPage = () =>
       <SiteFooter />
     </>
   ) : (
-    <ErrorPage />
+    <ErrorPage error="Unable to generate referral link." />
   );
 
 export default AlphaPage;

--- a/resources/assets/components/pages/ReferralPage/Beta/BetaPage.js
+++ b/resources/assets/components/pages/ReferralPage/Beta/BetaPage.js
@@ -23,7 +23,7 @@ const BetaPage = () => {
   const campaignId = getReferralCampaignId();
 
   if (!userId || !campaignId) {
-    return <ErrorPage />;
+    return <ErrorPage error="Missing User ID or Campaign ID." />;
   }
 
   return (
@@ -31,7 +31,7 @@ const BetaPage = () => {
     <Query query={REFERRAL_PAGE_USER} variables={{ id: userId }}>
       {data => {
         if (!data.user) {
-          return <ErrorPage />;
+          return <ErrorPage error={`User not found for ID: ${userId}.`} />;
         }
 
         const firstName = data.user.firstName;

--- a/resources/assets/components/pages/ReferralPage/Beta/BetaPageCampaignLink.js
+++ b/resources/assets/components/pages/ReferralPage/Beta/BetaPageCampaignLink.js
@@ -28,7 +28,11 @@ const ReferralPageCampaignLink = ({ campaignId, userId }) => (
       const data = res.campaignWebsiteByCampaignId;
 
       if (!data) {
-        return <ErrorBlock />;
+        return (
+          <ErrorBlock
+            error={`Referral Page Campaign Link could not find Campaign Website for Campaign ID: ${campaignId}`}
+          />
+        );
       }
 
       return (

--- a/resources/assets/components/utilities/ContentfulAsset/ContentfulAsset.js
+++ b/resources/assets/components/utilities/ContentfulAsset/ContentfulAsset.js
@@ -39,7 +39,11 @@ const ContentfulAsset = ({ id, width, height }) => (
       }
 
       if (error || !data.asset) {
-        return <ErrorBlock />;
+        return (
+          <ErrorBlock
+            error={error || `Could not load Contentful Asset for ID: ${id}.`}
+          />
+        );
       }
 
       const { url, description } = data.asset;

--- a/resources/assets/components/utilities/Embed/Embed.js
+++ b/resources/assets/components/utilities/Embed/Embed.js
@@ -64,7 +64,7 @@ const Embed = props => {
           const embed = get(data, 'embed', {});
 
           if (error) {
-            return <ErrorBlock />;
+            return <ErrorBlock error={error} />;
           }
 
           // If an <iframe> code snippet is provided, use that.

--- a/resources/assets/components/utilities/Placeholder.js
+++ b/resources/assets/components/utilities/Placeholder.js
@@ -6,7 +6,7 @@ import ErrorBlock from '../blocks/ErrorBlock/ErrorBlock';
 
 const Placeholder = ({ error }) => {
   if (error) {
-    return <ErrorBlock />;
+    return <ErrorBlock error={error} />;
   }
 
   return (


### PR DESCRIPTION
### What's this PR do?

This pull request adds an `error` value to all rendered `ErrorBlock`s and `ErrorPage`s

### How should this be reviewed?
Do you agree that the `error` prop should be required? (I couldn't think of a use case where we wouldn't want one).
Do the error messages make sense?
Does it make sense to just use a `state.error` field in the `ContentfulEntry`?

### Any background context you want to provide?
Per the awesome work in https://github.com/DoSomething/phoenix-next/pull/2068, we now expose error details in error blocks/pages and Help center questions which help us debug user reported errors.

Per [this reported error in slack](https://dosomething.slack.com/archives/C09ANFQLA/p1592406507132700), we noticed that we weren't exposing the error since we weren't passing an `error` prop to the rendered `ErrorBlock`. 

I figured it would be prudent to add one to all Error Blocks, (and then said heck, Error Pages as well), as well as make the prop required to help nudge us to always pass along as error or error message when making use of these components.

### Relevant tickets
https://dosomething.slack.com/archives/C09ANFQLA/p1592406507132700

