### PR TITLE
Display Spinner after submitting StartVoterRegistrationForm

### DIFF
--- a/resources/assets/components/utilities/StartVoterRegistrationForm/StartVoterRegistrationForm.js
+++ b/resources/assets/components/utilities/StartVoterRegistrationForm/StartVoterRegistrationForm.js
@@ -8,6 +8,7 @@ import {
   trackAnalyticsEvent,
 } from '../../../helpers/analytics';
 import PrimaryButton from '../Button/PrimaryButton';
+import Spinner from '../../artifacts/Spinner/Spinner';
 import { getVoterRegistrationTrackingSource } from '../../../helpers';
 
 const StartVoterRegistrationForm = ({
@@ -105,7 +106,16 @@ const StartVoterRegistrationForm = ({
             attributes={{ 'data-testid': 'voter-registration-submit-button' }}
             className="w-full"
             isDisabled={isDisabled}
-            text={submitted ? 'Processing...' : 'Start Your Registration'}
+            text={
+              submitted ? (
+                <div className="flex justify-center">
+                  <Spinner />
+                  <span className="pl-1 pt-1">Processing...</span>
+                </div>
+              ) : (
+                'Start Your Registration'
+              )
+            }
             type="submit"
           />
         </form>

--- a/resources/assets/components/utilities/StartVoterRegistrationForm/StartVoterRegistrationForm.js
+++ b/resources/assets/components/utilities/StartVoterRegistrationForm/StartVoterRegistrationForm.js
@@ -20,6 +20,7 @@ const StartVoterRegistrationForm = ({
 }) => {
   const [email, setEmail] = useState('');
   const [zip, setZip] = useState('');
+  const [submitted, setSubmitted] = useState(false);
 
   const trackingSource = getVoterRegistrationTrackingSource(
     sourceDetail,
@@ -34,6 +35,8 @@ const StartVoterRegistrationForm = ({
   };
 
   const handleSubmit = () => {
+    setSubmitted(true);
+
     trackAnalyticsEvent('clicked_voter_registration_action', {
       action: 'button_clicked',
       category: EVENT_CATEGORIES.campaignAction,
@@ -102,7 +105,7 @@ const StartVoterRegistrationForm = ({
             attributes={{ 'data-testid': 'voter-registration-submit-button' }}
             className="w-full"
             isDisabled={isDisabled}
-            text="Start Your Registration"
+            text={submitted ? 'Processing...' : 'Start Your Registration'}
             type="submit"
           />
         </form>


### PR DESCRIPTION
### What's this PR do?

This pull request changes the button text on our `StartVoterRegistrationForm` to display a `Spinner` with a "Processing..." label, after the form is submitted and we redirect to Rock the Vote. 

This [Slack thread](https://dosomething.slack.com/archives/CTVPG6L4R/p1592425941490000) provides context for making this change (users may not realize they are being redirected).

<img width="400" alt="Screen Shot 2020-06-17 at 4 24 06 PM" src="https://user-images.githubusercontent.com/1236811/84960633-0fdf0800-b0b7-11ea-8183-e75d0135b367.png">


### How should this be reviewed?

* 👀 
* Manually test by submitting form in the review app: https://dosomething-phoenix-de-pr-2222.herokuapp.com/us/quiz-results/347iYsbykgQe6KqeGceMUk

### Any background context you want to provide?

I think passing a React component as `text` prop on the `PrimaryButton` is far from ideal... but I think we're better off with this minimal-footprint hack for now while we're out of office, vs adding support for a "loading" state into the `PrimaryButton` for re-use in other components (see Platforms [#173015832](https://www.pivotaltracker.com/n/projects/2328687/stories/173015832) and related [Slack thread](https://dosomething.slack.com/archives/C09ANFQLA/p1590251704036700)).

### Relevant tickets

References [Pivotal #173348153](https://www.pivotaltracker.com/story/show/173348153).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added screenshots of front-end changes on small, medium, and large screens.
- [ ] Added appropriate feature/unit tests.
