### PR TITLE
Add callToAction to list of Embedded Entries in Company Pages

### DIFF
--- a/contentful/content-types/companyPage.js
+++ b/contentful/content-types/companyPage.js
@@ -109,6 +109,7 @@ module.exports = function(migration) {
           'embedded-entry-block': [
             {
               linkContentType: [
+                'callToAction',
                 'contentBlock',
                 'galleryBlock',
                 'imagesBlock',


### PR DESCRIPTION
### What's this PR do?

This pull request adds the `callToAction` block as a valid embedded entry to the Company Page `content` field.

### How should this be reviewed?
👁️ 

### Any background context you want to provide?
In #2106 I think we forgot to address Company Pages and migrating their archived Link Actions with `cta` templates. Luckily, I only spotted two pages with them and fixed them manually. But in order to replace them, we need to use the new Call To Action block. 

Noticed this via a failed [Ghost Inspector test](https://app.ghostinspector.com/tests/5c47753d638e692a230fbc9c) on QA showing Not Found blocks where these CTA's should be.