### PR TITLE
Uses ErrorBlock instead of Page

### DIFF
--- a/resources/assets/components/CampaignBanner/CampaignBanner.js
+++ b/resources/assets/components/CampaignBanner/CampaignBanner.js
@@ -5,11 +5,11 @@ import { css } from '@emotion/core';
 import { useQuery } from '@apollo/react-hooks';
 import React, { useState, useEffect } from 'react';
 
-import ErrorPage from '../pages/ErrorPage';
 import Modal from '../utilities/Modal/Modal';
 import ContentfulEntry from '../ContentfulEntry';
 import Placeholder from '../utilities/Placeholder';
 import CampaignHeader from '../utilities/CampaignHeader';
+import ErrorBlock from '../blocks/ErrorBlock/ErrorBlock';
 import CoverImage from '../utilities/CoverImage/CoverImage';
 import TextContent from '../utilities/TextContent/TextContent';
 import { SCHOLARSHIP_SIGNUP_BUTTON_TEXT } from '../../constants';
@@ -70,7 +70,7 @@ const CampaignBanner = ({
   });
 
   if (error) {
-    return <ErrorPage error={error} />;
+    return <ErrorBlock error={error} />;
   }
 
   const campaignGroupTypeId = get(data, 'campaign.groupTypeId', null);


### PR DESCRIPTION
### What's this PR do?

This pull request makes a small tweak to the `CampaignBanner` error handling. We were rendering a full `ErrorPage` inside the Campaign, which caused double site nav etc.

### How should this be reviewed?

👀 

### Any background context you want to provide?

Pointed out [in slack ](https://dosomething.slack.com/archives/CUQMU4Q6B/p1592493506009000)

### Relevant tickets

References [Pivotal #](). N/A quick bug fix

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added screenshots of front-end changes on small, medium, and large screens.
- [ ] Added appropriate feature/unit tests.
