### PR TITLE
Fix UI Bug for Social Drive Action link field

### DIFF
--- a/resources/assets/components/actions/SocialDriveAction/SocialDriveAction.js
+++ b/resources/assets/components/actions/SocialDriveAction/SocialDriveAction.js
@@ -174,7 +174,7 @@ class SocialDriveAction extends React.Component {
                 </div>
               ) : null}
 
-              <div className="link-bar">
+              <div className="link-bar h-10">
                 <input
                   readOnly
                   type="text"
@@ -185,7 +185,7 @@ class SocialDriveAction extends React.Component {
                 />
                 <button
                   type="button"
-                  className="text-field link-copy-button"
+                  className="text-field link-copy-button py-2"
                   onClick={this.handleCopyLinkClick}
                   disabled={loading}
                 >

--- a/resources/assets/components/actions/SocialDriveAction/social-drive.scss
+++ b/resources/assets/components/actions/SocialDriveAction/social-drive.scss
@@ -22,12 +22,8 @@
       display: flex;
       flex: 1;
 
-      .link,
-      .link-copy-button {
-        padding: 6px 12px;
-      }
-
       .link {
+        padding: 6px 12px;
         color: $dark-gray;
         overflow: scroll;
         padding-right: 0;


### PR DESCRIPTION
### What's this PR do?

This pull request addresses a weird visual bug that popped up in the Social Drive Action's link field on Chrome which futzes the vertical alignment of the link copy button.

### How should this be reviewed?
Does this approach feel good? See below.

### Any background context you want to provide?
I couldn't precisely pinpoint the issue, but there seems to be an element height discrepancy (perhaps new to Chrome) which causes the input text to take up more space than it used to, which makes the element higher which throws off the alignment since the padding now isn't enough.

Since we're due to restructure the styling in general to Tailwind-ify and perhaps evolve from the Forge classes, I opted to just enforce a static height for consistency, and a new padding arrangement.

### Relevant tickets
https://dosomething.slack.com/archives/CP2D7UGAU/p1592843737004400?thread_ts=1590602921.083200&cid=CP2D7UGAU


BEFORE:
![image](https://user-images.githubusercontent.com/12417657/85313208-dbd46000-b485-11ea-89a2-c3092db62563.png)


AFTER:
![image](https://user-images.githubusercontent.com/12417657/85313367-eee73000-b485-11ea-9f79-d44aed57b29d.png)

[CURRENT ON FIREFOX](https://user-images.githubusercontent.com/12417657/85314429-826d3080-b487-11ea-8a57-c6010141e0e5.png).


- [SMALL](https://user-images.githubusercontent.com/12417657/85313588-44234180-b486-11ea-8a3c-177e473c8dce.png)
- [MEDIIUM](https://user-images.githubusercontent.com/12417657/85313589-44bbd800-b486-11ea-875e-c52a8a30a118.png)
- [LARGE](https://user-images.githubusercontent.com/12417657/85313592-44bbd800-b486-11ea-95d6-3ec06418c561.png)

