### PR TITLE
Progress bar OVRD Groups

### DIFF
--- a/resources/assets/components/blocks/VoterRegistrationReferralsBlock/templates/Group.js
+++ b/resources/assets/components/blocks/VoterRegistrationReferralsBlock/templates/Group.js
@@ -59,7 +59,7 @@ const GroupTemplate = ({ group }) => {
         {data => (
           <>
             <ProgressBar
-              goalProgess={data.groupReferrals.length || 35}
+              goalProgess={data.groupReferrals.length}
               goalTotal={group.goal || 50}
               testId="group-progress"
             />

--- a/resources/assets/components/blocks/VoterRegistrationReferralsBlock/templates/Group.js
+++ b/resources/assets/components/blocks/VoterRegistrationReferralsBlock/templates/Group.js
@@ -59,7 +59,7 @@ const GroupTemplate = ({ group }) => {
         {data => (
           <>
             <ProgressBar
-              goalProgess={data.groupReferrals.length || 30}
+              goalProgess={data.groupReferrals.length}
               goalTotal={group.goal || 50}
               testId="group-progress"
             />

--- a/resources/assets/components/blocks/VoterRegistrationReferralsBlock/templates/Group.js
+++ b/resources/assets/components/blocks/VoterRegistrationReferralsBlock/templates/Group.js
@@ -59,7 +59,7 @@ const GroupTemplate = ({ group }) => {
         {data => (
           <>
             <ProgressBar
-              goalProgess={data.groupReferrals.length}
+              goalProgess={data.groupReferrals.length || 30}
               goalTotal={group.goal || 50}
               testId="group-progress"
             />

--- a/resources/assets/components/blocks/VoterRegistrationReferralsBlock/templates/Group.js
+++ b/resources/assets/components/blocks/VoterRegistrationReferralsBlock/templates/Group.js
@@ -59,7 +59,7 @@ const GroupTemplate = ({ group }) => {
         {data => (
           <>
             <ProgressBar
-              goalProgess={data.groupReferrals.length}
+              goalProgess={data.groupReferrals.length || 57}
               goalTotal={group.goal || 50}
               testId="group-progress"
             />

--- a/resources/assets/components/blocks/VoterRegistrationReferralsBlock/templates/Group.js
+++ b/resources/assets/components/blocks/VoterRegistrationReferralsBlock/templates/Group.js
@@ -1,8 +1,10 @@
 import React from 'react';
 import gql from 'graphql-tag';
 import PropTypes from 'prop-types';
+import { css } from '@emotion/core';
 
 import Query from '../../../Query';
+import { tailwind } from '../../../../helpers';
 import { getUserId } from '../../../../helpers/auth';
 import SectionHeader from '../../../utilities/SectionHeader/SectionHeader';
 
@@ -48,15 +50,33 @@ StatBlock.propTypes = {
 
 const ProgressBar = ({ goalTotal, goalProgess, testId }) => {
   const percentCompleted = (goalProgess / goalTotal) * 100;
+
+  const tailwindYellow = tailwind('colors.yellow');
+  const tailwindGray = tailwind('colors.gray');
+  const progressBarContainer = css`
+    position: relative;
+    background: ${tailwindGray['200']};
+    height: 20px;
+    width: 350px;
+    border-radius: 50px;
+    border: 1px solid #fff;
+  `;
+  const progressBar = css`
+    background: ${tailwindYellow['500']};
+    height: 100%;
+    border-radius: inherit;
+    transition: width 5s ease-in;
+  `;
+  const label =
+    percentCompleted > 100
+      ? "You're over your goal!"
+      : `${percentCompleted}% To Your Goal!`;
   return (
-    <div className="pt-3">
-      <span className="font-bold uppercase text-gray-600">{`${percentCompleted}% To Your Goal!`}</span>
-      <h1
-        data-testid={testId}
-        className="font-normal font-league-gothic text-3xl"
-      >
-        {percentCompleted}
-      </h1>
+    <div data-testid={testId} className="pt-3">
+      <span className="font-bold uppercase text-gray-600">{label}</span>
+      <div css={progressBarContainer}>
+        <div css={progressBar} style={{ width: `${percentCompleted}%` }} />
+      </div>
     </div>
   );
 };
@@ -79,7 +99,7 @@ const GroupTemplate = ({ group }) => {
         {data => (
           <>
             <ProgressBar
-              goalProgess={data.groupReferrals.length || 5}
+              goalProgess={data.groupReferrals.length || 60}
               goalTotal={group.goal || 50}
               testId="group-progress"
             />

--- a/resources/assets/components/blocks/VoterRegistrationReferralsBlock/templates/Group.js
+++ b/resources/assets/components/blocks/VoterRegistrationReferralsBlock/templates/Group.js
@@ -46,6 +46,27 @@ StatBlock.propTypes = {
   testId: PropTypes.string.isRequired,
 };
 
+const ProgressBar = ({ goalTotal, goalProgess, testId }) => {
+  const percentCompleted = (goalProgess / goalTotal) * 100;
+  return (
+    <div className="pt-3">
+      <span className="font-bold uppercase text-gray-600">{`${percentCompleted}% To Your Goal!`}</span>
+      <h1
+        data-testid={testId}
+        className="font-normal font-league-gothic text-3xl"
+      >
+        {percentCompleted}
+      </h1>
+    </div>
+  );
+};
+
+ProgressBar.propTypes = {
+  goalProgess: PropTypes.number.isRequired,
+  goalTotal: PropTypes.number.isRequired,
+  testId: PropTypes.string.isRequired,
+};
+
 const GroupTemplate = ({ group }) => {
   return (
     <>
@@ -57,6 +78,11 @@ const GroupTemplate = ({ group }) => {
       >
         {data => (
           <>
+            <ProgressBar
+              goalProgess={data.groupReferrals.length || 5}
+              goalTotal={group.goal || 50}
+              testId="group-progress"
+            />
             <StatBlock
               amount={group.goal || 50}
               label="Your group’s registration goal"

--- a/resources/assets/components/blocks/VoterRegistrationReferralsBlock/templates/Group.js
+++ b/resources/assets/components/blocks/VoterRegistrationReferralsBlock/templates/Group.js
@@ -59,8 +59,8 @@ const GroupTemplate = ({ group }) => {
         {data => (
           <>
             <ProgressBar
-              goalProgess={data.groupReferrals.length || 57}
-              goalTotal={group.goal || 50}
+              completed={data.groupReferrals.length}
+              target={group.goal || 50}
               testId="group-progress"
             />
             <StatBlock

--- a/resources/assets/components/blocks/VoterRegistrationReferralsBlock/templates/Group.js
+++ b/resources/assets/components/blocks/VoterRegistrationReferralsBlock/templates/Group.js
@@ -1,11 +1,10 @@
 import React from 'react';
 import gql from 'graphql-tag';
 import PropTypes from 'prop-types';
-import { css } from '@emotion/core';
 
 import Query from '../../../Query';
-import { tailwind } from '../../../../helpers';
 import { getUserId } from '../../../../helpers/auth';
+import ProgressBar from '../../../utilities/ProgressBar/ProgressBar';
 import SectionHeader from '../../../utilities/SectionHeader/SectionHeader';
 
 const GROUP_VOTER_REGISTRATION_REFERRALS_QUERY = gql`
@@ -48,45 +47,6 @@ StatBlock.propTypes = {
   testId: PropTypes.string.isRequired,
 };
 
-const ProgressBar = ({ goalTotal, goalProgess, testId }) => {
-  const percentCompleted = (goalProgess / goalTotal) * 100;
-
-  const tailwindYellow = tailwind('colors.yellow');
-  const tailwindGray = tailwind('colors.gray');
-  const progressBarContainer = css`
-    position: relative;
-    background: ${tailwindGray['200']};
-    height: 20px;
-    width: 350px;
-    border-radius: 50px;
-    border: 1px solid #fff;
-  `;
-  const progressBar = css`
-    background: ${tailwindYellow['500']};
-    height: 100%;
-    border-radius: inherit;
-    transition: width 5s ease-in;
-  `;
-  const label =
-    percentCompleted > 100
-      ? "You're over your goal!"
-      : `${percentCompleted}% To Your Goal!`;
-  return (
-    <div data-testid={testId} className="pt-3">
-      <span className="font-bold uppercase text-gray-600">{label}</span>
-      <div css={progressBarContainer}>
-        <div css={progressBar} style={{ width: `${percentCompleted}%` }} />
-      </div>
-    </div>
-  );
-};
-
-ProgressBar.propTypes = {
-  goalProgess: PropTypes.number.isRequired,
-  goalTotal: PropTypes.number.isRequired,
-  testId: PropTypes.string.isRequired,
-};
-
 const GroupTemplate = ({ group }) => {
   return (
     <>
@@ -99,7 +59,7 @@ const GroupTemplate = ({ group }) => {
         {data => (
           <>
             <ProgressBar
-              goalProgess={data.groupReferrals.length || 60}
+              goalProgess={data.groupReferrals.length || 35}
               goalTotal={group.goal || 50}
               testId="group-progress"
             />

--- a/resources/assets/components/utilities/ProgressBar/ProgressBar.js
+++ b/resources/assets/components/utilities/ProgressBar/ProgressBar.js
@@ -19,13 +19,14 @@ const ProgressBar = ({ goalTotal, goalProgess, testId }) => {
   const progressBar = css`
     background: ${tailwindYellow['500']};
     height: 100%;
+    width: 0px;
     border-radius: inherit;
-    transition: width 5s ease-in;
+    transition: width 1s ease-in;
   `;
 
   const label =
     percentCompleted > 100
-      ? "You're over your goal!"
+      ? `You're ${percentCompleted}% to your goal!`
       : `${percentCompleted}% To Your Goal!`;
 
   const barWidth = percentCompleted > 100 ? 100 : percentCompleted;

--- a/resources/assets/components/utilities/ProgressBar/ProgressBar.js
+++ b/resources/assets/components/utilities/ProgressBar/ProgressBar.js
@@ -1,0 +1,46 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { css } from '@emotion/core';
+
+import { tailwind } from '../../../helpers';
+
+const ProgressBar = ({ goalTotal, goalProgess, testId }) => {
+  const percentCompleted = (goalProgess / goalTotal) * 100;
+
+  const tailwindYellow = tailwind('colors.yellow');
+  const tailwindGray = tailwind('colors.gray');
+  const progressBarContainer = css`
+    position: relative;
+    background: ${tailwindGray['200']};
+    height: 25px;
+    width: 350px;
+    border-radius: 50px;
+    border: 1px solid #fff;
+  `;
+  const progressBar = css`
+    background: ${tailwindYellow['500']};
+    height: 100%;
+    border-radius: inherit;
+    transition: width 5s ease-in;
+  `;
+  const label =
+    percentCompleted > 100
+      ? "You're over your goal!"
+      : `${percentCompleted}% To Your Goal!`;
+  return (
+    <div data-testid={testId} className="py-3">
+      <span className="font-bold uppercase text-gray-600">{label}</span>
+      <div css={progressBarContainer}>
+        <div css={progressBar} style={{ width: `${percentCompleted}%` }} />
+      </div>
+    </div>
+  );
+};
+
+ProgressBar.propTypes = {
+  goalProgess: PropTypes.number.isRequired,
+  goalTotal: PropTypes.number.isRequired,
+  testId: PropTypes.string.isRequired,
+};
+
+export default ProgressBar;

--- a/resources/assets/components/utilities/ProgressBar/ProgressBar.js
+++ b/resources/assets/components/utilities/ProgressBar/ProgressBar.js
@@ -19,9 +19,7 @@ const ProgressBar = ({ goalTotal, goalProgess, testId }) => {
   const progressBar = css`
     background: ${tailwindYellow['500']};
     height: 100%;
-    width: 0px;
     border-radius: inherit;
-    transition: width 1s ease-in;
   `;
 
   const label =

--- a/resources/assets/components/utilities/ProgressBar/ProgressBar.js
+++ b/resources/assets/components/utilities/ProgressBar/ProgressBar.js
@@ -4,8 +4,8 @@ import { css } from '@emotion/core';
 
 import { tailwind } from '../../../helpers';
 
-const ProgressBar = ({ goalTotal, goalProgess, testId }) => {
-  const percentCompleted = Math.round((goalProgess / goalTotal) * 100);
+const ProgressBar = ({ completed, target, testId }) => {
+  const percentCompleted = Math.round((completed / target) * 100);
 
   const tailwindYellow = tailwind('colors.yellow');
 
@@ -40,8 +40,8 @@ const ProgressBar = ({ goalTotal, goalProgess, testId }) => {
 };
 
 ProgressBar.propTypes = {
-  goalProgess: PropTypes.number.isRequired,
-  goalTotal: PropTypes.number.isRequired,
+  completed: PropTypes.number.isRequired,
+  target: PropTypes.number.isRequired,
   testId: PropTypes.string.isRequired,
 };
 

--- a/resources/assets/components/utilities/ProgressBar/ProgressBar.js
+++ b/resources/assets/components/utilities/ProgressBar/ProgressBar.js
@@ -8,30 +8,33 @@ const ProgressBar = ({ goalTotal, goalProgess, testId }) => {
   const percentCompleted = (goalProgess / goalTotal) * 100;
 
   const tailwindYellow = tailwind('colors.yellow');
-  const tailwindGray = tailwind('colors.gray');
+
   const progressBarContainer = css`
-    position: relative;
-    background: ${tailwindGray['200']};
     height: 25px;
     width: 350px;
     border-radius: 50px;
     border: 1px solid #fff;
   `;
+
   const progressBar = css`
     background: ${tailwindYellow['500']};
     height: 100%;
     border-radius: inherit;
     transition: width 5s ease-in;
   `;
+
   const label =
     percentCompleted > 100
       ? "You're over your goal!"
       : `${percentCompleted}% To Your Goal!`;
+
+  const barWidth = percentCompleted > 100 ? 100 : percentCompleted;
+
   return (
     <div data-testid={testId} className="py-3">
       <span className="font-bold uppercase text-gray-600">{label}</span>
-      <div css={progressBarContainer}>
-        <div css={progressBar} style={{ width: `${percentCompleted}%` }} />
+      <div className="relative bg-gray-200" css={progressBarContainer}>
+        <div css={progressBar} style={{ width: `${barWidth}%` }} />
       </div>
     </div>
   );

--- a/resources/assets/components/utilities/ProgressBar/ProgressBar.js
+++ b/resources/assets/components/utilities/ProgressBar/ProgressBar.js
@@ -5,7 +5,7 @@ import { css } from '@emotion/core';
 import { tailwind } from '../../../helpers';
 
 const ProgressBar = ({ goalTotal, goalProgess, testId }) => {
-  const percentCompleted = (goalProgess / goalTotal) * 100;
+  const percentCompleted = Math.round((goalProgess / goalTotal) * 100);
 
   const tailwindYellow = tailwind('colors.yellow');
 


### PR DESCRIPTION
### What's this PR do?

This pull request adds a progress bar to the OVRD groups page so users can easily see how far their group has gotten with registrations. 

### How should this be reviewed?

👀 
<img width="803" alt="Screen Shot 2020-06-22 at 4 17 32 PM" src="https://user-images.githubusercontent.com/15236023/85336581-70e65180-b4a4-11ea-831e-02c214668c1b.png">

<img width="374" alt="Screen Shot 2020-06-22 at 4 18 06 PM" src="https://user-images.githubusercontent.com/15236023/85336594-75126f00-b4a4-11ea-81dd-343b1dd96831.png">


### Any background context you want to provide?

N/A

### Relevant tickets

References [Pivotal # 173290162](https://www.pivotaltracker.com/story/show/173290162).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added screenshots of front-end changes on small, medium, and large screens.
- [ ] Added appropriate feature/unit tests.
