### PR TITLE
Search for groups by name

### DIFF
--- a/cypress/integration/campaign-signup.js
+++ b/cypress/integration/campaign-signup.js
@@ -211,7 +211,9 @@ describe('Campaign Signup', () => {
     );
     cy.findByTestId('join-group-signup-button').should('be.disabled');
     cy.get('#select-group-dropdown').click();
-    cy.get('#react-select-select-group--option-0').click();
-    cy.findByTestId('join-group-signup-button').should('be.enabled');
+    cy.get('#react-select-select-group--input').type('new');
+    // TODO: Fix me
+    //cy.get('#react-select-select-group--option-0').click();
+    //cy.findByTestId('join-group-signup-button').should('be.enabled');
   });
 });

--- a/cypress/integration/campaign-signup.js
+++ b/cypress/integration/campaign-signup.js
@@ -212,8 +212,7 @@ describe('Campaign Signup', () => {
     cy.findByTestId('join-group-signup-button').should('be.disabled');
     cy.get('#select-group-dropdown').click();
     cy.get('#react-select-select-group--input').type('new');
-    // TODO: Fix me
-    //cy.get('#react-select-select-group--option-0').click();
-    //cy.findByTestId('join-group-signup-button').should('be.enabled');
+    cy.get('#react-select-select-group--option-0').click();
+    cy.findByTestId('join-group-signup-button').should('be.enabled');
   });
 });

--- a/resources/assets/components/SignupButton/GroupSelect.js
+++ b/resources/assets/components/SignupButton/GroupSelect.js
@@ -36,12 +36,10 @@ const GroupSelect = ({ groupTypeId, onChange }) => {
    */
   return (
     <AsyncSelect
-      defaultOptions
       getOptionLabel={group => group.name}
       getOptionValue={group => group.id}
       id="select-group-dropdown"
       instanceId="select-group-"
-      isClearable
       loadOptions={(input, callback) => {
         if (!input) {
           return Promise.resolve([]);

--- a/resources/assets/components/SignupButton/GroupSelect.js
+++ b/resources/assets/components/SignupButton/GroupSelect.js
@@ -1,19 +1,13 @@
 import React from 'react';
 import gql from 'graphql-tag';
-import Select from 'react-select';
+import { debounce } from 'lodash';
 import PropTypes from 'prop-types';
-import { useQuery } from '@apollo/react-hooks';
+import AsyncSelect from 'react-select/async';
+import { useApolloClient } from '@apollo/react-hooks';
 
-import Spinner from '../artifacts/Spinner/Spinner';
-import ErrorBlock from '../blocks/ErrorBlock/ErrorBlock';
-
-/**
- * Note: eventually we'll need to query by the group name, once we have more than 20 results
- * in a list of groups. Will also want to debounce search (see CurrentSchoolBlock).
- */
 const SEARCH_GROUPS_QUERY = gql`
-  query SearchGroupsQuery($groupTypeId: Int!) {
-    groups(groupTypeId: $groupTypeId) {
+  query SearchGroupsQuery($groupTypeId: Int!, $name: String!) {
+    groups(groupTypeId: $groupTypeId, name: $name) {
       id
       name
     }
@@ -21,31 +15,41 @@ const SEARCH_GROUPS_QUERY = gql`
 `;
 
 const GroupSelect = ({ groupTypeId, onChange }) => {
-  const { loading, error, data } = useQuery(SEARCH_GROUPS_QUERY, {
-    variables: { groupTypeId },
-  });
+  const client = useApolloClient();
 
-  if (loading) {
-    return <Spinner className="flex justify-center p-3" />;
-  }
-
-  if (error) {
-    return <ErrorBlock error={error} />;
-  }
+  const fetchGroups = debounce((searchString, callback) => {
+    client
+      .query({
+        query: SEARCH_GROUPS_QUERY,
+        variables: {
+          groupTypeId,
+          name: searchString,
+        },
+      })
+      .then(result => callback(result.data.groups.length))
+      .catch(error => callback(error));
+  }, 250);
 
   /**
    * Passing id and instanceId props to the Select for use in our Cypress tests.
    * @see https://react-select.com/props#select-props
    */
   return (
-    <Select
+    <AsyncSelect
+      defaultOptions
+      getOptionLabel={group => group.name}
+      getOptionValue={group => group.id}
       id="select-group-dropdown"
       instanceId="select-group-"
+      isClearable
+      loadOptions={(input, callback) => {
+        if (!input) {
+          return Promise.resolve([]);
+        }
+        return fetchGroups(input, callback);
+      }}
+      noOptionsMessage={() => 'Enter your chapter name'}
       onChange={onChange}
-      options={data.groups.map(group => ({
-        value: group.id,
-        label: group.name,
-      }))}
     />
   );
 };

--- a/resources/assets/components/SignupButton/GroupSelect.js
+++ b/resources/assets/components/SignupButton/GroupSelect.js
@@ -15,6 +15,10 @@ const SEARCH_GROUPS_QUERY = gql`
 `;
 
 const GroupSelect = ({ groupTypeId, onChange }) => {
+  /**
+   * This is copied by example from the blocks/CurrentSchoolBlock/SchoolSelect, which has comments
+   * detailing debouncing the useApolloClient hook (AsyncSelect loadOptions expects a Promise).
+   */
   const client = useApolloClient();
 
   const fetchGroups = debounce((searchString, callback) => {

--- a/resources/assets/components/SignupButton/GroupSelect.js
+++ b/resources/assets/components/SignupButton/GroupSelect.js
@@ -26,7 +26,7 @@ const GroupSelect = ({ groupTypeId, onChange }) => {
           name: searchString,
         },
       })
-      .then(result => callback(result.data.groups.length))
+      .then(result => callback(result.data.groups))
       .catch(error => callback(error));
   }, 250);
 

--- a/resources/assets/components/SignupButton/SignupButton.js
+++ b/resources/assets/components/SignupButton/SignupButton.js
@@ -88,7 +88,7 @@ const SignupButton = props => {
           <div className="pb-3">
             <GroupSelect
               groupTypeId={campaignGroupTypeId}
-              onChange={selected => setGroupId(selected.value)}
+              onChange={selected => setGroupId(selected.id)}
             />
           </div>
           <PrimaryButton

--- a/schema.json
+++ b/schema.json
@@ -276,7 +276,7 @@
           },
           {
             "name": "paginatedCampaigns",
-            "description": "Experimental: Get a Relay-style paginated collection of campaigns.",
+            "description": "Get a Relay-style paginated collection of campaigns.",
             "args": [
               {
                 "name": "first",
@@ -396,8 +396,22 @@
                 "name": "groupTypeId",
                 "description": "The group type ID to filter groups by.",
                 "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "name",
+                "description": "The group name to filter groups by.",
+                "type": {
                   "kind": "SCALAR",
-                  "name": "Int",
+                  "name": "String",
                   "ofType": null
                 },
                 "defaultValue": null
@@ -411,6 +425,63 @@
                 "name": "Group",
                 "ofType": null
               }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "paginatedGroups",
+            "description": "Get a Relay-style paginated collection of groups.",
+            "args": [
+              {
+                "name": "first",
+                "description": "Get the first N results.",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": "20"
+              },
+              {
+                "name": "after",
+                "description": "The cursor to return results after.",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "groupTypeId",
+                "description": "The group type ID to filter groups by.",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "name",
+                "description": "The group name to filter groups by.",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null
+              }
+            ],
+            "type": {
+              "kind": "OBJECT",
+              "name": "GroupCollection",
+              "ofType": null
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -1017,7 +1088,7 @@
           },
           {
             "name": "signups",
-            "description": "Get a paginated collection of signups.",
+            "description": "Get a list of signups.",
             "args": [
               {
                 "name": "campaignId",
@@ -1114,7 +1185,7 @@
           },
           {
             "name": "paginatedSignups",
-            "description": null,
+            "description": "Get a paginated collection of signups.",
             "args": [
               {
                 "name": "campaignId",
@@ -4227,7 +4298,7 @@
           },
           {
             "name": "contentfulCampaignId",
-            "description": "The contentful campaign id where this campaign is being used.",
+            "description": "The Contentful campaign ID where this campaign is being used.",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -4363,11 +4434,23 @@
           },
           {
             "name": "groupTypeId",
-            "description": "The group type id associated with this campaign.",
+            "description": "The user activity group type ID associated with this campaign.",
             "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "Int",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "groupType",
+            "description": "The user activity group type associated with this campaign.",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "GroupType",
               "ofType": null
             },
             "isDeprecated": false,
@@ -4424,6 +4507,73 @@
                 "name": "String",
                 "ofType": null
               }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "GroupType",
+        "description": "A type of user activity group.",
+        "fields": [
+          {
+            "name": "id",
+            "description": "The unique ID for this group type.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "name",
+            "description": "The name of the group type.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "updatedAt",
+            "description": "The time this group type was last modified.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "DateTime",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "createdAt",
+            "description": "The time when this group type was originally created.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "DateTime",
+              "ofType": null
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -6032,73 +6182,6 @@
         "possibleTypes": null
       },
       {
-        "kind": "OBJECT",
-        "name": "GroupType",
-        "description": "A type of user activity group.",
-        "fields": [
-          {
-            "name": "id",
-            "description": "The unique ID for this group type.",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "Int",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "name",
-            "description": "The name of the group type.",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "updatedAt",
-            "description": "The time this group type was last modified.",
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "DateTime",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "createdAt",
-            "description": "The time when this group type was originally created.",
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "DateTime",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "inputFields": null,
-        "interfaces": [],
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
         "kind": "ENUM",
         "name": "ReviewStatus",
         "description": "Posts are reviewed by DoSomething.org staff for content.",
@@ -6571,7 +6654,7 @@
       {
         "kind": "OBJECT",
         "name": "CampaignCollection",
-        "description": "Experimental: A paginated list of campaigns. This is a 'Connection' in Relay's\nparlance, and follows the [Relay Cursor Connections](https://dfurn.es/338oQ6i) specification.",
+        "description": "A paginated list of campaigns. This is a 'Connection' in Relay's parlance, and\nfollows the [Relay Cursor Connections](https://dfurn.es/338oQ6i) specification.",
         "fields": [
           {
             "name": "edges",
@@ -6614,7 +6697,7 @@
       {
         "kind": "OBJECT",
         "name": "CampaignEdge",
-        "description": "Experimental: Campaign in a paginated list.",
+        "description": "Campaign in a paginated list.",
         "fields": [
           {
             "name": "cursor",
@@ -6657,7 +6740,7 @@
       {
         "kind": "OBJECT",
         "name": "PageInfo",
-        "description": "Experimental: Information about a paginated list.",
+        "description": "Information about a paginated list.",
         "fields": [
           {
             "name": "endCursor",
@@ -6697,6 +6780,92 @@
               "ofType": {
                 "kind": "SCALAR",
                 "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "GroupCollection",
+        "description": "A paginated list of user activity groups. This is a 'Connection' in Relay's\nparlance, and follows the [Relay Cursor Connections](https://dfurn.es/338oQ6i) specification.",
+        "fields": [
+          {
+            "name": "edges",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "GroupEdge",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "pageInfo",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "PageInfo",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "GroupEdge",
+        "description": "User activity group in a paginated list.",
+        "fields": [
+          {
+            "name": "cursor",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "node",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "Group",
                 "ofType": null
               }
             },
@@ -6798,7 +6967,7 @@
       {
         "kind": "OBJECT",
         "name": "SignupCollection",
-        "description": "Experimental: A paginated list of signups. This is a 'Connection' in Relay's\nparlance, and follows the [Relay Cursor Connections](https://dfurn.es/338oQ6i) specification.",
+        "description": "A paginated list of signups. This is a 'Connection' in Relay's parlance, and\nfollows the [Relay Cursor Connections](https://dfurn.es/338oQ6i) specification.",
         "fields": [
           {
             "name": "edges",
@@ -6841,7 +7010,7 @@
       {
         "kind": "OBJECT",
         "name": "SignupEdge",
-        "description": "Experimental: Signup in a paginated list.",
+        "description": "Signup in a paginated list.",
         "fields": [
           {
             "name": "cursor",


### PR DESCRIPTION
### What's this PR do?

This pull request modifies the Group Finder to populate the dropdown options with groups that match what the user types, instead of loading the first page of groups results. It follows the School Finder by example to use React Select's [`AsyncSelect`](https://react-select.com/async) component.

I've been building against my local GraphQL and Rogue, but merging this (and testing in a review app) is blocked until https://github.com/DoSomething/graphql/pull/248 is merged, which is blocked by https://github.com/DoSomething/rogue/pull/1049. 

### Screenshots

<img width="398" alt="Screen Shot 2020-06-23 at 9 58 08 AM" src="https://user-images.githubusercontent.com/1236811/85433577-7cd02300-b539-11ea-98ee-eb6cb96edaf0.png">

<img width="376" alt="Screen Shot 2020-06-23 at 9 58 16 AM" src="https://user-images.githubusercontent.com/1236811/85433611-85c0f480-b539-11ea-8aa5-bcbeab4bb467.png">

<img width="384" alt="Screen Shot 2020-06-23 at 9 58 22 AM" src="https://user-images.githubusercontent.com/1236811/85433620-89547b80-b539-11ea-8ce8-67d0e08313a8.png">

### How should this be reviewed?

👀 

### Any background context you want to provide?

 I'm hoping that the Cypress test may be failing because the `schema.json` isn't up to date (which also is blocked by https://github.com/DoSomething/graphql/pull/248) -- I did try to [add delay](https://github.com/tgriesser/cypress-graphql-mock#delay), which the cypress-graphql-mocks state may be needed to test asynchronous behavior, which is exactly what we're trying to test.


### Relevant tickets

References [Pivotal #173232032](https://www.pivotaltracker.com/story/show/173232032).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added screenshots of front-end changes on small, medium, and large screens.
- [ ] Added appropriate feature/unit tests.
