### PR TITLE
Adds Analytics Events to Group Finder elements

### DIFF
--- a/resources/assets/components/SignupButton/GroupSelect.js
+++ b/resources/assets/components/SignupButton/GroupSelect.js
@@ -14,7 +14,7 @@ const SEARCH_GROUPS_QUERY = gql`
   }
 `;
 
-const GroupSelect = ({ groupTypeId, onChange }) => {
+const GroupSelect = ({ groupTypeId, onChange, onFocus }) => {
   /**
    * This is copied by example from the blocks/CurrentSchoolBlock/SchoolSelect, which has comments
    * detailing debouncing the useApolloClient hook (AsyncSelect loadOptions expects a Promise).
@@ -52,6 +52,7 @@ const GroupSelect = ({ groupTypeId, onChange }) => {
       }}
       noOptionsMessage={() => 'Enter your chapter name'}
       onChange={onChange}
+      onFocus={onFocus}
     />
   );
 };

--- a/resources/assets/components/SignupButton/GroupSelect.js
+++ b/resources/assets/components/SignupButton/GroupSelect.js
@@ -59,6 +59,7 @@ const GroupSelect = ({ groupTypeId, onChange }) => {
 GroupSelect.propTypes = {
   groupTypeId: PropTypes.number.isRequired,
   onChange: PropTypes.func.isRequired,
+  onFocus: PropTypes.func.isRequired,
 };
 
 export default GroupSelect;

--- a/resources/assets/components/SignupButton/SignupButton.js
+++ b/resources/assets/components/SignupButton/SignupButton.js
@@ -62,7 +62,7 @@ const SignupButton = props => {
     });
   };
 
-  const onFocus = () => {
+  const handleFocus = () => {
     trackAnalyticsEvent('clicked_group_finder', {
       action: 'form_clicked',
       category: EVENT_CATEGORIES.campaignAction,
@@ -97,7 +97,7 @@ const SignupButton = props => {
             <GroupSelect
               groupTypeId={campaignGroupTypeId}
               onChange={selected => setGroupId(selected.id)}
-              onFocus={onFocus}
+              onFocus={handleFocus}
             />
           </div>
           <PrimaryButton

--- a/resources/assets/components/SignupButton/SignupButton.js
+++ b/resources/assets/components/SignupButton/SignupButton.js
@@ -83,6 +83,7 @@ const SignupButton = props => {
       label: 'group_finder',
       context: {
         campaignId,
+        groupId,
         pageId,
       },
     });

--- a/resources/assets/components/SignupButton/SignupButton.js
+++ b/resources/assets/components/SignupButton/SignupButton.js
@@ -42,6 +42,7 @@ const SignupButton = props => {
       context: {
         campaignId,
         contextSource,
+        groupId,
         pageId,
       },
     });

--- a/resources/assets/components/SignupButton/SignupButton.js
+++ b/resources/assets/components/SignupButton/SignupButton.js
@@ -96,7 +96,7 @@ const SignupButton = props => {
           <div className="pb-3">
             <GroupSelect
               groupTypeId={campaignGroupTypeId}
-              onChange={selected => setGroupId(selected.value)}
+              onChange={selected => setGroupId(selected.id)}
               onFocus={onFocus}
             />
           </div>

--- a/resources/assets/components/SignupButton/SignupButton.js
+++ b/resources/assets/components/SignupButton/SignupButton.js
@@ -74,6 +74,20 @@ const SignupButton = props => {
     });
   };
 
+  const handleChange = selected => {
+    setGroupId(selected.id);
+
+    trackAnalyticsEvent('clicked_group_finder_group', {
+      action: 'form_clicked',
+      category: EVENT_CATEGORIES.campaignAction,
+      label: 'group_finder',
+      context: {
+        campaignId,
+        pageId,
+      },
+    });
+  };
+
   // In descending priority: button-specific text prop,
   // campaign action text override, or standard "Take Action" copy.
   const buttonCopy = text || campaignActionText;
@@ -96,7 +110,7 @@ const SignupButton = props => {
           <div className="pb-3">
             <GroupSelect
               groupTypeId={campaignGroupTypeId}
-              onChange={selected => setGroupId(selected.id)}
+              onChange={handleChange}
               onFocus={handleFocus}
             />
           </div>

--- a/resources/assets/components/SignupButton/SignupButton.js
+++ b/resources/assets/components/SignupButton/SignupButton.js
@@ -63,7 +63,7 @@ const SignupButton = props => {
   };
 
   const handleFocus = () => {
-    trackAnalyticsEvent('clicked_group_finder', {
+    trackAnalyticsEvent('focused_group_finder_group', {
       action: 'field_focused',
       category: EVENT_CATEGORIES.campaignAction,
       label: 'group_finder',

--- a/resources/assets/components/SignupButton/SignupButton.js
+++ b/resources/assets/components/SignupButton/SignupButton.js
@@ -83,7 +83,8 @@ const SignupButton = props => {
       label: 'group_finder',
       context: {
         campaignId,
-        groupId,
+        // Pass our selected.id to avoid race condition with setting groupId state.
+        groupId: selected.id,
         pageId,
       },
     });

--- a/resources/assets/components/SignupButton/SignupButton.js
+++ b/resources/assets/components/SignupButton/SignupButton.js
@@ -61,6 +61,18 @@ const SignupButton = props => {
     });
   };
 
+  const onFocus = () => {
+    trackAnalyticsEvent('clicked_group_finder', {
+      action: 'form_clicked',
+      category: EVENT_CATEGORIES.campaignAction,
+      label: 'group_finder',
+      context: {
+        campaignId,
+        pageId,
+      },
+    });
+  };
+
   // In descending priority: button-specific text prop,
   // campaign action text override, or standard "Take Action" copy.
   const buttonCopy = text || campaignActionText;
@@ -83,7 +95,8 @@ const SignupButton = props => {
           <div className="pb-3">
             <GroupSelect
               groupTypeId={campaignGroupTypeId}
-              onChange={selected => setGroupId(selected.id)}
+              onChange={selected => setGroupId(selected.value)}
+              onFocus={onFocus}
             />
           </div>
           <PrimaryButton

--- a/resources/assets/components/SignupButton/SignupButton.js
+++ b/resources/assets/components/SignupButton/SignupButton.js
@@ -64,7 +64,7 @@ const SignupButton = props => {
 
   const handleFocus = () => {
     trackAnalyticsEvent('clicked_group_finder', {
-      action: 'form_clicked',
+      action: 'field_focused',
       category: EVENT_CATEGORIES.campaignAction,
       label: 'group_finder',
       context: {


### PR DESCRIPTION
### What's this PR do?

This pull request adds analytics tracking to group finder elements on the campaign signup page.

### How should this be reviewed?

When in the test campaign, do you see the `clicked_group_finder` event from GA and Snowplow after you focus on the dropdown for group options?

And after you submit, do you see the `groupId` included in the context object on the `clicked_signup` event?

### Any background context you want to provide?

We are adding tracking to our group finder elements to keep track of where users end up in the journey and whether it's being used as expected.

### Relevant tickets

References [Pivotal # 173271652](https://www.pivotaltracker.com/story/show/173271652).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added screenshots of front-end changes on small, medium, and large screens.
- [ ] Added appropriate feature/unit tests.
