### PR TITLE
Track Referrer User ID in Posts and Signups

### DIFF
--- a/docs/development/features/referral-pages.md
+++ b/docs/development/features/referral-pages.md
@@ -53,7 +53,7 @@ The campaign URL that the Beta Page links to will include the alpha's user ID as
 https://www.dosomething.org/us/campaigns/teens-jeans?referrer_user_id=5547be89469c64ec7d8b518d
 ```
 
-This `referrer_user_id` query parameter will be added to the `source_detail` of any new user accounts created by betas.
+This `referrer_user_id` query parameter will be added to the `referrer_user_id` of any new user accounts created by betas, as well as appended to the campaign signup or reportback submitted when the query parameter is attached.
 
 ## Iterations
 

--- a/resources/assets/components/SignupButton/SignupButton.js
+++ b/resources/assets/components/SignupButton/SignupButton.js
@@ -50,15 +50,10 @@ const SignupButton = props => {
       body: {
         details: JSON.stringify(details),
         group_id: groupId,
-        /**
-         * Uncomment line below when we're ready to start storing signup.referrer_user_id.
-         * @see https://www.pivotaltracker.com/story/show/172747771
-         */
-        // referrer_user_id: query('referrer_user_id'),
+        referrer_user_id: query('referrer_user_id'),
         source_details: JSON.stringify(
           withoutNulls({
             contentful_id: pageId,
-            referrer_user_id: query('referrer_user_id'),
             ...getUtms(),
           }),
         ),

--- a/resources/assets/helpers/forms.js
+++ b/resources/assets/helpers/forms.js
@@ -2,8 +2,8 @@
 
 import { forEach, get, isInteger } from 'lodash';
 
-import { withoutValueless } from '.';
 import { getUtms } from './utm';
+import { query, withoutValueless } from '.';
 
 /**
  * Calculate the difference between a total value and a submitted value.
@@ -115,6 +115,11 @@ export function getFormData(formData) {
  */
 export function formatPostPayload(data = {}) {
   let formattedData = data;
+
+  // Attach the Referrer User ID query parameter to the payload.
+  if (query('referrer_user_id')) {
+    formattedData.referrer_user_id = query('referrer_user_id');
+  }
 
   // JSON serialize details field which gets validated as JSON.
   if (data.details) {


### PR DESCRIPTION
### What's this PR do?

This pull request appends the `referrer_user_id` per query parameter of the same name to Campaign Signups (moving it from the `source_details` to a top-level field) as well as Rogue Posts.

### How should this be reviewed?
👀 

### Any background context you want to provide?
All posts to Rogue from 'Action blocks' should be invoking the `formatPostPayload` where we perform all our furnishing work (location information, UTMs for the source details, etc.), so I added the `referrer_user_id` there.

I was thinking about testing and wasn't sure of the best direction. To me, unit tests on these helpers seem like a good idea and perhaps something for the freezer. Of course though, there's the option of adding a Cypress integration test specifically for this, to see if hitting a campaign with a `?referrer_user_id...` ended up in the signup request payload, but I wasn't sure if that was overkill? Would love thoughts!

### Relevant tickets

References [Pivotal #172747771](https://www.pivotaltracker.com/story/show/172747771).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [x] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
