### PR TITLE
Test Referrer User ID / Group ID in Signups (& UI Bug Fix)

### DIFF
--- a/resources/assets/components/CampaignBanner/CampaignBanner.js
+++ b/resources/assets/components/CampaignBanner/CampaignBanner.js
@@ -129,6 +129,7 @@ const CampaignBanner = ({
                   />
                 ) : (
                   <Spinner className="flex justify-center p-6" />
+                  <Spinner className="flex justify-center p-6 mb-3" />
                 )}
 
                 {affiliateOptInContent ? (

--- a/resources/assets/components/CampaignBanner/CampaignBanner.js
+++ b/resources/assets/components/CampaignBanner/CampaignBanner.js
@@ -128,7 +128,6 @@ const CampaignBanner = ({
                     contextSource="campaign_landing_page"
                   />
                 ) : (
-                  <Spinner className="flex justify-center p-6" />
                   <Spinner className="flex justify-center p-6 mb-3" />
                 )}
 

--- a/resources/assets/components/CampaignBanner/CampaignBanner.js
+++ b/resources/assets/components/CampaignBanner/CampaignBanner.js
@@ -7,7 +7,7 @@ import React, { useState, useEffect } from 'react';
 
 import Modal from '../utilities/Modal/Modal';
 import ContentfulEntry from '../ContentfulEntry';
-import Placeholder from '../utilities/Placeholder';
+import Spinner from '../artifacts/Spinner/Spinner';
 import CampaignHeader from '../utilities/CampaignHeader';
 import ErrorBlock from '../blocks/ErrorBlock/ErrorBlock';
 import CoverImage from '../utilities/CoverImage/CoverImage';
@@ -128,7 +128,7 @@ const CampaignBanner = ({
                     contextSource="campaign_landing_page"
                   />
                 ) : (
-                  <Placeholder />
+                  <Spinner className="flex justify-center p-6" />
                 )}
 
                 {affiliateOptInContent ? (
@@ -192,7 +192,7 @@ const CampaignBanner = ({
                     contextSource="scholarship_modal"
                   />
                 ) : (
-                  <Placeholder />
+                  <Spinner className="flex justify-center p-6" />
                 )}
               </div>
             ) : null}


### PR DESCRIPTION
### What's this PR do?

This pull request adds Cypress tests in our `campaign-signup` suite asserting that `referrer_user_id` & `group_id` fields are appended to the Rogue signup request where applicable.

It also addresses a small UI bug with our loading states on the campaign banner signup buttons, that I noticed while testing this.

### How should this be reviewed?
👁️ 

### Any background context you want to provide?
https://github.com/DoSomething/phoenix-next/pull/2232#pullrequestreview-437526886

### Relevant tickets

References [Pivotal #172747771](https://www.pivotaltracker.com/story/show/172747771).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [x] Added screenshots of front-end changes on small, medium, and large screens.
- [x] Added appropriate feature/unit tests.

📸 

**BEFORE**:
- [Scholarship Modal](https://user-images.githubusercontent.com/12417657/85762058-5a790980-b6e1-11ea-8088-d04f9dcf4992.png)
- [Banner](https://user-images.githubusercontent.com/12417657/85762064-5baa3680-b6e1-11ea-8bcd-22a4acf8ea50.png)

**AFTER**
- [Scholarship Modal](https://user-images.githubusercontent.com/12417657/85762108-6664cb80-b6e1-11ea-92af-8898699fb510.png)
- [Banner](https://user-images.githubusercontent.com/12417657/85762113-682e8f00-b6e1-11ea-869f-511e8cdb8781.png)
