### PR TITLE
Remove Feature Flag Gate from CTA Referral Page Banner in Campaign Signup Affirmation

### DIFF
--- a/cypress/fixtures/contentful/exampleCampaign.js
+++ b/cypress/fixtures/contentful/exampleCampaign.js
@@ -210,8 +210,44 @@ export default {
         internalTitle: '[Test] Example Campaign Landing Page',
         title: 'Example Campaign Landing Page',
         subTitle: null,
-        content:
-          '## The Problem\nLorem ipsum dolor sit amet, consectetur adipiscing elit. Integer suscipit elementum erat in cursus. Donec aliquam tellus at erat gravida, sit amet vehicula velit vehicula. Nam sollicitudin posuere augue et ultricies. Nam dapibus lorem non dui ullamcorper, ac volutpat nunc interdum.\n\n## The Solution\nSed mi est, venenatis at turpis id, scelerisque blandit elit. Phasellus volutpat accumsan arcu, nec porttitor odio sollicitudin non. Maecenas dictum dignissim diam, a rutrum metus tincidunt et. Curabitur felis purus, auctor quis efficitur nec, cursus eget nunc. Integer quis tellus non justo vulputate eleifend ut sit amet leo.',
+        content: {
+          nodeType: 'document',
+          data: [],
+          content: [
+            {
+              nodeType: 'heading-1',
+              content: [
+                {
+                  nodeType: 'text',
+                  value: 'This will have a yellow border bottom',
+                  marks: [],
+                  data: [],
+                },
+              ],
+              data: {
+                target: {
+                  sys: {
+                    id: '7qT9bG21eOhu9svaFL3rJ6',
+                    type: 'Link',
+                    linkType: 'Entry',
+                  },
+                },
+              },
+            },
+            {
+              nodeType: 'paragraph',
+              content: [
+                {
+                  nodeType: 'text',
+                  value: 'This is Rich Text content.',
+                  marks: [],
+                  data: [],
+                },
+              ],
+              data: [],
+            },
+          ],
+        },
         sidebar: [],
         blocks: [],
         additionalContent: null,

--- a/cypress/fixtures/graphql.js
+++ b/cypress/fixtures/graphql.js
@@ -155,6 +155,7 @@ export const mocks = {
   }),
   PostGalleryBlock: () => ({
     hideReactions: false,
+    itemsPerRow: 3,
   }),
   CompanyPage: () => ({
     nodeType: 'document',

--- a/cypress/integration/campaign-signup.js
+++ b/cypress/integration/campaign-signup.js
@@ -117,7 +117,7 @@ describe('Campaign Signup', () => {
 
   context('Campaign ID configured as referral campaign', () => {
     /** @test */
-    it('Display Referral Page Banner CTA in affirmation for configured campaign & feature flagged user', () => {
+    it('Displays Referral Page Banner CTA in affirmation for configured campaign', () => {
       const user = userFactory();
       cy.mockGraphqlOp('CampaignBannerQuery', {
         campaign: {
@@ -125,24 +125,18 @@ describe('Campaign Signup', () => {
           groupTypeId: null,
         },
       });
+
       // Log in & visit the campaign pitch page:
       cy.authVisitCampaignWithoutSignup(user, exampleReferralCampaign);
 
       // Mock the response we'll be expecting once we hit "Join Now":
       cy.route('POST', `${API}/signups`, newSignup(campaignId, user));
 
-      // Mock the GraphQL response for the user to ensure they have the
-      // Refer a Friend feature flag enabled.
-      cy.mockGraphqlOp('UserAccountAndSignupsCountQuery', {
-        user: {
-          hasFeatureFlag: () => true,
-        },
-      });
-
       // Click "Join Now" & should get the affirmation modal:
       cy.contains('button', 'Join Us').click();
-      cy.get('.card.affirmation').contains('Thanks for joining us!');
-      cy.get('.cta-register-banner').contains('Benefits With Friends');
+      cy.get('.card.affirmation')
+        .findByTestId('cta-referral-page-banner')
+        .contains('Benefits With Friends');
     });
   });
 
@@ -164,18 +158,11 @@ describe('Campaign Signup', () => {
       // Mock the response we'll be expecting once we hit "Join Now":
       cy.route('POST', `${API}/signups`, newSignup(campaignId, user));
 
-      // Mock the GraphQL response for the user to ensure they have the
-      // Refer a Friend feature flag enabled.
-      cy.mockGraphqlOp('UserAccountAndSignupsCountQuery', {
-        user: {
-          hasFeatureFlag: () => true,
-        },
-      });
-
       // Click "Join Now" & should get the affirmation modal:
       cy.contains('button', 'Join Us').click();
-      cy.get('.card.affirmation').contains('Thanks for joining us!');
-      cy.get('.cta-register-banner').should('not.exist');
+      cy.get('.card.affirmation')
+        .findByTestId('cta-referral-page-banner')
+        .should('not.exist');
     });
   });
 

--- a/docs/development/features/referral-pages.md
+++ b/docs/development/features/referral-pages.md
@@ -11,7 +11,7 @@ We commonly use these terms (in the business, and in code) when describing this 
 
 Both the alpha and beta may earn a reward for the beta registering and signing up for the campaign.
 
-We offer a second scholarship entry as the reward. Users who have `refer-friends-scholarship` feature flag set will see a Referral Page Banner after signing up for any campaign configured for this feature, which refers them to their Alpha Referral Page.
+We offer a second scholarship entry as the reward. Users will see a Referral Page Banner after signing up for any campaign configured for this feature, which refers them to their Alpha Referral Page.
 
 ## Details
 
@@ -19,7 +19,7 @@ To opt a campaign into the referral feature, its `displayReferralPage` field sho
 
 ### Referral Page Banner
 
-After signing up for the campaign, users who have the `refer-friends-scholarship` flag set will see a Referral Page Banner within the signup Affirmation, which links to their Alpha Referral Page.
+After signing up for the campaign, users will see a Referral Page Banner within the signup Affirmation, which links to their Alpha Referral Page.
 
 ![Referral Page Banner Example](../../.gitbook/assets/referral-page-banner.png)
 
@@ -67,4 +67,6 @@ dosomething.org/us/join?user_id=:userId&campaign_id=9037
 
 If this campaign ID matched a hardcoded referral page campaign, we'd link to this campaign in the first block on the Beta Referral Page.
 
-The second iteration of RAF allowed the list of campaigns (as well as the default campaign) to be configured via environment variable feature flags. This was deprecated in [#1940](https://github.com/DoSomething/phoenix-next/pull/1940) by the addition of the `displayReferralPage` field.
+The second iteration of RAF allowed the list of campaigns (as well as the default campaign) to be configured via environment variable feature flags. This was deprecated in [#1940](https://github.com/DoSomething/phoenix-next/pull/1940) by the addition of the `displayReferralPage` field. The Referral Page Banner in the campaign signup affirmation was still only exposed to _new_ users who were assigned the `refer-friends-scholarship` feature flag.
+
+In anticipation of launching a fully formalized version of RAF, we deprecated the `refer-friends-scholarship` feature flag, and exposed the RAF CTA Banner to _all_ users signing up for a campaign opted into RAF in the Referral Page Banner.

--- a/resources/assets/components/Affirmation/Affirmation.js
+++ b/resources/assets/components/Affirmation/Affirmation.js
@@ -37,9 +37,6 @@ const USER_QUERY = gql`
     user(id: $userId) {
       id
       hasBadgesFlag: hasFeatureFlag(feature: "badges")
-      hasReferFriendsScholarshipFlag: hasFeatureFlag(
-        feature: "refer-friends-scholarship"
-      )
     }
     signupsCount(userId: $userId, limit: 2)
   }
@@ -105,9 +102,7 @@ const Affirmation = ({
               />
             ) : null}
 
-            {get(res, 'user.hasReferFriendsScholarshipFlag', false) ? (
-              <CtaReferralPageBannerContainer />
-            ) : null}
+            <CtaReferralPageBannerContainer />
 
             <div className="p-3">
               <button

--- a/resources/assets/components/CampaignBanner/CampaignBanner.js
+++ b/resources/assets/components/CampaignBanner/CampaignBanner.js
@@ -1,7 +1,6 @@
 import { get } from 'lodash';
 import gql from 'graphql-tag';
 import PropTypes from 'prop-types';
-import { css } from '@emotion/core';
 import { useQuery } from '@apollo/react-hooks';
 import React, { useState, useEffect } from 'react';
 
@@ -21,7 +20,6 @@ import AffiliateOptInToggleContainer from '../AffiliateOptInToggle/AffiliateOptI
 import {
   isScholarshipAffiliateReferral,
   getScholarshipAffiliateLabel,
-  tailwind,
 } from '../../helpers';
 
 const CAMPAIGN_BANNER_QUERY = gql`
@@ -108,11 +106,6 @@ const CampaignBanner = ({
               <div
                 data-testid="campaign-banner-signup-button"
                 className="bg-white bottom-0 md:bottom-auto left-0 md:left-auto p-3 md:p-0 fixed md:static w-full md:w-auto z-10 md:z-auto"
-                css={css`
-                  @media (min-width: ${tailwind('screens.medium')}) {
-                    background-color: none;
-                  }
-                `}
               >
                 {!loading ? (
                   <SignupButtonContainer

--- a/resources/assets/components/CampaignBanner/CampaignBanner.js
+++ b/resources/assets/components/CampaignBanner/CampaignBanner.js
@@ -109,8 +109,6 @@ const CampaignBanner = ({
                 data-testid="campaign-banner-signup-button"
                 className="bg-white bottom-0 md:bottom-auto left-0 md:left-auto p-3 md:p-0 fixed md:static w-full md:w-auto z-10 md:z-auto"
                 css={css`
-                  border-top: 1px solid tailwind('colors.gray.200');
-
                   @media (min-width: ${tailwind('screens.medium')}) {
                     background-color: none;
                   }

--- a/resources/assets/components/utilities/CtaReferralPageBanner/CtaReferralPageBanner.js
+++ b/resources/assets/components/utilities/CtaReferralPageBanner/CtaReferralPageBanner.js
@@ -6,7 +6,7 @@ import './cta-referral-page-banner.scss';
 const CtaReferralPageBanner = ({ campaignId, displayReferralPage }) => (
   <React.Fragment>
     {displayReferralPage ? (
-      <div className="p-3">
+      <div className="p-3" data-testid="cta-referral-page-banner">
         <div className="cta-register-banner md:px-6 pt-3 clearfix">
           <div className="cta-register-banner__content p-6 md:pr-0 text-center md:text-left">
             <h3 className="text-white">Benefits With Friends</h3>


### PR DESCRIPTION
### What's this PR do?

This pull request removes the `refer-friends-scholarship` feature flag gate from the `CtaReferralPageBanner` in the Campaign signup `Affirmation`, exposing this feature to _all_ users (if the campaign is opted in to RAF).

I snuck in some misc cleanup too:
- https://github.com/DoSomething/phoenix-next/commit/409db9818e9df871d47b3c02be36a7d504f37b42 and https://github.com/DoSomething/phoenix-next/commit/7993d44ed355478efda9850711d39ddc76662d83 remove some broken styling I had added in #2162. 
  - The white background-color was being removed for medium screens, but now that the signup button has loading state, this actually works well for us. (See #2233)
  - When I fixed the border-top rule, I noticed that it wasn't discernable, I think it's a legacy relic.
- https://github.com/DoSomething/phoenix-next/commit/c315a2609ebb73b7c1e51917c2eeff7d920d5a8c Cypress tests were console warning about the missing `itemsPerRow` required property not being stubbed.
- https://github.com/DoSomething/phoenix-next/commit/3ac3958abb4b4d09b530986117cc2f26c0222e5b Our landing page fixture was a String, but the expected format is a Rich Text object.

### How should this be reviewed?
👀 


### Any background context you want to provide?
For RAF V2 we no longer want this [feature flagged](https://github.com/DoSomething/northstar/blob/cd6c65658b66665be79a5a42a716a5c8b02a80e7/app/Auth/Registrar.php#L262-L265). There's no need to feature flag the removal of the feature flag until we formally launch V2 since this is still a campaign opt-in feature so all this is doing is including existing members pre RAF scholarship feature-flag launch.

### Relevant tickets

References [Pivotal #172627809](https://www.pivotaltracker.com/story/show/172627809).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [x] Documentation added for new features/changed endpoints.
- [ ] Added screenshots of front-end changes on small, medium, and large screens. - _no actual visual changes_
- [x] Added appropriate feature/unit tests.
