### PR TITLE
Volunteer Credits Table Campaign Previews Link to Campaigns

### DIFF
--- a/resources/assets/components/pages/AccountPage/Credits/CampaignPreview.js
+++ b/resources/assets/components/pages/AccountPage/Credits/CampaignPreview.js
@@ -41,6 +41,7 @@ const CampaignPreview = ({ campaignWebsite }) => {
 
 CampaignPreview.propTypes = {
   campaignWebsite: PropTypes.shape({
+    path: PropTypes.string.isRequired,
     showcaseTitle: PropTypes.string.isRequired,
     showcaseDescription: PropTypes.string.isRequired,
     showcaseImage: PropTypes.shape({

--- a/resources/assets/components/pages/AccountPage/Credits/CampaignPreview.js
+++ b/resources/assets/components/pages/AccountPage/Credits/CampaignPreview.js
@@ -8,7 +8,12 @@ import {
 } from '../../../../helpers';
 
 const CampaignPreview = ({ campaignWebsite }) => {
-  const { showcaseTitle, showcaseDescription, showcaseImage } = campaignWebsite;
+  const {
+    path,
+    showcaseTitle,
+    showcaseDescription,
+    showcaseImage,
+  } = campaignWebsite;
 
   // @TODO: Can we use srcset instead of this logic?
   const showcaseImageUrl =
@@ -17,7 +22,7 @@ const CampaignPreview = ({ campaignWebsite }) => {
       : contentfulImageUrl(showcaseImage.url, 640, 360, 'fill');
 
   return (
-    <div className="flex">
+    <a className="flex" href={path}>
       <LazyImage
         className="h-16 sm:h-auto xl:h-16 md:hidden xl:block"
         src={showcaseImageUrl}
@@ -25,9 +30,11 @@ const CampaignPreview = ({ campaignWebsite }) => {
       />
       <div className="pl-3 md:p-0 xl:pl-3">
         <h3 className="font-bold text-base text-blue-500">{showcaseTitle}</h3>
-        <p className="mt-1 text-gray-500 text-sm">{showcaseDescription}</p>
+        <p className="font-normal mt-1 text-gray-500 text-sm">
+          {showcaseDescription}
+        </p>
       </div>
-    </div>
+    </a>
   );
 };
 

--- a/resources/assets/components/pages/AccountPage/Credits/CampaignPreview.js
+++ b/resources/assets/components/pages/AccountPage/Credits/CampaignPreview.js
@@ -30,6 +30,7 @@ const CampaignPreview = ({ campaignWebsite }) => {
       />
       <div className="pl-3 md:p-0 xl:pl-3">
         <h3 className="font-bold text-base text-blue-500">{showcaseTitle}</h3>
+
         <p className="font-normal mt-1 text-gray-500 text-sm">
           {showcaseDescription}
         </p>

--- a/resources/assets/components/pages/AccountPage/Credits/CertificateTemplate.js
+++ b/resources/assets/components/pages/AccountPage/Credits/CertificateTemplate.js
@@ -23,6 +23,7 @@ import sourceSansProItalic from '../../../../fonts/sourcesanspro-italic.woff';
 export const certificatePostType = PropTypes.shape({
   actionId: PropTypes.number.isRequired,
   campaignWebsite: PropTypes.shape({
+    path: PropTypes.string.isRequired,
     showcaseTitle: PropTypes.string.isRequired,
     showcaseDescription: PropTypes.string.isRequired,
     showcaseImage: PropTypes.shape({

--- a/resources/assets/components/pages/AccountPage/Credits/VolunteerCreditsQuery.js
+++ b/resources/assets/components/pages/AccountPage/Credits/VolunteerCreditsQuery.js
@@ -35,6 +35,7 @@ export const VOLUNTEER_CREDIT_POSTS_QUERY = gql`
           }
           campaign {
             campaignWebsite {
+              path
               showcaseImage {
                 url
                 description

--- a/resources/assets/components/pages/AccountPage/Credits/volunteer-credits-mock-data.js
+++ b/resources/assets/components/pages/AccountPage/Credits/volunteer-credits-mock-data.js
@@ -41,6 +41,7 @@ const AFFILIATE_SPONSORS = [
 
 // Mock Campaign Website Showcase:
 const CAMPAIGN_ONE = {
+  path: '/us/campaigns/escape-the-vape',
   showcaseImage: {
     url: 'https://images.api.info/1',
     description: 'Cover Photo 1',
@@ -51,6 +52,7 @@ const CAMPAIGN_ONE = {
 };
 
 const CAMPAIGN_TWO = {
+  path: '/us/campaigns/escape-the-crepe',
   showcaseImage: {
     url: 'https://images.api.info/2',
     description: 'Cover Photo 2',
@@ -61,6 +63,7 @@ const CAMPAIGN_TWO = {
 };
 
 const CAMPAIGN_THREE = {
+  path: '/us/campaigns/escape-the-severus-snape',
   showcaseImage: {
     url: 'https://images.api.info/3',
     description: 'Cover Photo 3',


### PR DESCRIPTION
### What's this PR do?

This pull request fixes a bug in the Volunteer Credits table campaign previews, where they should have been linking to the previewed campaigns.

### How should this be reviewed?
👀 

### Any background context you want to provide?
Not on a Friday afternoon, no. But thanks.

### Relevant tickets

References [Pivotal #172675007](https://www.pivotaltracker.com/story/show/172675007).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added screenshots of front-end changes on small, medium, and large screens.
- [x] Added appropriate feature/unit tests.

![Kapture 2020-06-26 at 13 35 08](https://user-images.githubusercontent.com/12417657/85885689-c11a2800-b7b2-11ea-807f-86517880727c.gif)

