### PR TITLE
Adds UsaStateSelect to GroupFinder

### DIFF
--- a/cypress/integration/campaign-signup.js
+++ b/cypress/integration/campaign-signup.js
@@ -212,9 +212,9 @@ describe('Campaign Signup', () => {
     );
   });
 
-  // TODO: Add context
+  // TODO: Use cypress context to better group this test once #2238 is merged.
   /** @test */
-  it('Signup button is enabled after selecting a group', () => {
+  it('If campaign group type does not filter by state, signup button is enabled after selecting group', () => {
     const user = userFactory();
 
     cy.mockGraphqlOp('SearchGroupsQuery', {

--- a/cypress/integration/campaign-signup.js
+++ b/cypress/integration/campaign-signup.js
@@ -265,77 +265,78 @@ describe('Campaign Signup', () => {
     cy.wait('@signupRequest')
       .its('request.body.group_id')
       .should('equal', 1);
-  }),
-    context(
-      'Campaign ID configured with group type that filters by state',
-      () => {
-        /** @test */
-        it('Signup button is enabled after selecting state, then group', () => {
-          const user = userFactory();
+  });
 
-          cy.mockGraphqlOp('SearchGroupsQuery', {
-            groups: [
-              { id: 1, name: 'New York', state: 'NY' },
-              { id: 2, name: 'Philadelphia', state: 'PA' },
-              { id: 3, name: 'San Francisco', state: 'CA' },
-            ],
-          });
+  context(
+    'Campaign ID configured with group type that filters by state',
+    () => {
+      /** @test */
+      it('Signup button is enabled after selecting state, then group', () => {
+        const user = userFactory();
 
-          cy.mockGraphqlOp('CampaignBannerQuery', {
-            campaign: {
-              id: campaignId,
-              groupTypeId: 1,
-              groupType: {
-                id: 1,
-                filterByState: true,
-              },
-            },
-          });
-
-          // Visit the campaign pitch page
-          cy.withState(exampleCampaign).visit(
-            '/us/campaigns/test-example-campaign',
-          );
-
-          cy.findByTestId('join-group-signup-form').should('have.length', 1);
-          cy.findByTestId('campaign-banner-signup-button').contains(
-            'button',
-            'Join Group',
-          );
-          cy.findByTestId('join-group-signup-button').should('be.disabled');
-          cy.get('#select-state-dropdown').should('have.length', 1);
-          cy.get('#select-group-dropdown').should('have.length', 0);
-          cy.get('#select-state-dropdown').click();
-          cy.get('#react-select-select-state--input').type('new');
-          // Select "New York"
-          cy.get('#react-select-select-state--option-32').click();
-          cy.findByTestId('join-group-signup-button').should('be.disabled');
-          cy.get('#select-group-dropdown').should('have.length', 1);
-          // Forcing these actions because this element gets covered by the SitewideBanner.
-          cy.get('#react-select-select-group--input').type('new', {
-            force: true,
-          });
-          cy.get('#react-select-select-group--option-0').click({ force: true });
-          cy.findByTestId('join-group-signup-button').should('be.enabled');
-
-          // Mock the responses we'll be expecting once we hit the signup button:
-          cy.route(
-            `${API}/signups?filter[northstar_id]=${user.id}`,
-            emptyResponse,
-          );
-          cy.route('POST', `${API}/signups`, newSignup(campaignId, user)).as(
-            'signupRequest',
-          );
-
-          cy.contains('button', 'Join Group')
-            .click()
-            .handleLogin(user);
-
-          // The outgoing signup request should include the selected group_id.
-          cy.wait('@signupRequest')
-            .its('request.body.group_id')
-            .should('equal', 1);
+        cy.mockGraphqlOp('SearchGroupsQuery', {
+          groups: [
+            { id: 1, name: 'New York', state: 'NY' },
+            { id: 2, name: 'Philadelphia', state: 'PA' },
+            { id: 3, name: 'San Francisco', state: 'CA' },
+          ],
         });
-      },
-    );
+
+        cy.mockGraphqlOp('CampaignBannerQuery', {
+          campaign: {
+            id: campaignId,
+            groupTypeId: 1,
+            groupType: {
+              id: 1,
+              filterByState: true,
+            },
+          },
+        });
+
+        // Visit the campaign pitch page
+        cy.withState(exampleCampaign).visit(
+          '/us/campaigns/test-example-campaign',
+        );
+
+        cy.findByTestId('join-group-signup-form').should('have.length', 1);
+        cy.findByTestId('campaign-banner-signup-button').contains(
+          'button',
+          'Join Group',
+        );
+        cy.findByTestId('join-group-signup-button').should('be.disabled');
+        cy.get('#select-state-dropdown').should('have.length', 1);
+        cy.get('#select-group-dropdown').should('have.length', 0);
+        cy.get('#select-state-dropdown').click();
+        cy.get('#react-select-select-state--input').type('new');
+        // Select "New York"
+        cy.get('#react-select-select-state--option-32').click();
+        cy.findByTestId('join-group-signup-button').should('be.disabled');
+        cy.get('#select-group-dropdown').should('have.length', 1);
+        // Forcing these actions because this element gets covered by the SitewideBanner.
+        cy.get('#react-select-select-group--input').type('new', {
+          force: true,
+        });
+        cy.get('#react-select-select-group--option-0').click({ force: true });
+        cy.findByTestId('join-group-signup-button').should('be.enabled');
+
+        // Mock the responses we'll be expecting once we hit the signup button:
+        cy.route(
+          `${API}/signups?filter[northstar_id]=${user.id}`,
+          emptyResponse,
+        );
+        cy.route('POST', `${API}/signups`, newSignup(campaignId, user)).as(
+          'signupRequest',
+        );
+
+        cy.contains('button', 'Join Group')
+          .click()
+          .handleLogin(user);
+
+        // The outgoing signup request should include the selected group_id.
+        cy.wait('@signupRequest')
+          .its('request.body.group_id')
+          .should('equal', 1);
+      });
+    },
+  );
 });

--- a/cypress/integration/campaign-signup.js
+++ b/cypress/integration/campaign-signup.js
@@ -212,56 +212,140 @@ describe('Campaign Signup', () => {
     );
   });
 
-  /** @test */
-  it('Visits a groups campaign page, as an unauthenticated user', () => {
-    const user = userFactory();
+  context(
+    'Campaign ID configured with group type that does not filter by state',
+    () => {
+      /** @test */
+      it('Signup button is enabled after selecting a group', () => {
+        const user = userFactory();
 
-    cy.mockGraphqlOp('SearchGroupsQuery', {
-      groups: [
-        { id: 1, name: 'New York' },
-        { id: 2, name: 'Philadelphia' },
-        { id: 3, name: 'San Francisco' },
-      ],
-    });
+        cy.mockGraphqlOp('SearchGroupsQuery', {
+          groups: [
+            { id: 1, name: 'New York' },
+            { id: 2, name: 'Philadelphia' },
+            { id: 3, name: 'San Francisco' },
+          ],
+        });
 
-    cy.mockGraphqlOp('CampaignBannerQuery', {
-      campaign: {
-        id: campaignId,
-        groupTypeId: 1,
-        groupType: {
-          id: 1,
-          filterByState: false,
-        },
-      },
-    });
+        cy.mockGraphqlOp('CampaignBannerQuery', {
+          campaign: {
+            id: campaignId,
+            groupTypeId: 1,
+            groupType: {
+              id: 1,
+              filterByState: false,
+            },
+          },
+        });
 
-    // Visit the campaign pitch page
-    cy.withState(exampleCampaign).visit('/us/campaigns/test-example-campaign');
+        // Visit the campaign pitch page
+        cy.withState(exampleCampaign).visit(
+          '/us/campaigns/test-example-campaign',
+        );
 
-    cy.findByTestId('join-group-signup-form').should('have.length', 1);
-    cy.findByTestId('campaign-banner-signup-button').contains(
-      'button',
-      'Join Group',
-    );
-    cy.findByTestId('join-group-signup-button').should('be.disabled');
-    cy.get('#select-group-dropdown').click();
-    cy.get('#react-select-select-group--input').type('new');
-    cy.get('#react-select-select-group--option-0').click();
-    cy.findByTestId('join-group-signup-button').should('be.enabled');
+        cy.findByTestId('join-group-signup-form').should('have.length', 1);
+        cy.findByTestId('campaign-banner-signup-button').contains(
+          'button',
+          'Join Group',
+        );
+        cy.findByTestId('join-group-signup-button').should('be.disabled');
+        cy.get('#select-state-dropdown').should('have.length', 0);
+        cy.get('#select-group-dropdown').click();
+        cy.get('#react-select-select-group--input').type('new');
+        cy.get('#react-select-select-group--option-0').click();
+        cy.findByTestId('join-group-signup-button').should('be.enabled');
 
-    // Mock the responses we'll be expecting once we hit the signup button:
-    cy.route(`${API}/signups?filter[northstar_id]=${user.id}`, emptyResponse);
-    cy.route('POST', `${API}/signups`, newSignup(campaignId, user)).as(
-      'signupRequest',
-    );
+        // Mock the responses we'll be expecting once we hit the signup button:
+        cy.route(
+          `${API}/signups?filter[northstar_id]=${user.id}`,
+          emptyResponse,
+        );
+        cy.route('POST', `${API}/signups`, newSignup(campaignId, user)).as(
+          'signupRequest',
+        );
 
-    cy.contains('button', 'Join Group')
-      .click()
-      .handleLogin(user);
+        cy.contains('button', 'Join Group')
+          .click()
+          .handleLogin(user);
 
-    // The outgoing signup request should include the selected group_id.
-    cy.wait('@signupRequest')
-      .its('request.body.group_id')
-      .should('equal', 1);
-  });
+        // The outgoing signup request should include the selected group_id.
+        cy.wait('@signupRequest')
+          .its('request.body.group_id')
+          .should('equal', 1);
+      });
+    },
+  );
+
+  context(
+    'Campaign ID configured with group type that filters by state',
+    () => {
+      /** @test */
+      it('Signup button is enabled after selecting state, then group', () => {
+        const user = userFactory();
+
+        cy.mockGraphqlOp('SearchGroupsQuery', {
+          groups: [
+            { id: 1, name: 'New York', state: 'NY' },
+            { id: 2, name: 'Philadelphia', state: 'PA' },
+            { id: 3, name: 'San Francisco', state: 'CA' },
+          ],
+        });
+
+        cy.mockGraphqlOp('CampaignBannerQuery', {
+          campaign: {
+            id: campaignId,
+            groupTypeId: 1,
+            groupType: {
+              id: 1,
+              filterByState: true,
+            },
+          },
+        });
+
+        // Visit the campaign pitch page
+        cy.withState(exampleCampaign).visit(
+          '/us/campaigns/test-example-campaign',
+        );
+
+        cy.findByTestId('join-group-signup-form').should('have.length', 1);
+        cy.findByTestId('campaign-banner-signup-button').contains(
+          'button',
+          'Join Group',
+        );
+        cy.findByTestId('join-group-signup-button').should('be.disabled');
+        cy.get('#select-state-dropdown').should('have.length', 1);
+        cy.get('#select-group-dropdown').should('have.length', 0);
+        cy.get('#select-state-dropdown').click();
+        cy.get('#react-select-select-state--input').type('new');
+        // Select "New York"
+        cy.get('#react-select-select-state--option-32').click();
+        cy.findByTestId('join-group-signup-button').should('be.disabled');
+        cy.get('#select-group-dropdown').should('have.length', 1);
+        // Forcing these actions because this element gets covered by the SitewideBanner.
+        cy.get('#react-select-select-group--input').type('new', {
+          force: true,
+        });
+        cy.get('#react-select-select-group--option-0').click({ force: true });
+        cy.findByTestId('join-group-signup-button').should('be.enabled');
+
+        // Mock the responses we'll be expecting once we hit the signup button:
+        cy.route(
+          `${API}/signups?filter[northstar_id]=${user.id}`,
+          emptyResponse,
+        );
+        cy.route('POST', `${API}/signups`, newSignup(campaignId, user)).as(
+          'signupRequest',
+        );
+
+        cy.contains('button', 'Join Group')
+          .click()
+          .handleLogin(user);
+
+        // The outgoing signup request should include the selected group_id.
+        cy.wait('@signupRequest')
+          .its('request.body.group_id')
+          .should('equal', 1);
+      });
+    },
+  );
 });

--- a/cypress/integration/campaign-signup.js
+++ b/cypress/integration/campaign-signup.js
@@ -212,140 +212,130 @@ describe('Campaign Signup', () => {
     );
   });
 
-  context(
-    'Campaign ID configured with group type that does not filter by state',
-    () => {
-      /** @test */
-      it('Signup button is enabled after selecting a group', () => {
-        const user = userFactory();
+  // TODO: Add context
+  /** @test */
+  it('Signup button is enabled after selecting a group', () => {
+    const user = userFactory();
 
-        cy.mockGraphqlOp('SearchGroupsQuery', {
-          groups: [
-            { id: 1, name: 'New York' },
-            { id: 2, name: 'Philadelphia' },
-            { id: 3, name: 'San Francisco' },
-          ],
-        });
+    cy.mockGraphqlOp('SearchGroupsQuery', {
+      groups: [
+        { id: 1, name: 'New York' },
+        { id: 2, name: 'Philadelphia' },
+        { id: 3, name: 'San Francisco' },
+      ],
+    });
 
-        cy.mockGraphqlOp('CampaignBannerQuery', {
-          campaign: {
-            id: campaignId,
-            groupTypeId: 1,
-            groupType: {
-              id: 1,
-              filterByState: false,
+    cy.mockGraphqlOp('CampaignBannerQuery', {
+      campaign: {
+        id: campaignId,
+        groupTypeId: 1,
+        groupType: {
+          id: 1,
+          filterByState: false,
+        },
+      },
+    });
+
+    // Visit the campaign pitch page
+    cy.withState(exampleCampaign).visit('/us/campaigns/test-example-campaign');
+
+    cy.findByTestId('join-group-signup-form').should('have.length', 1);
+    cy.findByTestId('campaign-banner-signup-button').contains(
+      'button',
+      'Join Group',
+    );
+    cy.findByTestId('join-group-signup-button').should('be.disabled');
+    cy.get('#select-state-dropdown').should('have.length', 0);
+    cy.get('#select-group-dropdown').click();
+    cy.get('#react-select-select-group--input').type('new');
+    cy.get('#react-select-select-group--option-0').click();
+    cy.findByTestId('join-group-signup-button').should('be.enabled');
+
+    // Mock the responses we'll be expecting once we hit the signup button:
+    cy.route(`${API}/signups?filter[northstar_id]=${user.id}`, emptyResponse);
+    cy.route('POST', `${API}/signups`, newSignup(campaignId, user)).as(
+      'signupRequest',
+    );
+
+    cy.contains('button', 'Join Group')
+      .click()
+      .handleLogin(user);
+
+    // The outgoing signup request should include the selected group_id.
+    cy.wait('@signupRequest')
+      .its('request.body.group_id')
+      .should('equal', 1);
+  }),
+    context(
+      'Campaign ID configured with group type that filters by state',
+      () => {
+        /** @test */
+        it('Signup button is enabled after selecting state, then group', () => {
+          const user = userFactory();
+
+          cy.mockGraphqlOp('SearchGroupsQuery', {
+            groups: [
+              { id: 1, name: 'New York', state: 'NY' },
+              { id: 2, name: 'Philadelphia', state: 'PA' },
+              { id: 3, name: 'San Francisco', state: 'CA' },
+            ],
+          });
+
+          cy.mockGraphqlOp('CampaignBannerQuery', {
+            campaign: {
+              id: campaignId,
+              groupTypeId: 1,
+              groupType: {
+                id: 1,
+                filterByState: true,
+              },
             },
-          },
+          });
+
+          // Visit the campaign pitch page
+          cy.withState(exampleCampaign).visit(
+            '/us/campaigns/test-example-campaign',
+          );
+
+          cy.findByTestId('join-group-signup-form').should('have.length', 1);
+          cy.findByTestId('campaign-banner-signup-button').contains(
+            'button',
+            'Join Group',
+          );
+          cy.findByTestId('join-group-signup-button').should('be.disabled');
+          cy.get('#select-state-dropdown').should('have.length', 1);
+          cy.get('#select-group-dropdown').should('have.length', 0);
+          cy.get('#select-state-dropdown').click();
+          cy.get('#react-select-select-state--input').type('new');
+          // Select "New York"
+          cy.get('#react-select-select-state--option-32').click();
+          cy.findByTestId('join-group-signup-button').should('be.disabled');
+          cy.get('#select-group-dropdown').should('have.length', 1);
+          // Forcing these actions because this element gets covered by the SitewideBanner.
+          cy.get('#react-select-select-group--input').type('new', {
+            force: true,
+          });
+          cy.get('#react-select-select-group--option-0').click({ force: true });
+          cy.findByTestId('join-group-signup-button').should('be.enabled');
+
+          // Mock the responses we'll be expecting once we hit the signup button:
+          cy.route(
+            `${API}/signups?filter[northstar_id]=${user.id}`,
+            emptyResponse,
+          );
+          cy.route('POST', `${API}/signups`, newSignup(campaignId, user)).as(
+            'signupRequest',
+          );
+
+          cy.contains('button', 'Join Group')
+            .click()
+            .handleLogin(user);
+
+          // The outgoing signup request should include the selected group_id.
+          cy.wait('@signupRequest')
+            .its('request.body.group_id')
+            .should('equal', 1);
         });
-
-        // Visit the campaign pitch page
-        cy.withState(exampleCampaign).visit(
-          '/us/campaigns/test-example-campaign',
-        );
-
-        cy.findByTestId('join-group-signup-form').should('have.length', 1);
-        cy.findByTestId('campaign-banner-signup-button').contains(
-          'button',
-          'Join Group',
-        );
-        cy.findByTestId('join-group-signup-button').should('be.disabled');
-        cy.get('#select-state-dropdown').should('have.length', 0);
-        cy.get('#select-group-dropdown').click();
-        cy.get('#react-select-select-group--input').type('new');
-        cy.get('#react-select-select-group--option-0').click();
-        cy.findByTestId('join-group-signup-button').should('be.enabled');
-
-        // Mock the responses we'll be expecting once we hit the signup button:
-        cy.route(
-          `${API}/signups?filter[northstar_id]=${user.id}`,
-          emptyResponse,
-        );
-        cy.route('POST', `${API}/signups`, newSignup(campaignId, user)).as(
-          'signupRequest',
-        );
-
-        cy.contains('button', 'Join Group')
-          .click()
-          .handleLogin(user);
-
-        // The outgoing signup request should include the selected group_id.
-        cy.wait('@signupRequest')
-          .its('request.body.group_id')
-          .should('equal', 1);
-      });
-    },
-  );
-
-  context(
-    'Campaign ID configured with group type that filters by state',
-    () => {
-      /** @test */
-      it('Signup button is enabled after selecting state, then group', () => {
-        const user = userFactory();
-
-        cy.mockGraphqlOp('SearchGroupsQuery', {
-          groups: [
-            { id: 1, name: 'New York', state: 'NY' },
-            { id: 2, name: 'Philadelphia', state: 'PA' },
-            { id: 3, name: 'San Francisco', state: 'CA' },
-          ],
-        });
-
-        cy.mockGraphqlOp('CampaignBannerQuery', {
-          campaign: {
-            id: campaignId,
-            groupTypeId: 1,
-            groupType: {
-              id: 1,
-              filterByState: true,
-            },
-          },
-        });
-
-        // Visit the campaign pitch page
-        cy.withState(exampleCampaign).visit(
-          '/us/campaigns/test-example-campaign',
-        );
-
-        cy.findByTestId('join-group-signup-form').should('have.length', 1);
-        cy.findByTestId('campaign-banner-signup-button').contains(
-          'button',
-          'Join Group',
-        );
-        cy.findByTestId('join-group-signup-button').should('be.disabled');
-        cy.get('#select-state-dropdown').should('have.length', 1);
-        cy.get('#select-group-dropdown').should('have.length', 0);
-        cy.get('#select-state-dropdown').click();
-        cy.get('#react-select-select-state--input').type('new');
-        // Select "New York"
-        cy.get('#react-select-select-state--option-32').click();
-        cy.findByTestId('join-group-signup-button').should('be.disabled');
-        cy.get('#select-group-dropdown').should('have.length', 1);
-        // Forcing these actions because this element gets covered by the SitewideBanner.
-        cy.get('#react-select-select-group--input').type('new', {
-          force: true,
-        });
-        cy.get('#react-select-select-group--option-0').click({ force: true });
-        cy.findByTestId('join-group-signup-button').should('be.enabled');
-
-        // Mock the responses we'll be expecting once we hit the signup button:
-        cy.route(
-          `${API}/signups?filter[northstar_id]=${user.id}`,
-          emptyResponse,
-        );
-        cy.route('POST', `${API}/signups`, newSignup(campaignId, user)).as(
-          'signupRequest',
-        );
-
-        cy.contains('button', 'Join Group')
-          .click()
-          .handleLogin(user);
-
-        // The outgoing signup request should include the selected group_id.
-        cy.wait('@signupRequest')
-          .its('request.body.group_id')
-          .should('equal', 1);
-      });
-    },
-  );
+      },
+    );
 });

--- a/cypress/integration/campaign-signup.js
+++ b/cypress/integration/campaign-signup.js
@@ -236,8 +236,7 @@ describe('Campaign Signup', () => {
       },
     });
 
-    // Visit the campaign pitch page
-    cy.withState(exampleCampaign).visit('/us/campaigns/test-example-campaign');
+    cy.anonVisitCampaign(exampleCampaign);
 
     cy.findByTestId('join-group-signup-form').should('have.length', 1);
     cy.findByTestId('campaign-banner-signup-button').contains(
@@ -293,10 +292,7 @@ describe('Campaign Signup', () => {
           },
         });
 
-        // Visit the campaign pitch page
-        cy.withState(exampleCampaign).visit(
-          '/us/campaigns/test-example-campaign',
-        );
+        cy.anonVisitCampaign(exampleCampaign);
 
         cy.findByTestId('join-group-signup-form').should('have.length', 1);
         cy.findByTestId('campaign-banner-signup-button').contains(

--- a/resources/assets/components/CampaignSignupForm/CampaignSignupForm.js
+++ b/resources/assets/components/CampaignSignupForm/CampaignSignupForm.js
@@ -63,7 +63,7 @@ const CampaignSignupForm = props => {
   };
 
   const handleGroupFinderChange = selected => {
-    setGroupId(selected.id);
+    setGroupId(selected ? selected.id : null);
 
     trackAnalyticsEvent('clicked_group_finder_group', {
       action: 'form_clicked',
@@ -72,7 +72,7 @@ const CampaignSignupForm = props => {
       context: {
         campaignId,
         // Pass our selected.id to avoid race condition with setting groupId state.
-        groupId: selected.id,
+        groupId: selected ? selected.id : null,
         pageId,
       },
     });

--- a/resources/assets/components/CampaignSignupForm/GroupFinder/GroupFinder.js
+++ b/resources/assets/components/CampaignSignupForm/GroupFinder/GroupFinder.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 
 import {
@@ -6,12 +6,15 @@ import {
   trackAnalyticsEvent,
 } from '../../../helpers/analytics';
 import GroupSelect from './GroupSelect';
+import UsaStateSelect from '../../utilities/UsaStateSelect';
 
 // These will be re-used once we add a UsaStateSelect utility component.
 const ANALYTICS_EVENT_CATEGORY = EVENT_CATEGORIES.campaignAction;
 const ANALYTICS_EVENT_LABEL = 'group_finder';
 
 const GroupFinder = ({ context, groupType, onChange }) => {
+  const [groupState, setGroupState] = useState(null);
+
   const handleGroupSelectFocus = () => {
     trackAnalyticsEvent(`focused_${ANALYTICS_EVENT_LABEL}_group`, {
       action: 'field_focused',
@@ -21,14 +24,43 @@ const GroupFinder = ({ context, groupType, onChange }) => {
     });
   };
 
+  const handleGroupStateSelectFocus = () => {
+    trackAnalyticsEvent(`focused_${ANALYTICS_EVENT_LABEL}_state`, {
+      action: 'field_focused',
+      category: ANALYTICS_EVENT_CATEGORY,
+      label: ANALYTICS_EVENT_LABEL,
+      context,
+    });
+  };
+
+  const handleGroupStateSelectChange = selected => {
+    setGroupState(selected.abbreviation);
+
+    trackAnalyticsEvent(`clicked_${ANALYTICS_EVENT_LABEL}_state`, {
+      action: 'form_clicked',
+      category: ANALYTICS_EVENT_CATEGORY,
+      label: ANALYTICS_EVENT_LABEL,
+      context,
+    });
+  };
+
   return (
-    <div className="pb-3">
-      <GroupSelect
-        groupTypeId={groupType.id}
-        onChange={onChange}
-        onFocus={handleGroupSelectFocus}
-      />
-    </div>
+    <>
+      <div className="pb-3">
+        <UsaStateSelect
+          onChange={handleGroupStateSelectChange}
+          onFocus={handleGroupStateSelectFocus}
+        />
+      </div>
+      <div className="pb-3">
+        <GroupSelect
+          groupState={groupState}
+          groupTypeId={groupType.id}
+          onChange={onChange}
+          onFocus={handleGroupSelectFocus}
+        />
+      </div>
+    </>
   );
 };
 

--- a/resources/assets/components/CampaignSignupForm/GroupFinder/GroupFinder.js
+++ b/resources/assets/components/CampaignSignupForm/GroupFinder/GroupFinder.js
@@ -49,6 +49,7 @@ const GroupFinder = ({ context, groupType, onChange }) => {
     <>
       {filterByState ? (
         <div className="pb-3">
+          <p className="font-bold pb-1">Select your state</p>
           <UsaStateSelect
             onChange={handleGroupStateSelectChange}
             onFocus={handleGroupStateSelectFocus}
@@ -57,6 +58,7 @@ const GroupFinder = ({ context, groupType, onChange }) => {
       ) : null}
       {!filterByState || (filterByState && groupState) ? (
         <div className="pb-3">
+          <p className="font-bold pb-1">Select your chapter location</p>
           <GroupSelect
             groupState={groupState}
             groupTypeId={groupType.id}

--- a/resources/assets/components/CampaignSignupForm/GroupFinder/GroupFinder.js
+++ b/resources/assets/components/CampaignSignupForm/GroupFinder/GroupFinder.js
@@ -49,7 +49,7 @@ const GroupFinder = ({ context, groupType, onChange }) => {
     <>
       {filterByState ? (
         <div className="pb-3">
-          <p className="font-bold pb-1">Select your state</p>
+          <p className="font-bold text-sm py-1">Select your state</p>
           <UsaStateSelect
             onChange={handleGroupStateSelectChange}
             onFocus={handleGroupStateSelectFocus}
@@ -58,7 +58,7 @@ const GroupFinder = ({ context, groupType, onChange }) => {
       ) : null}
       {!filterByState || (filterByState && groupState) ? (
         <div className="pb-3">
-          <p className="font-bold pb-1">Select your chapter location</p>
+          <p className="font-bold text-sm py-1">Select your chapter</p>
           <GroupSelect
             groupState={groupState}
             groupTypeId={groupType.id}

--- a/resources/assets/components/CampaignSignupForm/GroupFinder/GroupFinder.js
+++ b/resources/assets/components/CampaignSignupForm/GroupFinder/GroupFinder.js
@@ -23,15 +23,6 @@ const GroupFinder = ({ context, groupType, onChange }) => {
     });
   };
 
-  const handleGroupStateSelectFocus = () => {
-    trackAnalyticsEvent(`focused_${ANALYTICS_EVENT_LABEL}_state`, {
-      action: 'field_focused',
-      category: ANALYTICS_EVENT_CATEGORY,
-      label: ANALYTICS_EVENT_LABEL,
-      context,
-    });
-  };
-
   const handleGroupStateSelectChange = selected => {
     setGroupState(selected.abbreviation);
 
@@ -43,9 +34,20 @@ const GroupFinder = ({ context, groupType, onChange }) => {
     });
   };
 
+  const handleGroupStateSelectFocus = () => {
+    trackAnalyticsEvent(`focused_${ANALYTICS_EVENT_LABEL}_state`, {
+      action: 'field_focused',
+      category: ANALYTICS_EVENT_CATEGORY,
+      label: ANALYTICS_EVENT_LABEL,
+      context,
+    });
+  };
+
+  const filterByState = { groupType };
+
   return (
     <>
-      {groupType.filterByState ? (
+      {filterByState ? (
         <div className="pb-3">
           <UsaStateSelect
             onChange={handleGroupStateSelectChange}
@@ -53,14 +55,16 @@ const GroupFinder = ({ context, groupType, onChange }) => {
           />
         </div>
       ) : null}
-      <div className="pb-3">
-        <GroupSelect
-          groupState={groupState}
-          groupTypeId={groupType.id}
-          onChange={onChange}
-          onFocus={handleGroupSelectFocus}
-        />
-      </div>
+      {!filterByState || (filterByState && groupState) ? (
+        <div className="pb-3">
+          <GroupSelect
+            groupState={groupState}
+            groupTypeId={groupType.id}
+            onChange={onChange}
+            onFocus={handleGroupSelectFocus}
+          />
+        </div>
+      ) : null}
     </>
   );
 };

--- a/resources/assets/components/CampaignSignupForm/GroupFinder/GroupFinder.js
+++ b/resources/assets/components/CampaignSignupForm/GroupFinder/GroupFinder.js
@@ -8,7 +8,6 @@ import {
 import GroupSelect from './GroupSelect';
 import UsaStateSelect from '../../utilities/UsaStateSelect';
 
-// These will be re-used once we add a UsaStateSelect utility component.
 const ANALYTICS_EVENT_CATEGORY = EVENT_CATEGORIES.campaignAction;
 const ANALYTICS_EVENT_LABEL = 'group_finder';
 
@@ -46,12 +45,14 @@ const GroupFinder = ({ context, groupType, onChange }) => {
 
   return (
     <>
-      <div className="pb-3">
-        <UsaStateSelect
-          onChange={handleGroupStateSelectChange}
-          onFocus={handleGroupStateSelectFocus}
-        />
-      </div>
+      {groupType.filterByState ? (
+        <div className="pb-3">
+          <UsaStateSelect
+            onChange={handleGroupStateSelectChange}
+            onFocus={handleGroupStateSelectFocus}
+          />
+        </div>
+      ) : null}
       <div className="pb-3">
         <GroupSelect
           groupState={groupState}

--- a/resources/assets/components/CampaignSignupForm/GroupFinder/GroupFinder.js
+++ b/resources/assets/components/CampaignSignupForm/GroupFinder/GroupFinder.js
@@ -43,7 +43,7 @@ const GroupFinder = ({ context, groupType, onChange }) => {
     });
   };
 
-  const filterByState = { groupType };
+  const { filterByState } = groupType;
 
   return (
     <>

--- a/resources/assets/components/CampaignSignupForm/GroupFinder/GroupSelect.js
+++ b/resources/assets/components/CampaignSignupForm/GroupFinder/GroupSelect.js
@@ -6,15 +6,17 @@ import AsyncSelect from 'react-select/async';
 import { useApolloClient } from '@apollo/react-hooks';
 
 const SEARCH_GROUPS_QUERY = gql`
-  query SearchGroupsQuery($groupTypeId: Int!, $name: String!) {
-    groups(groupTypeId: $groupTypeId, name: $name) {
+  query SearchGroupsQuery($groupTypeId: Int!, $name: String!, $state: String) {
+    groups(groupTypeId: $groupTypeId, name: $name, state: $state) {
       id
       name
+      city
+      state
     }
   }
 `;
 
-const GroupSelect = ({ groupTypeId, onChange, onFocus }) => {
+const GroupSelect = ({ groupState, groupTypeId, onChange, onFocus }) => {
   /**
    * This is copied by example from the blocks/CurrentSchoolBlock/SchoolSelect, which has comments
    * detailing debouncing the useApolloClient hook (AsyncSelect loadOptions expects a Promise).
@@ -28,6 +30,7 @@ const GroupSelect = ({ groupTypeId, onChange, onFocus }) => {
         variables: {
           groupTypeId,
           name: searchString,
+          state: groupState,
         },
       })
       .then(result => callback(result.data.groups))
@@ -40,8 +43,13 @@ const GroupSelect = ({ groupTypeId, onChange, onFocus }) => {
    */
   return (
     <AsyncSelect
-      getOptionLabel={group => group.name}
+      getOptionLabel={group =>
+        group.city
+          ? `${group.name} - ${group.city}, ${group.state}`
+          : group.name
+      }
       getOptionValue={group => group.id}
+      key={groupState}
       id="select-group-dropdown"
       instanceId="select-group-"
       loadOptions={(input, callback) => {
@@ -58,9 +66,14 @@ const GroupSelect = ({ groupTypeId, onChange, onFocus }) => {
 };
 
 GroupSelect.propTypes = {
+  groupState: PropTypes.string,
   groupTypeId: PropTypes.number.isRequired,
   onChange: PropTypes.func.isRequired,
   onFocus: PropTypes.func.isRequired,
+};
+
+GroupSelect.defaultProps = {
+  groupState: null,
 };
 
 export default GroupSelect;

--- a/resources/assets/components/CampaignSignupForm/GroupFinder/GroupSelect.js
+++ b/resources/assets/components/CampaignSignupForm/GroupFinder/GroupSelect.js
@@ -33,7 +33,7 @@ const GroupSelect = ({ groupState, groupTypeId, onChange, onFocus }) => {
       variables.state = groupState;
     }
 
-    return client
+    client
       .query({ query: SEARCH_GROUPS_QUERY, variables })
       .then(result => callback(result.data.groups))
       .catch(error => callback(error));

--- a/resources/assets/components/CampaignSignupForm/GroupFinder/GroupSelect.js
+++ b/resources/assets/components/CampaignSignupForm/GroupFinder/GroupSelect.js
@@ -54,6 +54,7 @@ const GroupSelect = ({ groupState, groupTypeId, onChange, onFocus }) => {
       key={groupState}
       id="select-group-dropdown"
       instanceId="select-group-"
+      isClearable
       loadOptions={(input, callback) => {
         if (!input) {
           return Promise.resolve([]);

--- a/resources/assets/components/CampaignSignupForm/GroupFinder/GroupSelect.js
+++ b/resources/assets/components/CampaignSignupForm/GroupFinder/GroupSelect.js
@@ -24,15 +24,17 @@ const GroupSelect = ({ groupState, groupTypeId, onChange, onFocus }) => {
   const client = useApolloClient();
 
   const fetchGroups = debounce((searchString, callback) => {
-    client
-      .query({
-        query: SEARCH_GROUPS_QUERY,
-        variables: {
-          groupTypeId,
-          name: searchString,
-          state: groupState,
-        },
-      })
+    const variables = {
+      groupTypeId,
+      name: searchString,
+    };
+
+    if (groupState) {
+      variables.state = groupState;
+    }
+
+    return client
+      .query({ query: SEARCH_GROUPS_QUERY, variables })
       .then(result => callback(result.data.groups))
       .catch(error => callback(error));
   }, 250);

--- a/resources/assets/components/blocks/CurrentSchoolBlock/CurrentSchoolForm.js
+++ b/resources/assets/components/blocks/CurrentSchoolBlock/CurrentSchoolForm.js
@@ -35,7 +35,7 @@ const CurrentSchoolForm = ({ description, userId }) => {
         <div className="mt-6" data-test="select-school">
           <SchoolSelect
             onChange={selected => setSchool(selected)}
-            filterByState={schoolState.abbreviation}
+            schoolState={schoolState.abbreviation}
           />
         </div>
       ) : null}

--- a/resources/assets/components/blocks/CurrentSchoolBlock/SchoolSelect.js
+++ b/resources/assets/components/blocks/CurrentSchoolBlock/SchoolSelect.js
@@ -21,7 +21,7 @@ const SEARCH_SCHOOLS_QUERY = gql`
   }
 `;
 
-const SchoolSelect = ({ filterByState, onChange }) => {
+const SchoolSelect = ({ onChange, schoolState }) => {
   const client = useApolloClient();
   // Debounce school search to query for schools after 250 ms typing pause.
   // @see https://github.com/JedWatson/react-select/issues/614#issuecomment-244006496
@@ -30,7 +30,7 @@ const SchoolSelect = ({ filterByState, onChange }) => {
       .query({
         query: SEARCH_SCHOOLS_QUERY,
         variables: {
-          state: filterByState,
+          state: schoolState,
           name: searchString,
         },
       })
@@ -59,12 +59,12 @@ const SchoolSelect = ({ filterByState, onChange }) => {
       getOptionValue={school => school.id}
       isClearable
       /**
-       * Changing per filterByState will result in clearing any selected options.
+       * Changing per schoolState will result in clearing any selected options.
        * If user selects a school, but then changes the school state to something else, they should
        * be forced to find school in the selected state.
        * @see https://stackoverflow.com/a/55142916
        */
-      key={filterByState}
+      key={schoolState}
       loadOptions={(input, callback) => {
         /**
          * Avoid querying by empty school name on page load.
@@ -82,8 +82,8 @@ const SchoolSelect = ({ filterByState, onChange }) => {
 };
 
 SchoolSelect.propTypes = {
-  filterByState: PropTypes.string.isRequired,
   onChange: PropTypes.func.isRequired,
+  schoolState: PropTypes.string.isRequired,
 };
 
 export default SchoolSelect;

--- a/resources/assets/components/utilities/UsaStateSelect.js
+++ b/resources/assets/components/utilities/UsaStateSelect.js
@@ -9,6 +9,8 @@ const UsaStateSelect = ({ onChange, onFocus }) => (
   <Select
     getOptionLabel={usaState => usaState.name}
     getOptionValue={usaState => usaState.abbreviation}
+    id="select-state-dropdown"
+    instanceId="select-state-"
     onChange={onChange}
     onFocus={onFocus}
     options={usaStateOptions}

--- a/resources/assets/components/utilities/UsaStateSelect.js
+++ b/resources/assets/components/utilities/UsaStateSelect.js
@@ -5,17 +5,23 @@ import { UsaStates } from 'usa-states';
 
 const usaStateOptions = new UsaStates().states;
 
-const UsaStateSelect = ({ onChange }) => (
+const UsaStateSelect = ({ onChange, onFocus }) => (
   <Select
     getOptionLabel={usaState => usaState.name}
     getOptionValue={usaState => usaState.abbreviation}
     onChange={onChange}
+    onFocus={onFocus}
     options={usaStateOptions}
   />
 );
 
 UsaStateSelect.propTypes = {
   onChange: PropTypes.func.isRequired,
+  onFocus: PropTypes.func,
+};
+
+UsaStateSelect.defaultProps = {
+  onFocus: () => {},
 };
 
 export default UsaStateSelect;


### PR DESCRIPTION
### What's this PR do?

This pull request modifies the Group Finder (added in #2235) to require user to select a US state first before selecting a group, if the campaign group type has a truthy `filter_with_state` attribute.

It also renames the `filterByState` prop in the existing `SchoolSelect` component to `schoolState`, to avoid confusion with the newly added `filterByState` field on our `GroupType` type in Rogue.

<img src="https://user-images.githubusercontent.com/1236811/86038641-13975680-b9f6-11ea-9155-c61d3e4a04aa.gif" width="400" />


### How should this be reviewed?

:eyes:

### Any background context you want to provide?

* Similar to https://github.com/DoSomething/rogue/pull/1058, this won't be testable in dev or QA until we get final files to import NASSP groups (which will have group types that filter by state, along with `city` and `state` values populated in the groups).

* I'll be adding documentation for Groups in a future PR to help keep this reviewable.

### Relevant tickets

References [Pivotal #173231765](https://www.pivotaltracker.com/story/show/173231765).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- ~~[ ] Documentation added for new features/changed endpoints.~~ -- will be provided in a future PR
- [ ] Added screenshots of front-end changes on small, medium, and large screens.
- [x] Added appropriate feature/unit tests.
