### PR TITLE
Fix Outdated Feature Flag Config References

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -10,7 +10,7 @@
 // Homepage
 $router->redirect('/', '/us');
 
-if (config('features.new_homepage')) {
+if (config('feature-flags.new_homepage')) {
     $router->view('/us', 'app');
 } else {
     $router->get('/us', 'HomePageController');
@@ -31,7 +31,7 @@ $router->view('/us/account/{clientRoute?}', 'app')
     ->middleware('auth');
 
 // Campaigns index
-if (config('features.dynamic_explore_campaigns')) {
+if (config('feature-flags.dynamic_explore_campaigns')) {
     $router->view('us/campaigns', 'app');
 } else {
     $router->get('us/campaigns', 'CampaignController@index');


### PR DESCRIPTION
### What's this PR do?

This pull request fixes a bug I introduced in #2239 where we renamed the `config/features` to `config/feature-flags`. I did a search for `config('features')`, but failed to search for nested variable invocation.

### How should this be reviewed?
👀 

### Any background context you want to provide?
Glad we caught this in the [explore campaigns test](https://app.ghostinspector.com/tests/5c48d2110bb17c1d6e272f1e) on Ghost Inspector QA! 