### PR TITLE
add links to bages

### DIFF
--- a/resources/assets/components/pages/AccountPage/Badges/BadgesTab.js
+++ b/resources/assets/components/pages/AccountPage/Badges/BadgesTab.js
@@ -55,7 +55,7 @@ const badgeModalContent = {
       'Hey, congrats! You earned a badge for signing up for your first campaign. More badges ahead…!',
     unearnedText: (
       <span>
-        Unlock this badge by $
+        Unlock this badge by
         {exploreCampaignsLink('signing up for a campaign')}.
       </span>
     ),

--- a/resources/assets/components/pages/AccountPage/Badges/BadgesTab.js
+++ b/resources/assets/components/pages/AccountPage/Badges/BadgesTab.js
@@ -5,7 +5,6 @@ import gql from 'graphql-tag';
 import Badge from './Badge';
 import Query from '../../../Query';
 import BadgeModal from './BadgeModal';
-import { Link } from 'react-router-dom';
 import './badges-tab.scss';
 
 const CONFIRMED = 'CONFIRMED';

--- a/resources/assets/components/pages/AccountPage/Badges/BadgesTab.js
+++ b/resources/assets/components/pages/AccountPage/Badges/BadgesTab.js
@@ -44,33 +44,61 @@ const VOTER_BADGE = gql`
   }
 `;
 
+const exploreCampaignsLink = text => {
+  return (
+    <a href="/us/campaigns" target="_blank" rel="noopener noreferrer">
+      {text}
+    </a>
+  );
+};
+
 const badgeModalContent = {
   signupBadge: {
     title: '1 SIGN-UP',
     earnedText:
       'Hey, congrats! You earned a badge for signing up for your first campaign. More badges ahead…!',
-    unearnedText: 'Unlock this badge by signing up for a campaign.',
+    unearnedText: (
+      <span>
+        Unlock this badge by $
+        {exploreCampaignsLink('signing up for a campaign')}.
+      </span>
+    ),
   },
   onePostBadge: {
     title: '1 ACTION',
     earnedText:
       'Congratulations! You rocked the campaign, made a serious difference, and earned this badge. Feel good? You totally should.',
-    unearnedText:
-      'Complete a DoSomething campaign by taking action and uploading a photo. You’ll transform your community *and* earn this badge!',
+    unearnedText: (
+      <span>
+        {exploreCampaignsLink('Complete a DoSomething campaign')} by taking
+        action and uploading a photo. You’ll transform your community *and* earn
+        this badge!
+      </span>
+    ),
   },
   twoPostsBadge: {
     title: '2 ACTIONS',
     earnedText:
       'Niiiiice! You just earned another badge for making an impact *again*. Hope you’re double proud of yourself.',
-    unearnedText:
-      'Want to earn your second Action badge? Rock another DoSomething campaign.',
+    unearnedText: (
+      <span>
+        Want to earn your second Action badge?
+        {exploreCampaignsLink('Rock another DoSomething campaign')}, our current
+        events newsletter.
+      </span>
+    ),
   },
   threePostsBadge: {
     title: '3 ACTIONS',
     earnedText:
       'OH YEAH! You rocked another campaign and earned your *third* Action badge. Welcome to the three timers club!',
-    unearnedText:
-      'Third time’s a charm! Complete another campaign to unlock this exclusive badge.',
+    unearnedText: (
+      <span>
+        Third time’s a charm!{' '}
+        {exploreCampaignsLink('Complete another campaign')} to unlock this
+        exclusive badge.
+      </span>
+    ),
   },
   oneStaffFaveBadge: {
     title: '1 STAFF FAVE',
@@ -120,56 +148,6 @@ const badgeModalContent = {
       </span>
     ),
   },
-};
-
-const addAnchorToUnearnedText = text => {
-  return (
-    <a
-      href="https://www.dosomething.org/us/campaigns"
-      target="_blank"
-      rel="noopener noreferrer"
-    >
-      {text}
-    </a>
-  );
-};
-
-const switchTextLinkInUnearnedText = unearnedText => {
-  const originalUnearnedText = unearnedText;
-
-  const findPhrase = term => {
-    if (originalUnearnedText.includes(term)) {
-      return originalUnearnedText;
-    }
-    return false;
-  };
-
-  switch (originalUnearnedText) {
-    case findPhrase('signing up for a campaign'):
-      return originalUnearnedText.replace(
-        'signing up for a campaign',
-        <addAnchorToUnearnedText text="signing up for a campaign" />,
-      );
-    case findPhrase('complete a DoSomething campaign'):
-      return originalUnearnedText.replace(
-        'complete a DoSomething campaign',
-        <addAnchorToUnearnedText text="complete a DoSomething campaign" />,
-      );
-    case findPhrase('Rock another DoSomething campaign'):
-      return originalUnearnedText.replace(
-        'Rock another DoSomething campaign',
-        <addAnchorToUnearnedText text="Rock another DoSomething campaign" />,
-      );
-    case findPhrase('Complete another campaign'):
-      return originalUnearnedText.replace(
-        'Complete another campaign',
-        <addAnchorToUnearnedText text="Complete another campaign" />,
-      );
-    default:
-      console.log('No unearnedText');
-  }
-
-  return originalUnearnedText;
 };
 
 class BadgesTab extends React.Component {
@@ -435,9 +413,7 @@ class BadgesTab extends React.Component {
             <p>
               {this.state.modalEarned
                 ? badgeModalContent[this.state.modalName].earnedText
-                : switchTextLinkInUnearnedText(
-                    badgeModalContent[this.state.modalName].unearnedText,
-                  )}
+                : badgeModalContent[this.state.modalName].unearnedText}
             </p>
           </BadgeModal>
         ) : null}

--- a/resources/assets/components/pages/AccountPage/Badges/BadgesTab.js
+++ b/resources/assets/components/pages/AccountPage/Badges/BadgesTab.js
@@ -122,6 +122,56 @@ const badgeModalContent = {
   },
 };
 
+const addAnchorToUnearnedText = text => {
+  return (
+    <a
+      href="https://www.dosomething.org/us/campaigns"
+      target="_blank"
+      rel="noopener noreferrer"
+    >
+      {text}
+    </a>
+  );
+};
+
+const switchTextLinkInUnearnedText = unearnedText => {
+  const originalUnearnedText = unearnedText;
+
+  const findPhrase = term => {
+    if (originalUnearnedText.includes(term)) {
+      return originalUnearnedText;
+    }
+    return false;
+  };
+
+  switch (originalUnearnedText) {
+    case findPhrase('signing up for a campaign'):
+      return originalUnearnedText.replace(
+        'signing up for a campaign',
+        <addAnchorToUnearnedText text="signing up for a campaign" />,
+      );
+    case findPhrase('complete a DoSomething campaign'):
+      return originalUnearnedText.replace(
+        'complete a DoSomething campaign',
+        <addAnchorToUnearnedText text="complete a DoSomething campaign" />,
+      );
+    case findPhrase('Rock another DoSomething campaign'):
+      return originalUnearnedText.replace(
+        'Rock another DoSomething campaign',
+        <addAnchorToUnearnedText text="Rock another DoSomething campaign" />,
+      );
+    case findPhrase('Complete another campaign'):
+      return originalUnearnedText.replace(
+        'Complete another campaign',
+        <addAnchorToUnearnedText text="Complete another campaign" />,
+      );
+    default:
+      console.log('No unearnedText');
+  }
+
+  return originalUnearnedText;
+};
+
 class BadgesTab extends React.Component {
   constructor(props) {
     super(props);
@@ -385,7 +435,9 @@ class BadgesTab extends React.Component {
             <p>
               {this.state.modalEarned
                 ? badgeModalContent[this.state.modalName].earnedText
-                : badgeModalContent[this.state.modalName].unearnedText}
+                : switchTextLinkInUnearnedText(
+                    badgeModalContent[this.state.modalName].unearnedText,
+                  )}
             </p>
           </BadgeModal>
         ) : null}

--- a/resources/assets/components/pages/AccountPage/Badges/BadgesTab.js
+++ b/resources/assets/components/pages/AccountPage/Badges/BadgesTab.js
@@ -3,8 +3,9 @@ import PropTypes from 'prop-types';
 import gql from 'graphql-tag';
 
 import Badge from './Badge';
-import BadgeModal from './BadgeModal';
 import Query from '../../../Query';
+import BadgeModal from './BadgeModal';
+import { Link } from 'react-router-dom';
 import './badges-tab.scss';
 
 const CONFIRMED = 'CONFIRMED';
@@ -45,11 +46,7 @@ const VOTER_BADGE = gql`
 `;
 
 const exploreCampaignsLink = text => {
-  return (
-    <a href="/us/campaigns" target="_blank" rel="noopener noreferrer">
-      {text}
-    </a>
-  );
+  return <a href="/us/campaigns">{text}</a>;
 };
 
 const badgeModalContent = {
@@ -83,8 +80,7 @@ const badgeModalContent = {
     unearnedText: (
       <span>
         Want to earn your second Action badge?
-        {exploreCampaignsLink('Rock another DoSomething campaign')}, our current
-        events newsletter.
+        {exploreCampaignsLink('Rock another DoSomething campaign')}.
       </span>
     ),
   },


### PR DESCRIPTION
created a helper function & component to replace the unearned text with an anchor tag as needed

### What's this PR do?

This pull request adds a link to unearned badges so yours will have an option to navigate to the campaigns page to earn a new badge

### How should this be reviewed?

...

### Any background context you want to provide?

...

### Relevant tickets

References [Pivotal #173231765](https://www.pivotaltracker.com/story/show/173119520).


### Checklist

- [ x ] This PR has been added to the relevant Pivotal card.
- [ x ] Added screenshots of front-end changes on small, medium, and large screens.

<img width="322" alt="Screen Shot 2020-06-29 at 6 34 14 PM" src="https://user-images.githubusercontent.com/20409413/86062629-29793b80-ba37-11ea-967f-2e2961596539.png">
<img width="669" alt="Screen Shot 2020-06-29 at 6 32 20 PM" src="https://user-images.githubusercontent.com/20409413/86062635-2da55900-ba37-11ea-99df-2d7e13df6b72.png">
<img width="718" alt="Screen Shot 2020-06-29 at 6 32 10 PM" src="https://user-images.githubusercontent.com/20409413/86062650-3433d080-ba37-11ea-857f-cd0fa222f3ca.png">
