### PR TITLE
Beta Referral Page - bring back that - Secondary Campaign Referral Link

### DIFF
--- a/config/site.php
+++ b/config/site.php
@@ -14,5 +14,5 @@ return [
     |
     */
 
-    'default-referral-campaign-id' => env('DS_DEFAULT_REFERRAL_CAMPAIGN_ID'),
+    'default_referral_campaign_id' => env('DS_DEFAULT_REFERRAL_CAMPAIGN_ID'),
 ];

--- a/cypress/integration/beta-referral-page.js
+++ b/cypress/integration/beta-referral-page.js
@@ -7,9 +7,7 @@ describe('Beta Referral Page', () => {
   beforeEach(() => cy.configureMocks());
 
   it('Visit beta referral page, with valid user and campaign ID set', () => {
-    cy.visit(
-      `/us/join?user_id=${userId}&campaign_id=${campaignId}`,
-    );
+    cy.visit(`/us/join?user_id=${userId}&campaign_id=${campaignId}`);
 
     cy.contains('campaign scholarship');
     cy.contains('FAQ');
@@ -33,5 +31,30 @@ describe('Beta Referral Page', () => {
 
     cy.get('.referral-page-campaign').should('have.length', 0);
     cy.get('.error-page').should('have.length', 1);
+  });
+
+  context('Refer Friends V2', () => {
+    it('Displays a secondary referral campaign link', () => {
+      cy.withFeatureFlags({ refer_friends_v2: true }).visit(
+        `/us/join?user_id=${userId}&campaign_id=${campaignId}`,
+      );
+
+      cy.findByTestId('secondary-campaign-referral-link').within(() => {
+        cy.get('a')
+          .should('have.attr', 'href')
+          .and('include', `referrer_user_id=${userId}`);
+      });
+    });
+
+    it('Displays only one referral campaign link if the provided campaign ID matches the default', () => {
+      cy.withFeatureFlags({ refer_friends_v2: true })
+        .withSiteConfig({ default_referral_campaign_id: campaignId })
+        .visit(`/us/join?user_id=${userId}&campaign_id=${campaignId}`);
+
+      cy.findByTestId('secondary-campaign-referral-link').should(
+        'have.length',
+        0,
+      );
+    });
   });
 });

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -128,6 +128,20 @@ Cypress.Commands.add('withFeatureFlags', featureFlags => {
 });
 
 /**
+ * Set environment site config variables.
+ *
+ * @param {Object} config
+ */
+Cypress.Commands.add('withSiteConfig', config => {
+  cy.on('window:before:load', window => {
+    window.ENV = {
+      ...window.ENV,
+      SITE: { ...window.ENV.SITE, ...config },
+    };
+  });
+});
+
+/**
  * Mock an existing signup for the logged-in user & given campaign.
  *
  * @param {Object} state

--- a/cypress/support/index.js
+++ b/cypress/support/index.js
@@ -17,6 +17,9 @@ Cypress.on('window:before:load', window => {
     FEATURE_FLAGS: {
       nps_survey: false,
     },
+    SITE: {
+      default_referral_campaign_id: 9001,
+    },
     SIXPACK_ENABLED: false,
     SIXPACK_BASE_URL: 'http://sixpack.test', // Our Sixpack service will throw an error if this isn't set.
     CONTENTFUL_USE_PREVIEW_API: false,

--- a/cypress/support/index.js
+++ b/cypress/support/index.js
@@ -18,7 +18,7 @@ Cypress.on('window:before:load', window => {
       nps_survey: false,
     },
     SITE: {
-      default_referral_campaign_id: 9001,
+      default_referral_campaign_id: '9001',
     },
     SIXPACK_ENABLED: false,
     SIXPACK_BASE_URL: 'http://sixpack.test', // Our Sixpack service will throw an error if this isn't set.

--- a/resources/assets/components/pages/ReferralPage/Beta/BetaPage.js
+++ b/resources/assets/components/pages/ReferralPage/Beta/BetaPage.js
@@ -3,10 +3,10 @@ import gql from 'graphql-tag';
 
 import Query from '../../../Query';
 import ErrorPage from '../../ErrorPage';
-import { query } from '../../../../helpers';
 import MoneyHandImage from './money-hand.svg';
 import CampaignLink from './BetaPageCampaignLink';
 import ArticleHeader from '../../../utilities/ArticleHeader';
+import { featureFlag, query, siteConfig } from '../../../../helpers';
 import { getReferralCampaignId } from '../../../../helpers/refer-friends';
 
 const REFERRAL_PAGE_USER = gql`
@@ -21,6 +21,12 @@ const REFERRAL_PAGE_USER = gql`
 const BetaPage = () => {
   const userId = query('user_id');
   const campaignId = getReferralCampaignId();
+
+  const defaultCampaignId = siteConfig('default_referral_campaign_id');
+
+  // We'll display a secondary campaign link option for RAF V2.
+  const displaySecondaryCampaign =
+    featureFlag('refer_friends_v2') && defaultCampaignId !== campaignId;
 
   if (!userId || !campaignId) {
     return <ErrorPage error="Missing User ID or Campaign ID." />;
@@ -55,6 +61,23 @@ const BetaPage = () => {
                 <div className="my-6">
                   <CampaignLink campaignId={campaignId} userId={userId} />
                 </div>
+
+                {displaySecondaryCampaign ? (
+                  <div
+                    className="my-6"
+                    data-testid="secondary-campaign-referral-link"
+                  >
+                    <p className="font-bold mb-3">
+                      Interested in doing a different campaign?
+                    </p>
+
+                    <CampaignLink
+                      campaignId={defaultCampaignId}
+                      userId={userId}
+                    />
+                  </div>
+                ) : null}
+
                 <div className="my-6">
                   <h3>FAQ</h3>
                   <h4>


### PR DESCRIPTION
### What's this PR do?

This pull request displays a secondary (default?) referral campaign link on the RAF Beta page. Also adds/fixes the site config for 'default referral campaign ID', and adds support in Cypress to override the site config.

### How should this be reviewed?
With a sensitive but strong eye to make sure this logic checks out.

I added the feature flag and a default campaign ID config of `9001` to the [review app](https://dosomething-phoenix-de-pr-2242.herokuapp.com/us/join?user_id=5bbd00271f1c570099415d02&campaign_id=9002).

### Any background context you want to provide?
This is feature-flagged behind the RAF V2.

I started reconsidering this site config `default_` prefix since we use this as the secondary campaign on the Beta page, and will use it (it's main purpose) as the referral `campaign_id` from the account alpha page. But I didn't have any better ideas. `primary`? *Plus, we _may_ end up using this as a default/fallback for the alpha/beta pages if the provided ID is invalid/missing. 

*[I did promise](https://www.pivotaltracker.com/story/show/172627879/comments/215681911) this much for the Alpha page, but I'm actually reconsidering whether this would generally be a good idea since it introduces a fair amount of complexity.


### Relevant tickets

References [Pivotal #172627879](https://www.pivotaltracker.com/story/show/172627879).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints. - _I'm holding off on documentation for a bit since there are more moving pieces_
- [x] Added screenshots of front-end changes on small, medium, and large screens.
- [x] Added appropriate feature/unit tests.

**Secondary Campaign Link**
![image](https://user-images.githubusercontent.com/12417657/86056582-b28a7580-ba2b-11ea-8624-6eb862a3432a.png)

**Not if the default config ID matches the provided `campaign_id`**
![image](https://user-images.githubusercontent.com/12417657/86056622-bd450a80-ba2b-11ea-8893-b544c25a009b.png)
