### PR TITLE
Refer a Friend Account Tab Referral Link / Default Referral Campaign ID

### DIFF
--- a/cypress/integration/beta-referral-page.js
+++ b/cypress/integration/beta-referral-page.js
@@ -35,9 +35,9 @@ describe('Beta Referral Page', () => {
 
   context('Refer Friends V2', () => {
     it('Displays a secondary referral campaign link', () => {
-      cy.withFeatureFlags({ refer_friends_v2: true }).visit(
-        `/us/join?user_id=${userId}&campaign_id=${campaignId}`,
-      );
+      cy.withFeatureFlags({ refer_friends_v2: true })
+        .withSiteConfig({ default_referral_campaign_id: '9001' })
+        .visit(`/us/join?user_id=${userId}&campaign_id=${campaignId}`);
 
       cy.findByTestId('secondary-campaign-referral-link').within(() => {
         cy.get('a')

--- a/cypress/integration/beta-referral-page.js
+++ b/cypress/integration/beta-referral-page.js
@@ -33,6 +33,7 @@ describe('Beta Referral Page', () => {
     cy.get('.error-page').should('have.length', 1);
   });
 
+  // @TODO: Fromalize the default campaign in the Cypress config & update tests once we launce V2.
   context('Refer Friends V2', () => {
     it('Displays a secondary referral campaign link', () => {
       cy.withFeatureFlags({ refer_friends_v2: true })

--- a/cypress/support/index.js
+++ b/cypress/support/index.js
@@ -17,9 +17,6 @@ Cypress.on('window:before:load', window => {
     FEATURE_FLAGS: {
       nps_survey: false,
     },
-    SITE: {
-      default_referral_campaign_id: '9001',
-    },
     SIXPACK_ENABLED: false,
     SIXPACK_BASE_URL: 'http://sixpack.test', // Our Sixpack service will throw an error if this isn't set.
     CONTENTFUL_USE_PREVIEW_API: false,

--- a/resources/assets/components/pages/AccountPage/ReferFriends/ReferFriendsTab.js
+++ b/resources/assets/components/pages/AccountPage/ReferFriends/ReferFriendsTab.js
@@ -2,6 +2,7 @@ import React from 'react';
 import tw from 'twin.macro';
 
 import SignupReferralsGallery from './SignupReferralsGallery';
+import { getReferFriendsLink } from '../../../../helpers/refer-friends';
 import SectionHeader from '../../../utilities/SectionHeader/SectionHeader';
 import SocialDriveActionContainer from '../../../actions/SocialDriveAction/SocialDriveActionContainer';
 
@@ -18,8 +19,7 @@ const ReferFriendsTab = () => (
       <SocialDriveActionContainer
         shareCardTitle="Refer a friend"
         shareCardDescription="When your friend signs up for their first DoSomething campaign, you’ll both enter to win a $10 gift card! Every 2 weeks, there will be 25 winners. The more friends you refer, the more chances you have to win. (Psst...there’s no limit on how many you can refer!)"
-        /* @TODO use refer-friends link generator helper once we establish a default campaign in https://bit.ly/3c9L7nT */
-        link="https://dosomething.org/us/campaigns/senior-homies"
+        link={getReferFriendsLink()}
         fullWidth
       />
     </div>

--- a/resources/assets/helpers/refer-friends.js
+++ b/resources/assets/helpers/refer-friends.js
@@ -1,6 +1,6 @@
-import { query } from './index';
 import { getUserId } from './auth';
 import { PHOENIX_URL } from '../constants';
+import { query, siteConfig } from './index';
 
 /**
  * Get referral campaign ID for refer-a-friend share URL.
@@ -8,7 +8,7 @@ import { PHOENIX_URL } from '../constants';
  * @return {string}
  */
 export function getReferralCampaignId() {
-  return query('campaign_id');
+  return query('campaign_id') || siteConfig('default_referral_campaign_id');
 }
 
 /**

--- a/resources/assets/helpers/refer-friends.test.js
+++ b/resources/assets/helpers/refer-friends.test.js
@@ -19,14 +19,14 @@ describe('getReferFriendsLink', () => {
   });
 
   /** @test */
-  it('returns referral link when user is autenticated & campaign ID query param is present', () => {
+  it('returns referral link when user is authenticated & campaign ID query param is present', () => {
     expect(getReferFriendsLink()).toEqual(
       `${referralUrl}&campaign_id=${referralCampaignId}`,
     );
   });
 
   /** @test */
-  it('returns referral link when user is autenticated & default campaign ID is configured', () => {
+  it('returns referral link when user is authenticated & default campaign ID is configured', () => {
     window.jsdom.reconfigure({ url: alphaPageUrl });
 
     global.ENV = {

--- a/resources/assets/helpers/refer-friends.test.js
+++ b/resources/assets/helpers/refer-friends.test.js
@@ -6,9 +6,12 @@ describe('getReferFriendsLink', () => {
   const referralCampaignId = '456';
   const defaultReferralCampaignId = '789';
 
+  const referralUrl = `${PHOENIX_URL}/us/join?user_id=${userId}`;
+  const alphaPageUrl = `${PHOENIX_URL}/us/refer-friends`;
+
   beforeEach(() => {
     window.jsdom.reconfigure({
-      url: `http://phoenix.test/join?campaign_id=${referralCampaignId}`,
+      url: `${alphaPageUrl}?campaign_id=${referralCampaignId}`,
     });
 
     global.AUTH = { id: userId };
@@ -18,20 +21,20 @@ describe('getReferFriendsLink', () => {
   /** @test */
   it('returns referral link when user is autenticated & campaign ID query param is present', () => {
     expect(getReferFriendsLink()).toEqual(
-      `${PHOENIX_URL}/us/join?user_id=${userId}&campaign_id=${referralCampaignId}`,
+      `${referralUrl}&campaign_id=${referralCampaignId}`,
     );
   });
 
   /** @test */
   it('returns referral link when user is autenticated & default campaign ID is configured', () => {
-    window.jsdom.reconfigure({ url: 'http://phoenix.test/join' });
+    window.jsdom.reconfigure({ url: alphaPageUrl });
 
     global.ENV = {
       SITE: { default_referral_campaign_id: defaultReferralCampaignId },
     };
 
     expect(getReferFriendsLink()).toEqual(
-      `${PHOENIX_URL}/us/join?user_id=${userId}&campaign_id=${defaultReferralCampaignId}`,
+      `${referralUrl}&campaign_id=${defaultReferralCampaignId}`,
     );
   });
 
@@ -44,9 +47,7 @@ describe('getReferFriendsLink', () => {
 
   /** @test */
   it('returns undefined if there is no campaign ID query param or default config', () => {
-    window.jsdom.reconfigure({
-      url: `http://phoenix.test/join`,
-    });
+    window.jsdom.reconfigure({ url: alphaPageUrl });
 
     expect(getReferFriendsLink()).toEqual(undefined);
   });

--- a/resources/assets/helpers/refer-friends.test.js
+++ b/resources/assets/helpers/refer-friends.test.js
@@ -4,17 +4,34 @@ import { getReferFriendsLink } from './refer-friends';
 describe('getReferFriendsLink', () => {
   const userId = '123';
   const referralCampaignId = '456';
+  const defaultReferralCampaignId = '789';
 
-  window.jsdom.reconfigure({
-    url: `http://phoenix.test/join?campaign_id=${referralCampaignId}`,
+  beforeEach(() => {
+    window.jsdom.reconfigure({
+      url: `http://phoenix.test/join?campaign_id=${referralCampaignId}`,
+    });
+
+    global.AUTH = { id: userId };
+    global.ENV = {};
   });
-
-  global.AUTH = { id: userId };
 
   /** @test */
   it('returns referral link when user is autenticated & campaign ID query param is present', () => {
     expect(getReferFriendsLink()).toEqual(
       `${PHOENIX_URL}/us/join?user_id=${userId}&campaign_id=${referralCampaignId}`,
+    );
+  });
+
+  /** @test */
+  it('returns referral link when user is autenticated & default campaign ID is configured', () => {
+    window.jsdom.reconfigure({ url: 'http://phoenix.test/join' });
+
+    global.ENV = {
+      SITE: { default_referral_campaign_id: defaultReferralCampaignId },
+    };
+
+    expect(getReferFriendsLink()).toEqual(
+      `${PHOENIX_URL}/us/join?user_id=${userId}&campaign_id=${defaultReferralCampaignId}`,
     );
   });
 
@@ -26,7 +43,7 @@ describe('getReferFriendsLink', () => {
   });
 
   /** @test */
-  it('returns undefined if there is no campaign ID query param', () => {
+  it('returns undefined if there is no campaign ID query param or default config', () => {
     window.jsdom.reconfigure({
       url: `http://phoenix.test/join`,
     });


### PR DESCRIPTION
### What's this PR do?

This pull request pulls the `default_referral_campaign_id` site config as a fallback option for referral links without a `campaign_id` query param to pull from.

This then allows us to generate a working referral link from the feature flagged RAF account tab alpha page.

### How should this be reviewed?
commit-by-commit

### Any background context you want to provide?
Logic outlined a bit in this [Pivotal comment](https://www.pivotaltracker.com/story/show/172627879/comments/215723602).

The bonus here is that the canonical Alpha & Beta page will now automatically function without a `campaign_id` query parameter since we'll fall back on the default with no extra work! 

Plus the account page's link with the default campaign ID can technically be overridden if we'd like (say for a one-off broadcast or some such Tej & Anthony foolery).

### Relevant tickets

References [Pivotal #172627879](https://www.pivotaltracker.com/story/show/172627879).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints. - _still holding off_
- [x] Added appropriate feature/unit tests.
