### PR TITLE
RAF V2 - Display CTA Referral Banner On All Campaigns

### DIFF
--- a/cypress/integration/campaign-signup.js
+++ b/cypress/integration/campaign-signup.js
@@ -192,7 +192,7 @@ describe('Campaign Signup', () => {
       // Mock the response we'll be expecting once we hit "Join Now":
       cy.route('POST', `${API}/signups`, newSignup(campaignId, user));
 
-      // Click "Join Now" & should get the affirmation modal:
+      // Click "Join Us" & should get the affirmation modal with the CTA referral page banner:
       cy.contains('button', 'Join Us').click();
       cy.get('.card.affirmation')
         .findByTestId('cta-referral-page-banner')

--- a/cypress/integration/campaign-signup.js
+++ b/cypress/integration/campaign-signup.js
@@ -171,6 +171,35 @@ describe('Campaign Signup', () => {
     });
   });
 
+  // @TODO: Formalize this test and remove the tests above once we launch RAF V2.
+  context('Refer Friends V2', () => {
+    it('Displays Referral Page Banner CTA regardless of displayReferralPage configuration', () => {
+      const user = userFactory();
+
+      cy.mockGraphqlOp('CampaignBannerQuery', {
+        campaign: {
+          id: campaignId,
+          groupTypeId: null,
+          groupType: null,
+        },
+      });
+
+      // Log in & visit the campaign pitch page:
+      cy.withFeatureFlags({
+        refer_friends_v2: true,
+      }).authVisitCampaignWithoutSignup(user, exampleCampaign);
+
+      // Mock the response we'll be expecting once we hit "Join Now":
+      cy.route('POST', `${API}/signups`, newSignup(campaignId, user));
+
+      // Click "Join Now" & should get the affirmation modal:
+      cy.contains('button', 'Join Us').click();
+      cy.get('.card.affirmation')
+        .findByTestId('cta-referral-page-banner')
+        .contains('Benefits With Friends');
+    });
+  });
+
   /** @test */
   it('Visit with existing signup, as an authenticated user', () => {
     const user = userFactory();

--- a/resources/assets/components/utilities/CtaReferralPageBanner/CtaReferralPageBanner.js
+++ b/resources/assets/components/utilities/CtaReferralPageBanner/CtaReferralPageBanner.js
@@ -1,11 +1,14 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
+import { featureFlag } from '../../../helpers';
+
 import './cta-referral-page-banner.scss';
 
 const CtaReferralPageBanner = ({ campaignId, displayReferralPage }) => (
   <React.Fragment>
-    {displayReferralPage ? (
+    {/* @TODO: Remove this displayReferralPage & container logic once we launch RAF V2 */}
+    {displayReferralPage || featureFlag('refer_friends_v2') ? (
       <div className="p-3" data-testid="cta-referral-page-banner">
         <div className="cta-register-banner md:px-6 pt-3 clearfix">
           <div className="cta-register-banner__content p-6 md:pr-0 text-center md:text-left">


### PR DESCRIPTION
### What's this PR do?

This pull request displays the CTA Referral Banner in the signup affirmation regardless of the respective campaign's `displayReferralPage` toggle. (Feature flagged).

### How should this be reviewed?
👀 

### Any background context you want to provide?
Since our V2 doesn't involve scholarship rewards, we're kicking this off to _all_ campaigns. Once this launches, we should be able to retire the Campaign toggle field & associated logic [Pivotal #173574881](https://www.pivotaltracker.com/story/show/173574881).

### Relevant tickets

References [Pivotal #173574872](https://www.pivotaltracker.com/story/show/173574872).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints. - _very soon_
- [x] Added appropriate feature/unit tests.
