### PR TITLE
Display group voter registrations on OVRD page if group_id query exists

### DIFF
--- a/cypress/integration/voter-registration-drive-page.js
+++ b/cypress/integration/voter-registration-drive-page.js
@@ -21,6 +21,12 @@ const campaignWebsite = {
 };
 const group = {
   id: faker.random.number(),
+  name: faker.company.companyName(),
+  goal: faker.random.number(),
+  groupType: {
+    id: faker.random.number(),
+    name: faker.company.companyName(),
+  },
 };
 
 /**
@@ -299,11 +305,16 @@ describe('Voter Registration Drive (OVRD) Page', () => {
   /** @test */
   it('If valid group_id query, tracking source contains group_id and group referrals block is displayed', () => {
     const user = userFactory();
+    const groupDescription = `${group.groupType.name}: ${group.name}`;
 
     cy.mockGraphqlOp('VoterRegistrationDrivePageQuery', {
       user,
       campaignWebsite,
       group,
+    });
+    cy.mockGraphqlOp('GroupVoterRegistrationReferralsQuery', {
+      // TODO: Update with queries once https://github.com/DoSomething/graphql/pull/252 merged.
+      posts: [{ id: faker.random.number() }, { id: faker.random.number() }],
     });
 
     cy.visit(getOvrdPagePathForUser(user, group));
@@ -317,5 +328,20 @@ describe('Voter Registration Drive (OVRD) Page', () => {
       'have.length',
       1,
     );
+    cy.findByTestId('group-goal')
+      .get('span')
+      .contains(`${groupDescription} registration goal`);
+    cy.findByTestId('group-total')
+      .get('span')
+      .contains(`People ${groupDescription} has registered`);
+    cy.findByTestId('group-total')
+      .get('h1')
+      .contains(2);
+    cy.findByTestId('individual-total')
+      .get('span')
+      .contains(`People ${user.firstName} has registered`);
+    cy.findByTestId('individual-total')
+      .get('h1')
+      .contains(2);
   });
 });

--- a/cypress/integration/voter-registration-drive-page.js
+++ b/cypress/integration/voter-registration-drive-page.js
@@ -149,13 +149,15 @@ describe('Voter Registration Drive (OVRD) Page', () => {
       'have.length',
       1,
     );
-    cy.get(
-      '[data-test=voter-registration-drive-page-campaign-info-block]',
-    ).should('have.length', 1);
+    cy.findByTestId('campaign-info-block-container').should('have.length', 1);
+    cy.findByTestId('group-voter-registration-referrals-block').should(
+      'have.length',
+      0,
+    );
     cy.contains('Win A Scholarship');
-    cy.get(
-      '[data-test=voter-registration-drive-page-campaign-info-block] > article > dl > dd.campaign-info__scholarship',
-    ).contains(`$1,500`);
+    cy.findByTestId('campaign-info-block-container')
+      .get('article > dl > dd.campaign-info__scholarship')
+      .contains(`$1,500`);
     cy.contains('button', 'View Scholarship Details');
     cy.contains(`April 25th, 2022`);
     cy.get('[data-test=voter-registration-drive-page-blurb]').contains(
@@ -295,7 +297,7 @@ describe('Voter Registration Drive (OVRD) Page', () => {
   });
 
   /** @test */
-  it('OVRD Start VR Form tracking source contains group_id key value if valid group_id', () => {
+  it('If valid group_id query, tracking source contains group_id and group referrals block is displayed', () => {
     const user = userFactory();
 
     cy.mockGraphqlOp('VoterRegistrationDrivePageQuery', {
@@ -309,6 +311,11 @@ describe('Voter Registration Drive (OVRD) Page', () => {
     cy.findByTestId('voter-registration-tracking-source').should(
       'have.value',
       `user:${user.id},source:web,source_details:onlinedrivereferral,group_id=${group.id},referral=true`,
+    );
+    cy.findByTestId('campaign-info-block-container').should('have.length', 0);
+    cy.findByTestId('group-voter-registration-referrals-block').should(
+      'have.length',
+      1,
     );
   });
 });

--- a/cypress/integration/voter-registration-referrals-block.js
+++ b/cypress/integration/voter-registration-referrals-block.js
@@ -133,11 +133,20 @@ describe('Voter Registration Referrals Block', () => {
       `${group.groupType.name}: ${group.name}`,
     );
     cy.findAllByTestId('group-goal')
+      .get('span')
+      .contains('Your group’s registration goal');
+    cy.findAllByTestId('group-goal')
       .get('h1')
       .contains(group.goal);
+    cy.findAllByTestId('group-goal')
+      .get('span')
+      .contains('People your group has registered');
     cy.findAllByTestId('group-total')
       .get('h1')
       .contains(5);
+    cy.findAllByTestId('individual-total')
+      .get('span')
+      .contains('People you have registered');
     cy.findAllByTestId('individual-total')
       .get('h1')
       .contains(5);

--- a/cypress/integration/voter-registration-referrals-block.js
+++ b/cypress/integration/voter-registration-referrals-block.js
@@ -132,9 +132,15 @@ describe('Voter Registration Referrals Block', () => {
     cy.get('.section-header__title').contains(
       `${group.groupType.name}: ${group.name}`,
     );
-    cy.findAllByTestId('group-goal').contains(group.goal);
-    cy.findAllByTestId('group-total').contains(5);
-    cy.findAllByTestId('individual-total').contains(5);
+    cy.findAllByTestId('group-goal')
+      .get('h1')
+      .contains(group.goal);
+    cy.findAllByTestId('group-total')
+      .get('h1')
+      .contains(5);
+    cy.findAllByTestId('individual-total')
+      .get('h1')
+      .contains(5);
     cy.findAllByTestId('group-progress').contains(
       `${percentCompleted}% to your goal!`,
     );

--- a/resources/assets/components/blocks/VoterRegistrationReferralsBlock/templates/Group.js
+++ b/resources/assets/components/blocks/VoterRegistrationReferralsBlock/templates/Group.js
@@ -47,12 +47,17 @@ StatBlock.propTypes = {
   testId: PropTypes.string.isRequired,
 };
 
+/**
+ * If a user is provided, display that user's referrals, else user is the authenticated user.
+ */
 const GroupTemplate = ({ group, user }) => {
+  const groupDescription = `${group.groupType.name}: ${group.name}`;
+
   return (
     <>
       {user ? null : (
         <>
-          <SectionHeader title={`${group.groupType.name}: ${group.name}`} />
+          <SectionHeader title={groupDescription} />
           <p>Track how many people you and your group register to vote!</p>
         </>
       )}
@@ -74,19 +79,25 @@ const GroupTemplate = ({ group, user }) => {
 
             <StatBlock
               amount={group.goal || 50}
-              label="Your group’s registration goal"
+              label={`${
+                user ? groupDescription : 'Your group’s'
+              } registration goal`}
               testId="group-goal"
             />
 
             <StatBlock
               amount={data.groupReferrals.length}
-              label="People your group has registered"
+              label={`People ${
+                user ? groupDescription : 'your group'
+              } has registered`}
               testId="group-total"
             />
 
             <StatBlock
               amount={data.individualReferrals.length}
-              label="People you have registered"
+              label={`People ${
+                user ? `${user.firstName} has` : 'you have'
+              } registered`}
               testId="individual-total"
             />
           </>

--- a/resources/assets/components/blocks/VoterRegistrationReferralsBlock/templates/Group.js
+++ b/resources/assets/components/blocks/VoterRegistrationReferralsBlock/templates/Group.js
@@ -122,7 +122,7 @@ GroupTemplate.propTypes = {
   }),
 };
 
-GroupTemplate.propTypes = {
+GroupTemplate.defaultProps = {
   user: null,
 };
 

--- a/resources/assets/components/blocks/VoterRegistrationReferralsBlock/templates/Group.js
+++ b/resources/assets/components/blocks/VoterRegistrationReferralsBlock/templates/Group.js
@@ -54,7 +54,7 @@ const GroupTemplate = ({ group, user }) => {
   const groupDescription = `${group.groupType.name}: ${group.name}`;
 
   return (
-    <>
+    <div data-testid="group-voter-registration-referrals-block">
       {user ? null : (
         <>
           <SectionHeader title={groupDescription} />
@@ -103,7 +103,7 @@ const GroupTemplate = ({ group, user }) => {
           </>
         )}
       </Query>
-    </>
+    </div>
   );
 };
 

--- a/resources/assets/components/blocks/VoterRegistrationReferralsBlock/templates/Group.js
+++ b/resources/assets/components/blocks/VoterRegistrationReferralsBlock/templates/Group.js
@@ -30,14 +30,9 @@ const GROUP_VOTER_REGISTRATION_REFERRALS_QUERY = gql`
 `;
 
 const StatBlock = ({ amount, label, testId }) => (
-  <div className="pt-3">
+  <div className="pt-3" data-testid={testId}>
     <span className="font-bold uppercase text-gray-600">{label}</span>
-    <h1
-      data-testid={testId}
-      className="font-normal font-league-gothic text-3xl"
-    >
-      {amount}
-    </h1>
+    <h1 className="font-normal font-league-gothic text-3xl">{amount}</h1>
   </div>
 );
 

--- a/resources/assets/components/blocks/VoterRegistrationReferralsBlock/templates/Group.js
+++ b/resources/assets/components/blocks/VoterRegistrationReferralsBlock/templates/Group.js
@@ -47,14 +47,22 @@ StatBlock.propTypes = {
   testId: PropTypes.string.isRequired,
 };
 
-const GroupTemplate = ({ group }) => {
+const GroupTemplate = ({ group, user }) => {
   return (
     <>
-      <SectionHeader title={`${group.groupType.name}: ${group.name}`} />
-      <p>Track how many people you and your group register to vote!</p>
+      {user ? null : (
+        <>
+          <SectionHeader title={`${group.groupType.name}: ${group.name}`} />
+          <p>Track how many people you and your group register to vote!</p>
+        </>
+      )}
+
       <Query
         query={GROUP_VOTER_REGISTRATION_REFERRALS_QUERY}
-        variables={{ groupId: group.id, referrerUserId: getUserId() }}
+        variables={{
+          groupId: group.id,
+          referrerUserId: user ? user.id : getUserId(),
+        }}
       >
         {data => (
           <>
@@ -63,16 +71,19 @@ const GroupTemplate = ({ group }) => {
               target={group.goal || 50}
               testId="group-progress"
             />
+
             <StatBlock
               amount={group.goal || 50}
               label="Your group’s registration goal"
               testId="group-goal"
             />
+
             <StatBlock
               amount={data.groupReferrals.length}
               label="People your group has registered"
               testId="group-total"
             />
+
             <StatBlock
               amount={data.individualReferrals.length}
               label="People you have registered"
@@ -86,7 +97,22 @@ const GroupTemplate = ({ group }) => {
 };
 
 GroupTemplate.propTypes = {
-  group: PropTypes.object.isRequired,
+  group: PropTypes.shape({
+    goal: PropTypes.number,
+    groupType: PropTypes.shape({
+      name: PropTypes.string,
+    }),
+    id: PropTypes.number,
+    name: PropTypes.string,
+  }).isRequired,
+  user: PropTypes.shape({
+    id: PropTypes.string,
+    firstName: PropTypes.string,
+  }),
+};
+
+GroupTemplate.propTypes = {
+  user: null,
 };
 
 export default GroupTemplate;

--- a/resources/assets/components/pages/VoterRegistrationDrivePage/VoterRegistrationDrivePage.js
+++ b/resources/assets/components/pages/VoterRegistrationDrivePage/VoterRegistrationDrivePage.js
@@ -42,7 +42,12 @@ const VOTER_REGISTRATION_DRIVE_PAGE_QUERY = gql`
 
     group(id: $groupId) {
       id
+      goal
       name
+      groupType {
+        id
+        name
+      }
     }
   }
 `;
@@ -109,9 +114,10 @@ const VoterRegistrationDrivePage = () => {
       <SiteNavigationContainer />
       <main data-test="voter-registration-drive-page">
         <VoterRegistrationDrivePageBanner
-          user={data.user}
           campaignInfo={data.campaignWebsite}
+          group={data.group}
           modalToggle={modalToggle}
+          user={data.user}
         />
         <div className="bg-white base-12-grid py-3 md:py-6">
           <div className="mx-auto py-6 grid-wide">

--- a/resources/assets/components/pages/VoterRegistrationDrivePage/VoterRegistrationDrivePageBanner.js
+++ b/resources/assets/components/pages/VoterRegistrationDrivePage/VoterRegistrationDrivePageBanner.js
@@ -6,11 +6,13 @@ import { query } from '../../../helpers';
 import CampaignHeader from '../../utilities/CampaignHeader';
 import CoverImage from '../../utilities/CoverImage/CoverImage';
 import CampaignInfoBlock from '../../blocks/CampaignInfoBlock/CampaignInfoBlock';
+import GroupTemplate from '../../blocks/VoterRegistrationReferralsBlock/templates/Group';
 
 const VoterRegistrationDrivePageBanner = ({
-  user,
   campaignInfo,
+  group,
   modalToggle,
+  user,
 }) => {
   const { firstName } = user;
   const {
@@ -102,12 +104,16 @@ const VoterRegistrationDrivePageBanner = ({
             data-test="voter-registration-drive-page-campaign-info-block"
             className="grid-wide-3/10 mb-6 xxl:row-start-1 xxl:row-span-3"
           >
-            <CampaignInfoBlock
-              campaignId={campaignId}
-              scholarshipAmount={scholarshipAmount}
-              scholarshipDeadline={scholarshipDeadline}
-              showModal={modalToggle}
-            />
+            {group ? (
+              <GroupTemplate group={group} user={user} />
+            ) : (
+              <CampaignInfoBlock
+                campaignId={campaignId}
+                scholarshipAmount={scholarshipAmount}
+                scholarshipDeadline={scholarshipDeadline}
+                showModal={modalToggle}
+              />
+            )}
           </div>
         </div>
       </div>
@@ -115,10 +121,15 @@ const VoterRegistrationDrivePageBanner = ({
   );
 };
 
-export default VoterRegistrationDrivePageBanner;
+VoterRegistrationDrivePageBanner.propTypes = {
+  campaignInfo: PropTypes.object.isRequired,
+  group: PropTypes.object,
+  modalToggle: PropTypes.func.isRequired,
+  user: PropTypes.object.isRequired,
+};
 
 VoterRegistrationDrivePageBanner.propTypes = {
-  user: PropTypes.object.isRequired,
-  campaignInfo: PropTypes.object.isRequired,
-  modalToggle: PropTypes.func.isRequired,
+  group: null,
 };
+
+export default VoterRegistrationDrivePageBanner;

--- a/resources/assets/components/pages/VoterRegistrationDrivePage/VoterRegistrationDrivePageBanner.js
+++ b/resources/assets/components/pages/VoterRegistrationDrivePage/VoterRegistrationDrivePageBanner.js
@@ -100,10 +100,7 @@ const VoterRegistrationDrivePageBanner = ({
             </p>
           </div>
 
-          <div
-            data-test="voter-registration-drive-page-campaign-info-block"
-            className="grid-wide-3/10 mb-6 xxl:row-start-1 xxl:row-span-3"
-          >
+          <div className="grid-wide-3/10 mb-6 xxl:row-start-1 xxl:row-span-3">
             {group ? (
               <GroupTemplate group={group} user={user} />
             ) : (

--- a/resources/assets/components/pages/VoterRegistrationDrivePage/VoterRegistrationDrivePageBanner.js
+++ b/resources/assets/components/pages/VoterRegistrationDrivePage/VoterRegistrationDrivePageBanner.js
@@ -123,12 +123,22 @@ const VoterRegistrationDrivePageBanner = ({
 
 VoterRegistrationDrivePageBanner.propTypes = {
   campaignInfo: PropTypes.object.isRequired,
-  group: PropTypes.object,
+  group: PropTypes.shape({
+    goal: PropTypes.number,
+    groupType: PropTypes.shape({
+      name: PropTypes.string,
+    }),
+    id: PropTypes.number,
+    name: PropTypes.string,
+  }),
   modalToggle: PropTypes.func.isRequired,
-  user: PropTypes.object.isRequired,
+  user: PropTypes.shape({
+    id: PropTypes.string,
+    firstName: PropTypes.string,
+  }).isRequired,
 };
 
-VoterRegistrationDrivePageBanner.propTypes = {
+VoterRegistrationDrivePageBanner.defaultProps = {
   group: null,
 };
 


### PR DESCRIPTION
### What's this PR do?

This pull request displays the `VoterRegistrationReferralsBlock` Group template instead of the `CampaignInfoBlock` in the `VoterRegistrationDrivePageBanner` if a `group_id` query parameter exists (and the group is valid). It tweaks the Group template to support passing a `user` parameter, which corresponds to the required `referrer_user_id` query parameter used on a OVRD page.

<img width="600" alt="Group OVRD page" src="https://user-images.githubusercontent.com/1236811/86254381-92150500-bb6a-11ea-8055-c7e507b1d4d6.png">


### How should this be reviewed?

Once the review app builds, I'll add example URL's of an OVRD page with and without a `group_id` query to verify expected behavior.

### Any background context you want to provide?

After this is merged, I'll cleanup the TODOs in the Cypress tests that have been waiting for https://github.com/DoSomething/graphql/pull/252 to properly mock separate counts for individual and group voter registration counts. 

### Relevant tickets

References [Pivotal #173044099](https://www.pivotaltracker.com/story/show/173044099).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added screenshots of front-end changes on small, medium, and large screens.
- [x] Added appropriate feature/unit tests.
