### PR TITLE
Use new voterRegistrationCount GraphQL queries

### DIFF
--- a/cypress/integration/voter-registration-drive-page.js
+++ b/cypress/integration/voter-registration-drive-page.js
@@ -313,8 +313,8 @@ describe('Voter Registration Drive (OVRD) Page', () => {
       group,
     });
     cy.mockGraphqlOp('GroupVoterRegistrationReferralsQuery', {
-      // TODO: Update with queries once https://github.com/DoSomething/graphql/pull/252 merged.
-      posts: [{ id: faker.random.number() }, { id: faker.random.number() }],
+      voterRegistrationsCountByGroupId: 31,
+      voterRegistrationsCountByReferrerUserId: 8,
     });
 
     cy.visit(getOvrdPagePathForUser(user, group));
@@ -336,12 +336,12 @@ describe('Voter Registration Drive (OVRD) Page', () => {
       .contains(`People ${groupDescription} has registered`);
     cy.findByTestId('group-total')
       .get('h1')
-      .contains(2);
+      .contains(31);
     cy.findByTestId('individual-total')
       .get('span')
       .contains(`People ${user.firstName} has registered`);
     cy.findByTestId('individual-total')
       .get('h1')
-      .contains(2);
+      .contains(8);
   });
 });

--- a/cypress/integration/voter-registration-referrals-block.js
+++ b/cypress/integration/voter-registration-referrals-block.js
@@ -117,14 +117,8 @@ describe('Voter Registration Referrals Block', () => {
       signups: [{ id: 11122016, group }],
     });
     cy.mockGraphqlOp('GroupVoterRegistrationReferralsQuery', {
-      // TODO: How can we mock aliases, to test against the two different queries?
-      posts: [
-        fakePost('Sarah C.'),
-        fakePost('Kyle R.'),
-        fakePost('John C.'),
-        fakePost('Miles D.'),
-        fakePost('Tarissa D.'),
-      ],
+      voterRegistrationsCountByGroupId: 5,
+      voterRegistrationsCountByReferrerUserId: 12,
     });
 
     cy.authVisitBlockPermalink(user, blockId, exampleCampaign);
@@ -149,7 +143,7 @@ describe('Voter Registration Referrals Block', () => {
       .contains('People you have registered');
     cy.findAllByTestId('individual-total')
       .get('h1')
-      .contains(5);
+      .contains(12);
     cy.findAllByTestId('group-progress').contains(
       `${percentCompleted}% to your goal!`,
     );
@@ -163,15 +157,15 @@ describe('Voter Registration Referrals Block', () => {
     cy.mockGraphqlOp('CampaignSignupQuery', {
       signups: [{ id: 11122016, group }],
     });
-    // TODO: Fix me (same as test above).
     cy.mockGraphqlOp('GroupVoterRegistrationReferralsQuery', {
-      posts: [],
+      voterRegistrationsCountByGroupId: 15,
+      voterRegistrationsCountByReferrerUserId: 0,
     });
 
     cy.authVisitBlockPermalink(user, blockId, exampleCampaign);
 
     cy.findAllByTestId('group-goal').contains(50);
-    cy.findAllByTestId('group-total').contains(0);
+    cy.findAllByTestId('group-total').contains(15);
     cy.findAllByTestId('individual-total').contains(0);
   });
 
@@ -184,14 +178,8 @@ describe('Voter Registration Referrals Block', () => {
       signups: [{ id: 11122016, group }],
     });
     cy.mockGraphqlOp('GroupVoterRegistrationReferralsQuery', {
-      // TODO: Fix me (same as tests above).
-      posts: [
-        fakePost('Sarah C.'),
-        fakePost('Kyle R.'),
-        fakePost('John C.'),
-        fakePost('Miles D.'),
-        fakePost('Tarissa D.'),
-      ],
+      voterRegistrationsCountByGroupId: 5,
+      voterRegistrationsCountByReferrerUserId: 1,
     });
 
     cy.authVisitBlockPermalink(user, blockId, exampleCampaign);

--- a/resources/assets/components/blocks/VoterRegistrationReferralsBlock/templates/Group.js
+++ b/resources/assets/components/blocks/VoterRegistrationReferralsBlock/templates/Group.js
@@ -12,20 +12,8 @@ const GROUP_VOTER_REGISTRATION_REFERRALS_QUERY = gql`
     $groupId: Int!
     $referrerUserId: String!
   ) {
-    groupReferrals: posts(
-      groupId: $groupId
-      type: "voter-reg"
-      status: [REGISTER_FORM, REGISTER_OVR]
-    ) {
-      id
-    }
-    individualReferrals: posts(
-      referrerUserId: $referrerUserId
-      type: "voter-reg"
-      status: [REGISTER_FORM, REGISTER_OVR]
-    ) {
-      id
-    }
+    voterRegistrationsCountByGroupId(groupId: $groupId)
+    voterRegistrationsCountByReferrerUserId(referrerUserId: $referrerUserId)
   }
 `;
 
@@ -64,39 +52,44 @@ const GroupTemplate = ({ group, user }) => {
           referrerUserId: user ? user.id : getUserId(),
         }}
       >
-        {data => (
-          <>
-            <ProgressBar
-              completed={data.groupReferrals.length}
-              target={group.goal || 50}
-              testId="group-progress"
-            />
+        {data => {
+          const groupGoal = group.goal || 50;
+          const groupReferralsCount = data.voterRegistrationsCountByGroupId;
 
-            <StatBlock
-              amount={group.goal || 50}
-              label={`${
-                user ? groupDescription : 'Your group’s'
-              } registration goal`}
-              testId="group-goal"
-            />
+          return (
+            <>
+              <ProgressBar
+                completed={groupReferralsCount}
+                target={groupGoal}
+                testId="group-progress"
+              />
 
-            <StatBlock
-              amount={data.groupReferrals.length}
-              label={`People ${
-                user ? groupDescription : 'your group'
-              } has registered`}
-              testId="group-total"
-            />
+              <StatBlock
+                amount={groupGoal}
+                label={`${
+                  user ? groupDescription : 'Your group’s'
+                } registration goal`}
+                testId="group-goal"
+              />
 
-            <StatBlock
-              amount={data.individualReferrals.length}
-              label={`People ${
-                user ? `${user.firstName} has` : 'you have'
-              } registered`}
-              testId="individual-total"
-            />
-          </>
-        )}
+              <StatBlock
+                amount={groupReferralsCount}
+                label={`People ${
+                  user ? groupDescription : 'your group'
+                } has registered`}
+                testId="group-total"
+              />
+
+              <StatBlock
+                amount={data.voterRegistrationsCountByReferrerUserId}
+                label={`People ${
+                  user ? `${user.firstName} has` : 'you have'
+                } registered`}
+                testId="individual-total"
+              />
+            </>
+          );
+        }}
       </Query>
     </div>
   );

--- a/resources/assets/components/blocks/VoterRegistrationReferralsBlock/templates/Group.js
+++ b/resources/assets/components/blocks/VoterRegistrationReferralsBlock/templates/Group.js
@@ -54,12 +54,12 @@ const GroupTemplate = ({ group, user }) => {
       >
         {data => {
           const groupGoal = group.goal || 50;
-          const groupReferralsCount = data.voterRegistrationsCountByGroupId;
+          const groupTotal = data.voterRegistrationsCountByGroupId;
 
           return (
             <>
               <ProgressBar
-                completed={groupReferralsCount}
+                completed={groupTotal}
                 target={groupGoal}
                 testId="group-progress"
               />
@@ -73,7 +73,7 @@ const GroupTemplate = ({ group, user }) => {
               />
 
               <StatBlock
-                amount={groupReferralsCount}
+                amount={groupTotal}
                 label={`People ${
                   user ? groupDescription : 'your group'
                 } has registered`}

--- a/schema.json
+++ b/schema.json
@@ -396,13 +396,9 @@
                 "name": "groupTypeId",
                 "description": "The group type ID to filter groups by.",
                 "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "Int",
-                    "ofType": null
-                  }
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
                 },
                 "defaultValue": null
               },
@@ -419,6 +415,16 @@
               {
                 "name": "state",
                 "description": "The group state to filter groups by.",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "schoolId",
+                "description": "The group school ID to filter groups by.",
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -467,13 +473,9 @@
                 "name": "groupTypeId",
                 "description": "The group type ID to filter groups by.",
                 "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "Int",
-                    "ofType": null
-                  }
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
                 },
                 "defaultValue": null
               },
@@ -490,6 +492,16 @@
               {
                 "name": "state",
                 "description": "The group state to filter groups by.",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "schoolId",
+                "description": "The group school ID to filter groups by.",
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -1363,7 +1375,7 @@
             "args": [
               {
                 "name": "campaignId",
-                "description": "The Campaign ID count signups for.",
+                "description": "The Campaign ID to count signups for.",
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -1531,6 +1543,60 @@
                   "ofType": null
                 },
                 "defaultValue": "20"
+              }
+            ],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "voterRegistrationsCountByGroupId",
+            "description": "Find out how many completed voter registrations a group has.",
+            "args": [
+              {
+                "name": "groupId",
+                "description": "The Group ID to count completed voter registrations for.",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null
+              }
+            ],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "voterRegistrationsCountByReferrerUserId",
+            "description": "Find out how many completed voter registrations a referring user has.",
+            "args": [
+              {
+                "name": "referrerUserId",
+                "description": "The Referrer User ID to count completed voter registrations for.",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null
               }
             ],
             "type": {
@@ -6172,8 +6238,8 @@
             "deprecationReason": null
           },
           {
-            "name": "externalId",
-            "description": "The group external ID.",
+            "name": "schoolId",
+            "description": "The group school ID.",
             "args": [],
             "type": {
               "kind": "SCALAR",


### PR DESCRIPTION
### What's this PR do?

This pull request updates the `VoterRegistrationReferralsBlock` Group template to execute new GraphQL queries, `voterRegistrationsCountByGroupId` and `voterRegistrationsCountByReferrerUserId` (added in https://github.com/DoSomething/graphql/pull/252), which fixes the TODOs in corresponding Cypress tests.

### How should this be reviewed?

👀 

### Any background context you want to provide?

We still need to execute a `posts` query in the Individual template of the `VoterRegistrationReferralsBlock`, as we need to display the names of the voter registration referrals.

### Relevant tickets

* https://www.pivotaltracker.com/story/show/173044099
* https://github.com/DoSomething/phoenix-next/pull/2216/files#r441566332
* https://github.com/DoSomething/rogue/pull/1061 

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added screenshots of front-end changes on small, medium, and large screens.
- [ ] Added appropriate feature/unit tests.
