### PR TITLE
Fix styles for OVRD group registration stats

### DIFF
--- a/resources/assets/components/blocks/VoterRegistrationReferralsBlock/templates/Group.js
+++ b/resources/assets/components/blocks/VoterRegistrationReferralsBlock/templates/Group.js
@@ -29,7 +29,10 @@ const StatBlock = ({ amount, isVertical, label, testId }) => {
   );
 
   return (
-    <div className={`pt-3 ${isVertical ? 'flex' : null}`} data-testid={testId}>
+    <div
+      className={`pt-3 ${isVertical ? 'pb-3 flex' : null}`}
+      data-testid={testId}
+    >
       {isVertical ? null : statLabel}
       <h1
         className={`font-normal font-league-gothic text-3xl ${
@@ -80,7 +83,11 @@ const GroupTemplate = ({ group, user }) => {
           return (
             <>
               <div data-testid="group-progress" className="py-3">
-                <span className="font-bold uppercase text-gray-600">
+                <span
+                  className={`font-bold uppercase ${
+                    user ? 'text-lg' : 'text-gray-600'
+                  }`}
+                >
                   {percentage > 100
                     ? `🎉 You're at ${percentage}% of your goal! 🎉`
                     : `${percentage}% to your goal!`}

--- a/resources/assets/components/blocks/VoterRegistrationReferralsBlock/templates/Group.js
+++ b/resources/assets/components/blocks/VoterRegistrationReferralsBlock/templates/Group.js
@@ -17,11 +17,11 @@ const GROUP_VOTER_REGISTRATION_REFERRALS_QUERY = gql`
   }
 `;
 
-const StatBlock = ({ amount, label, testId, condensed }) => {
+const StatBlock = ({ amount, isVertical, label, testId }) => {
   const statLabel = (
     <div
       className={`font-bold uppercase text-gray-600 ${
-        condensed ? 'w-5/6 pb-2' : ''
+        isVertical ? 'w-5/6 pb-2' : ''
       }`}
     >
       {label}
@@ -29,23 +29,23 @@ const StatBlock = ({ amount, label, testId, condensed }) => {
   );
 
   return (
-    <div className={`pt-3 ${condensed ? 'flex' : null}`} data-testid={testId}>
-      {condensed ? null : statLabel}
+    <div className={`pt-3 ${isVertical ? 'flex' : null}`} data-testid={testId}>
+      {isVertical ? null : statLabel}
       <h1
         className={`font-normal font-league-gothic text-3xl ${
-          condensed ? ' w-1/6' : ''
+          isVertical ? ' w-1/6' : ''
         }`}
       >
         {amount}
       </h1>
-      {condensed ? statLabel : null}
+      {isVertical ? statLabel : null}
     </div>
   );
 };
 
 StatBlock.propTypes = {
   amount: PropTypes.number.isRequired,
-  condensed: PropTypes.bool.isRequired,
+  isVertical: PropTypes.bool.isRequired,
   label: PropTypes.string.isRequired,
   testId: PropTypes.string.isRequired,
 };
@@ -75,18 +75,22 @@ const GroupTemplate = ({ group, user }) => {
         {data => {
           const groupGoal = group.goal || 50;
           const groupTotal = data.voterRegistrationsCountByGroupId;
+          const percentage = Math.round((groupTotal / groupGoal) * 100);
 
           return (
             <>
-              <ProgressBar
-                completed={groupTotal}
-                target={groupGoal}
-                testId="group-progress"
-              />
+              <div data-testid="group-progress" className="py-3">
+                <span className="font-bold uppercase text-gray-600">
+                  {percentage > 100
+                    ? `🎉 You're at ${percentage}% of your goal! 🎉`
+                    : `${percentage}% to your goal!`}
+                </span>
+                <ProgressBar percentage={percentage} />
+              </div>
 
               <StatBlock
                 amount={groupGoal}
-                condensed={!!user}
+                isVertical={!!user}
                 label={`${
                   user ? groupDescription : 'Your group’s'
                 } registration goal`}
@@ -95,7 +99,7 @@ const GroupTemplate = ({ group, user }) => {
 
               <StatBlock
                 amount={groupTotal}
-                condensed={!!user}
+                isVertical={!!user}
                 label={`People ${
                   user ? groupDescription : 'your group'
                 } has registered`}
@@ -104,7 +108,7 @@ const GroupTemplate = ({ group, user }) => {
 
               <StatBlock
                 amount={data.voterRegistrationsCountByReferrerUserId}
-                condensed={!!user}
+                isVertical={!!user}
                 label={`People ${
                   user ? `${user.firstName} has` : 'you have'
                 } registered`}

--- a/resources/assets/components/blocks/VoterRegistrationReferralsBlock/templates/Group.js
+++ b/resources/assets/components/blocks/VoterRegistrationReferralsBlock/templates/Group.js
@@ -19,13 +19,13 @@ const GROUP_VOTER_REGISTRATION_REFERRALS_QUERY = gql`
 
 const StatBlock = ({ amount, isVertical, label, testId }) => {
   const statLabel = (
-    <div
+    <span
       className={`font-bold uppercase text-gray-600 ${
         isVertical ? 'w-5/6 pb-2' : ''
       }`}
     >
       {label}
-    </div>
+    </span>
   );
 
   return (

--- a/resources/assets/components/blocks/VoterRegistrationReferralsBlock/templates/Group.js
+++ b/resources/assets/components/blocks/VoterRegistrationReferralsBlock/templates/Group.js
@@ -17,15 +17,35 @@ const GROUP_VOTER_REGISTRATION_REFERRALS_QUERY = gql`
   }
 `;
 
-const StatBlock = ({ amount, label, testId }) => (
-  <div className="pt-3" data-testid={testId}>
-    <span className="font-bold uppercase text-gray-600">{label}</span>
-    <h1 className="font-normal font-league-gothic text-3xl">{amount}</h1>
-  </div>
-);
+const StatBlock = ({ amount, label, testId, condensed }) => {
+  const statLabel = (
+    <div
+      className={`font-bold uppercase text-gray-600 ${
+        condensed ? 'w-5/6 pb-2' : ''
+      }`}
+    >
+      {label}
+    </div>
+  );
+
+  return (
+    <div className={`pt-3 ${condensed ? 'flex' : null}`} data-testid={testId}>
+      {condensed ? null : statLabel}
+      <h1
+        className={`font-normal font-league-gothic text-3xl ${
+          condensed ? ' w-1/6' : ''
+        }`}
+      >
+        {amount}
+      </h1>
+      {condensed ? statLabel : null}
+    </div>
+  );
+};
 
 StatBlock.propTypes = {
   amount: PropTypes.number.isRequired,
+  condensed: PropTypes.bool.isRequired,
   label: PropTypes.string.isRequired,
   testId: PropTypes.string.isRequired,
 };
@@ -66,6 +86,7 @@ const GroupTemplate = ({ group, user }) => {
 
               <StatBlock
                 amount={groupGoal}
+                condensed={!!user}
                 label={`${
                   user ? groupDescription : 'Your group’s'
                 } registration goal`}
@@ -74,6 +95,7 @@ const GroupTemplate = ({ group, user }) => {
 
               <StatBlock
                 amount={groupTotal}
+                condensed={!!user}
                 label={`People ${
                   user ? groupDescription : 'your group'
                 } has registered`}
@@ -82,6 +104,7 @@ const GroupTemplate = ({ group, user }) => {
 
               <StatBlock
                 amount={data.voterRegistrationsCountByReferrerUserId}
+                condensed={!!user}
                 label={`People ${
                   user ? `${user.firstName} has` : 'you have'
                 } registered`}

--- a/resources/assets/components/blocks/VoterRegistrationReferralsBlock/templates/Group.js
+++ b/resources/assets/components/blocks/VoterRegistrationReferralsBlock/templates/Group.js
@@ -34,6 +34,7 @@ const StatBlock = ({ amount, isVertical, label, testId }) => {
       data-testid={testId}
     >
       {isVertical ? null : statLabel}
+
       <h1
         className={`font-normal font-league-gothic text-3xl ${
           isVertical ? ' w-1/6' : ''
@@ -41,6 +42,7 @@ const StatBlock = ({ amount, isVertical, label, testId }) => {
       >
         {amount}
       </h1>
+
       {isVertical ? statLabel : null}
     </div>
   );
@@ -92,6 +94,7 @@ const GroupTemplate = ({ group, user }) => {
                     ? `🎉 You're at ${percentage}% of your goal! 🎉`
                     : `${percentage}% to your goal!`}
                 </span>
+
                 <ProgressBar percentage={percentage} />
               </div>
 

--- a/resources/assets/components/blocks/VoterRegistrationReferralsBlock/templates/Group.js
+++ b/resources/assets/components/blocks/VoterRegistrationReferralsBlock/templates/Group.js
@@ -58,7 +58,7 @@ StatBlock.propTypes = {
 /**
  * If a user is provided, display that user's referrals, else user is the authenticated user.
  */
-const GroupTemplate = ({ group, user }) => {
+const GroupTemplate = ({ group, isVertical, user }) => {
   const groupDescription = `${group.groupType.name}: ${group.name}`;
 
   return (
@@ -87,7 +87,7 @@ const GroupTemplate = ({ group, user }) => {
               <div data-testid="group-progress" className="py-3">
                 <span
                   className={`font-bold uppercase ${
-                    user ? 'text-lg' : 'text-gray-600'
+                    isVertical ? 'text-lg' : 'text-gray-600'
                   }`}
                 >
                   {percentage > 100
@@ -100,7 +100,7 @@ const GroupTemplate = ({ group, user }) => {
 
               <StatBlock
                 amount={groupGoal}
-                isVertical={!!user}
+                isVertical={isVertical}
                 label={`${
                   user ? groupDescription : 'Your group’s'
                 } registration goal`}
@@ -109,7 +109,7 @@ const GroupTemplate = ({ group, user }) => {
 
               <StatBlock
                 amount={groupTotal}
-                isVertical={!!user}
+                isVertical={isVertical}
                 label={`People ${
                   user ? groupDescription : 'your group'
                 } has registered`}
@@ -118,7 +118,7 @@ const GroupTemplate = ({ group, user }) => {
 
               <StatBlock
                 amount={data.voterRegistrationsCountByReferrerUserId}
-                isVertical={!!user}
+                isVertical={isVertical}
                 label={`People ${
                   user ? `${user.firstName} has` : 'you have'
                 } registered`}
@@ -141,6 +141,7 @@ GroupTemplate.propTypes = {
     id: PropTypes.number,
     name: PropTypes.string,
   }).isRequired,
+  isVertical: PropTypes.bool,
   user: PropTypes.shape({
     id: PropTypes.string,
     firstName: PropTypes.string,
@@ -148,6 +149,7 @@ GroupTemplate.propTypes = {
 };
 
 GroupTemplate.defaultProps = {
+  isVertical: false,
   user: null,
 };
 

--- a/resources/assets/components/blocks/VoterRegistrationReferralsBlock/templates/Group.js
+++ b/resources/assets/components/blocks/VoterRegistrationReferralsBlock/templates/Group.js
@@ -17,8 +17,11 @@ const GROUP_VOTER_REGISTRATION_REFERRALS_QUERY = gql`
   }
 `;
 
-const StatBlock = ({ amount, isVertical, label, testId }) => {
-  const statLabel = (
+const StatBlock = ({ amount, isVertical, label, testId }) => (
+  <div
+    className={`pt-3 ${isVertical ? 'pb-3 flex flex-row-reverse' : null}`}
+    data-testid={testId}
+  >
     <span
       className={`font-bold uppercase text-gray-600 ${
         isVertical ? 'w-5/6 pb-2' : ''
@@ -26,27 +29,16 @@ const StatBlock = ({ amount, isVertical, label, testId }) => {
     >
       {label}
     </span>
-  );
 
-  return (
-    <div
-      className={`pt-3 ${isVertical ? 'pb-3 flex' : null}`}
-      data-testid={testId}
+    <h1
+      className={`font-normal font-league-gothic text-3xl ${
+        isVertical ? ' w-1/6' : ''
+      }`}
     >
-      {isVertical ? null : statLabel}
-
-      <h1
-        className={`font-normal font-league-gothic text-3xl ${
-          isVertical ? ' w-1/6' : ''
-        }`}
-      >
-        {amount}
-      </h1>
-
-      {isVertical ? statLabel : null}
-    </div>
-  );
-};
+      {amount}
+    </h1>
+  </div>
+);
 
 StatBlock.propTypes = {
   amount: PropTypes.number.isRequired,

--- a/resources/assets/components/pages/VoterRegistrationDrivePage/VoterRegistrationDrivePageBanner.js
+++ b/resources/assets/components/pages/VoterRegistrationDrivePage/VoterRegistrationDrivePageBanner.js
@@ -102,7 +102,7 @@ const VoterRegistrationDrivePageBanner = ({
 
           <div className="grid-wide-3/10 mb-6 xxl:row-start-1 xxl:row-span-3">
             {group ? (
-              <GroupTemplate group={group} user={user} />
+              <GroupTemplate group={group} isVertical user={user} />
             ) : (
               <CampaignInfoBlock
                 campaignId={campaignId}

--- a/resources/assets/components/utilities/ProgressBar/ProgressBar.js
+++ b/resources/assets/components/utilities/ProgressBar/ProgressBar.js
@@ -13,7 +13,6 @@ const ProgressBar = ({ completed, target, testId }) => {
     height: 25px;
     width: 350px;
     border-radius: 50px;
-    border: 1px solid #fff;
   `;
 
   const progressBar = css`

--- a/resources/assets/components/utilities/ProgressBar/ProgressBar.js
+++ b/resources/assets/components/utilities/ProgressBar/ProgressBar.js
@@ -4,9 +4,7 @@ import { css } from '@emotion/core';
 
 import { tailwind } from '../../../helpers';
 
-const ProgressBar = ({ completed, target, testId }) => {
-  const percentCompleted = Math.round((completed / target) * 100);
-
+const ProgressBar = ({ percentage }) => {
   const tailwindYellow = tailwind('colors.yellow');
 
   const progressBarContainer = css`
@@ -21,27 +19,18 @@ const ProgressBar = ({ completed, target, testId }) => {
     border-radius: inherit;
   `;
 
-  const label =
-    percentCompleted > 100
-      ? `🎉 You're at ${percentCompleted}% of your goal! 🎉`
-      : `${percentCompleted}% to your goal!`;
-
-  const barWidth = percentCompleted > 100 ? 100 : percentCompleted;
-
   return (
-    <div data-testid={testId} className="py-3">
-      <span className="font-bold uppercase text-gray-600">{label}</span>
-      <div className="relative bg-gray-200" css={progressBarContainer}>
-        <div css={progressBar} style={{ width: `${barWidth}%` }} />
-      </div>
+    <div className="relative bg-gray-200" css={progressBarContainer}>
+      <div
+        css={progressBar}
+        style={{ width: `${percentage > 100 ? 100 : percentage}%` }}
+      />
     </div>
   );
 };
 
 ProgressBar.propTypes = {
-  completed: PropTypes.number.isRequired,
-  target: PropTypes.number.isRequired,
-  testId: PropTypes.string.isRequired,
+  percentage: PropTypes.number.isRequired,
 };
 
 export default ProgressBar;


### PR DESCRIPTION
### What's this PR do?

This pull request branches from #2250 to add some of the style changes needed in the `VoterRegistrationReferralsBlock` Group template when displaying it on an OVRD page with a `group_id` (added in #2246) per [design review](https://dosomething.slack.com/archives/CTVPG6L4R/p1593635632146500?thread_ts=1593634325.143200&cid=CTVPG6L4R). This PR adds support for slight differences that the OVRD page requires:

* The percentage label should be larger text, and black, not gray
* The stat number should appear to the left of each label

It also removes the white border around the progress bar that is not in design, per [Slack request](https://dosomething.slack.com/archives/CTVPG6L4R/p1593635816147200?thread_ts=1593634325.143200&cid=CTVPG6L4R).

**OVRD page**

<img width="600" alt="OVRD group stats" src="https://user-images.githubusercontent.com/1236811/86385459-2b184e80-bc45-11ea-8155-7d0073cf93c0.png">


**Action Page** (no visual changes made)

<img width="600" alt="Action page group stats" src="https://user-images.githubusercontent.com/1236811/86385510-3c615b00-bc45-11ea-95f1-d80d779c3dbe.png">

### How should this be reviewed?

👀 

### Any background context you want to provide?

* This PR removes the percentage label "You're 20% to your goal" out of the `ProgressBar` component and into the `Group` template of the `VoterRegistrationReferralsBlock`, so it'll be easier to reuse the `ProgressBar`in other places should we ever need to

* The one style change I struggled with and held on for now is vertically centering the stat label with the stat number on the OVRD page view. I tried using Tailwind's [`align-middle`](https://tailwindcss.com/docs/vertical-align/) class but it didn't do the trick. Held off on this for now to get the majority of needed changes in

* This is blocked from merge until #2250 is merged, and I'll need to remember to edit this PR to merge into master once that happens before this is approved/merged.

### Relevant tickets

References [Pivotal #173044099](https://www.pivotaltracker.com/n/projects/2417735/stories/173044099).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added screenshots of front-end changes on small, medium, and large screens.
- [ ] Added appropriate feature/unit tests.
