### PR TITLE
Alpha Referral Page Copy Fix

### DIFF
--- a/resources/assets/components/pages/ReferralPage/Alpha/AlphaPage.js
+++ b/resources/assets/components/pages/ReferralPage/Alpha/AlphaPage.js
@@ -55,15 +55,6 @@ const AlphaPage = () =>
                 <a href="/us/account/refer-friends">Refer a Friend section</a>{' '}
                 of your profile. Yep, that easy.
               </p>
-
-              <h4>Where can I find the full rules?</h4>
-              <p>
-                This offer is for a limited time only. See the{' '}
-                <a href="/us/refer-a-friend-official-rules">
-                  Refer A Friend Official Rules
-                </a>
-                .
-              </p>
             </>
           ) : (
             <>


### PR DESCRIPTION
Ummm wtf github? I hit COMMAND + SHIFT + ARROW DOWN, and the title/description was replaced with some placeholder and COMMAND + Z failed to bring back the original 🙅 

This PR Removes some duplicate copy for a shared FAQ across the features that's already displayed below. Fix from #2247 