### PR TITLE
Modifies GroupFinder no options message

### DIFF
--- a/resources/assets/components/CampaignSignupForm/GroupFinder/GroupFinder.js
+++ b/resources/assets/components/CampaignSignupForm/GroupFinder/GroupFinder.js
@@ -44,6 +44,7 @@ const GroupFinder = ({ context, groupType, onChange }) => {
   };
 
   const { filterByState } = groupType;
+  const groupLabel = 'chapter';
 
   return (
     <>
@@ -58,8 +59,9 @@ const GroupFinder = ({ context, groupType, onChange }) => {
       ) : null}
       {!filterByState || (filterByState && groupState) ? (
         <div className="pb-3">
-          <p className="font-bold text-sm py-1">Select your chapter</p>
+          <p className="font-bold text-sm py-1">Select your {groupLabel}</p>
           <GroupSelect
+            groupLabel={groupLabel}
             groupState={groupState}
             groupTypeId={groupType.id}
             onChange={onChange}

--- a/resources/assets/components/CampaignSignupForm/GroupFinder/GroupSelect.js
+++ b/resources/assets/components/CampaignSignupForm/GroupFinder/GroupSelect.js
@@ -16,7 +16,13 @@ const SEARCH_GROUPS_QUERY = gql`
   }
 `;
 
-const GroupSelect = ({ groupState, groupTypeId, onChange, onFocus }) => {
+const GroupSelect = ({
+  groupDescription,
+  groupState,
+  groupTypeId,
+  onChange,
+  onFocus,
+}) => {
   /**
    * This is copied by example from the blocks/CurrentSchoolBlock/SchoolSelect, which has comments
    * detailing debouncing the useApolloClient hook (AsyncSelect loadOptions expects a Promise).
@@ -63,8 +69,8 @@ const GroupSelect = ({ groupState, groupTypeId, onChange, onFocus }) => {
       }}
       noOptionsMessage={({ inputValue }) =>
         inputValue.length
-          ? "Can't find your group? Email tej@dosomething.org"
-          : 'Enter your chapter name'
+          ? `Oops, we can't find a ${groupDescription} called "${inputValue}"`
+          : `Enter your ${groupDescription} name`
       }
       onChange={onChange}
       onFocus={onFocus}
@@ -73,6 +79,7 @@ const GroupSelect = ({ groupState, groupTypeId, onChange, onFocus }) => {
 };
 
 GroupSelect.propTypes = {
+  groupDescription: PropTypes.string,
   groupState: PropTypes.string,
   groupTypeId: PropTypes.number.isRequired,
   onChange: PropTypes.func.isRequired,
@@ -80,6 +87,7 @@ GroupSelect.propTypes = {
 };
 
 GroupSelect.defaultProps = {
+  groupDescription: 'chapter',
   groupState: null,
 };
 

--- a/resources/assets/components/CampaignSignupForm/GroupFinder/GroupSelect.js
+++ b/resources/assets/components/CampaignSignupForm/GroupFinder/GroupSelect.js
@@ -17,7 +17,7 @@ const SEARCH_GROUPS_QUERY = gql`
 `;
 
 const GroupSelect = ({
-  groupDescription,
+  groupLabel,
   groupState,
   groupTypeId,
   onChange,
@@ -69,8 +69,8 @@ const GroupSelect = ({
       }}
       noOptionsMessage={({ inputValue }) =>
         inputValue.length
-          ? `Oops, we can't find a ${groupDescription} called "${inputValue}"`
-          : `Enter your ${groupDescription} name`
+          ? `Oops, we can't find a ${groupLabel} called "${inputValue}"`
+          : `Enter your ${groupLabel} name`
       }
       onChange={onChange}
       onFocus={onFocus}
@@ -79,7 +79,7 @@ const GroupSelect = ({
 };
 
 GroupSelect.propTypes = {
-  groupDescription: PropTypes.string,
+  groupLabel: PropTypes.string.isRequired,
   groupState: PropTypes.string,
   groupTypeId: PropTypes.number.isRequired,
   onChange: PropTypes.func.isRequired,
@@ -87,7 +87,6 @@ GroupSelect.propTypes = {
 };
 
 GroupSelect.defaultProps = {
-  groupDescription: 'chapter',
   groupState: null,
 };
 

--- a/resources/assets/components/CampaignSignupForm/GroupFinder/GroupSelect.js
+++ b/resources/assets/components/CampaignSignupForm/GroupFinder/GroupSelect.js
@@ -61,7 +61,11 @@ const GroupSelect = ({ groupState, groupTypeId, onChange, onFocus }) => {
         }
         return fetchGroups(input, callback);
       }}
-      noOptionsMessage={() => 'Enter your chapter name'}
+      noOptionsMessage={({ inputValue }) =>
+        inputValue.length
+          ? "Can't find your group? Email tej@dosomething.org"
+          : 'Enter your chapter name'
+      }
       onChange={onChange}
       onFocus={onFocus}
     />


### PR DESCRIPTION
### What's this PR do?

This pull request modifies the GroupFinder dropdown to better indicate we couldn't find any matches when a user has typed into the Group Finder search and no groups were found, instead of just displaying "Enter your chapter name". 

![No groups found](https://user-images.githubusercontent.com/1236811/87093397-fcc0e300-c1f1-11ea-8a5b-0aeca13a7dd6.png)

It also adds a `groupLabel` prop to the `GroupFinder` which defaults to `chapter`. We may get asked later down the line to dynamically change this per group type (e.g. it'd probably read better as `school` for some group types like https://github.com/DoSomething/rogue/pull/1062), so this gets us set up to make that change quicker should we ever need to (e.g. we'd do so by adding a new field to the [Group Type resource](https://github.com/DoSomething/rogue/blob/master/docs/endpoints/group-types.md))

### How should this be reviewed?

👀 

### Any background context you want to provide?

🔍 

### Relevant tickets

References [Pivotal #173519727](https://www.pivotaltracker.com/story/show/173519727).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added screenshots of front-end changes on small, medium, and large screens.
- [ ] Added appropriate feature/unit tests.
