### PR TITLE
add tracking to RB affirmation modal

### DIFF
--- a/resources/assets/components/actions/PostCreatedModal.js
+++ b/resources/assets/components/actions/PostCreatedModal.js
@@ -25,7 +25,7 @@ const POST_COUNT_BADGE = gql`
 `;
 
 const PostCreatedModal = ({ affirmationContent, onClose, title, userId }) => (
-  <Modal onClose={onClose}>
+  <Modal onClose={onClose} trackingId="REPORTBACK_AFFIRMATION_MODAL">
     <Card className="bordered rounded" title={title}>
       {userId ? (
         <Query query={BADGE_QUERY} variables={{ userId }} hideSpinner>


### PR DESCRIPTION
### What's this PR do?

This pull request adds a `trackingId` to the RB affirmation modal (`PostCreatedModal`).

### How should this be reviewed?

Is this where this should be and what it should be called?

### Any background context you want to provide?

We want to be able to better track when this modal opens and close

### Relevant tickets

References [Pivotal #172157205](https://www.pivotaltracker.com/story/show/173021322).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added screenshots of front-end changes on small, medium, and large screens.
- [ ] Added appropriate feature/unit tests.
