### PR TITLE
Deprecate General & Campaign Page Sidebar

### DIFF
--- a/docs/development/content-types/page.md
+++ b/docs/development/content-types/page.md
@@ -26,7 +26,7 @@ The Page Content Type is used across the app in several forms:
 
 - **Content**: The markdown content for this page.
 
-- **Sidebar** _(optional)_: A list of Call To Action or Custom Block references displayed as a sidebar on the page.
+- _deprecated!_ ~**Sidebar** _(optional)_: A list of Call To Action or Custom Block references displayed as a sidebar on the page.~
 
 - **Blocks** _(optional)_: A list of blocks displayed on the page beneath the **Content**. (Supports most standalone block widgets in our Contentful arsenal).
 

--- a/resources/assets/components/pages/CampaignPage/CampaignPageContent.js
+++ b/resources/assets/components/pages/CampaignPage/CampaignPageContent.js
@@ -24,7 +24,7 @@ const CampaignPageContent = props => {
     );
   }
 
-  const { content, sidebar, blocks } = subPage.fields;
+  const { content, blocks } = subPage.fields;
 
   return (
     <div className="leading-normal text-base" id={subPage.id}>
@@ -35,15 +35,6 @@ const CampaignPageContent = props => {
           <div className="grid-wide-7/10">
             <TextContent className="mx-3">{content}</TextContent>
           </div>
-          {sidebar.length ? (
-            <div className="grid-wide-3/10">
-              {sidebar.map(block => (
-                <div className="mb-6 mx-3" key={block.id}>
-                  <ContentfulEntryLoader id={block.id} />
-                </div>
-              ))}
-            </div>
-          ) : null}
         </div>
       ) : null}
 

--- a/resources/assets/components/pages/GeneralPage/GeneralPage.js
+++ b/resources/assets/components/pages/GeneralPage/GeneralPage.js
@@ -38,7 +38,6 @@ const GeneralPage = props => {
     coverImage,
     content,
     additionalContent,
-    sidebar,
     blocks,
     displaySocialShare,
     isAuthenticated,
@@ -85,23 +84,7 @@ const GeneralPage = props => {
               />
             ) : null}
 
-            {content ? (
-              <div className={classnames({ row: sidebar.length })}>
-                <div className="primary">
-                  <TextContent>{content}</TextContent>
-                </div>
-
-                {sidebar.length ? (
-                  <div className="secondary">
-                    {sidebar.map(block => (
-                      <div className="mx-3 mb-6" key={block.id}>
-                        <ContentfulEntryLoader id={block.id} />
-                      </div>
-                    ))}
-                  </div>
-                ) : null}
-              </div>
-            ) : null}
+            {content ? <TextContent>{content}</TextContent> : null}
 
             {blocks.map(block => (
               <div className="general-page__block my-6" key={block.id}>
@@ -186,7 +169,6 @@ GeneralPage.propTypes = {
   }),
   content: PropTypes.string,
   additionalContent: PropTypes.object,
-  sidebar: PropTypes.arrayOf(PropTypes.object),
   blocks: PropTypes.arrayOf(PropTypes.object).isRequired,
   displaySocialShare: PropTypes.bool,
   isAuthenticated: PropTypes.bool.isRequired,
@@ -198,7 +180,6 @@ GeneralPage.defaultProps = {
   coverImage: {},
   content: null,
   additionalContent: {},
-  sidebar: [],
   subTitle: null,
   displaySocialShare: false,
 };

--- a/resources/assets/components/pages/GeneralPage/GeneralPage.js
+++ b/resources/assets/components/pages/GeneralPage/GeneralPage.js
@@ -3,7 +3,6 @@
 import React from 'react';
 import get from 'lodash/get';
 import PropTypes from 'prop-types';
-import classnames from 'classnames';
 
 import LazyImage from '../../utilities/LazyImage';
 import Byline from '../../utilities/Byline/Byline';
@@ -57,7 +56,7 @@ const GeneralPage = props => {
           <div className="grid-narrow">
             <ArticleHeader title={title} subtitle={subTitle}>
               {authors.length ? (
-                <div className="general-page__authors">
+                <div className="inline-block text-left">
                   {authors.map(author => (
                     <Byline
                       key={author.id}
@@ -102,7 +101,7 @@ const GeneralPage = props => {
             ) : null}
 
             {authors.length ? (
-              <ul className="general-page__author-bios">
+              <ul className="border-t-2 border-solid border-gray-300 py-3">
                 {authors.map(author => (
                   <li className="py-3" key={author.id}>
                     <AuthorBio

--- a/resources/assets/components/pages/GeneralPage/general-page.scss
+++ b/resources/assets/components/pages/GeneralPage/general-page.scss
@@ -1,8 +1,6 @@
 @import '../../../scss/next-toolbox';
 
 .general-page {
-  position: inherit;
-
   // HACK: If a Content Block is found on a "general page" without an
   // image, we want to force it to full-width so it looks normal.
   .hack-article-content-widths {

--- a/resources/assets/components/pages/GeneralPage/general-page.scss
+++ b/resources/assets/components/pages/GeneralPage/general-page.scss
@@ -1,19 +1,7 @@
-@import '../../../scss/next-toolbox';
-
 .general-page {
   // HACK: If a Content Block is found on a "general page" without an
   // image, we want to force it to full-width so it looks normal.
   .hack-article-content-widths {
     grid-column: span 3 / span 3 !important;
-  }
-
-  .general-page__authors {
-    display: inline-block;
-    text-align: left;
-  }
-
-  .general-page__author-bios {
-    border-top: 2px solid #dcdcdc;
-    padding: theme('spacing.3') 0;
   }
 }

--- a/resources/assets/components/pages/GeneralPage/general-page.scss
+++ b/resources/assets/components/pages/GeneralPage/general-page.scss
@@ -18,28 +18,4 @@
     border-top: 2px solid #dcdcdc;
     padding: theme('spacing.3') 0;
   }
-
-  .row {
-    .primary {
-      margin: 0 0 theme('spacing.6');
-
-      @include media($large) {
-        float: left;
-        padding-right: theme('spacing.3');
-        width: 66.6666666666666%;
-      }
-    }
-
-    .secondary {
-      display: none;
-
-      @include media($large) {
-        display: block;
-        float: right;
-        padding-left: theme('spacing.3');
-        margin: 0 0 theme('spacing.6');
-        width: 33.3333333333333%;
-      }
-    }
-  }
 }


### PR DESCRIPTION
### What's this PR do?

This pull request deprecates rendering support for the soon-to-be-deprecated `sidebar` field from General Pages and Campaign subpages.

I took the opp to inline some of the General Page scss styles as Tailwind classes.

### How should this be reviewed?
commit-by-commit if you please!
Did I miss any sidebar references? Does the inlined styling look good?

### Any background context you want to provide?
We've not used this field in a hot minute. See Pivotal ticket for more context.

I left the `hack-article-content-widths` class in the `general-page.scss` but have an idea to help formalize this better for an upcoming PR!

The other follow-up will be formally removing this field from our Contentful/GraphQL ecosystem.

### Relevant tickets

References [Pivotal #173738645](https://www.pivotaltracker.com/story/show/173738645).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [x] Documentation added for new features/changed endpoints.
- [x] Added screenshots of front-end changes on small, medium, and large screens.
- [ ] Added appropriate feature/unit tests.

📸 
- [General Page with (broken) sidebar](https://user-images.githubusercontent.com/12417657/87181701-bed6c400-c2b0-11ea-89a8-c92b3a3cb7ad.png)
- [Without](https://user-images.githubusercontent.com/12417657/87181736-d3b35780-c2b0-11ea-9632-29075e63842b.png)

The one visual difference in styling is that I replaced a custom border color on top of the general page author bio with a tailwind color that seemed similar enough.

- [Before](https://user-images.githubusercontent.com/12417657/87181751-d910a200-c2b0-11ea-8471-5c0c4ef66f08.png)
- [After](https://user-images.githubusercontent.com/12417657/87181752-d910a200-c2b0-11ea-8de8-87bb8558cf91.png)