### PR TITLE
Modify individual VoterRegistrationReferralsBlock to retrieve all referrals

### DIFF
--- a/cypress/fixtures/user.js
+++ b/cypress/fixtures/user.js
@@ -1,10 +1,15 @@
 import faker from 'faker';
 import { ObjectID } from 'bson';
 
-export const userFactory = () => ({
-  id: new ObjectID().toString(),
-  role: 'user',
-  firstName: faker.name.firstName(),
-});
+export const userFactory = () => {
+  const firstName = faker.name.firstName();
+
+  return {
+    id: new ObjectID().toString(),
+    role: 'user',
+    firstName,
+    displayName: `${firstName} ${faker.name.lastName().charAt(0)}.`,
+  };
+};
 
 export default {};

--- a/cypress/integration/voter-registration-referrals-block.js
+++ b/cypress/integration/voter-registration-referrals-block.js
@@ -105,6 +105,7 @@ describe('Voter Registration Referrals Block', () => {
         voterRegPost(thirdCompletedReferralUser, 'STEP_3'),
         voterRegPost(thirdCompletedReferralUser, 'STEP_2'),
         voterRegPost(thirdCompletedReferralUser, 'REGISTER_OVR'),
+        voterRegPost(thirdCompletedReferralUser, 'STEP_4'),
         voterRegPost(userFactory(), 'STEP_1'),
         voterRegPost(userFactory(), 'REGISTER_OVR'),
         voterRegPost(userFactory(), 'REJECTED'),

--- a/cypress/integration/voter-registration-referrals-block.js
+++ b/cypress/integration/voter-registration-referrals-block.js
@@ -101,6 +101,9 @@ describe('Voter Registration Referrals Block', () => {
       posts: [
         voterRegPost(firstCompletedReferralUser, 'REGISTER_FORM'),
         voterRegPost(secondCompletedReferralUser, 'REGISTER_OVR'),
+        // Users may have multiple voter registration posts.
+        voterRegPost(thirdCompletedReferralUser, 'STEP_3'),
+        voterRegPost(thirdCompletedReferralUser, 'STEP_2'),
         voterRegPost(thirdCompletedReferralUser, 'REGISTER_OVR'),
         voterRegPost(userFactory(), 'STEP_1'),
         voterRegPost(userFactory(), 'REGISTER_OVR'),

--- a/resources/assets/components/blocks/VoterRegistrationReferralsBlock/templates/Individual.js
+++ b/resources/assets/components/blocks/VoterRegistrationReferralsBlock/templates/Individual.js
@@ -30,11 +30,7 @@ const INDIVIDUAL_VOTER_REGISTRATION_REFERRALS_QUERY = gql`
 const parseVoterRegistrationReferrals = voterRegPosts => {
   const result = { complete: {}, incomplete: {} };
 
-  /**
-   * @param {String} status
-   * @param {Object} user
-   */
-  const parseVoterRegistrationReferral = ({ status, user }) => {
+  voterRegPosts.forEach(({ status, user }) => {
     const userId = user.id;
 
     // If status is incomplete:
@@ -55,9 +51,7 @@ const parseVoterRegistrationReferrals = voterRegPosts => {
     }
 
     result.complete[userId] = user;
-  };
-
-  voterRegPosts.forEach(parseVoterRegistrationReferral);
+  });
 
   return result;
 };

--- a/resources/assets/components/blocks/VoterRegistrationReferralsBlock/templates/Individual.js
+++ b/resources/assets/components/blocks/VoterRegistrationReferralsBlock/templates/Individual.js
@@ -12,18 +12,55 @@ import ReferralsGallery from '../../../utilities/ReferralsGallery/ReferralsGalle
 
 const INDIVIDUAL_VOTER_REGISTRATION_REFERRALS_QUERY = gql`
   query IndividualVoterRegistrationReferralsQuery($referrerUserId: String!) {
-    posts(
-      referrerUserId: $referrerUserId
-      type: "voter-reg"
-      status: [REGISTER_FORM, REGISTER_OVR]
-    ) {
+    posts(referrerUserId: $referrerUserId, type: "voter-reg") {
       id
+      status
       user {
+        id
         displayName
       }
     }
   }
 `;
+
+/**
+ * @param {Array} voterRegPosts
+ * @return {Object}
+ */
+const parseVoterRegistrationReferrals = voterRegPosts => {
+  const result = { complete: {}, incomplete: {} };
+
+  /**
+   * @param {String} status
+   * @param {Object} user
+   */
+  const parseVoterRegistrationReferral = ({ status, user }) => {
+    const userId = user.id;
+
+    // If status is incomplete:
+    if (!['REGISTER_FORM', 'REGISTER_OVR'].includes(status)) {
+      // And user already has a completed registration, skip this registration.
+      if (result.complete[userId]) {
+        return;
+      }
+
+      result.incomplete[userId] = user;
+
+      return;
+    }
+
+    // Remove user from incomplete set, if exists.
+    if (result.incomplete[userId]) {
+      delete result.incomplete[userId];
+    }
+
+    result.complete[userId] = user;
+  };
+
+  voterRegPosts.forEach(parseVoterRegistrationReferral);
+
+  return result;
+};
 
 const IndividualTemplate = ({ title }) => (
   <>
@@ -33,15 +70,16 @@ const IndividualTemplate = ({ title }) => (
       variables={{ referrerUserId: getUserId() }}
     >
       {data => {
-        const numberOfReferrals = data.posts.length;
+        const parsed = parseVoterRegistrationReferrals(data.posts);
+        const completed = Object.values(parsed.complete);
 
         return (
           <>
-            {numberOfReferrals ? (
+            {completed.length ? (
               <div className="pb-3 md:pb-6">
                 You have registered{' '}
                 <strong>
-                  {numberOfReferrals} {pluralize('person', numberOfReferrals)}
+                  {completed.length} {pluralize('person', completed.length)}
                 </strong>{' '}
                 so far.
               </div>
@@ -53,9 +91,7 @@ const IndividualTemplate = ({ title }) => (
             )}
 
             <ReferralsGallery
-              referralLabels={data.posts.map(
-                referral => referral.user.displayName,
-              )}
+              referralLabels={completed.map(referral => referral.displayName)}
               referralIcon={CompletedRegistrationImage}
               placeholderIcon={EmptyRegistrationImage}
             />

--- a/resources/assets/components/blocks/VoterRegistrationReferralsBlock/templates/Individual.js
+++ b/resources/assets/components/blocks/VoterRegistrationReferralsBlock/templates/Individual.js
@@ -12,7 +12,12 @@ import ReferralsGallery from '../../../utilities/ReferralsGallery/ReferralsGalle
 
 const INDIVIDUAL_VOTER_REGISTRATION_REFERRALS_QUERY = gql`
   query IndividualVoterRegistrationReferralsQuery($referrerUserId: String!) {
-    posts(referrerUserId: $referrerUserId, type: "voter-reg", count: 50) {
+    posts(
+      referrerUserId: $referrerUserId
+      status: [REGISTER_FORM, REGISTER_OVR, STEP_1, STEP_2, STEP_3, STEP_4]
+      type: "voter-reg"
+      count: 50
+    ) {
       id
       status
       user {

--- a/resources/assets/components/blocks/VoterRegistrationReferralsBlock/templates/Individual.js
+++ b/resources/assets/components/blocks/VoterRegistrationReferralsBlock/templates/Individual.js
@@ -12,7 +12,7 @@ import ReferralsGallery from '../../../utilities/ReferralsGallery/ReferralsGalle
 
 const INDIVIDUAL_VOTER_REGISTRATION_REFERRALS_QUERY = gql`
   query IndividualVoterRegistrationReferralsQuery($referrerUserId: String!) {
-    posts(referrerUserId: $referrerUserId, type: "voter-reg") {
+    posts(referrerUserId: $referrerUserId, type: "voter-reg", count: 50) {
       id
       status
       user {
@@ -91,7 +91,7 @@ const IndividualTemplate = ({ title }) => (
             )}
 
             <ReferralsGallery
-              referralLabels={completed.map(referral => referral.displayName)}
+              referralLabels={completed.map(user => user.displayName)}
               referralIcon={CompletedRegistrationImage}
               placeholderIcon={EmptyRegistrationImage}
             />


### PR DESCRIPTION
### What's this PR do?

This pull request modifies the GraphQL query in the individual template of the `VoterRegistrationReferralsBlock` to retrieve all referrals, regardless of status -- instead of only completed referrals. 

It doesn't make any corresponding UI changes -- the component still only displays completed referrals. This work is in preparation for displaying the total list of an alpha's registrations, including those who haven't completed, per [Pivotal #173230283](https://www.pivotaltracker.com/story/show/173230283).

### How should this be reviewed?

👀 

### Any background context you want to provide?

🥍 

### Relevant tickets

References [Pivotal #173230283](https://www.pivotaltracker.com/story/show/173230283).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added screenshots of front-end changes on small, medium, and large screens.
- [x] Added appropriate feature/unit tests.
