### PR TITLE
Added Cypress Test for Scholarship Modal - Authenticated User Already Signed up via Partner 

### DIFF
--- a/cypress/integration/campaign-signup.js
+++ b/cypress/integration/campaign-signup.js
@@ -212,6 +212,25 @@ describe('Campaign Signup', () => {
     );
   });
 
+  /** @test */
+  it('Visits a campaign page from a scholarship partner, as an authenticated user', () => {
+    const user = userFactory();
+
+    //Log in and visit the campaign pitch page
+    cy.authVisitCampaignWithSignup(user, exampleCampaign).visit(
+      '/us/campaigns/test-example-campaign?utm_campaign=fastweb&utm_source=scholarship',
+
+      //Find the example campaign
+      cy.contains('Example Campaign'),
+      cy.contains('This is an example campaign for automated testing.'),
+
+      // We shouldn't see the "Join Now" button or affirmation modal,
+      // since the user is already signed up for this campaign:
+      cy.findByTestId('campaign-banner-signup-button').should('not.exist'),
+      cy.get('.card.affirmation').should('not.exist'),
+    );
+  });
+
   // TODO: Use cypress context to better group this test once #2238 is merged.
   /** @test */
   it('If campaign group type does not filter by state, signup button is enabled after selecting group', () => {

--- a/cypress/integration/campaign-signup.js
+++ b/cypress/integration/campaign-signup.js
@@ -217,18 +217,20 @@ describe('Campaign Signup', () => {
     const user = userFactory();
 
     //Log in and visit the campaign pitch page
-    cy.authVisitCampaignWithSignup(user, exampleCampaign).visit(
+    cy.authVisitCampaignWithSignup(user, exampleCampaign);
+
+    // Visit the campaign pitch page
+    cy.withState(exampleCampaign).visit(
       '/us/campaigns/test-example-campaign?utm_campaign=fastweb&utm_source=scholarship',
+    );
 
-      //Find the example campaign
-      cy.contains('Example Campaign'),
+    //Find the example campaign
+    cy.contains('Example Campaign'),
       cy.contains('This is an example campaign for automated testing.'),
-
       // We shouldn't see the "Join Now" button or affirmation modal,
       // since the user is already signed up for this campaign:
       cy.findByTestId('campaign-banner-signup-button').should('not.exist'),
-      cy.get('.card.affirmation').should('not.exist'),
-    );
+      cy.get('.card.affirmation').should('not.exist');
   });
 
   // TODO: Use cypress context to better group this test once #2238 is merged.

--- a/cypress/integration/campaign-signup.js
+++ b/cypress/integration/campaign-signup.js
@@ -217,20 +217,21 @@ describe('Campaign Signup', () => {
     const user = userFactory();
 
     //Log in and visit the campaign pitch page
-    cy.authVisitCampaignWithSignup(user, exampleCampaign);
-
-    // Visit the campaign pitch page
-    cy.withState(exampleCampaign).visit(
-      '/us/campaigns/test-example-campaign?utm_campaign=fastweb&utm_source=scholarship',
-    );
+    cy.login(user)
+      .withState(exampleCampaign)
+      .withSignup(exampleCampaign.campaign.campaignId)
+      .visit(
+        '/us/campaigns/test-example-campaign?utm_campaign=fastweb&utm_source=scholarship',
+      );
 
     //Find the example campaign
     cy.contains('Example Campaign'),
       cy.contains('This is an example campaign for automated testing.'),
       // We shouldn't see the "Join Now" button or affirmation modal,
       // since the user is already signed up for this campaign:
-      cy.findByTestId('campaign-banner-signup-button').should('not.exist'),
-      cy.get('.card.affirmation').should('not.exist');
+      cy
+        .findByTestId('campaign-info-block-scholarship-details')
+        .should('not.contain', 'Apply Now');
   });
 
   // TODO: Use cypress context to better group this test once #2238 is merged.

--- a/cypress/integration/campaign-signup.js
+++ b/cypress/integration/campaign-signup.js
@@ -227,7 +227,7 @@ describe('Campaign Signup', () => {
     //Find the example campaign
     cy.contains('Example Campaign'),
       cy.contains('This is an example campaign for automated testing.'),
-      // We shouldn't see the "Join Now" button or affirmation modal,
+      // We shouldn't see the "Apply Now" button,
       // since the user is already signed up for this campaign:
       cy
         .findByTestId('campaign-info-block-scholarship-details')


### PR DESCRIPTION
### What's this PR do?

This pull request adds a cypress test to the scholarship modal to test the flow for a user coming from a scholarship partner website 

### How should this be reviewed?
Is this the correct flow for the user coming from a scholarship partner?
Is there a more simple way to do this?

### Relevant tickets

References [Pivotal #172546539](https://www.pivotaltracker.com/story/show/172546539).

### Checklist

- [ x ] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added screenshots of front-end changes on small, medium, and large screens.
- [ ] Added appropriate feature/unit tests.
