### PR TITLE
Adding Helper text to the group finder form

### DIFF
--- a/resources/assets/components/CampaignSignupForm/CampaignSignupForm.js
+++ b/resources/assets/components/CampaignSignupForm/CampaignSignupForm.js
@@ -110,7 +110,9 @@ const CampaignSignupForm = props => {
             text="Join Group"
           />
           <p className="text-sm text-gray-500 pt-3 md:pt-0">
-            Can&apos;t find your group? <br />
+            Can&apos;t find your group?
+          </p>
+          <p className="text-sm text-gray-500 mt-0">
             Email tej@dosomething.org for help.
           </p>
         </div>

--- a/resources/assets/components/CampaignSignupForm/CampaignSignupForm.js
+++ b/resources/assets/components/CampaignSignupForm/CampaignSignupForm.js
@@ -109,6 +109,10 @@ const CampaignSignupForm = props => {
             onClick={handleSignup}
             text="Join Group"
           />
+          <p className="text-sm text-gray-500 pt-3 md:pt-0">
+            Can&apos;t find your group? <br />
+            Email tej@dosomething.org for help.
+          </p>
         </div>
       </Card>
     </div>


### PR DESCRIPTION
### What's this PR do?

This pull request adds helper text to the group finder form so users have a contact if they can't find their group.

### How should this be reviewed?

👀 

Mobile:
<img width="361" alt="Screen Shot 2020-07-14 at 1 54 48 PM" src="https://user-images.githubusercontent.com/15236023/87459979-20ad6b80-c5da-11ea-870b-95b388dd7107.png">

Desktop:
<img width="317" alt="Screen Shot 2020-07-14 at 1 54 25 PM" src="https://user-images.githubusercontent.com/15236023/87459983-22772f00-c5da-11ea-92bf-3a066d18c05a.png">


### Any background context you want to provide?

This is in addition to the alert that your group can't be found within the dropdown that Aaron added in #2255 

### Relevant tickets

References [Pivotal # 173519727](https://www.pivotaltracker.com/story/show/173519727).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added screenshots of front-end changes on small, medium, and large screens.
- [ ] Added appropriate feature/unit tests.
