### PR TITLE
Campaign Page Blocks Span Updates

### DIFF
--- a/resources/assets/components/pages/CampaignPage/CampaignPageContent.js
+++ b/resources/assets/components/pages/CampaignPage/CampaignPageContent.js
@@ -52,6 +52,7 @@ const CampaignPageContent = props => {
               classNameByEntryDefault={narrowSpan}
               classNameByEntry={{
                 ContentBlock: wideSpan,
+                GalleryBlock: wideSpan,
                 ImagesBlock: wideSpan,
                 PostGalleryBlock: wideSpan,
                 PhotoSubmissionBlock: wideSpan,

--- a/resources/assets/components/pages/CampaignPage/CampaignPageContent.js
+++ b/resources/assets/components/pages/CampaignPage/CampaignPageContent.js
@@ -26,13 +26,17 @@ const CampaignPageContent = props => {
 
   const { content, blocks } = subPage.fields;
 
+  // Grid column span classes for styling our content.
+  const narrowSpan = 'col-span-4 md:col-span-6 lg:col-start-2 lg:col-span-7';
+  const wideSpan = 'col-span-4 md:col-span-8 lg:col-start-2 lg:col-span-10';
+
   return (
     <div className="leading-normal text-base" id={subPage.id}>
       <ScrollConcierge trigger={!shouldShowAffirmation} />
 
       {content ? (
         <div className="base-12-grid py-3 md:py-6">
-          <div className="grid-wide-7/10">
+          <div className={narrowSpan}>
             <TextContent className="mx-3">{content}</TextContent>
           </div>
         </div>
@@ -45,16 +49,16 @@ const CampaignPageContent = props => {
               key={block.id}
               id={block.id}
               className="mb-6 clear-both"
-              classNameByEntryDefault="grid-wide-7/10"
+              classNameByEntryDefault={narrowSpan}
               classNameByEntry={{
-                ContentBlock: 'grid-wide',
-                ImagesBlock: 'grid-wide',
-                PostGalleryBlock: 'grid-wide',
-                PhotoSubmissionBlock: 'grid-wide',
-                QuizBlock: 'grid-wide',
-                SocialDriveBlock: 'grid-wide',
-                VoterRegistrationDriveBlock: 'grid-wide',
-                VoterRegistrationReferralsBlock: 'grid-wide',
+                ContentBlock: wideSpan,
+                ImagesBlock: wideSpan,
+                PostGalleryBlock: wideSpan,
+                PhotoSubmissionBlock: wideSpan,
+                QuizBlock: wideSpan,
+                SocialDriveBlock: wideSpan,
+                VoterRegistrationDriveBlock: wideSpan,
+                VoterRegistrationReferralsBlock: wideSpan,
               }}
             />
           ))}


### PR DESCRIPTION
### What's this PR do?

This pull request updates the grid column-span styling on our `CampaignPageContent` blocks to allow a more generous width on mid-size viewports per a UI bug we noticed (see attached Pivotal ticket).

## How should this be reviewed?
Feel free to mess around with the before & after spans on our epic Test Teens for Jeans Campaign:
- https://dev.dosomething.org/us/campaigns/test-teens-for-jeans/action
- https://dosomething-phoenix-de-pr-2278.herokuapp.com/us/campaigns/test-teens-for-jeans/action

The update is pretty straightforward, but it might help to take a look at the[ `.grid-wide-7\/10` class](https://github.com/DoSomething/phoenix-next/blob/9d297dbfb1a7c51b18696bd11b076a5468883f2f/resources/assets/scss/base.scss#L398-L415) we were using previously to see the difference.

Do you think this new layout looks good, makes sense? Any flags?

### Any background context you want to provide?
Essentially, the issue was that we're allowing a pretty narrow width for Medium & Large screens (cutting off at the `midway` column which is half of the page), this caused blocks confined to this width to appear pretty tightly constrained and narrow.

We switch to using Tailwind grid span classes, and simply allowing a more generous width on Medium & Large screens. 
While I was at it, I also updated the `grid-wide` blocks to use Tailwind classes, but those should still be more or less the same spans as before.


### Relevant tickets

References [Pivotal #171522463](https://www.pivotaltracker.com/story/show/171522463).

(This doesn't totally address [Pivotal #172820107](https://www.pivotaltracker.com/story/show/172820107) but figured it's a good rough start. We've also discussed formalizing some of these grid span stylings as formal Components, but I don't quite feel ready to do that yet personally).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [x] Added screenshots of front-end changes on small, medium, and large screens.
- [ ] Added appropriate feature/unit tests.

📸 
- [Medium Before](https://user-images.githubusercontent.com/12417657/87572830-1eaae180-c69a-11ea-8e9e-afd4a9763672.jpg)
- [Medium After](https://user-images.githubusercontent.com/12417657/87572892-2d919400-c69a-11ea-9112-10cc936832d3.jpg)

- [Large Before](https://user-images.githubusercontent.com/12417657/87572897-308c8480-c69a-11ea-89d3-84732029c6d9.jpg)
- [Large After](https://user-images.githubusercontent.com/12417657/87572906-32eede80-c69a-11ea-8d63-c7fb4958df42.jpg)




