### PR TITLE
Fixes Bug Preventing Email Subscription Status Auto-Refresh

### DIFF
--- a/resources/assets/components/pages/AccountPage/Subscriptions/CancelEmailSubscription.js
+++ b/resources/assets/components/pages/AccountPage/Subscriptions/CancelEmailSubscription.js
@@ -24,6 +24,7 @@ const EMAIL_SUBSCRIPTION_STATUS_MUTATION = gql`
     ) {
       id
       emailSubscriptionStatus
+      emailSubscriptionTopics
     }
   }
 `;
@@ -58,7 +59,6 @@ const CancelEmailSubscription = props => {
                 variables: {
                   emailSubscriptionStatus: false,
                 },
-                refetchQueries: ['EmailSubscriptionsQuery'],
               })
             }
           >

--- a/resources/assets/components/pages/AccountPage/Subscriptions/EmailSubscriptionItem.js
+++ b/resources/assets/components/pages/AccountPage/Subscriptions/EmailSubscriptionItem.js
@@ -28,6 +28,7 @@ const EMAIL_SUBSCRIPTION_MUTATION = gql`
     ) {
       id
       emailSubscriptionTopics
+      emailSubscriptionStatus
     }
   }
 `;
@@ -84,7 +85,6 @@ const EmailSubscriptionItem = ({
                   variables: {
                     topic,
                     subscribed: !topics.includes(topic),
-                    refetchQueries: ['EmailSubscriptionStatus'],
                   },
                 })
               }


### PR DESCRIPTION


### What's this PR do?

This pull request fixes the refresh issue we were having with the global unsubscribe link. See [here](https://github.com/DoSomething/phoenix-next/pull/2201#discussion_r455088893)

### How should this be reviewed?

👀

### Any background context you want to provide?

Originally used `refetchQueries` to fix refresh problem but the problem ensued and we determined that it would no longer be needed and that the gql mutation should just work if modified items are included 

### Relevant tickets
N/A
References [Pivotal #]().

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added screenshots of front-end changes on small, medium, and large screens.
- [ ] Added appropriate feature/unit tests.
