### PR TITLE
Bug Fix: Zendesk Modal FAQ Link for Unaffiliated Users

### DIFF
--- a/cypress/integration/zendesk-form.js
+++ b/cypress/integration/zendesk-form.js
@@ -24,6 +24,7 @@ describe('Zendesk Modal', () => {
     cy.get('.modal .zendesk-form').contains('h1', 'Contact Us');
   });
 
+  /** @test */
   it('Links to the FAQ page for affiliated users, and the help center for unaffiliated users', () => {
     cy.findByTestId('zendesk-form-faq-link')
       .should('have.attr', 'href')
@@ -38,6 +39,7 @@ describe('Zendesk Modal', () => {
       .and('include', `/us/campaigns/${exampleCampaign.campaign.slug}/faqs`);
   });
 
+  /** @test */
   it('Submits a question successfully and displays affirmation', () => {
     cy.route('POST', '/api/v2/zendesk-tickets', []);
 
@@ -48,6 +50,7 @@ describe('Zendesk Modal', () => {
     cy.get('.zendesk-form h1').contains('Thank You');
   });
 
+  /** @test */
   it('Submits a question unsuccessfully and displays error message', () => {
     cy.route({ method: 'POST', url: '/api/v2/zendesk-tickets', status: 500 });
 

--- a/cypress/integration/zendesk-form.js
+++ b/cypress/integration/zendesk-form.js
@@ -24,7 +24,7 @@ describe('Zendesk Modal', () => {
     cy.get('.modal .zendesk-form').contains('h1', 'Contact Us');
   });
 
-  it('links to the FAQ page for affiliated users, and the help center for unaffiliated users', () => {
+  it('Links to the FAQ page for affiliated users, and the help center for unaffiliated users', () => {
     cy.findByTestId('zendesk-form-faq-link')
       .should('have.attr', 'href')
       .and('include', HELP_LINK);

--- a/cypress/integration/zendesk-form.js
+++ b/cypress/integration/zendesk-form.js
@@ -1,14 +1,16 @@
 /// <reference types="Cypress" />
 import { userFactory } from '../fixtures/user';
+import { HELP_LINK } from '../../resources/assets/constants';
 import exampleCampaign from '../fixtures/contentful/exampleCampaign';
 
 const QUESTION = 'causeyhippo';
 
 describe('Zendesk Modal', () => {
+  const user = userFactory();
+
   beforeEach(() => {
     cy.configureMocks();
 
-    const user = userFactory();
     cy.authVisitCampaignWithoutSignup(user, exampleCampaign);
 
     cy.get('.info-bar .info-bar__secondary button')
@@ -16,6 +18,19 @@ describe('Zendesk Modal', () => {
       .click();
 
     cy.get('.modal .zendesk-form').contains('h1', 'Contact Us');
+  });
+
+  it('links to the FAQ page for affiliated users, and the help center for unaffiliated users', () => {
+    cy.findByTestId('zendesk-form-faq-link')
+      .should('have.attr', 'href')
+      .and('include', HELP_LINK);
+
+    cy.authVisitCampaignWithSignup(user, exampleCampaign);
+
+    cy.get('.info-bar .info-bar__secondary button')
+      .contains('button', 'Contact Us')
+      .click();
+
     cy.findByTestId('zendesk-form-faq-link')
       .should('have.attr', 'href')
       .and('include', `/us/campaigns/${exampleCampaign.campaign.slug}/faqs`);

--- a/cypress/integration/zendesk-form.js
+++ b/cypress/integration/zendesk-form.js
@@ -8,14 +8,18 @@ const QUESTION = 'causeyhippo';
 describe('Zendesk Modal', () => {
   const user = userFactory();
 
+  const clickOnTheContactUsLink = () => {
+    cy.get('.info-bar .info-bar__secondary button')
+      .contains('button', 'Contact Us')
+      .click();
+  };
+
   beforeEach(() => {
     cy.configureMocks();
 
     cy.authVisitCampaignWithoutSignup(user, exampleCampaign);
 
-    cy.get('.info-bar .info-bar__secondary button')
-      .contains('button', 'Contact Us')
-      .click();
+    clickOnTheContactUsLink();
 
     cy.get('.modal .zendesk-form').contains('h1', 'Contact Us');
   });
@@ -27,9 +31,7 @@ describe('Zendesk Modal', () => {
 
     cy.authVisitCampaignWithSignup(user, exampleCampaign);
 
-    cy.get('.info-bar .info-bar__secondary button')
-      .contains('button', 'Contact Us')
-      .click();
+    clickOnTheContactUsLink();
 
     cy.findByTestId('zendesk-form-faq-link')
       .should('have.attr', 'href')

--- a/docs/development/features/zendesk-form.md
+++ b/docs/development/features/zendesk-form.md
@@ -1,8 +1,8 @@
 # Zendesk Form
 
-The `ZendeskForm` component presents a form interface for campaign-affiliated users to submit questions to our Zendesk helpdesk.
+The `ZendeskForm` component presents a form interface for authenticated users to submit questions to our Zendesk helpdesk.
 
-It'll also present a link to the Campaign's FAQ page if available, or our Help center otherwise.
+It'll also present a link to the Campaign's FAQ page if available (& the user is signed up for the campaign), or our Help center otherwise.
 
 The form submits via the internal `api/v2/zendesk-tickets` API which creates a new Zendesk Ticket for the user.
 

--- a/resources/assets/components/utilities/ZendeskForm/ZendeskForm.js
+++ b/resources/assets/components/utilities/ZendeskForm/ZendeskForm.js
@@ -6,9 +6,10 @@ import Card from '../Card/Card';
 import { report } from '../../../helpers';
 import { postRequest } from '../../../helpers/api';
 import PrimaryButton from '../Button/PrimaryButton';
+import { getUserToken } from '../../../helpers/auth';
 import { HELP_LINK, HELP_REQUEST_LINK } from '../../../constants';
 
-const ZendeskForm = ({ campaignId, campaignName, faqLink, token }) => {
+const ZendeskForm = ({ campaignId, campaignName, faqLink }) => {
   const [question, setQuestion] = useState('');
   const [status, setStatus] = useState({
     loading: false,
@@ -27,7 +28,7 @@ const ZendeskForm = ({ campaignId, campaignName, faqLink, token }) => {
       question,
     };
 
-    postRequest('/api/v2/zendesk-tickets', data, token)
+    postRequest('/api/v2/zendesk-tickets', data, getUserToken())
       .then(() => setStatus({ ...status, loading: false, success: true }))
       .catch(error => {
         setStatus({ ...status, loading: false, error });
@@ -116,7 +117,6 @@ const ZendeskForm = ({ campaignId, campaignName, faqLink, token }) => {
 ZendeskForm.propTypes = {
   campaignId: PropTypes.string.isRequired,
   campaignName: PropTypes.string.isRequired,
-  token: PropTypes.string.isRequired,
   faqLink: PropTypes.string,
 };
 

--- a/resources/assets/components/utilities/ZendeskForm/ZendeskFormContainer.js
+++ b/resources/assets/components/utilities/ZendeskForm/ZendeskFormContainer.js
@@ -1,7 +1,6 @@
 import { connect } from 'react-redux';
 
 import ZendeskForm from './ZendeskForm';
-import { getUserToken } from '../../../selectors/user';
 import { isSignedUp } from '../../../selectors/signup';
 import { getCampaignFaqPath } from '../../../helpers/campaign';
 
@@ -9,7 +8,6 @@ import { getCampaignFaqPath } from '../../../helpers/campaign';
  * Provide state from the Redux store as props for this component.
  */
 const mapStateToProps = state => ({
-  token: getUserToken(state),
   campaignId: state.campaign.campaignId,
   campaignName: state.campaign.title,
   // @TODO: utilize the campaign sighnups GraphQL query (https://git.io/JJZ62) within the component to determine affiliation status

--- a/resources/assets/components/utilities/ZendeskForm/ZendeskFormContainer.js
+++ b/resources/assets/components/utilities/ZendeskForm/ZendeskFormContainer.js
@@ -10,7 +10,7 @@ import { getCampaignFaqPath } from '../../../helpers/campaign';
 const mapStateToProps = state => ({
   campaignId: state.campaign.campaignId,
   campaignName: state.campaign.title,
-  // @TODO: utilize the campaign sighnups GraphQL query (https://git.io/JJZ62) within the component to determine affiliation status
+  // @TODO: utilize the campaign signups GraphQL query (https://git.io/JJZ62) within the component to determine affiliation status
   // instead of the Redux store once we can refactor that into using an @include Directive for the group field. (https://bit.ly/2ZCMIzx).
   faqLink: isSignedUp(state) ? getCampaignFaqPath() : undefined,
 });

--- a/resources/assets/components/utilities/ZendeskForm/ZendeskFormContainer.js
+++ b/resources/assets/components/utilities/ZendeskForm/ZendeskFormContainer.js
@@ -2,6 +2,7 @@ import { connect } from 'react-redux';
 
 import ZendeskForm from './ZendeskForm';
 import { getUserToken } from '../../../selectors/user';
+import { isSignedUp } from '../../../selectors/signup';
 import { getCampaignFaqPath } from '../../../helpers/campaign';
 
 /**
@@ -11,7 +12,9 @@ const mapStateToProps = state => ({
   token: getUserToken(state),
   campaignId: state.campaign.campaignId,
   campaignName: state.campaign.title,
-  faqLink: getCampaignFaqPath(),
+  // @TODO: utilize the campaign sighnups GraphQL query (https://git.io/JJZ62) within the component to determine affiliation status
+  // instead of the Redux store once we can refactor that into using an @include Directive for the group field. (https://bit.ly/2ZCMIzx).
+  faqLink: isSignedUp(state) ? getCampaignFaqPath() : undefined,
 });
 
 // Export the container component.

--- a/resources/assets/helpers/auth.js
+++ b/resources/assets/helpers/auth.js
@@ -88,6 +88,13 @@ export const isAuthenticated = () => window.AUTH.isAuthenticated;
 export const getUserId = () => window.AUTH.id;
 
 /**
+ * Get the user auth token.
+ *
+ * @return {String}
+ */
+export const getUserToken = () => window.AUTH.token;
+
+/**
  * This hook allows a component to trigger an authentication gate, and
  * optionally "flash" data to the session for when they return.
  *


### PR DESCRIPTION
### What's this PR do?

This pull request fixes a lil bug wherein unaffiliated users were granted a link to the Campaign FAQ page which is gated and inaccessible unless you're signed up! 

It also adds another test for this flow, and a lil refactor to use a new helper method to fetch the user token to help us continue to offboard the Redux store and fetch from the `window.AUTH` directly.

### How should this be reviewed?
commit-by-commit cuz why not!

### Any background context you want to provide?
We fallback to a link to our general help center for campaigns that do not have an FAQ page of their own. Now, we can simply use this fallback for unaffiliated users to begin with!

You'll notice a whole TODO about directives and whatnot per my [kerfuffle yesterday](https://dosomething.slack.com/archives/CUQMU4Q6B/p1594922514011000) here. But otherwise, this should all be straightforward!


### Relevant tickets

References [Pivotal #172544459](https://www.pivotaltracker.com/story/show/172544459).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [x] Documentation added for new features/changed endpoints.
- [x] Added appropriate feature/unit tests.
