### PR TITLE
Remove Facebook share button on affirmation modal 

### DIFF
--- a/resources/assets/components/Affirmation/Affirmation.js
+++ b/resources/assets/components/Affirmation/Affirmation.js
@@ -83,9 +83,6 @@ const Affirmation = ({
                 <h3>{callToActionHeader}</h3>
                 <p>{callToActionDescription}</p>
               </FlexCell>
-              <FlexCell className="p-3" width="half">
-                <Share variant="blue" parentSource="affirmation" />
-              </FlexCell>
             </Flex>
 
             {author ? (

--- a/resources/assets/components/Affirmation/Affirmation.js
+++ b/resources/assets/components/Affirmation/Affirmation.js
@@ -4,7 +4,6 @@ import gql from 'graphql-tag';
 import PropTypes from 'prop-types';
 
 import Query from '../Query';
-import { Flex, FlexCell } from '../Flex';
 import Card from '../utilities/Card/Card';
 import Byline from '../utilities/Byline/Byline';
 import { contentfulImageUrl } from '../../helpers';
@@ -77,12 +76,10 @@ const Affirmation = ({
               </Badge>
             ) : null}
 
-            <Flex className="items-center">
-              <FlexCell className="affirmation__cta p-3" width="half">
-                <h3>{callToActionHeader}</h3>
-                <p>{callToActionDescription}</p>
-              </FlexCell>
-            </Flex>
+            <div className="affirmation__cta p-3">
+              <h3>{callToActionHeader}</h3>
+              <p>{callToActionDescription}</p>
+            </div>
 
             {author ? (
               <Byline

--- a/resources/assets/components/Affirmation/Affirmation.js
+++ b/resources/assets/components/Affirmation/Affirmation.js
@@ -6,7 +6,6 @@ import PropTypes from 'prop-types';
 import Query from '../Query';
 import { Flex, FlexCell } from '../Flex';
 import Card from '../utilities/Card/Card';
-import Share from '../utilities/Share/Share';
 import Byline from '../utilities/Byline/Byline';
 import { contentfulImageUrl } from '../../helpers';
 import Badge from '../pages/AccountPage/Badges/Badge';


### PR DESCRIPTION
### What's this PR do?

This pull request removes  the Facebook share button on affirmation modal 

### How should this be reviewed?

...

### Any background context you want to provide?

...

### Relevant tickets

References [Pivotal # 172631182](https://www.pivotaltracker.com/n/projects/2401401/stories/172631182).

### Checklist

- [ x ] This PR has been added to the relevant Pivotal card.
- [ x ] Added screenshots of front-end changes on small, medium, and large screens.

<img width="1185" alt="Screen Shot 2020-07-19 at 10 50 24 PM" src="https://user-images.githubusercontent.com/20409413/87895003-54412900-ca12-11ea-9183-264e0ab84c55.png">
