### PR TITLE
Fix Group VR Referrals Block styles when vertical

### DIFF
--- a/resources/assets/components/blocks/VoterRegistrationReferralsBlock/templates/Group.js
+++ b/resources/assets/components/blocks/VoterRegistrationReferralsBlock/templates/Group.js
@@ -26,7 +26,7 @@ const StatBlock = ({ amount, isVertical, label, testId }) => (
   >
     <span
       className={`font-bold uppercase text-gray-600 ${
-        isVertical ? 'w-5/6' : ''
+        isVertical ? 'w-3/4' : ''
       }`}
     >
       {label}
@@ -34,7 +34,7 @@ const StatBlock = ({ amount, isVertical, label, testId }) => (
 
     <h2
       className={`font-normal font-league-gothic text-3xl ${
-        isVertical ? ' w-1/6 mb-0' : ''
+        isVertical ? ' w-1/4 mb-0' : ''
       }`}
     >
       {amount}
@@ -80,7 +80,7 @@ const GroupTemplate = ({ group, isVertical, user }) => {
           const percentage = Math.round((groupTotal / groupGoal) * 100);
 
           return (
-            <div className="md:w-2/3">
+            <div className={isVertical ? null : 'md:w-2/3'}>
               <div data-testid="group-progress" className="py-3">
                 <span
                   className={`font-bold uppercase ${


### PR DESCRIPTION
### What's this PR do?

This pull request fixes a visual bug introduced in #2271, where the group stats in an OVRD page banner get squished ➡️ ⬅️  .

Before:

<img src="https://user-images.githubusercontent.com/1236811/88088298-0a099600-cb3f-11ea-90f0-e277b9ac86e4.png">

After:

<img src="https://user-images.githubusercontent.com/1236811/88088323-10980d80-cb3f-11ea-9ad1-5c33e42b44c0.png">

It also adjusts the width of the stat and label to 1/4, 3/4 to better display goals with 4 digits:

<img src="https://user-images.githubusercontent.com/1236811/88088648-97e58100-cb3f-11ea-85e3-9ad458ba62be.png">



### How should this be reviewed?

In a future PR, we'll need to adjust a `VoterRegistrationReferralBlock` component to display both the individual and group templates when viewing from an action page block (and no longer display the individual's total count, since we'll display the names of all voter-reg referrals). At that point, i think it'll be time to drop the `isVertical` prop and conditional logic in the group template, and just render separate components within the block and the OVRD page banner.

### Any background context you want to provide?

🐞 

### Relevant tickets

References [Slack thread](https://dosomething.slack.com/archives/CTVPG6L4R/p1595349109134800), [Pivotal #173927270](https://www.pivotaltracker.com/n/projects/2417735/stories/173927270)

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added screenshots of front-end changes on small, medium, and large screens.
- [ ] Added appropriate feature/unit tests.
