### PR TITLE
VoterRegistrationReferralsBlock makeover - Part 1

### DIFF
--- a/cypress/integration/voter-registration-referrals-block.js
+++ b/cypress/integration/voter-registration-referrals-block.js
@@ -151,7 +151,7 @@ describe('Voter Registration Referrals Block', () => {
     );
   });
 
-  it('Group displays group goal, group referrals count, and individual referrals count', () => {
+  it('Group displays group goal and group referrals count', () => {
     const user = userFactory();
     const group = groupFactory();
 
@@ -182,12 +182,6 @@ describe('Voter Registration Referrals Block', () => {
     cy.findAllByTestId('group-total')
       .get('h2')
       .contains(5);
-    cy.findAllByTestId('individual-total')
-      .get('span')
-      .contains('People you have registered');
-    cy.findAllByTestId('individual-total')
-      .get('h2')
-      .contains(12);
     cy.findAllByTestId('group-progress').contains(
       `${percentCompleted}% to your goal!`,
     );
@@ -210,7 +204,6 @@ describe('Voter Registration Referrals Block', () => {
 
     cy.findAllByTestId('group-goal').contains(50);
     cy.findAllByTestId('group-total').contains(15);
-    cy.findAllByTestId('individual-total').contains(0);
   });
 
   it('Group displays group progress if over the group goal', () => {

--- a/cypress/integration/voter-registration-referrals-block.js
+++ b/cypress/integration/voter-registration-referrals-block.js
@@ -34,7 +34,7 @@ describe('Voter Registration Referrals Block', () => {
     cy.mockGraphqlOp('ContentfulBlockQuery', contentfulBlockQueryResult);
   });
 
-  it('Individual displays help text if no referrals found', () => {
+  it('Displays help text if no referrals found', () => {
     const user = userFactory();
 
     cy.mockGraphqlOp('CampaignSignupQuery', {
@@ -62,7 +62,7 @@ describe('Voter Registration Referrals Block', () => {
     );
   });
 
-  it('Individual displays completed and started referrals', () => {
+  it('Displays completed and started referrals', () => {
     const user = userFactory();
     const firstCompletedReferralUser = userFactory();
     const secondCompletedReferralUser = userFactory();
@@ -115,7 +115,7 @@ describe('Voter Registration Referrals Block', () => {
     );
   });
 
-  it('Individual does not count incomplete referrals if completed exists for user', () => {
+  it('Does not count incomplete referrals if completed exists for user', () => {
     const user = userFactory();
     const firstCompletedReferralUser = userFactory();
     const secondCompletedReferralUser = userFactory();
@@ -151,7 +151,7 @@ describe('Voter Registration Referrals Block', () => {
     );
   });
 
-  it('Group displays group goal and group referrals count', () => {
+  it('Group signup displays group goal and group referrals count', () => {
     const user = userFactory();
     const group = groupFactory();
 
@@ -159,6 +159,12 @@ describe('Voter Registration Referrals Block', () => {
 
     cy.mockGraphqlOp('CampaignSignupQuery', {
       signups: [{ id: 11122016, group }],
+    });
+    cy.mockGraphqlOp('IndividualVoterRegistrationReferralsQuery', {
+      posts: [
+        voterRegPost(userFactory(), 'REGISTER_FORM'),
+        voterRegPost(userFactory(), 'REGISTER_OVR'),
+      ],
     });
     cy.mockGraphqlOp('GroupVoterRegistrationReferralsQuery', {
       voterRegistrationsCountByGroupId: 5,
@@ -185,9 +191,16 @@ describe('Voter Registration Referrals Block', () => {
     cy.findAllByTestId('group-progress').contains(
       `${percentCompleted}% to your goal!`,
     );
+    cy.findAllByTestId('referrals-count-description').contains(
+      'You have registered 2 people so far.',
+    );
+    cy.findAllByTestId('voter-registration-referral-completed').should(
+      'have.length',
+      2,
+    );
   });
 
-  it('Group displays group goal as 50 if not set on group', () => {
+  it('Group signup displays group goal as 50 if not set on group', () => {
     const user = userFactory();
     const group = groupFactory();
     group.goal = null;
@@ -206,7 +219,7 @@ describe('Voter Registration Referrals Block', () => {
     cy.findAllByTestId('group-total').contains(15);
   });
 
-  it('Group displays group progress if over the group goal', () => {
+  it('Group signup displays group progress if over the group goal', () => {
     const user = userFactory();
     const group = groupFactory();
     group.goal = 3;

--- a/resources/assets/components/blocks/VoterRegistrationReferralsBlock/VoterRegistrationReferralsBlock.js
+++ b/resources/assets/components/blocks/VoterRegistrationReferralsBlock/VoterRegistrationReferralsBlock.js
@@ -28,7 +28,7 @@ const VoterRegistrationReferralsBlock = ({ title }) => (
 
         return (
           <>
-            {signup && signup.groupId ? (
+            {signup && signup.group ? (
               <div className="pb-3">
                 <SectionHeader
                   title={`${signup.group.groupType.name}: ${signup.group.name}`}

--- a/resources/assets/components/blocks/VoterRegistrationReferralsBlock/VoterRegistrationReferralsBlock.js
+++ b/resources/assets/components/blocks/VoterRegistrationReferralsBlock/VoterRegistrationReferralsBlock.js
@@ -28,8 +28,16 @@ const VoterRegistrationReferralsBlock = ({ title }) => (
 
         return (
           <>
-            {signup && signup.group ? (
+            {signup && signup.groupId ? (
               <div className="pb-3">
+                <SectionHeader
+                  title={`${signup.group.groupType.name}: ${signup.group.name}`}
+                />
+
+                <p>
+                  Track how many people you and your group register to vote!
+                </p>
+
                 <GroupTemplate group={signup.group} />
               </div>
             ) : null}

--- a/resources/assets/components/blocks/VoterRegistrationReferralsBlock/VoterRegistrationReferralsBlock.js
+++ b/resources/assets/components/blocks/VoterRegistrationReferralsBlock/VoterRegistrationReferralsBlock.js
@@ -34,17 +34,21 @@ const VoterRegistrationReferralsBlock = ({ title }) => (
                   title={`${signup.group.groupType.name}: ${signup.group.name}`}
                 />
 
-                <p>
-                  Track how many people you and your group register to vote!
-                </p>
+                <div className="md:w-2/3">
+                  <p>
+                    Track how many people you and your group register to vote!
+                  </p>
 
-                <GroupTemplate group={signup.group} />
+                  <GroupTemplate group={signup.group} />
+                </div>
               </div>
             ) : null}
 
             {title ? <SectionHeader underlined title={title} /> : null}
 
-            <IndividualTemplate />
+            <div className="md:w-2/3">
+              <IndividualTemplate />
+            </div>
           </>
         );
       }}

--- a/resources/assets/components/blocks/VoterRegistrationReferralsBlock/VoterRegistrationReferralsBlock.js
+++ b/resources/assets/components/blocks/VoterRegistrationReferralsBlock/VoterRegistrationReferralsBlock.js
@@ -9,6 +9,7 @@ import {
 } from '../../../helpers/campaign';
 import GroupTemplate from './templates/Group';
 import IndividualTemplate from './templates/Individual';
+import SectionHeader from '../../utilities/SectionHeader/SectionHeader';
 
 export const VoterRegistrationReferralsBlockFragment = gql`
   fragment VoterRegistrationReferralsBlockFragment on VoterRegistrationReferralsBlock {
@@ -25,10 +26,18 @@ const VoterRegistrationReferralsBlock = ({ title }) => (
       {data => {
         const signup = data.signups[0];
 
-        return signup && signup.group ? (
-          <GroupTemplate group={signup.group} />
-        ) : (
-          <IndividualTemplate title={title} />
+        return (
+          <>
+            {signup && signup.group ? (
+              <div className="pb-3">
+                <GroupTemplate group={signup.group} />
+              </div>
+            ) : null}
+
+            {title ? <SectionHeader underlined title={title} /> : null}
+
+            <IndividualTemplate />
+          </>
         );
       }}
     </Query>

--- a/resources/assets/components/blocks/VoterRegistrationReferralsBlock/templates/Group.js
+++ b/resources/assets/components/blocks/VoterRegistrationReferralsBlock/templates/Group.js
@@ -5,7 +5,6 @@ import PropTypes from 'prop-types';
 import Query from '../../../Query';
 import { getUserId } from '../../../../helpers/auth';
 import ProgressBar from '../../../utilities/ProgressBar/ProgressBar';
-import SectionHeader from '../../../utilities/SectionHeader/SectionHeader';
 
 const GROUP_VOTER_REGISTRATION_REFERRALS_QUERY = gql`
   query GroupVoterRegistrationReferralsQuery(
@@ -57,13 +56,6 @@ const GroupTemplate = ({ group, isVertical, user }) => {
 
   return (
     <div data-testid="group-voter-registration-referrals-block">
-      {user ? null : (
-        <>
-          <SectionHeader title={groupDescription} />
-          <p>Track how many people you and your group register to vote!</p>
-        </>
-      )}
-
       <Query
         query={GROUP_VOTER_REGISTRATION_REFERRALS_QUERY}
         variables={{

--- a/resources/assets/components/blocks/VoterRegistrationReferralsBlock/templates/Group.js
+++ b/resources/assets/components/blocks/VoterRegistrationReferralsBlock/templates/Group.js
@@ -113,14 +113,14 @@ const GroupTemplate = ({ group, isVertical, user }) => {
                 testId="group-total"
               />
 
-              <StatBlock
-                amount={data.voterRegistrationsCountByReferrerUserId}
-                isVertical={isVertical}
-                label={`People ${
-                  user ? `${user.firstName} has` : 'you have'
-                } registered`}
-                testId="individual-total"
-              />
+              {user ? (
+                <StatBlock
+                  amount={data.voterRegistrationsCountByReferrerUserId}
+                  isVertical={isVertical}
+                  label={`People ${user.firstName} has registered`}
+                  testId="individual-total"
+                />
+              ) : null}
             </div>
           );
         }}

--- a/resources/assets/components/blocks/VoterRegistrationReferralsBlock/templates/Group.js
+++ b/resources/assets/components/blocks/VoterRegistrationReferralsBlock/templates/Group.js
@@ -69,7 +69,7 @@ const GroupTemplate = ({ group, isVertical, user }) => {
           const percentage = Math.round((groupTotal / groupGoal) * 100);
 
           return (
-            <div className={isVertical ? null : 'md:w-2/3'}>
+            <>
               <div data-testid="group-progress" className="py-3">
                 <span
                   className={`font-bold uppercase ${
@@ -110,7 +110,7 @@ const GroupTemplate = ({ group, isVertical, user }) => {
                   testId="individual-total"
                 />
               ) : null}
-            </div>
+            </>
           );
         }}
       </Query>

--- a/resources/assets/components/blocks/VoterRegistrationReferralsBlock/templates/Group.js
+++ b/resources/assets/components/blocks/VoterRegistrationReferralsBlock/templates/Group.js
@@ -6,6 +6,7 @@ import Query from '../../../Query';
 import { getUserId } from '../../../../helpers/auth';
 import ProgressBar from '../../../utilities/ProgressBar/ProgressBar';
 
+// TODO: We only need to query for referrer count on OVRD page.
 const GROUP_VOTER_REGISTRATION_REFERRALS_QUERY = gql`
   query GroupVoterRegistrationReferralsQuery(
     $groupId: Int!

--- a/resources/assets/components/blocks/VoterRegistrationReferralsBlock/templates/Group.js
+++ b/resources/assets/components/blocks/VoterRegistrationReferralsBlock/templates/Group.js
@@ -6,7 +6,6 @@ import Query from '../../../Query';
 import { getUserId } from '../../../../helpers/auth';
 import ProgressBar from '../../../utilities/ProgressBar/ProgressBar';
 
-// TODO: We only need to query for referrer count on OVRD page.
 const GROUP_VOTER_REGISTRATION_REFERRALS_QUERY = gql`
   query GroupVoterRegistrationReferralsQuery(
     $groupId: Int!

--- a/resources/assets/components/blocks/VoterRegistrationReferralsBlock/templates/Group.js
+++ b/resources/assets/components/blocks/VoterRegistrationReferralsBlock/templates/Group.js
@@ -56,10 +56,7 @@ const GroupTemplate = ({ group, isVertical, user }) => {
   const groupDescription = `${group.groupType.name}: ${group.name}`;
 
   return (
-    <div
-      data-testid="group-voter-registration-referrals-block"
-      className="mx-3"
-    >
+    <div data-testid="group-voter-registration-referrals-block">
       {user ? null : (
         <>
           <SectionHeader title={groupDescription} />

--- a/resources/assets/components/blocks/VoterRegistrationReferralsBlock/templates/Individual.js
+++ b/resources/assets/components/blocks/VoterRegistrationReferralsBlock/templates/Individual.js
@@ -57,21 +57,23 @@ const parseVoterRegistrationReferrals = voterRegPosts => {
 };
 
 const IndividualTemplate = () => (
-  <Query
-    query={INDIVIDUAL_VOTER_REGISTRATION_REFERRALS_QUERY}
-    variables={{ referrerUserId: getUserId() }}
-  >
-    {data => {
-      const parsed = parseVoterRegistrationReferrals(data.posts);
+  <div className="md:w-2/3">
+    <Query
+      query={INDIVIDUAL_VOTER_REGISTRATION_REFERRALS_QUERY}
+      variables={{ referrerUserId: getUserId() }}
+    >
+      {data => {
+        const parsed = parseVoterRegistrationReferrals(data.posts);
 
-      return (
-        <VoterRegistrationReferrals
-          completed={Object.values(parsed.complete)}
-          started={Object.values(parsed.incomplete)}
-        />
-      );
-    }}
-  </Query>
+        return (
+          <VoterRegistrationReferrals
+            completed={Object.values(parsed.complete)}
+            started={Object.values(parsed.incomplete)}
+          />
+        );
+      }}
+    </Query>
+  </div>
 );
 
 export default IndividualTemplate;

--- a/resources/assets/components/blocks/VoterRegistrationReferralsBlock/templates/Individual.js
+++ b/resources/assets/components/blocks/VoterRegistrationReferralsBlock/templates/Individual.js
@@ -5,7 +5,6 @@ import PropTypes from 'prop-types';
 import Query from '../../../Query';
 import { getUserId } from '../../../../helpers/auth';
 import VoterRegistrationReferrals from '../VoterRegistrationReferrals';
-import SectionHeader from '../../../utilities/SectionHeader/SectionHeader';
 
 const INDIVIDUAL_VOTER_REGISTRATION_REFERRALS_QUERY = gql`
   query IndividualVoterRegistrationReferralsQuery($referrerUserId: String!) {
@@ -58,35 +57,22 @@ const parseVoterRegistrationReferrals = voterRegPosts => {
   return result;
 };
 
-const IndividualTemplate = ({ title }) => (
-  <>
-    {title ? <SectionHeader underlined title={title} /> : null}
-    <Query
-      query={INDIVIDUAL_VOTER_REGISTRATION_REFERRALS_QUERY}
-      variables={{ referrerUserId: getUserId() }}
-    >
-      {data => {
-        const parsed = parseVoterRegistrationReferrals(data.posts);
+const IndividualTemplate = () => (
+  <Query
+    query={INDIVIDUAL_VOTER_REGISTRATION_REFERRALS_QUERY}
+    variables={{ referrerUserId: getUserId() }}
+  >
+    {data => {
+      const parsed = parseVoterRegistrationReferrals(data.posts);
 
-        return (
-          <div className="md:w-2/3">
-            <VoterRegistrationReferrals
-              completed={Object.values(parsed.complete)}
-              started={Object.values(parsed.incomplete)}
-            />
-          </div>
-        );
-      }}
-    </Query>
-  </>
+      return (
+        <VoterRegistrationReferrals
+          completed={Object.values(parsed.complete)}
+          started={Object.values(parsed.incomplete)}
+        />
+      );
+    }}
+  </Query>
 );
-
-IndividualTemplate.propTypes = {
-  title: PropTypes.string,
-};
-
-IndividualTemplate.defaultProps = {
-  title: null,
-};
 
 export default IndividualTemplate;

--- a/resources/assets/components/blocks/VoterRegistrationReferralsBlock/templates/Individual.js
+++ b/resources/assets/components/blocks/VoterRegistrationReferralsBlock/templates/Individual.js
@@ -57,23 +57,21 @@ const parseVoterRegistrationReferrals = voterRegPosts => {
 };
 
 const IndividualTemplate = () => (
-  <div className="md:w-2/3">
-    <Query
-      query={INDIVIDUAL_VOTER_REGISTRATION_REFERRALS_QUERY}
-      variables={{ referrerUserId: getUserId() }}
-    >
-      {data => {
-        const parsed = parseVoterRegistrationReferrals(data.posts);
+  <Query
+    query={INDIVIDUAL_VOTER_REGISTRATION_REFERRALS_QUERY}
+    variables={{ referrerUserId: getUserId() }}
+  >
+    {data => {
+      const parsed = parseVoterRegistrationReferrals(data.posts);
 
-        return (
-          <VoterRegistrationReferrals
-            completed={Object.values(parsed.complete)}
-            started={Object.values(parsed.incomplete)}
-          />
-        );
-      }}
-    </Query>
-  </div>
+      return (
+        <VoterRegistrationReferrals
+          completed={Object.values(parsed.complete)}
+          started={Object.values(parsed.incomplete)}
+        />
+      );
+    }}
+  </Query>
 );
 
 export default IndividualTemplate;

--- a/resources/assets/components/blocks/VoterRegistrationReferralsBlock/templates/Individual.js
+++ b/resources/assets/components/blocks/VoterRegistrationReferralsBlock/templates/Individual.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import gql from 'graphql-tag';
-import PropTypes from 'prop-types';
 
 import Query from '../../../Query';
 import { getUserId } from '../../../../helpers/auth';

--- a/resources/assets/helpers/campaign.js
+++ b/resources/assets/helpers/campaign.js
@@ -58,7 +58,6 @@ export const CAMPAIGN_SIGNUP_QUERY = gql`
   query CampaignSignupQuery($userId: String!, $campaignId: String!) {
     signups(userId: $userId, campaignId: $campaignId) {
       id
-      groupId
       group {
         id
         goal

--- a/resources/assets/helpers/campaign.js
+++ b/resources/assets/helpers/campaign.js
@@ -58,6 +58,7 @@ export const CAMPAIGN_SIGNUP_QUERY = gql`
   query CampaignSignupQuery($userId: String!, $campaignId: String!) {
     signups(userId: $userId, campaignId: $campaignId) {
       id
+      groupId
       group {
         id
         goal


### PR DESCRIPTION
### What's this PR do?

This pull request modifies the `VoterRegistrationReferralsBlock` per [requested design](https://www.pivotaltracker.com/story/show/173807000/comments/216293356) to display the individual template underneath the group template, if the block is being used on a groups campaign.

The design removes the individual's count of referrals from the group template, since the current user's referrals are now displayed underneath when used on an action page.

<img width="500" src="https://user-images.githubusercontent.com/1236811/88206234-cd9f6e00-cc02-11ea-901a-90c458af0423.png">


### How should this be reviewed?

👀 

### Any background context you want to provide?

Part 2 will entail refactoring the group template to be separate components, instead of using the `isVertical` prop and conditional logic -- which I think overcomplicates things for the sake of not repeating a few elements (and especially since we're now making an extra GraphQL query we don't need to when viewing the group template in the block, and not the OVRD page)

### Relevant tickets

References [Pivotal #173807000](https://www.pivotaltracker.com/story/show/173807000).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added screenshots of front-end changes on small, medium, and large screens.
- [ ] Added appropriate feature/unit tests.
