### PR TITLE
VoterRegistrationReferralsBlock makeover - Part 2

### DIFF
--- a/cypress/integration/voter-registration-drive-page.js
+++ b/cypress/integration/voter-registration-drive-page.js
@@ -22,7 +22,7 @@ const campaignWebsite = {
 const group = {
   id: faker.random.number(),
   name: faker.company.companyName(),
-  goal: faker.random.number(),
+  goal: null,
   groupType: {
     id: faker.random.number(),
     name: faker.company.companyName(),
@@ -313,7 +313,7 @@ describe('Voter Registration Drive (OVRD) Page', () => {
       group,
     });
     cy.mockGraphqlOp('VoterRegistrationDrivePageReferralsQuery', {
-      voterRegistrationsCountByGroupId: 31,
+      voterRegistrationsCountByGroupId: 25,
       voterRegistrationsCountByReferrerUserId: 8,
     });
 
@@ -328,6 +328,9 @@ describe('Voter Registration Drive (OVRD) Page', () => {
       'have.length',
       1,
     );
+    cy.findByTestId('group-progress')
+      .get('span')
+      .contains('50% to your goal');
     cy.findByTestId('group-goal')
       .get('span')
       .contains(`${groupDescription} registration goal`);
@@ -336,7 +339,7 @@ describe('Voter Registration Drive (OVRD) Page', () => {
       .contains(`People ${groupDescription} has registered`);
     cy.findByTestId('group-total')
       .get('h2')
-      .contains(31);
+      .contains(25);
     cy.findByTestId('individual-total')
       .get('span')
       .contains(`People ${user.firstName} has registered`);

--- a/cypress/integration/voter-registration-drive-page.js
+++ b/cypress/integration/voter-registration-drive-page.js
@@ -156,7 +156,7 @@ describe('Voter Registration Drive (OVRD) Page', () => {
       1,
     );
     cy.findByTestId('campaign-info-block-container').should('have.length', 1);
-    cy.findByTestId('group-voter-registration-referrals-block').should(
+    cy.findByTestId('voter-registration-drive-page-referrals-info').should(
       'have.length',
       0,
     );
@@ -312,7 +312,7 @@ describe('Voter Registration Drive (OVRD) Page', () => {
       campaignWebsite,
       group,
     });
-    cy.mockGraphqlOp('GroupVoterRegistrationReferralsQuery', {
+    cy.mockGraphqlOp('VoterRegistrationDrivePageReferralsQuery', {
       voterRegistrationsCountByGroupId: 31,
       voterRegistrationsCountByReferrerUserId: 8,
     });
@@ -324,7 +324,7 @@ describe('Voter Registration Drive (OVRD) Page', () => {
       `user:${user.id},source:web,source_details:onlinedrivereferral,group_id=${group.id},referral=true`,
     );
     cy.findByTestId('campaign-info-block-container').should('have.length', 0);
-    cy.findByTestId('group-voter-registration-referrals-block').should(
+    cy.findByTestId('voter-registration-drive-page-referrals-info').should(
       'have.length',
       1,
     );

--- a/resources/assets/components/blocks/VoterRegistrationReferralsBlock/GroupReferrals.js
+++ b/resources/assets/components/blocks/VoterRegistrationReferralsBlock/GroupReferrals.js
@@ -3,9 +3,9 @@ import tw from 'twin.macro';
 import gql from 'graphql-tag';
 import PropTypes from 'prop-types';
 
-import Query from '../../../Query';
-import { getGoalInfo } from '../../../../helpers/voter-registration';
-import ProgressBar from '../../../utilities/ProgressBar/ProgressBar';
+import Query from '../../Query';
+import { getGoalInfo } from '../../../helpers/voter-registration';
+import ProgressBar from '../../utilities/ProgressBar/ProgressBar';
 
 const GROUP_VOTER_REGISTRATION_REFERRALS_QUERY = gql`
   query GroupVoterRegistrationReferralsQuery($groupId: Int!) {
@@ -16,7 +16,7 @@ const GROUP_VOTER_REGISTRATION_REFERRALS_QUERY = gql`
 const StatLabel = tw.span`font-bold uppercase text-gray-600`;
 const StatAmount = tw.h2`font-normal font-league-gothic text-3xl`;
 
-const GroupTemplate = ({ group }) => (
+const GroupReferrals = ({ group }) => (
   <Query
     query={GROUP_VOTER_REGISTRATION_REFERRALS_QUERY}
     variables={{ groupId: group.id }}
@@ -55,11 +55,11 @@ const GroupTemplate = ({ group }) => (
   </Query>
 );
 
-GroupTemplate.propTypes = {
+GroupReferrals.propTypes = {
   group: PropTypes.shape({
     goal: PropTypes.number,
     id: PropTypes.number,
   }).isRequired,
 };
 
-export default GroupTemplate;
+export default GroupReferrals;

--- a/resources/assets/components/blocks/VoterRegistrationReferralsBlock/IndividualReferrals.js
+++ b/resources/assets/components/blocks/VoterRegistrationReferralsBlock/IndividualReferrals.js
@@ -1,9 +1,9 @@
 import React from 'react';
 import gql from 'graphql-tag';
 
-import Query from '../../../Query';
-import { getUserId } from '../../../../helpers/auth';
-import VoterRegistrationReferrals from '../VoterRegistrationReferrals';
+import Query from '../../Query';
+import { getUserId } from '../../../helpers/auth';
+import VoterRegistrationReferrals from './VoterRegistrationReferrals';
 
 const INDIVIDUAL_VOTER_REGISTRATION_REFERRALS_QUERY = gql`
   query IndividualVoterRegistrationReferralsQuery($referrerUserId: String!) {
@@ -56,7 +56,7 @@ const parseVoterRegistrationReferrals = voterRegPosts => {
   return result;
 };
 
-const IndividualTemplate = () => (
+const IndividualReferrals = () => (
   <Query
     query={INDIVIDUAL_VOTER_REGISTRATION_REFERRALS_QUERY}
     variables={{ referrerUserId: getUserId() }}
@@ -74,4 +74,4 @@ const IndividualTemplate = () => (
   </Query>
 );
 
-export default IndividualTemplate;
+export default IndividualReferrals;

--- a/resources/assets/components/blocks/VoterRegistrationReferralsBlock/VoterRegistrationReferralsBlock.js
+++ b/resources/assets/components/blocks/VoterRegistrationReferralsBlock/VoterRegistrationReferralsBlock.js
@@ -7,8 +7,8 @@ import {
   CAMPAIGN_SIGNUP_QUERY,
   getCampaignSignupQueryVariables,
 } from '../../../helpers/campaign';
-import GroupTemplate from './templates/Group';
-import IndividualTemplate from './templates/Individual';
+import GroupReferrals from './GroupReferrals';
+import IndividualReferrals from './IndividualReferrals';
 import SectionHeader from '../../utilities/SectionHeader/SectionHeader';
 
 export const VoterRegistrationReferralsBlockFragment = gql`
@@ -39,7 +39,7 @@ const VoterRegistrationReferralsBlock = ({ title }) => (
                     Track how many people you and your group register to vote!
                   </p>
 
-                  <GroupTemplate group={signup.group} />
+                  <GroupReferrals group={signup.group} />
                 </div>
               </div>
             ) : null}
@@ -47,7 +47,7 @@ const VoterRegistrationReferralsBlock = ({ title }) => (
             {title ? <SectionHeader underlined title={title} /> : null}
 
             <div className="md:w-2/3">
-              <IndividualTemplate />
+              <IndividualReferrals />
             </div>
           </>
         );

--- a/resources/assets/components/blocks/VoterRegistrationReferralsBlock/templates/Group.js
+++ b/resources/assets/components/blocks/VoterRegistrationReferralsBlock/templates/Group.js
@@ -3,113 +3,66 @@ import gql from 'graphql-tag';
 import PropTypes from 'prop-types';
 
 import Query from '../../../Query';
-import { getUserId } from '../../../../helpers/auth';
+import { getGoalInfo } from '../../../../helpers/voter-registration';
 import ProgressBar from '../../../utilities/ProgressBar/ProgressBar';
 
 const GROUP_VOTER_REGISTRATION_REFERRALS_QUERY = gql`
-  query GroupVoterRegistrationReferralsQuery(
-    $groupId: Int!
-    $referrerUserId: String!
-  ) {
+  query GroupVoterRegistrationReferralsQuery($groupId: Int!) {
     voterRegistrationsCountByGroupId(groupId: $groupId)
-    voterRegistrationsCountByReferrerUserId(referrerUserId: $referrerUserId)
   }
 `;
 
-const StatBlock = ({ amount, isVertical, label, testId }) => (
-  <div
-    className={`pt-3 ${
-      isVertical ? 'pb-3 flex flex-row-reverse items-center' : null
-    }`}
-    data-testid={testId}
-  >
-    <span
-      className={`font-bold uppercase text-gray-600 ${
-        isVertical ? 'w-3/4' : ''
-      }`}
-    >
-      {label}
-    </span>
+const StatBlock = ({ amount, label, testId }) => (
+  <div className="pt-3" data-testid={testId}>
+    <span className="font-bold uppercase text-gray-600">{label}</span>
 
-    <h2
-      className={`font-normal font-league-gothic text-3xl ${
-        isVertical ? ' w-1/4 mb-0' : ''
-      }`}
-    >
-      {amount}
-    </h2>
+    <h2 className="font-normal font-league-gothic text-3xl">{amount}</h2>
   </div>
 );
 
 StatBlock.propTypes = {
   amount: PropTypes.number.isRequired,
-  isVertical: PropTypes.bool.isRequired,
   label: PropTypes.string.isRequired,
   testId: PropTypes.string.isRequired,
 };
 
-/**
- * If a user is provided, display that user's referrals, else user is the authenticated user.
- */
-const GroupTemplate = ({ group, isVertical, user }) => {
+const GroupTemplate = ({ group }) => {
   const groupDescription = `${group.groupType.name}: ${group.name}`;
 
   return (
     <div data-testid="group-voter-registration-referrals-block">
       <Query
         query={GROUP_VOTER_REGISTRATION_REFERRALS_QUERY}
-        variables={{
-          groupId: group.id,
-          referrerUserId: user ? user.id : getUserId(),
-        }}
+        variables={{ groupId: group.id }}
       >
         {data => {
-          const groupGoal = group.goal || 50;
           const groupTotal = data.voterRegistrationsCountByGroupId;
-          const percentage = Math.round((groupTotal / groupGoal) * 100);
+          const { goal, percentage, description } = getGoalInfo(
+            group.goal,
+            groupTotal,
+          );
 
           return (
             <>
               <div data-testid="group-progress" className="py-3">
-                <span
-                  className={`font-bold uppercase ${
-                    isVertical ? 'text-lg' : 'text-gray-600'
-                  }`}
-                >
-                  {percentage > 100
-                    ? `🎉 You're at ${percentage}% of your goal! 🎉`
-                    : `${percentage}% to your goal!`}
+                <span className="font-bold uppercase text-gray-600">
+                  {description}
                 </span>
 
                 <ProgressBar percentage={percentage} />
               </div>
 
               <StatBlock
-                amount={groupGoal}
-                isVertical={isVertical}
-                label={`${
-                  user ? groupDescription : 'Your group’s'
-                } registration goal`}
+                amount={goal}
+                label="Your group’s registration goal"
                 testId="group-goal"
               />
 
               <StatBlock
                 amount={groupTotal}
-                isVertical={isVertical}
-                label={`People ${
-                  user ? groupDescription : 'your group'
-                } has registered`}
+                label="People your group has registered"
                 testId="group-total"
               />
-
-              {user ? (
-                <StatBlock
-                  amount={data.voterRegistrationsCountByReferrerUserId}
-                  isVertical={isVertical}
-                  label={`People ${user.firstName} has registered`}
-                  testId="individual-total"
-                />
-              ) : null}
             </>
           );
         }}

--- a/resources/assets/components/blocks/VoterRegistrationReferralsBlock/templates/Group.js
+++ b/resources/assets/components/blocks/VoterRegistrationReferralsBlock/templates/Group.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import tw from 'twin.macro';
 import gql from 'graphql-tag';
 import PropTypes from 'prop-types';
 
@@ -12,59 +13,46 @@ const GROUP_VOTER_REGISTRATION_REFERRALS_QUERY = gql`
   }
 `;
 
-const StatBlock = ({ amount, label, testId }) => (
-  <div className="pt-3" data-testid={testId}>
-    <span className="font-bold uppercase text-gray-600">{label}</span>
-
-    <h2 className="font-normal font-league-gothic text-3xl">{amount}</h2>
-  </div>
-);
-
-StatBlock.propTypes = {
-  amount: PropTypes.number.isRequired,
-  label: PropTypes.string.isRequired,
-  testId: PropTypes.string.isRequired,
-};
+const StatLabel = tw.span`font-bold uppercase text-gray-600`;
+const StatAmount = tw.h2`font-normal font-league-gothic text-3xl`;
 
 const GroupTemplate = ({ group }) => (
-  <div data-testid="group-voter-registration-referrals-block">
-    <Query
-      query={GROUP_VOTER_REGISTRATION_REFERRALS_QUERY}
-      variables={{ groupId: group.id }}
-    >
-      {data => {
-        const groupTotal = data.voterRegistrationsCountByGroupId;
-        const { goal, percentage, description } = getGoalInfo(
-          group.goal,
-          groupTotal,
-        );
+  <Query
+    query={GROUP_VOTER_REGISTRATION_REFERRALS_QUERY}
+    variables={{ groupId: group.id }}
+  >
+    {data => {
+      const groupTotal = data.voterRegistrationsCountByGroupId;
+      const { goal, percentage, description } = getGoalInfo(
+        group.goal,
+        groupTotal,
+      );
 
-        return (
-          <>
-            <div data-testid="group-progress" className="py-3">
-              <span className="font-bold uppercase text-gray-600">
-                {description}
-              </span>
+      return (
+        <div data-testid="group-voter-registration-referrals-block">
+          <div data-testid="group-progress" className="py-3">
+            <span className="font-bold uppercase text-gray-600">
+              {description}
+            </span>
 
-              <ProgressBar percentage={percentage} />
-            </div>
+            <ProgressBar percentage={percentage} />
+          </div>
 
-            <StatBlock
-              amount={goal}
-              label="Your group’s registration goal"
-              testId="group-goal"
-            />
+          <div className="pt-3" data-testid="group-goal">
+            <StatLabel>Your group’s registration goal</StatLabel>
 
-            <StatBlock
-              amount={groupTotal}
-              label="People your group has registered"
-              testId="group-total"
-            />
-          </>
-        );
-      }}
-    </Query>
-  </div>
+            <StatAmount>{goal}</StatAmount>
+          </div>
+
+          <div className="pt-3" data-testid="group-total">
+            <StatLabel>People your group has registered</StatLabel>
+
+            <StatAmount>{groupTotal}</StatAmount>
+          </div>
+        </div>
+      );
+    }}
+  </Query>
 );
 
 GroupTemplate.propTypes = {

--- a/resources/assets/components/blocks/VoterRegistrationReferralsBlock/templates/Group.js
+++ b/resources/assets/components/blocks/VoterRegistrationReferralsBlock/templates/Group.js
@@ -26,70 +26,52 @@ StatBlock.propTypes = {
   testId: PropTypes.string.isRequired,
 };
 
-const GroupTemplate = ({ group }) => {
-  const groupDescription = `${group.groupType.name}: ${group.name}`;
+const GroupTemplate = ({ group }) => (
+  <div data-testid="group-voter-registration-referrals-block">
+    <Query
+      query={GROUP_VOTER_REGISTRATION_REFERRALS_QUERY}
+      variables={{ groupId: group.id }}
+    >
+      {data => {
+        const groupTotal = data.voterRegistrationsCountByGroupId;
+        const { goal, percentage, description } = getGoalInfo(
+          group.goal,
+          groupTotal,
+        );
 
-  return (
-    <div data-testid="group-voter-registration-referrals-block">
-      <Query
-        query={GROUP_VOTER_REGISTRATION_REFERRALS_QUERY}
-        variables={{ groupId: group.id }}
-      >
-        {data => {
-          const groupTotal = data.voterRegistrationsCountByGroupId;
-          const { goal, percentage, description } = getGoalInfo(
-            group.goal,
-            groupTotal,
-          );
+        return (
+          <>
+            <div data-testid="group-progress" className="py-3">
+              <span className="font-bold uppercase text-gray-600">
+                {description}
+              </span>
 
-          return (
-            <>
-              <div data-testid="group-progress" className="py-3">
-                <span className="font-bold uppercase text-gray-600">
-                  {description}
-                </span>
+              <ProgressBar percentage={percentage} />
+            </div>
 
-                <ProgressBar percentage={percentage} />
-              </div>
+            <StatBlock
+              amount={goal}
+              label="Your group’s registration goal"
+              testId="group-goal"
+            />
 
-              <StatBlock
-                amount={goal}
-                label="Your group’s registration goal"
-                testId="group-goal"
-              />
-
-              <StatBlock
-                amount={groupTotal}
-                label="People your group has registered"
-                testId="group-total"
-              />
-            </>
-          );
-        }}
-      </Query>
-    </div>
-  );
-};
+            <StatBlock
+              amount={groupTotal}
+              label="People your group has registered"
+              testId="group-total"
+            />
+          </>
+        );
+      }}
+    </Query>
+  </div>
+);
 
 GroupTemplate.propTypes = {
   group: PropTypes.shape({
     goal: PropTypes.number,
-    groupType: PropTypes.shape({
-      name: PropTypes.string,
-    }),
     id: PropTypes.number,
-    name: PropTypes.string,
   }).isRequired,
-  isVertical: PropTypes.bool,
-  user: PropTypes.shape({
-    id: PropTypes.string,
-    firstName: PropTypes.string,
-  }),
-};
-
-GroupTemplate.defaultProps = {
-  isVertical: false,
-  user: null,
 };
 
 export default GroupTemplate;

--- a/resources/assets/components/pages/VoterRegistrationDrivePage/ReferralsInfo.js
+++ b/resources/assets/components/pages/VoterRegistrationDrivePage/ReferralsInfo.js
@@ -25,55 +25,51 @@ const ReferralsInfo = ({ group, user }) => {
   const groupLabel = `${group.groupType.name}: ${group.name}`;
 
   return (
-    <div data-testid="voter-registration-drive-page-referrals-info">
-      <Query
-        query={VOTER_REGISTRATION_DRIVE_PAGE_REFERRALS_QUERY}
-        variables={{
-          groupId: group.id,
-          referrerUserId: user.id,
-        }}
-      >
-        {data => {
-          const groupTotal = data.voterRegistrationsCountByGroupId;
-          const { goal, percentage, description } = getGoalInfo(
-            group.goal,
-            groupTotal,
-          );
+    <Query
+      query={VOTER_REGISTRATION_DRIVE_PAGE_REFERRALS_QUERY}
+      variables={{
+        groupId: group.id,
+        referrerUserId: user.id,
+      }}
+    >
+      {data => {
+        const groupTotal = data.voterRegistrationsCountByGroupId;
+        const { goal, percentage, description } = getGoalInfo(
+          group.goal,
+          groupTotal,
+        );
 
-          return (
-            <>
-              <div data-testid="group-progress" className="py-3">
-                <span className="font-bold uppercase text-lg">
-                  {description}
-                </span>
+        return (
+          <div data-testid="voter-registration-drive-page-referrals-info">
+            <div data-testid="group-progress" className="py-3">
+              <span className="font-bold uppercase text-lg">{description}</span>
 
-                <ProgressBar percentage={percentage} />
-              </div>
+              <ProgressBar percentage={percentage} />
+            </div>
 
-              <div data-testid="group-goal" className={statClassName}>
-                <StatAmount>{goal}</StatAmount>
+            <div data-testid="group-goal" className={statClassName}>
+              <StatAmount>{goal}</StatAmount>
 
-                <StatLabel>{groupLabel} registration goal</StatLabel>
-              </div>
+              <StatLabel>{groupLabel} registration goal</StatLabel>
+            </div>
 
-              <div data-testid="group-total" className={statClassName}>
-                <StatAmount>{groupTotal}</StatAmount>
+            <div data-testid="group-total" className={statClassName}>
+              <StatAmount>{groupTotal}</StatAmount>
 
-                <StatLabel>People {groupLabel} has registered</StatLabel>
-              </div>
+              <StatLabel>People {groupLabel} has registered</StatLabel>
+            </div>
 
-              <div data-testid="individual-total" className={statClassName}>
-                <StatAmount>
-                  {data.voterRegistrationsCountByReferrerUserId}
-                </StatAmount>
+            <div data-testid="individual-total" className={statClassName}>
+              <StatAmount>
+                {data.voterRegistrationsCountByReferrerUserId}
+              </StatAmount>
 
-                <StatLabel>People {user.firstName} has registered</StatLabel>
-              </div>
-            </>
-          );
-        }}
-      </Query>
-    </div>
+              <StatLabel>People {user.firstName} has registered</StatLabel>
+            </div>
+          </div>
+        );
+      }}
+    </Query>
   );
 };
 

--- a/resources/assets/components/pages/VoterRegistrationDrivePage/ReferralsInfo.js
+++ b/resources/assets/components/pages/VoterRegistrationDrivePage/ReferralsInfo.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import tw from 'twin.macro';
 import gql from 'graphql-tag';
 import PropTypes from 'prop-types';
 
@@ -16,27 +17,12 @@ const VOTER_REGISTRATION_DRIVE_PAGE_REFERRALS_QUERY = gql`
   }
 `;
 
-const StatBlock = ({ amount, label, testId }) => (
-  <div
-    className="pt-3 pb-3 flex flex-row-reverse items-center'"
-    data-testid={testId}
-  >
-    <span className="font-bold uppercase text-gray-600 w-3/4">{label}</span>
-
-    <h2 className="font-normal font-league-gothic text-3xl w-1/4 mb-0">
-      {amount}
-    </h2>
-  </div>
-);
-
-StatBlock.propTypes = {
-  amount: PropTypes.number.isRequired,
-  label: PropTypes.string.isRequired,
-  testId: PropTypes.string.isRequired,
-};
+const statClassName = 'pt-3 pb-3 flex items-center';
+const StatLabel = tw.span`font-bold uppercase text-gray-600 w-3/4`;
+const StatAmount = tw.h2`font-normal font-league-gothic text-3xl w-1/4 mb-0`;
 
 const ReferralsInfo = ({ group, user }) => {
-  const groupDescription = `${group.groupType.name}: ${group.name}`;
+  const groupLabel = `${group.groupType.name}: ${group.name}`;
 
   return (
     <div data-testid="voter-registration-drive-page-referrals-info">
@@ -64,23 +50,25 @@ const ReferralsInfo = ({ group, user }) => {
                 <ProgressBar percentage={percentage} />
               </div>
 
-              <StatBlock
-                amount={goal}
-                label={`${groupDescription} registration goal`}
-                testId="group-goal"
-              />
+              <div data-testid="group-goal" className={statClassName}>
+                <StatAmount>{goal}</StatAmount>
 
-              <StatBlock
-                amount={groupTotal}
-                label={`People ${groupDescription} has registered`}
-                testId="group-total"
-              />
+                <StatLabel>{groupLabel} registration goal</StatLabel>
+              </div>
 
-              <StatBlock
-                amount={data.voterRegistrationsCountByReferrerUserId}
-                label={`People ${user.firstName} has registered`}
-                testId="individual-total"
-              />
+              <div data-testid="group-total" className={statClassName}>
+                <StatAmount>{groupTotal}</StatAmount>
+
+                <StatLabel>People {groupLabel} has registered</StatLabel>
+              </div>
+
+              <div data-testid="individual-total" className={statClassName}>
+                <StatAmount>
+                  {data.voterRegistrationsCountByReferrerUserId}
+                </StatAmount>
+
+                <StatLabel>People {user.firstName} has registered</StatLabel>
+              </div>
             </>
           );
         }}

--- a/resources/assets/components/pages/VoterRegistrationDrivePage/ReferralsInfo.js
+++ b/resources/assets/components/pages/VoterRegistrationDrivePage/ReferralsInfo.js
@@ -1,0 +1,107 @@
+import React from 'react';
+import gql from 'graphql-tag';
+import PropTypes from 'prop-types';
+
+import Query from '../../Query';
+import { getGoalInfo } from '../../../helpers/voter-registration';
+import ProgressBar from '../../utilities/ProgressBar/ProgressBar';
+
+const VOTER_REGISTRATION_DRIVE_PAGE_REFERRALS_QUERY = gql`
+  query VoterRegistrationDrivePageReferralsQuery(
+    $groupId: Int!
+    $referrerUserId: String!
+  ) {
+    voterRegistrationsCountByGroupId(groupId: $groupId)
+    voterRegistrationsCountByReferrerUserId(referrerUserId: $referrerUserId)
+  }
+`;
+
+const StatBlock = ({ amount, label, testId }) => (
+  <div
+    className="pt-3 pb-3 flex flex-row-reverse items-center'"
+    data-testid={testId}
+  >
+    <span className="font-bold uppercase text-gray-600 w-3/4">{label}</span>
+
+    <h2 className="font-normal font-league-gothic text-3xl w-1/4 mb-0">
+      {amount}
+    </h2>
+  </div>
+);
+
+StatBlock.propTypes = {
+  amount: PropTypes.number.isRequired,
+  label: PropTypes.string.isRequired,
+  testId: PropTypes.string.isRequired,
+};
+
+const ReferralsInfo = ({ group, user }) => {
+  const groupDescription = `${group.groupType.name}: ${group.name}`;
+
+  return (
+    <div data-testid="voter-registration-drive-page-referrals-info">
+      <Query
+        query={VOTER_REGISTRATION_DRIVE_PAGE_REFERRALS_QUERY}
+        variables={{
+          groupId: group.id,
+          referrerUserId: user.id,
+        }}
+      >
+        {data => {
+          const groupTotal = data.voterRegistrationsCountByGroupId;
+          const { goal, percentage, description } = getGoalInfo(
+            group.goal,
+            groupTotal,
+          );
+
+          return (
+            <>
+              <div data-testid="group-progress" className="py-3">
+                <span className="font-bold uppercase text-lg">
+                  {description}
+                </span>
+
+                <ProgressBar percentage={percentage} />
+              </div>
+
+              <StatBlock
+                amount={goal}
+                label={`${groupDescription} registration goal`}
+                testId="group-goal"
+              />
+
+              <StatBlock
+                amount={groupTotal}
+                label={`People ${groupDescription} has registered`}
+                testId="group-total"
+              />
+
+              <StatBlock
+                amount={data.voterRegistrationsCountByReferrerUserId}
+                label={`People ${user.firstName} has registered`}
+                testId="individual-total"
+              />
+            </>
+          );
+        }}
+      </Query>
+    </div>
+  );
+};
+
+ReferralsInfo.propTypes = {
+  group: PropTypes.shape({
+    goal: PropTypes.number,
+    groupType: PropTypes.shape({
+      name: PropTypes.string,
+    }),
+    id: PropTypes.number,
+    name: PropTypes.string,
+  }).isRequired,
+  user: PropTypes.shape({
+    id: PropTypes.string,
+    firstName: PropTypes.string,
+  }).isRequired,
+};
+
+export default ReferralsInfo;

--- a/resources/assets/components/pages/VoterRegistrationDrivePage/VoterRegistrationDrivePageBanner.js
+++ b/resources/assets/components/pages/VoterRegistrationDrivePage/VoterRegistrationDrivePageBanner.js
@@ -3,10 +3,10 @@ import PropTypes from 'prop-types';
 
 import { votingReasons } from './config';
 import { query } from '../../../helpers';
+import ReferralsInfo from './ReferralsInfo';
 import CampaignHeader from '../../utilities/CampaignHeader';
 import CoverImage from '../../utilities/CoverImage/CoverImage';
 import CampaignInfoBlock from '../../blocks/CampaignInfoBlock/CampaignInfoBlock';
-import GroupTemplate from '../../blocks/VoterRegistrationReferralsBlock/templates/Group';
 
 const VoterRegistrationDrivePageBanner = ({
   campaignInfo,
@@ -102,7 +102,7 @@ const VoterRegistrationDrivePageBanner = ({
 
           <div className="grid-wide-3/10 mb-6 xxl:row-start-1 xxl:row-span-3">
             {group ? (
-              <GroupTemplate group={group} isVertical user={user} />
+              <ReferralsInfo group={group} user={user} />
             ) : (
               <CampaignInfoBlock
                 campaignId={campaignId}

--- a/resources/assets/helpers/voter-registration.js
+++ b/resources/assets/helpers/voter-registration.js
@@ -1,0 +1,20 @@
+/**
+ * Returns percentage completed and corresponding label.
+ *
+ * @param {Number} goalAmount
+ * @param {Number} completedAmount
+ * @return {Object}
+ */
+export function getGoalInfo(goalAmount, completedAmount) {
+  const goal = goalAmount || 50;
+  const percentage = Math.round((completedAmount / goal) * 100);
+
+  return {
+    goal,
+    percentage,
+    description:
+      percentage > 100
+        ? `🎉 You're at ${percentage}% of your goal! 🎉`
+        : `${percentage}% to your goal!`,
+  };
+}

--- a/resources/assets/helpers/voter-registration.js
+++ b/resources/assets/helpers/voter-registration.js
@@ -18,3 +18,5 @@ export function getGoalInfo(goalAmount, completedAmount) {
         : `${percentage}% to your goal!`,
   };
 }
+
+export { getGoalInfo as default };


### PR DESCRIPTION
### What's this PR do?

As advertised in Part 1 (#2291), this pull request splits the group template of the `VoterRegistrationReferralsBlock` into two different components:

* `blocks/VoterRegistrationReferralsBlock/GroupReferrals.js` -- used by the `VoterRegistrationReferralsBlock` on a campaign action page if the campaign is a groups campaign. This component now uses a separate GraphQL query, as we only need to display the registration count for the group, and not the individual

* `pages/VoterRegistrationDrivePage/ReferralsInfo.js` -- used within the OVRD page banner if a `group_id` query parameter exists, to display registration count for the group and referrer (as the previous group template did)

It also adds a new `voter-registration` helper to DRY getting a group's goal percentage amount and description.

There are no UI changes, this PR is to simplify the complexity introduced in #2253, #2290.

### How should this be reviewed?

👀 

### Any background context you want to provide?

Holding off on adding unit tests for the new helper and documentation updates to hopefully keep this easier to review. Will open a final Part3 PR to finalize these changes with docs.

### Relevant tickets

References [Pivotal #173807000](https://www.pivotaltracker.com/n/projects/2417735/stories/173807000).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added screenshots of front-end changes on small, medium, and large screens.
- [x] Added appropriate feature/unit tests.
