### PR TITLE
Add Link to Groups Campaign Page on Beta OVRD page

### DIFF
--- a/resources/assets/components/pages/VoterRegistrationDrivePage/GroupTypeLink.js
+++ b/resources/assets/components/pages/VoterRegistrationDrivePage/GroupTypeLink.js
@@ -61,6 +61,8 @@ const GroupTypeLink = ({ group }) => {
           ) : (
             <a
               href={groupCampaignPath}
+              target="_blank"
+              rel="noopener noreferrer"
               data-test="voter-registration-drive-page-group-campaign-link"
             >
               What&lsquo;s {group.groupType.name}?

--- a/resources/assets/components/pages/VoterRegistrationDrivePage/GroupTypeLink.js
+++ b/resources/assets/components/pages/VoterRegistrationDrivePage/GroupTypeLink.js
@@ -1,0 +1,84 @@
+import React from 'react';
+import { get } from 'lodash';
+import gql from 'graphql-tag';
+import PropTypes from 'prop-types';
+import { useQuery } from '@apollo/react-hooks';
+
+import ErrorBlock from '../../blocks/ErrorBlock/ErrorBlock';
+import PlaceholderText from '../../utilities/PlaceholderText/PlaceholderText';
+
+const GROUPS_CAMPAIGN_QUERY = gql`
+  query GroupsCampaignQuery($groupTypeId: Int!, $causes: [String]) {
+    campaigns(groupTypeId: $groupTypeId, causes: $causes) {
+      id
+    }
+  }
+`;
+
+const GROUPS_CAMPAIGN_WEBSITE_QUERY = gql`
+  query GroupsCampaignWebsiteQuery($campaignId: String!) {
+    campaignWebsiteByCampaignId(campaignId: $campaignId) {
+      id
+      path
+      url
+    }
+  }
+`;
+
+const GroupTypeLink = ({ group }) => {
+  const { loading, error, data } = useQuery(GROUPS_CAMPAIGN_QUERY, {
+    variables: {
+      groupTypeId: get(group, 'groupType.id'),
+      causes: ['voter-registration'],
+    },
+  });
+  const groupTypeCampaignId = get(data, 'campaigns[0].id', null);
+
+  const {
+    loading: campaignWebsiteLoading,
+    error: campaignWebsiteError,
+    data: campaignWebsiteData,
+  } = useQuery(GROUPS_CAMPAIGN_WEBSITE_QUERY, {
+    skip: groupTypeCampaignId == null,
+    variables: {
+      campaignId: String(groupTypeCampaignId),
+    },
+  });
+  const groupCampaignPath = get(
+    campaignWebsiteData,
+    'campaignWebsiteByCampaignId.path',
+    null,
+  );
+
+  return (
+    <>
+      {error || campaignWebsiteError ? (
+        <ErrorBlock error={error || campaignWebsiteError} />
+      ) : (
+        <div className="mt-3">
+          {loading || campaignWebsiteLoading ? (
+            <PlaceholderText size="medium" />
+          ) : (
+            <a
+              href={groupCampaignPath}
+              data-test="voter-registration-drive-page-group-campaign-link"
+            >
+              What&lsquo;s {group.groupType.name}?
+            </a>
+          )}
+        </div>
+      )}
+    </>
+  );
+};
+
+GroupTypeLink.propTypes = {
+  group: PropTypes.shape({
+    groupType: PropTypes.shape({
+      id: PropTypes.number,
+      name: PropTypes.string,
+    }),
+  }).isRequired,
+};
+
+export default GroupTypeLink;

--- a/resources/assets/components/pages/VoterRegistrationDrivePage/GroupTypeLink.js
+++ b/resources/assets/components/pages/VoterRegistrationDrivePage/GroupTypeLink.js
@@ -25,10 +25,10 @@ const GROUPS_CAMPAIGN_WEBSITE_QUERY = gql`
   }
 `;
 
-const GroupTypeLink = ({ group }) => {
+const GroupTypeLink = ({ id, name }) => {
   const { loading, error, data } = useQuery(GROUPS_CAMPAIGN_QUERY, {
     variables: {
-      groupTypeId: get(group, 'groupType.id'),
+      groupTypeId: id,
       causes: ['voter-registration'],
     },
   });
@@ -65,7 +65,7 @@ const GroupTypeLink = ({ group }) => {
               rel="noopener noreferrer"
               data-test="voter-registration-drive-page-group-campaign-link"
             >
-              What&lsquo;s {group.groupType.name}?
+              What&lsquo;s {name}?
             </a>
           )}
         </div>
@@ -75,12 +75,8 @@ const GroupTypeLink = ({ group }) => {
 };
 
 GroupTypeLink.propTypes = {
-  group: PropTypes.shape({
-    groupType: PropTypes.shape({
-      id: PropTypes.number,
-      name: PropTypes.string,
-    }),
-  }).isRequired,
+  id: PropTypes.number.isRequired,
+  name: PropTypes.string.isRequired,
 };
 
 export default GroupTypeLink;

--- a/resources/assets/components/pages/VoterRegistrationDrivePage/GroupTypeLink.js
+++ b/resources/assets/components/pages/VoterRegistrationDrivePage/GroupTypeLink.js
@@ -20,7 +20,6 @@ const GROUPS_CAMPAIGN_WEBSITE_QUERY = gql`
     campaignWebsiteByCampaignId(campaignId: $campaignId) {
       id
       path
-      url
     }
   }
 `;

--- a/resources/assets/components/pages/VoterRegistrationDrivePage/VoterRegistrationDrivePageBanner.js
+++ b/resources/assets/components/pages/VoterRegistrationDrivePage/VoterRegistrationDrivePageBanner.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { get } from 'lodash';
 import PropTypes from 'prop-types';
 
 import { votingReasons } from './config';
@@ -99,7 +100,12 @@ const VoterRegistrationDrivePageBanner = ({
               After you register, share with your friends to enter to win a $
               {`${scholarshipAmount.toLocaleString()}`} scholarship!
             </p>
-            {group ? <GroupTypeLink group={group} /> : null}
+            {group ? (
+              <GroupTypeLink
+                id={get(group, 'groupType.id', null)}
+                name={get(group, 'groupType.name', null)}
+              />
+            ) : null}
           </div>
 
           <div className="grid-wide-3/10 mb-6 xxl:row-start-1 xxl:row-span-3">

--- a/resources/assets/components/pages/VoterRegistrationDrivePage/VoterRegistrationDrivePageBanner.js
+++ b/resources/assets/components/pages/VoterRegistrationDrivePage/VoterRegistrationDrivePageBanner.js
@@ -98,6 +98,16 @@ const VoterRegistrationDrivePageBanner = ({
               After you register, share with your friends to enter to win a $
               {`${scholarshipAmount.toLocaleString()}`} scholarship!
             </p>
+            <div className="mt-3">
+              {group ? (
+                <a
+                  href="google.com"
+                  data-test="voter-registration-drive-page-group-campaign-link"
+                >
+                  What&lsquo;s {group.groupType.name}?
+                </a>
+              ) : null}
+            </div>
           </div>
 
           <div className="grid-wide-3/10 mb-6 xxl:row-start-1 xxl:row-span-3">

--- a/resources/assets/components/pages/VoterRegistrationDrivePage/VoterRegistrationDrivePageBanner.js
+++ b/resources/assets/components/pages/VoterRegistrationDrivePage/VoterRegistrationDrivePageBanner.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import { get } from 'lodash';
 import PropTypes from 'prop-types';
 
 import { votingReasons } from './config';
@@ -102,8 +101,8 @@ const VoterRegistrationDrivePageBanner = ({
             </p>
             {group ? (
               <GroupTypeLink
-                id={get(group, 'groupType.id', null)}
-                name={get(group, 'groupType.name', null)}
+                id={group.groupType.id}
+                name={group.groupType.name}
               />
             ) : null}
           </div>

--- a/resources/assets/components/pages/VoterRegistrationDrivePage/VoterRegistrationDrivePageBanner.js
+++ b/resources/assets/components/pages/VoterRegistrationDrivePage/VoterRegistrationDrivePageBanner.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 
 import { votingReasons } from './config';
 import { query } from '../../../helpers';
+import GroupTypeLink from './GroupTypeLink';
 import ReferralsInfo from './ReferralsInfo';
 import CampaignHeader from '../../utilities/CampaignHeader';
 import CoverImage from '../../utilities/CoverImage/CoverImage';
@@ -98,16 +99,7 @@ const VoterRegistrationDrivePageBanner = ({
               After you register, share with your friends to enter to win a $
               {`${scholarshipAmount.toLocaleString()}`} scholarship!
             </p>
-            <div className="mt-3">
-              {group ? (
-                <a
-                  href="google.com"
-                  data-test="voter-registration-drive-page-group-campaign-link"
-                >
-                  What&lsquo;s {group.groupType.name}?
-                </a>
-              ) : null}
-            </div>
+            {group ? <GroupTypeLink group={group} /> : null}
           </div>
 
           <div className="grid-wide-3/10 mb-6 xxl:row-start-1 xxl:row-span-3">
@@ -133,6 +125,7 @@ VoterRegistrationDrivePageBanner.propTypes = {
   group: PropTypes.shape({
     goal: PropTypes.number,
     groupType: PropTypes.shape({
+      id: PropTypes.number,
       name: PropTypes.string,
     }),
     id: PropTypes.number,


### PR DESCRIPTION
### What's this PR do?

This pull request adds a link to the group campaign page for Beta users in case they're interested in learning more or in signing up via the group campaign page vs individual. The text reads `What's INSERT_GROUPTYPE_NAME` and links out to a different campaign page.

### How should this be reviewed?

Let me know if there's any refactoring that could happen here, naming makes sense, etc!

Desktop:
<img width="1133" alt="Screen Shot 2020-07-23 at 4 50 08 PM" src="https://user-images.githubusercontent.com/15236023/88337374-a5983380-cd04-11ea-9dd9-055fdea492fe.png">

Mobile:
<img width="372" alt="Screen Shot 2020-07-23 at 4 50 21 PM" src="https://user-images.githubusercontent.com/15236023/88337386-aaf57e00-cd04-11ea-9032-e484a930b24f.png">


### Any background context you want to provide?

We're providing more context to users who are visiting a beta page and may not have background info on the group their friend is a part of.

### Relevant tickets

References [Pivotal # 173410336](https://www.pivotaltracker.com/story/show/173410336).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [x] Added screenshots of front-end changes on small, medium, and large screens.
- [ ] Added appropriate feature/unit tests.
