### PR TITLE
Adds dynamic header and sourceDetails to Quiz Result Page

### DIFF
--- a/cypress/integration/quiz-result-page.js
+++ b/cypress/integration/quiz-result-page.js
@@ -4,8 +4,7 @@ import faker from 'faker';
 
 import { userFactory } from '../fixtures/user';
 
-const quizResultId = '347iYsbykgQe6KqeGceMUk';
-const quizResultPath = `/us/quiz-results/${quizResultId}`;
+const quizResultPath = '/us/quiz-results/347iYsbykgQe6KqeGceMUk';
 
 /**
  * @param {String} sourceDetails
@@ -14,7 +13,7 @@ const quizResultPath = `/us/quiz-results/${quizResultId}`;
  */
 const linkBlock = (sourceDetails, hasAsset = true) => {
   return {
-    id: quizResultId,
+    id: '347iYsbykgQe6KqeGceMUk',
     __typename: 'LinkBlock',
     title: faker.company.bsBuzz(),
     content: faker.lorem.sentence(),
@@ -39,18 +38,35 @@ describe('Quiz Result Page', () => {
   });
 
   /** @test */
-  it('Renders GraphQL title and content', () => {
+  it('Renders GraphQL title, header asset, content', () => {
     const block = linkBlock(null);
+    const imageUrl = faker.image.imageUrl();
 
     cy.mockGraphqlOp('QuizResultPageQuery', {
       block,
+    });
+    cy.mockGraphqlOp('ContentfulAssetQuery', {
+      asset: {
+        url: imageUrl,
+      },
     });
 
     cy.visit(quizResultPath);
 
     cy.findByTestId('quiz-result-page').should('have.length', 1);
+    cy.get('header img').should('have.attr', 'src', imageUrl);
     cy.get('h1').should('contain', block.title);
     cy.findByTestId('quiz-result-page').contains(block.content);
+  });
+
+  it('Does not display header image if asset is null', () => {
+    cy.mockGraphqlOp('QuizResultPageQuery', {
+      block: linkBlock(null, false),
+    });
+
+    cy.visit(quizResultPath);
+
+    cy.get('header img').should('have.length', 0);
   });
 
   /** @test */
@@ -62,7 +78,10 @@ describe('Quiz Result Page', () => {
     cy.visit(quizResultPath);
 
     cy.findByTestId('quiz-result-page').should('have.length', 1);
-    cy.findByTestId('voter-registration-form-card').should('have.length', 0);
+    cy.findByTestId('quiz-result-page-registration-section').should(
+      'have.length',
+      0,
+    );
   });
 
   /** @test */
@@ -73,7 +92,10 @@ describe('Quiz Result Page', () => {
 
     cy.visit(quizResultPath);
 
-    cy.findByTestId('quiz-result-page').should('have.length', 1);
+    cy.findByTestId('quiz-result-page-registration-section').should(
+      'have.length',
+      1,
+    );
     cy.findByTestId('voter-registration-tracking-source').should(
       'have.value',
       'source:web,source_details:VoterRegQuiz_completed_notsure',

--- a/docs/development/features/voter-registration.md
+++ b/docs/development/features/voter-registration.md
@@ -112,46 +112,39 @@ This page had inline JS that would query Northstar to find a user's first name b
 
 ## Quiz
 
-### Voting Quiz Campaign
+The Quiz content type is only used for voter registration campaigns.
 
-Our Voting Quiz campaign (`/us/campaigns/ready-vote`) uses the legacy Quiz content type, which has been deprecated for Typeform except for this one warrior entry. It has two entry points:
+Users are redirected to `/us/quiz-results/:id` to see their quiz result on a Quiz Result Page.
+
+The `QuizResultPage` component expects the `:id` route parameter to be the ID of one of the Link Action entries referenced by the Quiz's Result Blocks multi-value reference field.
+
+To display the Start Voter Registration Form on a quiz result, add a `sourceDetails` property to the Additional Content field on the quiz result's Link Action entry. This value will be set to the `source_details` of the voter registration tracking source if a user submits the form.
+
+A header image can be added by selecting an asset in the Affiliate Logo field.
+
+A static Gallery Block entry is displayed all for all Quiz result ID's:
+
+- Production: 78WaGsvDEzAxnreEvNx3Za
+- Dev: 2VGFq3XBcqCfKOA8mC5mP4
+
+### Voting Quiz Campaign
 
 - Gated: `/us/campaigns/ready-vote` - user must signup to take the quiz from the action page
 
 - Ungated: `/us/campaigns/ready-vote/quiz/ready` - user can take quiz but must signup to see their result
 
-### Quiz Result Page
+Production Quiz Results:
 
-When the `DS_ENABLE_QUIZ_RESULT_PAGE` configuration variable is set to `true`, the current user is redirected to `/us/quiz-results/:id` to see their quiz result.
+- [p7hqjSP4Y1U6ad0UDz4iS](https://www.dosomething.org/us/quiz-results/p7hqjSP4Y1U6ad0UDz4iS) - Vote By Mail
+- [1giTEF3B2hO2CyccmhlVDm](https://www.dosomething.org/us/quiz-results/1giTEF3B2hO2CyccmhlVDm) - In-Person Voting
+- [21PDBge2bKCTWMe5f9eo1H](https://www.dosomething.org/us/quiz-results/21PDBge2bKCTWMe5f9eo1H) - Unsure of Voting
+- [14KfeAs265httjNMf1jwTw](https://www.dosomething.org/us/quiz-results/14KfeAs265httjNMf1jwTw) - Ineligible to Vote
 
-The `QuizResultPage` component expects the `:id` route parameter to be the ID of one of the Link Action entries referenced by the Quiz's `resultBlocks` multi-value reference field.
+Dev Quiz Results:
 
-The `QuizResultPage` displays a static `GalleryBlock` for all of the different result ID's.
-
-**Production:**
-
-Gallery Block: 78WaGsvDEzAxnreEvNx3Za
-
-Quiz Results:
-
-| id                                                                                           | title               | internalTitle      | assetId                |
-| -------------------------------------------------------------------------------------------- | ------------------- | ------------------ | ---------------------- |
-| [p7hqjSP4Y1U6ad0UDz4iS](https://www.dosomething.org/us/quiz-results/p7hqjSP4Y1U6ad0UDz4iS)   | Shell-tered Voter   | Vote By Mail       | 49Y4ucuGbJbgZL7IDDfxG0 |
-| [1giTEF3B2hO2CyccmhlVDm](https://www.dosomething.org/us/quiz-results/1giTEF3B2hO2CyccmhlVDm) | Hare Who Dares      | In-Person Voting   | 2f2kgaHl9w5VtdswKkaBWT |
-| [21PDBge2bKCTWMe5f9eo1H](https://www.dosomething.org/us/quiz-results/21PDBge2bKCTWMe5f9eo1H) | Sloth At a Loss     | Unsure of Voting   | 1YomtHAeqXJ3qbjQNgsM0v |
-| [14KfeAs265httjNMf1jwTw](https://www.dosomething.org/us/quiz-results/14KfeAs265httjNMf1jwTw) | Moral Support Panda | Ineligible to Vote | 3WjT0QGNnJEPPz2yMd3inj |
-
-**Dev:**
-
-Gallery Block: 2VGFq3XBcqCfKOA8mC5mP4
-
-Quiz Results:
-
-| id                                                                                           | title               | internalTitle    | assetId                |
-| -------------------------------------------------------------------------------------------- | ------------------- | ---------------- | ---------------------- |
-| [347iYsbykgQe6KqeGceMUk](https://dev.dosomething.org/us/quiz-results/347iYsbykgQe6KqeGceMUk) | Moral Support Panda | Super Motivated  | 6J13jUL4YGGC1fyYMNEfbc |
-| [1lvJHhlJqQSgKgwIwUymQ8](https://dev.dosomething.org/us/quiz-results/1lvJHhlJqQSgKgwIwUymQ8) | Shell-tered Voter   | Social Voter     | 3iLKsRlFQ1k9ddQbRb3RN8 |
-| [2KfkCOTi7u4CqAyyCuGyci](https://dev.dosomething.org/us/quiz-results/2KfkCOTi7u4CqAyyCuGyci) | Hare Who Dares      | Election Dabbler | 3uB88eZmTNEaoFxV9pZ8hX |
+- [347iYsbykgQe6KqeGceMUk](https://dev.dosomething.org/us/quiz-results/347iYsbykgQe6KqeGceMUk)
+- [1lvJHhlJqQSgKgwIwUymQ8](https://dev.dosomething.org/us/quiz-results/1lvJHhlJqQSgKgwIwUymQ8)
+- [2KfkCOTi7u4CqAyyCuGyci](https://dev.dosomething.org/us/quiz-results/2KfkCOTi7u4CqAyyCuGyci)
 
 **Related links:**
 
@@ -160,12 +153,5 @@ Quiz Results:
 - [Quiz documentation](https://github.com/DoSomething/phoenix-next/blob/8b5a97fdd973c8eb925191f78b36c2f676d2707a/docs/content-publishing/quiz.md) - This was removed in [#1369](https://github.com/DoSomething/phoenix-next/pull/1369) when we moved editorial guides into the Campaign Playbook.
 
 **Notes:**
-
-- While we're still developing this component, we're displaying placeholder copy for the Link Action content unless a `preview=true` query parameter is present. Examples:
-
-  - Placeholder content = https://qa.dosomething.org/us/quiz-results/p7hqjSP4Y1U6ad0UDz4iS
-  - Live content - https://qa.dosomething.org/us/quiz-results/p7hqjSP4Y1U6ad0UDz4iS?preview=true
-
-This is because the current content in Contentful for our result entries contains the banner image inline (so they are displayed twice, once within the header and a second time within the copy). When we're ready to go live, we'll have the campaigns team edit the content and remove the requirement to include the `preview` query.
 
 - Please avoid editing the Quiz entries if possible, as [they are delicately configured](https://github.com/DoSomething/phoenix-next/blob/8b5a97fdd973c8eb925191f78b36c2f676d2707a/docs/content-publishing/quiz.md#adding-available-choices-for-question) (deleting one of the `LinkAction` entries referenced by the `resultBlocks` field would not be pretty).

--- a/resources/assets/components/actions/LinkAction/LinkAction.js
+++ b/resources/assets/components/actions/LinkAction/LinkAction.js
@@ -14,6 +14,7 @@ export const LinkBlockFragment = gql`
     linkBlockLink: link
     buttonText
     affiliateLogo {
+      id
       url(w: 200, h: 100)
       description
     }

--- a/resources/assets/components/pages/QuizResultPage/QuizResultPage.js
+++ b/resources/assets/components/pages/QuizResultPage/QuizResultPage.js
@@ -47,9 +47,10 @@ const QuizResultPage = ({ id }) => {
     return <NotFoundPage id={id} />;
   }
 
-  const config = isDevEnvironment()
+  const { galleryBlockId } = isDevEnvironment()
     ? gqlVariables.development
     : gqlVariables.production;
+
   const {
     additionalContent,
     affiliateLogo,
@@ -84,10 +85,7 @@ const QuizResultPage = ({ id }) => {
             <img className="m-auto" src={triangle} alt="triangle" />
           </div>
           <div className="bg-white base-12-grid py-3 md:py-6">
-            <ContentfulEntryLoader
-              id={config.galleryBlockId}
-              className="grid-full"
-            />
+            <ContentfulEntryLoader id={galleryBlockId} className="grid-full" />
 
             {additionalContent && additionalContent.sourceDetails ? (
               <div

--- a/resources/assets/components/pages/QuizResultPage/QuizResultPage.js
+++ b/resources/assets/components/pages/QuizResultPage/QuizResultPage.js
@@ -90,7 +90,10 @@ const QuizResultPage = ({ id }) => {
             />
 
             {additionalContent && additionalContent.sourceDetails ? (
-              <div className="grid-full grid-main py-3 md:py-6">
+              <div
+                className="grid-full grid-main py-3 md:py-6"
+                data-testid="quiz-result-page-registration-section"
+              >
                 <h1 className="mx-auto text-center mb-3">
                   <span className="font-normal font-league-gothic uppercase text-4xl pb-3">
                     What&rsquo;s Next? Register to Vote

--- a/resources/assets/components/pages/QuizResultPage/QuizResultPage.js
+++ b/resources/assets/components/pages/QuizResultPage/QuizResultPage.js
@@ -50,7 +50,12 @@ const QuizResultPage = ({ id }) => {
   const config = isDevEnvironment()
     ? gqlVariables.development
     : gqlVariables.production;
-  const { additionalContent, affiliateLogo, linkBlockTitle } = data.block;
+  const {
+    additionalContent,
+    affiliateLogo,
+    content,
+    linkBlockTitle,
+  } = data.block;
 
   return (
     <>
@@ -71,7 +76,7 @@ const QuizResultPage = ({ id }) => {
                 </span>
               </h1>
               <div className="color-white">
-                <TextContent>{data.block.content}</TextContent>
+                <TextContent>{content}</TextContent>
               </div>
             </div>
           </header>
@@ -83,7 +88,8 @@ const QuizResultPage = ({ id }) => {
               id={config.galleryBlockId}
               className="grid-full"
             />
-            {additionalContent ? (
+
+            {additionalContent && additionalContent.sourceDetails ? (
               <div className="grid-full grid-main py-3 md:py-6">
                 <h1 className="mx-auto text-center mb-3">
                   <span className="font-normal font-league-gothic uppercase text-4xl pb-3">

--- a/resources/assets/components/pages/QuizResultPage/QuizResultPage.js
+++ b/resources/assets/components/pages/QuizResultPage/QuizResultPage.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import { get } from 'lodash';
 import gql from 'graphql-tag';
 import PropTypes from 'prop-types';
 import { useQuery } from 'react-apollo';
@@ -51,9 +50,7 @@ const QuizResultPage = ({ id }) => {
   const config = isDevEnvironment()
     ? gqlVariables.development
     : gqlVariables.production;
-  const { linkBlockTitle } = data.block;
-  const assetId = get(config, `results.${id}.assetId`, null);
-  const sourceDetail = get(config, `results.${id}.sourceDetail`, null);
+  const { additionalContent, affiliateLogo, linkBlockTitle } = data.block;
 
   return (
     <>
@@ -63,7 +60,9 @@ const QuizResultPage = ({ id }) => {
         <article data-testid="quiz-result-page">
           <header role="banner" className="base-12-grid bg-blurple-500 py-3">
             <div className="col-span-4 md:col-span-3 bg-bottom md:col-start-2">
-              {assetId ? <ContentfulAsset id={assetId} width={375} /> : null}
+              {affiliateLogo ? (
+                <ContentfulAsset id={affiliateLogo.id} width={375} />
+              ) : null}
             </div>
             <div className="col-span-4 md:col-span-7 md:my-auto">
               <h1 className="font-normal font-league-gothic color-white uppercase">
@@ -84,7 +83,7 @@ const QuizResultPage = ({ id }) => {
               id={config.galleryBlockId}
               className="grid-full"
             />
-            {sourceDetail ? (
+            {additionalContent ? (
               <div className="grid-full grid-main py-3 md:py-6">
                 <h1 className="mx-auto text-center mb-3">
                   <span className="font-normal font-league-gothic uppercase text-4xl pb-3">
@@ -103,7 +102,7 @@ const QuizResultPage = ({ id }) => {
                 <StartVoterRegistrationForm
                   contextSource="voter-registration-quiz-results-page"
                   className="md:mx-auto xl:w-4/5"
-                  sourceDetail={sourceDetail}
+                  sourceDetail={additionalContent.sourceDetails}
                 />
               </div>
             ) : null}

--- a/resources/assets/components/pages/QuizResultPage/config.js
+++ b/resources/assets/components/pages/QuizResultPage/config.js
@@ -1,67 +1,10 @@
-/**
- * Quiz results with a sourceDetail property should pass that value along to the tracking source
- * of the StartVoterRegistrationForm displayed on the page.
- */
-const sourceDetailPrefix = 'VoterRegQuiz_completed_';
-
+// Values for GraphQL queries.
 const gqlVariables = {
   production: {
     galleryBlockId: '78WaGsvDEzAxnreEvNx3Za',
-    results: {
-      // Vote by mail / Turtle
-      p7hqjSP4Y1U6ad0UDz4iS: {
-        assetId: '49Y4ucuGbJbgZL7IDDfxG0',
-        sourceDetail: `${sourceDetailPrefix}votebymail`,
-      },
-      // In-person voting / Rabbit
-      '1giTEF3B2hO2CyccmhlVDm': {
-        assetId: '2f2kgaHl9w5VtdswKkaBWT',
-        sourceDetail: `${sourceDetailPrefix}inperson`,
-      },
-      // Unsure of voting / Slothie Boi
-      '21PDBge2bKCTWMe5f9eo1H': {
-        assetId: '1YomtHAeqXJ3qbjQNgsM0v',
-        sourceDetail: `${sourceDetailPrefix}notsure`,
-      },
-      // Ineligible to vote / Panda
-      '14KfeAs265httjNMf1jwTw': {
-        assetId: '3WjT0QGNnJEPPz2yMd3inj',
-        // @see https://dosomething.slack.com/archives/CTVPG6L4R/p1592329248450700?thread_ts=1592328663.448100&cid=CTVPG6L4R
-        sourceDetail: `${sourceDetailPrefix}housing`,
-      },
-    },
   },
   development: {
     galleryBlockId: '2VGFq3XBcqCfKOA8mC5mP4',
-    /**
-     * The content of these dev entries don't need to match our production assets or entry titles,
-     * we're using an older version of the quiz for convenience (to avoid manually editing the quiz
-     * entry's questions JSON field with result block ID's for sake of having the content match).
-     */
-    results: {
-      // Super Motivated
-      '347iYsbykgQe6KqeGceMUk': {
-        // Panda
-        assetId: '6J13jUL4YGGC1fyYMNEfbc',
-        sourceDetail: `${sourceDetailPrefix}notsure`,
-      },
-      // Social Voter
-      '1lvJHhlJqQSgKgwIwUymQ8': {
-        // Turtle:
-        assetId: '3iLKsRlFQ1k9ddQbRb3RN8',
-        sourceDetail: `${sourceDetailPrefix}votebymail`,
-      },
-      /**
-       * This quiz result is intentionally missing a sourceDetail for sake of testing.
-       * A previous iteration of the quiz had one result where we didn't want to display the start
-       * voter registration form (for users who are ineligible to vote), so we didn't include a
-       * sourceDetail.
-       */
-      '2KfkCOTi7u4CqAyyCuGyci': {
-        // Rabbit:
-        assetId: '3uB88eZmTNEaoFxV9pZ8hX',
-      },
-    },
   },
 };
 


### PR DESCRIPTION
### What's this PR do?

This pull request modifies the `QuizResultPage` component to source its header image and RTV tracking source details from fields on the result's Link Action entry, instead of hardcoded config.



### How should this be reviewed?

I've manually edited dev Link Action entries for the dev voting quiz campaign, will add links to 👀 once the review app builds.

### Any background context you want to provide?

This PR uses the existing Link Action's Affiliate Logo field (which conveniently links to a Contentful asset) to display the header image. 

I manually added an `additionalContent` JSON field to the `linkAction` content type. [GraphQL is already looking for it](https://github.com/DoSomething/graphql/blob/8b39984cbbf0560e389eb41d83d52e0f208740c7/src/schema/contentful/phoenix.js#L462-L463), which made this a quick win.  

We don't have a content type definition for the `linkAction`- and it sure looks like a lot has been deprecated (e.g. the `template` field is hidden in Contentful), so I'm holding off adding any Link Action docs to keep this PR in scope and easier to review.

### Relevant tickets

References [Pivotal #173844301](https://www.pivotaltracker.com/story/show/173844301).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [x] Documentation added for new features/changed endpoints.
- [ ] Added screenshots of front-end changes on small, medium, and large screens.
- [x] Added appropriate feature/unit tests.
