### PR TITLE
StyleCI Update - Remove 'simplified_null_return' Disabled Setting

### DIFF
--- a/.styleci.yml
+++ b/.styleci.yml
@@ -3,7 +3,6 @@ preset: laravel
 disabled:
   - concat_without_spaces
   - no_useless_return
-  - simplified_null_return
   - phpdoc_no_package
   - phpdoc_summary
   - phpdoc_var_without_name


### PR DESCRIPTION
StyleCI is complaining on [new builds](https://github.styleci.io/analyses/rdw73V?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link) about this setting:

> The provided fixer 'simplified_null_return' cannot be disabled unless it was already enabled by your preset.

