### PR TITLE
Connect hola bar with user vr status,

### DIFF
--- a/cypress/integration/sitewide-banner.js
+++ b/cypress/integration/sitewide-banner.js
@@ -5,18 +5,6 @@ import faker from 'faker';
 import { userFactory } from '../fixtures/user';
 import exampleCampaign from '../fixtures/contentful/exampleCampaign';
 
-const exampleRegisteredUser = {
-  id: '3401458',
-  displayName: 'Michael',
-  voterRegistrationStatus: 'REGISTRATION_COMPLETE',
-};
-
-const exampleUnregisteredUser = {
-  id: '3401458',
-  displayName: 'Michael',
-  voterRegistrationStatus: 'UNREGISTERED',
-};
-
 describe('Site Wide Banner', () => {
   beforeEach(() => {
     cy.configureMocks();
@@ -157,12 +145,13 @@ describe('Site Wide Banner', () => {
     if ('#banner-portal > .wrapper > [data-test=site-wide-banner]') {
       cy.authVisitCampaignWithoutSignup(user, exampleCampaign);
 
-      cy.findByTestId('sitewide-banner-button').should('have.length', 1);
-      cy.findByTestId('sitewide-banner-button').should(
-        'have.attr',
-        'href',
-        `https://vote.dosomething.org/?r=user:${user.id},source:web,source_details:hellobar`,
-      );
-    }
+    cy.authVisitCampaignWithoutSignup(user, exampleCampaign);
+
+    cy.findByTestId('sitewide-banner-button').should('have.length', 1);
+    cy.findByTestId('sitewide-banner-button').should(
+      'have.attr',
+      'href',
+      `https://vote.dosomething.org/?r=user:${user.id},source:web,source_details:hellobar`,
+    );
   });
 });

--- a/cypress/integration/sitewide-banner.js
+++ b/cypress/integration/sitewide-banner.js
@@ -140,13 +140,8 @@ describe('Site Wide Banner', () => {
       },
     });
 
-    cy.authVisitCampaignWithoutSignup(user, exampleCampaign);
-
     if ('#banner-portal > .wrapper > [data-test=site-wide-banner]') {
       cy.authVisitCampaignWithoutSignup(user, exampleCampaign);
-
-      cy.authVisitCampaignWithoutSignup(user, exampleCampaign);
-
       cy.findByTestId('sitewide-banner-button').should('have.length', 1);
       cy.findByTestId('sitewide-banner-button').should(
         'have.attr',

--- a/cypress/integration/sitewide-banner.js
+++ b/cypress/integration/sitewide-banner.js
@@ -5,6 +5,18 @@ import faker from 'faker';
 import { userFactory } from '../fixtures/user';
 import exampleCampaign from '../fixtures/contentful/exampleCampaign';
 
+const exampleRegisteredUser = {
+  id: '3401458',
+  displayName: 'Michael',
+  voterRegistrationStatus: 'REGISTRATION_COMPLETE',
+};
+
+const exampleUnregisteredUser = {
+  id: '3401458',
+  displayName: 'Michael',
+  voterRegistrationStatus: 'UNREGISTERED',
+};
+
 describe('Site Wide Banner', () => {
   beforeEach(() => {
     cy.configureMocks();
@@ -23,9 +35,17 @@ describe('Site Wide Banner', () => {
   it('The Site Wide Banner is displayed on campaign pages', () => {
     cy.anonVisitCampaign(exampleCampaign);
 
+    if ('#banner-portal > .wrapper > [data-test=site-wide-banner]') {
+      cy.get('#banner-portal > .wrapper > [data-test=site-wide-banner]').should(
+        'have.length',
+        1,
+      );
+    }
+  });
+
+  it('Site Wide Banner is not displayed on any pages when data-test=site-wide-banner is not visible', () => {
     cy.get('#banner-portal > .wrapper > [data-test=site-wide-banner]').should(
-      'have.length',
-      1,
+      'not.exist',
     );
   });
 

--- a/cypress/integration/sitewide-banner.js
+++ b/cypress/integration/sitewide-banner.js
@@ -43,12 +43,6 @@ describe('Site Wide Banner', () => {
     }
   });
 
-  it('Site Wide Banner is not displayed on any pages when data-test=site-wide-banner is not visible', () => {
-    cy.get('#banner-portal > .wrapper > [data-test=site-wide-banner]').should(
-      'not.exist',
-    );
-  });
-
   it('The Site Wide Banner is not displayed on the beta voter registration (OVRD) drive page', () => {
     const user = userFactory();
 
@@ -106,12 +100,14 @@ describe('Site Wide Banner', () => {
   it('The Site Wide Banner CTA URL is correct for an unauthenticated user', () => {
     cy.anonVisitCampaign(exampleCampaign);
 
-    cy.findByTestId('sitewide-banner-button').should('have.length', 1);
-    cy.findByTestId('sitewide-banner-button').should(
-      'have.attr',
-      'href',
-      'https://vote.dosomething.org/?r=source:web,source_details:hellobar',
-    );
+    if ('#banner-portal > .wrapper > [data-test=site-wide-banner]') {
+      cy.findByTestId('sitewide-banner-button').should('have.length', 1);
+      cy.findByTestId('sitewide-banner-button').should(
+        'have.attr',
+        'href',
+        'https://vote.dosomething.org/?r=source:web,source_details:hellobar',
+      );
+    }
   });
 
   /** @test */
@@ -119,13 +115,16 @@ describe('Site Wide Banner', () => {
     const user = userFactory();
 
     // Log in & visit the campaign pitch page:
-    cy.authVisitCampaignWithoutSignup(user, exampleCampaign);
 
-    cy.findByTestId('sitewide-banner-button').should('have.length', 1);
-    cy.findByTestId('sitewide-banner-button').should(
-      'have.attr',
-      'href',
-      `https://vote.dosomething.org/?r=user:${user.id},source:web,source_details:hellobar`,
-    );
+    if ('#banner-portal > .wrapper > [data-test=site-wide-banner]') {
+      cy.authVisitCampaignWithoutSignup(user, exampleCampaign);
+
+      cy.findByTestId('sitewide-banner-button').should('have.length', 1);
+      cy.findByTestId('sitewide-banner-button').should(
+        'have.attr',
+        'href',
+        `https://vote.dosomething.org/?r=user:${user.id},source:web,source_details:hellobar`,
+      );
+    }
   });
 });

--- a/cypress/integration/sitewide-banner.js
+++ b/cypress/integration/sitewide-banner.js
@@ -136,8 +136,9 @@ describe('Site Wide Banner', () => {
       },
     });
 
+    cy.authVisitCampaignWithoutSignup(user, exampleCampaign);
+
     if ('#banner-portal > .wrapper > [data-test=site-wide-banner]') {
-      cy.authVisitCampaignWithoutSignup(user, exampleCampaign);
       cy.findByTestId('sitewide-banner-button').should('have.length', 1);
       cy.findByTestId('sitewide-banner-button').should(
         'have.attr',

--- a/cypress/integration/sitewide-banner.js
+++ b/cypress/integration/sitewide-banner.js
@@ -145,13 +145,14 @@ describe('Site Wide Banner', () => {
     if ('#banner-portal > .wrapper > [data-test=site-wide-banner]') {
       cy.authVisitCampaignWithoutSignup(user, exampleCampaign);
 
-    cy.authVisitCampaignWithoutSignup(user, exampleCampaign);
+      cy.authVisitCampaignWithoutSignup(user, exampleCampaign);
 
-    cy.findByTestId('sitewide-banner-button').should('have.length', 1);
-    cy.findByTestId('sitewide-banner-button').should(
-      'have.attr',
-      'href',
-      `https://vote.dosomething.org/?r=user:${user.id},source:web,source_details:hellobar`,
-    );
+      cy.findByTestId('sitewide-banner-button').should('have.length', 1);
+      cy.findByTestId('sitewide-banner-button').should(
+        'have.attr',
+        'href',
+        `https://vote.dosomething.org/?r=user:${user.id},source:web,source_details:hellobar`,
+      );
+    }
   });
 });

--- a/cypress/integration/sitewide-banner.js
+++ b/cypress/integration/sitewide-banner.js
@@ -154,11 +154,15 @@ describe('Site Wide Banner', () => {
 
     cy.authVisitCampaignWithoutSignup(user, exampleCampaign);
 
-    cy.findByTestId('sitewide-banner-button').should('have.length', 1);
-    cy.findByTestId('sitewide-banner-button').should(
-      'have.attr',
-      'href',
-      `https://vote.dosomething.org/?r=user:${user.id},source:web,source_details:hellobar`,
-    );
+    if ('#banner-portal > .wrapper > [data-test=site-wide-banner]') {
+      cy.authVisitCampaignWithoutSignup(user, exampleCampaign);
+
+      cy.findByTestId('sitewide-banner-button').should('have.length', 1);
+      cy.findByTestId('sitewide-banner-button').should(
+        'have.attr',
+        'href',
+        `https://vote.dosomething.org/?r=user:${user.id},source:web,source_details:hellobar`,
+      );
+    }
   });
 });

--- a/cypress/integration/sitewide-banner.js
+++ b/cypress/integration/sitewide-banner.js
@@ -5,6 +5,18 @@ import faker from 'faker';
 import { userFactory } from '../fixtures/user';
 import exampleCampaign from '../fixtures/contentful/exampleCampaign';
 
+const exampleRegisteredUser = {
+  id: '3401458',
+  displayName: 'Michael',
+  voterRegistrationStatus: 'REGISTRATION_COMPLETE',
+};
+
+const exampleUnregisteredUser = {
+  id: '3401458',
+  displayName: 'Michael',
+  voterRegistrationStatus: 'UNREGISTERED',
+};
+
 describe('Site Wide Banner', () => {
   beforeEach(() => {
     cy.configureMocks();
@@ -42,8 +54,7 @@ describe('Site Wide Banner', () => {
 
     cy.authVisitCampaignWithoutSignup(user, exampleCampaign);
     cy.get('#banner-portal > .wrapper > [data-test=site-wide-banner]').should(
-      'have.length',
-      1,
+      'not.exist',
     );
   });
 

--- a/cypress/integration/sitewide-banner.js
+++ b/cypress/integration/sitewide-banner.js
@@ -47,7 +47,7 @@ describe('Site Wide Banner', () => {
   it('The Site Wide Banner is not displayed on campaign pages for authenticated users who are registered to vote', () => {
     const user = userFactory();
 
-    cy.mockGraphqlOp('VoterRegSiteWideBannerQuery', {
+    cy.mockGraphqlOp('VoterRegSitewideBannerQuery', {
       user: {
         voterRegistrationStatus: 'REGISTRATION_COMPLETE',
       },

--- a/cypress/integration/sitewide-banner.js
+++ b/cypress/integration/sitewide-banner.js
@@ -32,7 +32,7 @@ describe('Site Wide Banner', () => {
   it('The Site Wide Banner is displayed on campaign pages for authenticated users who are not registered to vote', () => {
     const user = userFactory();
 
-    cy.mockGraphqlOp('VoterRegSiteWideBannerQuery', {
+    cy.mockGraphqlOp('VoterRegSitewideBannerQuery', {
       user: {
         voterRegistrationStatus: 'UNREGISTERED',
       },

--- a/cypress/integration/sitewide-banner.js
+++ b/cypress/integration/sitewide-banner.js
@@ -137,14 +137,11 @@ describe('Site Wide Banner', () => {
     });
 
     cy.authVisitCampaignWithoutSignup(user, exampleCampaign);
-
-    if ('#banner-portal > .wrapper > [data-test=site-wide-banner]') {
-      cy.findByTestId('sitewide-banner-button').should('have.length', 1);
-      cy.findByTestId('sitewide-banner-button').should(
-        'have.attr',
-        'href',
-        `https://vote.dosomething.org/?r=user:${user.id},source:web,source_details:hellobar`,
-      );
-    }
+    cy.findByTestId('sitewide-banner-button').should('have.length', 1);
+    cy.findByTestId('sitewide-banner-button').should(
+      'have.attr',
+      'href',
+      `https://vote.dosomething.org/?r=user:${user.id},source:web,source_details:hellobar`,
+    );
   });
 });

--- a/cypress/integration/sitewide-banner.js
+++ b/cypress/integration/sitewide-banner.js
@@ -130,7 +130,7 @@ describe('Site Wide Banner', () => {
 
     // Log in & visit the campaign pitch page:
 
-    cy.mockGraphqlOp('VoterRegSiteWideBannerQuery', {
+    cy.mockGraphqlOp('VoterRegSitewideBannerQuery', {
       user: {
         voterRegistrationStatus: 'UNREGISTERED',
       },

--- a/resources/assets/components/App.js
+++ b/resources/assets/components/App.js
@@ -37,22 +37,6 @@ const App = ({ store, history }) => {
   return (
     <ReduxProvider store={store}>
       <ErrorBoundary FallbackComponent={ErrorPage}>
-        <DismissableElement
-          name="sitewide_banner_call_to_action"
-          daysToReRender={7}
-          context={{ contextSource: 'voter_registration' }}
-          render={(handleClose, handleComplete) => (
-            <SitewideBanner
-              cta="Get Started"
-              description="Make your voice heard. Register to vote in less than 2 minutes."
-              handleClose={handleClose}
-              handleComplete={handleComplete}
-              link={`https://vote.dosomething.org/?r=${getTrackingSource(
-                'hellobar',
-              )}`}
-            />
-          )}
-        />
         <ApolloProvider client={graphqlClient(env('GRAPHQL_URL'))}>
           <DismissableElement
             name="sitewide_banner_call_to_action"

--- a/resources/assets/components/App.js
+++ b/resources/assets/components/App.js
@@ -38,22 +38,6 @@ const App = ({ store, history }) => {
     <ReduxProvider store={store}>
       <ErrorBoundary FallbackComponent={ErrorPage}>
         <ApolloProvider client={graphqlClient(env('GRAPHQL_URL'))}>
-          <DismissableElement
-            name="sitewide_banner_call_to_action"
-            daysToReRender={7}
-            context={{ contextSource: 'voter_registration' }}
-            render={(handleClose, handleComplete) => (
-              <SitewideBanner
-                cta="Get Started"
-                description="Make your voice heard. Register to vote in less than 2 minutes."
-                handleClose={handleClose}
-                handleComplete={handleComplete}
-                link={`https://vote.dosomething.org/?r=${getVoterRegistrationTrackingSource(
-                  'hellobar',
-                )}`}
-              />
-            )}
-          />
           {featureFlag('sitewide_nps_survey') &&
           window.location.pathname !== '/us' ? (
             <TrafficDistribution percentage={5} feature="nps_survey">

--- a/resources/assets/components/App.js
+++ b/resources/assets/components/App.js
@@ -54,6 +54,22 @@ const App = ({ store, history }) => {
           )}
         />
         <ApolloProvider client={graphqlClient(env('GRAPHQL_URL'))}>
+          <DismissableElement
+            name="sitewide_banner_call_to_action"
+            daysToReRender={7}
+            context={{ contextSource: 'voter_registration' }}
+            render={(handleClose, handleComplete) => (
+              <SitewideBanner
+                cta="Get Started"
+                description="Make your voice heard. Register to vote in less than 2 minutes."
+                handleClose={handleClose}
+                handleComplete={handleComplete}
+                link={`https://vote.dosomething.org/?r=${getVoterRegistrationTrackingSource(
+                  'hellobar',
+                )}`}
+              />
+            )}
+          />
           {featureFlag('sitewide_nps_survey') &&
           window.location.pathname !== '/us' ? (
             <TrafficDistribution percentage={5} feature="nps_survey">

--- a/resources/assets/components/App.js
+++ b/resources/assets/components/App.js
@@ -37,29 +37,29 @@ const App = ({ store, history }) => {
   return (
     <ReduxProvider store={store}>
       <ErrorBoundary FallbackComponent={ErrorPage}>
+        <DismissableElement
+          name="sitewide_banner_call_to_action"
+          daysToReRender={7}
+          context={{ contextSource: 'voter_registration' }}
+          render={(handleClose, handleComplete) => (
+            <SitewideBanner
+              cta="Get Started"
+              description="Make your voice heard. Register to vote in less than 2 minutes."
+              handleClose={handleClose}
+              handleComplete={handleComplete}
+              link={`https://vote.dosomething.org/?r=${getTrackingSource(
+                'hellobar',
+              )}`}
+            />
+          )}
+        />
         <ApolloProvider client={graphqlClient(env('GRAPHQL_URL'))}>
           {featureFlag('sitewide_nps_survey') &&
           window.location.pathname !== '/us' ? (
-            <TrafficDistribution percentage={5} feature="nps_survey">
-              <DismissableElement
-                name="nps_survey"
-                render={(handleClose, handleComplete) => (
-                  <DelayedElement delay={30}>
-                    <Modal onClose={handleClose} trackingId="SURVEY_MODAL">
-                      <TypeFormEmbed
-                        displayType="modal"
-                        typeformUrl="https://dosomething.typeform.com/to/Phi9pA"
-                        queryParameters={{
-                          northstar_id: get(window.AUTH, 'id', null),
-                          url: window.location.pathname,
-                        }}
-                        onSubmit={handleComplete}
-                      />
-                    </Modal>
-                  </DelayedElement>
-                )}
-              />
-            </TrafficDistribution>
+            <TrafficDistribution
+              percentage={5}
+              feature="nps_survey"
+            ></TrafficDistribution>
           ) : null}
 
           <Router history={history}>

--- a/resources/assets/components/App.js
+++ b/resources/assets/components/App.js
@@ -37,23 +37,23 @@ const App = ({ store, history }) => {
   return (
     <ReduxProvider store={store}>
       <ErrorBoundary FallbackComponent={ErrorPage}>
-        <DismissableElement
-          name="sitewide_banner_call_to_action"
-          daysToReRender={7}
-          context={{ contextSource: 'voter_registration' }}
-          render={(handleClose, handleComplete) => (
-            <SitewideBanner
-              cta="Get Started"
-              description="Make your voice heard. Register to vote in less than 2 minutes."
-              handleClose={handleClose}
-              handleComplete={handleComplete}
-              link={`https://vote.dosomething.org/?r=${getTrackingSource(
-                'hellobar',
-              )}`}
-            />
-          )}
-        />
         <ApolloProvider client={graphqlClient(env('GRAPHQL_URL'))}>
+          <DismissableElement
+            name="sitewide_banner_call_to_action"
+            daysToReRender={7}
+            context={{ contextSource: 'voter_registration' }}
+            render={(handleClose, handleComplete) => (
+              <SitewideBanner
+                cta="Get Started"
+                description="Make your voice heard. Register to vote in less than 2 minutes."
+                handleClose={handleClose}
+                handleComplete={handleComplete}
+                link={`https://vote.dosomething.org/?r=${getTrackingSource(
+                  'hellobar',
+                )}`}
+              />
+            )}
+          />
           {featureFlag('sitewide_nps_survey') &&
           window.location.pathname !== '/us' ? (
             <TrafficDistribution percentage={5} feature="nps_survey">

--- a/resources/assets/components/App.js
+++ b/resources/assets/components/App.js
@@ -56,10 +56,26 @@ const App = ({ store, history }) => {
         <ApolloProvider client={graphqlClient(env('GRAPHQL_URL'))}>
           {featureFlag('sitewide_nps_survey') &&
           window.location.pathname !== '/us' ? (
-            <TrafficDistribution
-              percentage={5}
-              feature="nps_survey"
-            ></TrafficDistribution>
+            <TrafficDistribution percentage={5} feature="nps_survey">
+              <DismissableElement
+                name="nps_survey"
+                render={(handleClose, handleComplete) => (
+                  <DelayedElement delay={30}>
+                    <Modal onClose={handleClose} trackingId="SURVEY_MODAL">
+                      <TypeFormEmbed
+                        displayType="modal"
+                        typeformUrl="https://dosomething.typeform.com/to/Phi9pA"
+                        queryParameters={{
+                          northstar_id: get(window.AUTH, 'id', null),
+                          url: window.location.pathname,
+                        }}
+                        onSubmit={handleComplete}
+                      />
+                    </Modal>
+                  </DelayedElement>
+                )}
+              />
+            </TrafficDistribution>
           ) : null}
 
           <Router history={history}>

--- a/resources/assets/components/utilities/SitewideBanner/SitewideBanner.js
+++ b/resources/assets/components/utilities/SitewideBanner/SitewideBanner.js
@@ -4,8 +4,8 @@ import { createPortal } from 'react-dom';
 import { useQuery } from '@apollo/react-hooks';
 import React, { useRef, useEffect } from 'react';
 import { useQuery } from '@apollo/react-hooks';
+import React, { useRef, useEffect } from 'react';
 
-import { getUserId } from '../../../helpers/auth';
 import excludedPaths from './config';
 import { getUserId } from '../../../helpers/auth';
 import SitewideBannerContent from './SitewideBannerContent';

--- a/resources/assets/components/utilities/SitewideBanner/SitewideBanner.js
+++ b/resources/assets/components/utilities/SitewideBanner/SitewideBanner.js
@@ -3,8 +3,6 @@ import gql from 'graphql-tag';
 import { createPortal } from 'react-dom';
 import { useQuery } from '@apollo/react-hooks';
 import React, { useRef, useEffect } from 'react';
-import { useQuery } from '@apollo/react-hooks';
-import React, { useRef, useEffect } from 'react';
 
 import excludedPaths from './config';
 import { getUserId } from '../../../helpers/auth';

--- a/resources/assets/components/utilities/SitewideBanner/SitewideBanner.js
+++ b/resources/assets/components/utilities/SitewideBanner/SitewideBanner.js
@@ -17,11 +17,7 @@ const VOTER_REGISTRATION_STATUS = gql`
   }
 `;
 
-const shouldDisplayRegistrationBanner = [
-  'UNCERTAIN',
-  'CONFIRMED',
-  'UNREGISTERED',
-];
+const unregisteredStatuses = ['UNCERTAIN', 'CONFIRMED', 'UNREGISTERED'];
 
 const isExcludedPath = pathname => {
   return excludedPaths.find(excludedPath => {
@@ -43,7 +39,7 @@ const SitewideBanner = props => {
   const options = { variables: { userId }, skip: !userId };
   const { data } = useQuery(VOTER_REGISTRATION_STATUS, options);
 
-  const unregistered = shouldDisplayRegistrationBanner.includes(
+  const unregistered = unregisteredStatuses.includes(
     get(data, 'user.voterRegistrationStatus'),
   );
 

--- a/resources/assets/components/utilities/SitewideBanner/SitewideBanner.js
+++ b/resources/assets/components/utilities/SitewideBanner/SitewideBanner.js
@@ -2,7 +2,6 @@ import gql from 'graphql-tag';
 import { createPortal } from 'react-dom';
 import React, { useRef, useEffect } from 'react';
 import { useQuery } from '@apollo/react-hooks';
-
 import { getUserId } from '../../../helpers/auth';
 import excludedPaths from './config';
 import SitewideBannerContent from './SitewideBannerContent';

--- a/resources/assets/components/utilities/SitewideBanner/SitewideBanner.js
+++ b/resources/assets/components/utilities/SitewideBanner/SitewideBanner.js
@@ -1,8 +1,32 @@
 import { createPortal } from 'react-dom';
 import React, { useRef, useEffect } from 'react';
+import { useQuery } from '@apollo/react-hooks';
+import Placeholder from '../Placeholder';
+import Spinner from '../../artifacts/Spinner/Spinner';
 
+import gql from 'graphql-tag';
+
+import { getUserId } from '../../../helpers/auth';
 import excludedPaths from './config';
 import SitewideBannerContent from './SitewideBannerContent';
+
+const VOTER_REGISTRATION_STATUS = gql`
+  query VoterRegBadgeQuery($userId: String!) {
+    user(id: $userId) {
+      id
+      voterRegistrationStatus
+    }
+  }
+`;
+
+const shouldDisplayRegistrationBanner = [
+  'UNCERTAIN',
+  'CONFIRMED',
+  'UNREGISTERED',
+];
+// If the user has a voterRegistrationStatus of uncertain, unregistered,
+// or confirmed, the banner should appear as it currently does, no changes.
+// For any other status, the banner should not show up at all.
 
 const isExcludedPath = pathname => {
   return excludedPaths.find(excludedPath => {
@@ -20,6 +44,17 @@ const isExcludedPath = pathname => {
 };
 
 const SitewideBanner = props => {
+  const options = { variables: { userId: getUserId() } };
+  const { data, loading, error } = useQuery(VOTER_REGISTRATION_STATUS, options);
+
+  if (loading) {
+    return <Placeholder />;
+  }
+
+  // shouldDisplayRegistrationBanner
+  // shouldDisplayRegistrationBanner.includes(data ? data.user['voterRegistrationStatus'] : {})
+  console.log('Banner:', data ? data.user['voterRegistrationStatus'] : {});
+
   const usePortal = id => {
     const rootElem = useRef(document.createElement('div'));
 

--- a/resources/assets/components/utilities/SitewideBanner/SitewideBanner.js
+++ b/resources/assets/components/utilities/SitewideBanner/SitewideBanner.js
@@ -4,11 +4,9 @@ import { createPortal } from 'react-dom';
 import { useQuery } from '@apollo/react-hooks';
 import React, { useRef, useEffect } from 'react';
 import { useQuery } from '@apollo/react-hooks';
+
 import Placeholder from '../Placeholder';
 import Spinner from '../../artifacts/Spinner/Spinner';
-
-import gql from 'graphql-tag';
-
 import { getUserId } from '../../../helpers/auth';
 import excludedPaths from './config';
 import { getUserId } from '../../../helpers/auth';

--- a/resources/assets/components/utilities/SitewideBanner/SitewideBanner.js
+++ b/resources/assets/components/utilities/SitewideBanner/SitewideBanner.js
@@ -1,10 +1,11 @@
+import { get } from 'lodash';
 import gql from 'graphql-tag';
 import { createPortal } from 'react-dom';
-import React, { useRef, useEffect } from 'react';
 import { useQuery } from '@apollo/react-hooks';
+import React, { useRef, useEffect } from 'react';
 
-import { getUserId } from '../../../helpers/auth';
 import excludedPaths from './config';
+import { getUserId } from '../../../helpers/auth';
 import SitewideBannerContent from './SitewideBannerContent';
 
 const VOTER_REGISTRATION_STATUS = gql`
@@ -38,11 +39,12 @@ const isExcludedPath = pathname => {
 };
 
 const SitewideBanner = props => {
-  const options = { variables: { userId: getUserId() } };
+  const userId = getUserId();
+  const options = { variables: { userId }, skip: !userId };
   const { data } = useQuery(VOTER_REGISTRATION_STATUS, options);
 
   const unregistered = shouldDisplayRegistrationBanner.includes(
-    data ? data.user.voterRegistrationStatus : {},
+    get(data, 'user.voterRegistrationStatus'),
   );
 
   const usePortal = id => {
@@ -62,7 +64,7 @@ const SitewideBanner = props => {
 
   const target = usePortal('banner-portal');
 
-  return !isExcludedPath(window.location.pathname) && unregistered
+  return !isExcludedPath(window.location.pathname) && (!userId || unregistered)
     ? createPortal(children, target)
     : null;
 };

--- a/resources/assets/components/utilities/SitewideBanner/SitewideBanner.js
+++ b/resources/assets/components/utilities/SitewideBanner/SitewideBanner.js
@@ -4,7 +4,6 @@ import { createPortal } from 'react-dom';
 import { useQuery } from '@apollo/react-hooks';
 import React, { useRef, useEffect } from 'react';
 import { useQuery } from '@apollo/react-hooks';
-
 import { getUserId } from '../../../helpers/auth';
 import excludedPaths from './config';
 import { getUserId } from '../../../helpers/auth';

--- a/resources/assets/components/utilities/SitewideBanner/SitewideBanner.js
+++ b/resources/assets/components/utilities/SitewideBanner/SitewideBanner.js
@@ -4,6 +4,7 @@ import { createPortal } from 'react-dom';
 import { useQuery } from '@apollo/react-hooks';
 import React, { useRef, useEffect } from 'react';
 import { useQuery } from '@apollo/react-hooks';
+
 import { getUserId } from '../../../helpers/auth';
 import excludedPaths from './config';
 import { getUserId } from '../../../helpers/auth';

--- a/resources/assets/components/utilities/SitewideBanner/SitewideBanner.js
+++ b/resources/assets/components/utilities/SitewideBanner/SitewideBanner.js
@@ -3,7 +3,13 @@ import gql from 'graphql-tag';
 import { createPortal } from 'react-dom';
 import { useQuery } from '@apollo/react-hooks';
 import React, { useRef, useEffect } from 'react';
+import { useQuery } from '@apollo/react-hooks';
+import Placeholder from '../Placeholder';
+import Spinner from '../../artifacts/Spinner/Spinner';
 
+import gql from 'graphql-tag';
+
+import { getUserId } from '../../../helpers/auth';
 import excludedPaths from './config';
 import { getUserId } from '../../../helpers/auth';
 import SitewideBannerContent from './SitewideBannerContent';

--- a/resources/assets/components/utilities/SitewideBanner/SitewideBanner.js
+++ b/resources/assets/components/utilities/SitewideBanner/SitewideBanner.js
@@ -8,7 +8,7 @@ import excludedPaths from './config';
 import SitewideBannerContent from './SitewideBannerContent';
 
 const VOTER_REGISTRATION_STATUS = gql`
-  query VoterRegBadgeQuery($userId: String!) {
+  query VoterRegSiteWideBannerQuery($userId: String!) {
     user(id: $userId) {
       id
       voterRegistrationStatus

--- a/resources/assets/components/utilities/SitewideBanner/SitewideBanner.js
+++ b/resources/assets/components/utilities/SitewideBanner/SitewideBanner.js
@@ -5,8 +5,6 @@ import { useQuery } from '@apollo/react-hooks';
 import React, { useRef, useEffect } from 'react';
 import { useQuery } from '@apollo/react-hooks';
 
-import Placeholder from '../Placeholder';
-import Spinner from '../../artifacts/Spinner/Spinner';
 import { getUserId } from '../../../helpers/auth';
 import excludedPaths from './config';
 import { getUserId } from '../../../helpers/auth';

--- a/resources/assets/components/utilities/SitewideBanner/SitewideBanner.js
+++ b/resources/assets/components/utilities/SitewideBanner/SitewideBanner.js
@@ -2,6 +2,7 @@ import gql from 'graphql-tag';
 import { createPortal } from 'react-dom';
 import React, { useRef, useEffect } from 'react';
 import { useQuery } from '@apollo/react-hooks';
+
 import { getUserId } from '../../../helpers/auth';
 import excludedPaths from './config';
 import SitewideBannerContent from './SitewideBannerContent';

--- a/resources/assets/components/utilities/SitewideBanner/SitewideBanner.js
+++ b/resources/assets/components/utilities/SitewideBanner/SitewideBanner.js
@@ -1,11 +1,10 @@
+import gql from 'graphql-tag';
 import { createPortal } from 'react-dom';
 import React, { useRef, useEffect } from 'react';
 import { useQuery } from '@apollo/react-hooks';
+
 import Placeholder from '../Placeholder';
 import Spinner from '../../artifacts/Spinner/Spinner';
-
-import gql from 'graphql-tag';
-
 import { getUserId } from '../../../helpers/auth';
 import excludedPaths from './config';
 import SitewideBannerContent from './SitewideBannerContent';
@@ -51,9 +50,13 @@ const SitewideBanner = props => {
     return <Placeholder />;
   }
 
+  if (error) {
+    return <Spinner className="flex justify-center p-3 pb-8" />;
+  }
+
   // shouldDisplayRegistrationBanner
   // shouldDisplayRegistrationBanner.includes(data ? data.user['voterRegistrationStatus'] : {})
-  console.log('Banner:', data ? data.user['voterRegistrationStatus'] : {});
+  console.log('Banner:', data ? data.user.voterRegistrationStatus : {});
 
   const usePortal = id => {
     const rootElem = useRef(document.createElement('div'));

--- a/resources/assets/components/utilities/SitewideBanner/SitewideBanner.js
+++ b/resources/assets/components/utilities/SitewideBanner/SitewideBanner.js
@@ -3,8 +3,6 @@ import { createPortal } from 'react-dom';
 import React, { useRef, useEffect } from 'react';
 import { useQuery } from '@apollo/react-hooks';
 
-import Placeholder from '../Placeholder';
-import Spinner from '../../artifacts/Spinner/Spinner';
 import { getUserId } from '../../../helpers/auth';
 import excludedPaths from './config';
 import SitewideBannerContent from './SitewideBannerContent';
@@ -23,9 +21,6 @@ const shouldDisplayRegistrationBanner = [
   'CONFIRMED',
   'UNREGISTERED',
 ];
-// If the user has a voterRegistrationStatus of uncertain, unregistered,
-// or confirmed, the banner should appear as it currently does, no changes.
-// For any other status, the banner should not show up at all.
 
 const isExcludedPath = pathname => {
   return excludedPaths.find(excludedPath => {
@@ -44,19 +39,11 @@ const isExcludedPath = pathname => {
 
 const SitewideBanner = props => {
   const options = { variables: { userId: getUserId() } };
-  const { data, loading, error } = useQuery(VOTER_REGISTRATION_STATUS, options);
+  const { data } = useQuery(VOTER_REGISTRATION_STATUS, options);
 
-  if (loading) {
-    return <Placeholder />;
-  }
-
-  if (error) {
-    return <Spinner className="flex justify-center p-3 pb-8" />;
-  }
-
-  // shouldDisplayRegistrationBanner
-  // shouldDisplayRegistrationBanner.includes(data ? data.user['voterRegistrationStatus'] : {})
-  console.log('Banner:', data ? data.user.voterRegistrationStatus : {});
+  const unregistered = shouldDisplayRegistrationBanner.includes(
+    data ? data.user.voterRegistrationStatus : {},
+  );
 
   const usePortal = id => {
     const rootElem = useRef(document.createElement('div'));
@@ -75,7 +62,7 @@ const SitewideBanner = props => {
 
   const target = usePortal('banner-portal');
 
-  return !isExcludedPath(window.location.pathname)
+  return !isExcludedPath(window.location.pathname) && unregistered
     ? createPortal(children, target)
     : null;
 };


### PR DESCRIPTION
### What's this PR do?

This pull request connect HolaBar with user VR status

### How should this be reviewed?

... 🥇 

### Any background context you want to provide?
users that are unregistered to vote will continue to see the Holabar
users that are ineligible or completed registration will not see the banner
...

### Relevant tickets

References [Pivotal # 172147696](https://www.pivotaltracker.com/n/projects/2401401/stories/172147696).

### Checklist

- [ x ] This PR has been added to the relevant Pivotal card.
- [ x ] Added screenshots of front-end changes on small, medium, and large screens.
- [ ] Added appropriate feature/unit tests.

USER REGISTRATION STATUS: registration_complete
<img width="840" alt="Screen Shot 2020-07-27 at 10 44 07 PM" src="https://user-images.githubusercontent.com/20409413/88613211-f9837f00-d05a-11ea-8abb-82899e81117b.png">

USER REGISTRATION STATUS: UNREGISTERED

<img width="847" alt="Screen Shot 2020-07-27 at 10 47 33 PM" src="https://user-images.githubusercontent.com/20409413/88613326-33ed1c00-d05b-11ea-9ad0-4985bc78c79b.png">


