### PR TITLE
URGENT: Bug Fix - Fetch scholarship information for campaigns in gallery block

### DIFF
--- a/resources/assets/components/blocks/GalleryBlock/GalleryBlock.js
+++ b/resources/assets/components/blocks/GalleryBlock/GalleryBlock.js
@@ -6,10 +6,12 @@ import { withoutNulls } from '../../../helpers';
 import Person from '../../utilities/Person/Person';
 import Gallery from '../../utilities/Gallery/Gallery';
 import SectionHeader from '../../utilities/SectionHeader/SectionHeader';
-import ScholarshipCard from '../../utilities/ScholarshipCard/ScholarshipCard';
 import CampaignCard, {
   campaignCardFragment,
 } from '../../utilities/CampaignCard/CampaignCard';
+import ScholarshipCard, {
+  scholarshipCardFragment,
+} from '../../utilities/ScholarshipCard/ScholarshipCard';
 import PageGalleryItem from '../../utilities/Gallery/templates/PageGalleryItem/PageGalleryItem';
 import ContentBlockGalleryItem from '../../utilities/Gallery/templates/ContentBlockGalleryItem';
 
@@ -38,10 +40,12 @@ export const GalleryBlockFragment = gql`
         slug
       }
       ...CampaignCard
+      ...ScholarshipCard
     }
   }
 
   ${campaignCardFragment}
+  ${scholarshipCardFragment}
 `;
 
 const renderBlock = (blockType, block, imageAlignment, imageFit) => {


### PR DESCRIPTION
### What's this PR do?

This pull request fixes what I broke in #2281 where we removed the scholarship fields queried for the ScholarshipCard gallery nodes. Here, we interpolate the `scholarshipCardFragment` so that we _do_ query these fields.

### How should this be reviewed?
👁️ 

### Any background context you want to provide?
You could argue that having both the CampaignCard & ScholarshipCard is superfluous, but for clarities sake I left the CampaignCard in (so that it's clear what fields we need for CAMPAIGN gallery nodes)

We should add a test for this gallery node!

### Relevant tickets
https://dosomething.slack.com/archives/C09ANFQLA/p1595963242139000

