### PR TITLE
Rename StartVoterRegistrationForm sourceDetails prop

### DIFF
--- a/docs/development/features/voter-registration.md
+++ b/docs/development/features/voter-registration.md
@@ -96,8 +96,6 @@ We hardcode specific configuration `ContentBlock` ID's:
 
 **Dev:**
 
-Content:
-
 - [Register To Vote ContentBlock](https://app.contentful.com/spaces/81iqaqpfd8fy/environments/dev/entries/bt0jUBYJaKoi1oab25Wmx) - bt0jUBYJaKoi1oab25Wmx
 - [FAQ ContentBlock](https://app.contentful.com/spaces/81iqaqpfd8fy/environments/dev/entries/3cXc0RPMVNeE4surEqFujL) - 3cXc0RPMVNeE4surEqFujL
 - [OVRD Campaign Link ContentBlock](https://app.contentful.com/spaces/81iqaqpfd8fy/environments/dev/entries/3p2qz2JPCvgVitgRVBoMFz) - 3p2qz2JPCvgVitgRVBoMFz
@@ -147,8 +145,6 @@ Dev Quiz Results:
 - [2KfkCOTi7u4CqAyyCuGyci](https://dev.dosomething.org/us/quiz-results/2KfkCOTi7u4CqAyyCuGyci)
 
 **Related links:**
-
-- [User Flows For Voting Quiz](https://docs.google.com/spreadsheets/d/10uIZNghJTMKWR0lk5_y-q9-NwabDKYyrf8Vxlj17S9c/edit#gid=1453114542)
 
 - [Quiz documentation](https://github.com/DoSomething/phoenix-next/blob/8b5a97fdd973c8eb925191f78b36c2f676d2707a/docs/content-publishing/quiz.md) - This was removed in [#1369](https://github.com/DoSomething/phoenix-next/pull/1369) when we moved editorial guides into the Campaign Playbook.
 

--- a/docs/development/features/voter-registration.md
+++ b/docs/development/features/voter-registration.md
@@ -146,7 +146,7 @@ Dev Quiz Results:
 
 **Related links:**
 
-- [Quiz documentation](https://github.com/DoSomething/phoenix-next/blob/8b5a97fdd973c8eb925191f78b36c2f676d2707a/docs/content-publishing/quiz.md) - This was removed in [#1369](https://github.com/DoSomething/phoenix-next/pull/1369) when we moved editorial guides into the Campaign Playbook.
+- [Quiz documentation](https://github.com/DoSomething/phoenix-next/blob/8b5a97fdd973c8eb925191f78b36c2f676d2707a/docs/content-publishing/quiz.md) - This was removed in [#1369](https://github.com/DoSomething/phoenix-next/pull/1369) when we moved editorial guides into the [Campaign Playbook](https://docs.google.com/document/d/1iOFgNNNN0ry9zyyRyxcuLI-tZm2CKkcPLbfUMos9WcI/edit?usp=sharing).
 
 **Notes:**
 

--- a/resources/assets/components/pages/QuizResultPage/QuizResultPage.js
+++ b/resources/assets/components/pages/QuizResultPage/QuizResultPage.js
@@ -109,7 +109,7 @@ const QuizResultPage = ({ id }) => {
                 <StartVoterRegistrationForm
                   contextSource="voter-registration-quiz-results-page"
                   className="md:mx-auto xl:w-4/5"
-                  sourceDetail={additionalContent.sourceDetails}
+                  sourceDetails={additionalContent.sourceDetails}
                 />
               </div>
             ) : null}

--- a/resources/assets/components/pages/VoterRegistrationDrivePage/VoterRegistrationDrivePage.js
+++ b/resources/assets/components/pages/VoterRegistrationDrivePage/VoterRegistrationDrivePage.js
@@ -132,7 +132,7 @@ const VoterRegistrationDrivePage = () => {
                 contextSource="beta-voter-registration-drive-page"
                 groupId={groupId}
                 referrerUserId={referrerUserId}
-                sourceDetail="onlinedrivereferral"
+                sourceDetails="onlinedrivereferral"
               />
             </div>
             <ContentfulEntryLoader

--- a/resources/assets/components/utilities/StartVoterRegistrationForm/StartVoterRegistrationForm.js
+++ b/resources/assets/components/utilities/StartVoterRegistrationForm/StartVoterRegistrationForm.js
@@ -17,7 +17,7 @@ const StartVoterRegistrationForm = ({
   contextSource,
   groupId,
   referrerUserId,
-  sourceDetail,
+  sourceDetails,
 }) => {
   const [email, setEmail] = useState('');
   const [zip, setZip] = useState('');
@@ -62,7 +62,7 @@ const StartVoterRegistrationForm = ({
           <input
             type="hidden"
             name="source"
-            value={getTrackingSource(sourceDetail, referrerUserId, groupId)}
+            value={getTrackingSource(sourceDetails, referrerUserId, groupId)}
             data-testid="voter-registration-tracking-source"
           />
 
@@ -125,7 +125,7 @@ StartVoterRegistrationForm.propTypes = {
   contextSource: PropTypes.string.isRequired,
   groupId: PropTypes.number,
   referrerUserId: PropTypes.string,
-  sourceDetail: PropTypes.string.isRequired,
+  sourceDetails: PropTypes.string.isRequired,
 };
 
 StartVoterRegistrationForm.defaultProps = {


### PR DESCRIPTION
### What's this PR do?

This pull request renames the prop from `sourceDetail` to `sourceDetails`, to align with the `source_details` key/value pair that gets sent in a voter registration tracking source.

It also removes a link to a Google sheet about the Voting Quiz that's no longer relevant (and links to the Campaign Playbook when documenting why the technical documentation on quizzes was removed).

### How should this be reviewed?

👀 

### Any background context you want to provide?

🐰 

### Relevant tickets

References https://github.com/DoSomething/phoenix-next/pull/2297#discussion_r460201874

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added screenshots of front-end changes on small, medium, and large screens.
- [ ] Added appropriate feature/unit tests.
