### PR TITLE
Group Finder tweaks

### DIFF
--- a/resources/assets/components/CampaignSignupForm/CampaignSignupForm.js
+++ b/resources/assets/components/CampaignSignupForm/CampaignSignupForm.js
@@ -97,24 +97,27 @@ const CampaignSignupForm = props => {
     <div className="my-3" data-testid="join-group-signup-form">
       <Card title="Join a group" className="rounded bordered">
         <div className="p-3">
+          <p className="text-sm text-gray-500 pt-3 md:pt-0">
+            Can&apos;t find your group?
+          </p>
+
+          <p className="text-sm text-gray-500 mt-0">
+            Email tej@dosomething.org for help.
+          </p>
+
           <GroupFinder
             context={{ campaignId, pageId }}
             groupType={groupType}
             onChange={handleGroupFinderChange}
           />
+
           <PrimaryButton
             attributes={{ 'data-testid': 'join-group-signup-button' }}
-            className={className}
+            className={`${className} py-2 md:py-3`}
             isDisabled={!groupId}
             onClick={handleSignup}
             text="Join Group"
           />
-          <p className="text-sm text-gray-500 pt-3 md:pt-0">
-            Can&apos;t find your group?
-          </p>
-          <p className="text-sm text-gray-500 mt-0">
-            Email tej@dosomething.org for help.
-          </p>
         </div>
       </Card>
     </div>

--- a/resources/assets/components/CampaignSignupForm/CampaignSignupForm.js
+++ b/resources/assets/components/CampaignSignupForm/CampaignSignupForm.js
@@ -97,10 +97,6 @@ const CampaignSignupForm = props => {
     <div className="my-3" data-testid="join-group-signup-form">
       <Card title="Join a group" className="rounded bordered">
         <div className="p-3">
-          <p className="text-sm text-gray-500 pt-3 md:pt-0">
-            Can&apos;t find your group? Email tej@dosomething.org for help.
-          </p>
-
           <GroupFinder
             context={{ campaignId, pageId }}
             groupType={groupType}
@@ -114,6 +110,10 @@ const CampaignSignupForm = props => {
             onClick={handleSignup}
             text="Join Group"
           />
+
+          <p className="text-sm text-gray-500 pt-3 md:pt-0">
+            Can&apos;t find your group? Email tej@dosomething.org for help.
+          </p>
         </div>
       </Card>
     </div>

--- a/resources/assets/components/CampaignSignupForm/CampaignSignupForm.js
+++ b/resources/assets/components/CampaignSignupForm/CampaignSignupForm.js
@@ -98,11 +98,7 @@ const CampaignSignupForm = props => {
       <Card title="Join a group" className="rounded bordered">
         <div className="p-3">
           <p className="text-sm text-gray-500 pt-3 md:pt-0">
-            Can&apos;t find your group?
-          </p>
-
-          <p className="text-sm text-gray-500 mt-0">
-            Email tej@dosomething.org for help.
+            Can&apos;t find your group? Email tej@dosomething.org for help.
           </p>
 
           <GroupFinder


### PR DESCRIPTION
### What's this PR do?

This pull request makes the Join Group button just a liiiitle bit smaller on mobile, and renders the help text in a single `p`

Before

<img width="497" alt="Screen Shot 2020-07-30 at 2 06 10 PM" src="https://user-images.githubusercontent.com/1236811/88974680-df6dba80-d26d-11ea-99ac-3052583ded4c.png">

After

<img width="497" alt="Screen Shot 2020-07-30 at 2 05 36 PM" src="https://user-images.githubusercontent.com/1236811/88974689-e268ab00-d26d-11ea-9d0d-21d4310723e5.png">




### How should this be reviewed?

👀 

### Any background context you want to provide?

🦈 

### Relevant tickets

References [Slack thread](https://dosomething.slack.com/archives/CTVPG6L4R/p1596132412220100).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added screenshots of front-end changes on small, medium, and large screens.
- [ ] Added appropriate feature/unit tests.
