### PR TITLE
Lightly Test The Hide Campaigns Feature

### DIFF
--- a/cypress/integration/cause-page.js
+++ b/cypress/integration/cause-page.js
@@ -131,4 +131,94 @@ describe('Cause Page', () => {
       },
     );
   });
+
+  context('With "Hide Campaigns" feature flag enabled', () => {
+    /** @test */
+    it('Does not display group campaigns', () => {
+      cy.mockGraphqlOp('CausePageQuery', {
+        causePageBySlug: {
+          slug: 'education',
+        },
+      });
+
+      // Stub the query to have a 'next page' so we show the 'view more' button.
+      cy.mockGraphqlOp('PaginatedCampaignQuery', {
+        paginatedCampaigns: {
+          edges: [
+            {
+              node: {
+                id: 1,
+                groupTypeId: null,
+              },
+            },
+            {
+              node: {
+                id: 2,
+                groupTypeId: null,
+              },
+            },
+            {
+              node: {
+                id: 3,
+                groupTypeId: 1,
+              },
+            },
+          ],
+          pageInfo: {
+            hasNextPage: true,
+          },
+        },
+      });
+
+      cy.withFeatureFlags({ hide_campaigns: true })
+        .withSiteConfig({ hide_campaign_ids: [] })
+        .visit('/us/causes/education');
+
+      cy.findAllByTestId('campaign-card').should('have.length', 2);
+    });
+
+    /** @test */
+    it('Does not display campaigns with IDs listed as "hidden"', () => {
+      cy.mockGraphqlOp('CausePageQuery', {
+        causePageBySlug: {
+          slug: 'education',
+        },
+      });
+
+      // Stub the query to have a 'next page' so we show the 'view more' button.
+      cy.mockGraphqlOp('PaginatedCampaignQuery', {
+        paginatedCampaigns: {
+          edges: [
+            {
+              node: {
+                id: 1,
+                groupTypeId: null,
+              },
+            },
+            {
+              node: {
+                id: 2,
+                groupTypeId: null,
+              },
+            },
+            {
+              node: {
+                id: 3,
+                groupTypeId: 1,
+              },
+            },
+          ],
+          pageInfo: {
+            hasNextPage: true,
+          },
+        },
+      });
+
+      cy.withFeatureFlags({ hide_campaigns: true })
+        .withSiteConfig({ hide_campaign_ids: ['1'] })
+        .visit('/us/causes/education');
+
+      cy.findAllByTestId('campaign-card').should('have.length', 1);
+    });
+  });
 });

--- a/resources/assets/components/utilities/CampaignCard/CampaignCard.js
+++ b/resources/assets/components/utilities/CampaignCard/CampaignCard.js
@@ -40,7 +40,10 @@ const CampaignCard = ({ campaign }) => {
   ]);
 
   return (
-    <article className="flex flex-col h-full relative text-left">
+    <article
+      className="flex flex-col h-full relative text-left"
+      data-testid="campaign-card"
+    >
       <a className="block" href={path}>
         <img
           alt={showcaseImage.description || `Cover photo for ${showcaseTitle}`}


### PR DESCRIPTION
### What's this PR do?

This pull request follows up on #2310 with two quick Cypress tests.

### How should this be reviewed?
👀 

### Any background context you want to provide?
i have failed you anakin

My original plan was to add some slightly more robust Jest unit tests for this component across this feature flag, but I ended spending too much of a bright day grappling with `MockedProvider` and ended up making this concession in the interest of time and being that we anticipate following this up with formally supported API filters for this functionality which should render this local hack obsolete. Amen and may it be their will.
