### PR TITLE
Adds migration for actionStatsBlock content type

### DIFF
--- a/contentful/content-types/actionStatsBlock.js
+++ b/contentful/content-types/actionStatsBlock.js
@@ -1,0 +1,49 @@
+module.exports = function(migration) {
+  const actionStatsBlock = migration
+    .createContentType('actionStatsBlock')
+    .name('Action Stats Block')
+    .description('Displays leaderboard for an Action ID.')
+    .displayField('internalTitle');
+
+  actionStatsBlock
+    .createField('internalTitle')
+    .name('Internal Title')
+    .type('Symbol')
+    .localized(false)
+    .required(true)
+    .validations([
+      {
+        unique: true,
+      },
+    ])
+    .disabled(false)
+    .omitted(false);
+
+  actionStatsBlock
+    .createField('actionId')
+    .name('Action ID')
+    .type('Integer')
+    .localized(false)
+    .required(true)
+    .validations([
+      {
+        range: {
+          min: 1,
+          max: null,
+        },
+      },
+    ])
+    .disabled(false)
+    .omitted(false);
+
+  actionStatsBlock.changeFieldControl(
+    'internalTitle',
+    'builtin',
+    'singleLine',
+    {},
+  );
+
+  actionStatsBlock.changeFieldControl('actionId', 'builtin', 'numberEditor', {
+    helpText: 'The Rogue Action ID to display a leaderboard for.',
+  });
+};


### PR DESCRIPTION
### What's this PR do?

This pull request adds a Contentful migration to add a new content type, `actionStatsBlock`, which only has 2 fields:

* Internal Title
* Action ID -- This corresponds to the Rogue action the block will display action stats for.

This block type will be used to display leaderboards for a given action ID. The corresponding GraphQL changes for this type can be reviewed in https://github.com/DoSomething/graphql/pull/265.

I've manually created this content type in the dev environment, and will run this migration on qa and prod once approved per our [workflow for creating new content types](https://dosomething.gitbook.io/phoenix-documentation/development/contentful/workflow#5-upon-merge-apply-changes-to-contentful-qa-and-master).

### How should this be reviewed?

[Example dev entry](https://app.contentful.com/spaces/81iqaqpfd8fy/environments/dev/entries/51SWUaRvyhsJsTWHRGGfjK):

<img src="https://user-images.githubusercontent.com/1236811/89241538-0c92d380-d5b4-11ea-823b-28f0bc6767b5.png">


### Any background context you want to provide?

Coming soon to a future PR:

* Adding this content type to the blocks fields of `Page` and `StoryPage` content types
* Adding documentation 

### Relevant tickets

References [Pivotal #174021616](https://www.pivotaltracker.com/story/show/174021616).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added screenshots of front-end changes on small, medium, and large screens.
- [ ] Added appropriate feature/unit tests.
