### PR TITLE
Adds GalleryBlockSignup Component For One-Click Campaign Signup

### DIFF
--- a/resources/assets/components/utilities/ScholarshipCard/GalleryBlockSignup.js
+++ b/resources/assets/components/utilities/ScholarshipCard/GalleryBlockSignup.js
@@ -13,22 +13,38 @@ export const CREATE_SIGNUP_MUTATION = gql`
     }
   }
 `;
-const GalleryBlockSignup = ({ campaignId }) => {
-  const [handleSignup] = useMutation(CREATE_SIGNUP_MUTATION, {
-    variables: { campaignId },
-  });
+const GalleryBlockSignup = ({ campaignId, slug }) => {
+  const [handleSignup, { called, error }] = useMutation(
+    CREATE_SIGNUP_MUTATION,
+    {
+      variables: { campaignId },
+    },
+  );
 
-  return <SecondaryButton
-    className="w-full"
-    text="Apply Now"
-    onClick={handleSignup}
-  /> ? (
-    <Redirect to={`/us/campaigns/${campaignId}`} />
-  ) : null;
+  if (called && !error) {
+    return <Redirect to={`/us/campaigns/${slug}`} />;
+  }
+
+  if (error) {
+    // TODO: show error state…
+  }
+
+  return (
+    <SecondaryButton
+      className="w-full"
+      text="Apply Now"
+      onClick={handleSignup}
+    />
+  );
 };
 
 GalleryBlockSignup.propTypes = {
-  campaignId: PropTypes.number.isRequired,
+  campaignId: PropTypes.number,
+  slug: PropTypes.string,
+};
+GalleryBlockSignup.defaultProps = {
+  campaignId: null,
+  slug: null,
 };
 
 export default GalleryBlockSignup;

--- a/resources/assets/components/utilities/ScholarshipCard/GalleryBlockSignup.js
+++ b/resources/assets/components/utilities/ScholarshipCard/GalleryBlockSignup.js
@@ -5,6 +5,7 @@ import { useMutation } from '@apollo/react-hooks';
 
 import SecondaryButton from '../Button/SecondaryButton';
 import Spinner from '../../artifacts/Spinner/Spinner';
+import ErrorBlock from '../../blocks/ErrorBlock/ErrorBlock';
 
 export const CREATE_SIGNUP_MUTATION = gql`
   mutation CampaignSignupMutation($campaignId: Int!) {
@@ -28,7 +29,7 @@ const GalleryBlockSignup = ({ campaignId, path }) => {
   }
 
   if (error) {
-    // TODO: show error state…
+    return <ErrorBlock error={error} />;
   }
 
   return (

--- a/resources/assets/components/utilities/ScholarshipCard/GalleryBlockSignup.js
+++ b/resources/assets/components/utilities/ScholarshipCard/GalleryBlockSignup.js
@@ -13,7 +13,7 @@ export const CREATE_SIGNUP_MUTATION = gql`
     }
   }
 `;
-const GalleryBlockSignup = ({ campaignId, slug }) => {
+const GalleryBlockSignup = ({ campaignId, path }) => {
   const [handleSignup, { called, error }] = useMutation(
     CREATE_SIGNUP_MUTATION,
     {
@@ -22,7 +22,7 @@ const GalleryBlockSignup = ({ campaignId, slug }) => {
   );
 
   if (called && !error) {
-    return <Redirect to={`/us/campaigns/${slug}`} />;
+    return <Redirect to={path} />;
   }
 
   if (error) {
@@ -40,11 +40,11 @@ const GalleryBlockSignup = ({ campaignId, slug }) => {
 
 GalleryBlockSignup.propTypes = {
   campaignId: PropTypes.number,
-  slug: PropTypes.string,
+  path: PropTypes.string,
 };
 GalleryBlockSignup.defaultProps = {
   campaignId: null,
-  slug: null,
+  path: null,
 };
 
 export default GalleryBlockSignup;

--- a/resources/assets/components/utilities/ScholarshipCard/GalleryBlockSignup.js
+++ b/resources/assets/components/utilities/ScholarshipCard/GalleryBlockSignup.js
@@ -13,7 +13,7 @@ export const CREATE_SIGNUP_MUTATION = gql`
     }
   }
 `;
-const GallleryBlockSignup = ({ id, campaignId }) => {
+const GalleryBlockSignup = ({ id, campaignId }) => {
   const [handleSignup] = useMutation(CREATE_SIGNUP_MUTATION, {
     variables: { campaignId },
   });
@@ -27,9 +27,9 @@ const GallleryBlockSignup = ({ id, campaignId }) => {
   return <Redirect to={`/us/campaigns/${campaignId}`} />;
 };
 
-GallleryBlockSignup.propTypes = {
+GalleryBlockSignup.propTypes = {
   id: PropTypes.string.isRequired,
   campaignId: PropTypes.number.isRequired,
 };
 
-export default GallleryBlockSignup;
+export default GalleryBlockSignup;

--- a/resources/assets/components/utilities/ScholarshipCard/GalleryBlockSignup.js
+++ b/resources/assets/components/utilities/ScholarshipCard/GalleryBlockSignup.js
@@ -4,7 +4,7 @@ import React, { useEffect } from 'react';
 import { Redirect } from 'react-router-dom';
 import { useMutation } from '@apollo/react-hooks';
 
-import { isAuthenticated } from '../../../helpers/auth';
+import SecondaryButton from '../Button/SecondaryButton';
 
 export const CREATE_SIGNUP_MUTATION = gql`
   mutation CampaignSignupMutation($campaignId: Int!) {
@@ -18,11 +18,12 @@ const GalleryBlockSignup = ({ id, campaignId }) => {
     variables: { campaignId },
   });
 
-  useEffect(() => {
-    if (isAuthenticated()) {
-      handleSignup();
-    }
-  }, [id]);
+  <SecondaryButton
+    className="w-full"
+    href={path}
+    text="Apply Now"
+    onClick={handleSignup}
+  />;
 
   return <Redirect to={`/us/campaigns/${campaignId}`} />;
 };

--- a/resources/assets/components/utilities/ScholarshipCard/GalleryBlockSignup.js
+++ b/resources/assets/components/utilities/ScholarshipCard/GalleryBlockSignup.js
@@ -1,6 +1,6 @@
 import gql from 'graphql-tag';
 import PropTypes from 'prop-types';
-import React, { useEffect } from 'react';
+import React from 'react';
 import { Redirect } from 'react-router-dom';
 import { useMutation } from '@apollo/react-hooks';
 
@@ -13,23 +13,21 @@ export const CREATE_SIGNUP_MUTATION = gql`
     }
   }
 `;
-const GalleryBlockSignup = ({ id, campaignId }) => {
+const GalleryBlockSignup = ({ campaignId }) => {
   const [handleSignup] = useMutation(CREATE_SIGNUP_MUTATION, {
     variables: { campaignId },
   });
 
-  <SecondaryButton
+  return <SecondaryButton
     className="w-full"
-    href={path}
     text="Apply Now"
     onClick={handleSignup}
-  />;
-
-  return <Redirect to={`/us/campaigns/${campaignId}`} />;
+  /> ? (
+    <Redirect to={`/us/campaigns/${campaignId}`} />
+  ) : null;
 };
 
 GalleryBlockSignup.propTypes = {
-  id: PropTypes.string.isRequired,
   campaignId: PropTypes.number.isRequired,
 };
 

--- a/resources/assets/components/utilities/ScholarshipCard/GalleryBlockSignup.js
+++ b/resources/assets/components/utilities/ScholarshipCard/GalleryBlockSignup.js
@@ -4,6 +4,7 @@ import React from 'react';
 import { useMutation } from '@apollo/react-hooks';
 
 import SecondaryButton from '../Button/SecondaryButton';
+import Spinner from '../../artifacts/Spinner/Spinner';
 
 export const CREATE_SIGNUP_MUTATION = gql`
   mutation CampaignSignupMutation($campaignId: Int!) {
@@ -21,7 +22,9 @@ const GalleryBlockSignup = ({ campaignId, path }) => {
   );
 
   if (called && !error) {
-    return (window.location = { path });
+    window.location = path;
+
+    return <Spinner className="flex justify-center p-4" />;
   }
 
   if (error) {

--- a/resources/assets/components/utilities/ScholarshipCard/GalleryBlockSignup.js
+++ b/resources/assets/components/utilities/ScholarshipCard/GalleryBlockSignup.js
@@ -1,0 +1,35 @@
+import gql from 'graphql-tag';
+import PropTypes from 'prop-types';
+import React, { useEffect } from 'react';
+import { Redirect } from 'react-router-dom';
+import { useMutation } from '@apollo/react-hooks';
+
+import { isAuthenticated } from '../../../helpers/auth';
+
+export const CREATE_SIGNUP_MUTATION = gql`
+  mutation CampaignSignupMutation($campaignId: Int!) {
+    createSignup(campaignId: $campaignId) {
+      id
+    }
+  }
+`;
+const GallleryBlockSignup = ({ id, campaignId }) => {
+  const [handleSignup] = useMutation(CREATE_SIGNUP_MUTATION, {
+    variables: { campaignId },
+  });
+
+  useEffect(() => {
+    if (isAuthenticated()) {
+      handleSignup();
+    }
+  }, [id]);
+
+  return <Redirect to={`/us/campaigns/${campaignId}`} />;
+};
+
+GallleryBlockSignup.propTypes = {
+  id: PropTypes.string.isRequired,
+  campaignId: PropTypes.number.isRequired,
+};
+
+export default GallleryBlockSignup;

--- a/resources/assets/components/utilities/ScholarshipCard/GalleryBlockSignup.js
+++ b/resources/assets/components/utilities/ScholarshipCard/GalleryBlockSignup.js
@@ -1,7 +1,6 @@
 import gql from 'graphql-tag';
 import PropTypes from 'prop-types';
 import React from 'react';
-import { Redirect } from 'react-router-dom';
 import { useMutation } from '@apollo/react-hooks';
 
 import SecondaryButton from '../Button/SecondaryButton';
@@ -22,7 +21,7 @@ const GalleryBlockSignup = ({ campaignId, path }) => {
   );
 
   if (called && !error) {
-    return <Redirect to={path} />;
+    return (window.location = { path });
   }
 
   if (error) {

--- a/resources/assets/components/utilities/ScholarshipCard/ScholarshipCard.js
+++ b/resources/assets/components/utilities/ScholarshipCard/ScholarshipCard.js
@@ -26,6 +26,8 @@ export const scholarshipCardFragment = gql`
     }
     ... on CampaignWebsite {
       id
+      campaignId
+      slug
       scholarshipAmount
       scholarshipDeadline
       staffPick
@@ -47,6 +49,7 @@ const ScholarshipCard = ({ campaign }) => {
     scholarshipDeadline,
     showcaseImage,
     campaignId,
+    slug,
     staffPick,
     path,
   } = campaign;
@@ -117,7 +120,7 @@ const ScholarshipCard = ({ campaign }) => {
         </div>
 
         {isAuthenticated ? (
-          <GalleryBlockSignup campaignId={campaignId} />
+          <GalleryBlockSignup campaignId={campaignId} campaignSlug={slug} />
         ) : (
           <SecondaryButton
             className="w-full"

--- a/resources/assets/components/utilities/ScholarshipCard/ScholarshipCard.js
+++ b/resources/assets/components/utilities/ScholarshipCard/ScholarshipCard.js
@@ -14,6 +14,7 @@ import {
   trackAnalyticsEvent,
   getPageContext,
 } from '../../../helpers/analytics';
+import { isAuthenticated } from '../../../selectors/user';
 
 // Write a graphql query to get campaign information for a specific id
 export const scholarshipCardFragment = gql`
@@ -57,7 +58,6 @@ const ScholarshipCard = ({ campaign }) => {
   ]);
 
   const handleScholarshipCardShareClick = () => {
-    GalleryBlockSignup();
     trackAnalyticsEvent('clicked_scholarship_gallery_block_apply_now', {
       action: 'button_clicked',
       category: EVENT_CATEGORIES.siteAction,
@@ -116,12 +116,16 @@ const ScholarshipCard = ({ campaign }) => {
           </div>
         </div>
 
-        <SecondaryButton
-          className="w-full"
-          href={path}
-          text="Apply Now"
-          onClick={handleScholarshipCardShareClick}
-        />
+        {isAuthenticated ? (
+          <GalleryBlockSignup />
+        ) : (
+          <SecondaryButton
+            className="w-full"
+            href={path}
+            text="Apply Now"
+            onClick={handleScholarshipCardShareClick}
+          />
+        )}
       </div>
     </article>
   );

--- a/resources/assets/components/utilities/ScholarshipCard/ScholarshipCard.js
+++ b/resources/assets/components/utilities/ScholarshipCard/ScholarshipCard.js
@@ -117,7 +117,7 @@ const ScholarshipCard = ({ campaign }) => {
         </div>
 
         {isAuthenticated ? (
-          <GalleryBlockSignup />
+          <GalleryBlockSignup campaignId={campaignId} />
         ) : (
           <SecondaryButton
             className="w-full"

--- a/resources/assets/components/utilities/ScholarshipCard/ScholarshipCard.js
+++ b/resources/assets/components/utilities/ScholarshipCard/ScholarshipCard.js
@@ -58,7 +58,6 @@ const ScholarshipCard = ({ campaign }) => {
   ]);
 
   const handleScholarshipCardShareClick = () => {
-    GalleryBlockSignup();
     trackAnalyticsEvent('clicked_scholarship_gallery_block_apply_now', {
       action: 'button_clicked',
       category: EVENT_CATEGORIES.siteAction,

--- a/resources/assets/components/utilities/ScholarshipCard/ScholarshipCard.js
+++ b/resources/assets/components/utilities/ScholarshipCard/ScholarshipCard.js
@@ -3,6 +3,7 @@ import gql from 'graphql-tag';
 import { propType } from 'graphql-anywhere';
 
 import SecondaryButton from '../Button/SecondaryButton';
+import GalleryBlockSignup from './GalleryBlockSignup';
 import {
   contentfulImageSrcset,
   contentfulImageUrl,
@@ -56,6 +57,7 @@ const ScholarshipCard = ({ campaign }) => {
   ]);
 
   const handleScholarshipCardShareClick = () => {
+    GalleryBlockSignup();
     trackAnalyticsEvent('clicked_scholarship_gallery_block_apply_now', {
       action: 'button_clicked',
       category: EVENT_CATEGORIES.siteAction,

--- a/resources/assets/components/utilities/ScholarshipCard/ScholarshipCard.js
+++ b/resources/assets/components/utilities/ScholarshipCard/ScholarshipCard.js
@@ -14,7 +14,7 @@ import {
   trackAnalyticsEvent,
   getPageContext,
 } from '../../../helpers/analytics';
-import { isAuthenticated } from '../../../selectors/user';
+import { isAuthenticated } from '../../../helpers/auth';
 
 // Write a graphql query to get campaign information for a specific id
 export const scholarshipCardFragment = gql`
@@ -118,7 +118,7 @@ const ScholarshipCard = ({ campaign }) => {
           </div>
         </div>
 
-        {isAuthenticated ? (
+        {isAuthenticated() ? (
           <GalleryBlockSignup campaignId={campaignId} path={path} />
         ) : (
           <SecondaryButton

--- a/resources/assets/components/utilities/ScholarshipCard/ScholarshipCard.js
+++ b/resources/assets/components/utilities/ScholarshipCard/ScholarshipCard.js
@@ -58,6 +58,7 @@ const ScholarshipCard = ({ campaign }) => {
   ]);
 
   const handleScholarshipCardShareClick = () => {
+    GalleryBlockSignup();
     trackAnalyticsEvent('clicked_scholarship_gallery_block_apply_now', {
       action: 'button_clicked',
       category: EVENT_CATEGORIES.siteAction,

--- a/resources/assets/components/utilities/ScholarshipCard/ScholarshipCard.js
+++ b/resources/assets/components/utilities/ScholarshipCard/ScholarshipCard.js
@@ -49,7 +49,6 @@ const ScholarshipCard = ({ campaign }) => {
     scholarshipDeadline,
     showcaseImage,
     campaignId,
-    slug,
     staffPick,
     path,
   } = campaign;
@@ -120,7 +119,7 @@ const ScholarshipCard = ({ campaign }) => {
         </div>
 
         {isAuthenticated ? (
-          <GalleryBlockSignup campaignId={campaignId} campaignSlug={slug} />
+          <GalleryBlockSignup campaignId={campaignId} path={path} />
         ) : (
           <SecondaryButton
             className="w-full"


### PR DESCRIPTION
### What's this PR do?

This pull request adds a graphql mutation in order to redirect an authenticated user to a campaign page with one click. The new `GalleryBlockSignup` uses a helper to check if the user is authenticated and then redirects them to the campaign page. I also added the`GalleryBlockSignup` to the scholarship card "apply now" button to ensure that it works but this is only the beginning so let me know if this is not the best logical approach.

### How should this be reviewed?

Is this the right approach? Did I add the component to a feasible location? How's the naming? (I'm terrible at naming things 🙈)

### Any background context you want to provide?

See pivotal ticket for more info

### Relevant tickets

References [Pivotal #173228830](https://www.pivotaltracker.com/story/show/173228830).

### Checklist

- [ x ] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added screenshots of front-end changes on small, medium, and large screens.
- [ ] Added appropriate feature/unit tests.
