### PR TITLE
Fix Buggy Cypress Tests on the Sitewide Banner

### DIFF
--- a/cypress/integration/sitewide-banner.js
+++ b/cypress/integration/sitewide-banner.js
@@ -51,7 +51,7 @@ describe('Site Wide Banner', () => {
 
     cy.authVisitCampaignWithoutSignup(user, exampleCampaign);
 
-    cy.findByTestId('sitewide-banner-hidden');
+    cy.findByTestId('sitewide-banner-hidden').should('have.length', 1);
   });
 
   it('The Site Wide Banner is not displayed on the beta voter registration (OVRD) drive page', () => {
@@ -78,7 +78,7 @@ describe('Site Wide Banner', () => {
 
     cy.visit(`/us/my-voter-registration-drive?referrer_user_id=${user.id}`);
 
-    cy.findByTestId('sitewide-banner-hidden');
+    cy.findByTestId('sitewide-banner-hidden').should('have.length', 1);
   });
 
   /** @test */
@@ -98,7 +98,7 @@ describe('Site Wide Banner', () => {
 
     cy.visit(`/us/quiz-results/${quizResultId}`);
 
-    cy.findByTestId('sitewide-banner-hidden');
+    cy.findByTestId('sitewide-banner-hidden').should('have.length', 1);
   });
 
   /** @test */

--- a/cypress/integration/sitewide-banner.js
+++ b/cypress/integration/sitewide-banner.js
@@ -23,10 +23,7 @@ describe('Site Wide Banner', () => {
   it('The Site Wide Banner is displayed on campaign pages', () => {
     cy.anonVisitCampaign(exampleCampaign);
 
-    cy.get('#banner-portal > .wrapper > [data-test=site-wide-banner]').should(
-      'have.length',
-      1,
-    );
+    cy.findByTestId('sitewide-banner').should('have.length', 1);
   });
 
   it('The Site Wide Banner is displayed on campaign pages for authenticated users who are not registered to vote', () => {
@@ -39,9 +36,8 @@ describe('Site Wide Banner', () => {
     });
 
     cy.authVisitCampaignWithoutSignup(user, exampleCampaign);
-    cy.get('#banner-portal > .wrapper > [data-test=site-wide-banner]').should(
-      'not.exist',
-    );
+
+    cy.findByTestId('sitewide-banner').should('have.length', 1);
   });
 
   it('The Site Wide Banner is not displayed on campaign pages for authenticated users who are registered to vote', () => {
@@ -54,9 +50,8 @@ describe('Site Wide Banner', () => {
     });
 
     cy.authVisitCampaignWithoutSignup(user, exampleCampaign);
-    cy.get('#banner-portal > .wrapper > [data-test=site-wide-banner]').should(
-      'not.exist',
-    );
+
+    cy.findByTestId('sitewide-banner-hidden');
   });
 
   it('The Site Wide Banner is not displayed on the beta voter registration (OVRD) drive page', () => {
@@ -83,10 +78,7 @@ describe('Site Wide Banner', () => {
 
     cy.visit(`/us/my-voter-registration-drive?referrer_user_id=${user.id}`);
 
-    cy.get('#banner-portal > .wrapper > [data-test=site-wide-banner]').should(
-      'have.length',
-      0,
-    );
+    cy.findByTestId('sitewide-banner-hidden');
   });
 
   /** @test */
@@ -106,10 +98,7 @@ describe('Site Wide Banner', () => {
 
     cy.visit(`/us/quiz-results/${quizResultId}`);
 
-    cy.get('#banner-portal > .wrapper > [data-test=site-wide-banner]').should(
-      'have.length',
-      0,
-    );
+    cy.findByTestId('sitewide-banner-hidden');
   });
 
   /** @test */
@@ -137,6 +126,7 @@ describe('Site Wide Banner', () => {
     });
 
     cy.authVisitCampaignWithoutSignup(user, exampleCampaign);
+
     cy.findByTestId('sitewide-banner-button').should('have.length', 1);
     cy.findByTestId('sitewide-banner-button').should(
       'have.attr',

--- a/resources/assets/components/utilities/SitewideBanner/SitewideBanner.js
+++ b/resources/assets/components/utilities/SitewideBanner/SitewideBanner.js
@@ -37,7 +37,7 @@ const isExcludedPath = pathname => {
 const SitewideBanner = props => {
   const userId = getUserId();
   const options = { variables: { userId }, skip: !userId };
-  const { data } = useQuery(VOTER_REGISTRATION_STATUS, options);
+  const { data, loading } = useQuery(VOTER_REGISTRATION_STATUS, options);
 
   const unregistered = unregisteredStatuses.includes(
     get(data, 'user.voterRegistrationStatus'),
@@ -56,13 +56,22 @@ const SitewideBanner = props => {
 
     return rootElem.current;
   };
+
   const children = <SitewideBannerContent {...props} />;
 
   const target = usePortal('banner-portal');
 
-  return !isExcludedPath(window.location.pathname) && (!userId || unregistered)
-    ? createPortal(children, target)
-    : null;
+  if (loading) {
+    return null;
+  }
+
+  if (isExcludedPath(window.location.pathname) || (userId && !unregistered)) {
+    target.setAttribute('data-testid', 'sitewide-banner-hidden');
+
+    return null;
+  }
+
+  return createPortal(children, target);
 };
 
 export default SitewideBanner;

--- a/resources/assets/components/utilities/SitewideBanner/SitewideBannerContent.js
+++ b/resources/assets/components/utilities/SitewideBanner/SitewideBannerContent.js
@@ -28,7 +28,7 @@ const SitewideBannerContent = ({
   return (
     <div
       className="w-full md:flex md:justify-center bg-yellow-500 p-8 pb-4 md:pt-4 sm:px-10 z-50"
-      data-test="site-wide-banner"
+      data-testid="sitewide-banner"
     >
       <CloseButton
         callback={handleClose}


### PR DESCRIPTION
### What's this PR do?

This pull request fixes a couple of test which were sporadically failing/passing due to the asynchronous nature of the `SiteWideBanner`.

This relates to the changes in #2299 

Since there's a slight delay before the banner displays, our assertions that the banner _does not_ display would be satisfied prematurely for some tests, when the banner simply hadn't _yet_ shown up.

By configuring the banner to explicitly assign a 'hidden' `data-testid` we can more explicitly assert on this scenario with predictable results.

(Also one test was simply making the wrong assertion & thus failing. But running it locally showed it passing sporadically which prompted this investigation & update).

### How should this be reviewed?
Do you agree with this rationale? Do you like the new flow?

### Relevant tickets
https://dosomething.slack.com/archives/CUQMU4Q6B/p1596811813001400?thread_ts=1596810626.000500&cid=CUQMU4Q6B

