### PR TITLE
Starts on ActionStatsBlock

### DIFF
--- a/resources/assets/components/ContentfulEntry/ContentfulEntry.js
+++ b/resources/assets/components/ContentfulEntry/ContentfulEntry.js
@@ -12,6 +12,7 @@ import SectionBlock from '../blocks/SectionBlock/SectionBlock';
 import CampaignUpdate from '../blocks/CampaignUpdate/CampaignUpdate';
 import AffirmationContainer from '../Affirmation/AffirmationContainer';
 import { parseContentfulType, report, withoutNulls } from '../../helpers';
+import ActionStatsBlock from '../blocks/ActionStatsBlock/ActionStatsBlock';
 import EmbedBlockContainer from '../blocks/EmbedBlock/EmbedBlockContainer';
 import LinkActionContainer from '../actions/LinkAction/LinkActionContainer';
 import CallToActionBlock from '../blocks/CallToActionBlock/CallToActionBlock';
@@ -60,6 +61,9 @@ class ContentfulEntry extends React.Component {
     const type = parseContentfulType(json);
 
     switch (type) {
+      case 'ActionStatsBlock':
+        return <ActionStatsBlock {...withoutNulls(json)} />;
+
       case 'AffirmationBlock':
         return (
           <AffirmationContainer

--- a/resources/assets/components/blocks/ActionStatsBlock/ActionStatsBlock.js
+++ b/resources/assets/components/blocks/ActionStatsBlock/ActionStatsBlock.js
@@ -12,19 +12,22 @@ export const ActionStatsBlockFragment = gql`
 `;
 
 const ActionStatsBlock = ({ filterByActionId }) => {
-  const [location, setLocation] = useState(null);
+  const [schoolLocation, setSchoolLocation] = useState(null);
 
   return (
     <>
       <div className="w-1/4 pb-3">
         <SelectLocationDropdown
           locationList="domestic"
-          onSelect={event => setLocation(event.target.value)}
-          selectedOption={location || ''}
+          onSelect={event => setSchoolLocation(event.target.value)}
+          selectedOption={schoolLocation || ''}
         />
       </div>
 
-      <ActionStatsTable actionId={filterByActionId} location={location} />
+      <ActionStatsTable
+        actionId={filterByActionId}
+        schoolLocation={schoolLocation}
+      />
     </>
   );
 };

--- a/resources/assets/components/blocks/ActionStatsBlock/ActionStatsBlock.js
+++ b/resources/assets/components/blocks/ActionStatsBlock/ActionStatsBlock.js
@@ -12,7 +12,7 @@ export const ActionStatsBlockFragment = gql`
 
 const ActionStatsBlock = ({ filterByActionId }) => (
   <>
-    <ActionStatsTable actionId={1} />
+    <ActionStatsTable actionId={filterByActionId} />
   </>
 );
 

--- a/resources/assets/components/blocks/ActionStatsBlock/ActionStatsBlock.js
+++ b/resources/assets/components/blocks/ActionStatsBlock/ActionStatsBlock.js
@@ -1,0 +1,21 @@
+import React from 'react';
+import gql from 'graphql-tag';
+import PropTypes from 'prop-types';
+
+export const ActionStatsBlockFragment = gql`
+  fragment ActionStatsBlockFragment on ActionStatsBlock {
+    actionId
+  }
+`;
+
+const ActionStatsBlock = ({ actionId }) => (
+  <>
+    <h1>{actionId}</h1>
+  </>
+);
+
+ActionStatsBlock.propTypes = {
+  actionId: PropTypes.number.isRequired,
+};
+
+export default ActionStatsBlock;

--- a/resources/assets/components/blocks/ActionStatsBlock/ActionStatsBlock.js
+++ b/resources/assets/components/blocks/ActionStatsBlock/ActionStatsBlock.js
@@ -2,6 +2,8 @@ import React from 'react';
 import gql from 'graphql-tag';
 import PropTypes from 'prop-types';
 
+import ActionStatsTable from './ActionStatsTable';
+
 export const ActionStatsBlockFragment = gql`
   fragment ActionStatsBlockFragment on ActionStatsBlock {
     filterByActionId: actionId
@@ -10,7 +12,7 @@ export const ActionStatsBlockFragment = gql`
 
 const ActionStatsBlock = ({ filterByActionId }) => (
   <>
-    <h1>{filterByActionId}</h1>
+    <ActionStatsTable actionId={1} />
   </>
 );
 

--- a/resources/assets/components/blocks/ActionStatsBlock/ActionStatsBlock.js
+++ b/resources/assets/components/blocks/ActionStatsBlock/ActionStatsBlock.js
@@ -1,8 +1,9 @@
-import React from 'react';
 import gql from 'graphql-tag';
 import PropTypes from 'prop-types';
+import React, { useState } from 'react';
 
 import ActionStatsTable from './ActionStatsTable';
+import SelectLocationDropdown from '../../utilities/SelectLocationDropdown/SelectLocationDropdown';
 
 export const ActionStatsBlockFragment = gql`
   fragment ActionStatsBlockFragment on ActionStatsBlock {
@@ -10,11 +11,23 @@ export const ActionStatsBlockFragment = gql`
   }
 `;
 
-const ActionStatsBlock = ({ filterByActionId }) => (
-  <>
-    <ActionStatsTable actionId={filterByActionId} />
-  </>
-);
+const ActionStatsBlock = ({ filterByActionId }) => {
+  const [location, setLocation] = useState(null);
+
+  return (
+    <>
+      <div className="w-1/4 pb-3">
+        <SelectLocationDropdown
+          locationList="domestic"
+          onSelect={event => setLocation(event.target.value)}
+          selectedOption={location || ''}
+        />
+      </div>
+
+      <ActionStatsTable actionId={filterByActionId} location={location} />
+    </>
+  );
+};
 
 ActionStatsBlock.propTypes = {
   filterByActionId: PropTypes.number.isRequired,

--- a/resources/assets/components/blocks/ActionStatsBlock/ActionStatsBlock.js
+++ b/resources/assets/components/blocks/ActionStatsBlock/ActionStatsBlock.js
@@ -4,18 +4,18 @@ import PropTypes from 'prop-types';
 
 export const ActionStatsBlockFragment = gql`
   fragment ActionStatsBlockFragment on ActionStatsBlock {
-    actionId
+    filterByActionId: actionId
   }
 `;
 
-const ActionStatsBlock = ({ actionId }) => (
+const ActionStatsBlock = ({ filterByActionId }) => (
   <>
-    <h1>{actionId}</h1>
+    <h1>{filterByActionId}</h1>
   </>
 );
 
 ActionStatsBlock.propTypes = {
-  actionId: PropTypes.number.isRequired,
+  filterByActionId: PropTypes.number.isRequired,
 };
 
 export default ActionStatsBlock;

--- a/resources/assets/components/blocks/ActionStatsBlock/ActionStatsTable.js
+++ b/resources/assets/components/blocks/ActionStatsBlock/ActionStatsTable.js
@@ -50,12 +50,6 @@ const PAGINATED_ACTION_STATS_QUERY = gql`
 const TableHeader = tw.thead`bg-blurple-500 font-bold p-4 pr-6 text-left text-white`;
 const TableCell = tw.td`p-2 text-base`;
 
-/**
- * This component handles fetching & paginating a list of action stats.
- *
- * @param {Number} actionId
- * @param {String} schoolId
- */
 const ActionStatsTable = ({ actionId, schoolId, schoolLocation }) => {
   const variables = { actionId };
 

--- a/resources/assets/components/blocks/ActionStatsBlock/ActionStatsTable.js
+++ b/resources/assets/components/blocks/ActionStatsBlock/ActionStatsTable.js
@@ -1,15 +1,17 @@
 import React from 'react';
 import gql from 'graphql-tag';
 import PropTypes from 'prop-types';
-import { assign, get, isArray, mergeWith } from 'lodash';
+import { assign, get } from 'lodash';
 import { useQuery } from '@apollo/react-hooks';
 
+import { updateQuery } from '../../../helpers';
 import ErrorBlock from '../ErrorBlock/ErrorBlock';
 import Spinner from '../../artifacts/Spinner/Spinner';
+import PrimaryButton from '../../utilities/Button/PrimaryButton';
 
 const ACTION_STATS_TABLE_QUERY = gql`
   query ActionStatsTableQuery {
-    stats: paginatedSchoolActionStats {
+    stats: paginatedSchoolActionStats(orderBy: "impact,desc") {
       edges {
         cursor
         node {
@@ -66,15 +68,7 @@ const ActionStatsTable = ({ actionId, location, schoolId }) => {
   const handleViewMore = () => {
     fetchMore({
       variables: { cursor: endCursor },
-      updateQuery: (previous, { fetchMoreResult }) => {
-        return mergeWith({}, previous, fetchMoreResult, (dest, src) => {
-          // By default, Lodash's `merge` would try to merge *each* array
-          // item (e.g. `edges[0]` with then next page's `edges[0]`).
-          if (isArray(dest)) {
-            return [...dest, ...src];
-          }
-        });
-      },
+      updateQuery,
     });
   };
 
@@ -90,7 +84,7 @@ const ActionStatsTable = ({ actionId, location, schoolId }) => {
 
   return (
     <>
-      <table>
+      <table className="w-full">
         <thead>
           <tr>
             <td>School Name</td>
@@ -127,13 +121,11 @@ const ActionStatsTable = ({ actionId, location, schoolId }) => {
           {hasNextPage ? (
             <tr>
               <td colSpan="3">
-                <button
-                  className="button -tertiary"
+                <PrimaryButton
                   onClick={handleViewMore}
-                  disabled={loading}
-                >
-                  view more...
-                </button>
+                  isDisabled={loading}
+                  text="Load More"
+                />
               </td>
             </tr>
           ) : null}

--- a/resources/assets/components/blocks/ActionStatsBlock/ActionStatsTable.js
+++ b/resources/assets/components/blocks/ActionStatsBlock/ActionStatsTable.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import tw from 'twin.macro';
 import gql from 'graphql-tag';
 import PropTypes from 'prop-types';
 import { assign, get } from 'lodash';
@@ -47,6 +48,9 @@ const PAGINATED_ACTION_STATS_QUERY = gql`
   }
 `;
 
+const TableHeader = tw.thead`bg-blurple-500 font-bold p-4 pr-6 text-left text-white`;
+const TableCell = tw.td`p-2 text-base`;
+
 /**
  * This component handles fetching & paginating a list of action stats.
  *
@@ -94,13 +98,15 @@ const ActionStatsTable = ({ actionId, location, schoolId }) => {
   return (
     <>
       <table className="w-full">
-        <thead>
+        <TableHeader>
           <tr>
-            <td>School Name</td>
-            <td>Location</td>
-            <td>Impact</td>
+            <TableCell>School Name</TableCell>
+
+            <TableCell>Location</TableCell>
+
+            <TableCell>Impact</TableCell>
           </tr>
-        </thead>
+        </TableHeader>
 
         <tbody>
           {stats.map(({ node, cursor }) => {
@@ -108,11 +114,13 @@ const ActionStatsTable = ({ actionId, location, schoolId }) => {
 
             return (
               <tr key={cursor}>
-                <td>{school.name}</td>
-                <td>
+                <TableCell>{school.name}</TableCell>
+
+                <TableCell>
                   {school.city}, {school.state}
-                </td>
-                <td>{impact}</td>
+                </TableCell>
+
+                <TableCell>{impact}</TableCell>
               </tr>
             );
           })}
@@ -121,15 +129,15 @@ const ActionStatsTable = ({ actionId, location, schoolId }) => {
         <tfoot className="form-actions">
           {loading ? (
             <tr>
-              <td colSpan="3">
-                <Spinner />
+              <td className="p-3" colSpan="3">
+                <Spinner className="flex justify-center" />
               </td>
             </tr>
           ) : null}
 
           {hasNextPage ? (
             <tr>
-              <td colSpan="3">
+              <td className="p-3" colSpan="3">
                 <PrimaryButton
                   onClick={handleViewMore}
                   isDisabled={loading}

--- a/resources/assets/components/blocks/ActionStatsBlock/ActionStatsTable.js
+++ b/resources/assets/components/blocks/ActionStatsBlock/ActionStatsTable.js
@@ -1,0 +1,157 @@
+import React from 'react';
+import gql from 'graphql-tag';
+import PropTypes from 'prop-types';
+import { assign, get, isArray, mergeWith } from 'lodash';
+import { useQuery } from '@apollo/react-hooks';
+
+import ErrorBlock from '../ErrorBlock/ErrorBlock';
+import Spinner from '../../artifacts/Spinner/Spinner';
+
+const ACTION_STATS_TABLE_QUERY = gql`
+  query ActionStatsTableQuery {
+    stats: paginatedSchoolActionStats {
+      edges {
+        cursor
+        node {
+          id
+          impact
+          location
+          schoolId
+          school {
+            id
+            name
+            city
+            state
+          }
+        }
+      }
+      pageInfo {
+        endCursor
+        hasNextPage
+      }
+    }
+  }
+`;
+
+/**
+ * This component handles fetching & paginating a list of action stats.
+ *
+ * @param {Number} actionId
+ * @param {String} schoolId
+ */
+const ActionStatsTable = ({ actionId, location, schoolId }) => {
+  const variables = { actionId };
+  console.log(variables);
+
+  if (location) {
+    assign(variables, { location });
+  }
+
+  if (schoolId) {
+    assign(variables, { schoolId });
+  }
+
+  const { error, loading, data, fetchMore } = useQuery(
+    ACTION_STATS_TABLE_QUERY,
+    {
+      variables,
+      notifyOnNetworkStatusChange: true,
+    },
+  );
+
+  const stats = data ? data.stats.edges : [];
+  const noResults = stats.length === 0 && !loading;
+  const { endCursor, hasNextPage } = get(data, 'stats.pageInfo', {});
+
+  const handleViewMore = () => {
+    fetchMore({
+      variables: { cursor: endCursor },
+      updateQuery: (previous, { fetchMoreResult }) => {
+        return mergeWith({}, previous, fetchMoreResult, (dest, src) => {
+          // By default, Lodash's `merge` would try to merge *each* array
+          // item (e.g. `edges[0]` with then next page's `edges[0]`).
+          if (isArray(dest)) {
+            return [...dest, ...src];
+          }
+        });
+      },
+    });
+  };
+
+  if (error) {
+    return <ErrorBlock error={error} />;
+  }
+
+  if (noResults && !hasNextPage) {
+    return <div>No results</div>;
+  }
+
+  console.log(stats);
+
+  return (
+    <>
+      <table>
+        <thead>
+          <tr>
+            <td>School Name</td>
+            <td>Location</td>
+            <td>Impact</td>
+          </tr>
+        </thead>
+
+        <tbody>
+          {stats.map(({ node, cursor }) => {
+            const { impact, school } = node;
+
+            return (
+              <tr key={cursor}>
+                <td>{school.name}</td>
+                <td>
+                  {school.city}, {school.state}
+                </td>
+                <td>{impact}</td>
+              </tr>
+            );
+          })}
+        </tbody>
+
+        <tfoot className="form-actions">
+          {loading ? (
+            <tr>
+              <td colSpan="3">
+                <Spinner />
+              </td>
+            </tr>
+          ) : null}
+
+          {hasNextPage ? (
+            <tr>
+              <td colSpan="3">
+                <button
+                  className="button -tertiary"
+                  onClick={handleViewMore}
+                  disabled={loading}
+                >
+                  view more...
+                </button>
+              </td>
+            </tr>
+          ) : null}
+        </tfoot>
+      </table>
+    </>
+  );
+};
+
+ActionStatsTable.propTypes = {
+  actionId: PropTypes.number.isRequired,
+  location: PropTypes.string,
+  schoolId: PropTypes.string,
+};
+
+ActionStatsTable.defaultProps = {
+  location: null,
+  schoolId: null,
+};
+
+export default ActionStatsTable;

--- a/resources/assets/components/blocks/ActionStatsBlock/ActionStatsTable.js
+++ b/resources/assets/components/blocks/ActionStatsBlock/ActionStatsTable.js
@@ -116,7 +116,7 @@ const ActionStatsTable = ({ actionId, location, schoolId }) => {
           {stats.map(({ node, cursor }) => {
             const { impact, school } = node;
 
-            rank++;
+            rank += 1;
 
             return (
               <tr key={cursor}>

--- a/resources/assets/components/blocks/ActionStatsBlock/ActionStatsTable.js
+++ b/resources/assets/components/blocks/ActionStatsBlock/ActionStatsTable.js
@@ -9,9 +9,21 @@ import ErrorBlock from '../ErrorBlock/ErrorBlock';
 import Spinner from '../../artifacts/Spinner/Spinner';
 import PrimaryButton from '../../utilities/Button/PrimaryButton';
 
-const ACTION_STATS_TABLE_QUERY = gql`
-  query ActionStatsTableQuery {
-    stats: paginatedSchoolActionStats(orderBy: "impact,desc") {
+const PAGINATED_ACTION_STATS_QUERY = gql`
+  query PaginatedActionStatsQuery(
+    $actionId: Int
+    $cursor: String
+    $location: String
+    $schoolId: String
+  ) {
+    stats: paginatedSchoolActionStats(
+      actionId: $actionId
+      after: $cursor
+      first: 20
+      location: $location
+      orderBy: "impact,desc"
+      schoolId: $schoolId
+    ) {
       edges {
         cursor
         node {
@@ -43,7 +55,6 @@ const ACTION_STATS_TABLE_QUERY = gql`
  */
 const ActionStatsTable = ({ actionId, location, schoolId }) => {
   const variables = { actionId };
-  console.log(variables);
 
   if (location) {
     assign(variables, { location });
@@ -54,7 +65,7 @@ const ActionStatsTable = ({ actionId, location, schoolId }) => {
   }
 
   const { error, loading, data, fetchMore } = useQuery(
-    ACTION_STATS_TABLE_QUERY,
+    PAGINATED_ACTION_STATS_QUERY,
     {
       variables,
       notifyOnNetworkStatusChange: true,
@@ -79,8 +90,6 @@ const ActionStatsTable = ({ actionId, location, schoolId }) => {
   if (noResults && !hasNextPage) {
     return <div>No results</div>;
   }
-
-  console.log(stats);
 
   return (
     <>

--- a/resources/assets/components/blocks/ActionStatsBlock/ActionStatsTable.js
+++ b/resources/assets/components/blocks/ActionStatsBlock/ActionStatsTable.js
@@ -20,7 +20,7 @@ const PAGINATED_ACTION_STATS_QUERY = gql`
     stats: paginatedSchoolActionStats(
       actionId: $actionId
       after: $cursor
-      first: 20
+      first: 10
       location: $location
       orderBy: "impact,desc"
       schoolId: $schoolId
@@ -95,16 +95,20 @@ const ActionStatsTable = ({ actionId, location, schoolId }) => {
     return <div>No results</div>;
   }
 
+  let rank = 0;
+
   return (
     <>
       <table className="w-full">
         <TableHeader>
           <tr>
+            <TableCell>{location ? 'State' : 'National'} Rank</TableCell>
+
             <TableCell>School Name</TableCell>
 
             <TableCell>Location</TableCell>
 
-            <TableCell>Impact</TableCell>
+            <TableCell>Voter Registrations</TableCell>
           </tr>
         </TableHeader>
 
@@ -112,8 +116,12 @@ const ActionStatsTable = ({ actionId, location, schoolId }) => {
           {stats.map(({ node, cursor }) => {
             const { impact, school } = node;
 
+            rank++;
+
             return (
               <tr key={cursor}>
+                <TableCell>{rank}</TableCell>
+
                 <TableCell>{school.name}</TableCell>
 
                 <TableCell>
@@ -129,7 +137,7 @@ const ActionStatsTable = ({ actionId, location, schoolId }) => {
         <tfoot className="form-actions">
           {loading ? (
             <tr>
-              <td className="p-3" colSpan="3">
+              <td className="p-3" colSpan="4">
                 <Spinner className="flex justify-center" />
               </td>
             </tr>
@@ -137,7 +145,7 @@ const ActionStatsTable = ({ actionId, location, schoolId }) => {
 
           {hasNextPage ? (
             <tr>
-              <td className="p-3" colSpan="3">
+              <td className="p-3" colSpan="4">
                 <PrimaryButton
                   onClick={handleViewMore}
                   isDisabled={loading}

--- a/resources/assets/components/blocks/ActionStatsBlock/ActionStatsTable.js
+++ b/resources/assets/components/blocks/ActionStatsBlock/ActionStatsTable.js
@@ -36,7 +36,6 @@ const PAGINATED_ACTION_STATS_QUERY = gql`
             id
             name
             city
-            state
           }
         }
       }
@@ -57,11 +56,11 @@ const TableCell = tw.td`p-2 text-base`;
  * @param {Number} actionId
  * @param {String} schoolId
  */
-const ActionStatsTable = ({ actionId, location, schoolId }) => {
+const ActionStatsTable = ({ actionId, schoolId, schoolLocation }) => {
   const variables = { actionId };
 
-  if (location) {
-    assign(variables, { location });
+  if (schoolLocation) {
+    assign(variables, { location: schoolLocation });
   }
 
   if (schoolId) {
@@ -102,7 +101,7 @@ const ActionStatsTable = ({ actionId, location, schoolId }) => {
       <table className="w-full">
         <TableHeader>
           <tr>
-            <TableCell>{location ? 'State' : 'National'} Rank</TableCell>
+            <TableCell>{schoolLocation ? 'State' : 'National'} Rank</TableCell>
 
             <TableCell>School Name</TableCell>
 
@@ -114,7 +113,7 @@ const ActionStatsTable = ({ actionId, location, schoolId }) => {
 
         <tbody>
           {stats.map(({ node, cursor }) => {
-            const { impact, school } = node;
+            const { impact, location, school } = node;
 
             rank += 1;
 
@@ -125,7 +124,7 @@ const ActionStatsTable = ({ actionId, location, schoolId }) => {
                 <TableCell>{school.name}</TableCell>
 
                 <TableCell>
-                  {school.city}, {school.state}
+                  {school.city}, {location.substring(3)}
                 </TableCell>
 
                 <TableCell>{impact}</TableCell>
@@ -162,13 +161,13 @@ const ActionStatsTable = ({ actionId, location, schoolId }) => {
 
 ActionStatsTable.propTypes = {
   actionId: PropTypes.number.isRequired,
-  location: PropTypes.string,
   schoolId: PropTypes.string,
+  schoolLocation: PropTypes.string,
 };
 
 ActionStatsTable.defaultProps = {
-  location: null,
   schoolId: null,
+  schoolLocation: null,
 };
 
 export default ActionStatsTable;

--- a/resources/assets/components/utilities/ContentfulEntryLoader/ContentfulEntryLoader.js
+++ b/resources/assets/components/utilities/ContentfulEntryLoader/ContentfulEntryLoader.js
@@ -22,6 +22,7 @@ import { ContentBlockFragment } from '../../blocks/ContentBlock/ContentBlock';
 import { CampaignDashboardFragment } from '../CampaignDashboard/CampaignDashboard';
 import { SixpackExperimentBlockFragment } from '../SixpackExperiment/SixpackExperiment';
 import { CampaignUpdateBlockFragment } from '../../blocks/CampaignUpdate/CampaignUpdate';
+import { ActionStatsBlockFragment } from '../../blocks/ActionStatsBlock/ActionStatsBlock';
 import { SocialDriveBlockFragment } from '../../actions/SocialDriveAction/SocialDriveAction';
 import { PostGalleryBlockFragment } from '../../blocks/PostGalleryBlock/PostGalleryBlockQuery';
 import { CurrentSchoolBlockFragment } from '../../blocks/CurrentSchoolBlock/CurrentSchoolBlock';
@@ -70,6 +71,9 @@ const CONTENTFUL_BLOCK_QUERY = gql`
       ... on PostGalleryBlock {
         ...PostGalleryBlockFragment
       }
+      ... on ActionStatsBlock {
+        ...ActionStatsBlockFragment
+      }
       ... on CampaignDashboard {
         ...CampaignDashboardFragment
       }
@@ -114,6 +118,7 @@ const CONTENTFUL_BLOCK_QUERY = gql`
   ${GalleryBlockFragment}
   ${ContentBlockFragment}
   ${SoftEdgeBlockFragment}
+  ${ActionStatsBlockFragment}
   ${AffirmationBlockFragment}
   ${SocialDriveBlockFragment}
   ${PostGalleryBlockFragment}


### PR DESCRIPTION
### What's this PR do?

This pull request starts on support for the `ActionStatsBlock` content type introduced in #2312, displaying paginated action stats for a required `actionId` field set on the content type, and allowing an end user to filter the list by location. It follows its counter-part in the Rogue admin UI by example (https://github.com/DoSomething/rogue/pull/1091)

<img src="https://user-images.githubusercontent.com/1236811/89793309-94a83a00-dada-11ea-980e-c363c21609be.gif">

### How should this be reviewed?

👀 

### Any background context you want to provide?

* There will be some additions to the block in future PR's, e.g. a better looking empty state if there are no results for a location. Those will be handled in the front-end story, [#173931767](https://www.pivotaltracker.com/story/show/173931767)

* I plan to add Cypress tests and documentation in a future PR to hopefully help keep this one easier to review.

### Relevant tickets

References [Pivotal #174021616](https://www.pivotaltracker.com/story/show/174021616).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added screenshots of front-end changes on small, medium, and large screens.
- [ ] Added appropriate feature/unit tests.
