### PR TITLE
Hide Hellobar on Groups pages

### DIFF
--- a/cypress/integration/sitewide-banner.js
+++ b/cypress/integration/sitewide-banner.js
@@ -113,10 +113,7 @@ describe('Site Wide Banner', () => {
 
     cy.anonVisitCampaign(exampleCampaign);
 
-    cy.get('#banner-portal > .wrapper > [data-test=site-wide-banner]').should(
-      'have.length',
-      0,
-    );
+    cy.findByTestId('sitewide-banner-hidden').should('have.length', 1);
   });
 
   /** @test */

--- a/cypress/integration/sitewide-banner.js
+++ b/cypress/integration/sitewide-banner.js
@@ -121,7 +121,7 @@ describe('Site Wide Banner', () => {
     cy.mockGraphqlOp('CampaignSitewideBannerQuery', {
       campaign: {
         id: campaignId,
-        groupTypeId: null,
+        groupTypeId: 1,
       },
     });
 

--- a/cypress/integration/sitewide-banner.js
+++ b/cypress/integration/sitewide-banner.js
@@ -3,6 +3,7 @@
 import faker from 'faker';
 
 import { userFactory } from '../fixtures/user';
+import { campaignId } from '../fixtures/constants';
 import exampleCampaign from '../fixtures/contentful/exampleCampaign';
 
 describe('Site Wide Banner', () => {
@@ -102,6 +103,23 @@ describe('Site Wide Banner', () => {
   });
 
   /** @test */
+  it('The Site Wide Banner is not displayed on groups campaign pages', () => {
+    cy.mockGraphqlOp('CampaignSitewideBannerQuery', {
+      campaign: {
+        id: campaignId,
+        groupTypeId: 1,
+      },
+    });
+
+    cy.anonVisitCampaign(exampleCampaign);
+
+    cy.get('#banner-portal > .wrapper > [data-test=site-wide-banner]').should(
+      'have.length',
+      0,
+    );
+  });
+
+  /** @test */
   it('The Site Wide Banner CTA URL is correct for an unauthenticated user', () => {
     cy.anonVisitCampaign(exampleCampaign);
 
@@ -122,6 +140,13 @@ describe('Site Wide Banner', () => {
     cy.mockGraphqlOp('VoterRegSitewideBannerQuery', {
       user: {
         voterRegistrationStatus: 'UNREGISTERED',
+      },
+    });
+
+    cy.mockGraphqlOp('CampaignSitewideBannerQuery', {
+      campaign: {
+        id: campaignId,
+        groupTypeId: null,
       },
     });
 

--- a/cypress/integration/sitewide-banner.js
+++ b/cypress/integration/sitewide-banner.js
@@ -22,9 +22,8 @@ describe('Site Wide Banner', () => {
   });
 
   it('The Site Wide Banner is displayed on campaign pages', () => {
-    cy.mockGraphqlOp('CampaignSitewideBannerQuery', {
+    cy.mockGraphqlOp('CampaignBannerQuery', {
       campaign: {
-        id: campaignId,
         groupTypeId: null,
       },
     });
@@ -37,16 +36,15 @@ describe('Site Wide Banner', () => {
   it('The Site Wide Banner is displayed on campaign pages for authenticated users who are not registered to vote', () => {
     const user = userFactory();
 
-    cy.mockGraphqlOp('VoterRegSitewideBannerQuery', {
-      user: {
-        voterRegistrationStatus: 'UNREGISTERED',
+    cy.mockGraphqlOp('CampaignBannerQuery', {
+      campaign: {
+        groupTypeId: null,
       },
     });
 
-    cy.mockGraphqlOp('CampaignSitewideBannerQuery', {
-      campaign: {
-        id: campaignId,
-        groupTypeId: null,
+    cy.mockGraphqlOp('VoterRegSitewideBannerQuery', {
+      user: {
+        voterRegistrationStatus: 'UNREGISTERED',
       },
     });
 
@@ -132,9 +130,8 @@ describe('Site Wide Banner', () => {
 
   /** @test */
   it('The Site Wide Banner CTA URL is correct for an unauthenticated user', () => {
-    cy.mockGraphqlOp('CampaignSitewideBannerQuery', {
+    cy.mockGraphqlOp('CampaignBannerQuery', {
       campaign: {
-        id: campaignId,
         groupTypeId: null,
       },
     });
@@ -153,7 +150,11 @@ describe('Site Wide Banner', () => {
   it('Sets up the correct tracking source for the RTV redirect URL for an authenticated user', () => {
     const user = userFactory();
 
-    // Log in & visit the campaign pitch page:
+    cy.mockGraphqlOp('CampaignBannerQuery', {
+      campaign: {
+        groupTypeId: null,
+      },
+    });
 
     cy.mockGraphqlOp('VoterRegSitewideBannerQuery', {
       user: {
@@ -161,13 +162,7 @@ describe('Site Wide Banner', () => {
       },
     });
 
-    cy.mockGraphqlOp('CampaignSitewideBannerQuery', {
-      campaign: {
-        id: campaignId,
-        groupTypeId: null,
-      },
-    });
-
+    // Log in & visit the campaign pitch page:
     cy.authVisitCampaignWithoutSignup(user, exampleCampaign);
 
     cy.findByTestId('sitewide-banner-button').should('have.length', 1);

--- a/cypress/integration/sitewide-banner.js
+++ b/cypress/integration/sitewide-banner.js
@@ -25,9 +25,7 @@ describe('Site Wide Banner', () => {
     cy.mockGraphqlOp('CampaignSitewideBannerQuery', {
       campaign: {
         id: campaignId,
-        groupType: {
-          id: null,
-        },
+        groupTypeId: null,
       },
     });
 
@@ -48,9 +46,7 @@ describe('Site Wide Banner', () => {
     cy.mockGraphqlOp('CampaignSitewideBannerQuery', {
       campaign: {
         id: campaignId,
-        groupType: {
-          id: null,
-        },
+        groupTypeId: null,
       },
     });
 
@@ -125,9 +121,7 @@ describe('Site Wide Banner', () => {
     cy.mockGraphqlOp('CampaignSitewideBannerQuery', {
       campaign: {
         id: campaignId,
-        groupType: {
-          id: 1,
-        },
+        groupTypeId: null,
       },
     });
 
@@ -141,9 +135,7 @@ describe('Site Wide Banner', () => {
     cy.mockGraphqlOp('CampaignSitewideBannerQuery', {
       campaign: {
         id: campaignId,
-        groupType: {
-          id: null,
-        },
+        groupTypeId: null,
       },
     });
 
@@ -172,9 +164,7 @@ describe('Site Wide Banner', () => {
     cy.mockGraphqlOp('CampaignSitewideBannerQuery', {
       campaign: {
         id: campaignId,
-        groupType: {
-          id: null,
-        },
+        groupTypeId: null,
       },
     });
 

--- a/cypress/integration/sitewide-banner.js
+++ b/cypress/integration/sitewide-banner.js
@@ -22,6 +22,16 @@ describe('Site Wide Banner', () => {
   });
 
   it('The Site Wide Banner is displayed on campaign pages', () => {
+    cy.mockGraphqlOp('CampaignSitewideBannerQuery', {
+      campaign: {
+        id: campaignId,
+        groupTypeId: null,
+        groupType: {
+          id: null,
+        },
+      },
+    });
+
     cy.anonVisitCampaign(exampleCampaign);
 
     cy.findByTestId('sitewide-banner').should('have.length', 1);
@@ -33,6 +43,16 @@ describe('Site Wide Banner', () => {
     cy.mockGraphqlOp('VoterRegSitewideBannerQuery', {
       user: {
         voterRegistrationStatus: 'UNREGISTERED',
+      },
+    });
+
+    cy.mockGraphqlOp('CampaignSitewideBannerQuery', {
+      campaign: {
+        id: campaignId,
+        groupTypeId: null,
+        groupType: {
+          id: null,
+        },
       },
     });
 
@@ -118,6 +138,16 @@ describe('Site Wide Banner', () => {
 
   /** @test */
   it('The Site Wide Banner CTA URL is correct for an unauthenticated user', () => {
+    cy.mockGraphqlOp('CampaignSitewideBannerQuery', {
+      campaign: {
+        id: campaignId,
+        groupTypeId: null,
+        groupType: {
+          id: null,
+        },
+      },
+    });
+
     cy.anonVisitCampaign(exampleCampaign);
 
     cy.findByTestId('sitewide-banner-button').should('have.length', 1);
@@ -144,6 +174,9 @@ describe('Site Wide Banner', () => {
       campaign: {
         id: campaignId,
         groupTypeId: null,
+        groupType: {
+          id: null,
+        },
       },
     });
 

--- a/cypress/integration/sitewide-banner.js
+++ b/cypress/integration/sitewide-banner.js
@@ -128,6 +128,9 @@ describe('Site Wide Banner', () => {
       campaign: {
         id: campaignId,
         groupTypeId: 1,
+        groupType: {
+          id: 1,
+        },
       },
     });
 

--- a/cypress/integration/sitewide-banner.js
+++ b/cypress/integration/sitewide-banner.js
@@ -25,7 +25,6 @@ describe('Site Wide Banner', () => {
     cy.mockGraphqlOp('CampaignSitewideBannerQuery', {
       campaign: {
         id: campaignId,
-        groupTypeId: null,
         groupType: {
           id: null,
         },
@@ -49,7 +48,6 @@ describe('Site Wide Banner', () => {
     cy.mockGraphqlOp('CampaignSitewideBannerQuery', {
       campaign: {
         id: campaignId,
-        groupTypeId: null,
         groupType: {
           id: null,
         },
@@ -127,7 +125,6 @@ describe('Site Wide Banner', () => {
     cy.mockGraphqlOp('CampaignSitewideBannerQuery', {
       campaign: {
         id: campaignId,
-        groupTypeId: 1,
         groupType: {
           id: 1,
         },
@@ -144,7 +141,6 @@ describe('Site Wide Banner', () => {
     cy.mockGraphqlOp('CampaignSitewideBannerQuery', {
       campaign: {
         id: campaignId,
-        groupTypeId: null,
         groupType: {
           id: null,
         },
@@ -176,7 +172,6 @@ describe('Site Wide Banner', () => {
     cy.mockGraphqlOp('CampaignSitewideBannerQuery', {
       campaign: {
         id: campaignId,
-        groupTypeId: null,
         groupType: {
           id: null,
         },

--- a/resources/assets/components/utilities/SitewideBanner/SitewideBanner.js
+++ b/resources/assets/components/utilities/SitewideBanner/SitewideBanner.js
@@ -70,8 +70,6 @@ const SitewideBanner = props => {
   );
   const campaignGroupTypeId = get(campaignData, 'campaign.groupType.id', null);
 
-  console.log(campaignGroupTypeId);
-
   const usePortal = id => {
     const rootElem = useRef(document.createElement('div'));
 

--- a/resources/assets/components/utilities/SitewideBanner/SitewideBanner.js
+++ b/resources/assets/components/utilities/SitewideBanner/SitewideBanner.js
@@ -82,25 +82,11 @@ const SitewideBanner = props => {
 
   const target = usePortal('banner-portal');
 
-<<<<<<< HEAD
-  if (loading) {
-    return null;
-  }
-
-  if (isExcludedPath(window.location.pathname) || (userId && !unregistered)) {
-    target.setAttribute('data-testid', 'sitewide-banner-hidden');
-
-    return null;
-  }
-
-  return createPortal(children, target);
-=======
   return !isExcludedPath(window.location.pathname) &&
     (!userId || unregistered) &&
     !campaignGroupTypeId
     ? createPortal(children, target)
     : null;
->>>>>>> add a query for a campaigns groupTypeId, and only show hellobar if it does not have one
 };
 
 export default SitewideBanner;

--- a/resources/assets/components/utilities/SitewideBanner/SitewideBanner.js
+++ b/resources/assets/components/utilities/SitewideBanner/SitewideBanner.js
@@ -22,7 +22,6 @@ const CAMPAIGN_GROUPTYPE_QUERY = gql`
   query CampaignSitewideBannerQuery($campaignId: Int!) {
     campaign(id: $campaignId) {
       id
-      groupTypeId
       groupType {
         id
       }
@@ -51,7 +50,7 @@ const isExcludedPath = pathname => {
 
 const SitewideBanner = props => {
   const userId = getUserId();
-  const campaignId = campaign ? parseInt(campaign.campaignId, 10) : null;
+  const campaignId = campaign ? Number(campaign.campaignId) : null;
 
   const options = { variables: { userId }, skip: !userId };
   const { data, loading } = useQuery(VOTER_REGISTRATION_STATUS, options);
@@ -68,7 +67,7 @@ const SitewideBanner = props => {
       skip: !campaignId,
     },
   );
-  const campaignGroupTypeId = get(campaignData, 'campaign.groupType.id', null);
+  const isGroupCampaign = !!get(campaignData, 'campaign.groupType.id');
 
   const usePortal = id => {
     const rootElem = useRef(document.createElement('div'));
@@ -95,7 +94,7 @@ const SitewideBanner = props => {
   if (
     isExcludedPath(window.location.pathname) ||
     (userId && !unregistered) ||
-    campaignGroupTypeId
+    isGroupCampaign
   ) {
     target.setAttribute('data-testid', 'sitewide-banner-hidden');
 

--- a/resources/assets/components/utilities/SitewideBanner/SitewideBanner.js
+++ b/resources/assets/components/utilities/SitewideBanner/SitewideBanner.js
@@ -29,8 +29,6 @@ const CAMPAIGN_GROUPTYPE_QUERY = gql`
 
 const unregisteredStatuses = ['UNCERTAIN', 'CONFIRMED', 'UNREGISTERED'];
 
-const campaign = getCampaign();
-
 const isExcludedPath = pathname => {
   return excludedPaths.find(excludedPath => {
     if (excludedPath.includes('*')) {
@@ -47,9 +45,13 @@ const isExcludedPath = pathname => {
 };
 
 const SitewideBanner = props => {
+  let campaignId;
   const userId = getUserId();
-  const campaignId = campaign ? Number(campaign.campaignId) : null;
-
+  useEffect(() => {
+    const campaign = getCampaign();
+    campaignId = campaign ? Number(campaign.campaignId) : null;
+  }, []);
+  console.log(campaignId);
   const options = { variables: { userId }, skip: !userId };
   const { data, loading } = useQuery(VOTER_REGISTRATION_STATUS, options);
   const unregistered = unregisteredStatuses.includes(

--- a/resources/assets/components/utilities/SitewideBanner/SitewideBanner.js
+++ b/resources/assets/components/utilities/SitewideBanner/SitewideBanner.js
@@ -45,13 +45,9 @@ const isExcludedPath = pathname => {
 };
 
 const SitewideBanner = props => {
-  let campaignId;
   const userId = getUserId();
-  useEffect(() => {
-    const campaign = getCampaign();
-    campaignId = campaign ? Number(campaign.campaignId) : null;
-  }, []);
-  console.log(campaignId);
+  const campaign = getCampaign();
+  const campaignId = campaign ? Number(campaign.campaignId) : null;
   const options = { variables: { userId }, skip: !userId };
   const { data, loading } = useQuery(VOTER_REGISTRATION_STATUS, options);
   const unregistered = unregisteredStatuses.includes(

--- a/resources/assets/components/utilities/SitewideBanner/SitewideBanner.js
+++ b/resources/assets/components/utilities/SitewideBanner/SitewideBanner.js
@@ -22,9 +22,7 @@ const CAMPAIGN_GROUPTYPE_QUERY = gql`
   query CampaignSitewideBannerQuery($campaignId: Int!) {
     campaign(id: $campaignId) {
       id
-      groupType {
-        id
-      }
+      groupTypeId
     }
   }
 `;
@@ -67,7 +65,7 @@ const SitewideBanner = props => {
       skip: !campaignId,
     },
   );
-  const isGroupCampaign = !!get(campaignData, 'campaign.groupType.id');
+  const isGroupCampaign = !!get(campaignData, 'campaign.groupTypeId');
 
   const usePortal = id => {
     const rootElem = useRef(document.createElement('div'));


### PR DESCRIPTION
### What's this PR do?

This pull request adds a graphql query to check for a set groupTypeId on the campaign. If it's set, we hide the hellobar!

### How should this be reviewed?

I am struggling with getting all the Cypress tests to pass and I'm not clear on why. The first test will intermittently fail, and the last test is consistently failing. Any insights there would be super helpful!

### Any background context you want to provide?
We're hiding the helloBar on groups campaigns because of the screen real estate it takes up when users are on mobile.

Current Groups Page:
![Screen Shot 2020-08-10 at 11 24 56 AM](https://user-images.githubusercontent.com/15236023/89799966-23797e80-dafc-11ea-94c1-7fde96815e68.png)

Hidden HB Groups Page:
![Screen Shot 2020-08-10 at 11 22 31 AM](https://user-images.githubusercontent.com/15236023/89800026-368c4e80-dafc-11ea-9dbc-d6e62e1a3ff4.png)


### Relevant tickets

References [Pivotal #174164390](https://www.pivotaltracker.com/story/show/174164390).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [x] Added screenshots of front-end changes on small, medium, and large screens.
- [x] Added appropriate feature/unit tests.
