### PR TITLE
Query groups by location instead of state

### DIFF
--- a/cypress/integration/campaign-signup.js
+++ b/cypress/integration/campaign-signup.js
@@ -326,7 +326,7 @@ describe('Campaign Signup', () => {
         groupTypeId: 1,
         groupType: {
           id: 1,
-          filterByState: false,
+          filterByLocation: false,
         },
       },
     });
@@ -382,7 +382,7 @@ describe('Campaign Signup', () => {
             groupTypeId: 1,
             groupType: {
               id: 1,
-              filterByState: true,
+              filterByLocation: true,
             },
           },
         });

--- a/resources/assets/components/CampaignBanner/CampaignBanner.js
+++ b/resources/assets/components/CampaignBanner/CampaignBanner.js
@@ -29,7 +29,7 @@ const CAMPAIGN_BANNER_QUERY = gql`
       groupTypeId
       groupType {
         id
-        filterByState
+        filterByLocation
       }
     }
   }

--- a/resources/assets/components/CampaignSignupForm/GroupFinder/GroupFinder.js
+++ b/resources/assets/components/CampaignSignupForm/GroupFinder/GroupFinder.js
@@ -62,7 +62,7 @@ const GroupFinder = ({ context, groupType, onChange }) => {
           <p className="font-bold text-sm py-1">Select your {groupLabel}</p>
           <GroupSelect
             groupLabel={groupLabel}
-            groupState={groupState}
+            groupLocation={groupState}
             groupTypeId={groupType.id}
             onChange={onChange}
             onFocus={handleGroupSelectFocus}

--- a/resources/assets/components/CampaignSignupForm/GroupFinder/GroupFinder.js
+++ b/resources/assets/components/CampaignSignupForm/GroupFinder/GroupFinder.js
@@ -6,6 +6,7 @@ import {
   trackAnalyticsEvent,
 } from '../../../helpers/analytics';
 import GroupSelect from './GroupSelect';
+// TODO: We should deprecate this for SelectLocationDropdown, but have to pass style overrides.
 import UsaStateSelect from '../../utilities/UsaStateSelect';
 
 const ANALYTICS_EVENT_CATEGORY = EVENT_CATEGORIES.campaignAction;

--- a/resources/assets/components/CampaignSignupForm/GroupFinder/GroupFinder.js
+++ b/resources/assets/components/CampaignSignupForm/GroupFinder/GroupFinder.js
@@ -12,7 +12,7 @@ const ANALYTICS_EVENT_CATEGORY = EVENT_CATEGORIES.campaignAction;
 const ANALYTICS_EVENT_LABEL = 'group_finder';
 
 const GroupFinder = ({ context, groupType, onChange }) => {
-  const [groupState, setGroupState] = useState(null);
+  const [groupLocation, setGroupLocation] = useState(null);
 
   const handleGroupSelectFocus = () => {
     trackAnalyticsEvent(`focused_${ANALYTICS_EVENT_LABEL}_group`, {
@@ -23,8 +23,8 @@ const GroupFinder = ({ context, groupType, onChange }) => {
     });
   };
 
-  const handleGroupStateSelectChange = selected => {
-    setGroupState(selected.abbreviation);
+  const handleGroupLocationSelectChange = selected => {
+    setGroupLocation(selected.abbreviation);
 
     trackAnalyticsEvent(`clicked_${ANALYTICS_EVENT_LABEL}_state`, {
       action: 'form_clicked',
@@ -34,7 +34,7 @@ const GroupFinder = ({ context, groupType, onChange }) => {
     });
   };
 
-  const handleGroupStateSelectFocus = () => {
+  const handleGroupLocationSelectFocus = () => {
     trackAnalyticsEvent(`focused_${ANALYTICS_EVENT_LABEL}_state`, {
       action: 'field_focused',
       category: ANALYTICS_EVENT_CATEGORY,
@@ -43,26 +43,26 @@ const GroupFinder = ({ context, groupType, onChange }) => {
     });
   };
 
-  const { filterByState } = groupType;
+  const { filterByLocation } = groupType;
   const groupLabel = 'chapter';
 
   return (
     <>
-      {filterByState ? (
+      {filterByLocation ? (
         <div className="pb-3">
           <p className="font-bold text-sm py-1">Select your state</p>
           <UsaStateSelect
-            onChange={handleGroupStateSelectChange}
-            onFocus={handleGroupStateSelectFocus}
+            onChange={handleGroupLocationSelectChange}
+            onFocus={handleGroupLocationSelectFocus}
           />
         </div>
       ) : null}
-      {!filterByState || (filterByState && groupState) ? (
+      {!filterByLocation || (filterByLocation && groupLocation) ? (
         <div className="pb-3">
           <p className="font-bold text-sm py-1">Select your {groupLabel}</p>
           <GroupSelect
             groupLabel={groupLabel}
-            groupLocation={groupState}
+            groupLocation={`US-${groupLocation}`}
             groupTypeId={groupType.id}
             onChange={onChange}
             onFocus={handleGroupSelectFocus}

--- a/resources/assets/components/CampaignSignupForm/GroupFinder/GroupSelect.js
+++ b/resources/assets/components/CampaignSignupForm/GroupFinder/GroupSelect.js
@@ -6,19 +6,23 @@ import AsyncSelect from 'react-select/async';
 import { useApolloClient } from '@apollo/react-hooks';
 
 const SEARCH_GROUPS_QUERY = gql`
-  query SearchGroupsQuery($groupTypeId: Int!, $name: String!, $state: String) {
-    groups(groupTypeId: $groupTypeId, name: $name, state: $state) {
+  query SearchGroupsQuery(
+    $groupTypeId: Int!
+    $name: String!
+    $location: String
+  ) {
+    groups(groupTypeId: $groupTypeId, name: $name, location: $location) {
       id
       name
       city
-      state
+      location
     }
   }
 `;
 
 const GroupSelect = ({
   groupLabel,
-  groupState,
+  groupLocation,
   groupTypeId,
   onChange,
   onFocus,
@@ -35,8 +39,8 @@ const GroupSelect = ({
       name: searchString,
     };
 
-    if (groupState) {
-      variables.state = groupState;
+    if (groupLocation) {
+      variables.location = groupLocation;
     }
 
     client
@@ -53,11 +57,11 @@ const GroupSelect = ({
     <AsyncSelect
       getOptionLabel={group =>
         group.city
-          ? `${group.name} - ${group.city}, ${group.state}`
+          ? `${group.name} - ${group.city}, ${group.location.substring(3)}`
           : group.name
       }
       getOptionValue={group => group.id}
-      key={groupState}
+      key={groupLocation}
       id="select-group-dropdown"
       instanceId="select-group-"
       isClearable
@@ -80,14 +84,14 @@ const GroupSelect = ({
 
 GroupSelect.propTypes = {
   groupLabel: PropTypes.string.isRequired,
-  groupState: PropTypes.string,
+  groupLocation: PropTypes.string,
   groupTypeId: PropTypes.number.isRequired,
   onChange: PropTypes.func.isRequired,
   onFocus: PropTypes.func.isRequired,
 };
 
 GroupSelect.defaultProps = {
-  groupState: null,
+  groupLocation: null,
 };
 
 export default GroupSelect;

--- a/schema.json
+++ b/schema.json
@@ -3632,8 +3632,8 @@
             "deprecationReason": null
           },
           {
-            "name": "filterByState",
-            "description": "Whether group finders for this type should first filter by state before searching by name.",
+            "name": "filterByLocation",
+            "description": "Whether group finders for this type should first filter by location before searching by name.",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -3642,6 +3642,18 @@
             },
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "filterByState",
+            "description": "Whether group finders for this type should first filter by state before searching by name.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
+            },
+            "isDeprecated": true,
+            "deprecationReason": "Use 'filterByLocation' instead."
           },
           {
             "name": "updatedAt",


### PR DESCRIPTION
### What's this PR do?

This pull request queries the Groups resource by location instead of state within the Group Finder per https://github.com/DoSomething/graphql/pull/263, and also checks for whether a Group Type should filter by location (vs filter by state) per https://github.com/DoSomething/graphql/pull/267. No user facing changes.

This cleanup work is being done to eventually drop the state column from the groups table once this is merged, in an effort to keep how we query for an entity's location consistent in different types, per https://github.com/DoSomething/rogue/pull/1079#issuecomment-666484121.

### How should this be reviewed?

👀 

### Any background context you want to provide?

🌎 

### Relevant tickets

References [Pivotal #174021616](https://www.pivotaltracker.com/story/show/174021616).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added screenshots of front-end changes on small, medium, and large screens.
- [x] Added appropriate feature/unit tests.
