### PR TITLE
Adds ActionStatsBlock to SectionBlock types, removes from StoryPage block types

### DIFF
--- a/contentful/content-types/sectionBlock.js
+++ b/contentful/content-types/sectionBlock.js
@@ -55,26 +55,6 @@ module.exports = function(migration) {
     .omitted(false);
 
   sectionBlock
-    .createField('hyperlinkColor')
-    .name('Hyperlink Color')
-    .type('Symbol')
-    .localized(false)
-    .required(false)
-    .validations([
-      {
-        regexp: {
-          pattern: '^#[0-9a-f]{6}$',
-          flags: 'i',
-        },
-
-        message:
-          'Hexadecimal value, must start with a "#" and follow it with 6 characters.',
-      },
-    ])
-    .disabled(false)
-    .omitted(false);
-
-  sectionBlock
     .createField('content')
     .name('Content')
     .type('RichText')
@@ -82,36 +62,12 @@ module.exports = function(migration) {
     .required(false)
     .validations([
       {
-        nodes: {
-          'embedded-entry-block': [
-            {
-              linkContentType: [
-                'callToAction',
-                'campaignUpdate',
-                'cardBlock',
-                'contentBlock',
-                'embed',
-                'imagesBlock',
-                'linkAction',
-                'petitionSubmissionAction',
-                'photoSubmissionAction',
-                'postGallery',
-                'referralSubmissionAction',
-                'shareAction',
-                'socialDriveAction',
-                'textSubmissionAction',
-                'voterRegistrationAction',
-              ],
-            },
-          ],
-        },
-      },
-      {
         enabledMarks: ['bold', 'italic', 'underline'],
         message: 'Only bold, italic, and underline marks are allowed',
       },
       {
         enabledNodeTypes: [
+          'heading-1',
           'heading-2',
           'heading-3',
           'heading-4',
@@ -121,25 +77,52 @@ module.exports = function(migration) {
           'unordered-list',
           'blockquote',
           'embedded-entry-block',
-          'embedded-asset-block',
-          'heading-1',
           'hyperlink',
+          'embedded-asset-block',
         ],
 
         message:
-          'Only heading 1, heading 2, heading 3, heading 4, heading 5, heading 6, ordered list, unordered list, quote, block entry, asset, and link to Url nodes are allowed',
+          'Only heading 1, heading 2, heading 3, heading 4, heading 5, heading 6, ordered list, unordered list, quote, block entry, link to Url, and asset nodes are allowed',
+      },
+      {
+        nodes: {
+          'embedded-entry-block': [
+            {
+              linkContentType: [
+                'actionStatsBlock',
+                'callToAction',
+                'campaignUpdate',
+                'contentBlock',
+                'embed',
+                'imagesBlock',
+                'linkAction',
+                'petitionSubmissionAction',
+                'photoSubmissionAction',
+                'postGallery',
+                'shareAction',
+                'socialDriveAction',
+                'textSubmissionAction',
+                'voterRegistrationAction',
+              ],
+            },
+          ],
+        },
       },
     ])
     .disabled(false)
     .omitted(false);
 
-  sectionBlock.changeEditorInterface('internalTitle', 'singleLine', {
+  sectionBlock.changeFieldControl('internalTitle', 'builtin', 'singleLine', {
     helpText:
       'This title is used internally to help find this content. It will not be displayed anywhere on the rendered web page.',
   });
 
-  sectionBlock.changeEditorInterface('backgroundColor', 'singleLine', {});
-  sectionBlock.changeEditorInterface('textColor', 'singleLine', {});
-  sectionBlock.changeEditorInterface('hyperlinkColor', 'singleLine', {});
-  sectionBlock.changeEditorInterface('content', 'richTextEditor', {});
+  sectionBlock.changeFieldControl(
+    'backgroundColor',
+    'builtin',
+    'singleLine',
+    {},
+  );
+  sectionBlock.changeFieldControl('textColor', 'builtin', 'singleLine', {});
+  sectionBlock.changeFieldControl('content', 'builtin', 'richTextEditor', {});
 };

--- a/contentful/content-types/storyPage.js
+++ b/contentful/content-types/storyPage.js
@@ -130,7 +130,7 @@ module.exports = function(migration) {
 
       validations: [
         {
-          linkContentType: ['actionStatsBlock', 'sectionBlock'],
+          linkContentType: ['sectionBlock'],
         },
       ],
 


### PR DESCRIPTION
### What's this PR do?

This pull request adds an `ActionStatsBlock` to the available types in a `SectionBlock`, and removes from the available types of a `StoryPage` blocks field, per https://github.com/DoSomething/phoenix-next/pull/2323#discussion_r468654075.

I've been creating this migrations from the `master` environment, since they seem more to up to date than the ones in dev.. which is where the other resulting changes in the `sectionBlock` migration are coming from.

### How should this be reviewed?

👀 

### Any background context you want to provide?

🌁 

### Relevant tickets

References [Pivotal #174021616](https://www.pivotaltracker.com/n/projects/2417735/stories/174021616).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added screenshots of front-end changes on small, medium, and large screens.
- [ ] Added appropriate feature/unit tests.
