### PR TITLE
Only sets fixed class when on a campaign page without a groupType

### DIFF
--- a/resources/assets/components/CampaignBanner/CampaignBanner.js
+++ b/resources/assets/components/CampaignBanner/CampaignBanner.js
@@ -111,8 +111,8 @@ const CampaignBanner = ({
               <div
                 data-testid="campaign-banner-signup-button"
                 className={classnames(
-                  'bg-white bottom-0 md:bottom-auto left-0 md:left-auto p-3 md:p-0 w-full md:w-auto z-10 md:z-auto',
-                  { 'fixed md:static': !groupType, static: groupType },
+                  'bg-white bottom-0 md:bottom-auto left-0 md:left-auto p-3 md:static md:p-0 w-full md:w-auto z-10 md:z-auto',
+                  { fixed: !groupType },
                 )}
               >
                 {!loading ? (

--- a/resources/assets/components/CampaignBanner/CampaignBanner.js
+++ b/resources/assets/components/CampaignBanner/CampaignBanner.js
@@ -1,6 +1,7 @@
 import { get } from 'lodash';
 import gql from 'graphql-tag';
 import PropTypes from 'prop-types';
+import classnames from 'classnames';
 import { useQuery } from '@apollo/react-hooks';
 import React, { useState, useEffect } from 'react';
 
@@ -109,7 +110,10 @@ const CampaignBanner = ({
             {!isAffiliated ? (
               <div
                 data-testid="campaign-banner-signup-button"
-                className="bg-white bottom-0 md:bottom-auto left-0 md:left-auto p-3 md:p-0 fixed md:static w-full md:w-auto z-10 md:z-auto"
+                className={classnames(
+                  'bg-white bottom-0 md:bottom-auto left-0 md:left-auto p-3 md:p-0 w-full md:w-auto z-10 md:z-auto',
+                  { 'fixed md:static': !groupType, static: groupType },
+                )}
               >
                 {!loading ? (
                   <CampaignSignupFormContainer


### PR DESCRIPTION
### What's this PR do?

This pull request adds a check for whether we're on a groups campaign before making the signup button sticky on mobile screens.

### How should this be reviewed?

👀 

**Before:**
<img width="380" alt="Screen Shot 2020-08-12 at 11 16 26 AM" src="https://user-images.githubusercontent.com/15236023/90033644-b1d13a00-dc8d-11ea-979f-d801ed616773.png">

**After:**
<img width="377" alt="Screen Shot 2020-08-12 at 11 15 05 AM" src="https://user-images.githubusercontent.com/15236023/90033674-bd246580-dc8d-11ea-8c59-030c8a880f09.png">


### Any background context you want to provide?

This is the second PR to clean up the mobile experience for users on groups campaigns. ([see slack thread](https://dosomething.slack.com/archives/CTVPG6L4R/p1596132412220100))

### Relevant tickets

References [Pivotal #174164406](https://www.pivotaltracker.com/story/show/174164406).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [x] Added screenshots of front-end changes on small, medium, and large screens.
- [ ] Added appropriate feature/unit tests.
