### PR TITLE
Filter ActionStatsBlock by school

### DIFF
--- a/resources/assets/components/CampaignSignupForm/GroupFinder/GroupFinder.js
+++ b/resources/assets/components/CampaignSignupForm/GroupFinder/GroupFinder.js
@@ -25,7 +25,7 @@ const GroupFinder = ({ context, groupType, onChange }) => {
   };
 
   const handleGroupLocationSelectChange = selected => {
-    setGroupLocation(selected.abbreviation);
+    setGroupLocation(selected.value);
 
     trackAnalyticsEvent(`clicked_${ANALYTICS_EVENT_LABEL}_state`, {
       action: 'form_clicked',
@@ -63,7 +63,7 @@ const GroupFinder = ({ context, groupType, onChange }) => {
           <p className="font-bold text-sm py-1">Select your {groupLabel}</p>
           <GroupSelect
             groupLabel={groupLabel}
-            groupLocation={`US-${groupLocation}`}
+            groupLocation={groupLocation}
             groupTypeId={groupType.id}
             onChange={onChange}
             onFocus={handleGroupSelectFocus}

--- a/resources/assets/components/blocks/ActionStatsBlock/ActionStatsBlock.js
+++ b/resources/assets/components/blocks/ActionStatsBlock/ActionStatsBlock.js
@@ -4,7 +4,8 @@ import React, { useState } from 'react';
 
 import ActionStatsTable from './ActionStatsTable';
 import ActionStatsLeaderboard from './ActionStatsLeaderboard';
-import SelectLocationDropdown from '../../utilities/SelectLocationDropdown/SelectLocationDropdown';
+import SchoolSelect from '../CurrentSchoolBlock/SchoolSelect';
+import SchoolLocationSelect from '../../utilities/UsaStateSelect';
 
 export const ActionStatsBlockFragment = gql`
   fragment ActionStatsBlockFragment on ActionStatsBlock {
@@ -13,22 +14,36 @@ export const ActionStatsBlockFragment = gql`
 `;
 
 const ActionStatsBlock = ({ filterByActionId }) => {
+  const [schoolId, setSchoolId] = useState(null);
   const [schoolLocation, setSchoolLocation] = useState(null);
 
   return (
     <>
       <ActionStatsLeaderboard actionId={filterByActionId} />
 
-      <div className="md:w-1/4 pb-3">
-        <SelectLocationDropdown
-          locationList="domestic"
-          onSelect={event => setSchoolLocation(event.target.value)}
-          selectedOption={schoolLocation || ''}
-        />
+      <div className="flex pb-3">
+        <div className="md:w-1/4 pb-3">
+          <SchoolLocationSelect
+            isClearable
+            onChange={selected =>
+              setSchoolLocation(selected ? selected.value : null)
+            }
+          />
+        </div>
+
+        {schoolLocation ? (
+          <div className="w-1/4 pb-3">
+            <SchoolSelect
+              schoolLocation={schoolLocation}
+              onChange={school => setSchoolId(school ? school.id : null)}
+            />
+          </div>
+        ) : null}
       </div>
 
       <ActionStatsTable
         actionId={filterByActionId}
+        schoolId={schoolId}
         schoolLocation={schoolLocation}
       />
     </>

--- a/resources/assets/components/blocks/CurrentSchoolBlock/CurrentSchoolForm.js
+++ b/resources/assets/components/blocks/CurrentSchoolBlock/CurrentSchoolForm.js
@@ -4,8 +4,8 @@ import React, { useState } from 'react';
 import { useMutation } from '@apollo/react-hooks';
 
 import SchoolSelect from './SchoolSelect';
-import SchoolStateSelect from '../../utilities/UsaStateSelect';
 import PrimaryButton from '../../utilities/Button/PrimaryButton';
+import SchoolLocationSelect from '../../utilities/UsaStateSelect';
 
 const USER_SCHOOL_MUTATION = gql`
   mutation UserSchoolMutation($userId: String!, $schoolId: String) {
@@ -18,7 +18,7 @@ const USER_SCHOOL_MUTATION = gql`
 
 const CurrentSchoolForm = ({ description, userId }) => {
   const [school, setSchool] = useState(null);
-  const [schoolState, setSchoolState] = useState(null);
+  const [schoolLocation, setSchoolLocation] = useState(null);
   const [updateUserSchool] = useMutation(USER_SCHOOL_MUTATION);
 
   return (
@@ -28,14 +28,17 @@ const CurrentSchoolForm = ({ description, userId }) => {
       <div className="mt-6" data-test="select-state">
         <strong>State</strong>
 
-        <SchoolStateSelect onChange={selected => setSchoolState(selected)} />
+        <SchoolLocationSelect
+          onChange={selected => setSchoolLocation(selected.value)}
+        />
       </div>
 
-      {schoolState ? (
+      {schoolLocation ? (
         <div className="mt-6" data-test="select-school">
           <SchoolSelect
+            includeSchoolNotAvailableOption
             onChange={selected => setSchool(selected)}
-            schoolState={schoolState.abbreviation}
+            schoolLocation={schoolLocation}
           />
         </div>
       ) : null}

--- a/resources/assets/components/utilities/UsaStateSelect.js
+++ b/resources/assets/components/utilities/UsaStateSelect.js
@@ -3,26 +3,33 @@ import Select from 'react-select';
 import PropTypes from 'prop-types';
 import { UsaStates } from 'usa-states';
 
-const usaStateOptions = new UsaStates().states;
+const options = new UsaStates().states.map(item => {
+  return {
+    label: item.name,
+    value: `US-${item.abbreviation}`,
+  };
+});
 
-const UsaStateSelect = ({ onChange, onFocus }) => (
+const UsaStateSelect = ({ isClearable, onChange, onFocus }) => (
   <Select
-    getOptionLabel={usaState => usaState.name}
-    getOptionValue={usaState => usaState.abbreviation}
     id="select-state-dropdown"
     instanceId="select-state-"
+    isClearable={isClearable}
     onChange={onChange}
     onFocus={onFocus}
-    options={usaStateOptions}
+    options={options}
+    placeholder="Select state"
   />
 );
 
 UsaStateSelect.propTypes = {
+  isClearable: PropTypes.bool,
   onChange: PropTypes.func.isRequired,
   onFocus: PropTypes.func,
 };
 
 UsaStateSelect.defaultProps = {
+  isClearable: false,
   onFocus: () => {},
 };
 


### PR DESCRIPTION
### What's this PR do?

This pull request adds a school finder to the `ActionStatsBlock`, which will appear if a user selects a US state. It still needs to be styled, but I'll be adding them in a followup PR to help keep this one reviewable.

Some details on the changes:

* Refactors the `ActionStatsBlock` to use the `UsaStateSelect` component that both the school and group finders use, vs the `SelectLocationDropdown` component I initially used in hopes to eventually deprecate the `UsaStateSelect` component. The `UsaStateSelect` component style matches the `SchoolSelect`'s style because they both use [React Select](https://react-select.com/), which makes this easier to get out the door for next week, and also gives us some UX wins like filtering list of locations as user types, and having a button to clear selection (via the [isClearable](https://react-select.com/props#select-props) prop).

* Refactors the `UsaStateSelect` to return a location value instead of a state abbreviation, and refactors the `SchoolSelect` component to query schools by the `location` field instead of `state`, per https://github.com/DoSomething/graphql/pull/268.

### How should this be reviewed?

👀 

### Any background context you want to provide?

Hoping to add test coverage in a a follow up PR as well, although ideally we'd want to mock different GraphQL results for the same query but different variables. I'm not sure if this is possible with [cypress-graphql-mock](https://github.com/tgriesser/cypress-graphql-mock), but haven't dug in too deep yet to see if it is.

### Relevant tickets

References [Pivotal #174301697](https://www.pivotaltracker.com/story/show/174301697).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added screenshots of front-end changes on small, medium, and large screens.
- [ ] Added appropriate feature/unit tests.
