### PR TITLE
ActionStatsTable styles

### DIFF
--- a/resources/assets/components/blocks/ActionStatsBlock/ActionStatsBlock.js
+++ b/resources/assets/components/blocks/ActionStatsBlock/ActionStatsBlock.js
@@ -21,8 +21,8 @@ const ActionStatsBlock = ({ filterByActionId }) => {
     <>
       <ActionStatsLeaderboard actionId={filterByActionId} />
 
-      <div className="flex pb-3">
-        <div className="flex-1">
+      <div className="flex bg-gray-100 flex-wrap py-8 px-4 border border-solid border-gray-400">
+        <div className="w-full lg:w-1/5">
           <SchoolLocationSelect
             isClearable
             onChange={selected =>
@@ -31,14 +31,14 @@ const ActionStatsBlock = ({ filterByActionId }) => {
           />
         </div>
 
-        <div className="flex-1">
+        <div className="w-full lg:w-2/5">
           <SchoolSelect
             schoolLocation={schoolLocation}
             onChange={school => setSchoolId(school ? school.id : null)}
           />
         </div>
 
-        <div className="flex-1">
+        <div className="w-full lg:w-2/5">
           If your school has <span className="font-bold">0 registrations</span>,
           it won’t show up in the leaderboard. Email tej@dosomething.org for
           help.

--- a/resources/assets/components/blocks/ActionStatsBlock/ActionStatsBlock.js
+++ b/resources/assets/components/blocks/ActionStatsBlock/ActionStatsBlock.js
@@ -22,7 +22,7 @@ const ActionStatsBlock = ({ filterByActionId }) => {
       <ActionStatsLeaderboard actionId={filterByActionId} />
 
       <div className="flex pb-3">
-        <div className="md:w-1/4 pb-3">
+        <div className="flex-1">
           <SchoolLocationSelect
             isClearable
             onChange={selected =>
@@ -31,14 +31,18 @@ const ActionStatsBlock = ({ filterByActionId }) => {
           />
         </div>
 
-        {schoolLocation ? (
-          <div className="w-1/4 pb-3">
-            <SchoolSelect
-              schoolLocation={schoolLocation}
-              onChange={school => setSchoolId(school ? school.id : null)}
-            />
-          </div>
-        ) : null}
+        <div className="flex-1">
+          <SchoolSelect
+            schoolLocation={schoolLocation}
+            onChange={school => setSchoolId(school ? school.id : null)}
+          />
+        </div>
+
+        <div className="flex-1">
+          If your school has <span className="font-bold">0 registrations</span>,
+          it won’t show up in the leaderboard. Email tej@dosomething.org for
+          help.
+        </div>
       </div>
 
       <ActionStatsTable

--- a/resources/assets/components/blocks/ActionStatsBlock/ActionStatsBlock.js
+++ b/resources/assets/components/blocks/ActionStatsBlock/ActionStatsBlock.js
@@ -21,7 +21,7 @@ const ActionStatsBlock = ({ filterByActionId }) => {
     <>
       <ActionStatsLeaderboard actionId={filterByActionId} />
 
-      <div className="flex bg-gray-100 flex-wrap py-8 px-4 border border-solid border-gray-400">
+      <div className="flex bg-gray-100 flex-wrap py-8 px-4 border border-solid border-gray-200">
         <div className="w-full lg:w-1/5">
           <SchoolLocationSelect
             isClearable
@@ -31,14 +31,14 @@ const ActionStatsBlock = ({ filterByActionId }) => {
           />
         </div>
 
-        <div className="w-full lg:w-2/5">
+        <div className="w-full py-3 lg:w-2/5 lg:px-3 lg:py-0">
           <SchoolSelect
             schoolLocation={schoolLocation}
             onChange={school => setSchoolId(school ? school.id : null)}
           />
         </div>
 
-        <div className="w-full lg:w-2/5">
+        <div className="w-full lg:w-2/5 text-sm text-gray-600">
           If your school has <span className="font-bold">0 registrations</span>,
           it won’t show up in the leaderboard. Email tej@dosomething.org for
           help.

--- a/resources/assets/components/blocks/ActionStatsBlock/ActionStatsBlock.js
+++ b/resources/assets/components/blocks/ActionStatsBlock/ActionStatsBlock.js
@@ -33,8 +33,9 @@ const ActionStatsBlock = ({ filterByActionId }) => {
 
         <div className="w-full py-3 lg:w-2/5 lg:px-3 lg:py-0">
           <SchoolSelect
-            schoolLocation={schoolLocation}
+            isDisabled={!schoolLocation}
             onChange={school => setSchoolId(school ? school.id : null)}
+            schoolLocation={schoolLocation}
           />
         </div>
 

--- a/resources/assets/components/blocks/ActionStatsBlock/ActionStatsLeaderboard.js
+++ b/resources/assets/components/blocks/ActionStatsBlock/ActionStatsLeaderboard.js
@@ -48,7 +48,7 @@ const ActionStatsLeaderboard = ({ actionId }) => {
       {loading ? (
         <Spinner className="flex justify-center" />
       ) : (
-        <div className="p-6 bg-white lg:w-2/3 mb-6">
+        <div className="p-6 bg-white lg:w-2/3">
           {leaders.map(leader => {
             const { impact, school, location, id } = leader;
 

--- a/resources/assets/components/blocks/ActionStatsBlock/ActionStatsTable.js
+++ b/resources/assets/components/blocks/ActionStatsBlock/ActionStatsTable.js
@@ -47,6 +47,7 @@ const PAGINATED_ACTION_STATS_QUERY = gql`
   }
 `;
 
+const Table = tw.table`w-full bordered`;
 const TableHeader = tw.thead`bg-blurple-500 font-bold p-4 pr-6 text-left text-white w-full`;
 const TableCell = tw.td`p-2 text-sm md:text-base`;
 
@@ -104,7 +105,7 @@ const ActionStatsTable = ({ actionId, schoolId, schoolLocation }) => {
 
   if (noResults && !hasNextPage) {
     return (
-      <table className="w-full">
+      <Table>
         {header}
 
         <tbody>
@@ -112,6 +113,7 @@ const ActionStatsTable = ({ actionId, schoolId, schoolLocation }) => {
             <td className="bg-gray-100 px-10 pt-10 pb-32" colSpan={colSpan}>
               <div className="bg-white p-6 bordered rounded">
                 <h3>No Schools Found</h3>
+
                 <p>
                   Uh oh! Looks like we don’t currently have any schools in your
                   state. Keep in mind that if your school has 0 registrations,
@@ -122,12 +124,12 @@ const ActionStatsTable = ({ actionId, schoolId, schoolLocation }) => {
             </td>
           </tr>
         </tbody>
-      </table>
+      </Table>
     );
   }
 
   return (
-    <table className="w-full">
+    <Table>
       {header}
 
       <tbody>
@@ -173,7 +175,7 @@ const ActionStatsTable = ({ actionId, schoolId, schoolLocation }) => {
           </tr>
         ) : null}
       </tfoot>
-    </table>
+    </Table>
   );
 };
 

--- a/resources/assets/components/blocks/ActionStatsBlock/ActionStatsTable.js
+++ b/resources/assets/components/blocks/ActionStatsBlock/ActionStatsTable.js
@@ -47,7 +47,7 @@ const PAGINATED_ACTION_STATS_QUERY = gql`
   }
 `;
 
-const Table = tw.table`w-full bordered`;
+const Table = tw.table`w-full border border-solid border-gray-200`;
 const TableHeader = tw.thead`bg-blurple-500 font-bold p-4 pr-6 text-left text-white w-full`;
 const TableCell = tw.td`p-2 text-sm md:text-base`;
 
@@ -111,7 +111,7 @@ const ActionStatsTable = ({ actionId, schoolId, schoolLocation }) => {
         <tbody>
           <tr>
             <td className="bg-gray-100 px-10 pt-10 pb-32" colSpan={colSpan}>
-              <div className="bg-white p-6 bordered rounded">
+              <div className="bg-white p-6 rounded">
                 <h3>No Schools Found</h3>
 
                 <p>

--- a/resources/assets/components/blocks/ActionStatsBlock/ActionStatsTable.js
+++ b/resources/assets/components/blocks/ActionStatsBlock/ActionStatsTable.js
@@ -84,73 +84,96 @@ const ActionStatsTable = ({ actionId, schoolId, schoolLocation }) => {
     return <ErrorBlock error={error} />;
   }
 
-  if (noResults && !hasNextPage) {
-    return <div>No results</div>;
-  }
-
   let rank = 0;
   const displayRank = !schoolLocation;
+  const colSpan = displayRank ? 4 : 3;
 
-  return (
-    <>
+  const header = (
+    <TableHeader>
+      <tr>
+        {displayRank ? <TableCell>National Rank</TableCell> : null}
+
+        <TableCell>School Name</TableCell>
+
+        <TableCell>Location</TableCell>
+
+        <TableCell>Voter Registrations</TableCell>
+      </tr>
+    </TableHeader>
+  );
+
+  if (noResults && !hasNextPage) {
+    return (
       <table className="w-full">
-        <TableHeader>
-          <tr>
-            {displayRank ? <TableCell>National Rank</TableCell> : null}
-
-            <TableCell>School Name</TableCell>
-
-            <TableCell>Location</TableCell>
-
-            <TableCell>Voter Registrations</TableCell>
-          </tr>
-        </TableHeader>
+        {header}
 
         <tbody>
-          {stats.map(({ node, cursor }) => {
-            const { impact, location, school } = node;
-
-            rank += 1;
-
-            return (
-              <tr key={cursor}>
-                {displayRank ? <TableCell>{rank}</TableCell> : null}
-
-                <TableCell>{school.name}</TableCell>
-
-                <TableCell>
-                  {school.city}, {location.substring(3)}
-                </TableCell>
-
-                <TableCell>{impact}</TableCell>
-              </tr>
-            );
-          })}
+          <tr>
+            <td className="bg-gray-100 px-10 pt-10 pb-32" colSpan={colSpan}>
+              <div className="bg-white p-6 bordered rounded">
+                <h3>No Schools Found</h3>
+                <p>
+                  Uh oh! Looks like we don’t currently have any schools in your
+                  state. Keep in mind that if your school has 0 registrations,
+                  it won’t show up in the leaderboard. Still have questions?
+                  Email tej@dosomething.org for help.
+                </p>
+              </div>
+            </td>
+          </tr>
         </tbody>
-
-        <tfoot className="form-actions">
-          {loading ? (
-            <tr>
-              <td className="p-3" colSpan={displayRank ? 4 : 3}>
-                <Spinner className="flex justify-center" />
-              </td>
-            </tr>
-          ) : null}
-
-          {hasNextPage ? (
-            <tr>
-              <td className="p-3" colSpan={displayRank ? 4 : 3}>
-                <PrimaryButton
-                  onClick={handleViewMore}
-                  isDisabled={loading}
-                  text="Load More"
-                />
-              </td>
-            </tr>
-          ) : null}
-        </tfoot>
       </table>
-    </>
+    );
+  }
+
+  return (
+    <table className="w-full">
+      {header}
+
+      <tbody>
+        {stats.map(({ node, cursor }) => {
+          const { impact, location, school } = node;
+
+          rank += 1;
+
+          return (
+            <tr key={cursor}>
+              {displayRank ? <TableCell>{rank}</TableCell> : null}
+
+              <TableCell>{school.name}</TableCell>
+
+              <TableCell>
+                {school.city}, {location.substring(3)}
+              </TableCell>
+
+              <TableCell>{impact}</TableCell>
+            </tr>
+          );
+        })}
+      </tbody>
+
+      <tfoot className="form-actions">
+        {loading ? (
+          <tr>
+            <td className="p-3" colSpan={colSpan}>
+              <Spinner className="flex justify-center" />
+            </td>
+          </tr>
+        ) : null}
+
+        {hasNextPage ? (
+          <tr>
+            <td className="p-3" colSpan={colSpan}>
+              <PrimaryButton
+                onClick={handleViewMore}
+                isDisabled={loading}
+                text="Load More"
+              />
+            </td>
+          </tr>
+        ) : null}
+      </tfoot>
+    </table>
   );
 };
 

--- a/resources/assets/components/blocks/ActionStatsBlock/ActionStatsTable.js
+++ b/resources/assets/components/blocks/ActionStatsBlock/ActionStatsTable.js
@@ -89,13 +89,14 @@ const ActionStatsTable = ({ actionId, schoolId, schoolLocation }) => {
   }
 
   let rank = 0;
+  const displayRank = !schoolLocation;
 
   return (
     <>
       <table className="w-full">
         <TableHeader>
           <tr>
-            <TableCell>{schoolLocation ? 'State' : 'National'} Rank</TableCell>
+            {displayRank ? <TableCell>National Rank</TableCell> : null}
 
             <TableCell>School Name</TableCell>
 
@@ -113,7 +114,7 @@ const ActionStatsTable = ({ actionId, schoolId, schoolLocation }) => {
 
             return (
               <tr key={cursor}>
-                <TableCell>{rank}</TableCell>
+                {displayRank ? <TableCell>{rank}</TableCell> : null}
 
                 <TableCell>{school.name}</TableCell>
 
@@ -130,7 +131,7 @@ const ActionStatsTable = ({ actionId, schoolId, schoolLocation }) => {
         <tfoot className="form-actions">
           {loading ? (
             <tr>
-              <td className="p-3" colSpan="4">
+              <td className="p-3" colSpan={displayRank ? 4 : 3}>
                 <Spinner className="flex justify-center" />
               </td>
             </tr>
@@ -138,7 +139,7 @@ const ActionStatsTable = ({ actionId, schoolId, schoolLocation }) => {
 
           {hasNextPage ? (
             <tr>
-              <td className="p-3" colSpan="4">
+              <td className="p-3" colSpan={displayRank ? 4 : 3}>
                 <PrimaryButton
                   onClick={handleViewMore}
                   isDisabled={loading}

--- a/resources/assets/components/blocks/ActionStatsBlock/ActionStatsTable.js
+++ b/resources/assets/components/blocks/ActionStatsBlock/ActionStatsTable.js
@@ -2,6 +2,7 @@ import React from 'react';
 import tw from 'twin.macro';
 import gql from 'graphql-tag';
 import PropTypes from 'prop-types';
+import { css } from '@emotion/core';
 import { assign, get } from 'lodash';
 import { useQuery } from '@apollo/react-hooks';
 
@@ -139,7 +140,12 @@ const ActionStatsTable = ({ actionId, schoolId, schoolLocation }) => {
           rank += 1;
 
           return (
-            <tr key={cursor}>
+            <tr
+              key={cursor}
+              css={css`{background-color: #${
+                rank % 2 === 0 ? 'f4f9ff' : 'ffffff'
+              }`}
+            >
               {displayRank ? <TableCell>{rank}</TableCell> : null}
 
               <TableCell>{school.name}</TableCell>

--- a/resources/assets/components/blocks/CurrentSchoolBlock/SchoolSelect.js
+++ b/resources/assets/components/blocks/CurrentSchoolBlock/SchoolSelect.js
@@ -23,7 +23,9 @@ const SEARCH_SCHOOLS_QUERY = gql`
 
 const SchoolSelect = ({
   includeSchoolNotAvailableOption,
+  isDisabled,
   onChange,
+  placeholder,
   schoolLocation,
 }) => {
   const client = useApolloClient();
@@ -65,6 +67,7 @@ const SchoolSelect = ({
       }
       getOptionValue={school => school.id}
       isClearable
+      isDisabled={isDisabled}
       /**
        * Changing per schoolLocation will result in clearing any selected options.
        * If user selects a school, but then changes location, force reselect.
@@ -88,18 +91,23 @@ const SchoolSelect = ({
           : 'Enter your school name'
       }
       onChange={onChange}
+      placeholder={placeholder}
     />
   );
 };
 
 SchoolSelect.propTypes = {
   includeSchoolNotAvailableOption: PropTypes.bool,
+  isDisabled: PropTypes.bool,
   onChange: PropTypes.func.isRequired,
+  placeholder: PropTypes.string,
   schoolLocation: PropTypes.string.isRequired,
 };
 
 SchoolSelect.defaultProps = {
   includeSchoolNotAvailableOption: false,
+  isDisabled: false,
+  placeholder: 'Enter school name',
 };
 
 export default SchoolSelect;

--- a/resources/assets/components/pages/CampaignPage/CampaignPageContent.js
+++ b/resources/assets/components/pages/CampaignPage/CampaignPageContent.js
@@ -51,6 +51,7 @@ const CampaignPageContent = props => {
               className="mb-6 clear-both"
               classNameByEntryDefault={narrowSpan}
               classNameByEntry={{
+                ActionStatsBlock: wideSpan,
                 ContentBlock: wideSpan,
                 GalleryBlock: wideSpan,
                 ImagesBlock: wideSpan,


### PR DESCRIPTION
### What's this PR do?

This PR styles the `ActionStatsBlock` and `ActionStatsTable` per [designs](https://share.goabstract.com/21f24c1d-8cf5-4606-a5a5-5343f358773c).

### How should this be reviewed?

* 👀 

* [Small](https://user-images.githubusercontent.com/1236811/90820619-80d4b300-e2e6-11ea-9b6e-c5826a3aed10.png)

*  [Medium](https://user-images.githubusercontent.com/1236811/90820491-4bc86080-e2e6-11ea-94ee-b228fb7ebf6e.png)

* [Desktop](https://user-images.githubusercontent.com/1236811/90820746-b5e10580-e2e6-11ea-90c1-ca1df73ad311.png)

### Any background context you want to provide?

There's are a few tweaks left to make per the designs that we can make in a follow up PR:

* add horizontal padding to the filters on the medium screen, for now they stretch across.

* clean up bottom leaderboard cell padding

Also will add tests in followup PR.

### Relevant tickets

References [Pivotal #174301697](https://www.pivotaltracker.com/story/show/174301697).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added screenshots of front-end changes on small, medium, and large screens.
- [ ] Added appropriate feature/unit tests.
