### PR TITLE
Adds actionStatsBlock to companyPage, removes from sectionBlock

### DIFF
--- a/contentful/content-types/companyPage.js
+++ b/contentful/content-types/companyPage.js
@@ -105,21 +105,6 @@ module.exports = function(migration) {
     .required(true)
     .validations([
       {
-        nodes: {
-          'embedded-entry-block': [
-            {
-              linkContentType: [
-                'callToAction',
-                'contentBlock',
-                'galleryBlock',
-                'imagesBlock',
-                'linkAction',
-              ],
-            },
-          ],
-        },
-      },
-      {
         enabledNodeTypes: [
           'heading-1',
           'heading-2',
@@ -139,6 +124,22 @@ module.exports = function(migration) {
 
         message:
           'Only heading 1, heading 2, heading 3, heading 4, heading 5, heading 6, ordered list, unordered list, horizontal rule, quote, block entry, asset, link to Url, and link to asset nodes are allowed',
+      },
+      {
+        nodes: {
+          'embedded-entry-block': [
+            {
+              linkContentType: [
+                'actionStatsBlock',
+                'callToAction',
+                'contentBlock',
+                'galleryBlock',
+                'imagesBlock',
+                'linkAction',
+              ],
+            },
+          ],
+        },
       },
     ])
     .disabled(false)

--- a/contentful/content-types/sectionBlock.js
+++ b/contentful/content-types/sectionBlock.js
@@ -89,7 +89,6 @@ module.exports = function(migration) {
           'embedded-entry-block': [
             {
               linkContentType: [
-                'actionStatsBlock',
                 'callToAction',
                 'campaignUpdate',
                 'contentBlock',


### PR DESCRIPTION
### What's this PR do?

This pull request updates the content type migrations for two types: 

* `companyPage` - allow embedding an `actionStatsBlock`.

* `sectionBlock` - remove embedding an `actionStatsBlock`. This likely would have required additional styling work to center the leaderboard component, but instead we can leave it as-is by using the left-aligned Company Page.

### How should this be reviewed?

This [company page](https://www.dosomething.org/us/about/democracy-powered-by-youth-competition) has an `ActionStatsBlock` embedded.

### Any background context you want to provide?

📊 

### Relevant tickets

References [Pivotal #174301702](https://www.pivotaltracker.com/story/show/174301702).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added screenshots of front-end changes on small, medium, and large screens.
- [ ] Added appropriate feature/unit tests.
