### PR TITLE
Removes CONFIRMED as an excluded voter reg status

### DIFF
--- a/cypress/integration/sitewide-banner.js
+++ b/cypress/integration/sitewide-banner.js
@@ -73,26 +73,6 @@ describe('Site Wide Banner', () => {
     cy.findByTestId('sitewide-banner').should('have.length', 1);
   });
 
-  it('The Site Wide Banner is not displayed for users with CONFIRMED voter reg status', () => {
-    const user = userFactory();
-
-    cy.mockGraphqlOp('CampaignBannerQuery', {
-      campaign: {
-        groupTypeId: null,
-      },
-    });
-
-    cy.mockGraphqlOp('UserSitewideBannerQuery', {
-      user: {
-        voterRegistrationStatus: 'CONFIRMED',
-      },
-    });
-
-    cy.authVisitCampaignWithoutSignup(user, exampleCampaign);
-
-    cy.findByTestId('sitewide-banner-hidden').should('have.length', 1);
-  });
-
   it('The Site Wide Banner is not displayed for users with INELIGIBLE voter reg status', () => {
     const user = userFactory();
 

--- a/resources/assets/components/utilities/SitewideBanner/config.js
+++ b/resources/assets/components/utilities/SitewideBanner/config.js
@@ -15,7 +15,6 @@ export const excludedPaths = [
 ];
 
 export const excludedVoterRegistrationStatuses = [
-  'CONFIRMED',
   'INELIGIBLE',
   'REGISTRATION_COMPLETE',
 ];


### PR DESCRIPTION
### What's this PR do?

This pull request removes `CONFIRMED` from the list of voter reg statuses to exclude, added accidentally in #2336. 

### How should this be reviewed?

👀 

### Any background context you want to provide?

This is a self reported status, and sometimes be [inaccurate](https://dosomething.slack.com/archives/CUQMU4Q6B/p1597679101007900?thread_ts=1597677647.001600&cid=CUQMU4Q6B), which is why we want to display the banner for this status.

### Relevant tickets

References [Pivotal #174352011](https://www.pivotaltracker.com/n/projects/2417735/stories/174352011).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added screenshots of front-end changes on small, medium, and large screens.
- [ ] Added appropriate feature/unit tests.
