### PR TITLE
Adding title and description to the socialActionDrive

### DIFF
--- a/contentful/content-types/socialDriveAction.js
+++ b/contentful/content-types/socialDriveAction.js
@@ -25,11 +25,26 @@ module.exports = function(migration) {
     .validations([])
     .disabled(false)
     .omitted(false);
-  socialDriveAction.changeFieldControl(
-    'internalTitle',
-    'builtin',
-    'singleLine',
-    {},
-  );
-  socialDriveAction.changeFieldControl('link', 'builtin', 'singleLine', {});
+  socialDriveAction
+    .createField('title')
+    .name('Title')
+    .type('Symbol')
+    .localized(false)
+    .required(false)
+    .validations([])
+    .disabled(false)
+    .omitted(false);
+  socialDriveAction
+    .createField('description')
+    .name('Description')
+    .type('Text')
+    .localized(false)
+    .required(false)
+    .validations([])
+    .disabled(false)
+    .omitted(false);
+  socialDriveAction.changeEditorInterface('internalTitle', 'singleLine', {});
+  socialDriveAction.changeEditorInterface('link', 'singleLine', {});
+  socialDriveAction.changeEditorInterface('title', 'singleLine', {});
+  socialDriveAction.changeEditorInterface('description', 'markdown', {});
 };

--- a/docs/development/content-types/social-drive-action.md
+++ b/docs/development/content-types/social-drive-action.md
@@ -8,6 +8,10 @@ Displays a shortened link for the user to share.
 
 ## Content Type Fields
 
-- **Internal Title**: This is for our internal Contentful organization and will be how the entry shows up in search results, etc.
+-   **Internal Title**: This is for our internal Contentful organization and will be how the entry shows up in search results, etc.
 
-- **Link**: The full URL that the user should share. This link will be shortened via Bertly's [Create Link](https://github.com/DoSomething/bertly/tree/master/documentation#create-link) endpoint when rendered in the browser.
+-   **Title**: This is the title that will display on the action for the user.
+
+-   **Description**: This is the description of the action that editors can add for users.
+
+-   **Link**: The full URL that the user should share. This link will be shortened via Bertly's [Create Link](https://github.com/DoSomething/bertly/tree/master/documentation#create-link) endpoint when rendered in the browser.


### PR DESCRIPTION
### What's this PR do?

This pull request adds two new fields to the socialDriveAction so that we can reuse the RAF block in our HRC campaign and use custom language for it and the OG RAF in the profile page.

### How should this be reviewed?

👀 

### Any background context you want to provide?

n/a

### Relevant tickets

References [Pivotal #174263168](https://www.pivotaltracker.com/story/show/174263168).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [x] Documentation added for new features/changed endpoints.
- [ ] Added screenshots of front-end changes on small, medium, and large screens.
- [ ] Added appropriate feature/unit tests.
