### PR TITLE
Adds config to display 'school' or 'chapter' group label in Group Finder

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -86,5 +86,6 @@ DS_ENABLE_VOLUNTEER_CREDITS=
 # ==============================================================================
 # Site Config
 # ==============================================================================
+DS_CHAPTER_GROUP_TYPE_IDS=
 DS_DEFAULT_REFERRAL_CAMPAIGN_ID=
 DS_HIDE_CAMPAIGN_IDS=

--- a/config/site.php
+++ b/config/site.php
@@ -14,6 +14,8 @@ return [
     |
     */
 
+    // These Group Type IDs have a 'chapter' group label instead of the default in Group Finders.
+    'chapter_group_type_ids' => explode(',', env('DS_CHAPTER_GROUP_TYPE_IDS')),
     'default_referral_campaign_id' => env('DS_DEFAULT_REFERRAL_CAMPAIGN_ID'),
     'hide_campaign_ids' => explode(',', env('DS_HIDE_CAMPAIGN_IDS')),
 ];

--- a/cypress/integration/campaign-signup.js
+++ b/cypress/integration/campaign-signup.js
@@ -37,9 +37,9 @@ const mockCampaignBannerQueryResult = (
 
 const mockSearchGroupsQueryResult = {
   groups: [
-    { id: 1, name: 'New York', state: 'NY' },
-    { id: 2, name: 'Philadelphia', state: 'PA' },
-    { id: 3, name: 'San Francisco', state: 'CA' },
+    { id: 1, name: 'New York Pizza', location: 'US-NY' },
+    { id: 2, name: 'Philadelphia Hoagies', location: 'US-PA' },
+    { id: 3, name: 'San Francisco Sourdough', location: 'US-CA' },
   ],
 };
 

--- a/cypress/integration/campaign-signup.js
+++ b/cypress/integration/campaign-signup.js
@@ -35,10 +35,6 @@ const mockCampaignBannerQueryResult = (
   };
 };
 
-/**
- * @param {Boolean} filterByLocation
- * @return {Object}
- */
 const mockSearchGroupsQueryResult = {
   groups: [
     { id: 1, name: 'New York', state: 'NY' },

--- a/cypress/integration/campaign-signup.js
+++ b/cypress/integration/campaign-signup.js
@@ -307,36 +307,6 @@ describe('Campaign Signup', () => {
   });
 
   context('Campaign ID configured with a group type', () => {
-    context.only('Group type label configuration', () => {
-      /** @test */
-      it('Group label is "school" if group type is not in chapter config', () => {
-        cy.mockGraphqlOp(
-          'CampaignBannerQuery',
-          mockCampaignBannerQueryResult(1, false),
-        );
-
-        cy.anonVisitCampaign(exampleCampaign);
-
-        cy.contains('start typing your school name');
-        cy.contains("Can't find your school?");
-      });
-
-      /** @test */
-      it('Group label is "chapter" if group type is in chapter config', () => {
-        cy.mockGraphqlOp(
-          'CampaignBannerQuery',
-          mockCampaignBannerQueryResult(20, false),
-        );
-
-        cy.withSiteConfig({
-          chapter_group_type_ids: '20,22',
-        }).anonVisitCampaign(exampleCampaign);
-
-        cy.contains('start typing your chapter name');
-        cy.contains("Can't find your chapter?");
-      });
-    });
-
     context('Group type does not filter by location', () => {
       /** @test */
       it('Signup button is enabled after selecting group', () => {
@@ -434,6 +404,36 @@ describe('Campaign Signup', () => {
         cy.wait('@signupRequest')
           .its('request.body.group_id')
           .should('equal', 1);
+      });
+    });
+
+    context('Group type label configuration', () => {
+      /** @test */
+      it('Group label is "school" if group type is not in chapter config', () => {
+        cy.mockGraphqlOp(
+          'CampaignBannerQuery',
+          mockCampaignBannerQueryResult(1, false),
+        );
+
+        cy.anonVisitCampaign(exampleCampaign);
+
+        cy.contains('start typing your school name');
+        cy.contains("Can't find your school?");
+      });
+
+      /** @test */
+      it('Group label is "chapter" if group type is in chapter config', () => {
+        cy.mockGraphqlOp(
+          'CampaignBannerQuery',
+          mockCampaignBannerQueryResult(20, false),
+        );
+
+        cy.withSiteConfig({
+          chapter_group_type_ids: '20,22',
+        }).anonVisitCampaign(exampleCampaign);
+
+        cy.contains('start typing your chapter name');
+        cy.contains("Can't find your chapter?");
       });
     });
   });

--- a/cypress/integration/campaign-signup.js
+++ b/cypress/integration/campaign-signup.js
@@ -27,6 +27,7 @@ const mockCampaignBannerQueryResult = (
       groupTypeId: groupTypeId || null,
       groupType: groupTypeId
         ? {
+            id: groupTypeId,
             filterByLocation,
           }
         : null,

--- a/cypress/integration/campaign-signup.js
+++ b/cypress/integration/campaign-signup.js
@@ -12,6 +12,40 @@ const API = `/api/v2/campaigns/${campaignId}`;
 const exampleBlurb = `Did you know that the world's oldest cat`;
 const exampleReferralCampaign = cloneDeep(exampleCampaign);
 
+/**
+ * @param {Number} groupTypeId
+ * @param {Boolean} filterByLocation
+ * @return {Object}
+ */
+const mockCampaignBannerQueryResult = (
+  groupTypeId,
+  filterByLocation = true,
+) => {
+  return {
+    campaign: {
+      id: campaignId,
+      groupTypeId: groupTypeId || null,
+      groupType: groupTypeId
+        ? {
+            filterByLocation,
+          }
+        : null,
+    },
+  };
+};
+
+/**
+ * @param {Boolean} filterByLocation
+ * @return {Object}
+ */
+const mockSearchGroupsQueryResult = {
+  groups: [
+    { id: 1, name: 'New York', state: 'NY' },
+    { id: 2, name: 'Philadelphia', state: 'PA' },
+    { id: 3, name: 'San Francisco', state: 'CA' },
+  ],
+};
+
 exampleReferralCampaign.campaign.displayReferralPage = true;
 
 describe('Campaign Signup', () => {
@@ -22,13 +56,7 @@ describe('Campaign Signup', () => {
   it('Create signup, as an anonymous user', () => {
     const user = userFactory();
 
-    cy.mockGraphqlOp('CampaignBannerQuery', {
-      campaign: {
-        id: campaignId,
-        groupTypeId: null,
-        groupType: null,
-      },
-    });
+    cy.mockGraphqlOp('CampaignBannerQuery', mockCampaignBannerQueryResult());
 
     // Visit the campaign landing page:
     cy.anonVisitCampaign(exampleCampaign);
@@ -56,13 +84,9 @@ describe('Campaign Signup', () => {
   /** @test */
   it('Create signup, as an authenticated user', () => {
     const user = userFactory();
-    cy.mockGraphqlOp('CampaignBannerQuery', {
-      campaign: {
-        id: campaignId,
-        groupTypeId: null,
-        groupType: null,
-      },
-    });
+
+    cy.mockGraphqlOp('CampaignBannerQuery', mockCampaignBannerQueryResult());
+
     // Log in & visit the campaign landing page:
     cy.authVisitCampaignWithoutSignup(user, exampleCampaign);
 
@@ -88,13 +112,7 @@ describe('Campaign Signup', () => {
     it('Includes the referrer_user_id query param in the signup payload', () => {
       const user = userFactory();
 
-      cy.mockGraphqlOp('CampaignBannerQuery', {
-        campaign: {
-          id: campaignId,
-          groupTypeId: null,
-          groupType: null,
-        },
-      });
+      cy.mockGraphqlOp('CampaignBannerQuery', mockCampaignBannerQueryResult());
 
       // Visit the campaign landing page:
       cy.withState(exampleCampaign).visit(
@@ -125,13 +143,10 @@ describe('Campaign Signup', () => {
         it('Beta Referral campaign signup displays the beta reward copy', () => {
           const user = userFactory();
 
-          cy.mockGraphqlOp('CampaignBannerQuery', {
-            campaign: {
-              id: campaignId,
-              groupTypeId: null,
-              groupType: null,
-            },
-          });
+          cy.mockGraphqlOp(
+            'CampaignBannerQuery',
+            mockCampaignBannerQueryResult(),
+          );
 
           // Visit the campaign landing page as an authenticated user with a referrer_user_id query param:
           cy.login(user)
@@ -165,13 +180,11 @@ describe('Campaign Signup', () => {
         /** @test */
         it('Regular Referral campaign signup displays the general incentive copy', () => {
           const user = userFactory();
-          cy.mockGraphqlOp('CampaignBannerQuery', {
-            campaign: {
-              id: campaignId,
-              groupTypeId: null,
-              groupType: null,
-            },
-          });
+
+          cy.mockGraphqlOp(
+            'CampaignBannerQuery',
+            mockCampaignBannerQueryResult(),
+          );
 
           // Log in & visit the campaign pitch page:
           cy.withFeatureFlags({
@@ -193,13 +206,11 @@ describe('Campaign Signup', () => {
         /** @test */
         it('displays the incentive free copy', () => {
           const user = userFactory();
-          cy.mockGraphqlOp('CampaignBannerQuery', {
-            campaign: {
-              id: campaignId,
-              groupTypeId: null,
-              groupType: null,
-            },
-          });
+
+          cy.mockGraphqlOp(
+            'CampaignBannerQuery',
+            mockCampaignBannerQueryResult(),
+          );
 
           // Log in & visit the campaign pitch page:
           cy.authVisitCampaignWithoutSignup(user, exampleReferralCampaign);
@@ -222,13 +233,7 @@ describe('Campaign Signup', () => {
     it("Doesn't display Referral Page Banner CTA in affirmation for non configured campaign", () => {
       const user = userFactory();
 
-      cy.mockGraphqlOp('CampaignBannerQuery', {
-        campaign: {
-          id: campaignId,
-          groupTypeId: null,
-          groupType: null,
-        },
-      });
+      cy.mockGraphqlOp('CampaignBannerQuery', mockCampaignBannerQueryResult());
 
       // Log in & visit the campaign pitch page:
       cy.authVisitCampaignWithoutSignup(user, exampleCampaign);
@@ -265,13 +270,7 @@ describe('Campaign Signup', () => {
 
   /** @test */
   it('Visits a campaign page from scholarship partner, as an unauthenticated user', () => {
-    cy.mockGraphqlOp('CampaignBannerQuery', {
-      campaign: {
-        id: campaignId,
-        groupTypeId: null,
-        groupType: null,
-      },
-    });
+    cy.mockGraphqlOp('CampaignBannerQuery', mockCampaignBannerQueryResult());
 
     // Visit the campaign pitch page
     cy.withState(exampleCampaign).visit(
@@ -313,24 +312,12 @@ describe('Campaign Signup', () => {
       it('Signup button is enabled after selecting group', () => {
         const user = userFactory();
 
-        cy.mockGraphqlOp('SearchGroupsQuery', {
-          groups: [
-            { id: 1, name: 'New York' },
-            { id: 2, name: 'Philadelphia' },
-            { id: 3, name: 'San Francisco' },
-          ],
-        });
+        cy.mockGraphqlOp('SearchGroupsQuery', mockSearchGroupsQueryResult);
 
-        cy.mockGraphqlOp('CampaignBannerQuery', {
-          campaign: {
-            id: campaignId,
-            groupTypeId: 1,
-            groupType: {
-              id: 1,
-              filterByLocation: false,
-            },
-          },
-        });
+        cy.mockGraphqlOp(
+          'CampaignBannerQuery',
+          mockCampaignBannerQueryResult(1, false),
+        );
 
         cy.anonVisitCampaign(exampleCampaign);
 
@@ -371,24 +358,11 @@ describe('Campaign Signup', () => {
       it('Signup button is enabled after selecting location, then group', () => {
         const user = userFactory();
 
-        cy.mockGraphqlOp('SearchGroupsQuery', {
-          groups: [
-            { id: 1, name: 'New York', state: 'NY' },
-            { id: 2, name: 'Philadelphia', state: 'PA' },
-            { id: 3, name: 'San Francisco', state: 'CA' },
-          ],
-        });
-
-        cy.mockGraphqlOp('CampaignBannerQuery', {
-          campaign: {
-            id: campaignId,
-            groupTypeId: 1,
-            groupType: {
-              id: 1,
-              filterByLocation: true,
-            },
-          },
-        });
+        cy.mockGraphqlOp('SearchGroupsQuery', mockSearchGroupsQueryResult);
+        cy.mockGraphqlOp(
+          'CampaignBannerQuery',
+          mockCampaignBannerQueryResult(1),
+        );
 
         cy.anonVisitCampaign(exampleCampaign);
 

--- a/cypress/integration/campaign-signup.js
+++ b/cypress/integration/campaign-signup.js
@@ -307,6 +307,36 @@ describe('Campaign Signup', () => {
   });
 
   context('Campaign ID configured with a group type', () => {
+    context.only('Group type label configuration', () => {
+      /** @test */
+      it('Group label is "school" if group type is not in chapter config', () => {
+        cy.mockGraphqlOp(
+          'CampaignBannerQuery',
+          mockCampaignBannerQueryResult(1, false),
+        );
+
+        cy.anonVisitCampaign(exampleCampaign);
+
+        cy.contains('start typing your school name');
+        cy.contains("Can't find your school?");
+      });
+
+      /** @test */
+      it('Group label is "chapter" if group type is in chapter config', () => {
+        cy.mockGraphqlOp(
+          'CampaignBannerQuery',
+          mockCampaignBannerQueryResult(20, false),
+        );
+
+        cy.withSiteConfig({
+          chapter_group_type_ids: '20,22',
+        }).anonVisitCampaign(exampleCampaign);
+
+        cy.contains('start typing your chapter name');
+        cy.contains("Can't find your chapter?");
+      });
+    });
+
     context('Group type does not filter by location', () => {
       /** @test */
       it('Signup button is enabled after selecting group', () => {

--- a/docs/development/features/groups.md
+++ b/docs/development/features/groups.md
@@ -1,6 +1,6 @@
 # Groups
 
-If a Rogue campaign is configured with a [group type]((https://activity.dosomething.org/group-types), a Group Finder will appear on the campaign landing page. Members must select a group to join in order to signup for the campaign (which will save their selected group ID to their signup).
+If a Rogue campaign is configured with a [group type](https://activity.dosomething.org/group-types), a Group Finder will appear on the campaign landing page. Members must select a group to join in order to signup for the campaign (which will save their selected group ID to their signup).
 
 ![Example Group Finder](../../.gitbook/assets/groups-landing-page.png)
 

--- a/docs/development/features/groups.md
+++ b/docs/development/features/groups.md
@@ -1,26 +1,20 @@
 # Groups
 
-If a Rogue campaign is configured with a group type, a Group Finder will appear on the campaign landing page. Members must select a group to join in order to signup for the campaign (which will save their selected group ID to their signup).
+If a Rogue campaign is configured with a [group type]((https://activity.dosomething.org/group-types), a Group Finder will appear on the campaign landing page. Members must select a group to join in order to signup for the campaign (which will save their selected group ID to their signup).
 
 ![Example Group Finder](../../.gitbook/assets/groups-landing-page.png)
 
 ## Group types
 
-Current list of group types:
+If a group type's `filter_by_location` boolean attribute is `true`, the Group Finder will require the member to select their group state first before searching for the group name.
 
-- [March For Our Lives](https://activity.dosomething.org/group-types/1)
-- [National Association of Secondary School Principals (NASSP)](https://activity.dosomething.org/group-types/5)
-- [National Honor Society](https://activity.dosomething.org/group-types/2) - a subset of NASSP groups
-- [National Junior Honor Society](https://activity.dosomething.org/group-types/3) - a subset of NASSP groups
-- [National Student Council](https://activity.dosomething.org/group-types/4) - a subset of NASSP groups
+![Filter by location example](../../.gitbook/assets/groups-filter-by-state.png)
 
-If a group type's `filter_by_state` boolean attribute is `true`, the Group Finder will require the member to select their group state first before searching for the group name.
-
-![Filter by state example](../../.gitbook/assets/groups-filter-by-state.png)
+By default the Group Finder will label a group as a "school", e.g. "Find your school". To override this label as "chapter", add the group type ID to the Phoenix `CHAPTER_GROUP_TYPE_IDS` site configuration variable.
 
 ## Online Voter Registration Drives
 
-These group types will be running [Online Voter Registration Drive (OVRD)](development/features/voter-registration.md#online-drives) campaigns. A [VoterRegistrationDriveAction](development/content-types/voter-registration-drive-action.md) used on an action page of a groups campaign will append the alpha's selected `group_id` as a query parameter to their OVRD page, e.g:
+Group types may run their own [Online Voter Registration Drive (OVRD)](development/features/voter-registration.md#online-drives) campaigns. A [VoterRegistrationDriveAction](development/content-types/voter-registration-drive-action.md) used on an action page of a groups campaign will append the alpha's selected `group_id` as a query parameter to their OVRD page, e.g:
 
 > /us/my-voter-registration-drive?group_id=172&referrer_user_id=5547be89469c64ec7d8b518d
 

--- a/resources/assets/components/CampaignSignupForm/CampaignSignupForm.js
+++ b/resources/assets/components/CampaignSignupForm/CampaignSignupForm.js
@@ -92,6 +92,9 @@ const CampaignSignupForm = props => {
       />
     );
   }
+  // TODO: Add a config variable to save chapter group types.
+  const groupLabel =
+    groupType.name === 'March For Our Lives' ? 'chapter' : 'school';
 
   return (
     <div className="my-3" data-testid="join-group-signup-form">
@@ -99,6 +102,7 @@ const CampaignSignupForm = props => {
         <div className="p-3">
           <GroupFinder
             context={{ campaignId, pageId }}
+            groupLabel={groupLabel}
             groupType={groupType}
             onChange={handleGroupFinderChange}
           />
@@ -112,7 +116,8 @@ const CampaignSignupForm = props => {
           />
 
           <p className="text-sm text-gray-500 pt-3 md:pt-0">
-            Can&apos;t find your group? Email tej@dosomething.org for help.
+            Can&apos;t find your {groupLabel}? Email tej@dosomething.org for
+            help.
           </p>
         </div>
       </Card>

--- a/resources/assets/components/CampaignSignupForm/CampaignSignupForm.js
+++ b/resources/assets/components/CampaignSignupForm/CampaignSignupForm.js
@@ -5,7 +5,12 @@ import Card from '../utilities/Card/Card';
 import { getUtms } from '../../helpers/utm';
 import GroupFinder from './GroupFinder/GroupFinder';
 import PrimaryButton from '../utilities/Button/PrimaryButton';
-import { isCampaignClosed, query, withoutNulls } from '../../helpers';
+import {
+  isCampaignClosed,
+  query,
+  siteConfig,
+  withoutNulls,
+} from '../../helpers';
 import { EVENT_CATEGORIES, trackAnalyticsEvent } from '../../helpers/analytics';
 
 const CampaignSignupForm = props => {
@@ -92,9 +97,12 @@ const CampaignSignupForm = props => {
       />
     );
   }
-  // TODO: Add a config variable to save chapter group types.
-  const groupLabel =
-    groupType.name === 'March For Our Lives' ? 'chapter' : 'school';
+
+  const groupLabel = siteConfig('chapter_group_type_ids').includes(
+    `${groupType.id}`,
+  )
+    ? 'chapter'
+    : 'school';
 
   return (
     <div className="my-3" data-testid="join-group-signup-form">

--- a/resources/assets/components/CampaignSignupForm/CampaignSignupForm.js
+++ b/resources/assets/components/CampaignSignupForm/CampaignSignupForm.js
@@ -98,7 +98,7 @@ const CampaignSignupForm = props => {
     );
   }
 
-  const groupLabel = siteConfig('chapter_group_type_ids').includes(
+  const groupLabel = siteConfig('chapter_group_type_ids', []).includes(
     `${groupType.id}`,
   )
     ? 'chapter'

--- a/resources/assets/components/CampaignSignupForm/CampaignSignupForm.js
+++ b/resources/assets/components/CampaignSignupForm/CampaignSignupForm.js
@@ -98,6 +98,10 @@ const CampaignSignupForm = props => {
     );
   }
 
+  /**
+   * TODO: Everything below should get moved into the GroupFinder component, so we'll simply
+   * render a GroupFinder here, passing props like groupType, handleSignup, className, etc.
+   */
   const groupLabel = siteConfig('chapter_group_type_ids', []).includes(
     `${groupType.id}`,
   )

--- a/resources/assets/components/CampaignSignupForm/GroupFinder/GroupFinder.js
+++ b/resources/assets/components/CampaignSignupForm/GroupFinder/GroupFinder.js
@@ -12,7 +12,7 @@ import UsaStateSelect from '../../utilities/UsaStateSelect';
 const ANALYTICS_EVENT_CATEGORY = EVENT_CATEGORIES.campaignAction;
 const ANALYTICS_EVENT_LABEL = 'group_finder';
 
-const GroupFinder = ({ context, groupType, onChange }) => {
+const GroupFinder = ({ context, groupLabel, groupType, onChange }) => {
   const [groupLocation, setGroupLocation] = useState(null);
 
   const handleGroupSelectFocus = () => {
@@ -45,7 +45,6 @@ const GroupFinder = ({ context, groupType, onChange }) => {
   };
 
   const { filterByLocation } = groupType;
-  const groupLabel = 'chapter';
 
   return (
     <>
@@ -60,7 +59,9 @@ const GroupFinder = ({ context, groupType, onChange }) => {
       ) : null}
       {!filterByLocation || (filterByLocation && groupLocation) ? (
         <div className="pb-3">
-          <p className="font-bold text-sm py-1">Select your {groupLabel}</p>
+          <p className="font-bold text-sm py-1">
+            Select your group (start typing your {groupLabel} name)
+          </p>
           <GroupSelect
             groupLabel={groupLabel}
             groupLocation={groupLocation}
@@ -76,6 +77,7 @@ const GroupFinder = ({ context, groupType, onChange }) => {
 
 GroupFinder.propTypes = {
   context: PropTypes.object.isRequired,
+  groupLabel: PropTypes.string.isRequired,
   groupType: PropTypes.object.isRequired,
   onChange: PropTypes.func.isRequired,
 };

--- a/resources/assets/components/CampaignSignupForm/GroupFinder/GroupFinder.js
+++ b/resources/assets/components/CampaignSignupForm/GroupFinder/GroupFinder.js
@@ -59,8 +59,9 @@ const GroupFinder = ({ context, groupLabel, groupType, onChange }) => {
       ) : null}
       {!filterByLocation || (filterByLocation && groupLocation) ? (
         <div className="pb-3">
-          <p className="font-bold text-sm py-1">
-            Select your group (start typing your {groupLabel} name)
+          <p className="text-sm py-1">
+            <span className="font-bold">Select your group</span> (start typing
+            your {groupLabel} name)
           </p>
           <GroupSelect
             groupLabel={groupLabel}

--- a/resources/assets/components/CampaignSignupForm/GroupFinder/GroupSelect.js
+++ b/resources/assets/components/CampaignSignupForm/GroupFinder/GroupSelect.js
@@ -70,6 +70,7 @@ const GroupSelect = ({
         if (!input) {
           return Promise.resolve([]);
         }
+
         return fetchGroups(input, callback);
       }}
       noOptionsMessage={({ inputValue }) =>

--- a/resources/assets/components/CampaignSignupForm/GroupFinder/GroupSelect.js
+++ b/resources/assets/components/CampaignSignupForm/GroupFinder/GroupSelect.js
@@ -26,6 +26,7 @@ const GroupSelect = ({
   groupTypeId,
   onChange,
   onFocus,
+  placeholder,
 }) => {
   /**
    * This is copied by example from the blocks/CurrentSchoolBlock/SchoolSelect, which has comments
@@ -78,6 +79,7 @@ const GroupSelect = ({
       }
       onChange={onChange}
       onFocus={onFocus}
+      placeholder={placeholder}
     />
   );
 };
@@ -88,10 +90,12 @@ GroupSelect.propTypes = {
   groupTypeId: PropTypes.number.isRequired,
   onChange: PropTypes.func.isRequired,
   onFocus: PropTypes.func.isRequired,
+  placeholder: PropTypes.string,
 };
 
 GroupSelect.defaultProps = {
   groupLocation: null,
+  placeholder: 'Start typing...',
 };
 
 export default GroupSelect;


### PR DESCRIPTION
### What's this PR do?

This pull request modifies the Group Finder to have a default `groupLabel` of `school`, and adds a `chapter_group_type_ids` config variable to set which group types should display `chapter` (currently, the only group type we want this for vs school is "March For Our Lives"). We've received a number of Zendesk tickets about the “Select your chapter” language — lots of confusion from teachers & students about what they should type.

Default (school):

<img width="400" src="https://user-images.githubusercontent.com/1236811/91186639-2485e080-e6a4-11ea-8079-6c17e2ff8680.png">

Override (chapter):

<img width="400" src="https://user-images.githubusercontent.com/1236811/91186654-29e32b00-e6a4-11ea-98f4-a24dd71d4f8c.png">


### How should this be reviewed?

👀 

### Any background context you want to provide?

This PR also adds some DRY to the signup tests, and adds a TODO to remove most GroupFinder logic into the `GroupFinder` component and out of its parent `CampaignSignupForm`, for a cleanup PR.

### Relevant tickets

References [Pivotal #174469617](https://www.pivotaltracker.com/n/projects/2417735/stories/174469617).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [x] Documentation added for new features/changed endpoints.
- [x] Added screenshots of front-end changes on small, medium, and large screens.
- [x] Added appropriate feature/unit tests.
