### PR TITLE
Add Contentful Club Block Content-Type Migration Script

### DIFF
--- a/contentful/content-types/clubBlock.js
+++ b/contentful/content-types/clubBlock.js
@@ -1,0 +1,23 @@
+module.exports = function(migration) {
+  const clubBlock = migration
+    .createContentType('clubBlock')
+    .name('Club Block')
+    .description(
+      "Displays the user's club, or allows the user to select a club to join.",
+    )
+    .displayField('internalTitle');
+  clubBlock
+    .createField('internalTitle')
+    .name('Internal title')
+    .type('Symbol')
+    .localized(false)
+    .required(true)
+    .validations([])
+    .disabled(false)
+    .omitted(false);
+
+  clubBlock.changeFieldControl('internalTitle', 'builtin', 'singleLine', {
+    helpText:
+      'This title is used internally to help find this content. It will not be displayed anywhere on the rendered web page.',
+  });
+};

--- a/contentful/content-types/currentClubBlock.js
+++ b/contentful/content-types/currentClubBlock.js
@@ -1,12 +1,12 @@
 module.exports = function(migration) {
-  const clubBlock = migration
-    .createContentType('clubBlock')
-    .name('Club Block')
+  const currentClubBlock = migration
+    .createContentType('currentClubBlock')
+    .name('Current Club Block')
     .description(
-      "Displays the user's club, or allows the user to select a club to join.",
+      "Displays the user's current club, or allows the user to select a club to join.",
     )
     .displayField('internalTitle');
-  clubBlock
+  currentClubBlock
     .createField('internalTitle')
     .name('Internal title')
     .type('Symbol')
@@ -16,7 +16,7 @@ module.exports = function(migration) {
     .disabled(false)
     .omitted(false);
 
-  clubBlock.changeFieldControl('internalTitle', 'builtin', 'singleLine', {
+  currentClubBlock.changeFieldControl('internalTitle', 'builtin', 'singleLine', {
     helpText:
       'This title is used internally to help find this content. It will not be displayed anywhere on the rendered web page.',
   });

--- a/contentful/content-types/sectionBlock.js
+++ b/contentful/content-types/sectionBlock.js
@@ -91,7 +91,7 @@ module.exports = function(migration) {
               linkContentType: [
                 'callToAction',
                 'campaignUpdate',
-                'clubBlock',
+                'currentClubBlock',
                 'contentBlock',
                 'embed',
                 'imagesBlock',

--- a/contentful/content-types/sectionBlock.js
+++ b/contentful/content-types/sectionBlock.js
@@ -91,6 +91,7 @@ module.exports = function(migration) {
               linkContentType: [
                 'callToAction',
                 'campaignUpdate',
+                'clubBlock',
                 'contentBlock',
                 'embed',
                 'imagesBlock',


### PR DESCRIPTION
### What's this PR do?

This pull request adds a new Contentful migration script for creating a Club Block Content-Type. It adds the `clubBlock` as a valid embedded entry within Section Block.

### How should this be reviewed?
👀 

### Any background context you want to provide?
There aren't any fields necessary for the Club Block as of yet, but it will function the same as the School Finder and similar to the Club Finder, where a user can pick a club to join, and it then displays their club.

We'll be using a Story Page as the club association landing page where club leaders will link their members to join, so Section Blocks will need to embed this new block.

### Relevant tickets

References [Pivotal #174339952](https://www.pivotaltracker.com/story/show/174339952).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints. _not yet_
- [ ] Added screenshots of front-end changes on small, medium, and large screens.
- [ ] Added appropriate feature/unit tests.
