### PR TITLE
Pulls title and description from contentful if added, updates props where needed

### DIFF
--- a/resources/assets/components/actions/SocialDriveAction/SocialDriveAction.js
+++ b/resources/assets/components/actions/SocialDriveAction/SocialDriveAction.js
@@ -28,6 +28,8 @@ import './social-drive.scss';
 export const SocialDriveBlockFragment = gql`
   fragment SocialDriveBlockFragment on SocialDriveBlock {
     link
+    title
+    description
   }
 `;
 
@@ -120,11 +122,11 @@ class SocialDriveAction extends React.Component {
     const {
       approvedPostCountActionId,
       approvedPostCountLabel,
+      description,
       fullWidth,
       link,
       queryOptions,
-      shareCardDescription,
-      shareCardTitle,
+      title,
       userId,
     } = this.props;
 
@@ -141,10 +143,10 @@ class SocialDriveAction extends React.Component {
             'lg:w-2/3 lg:pr-3': !fullWidth,
           })}
         >
-          <Card className="rounded bordered" title={shareCardTitle}>
-            {shareCardDescription ? (
+          <Card className="rounded bordered" title={title}>
+            {description ? (
               <div className="p-3">
-                <p>{shareCardDescription}</p>
+                <p>{description}</p>
               </div>
             ) : null}
 
@@ -225,6 +227,7 @@ SocialDriveAction.propTypes = {
   approvedPostCountActionId: PropTypes.number,
   approvedPostCountLabel: PropTypes.string,
   campaignId: PropTypes.string,
+  description: PropTypes.string,
   /**
    * This prop allows us to force the "main" block to fill the width of the container.
    * @see https://git.io/Jfnqy
@@ -237,8 +240,7 @@ SocialDriveAction.propTypes = {
    * @see /resources/assets/components/pages/VoterRegistrationDrivePage/Alpha/AlphaPage
    */
   queryOptions: PropTypes.element,
-  shareCardDescription: PropTypes.string,
-  shareCardTitle: PropTypes.string,
+  title: PropTypes.string,
   token: PropTypes.string.isRequired,
   userId: PropTypes.string.isRequired,
 };
@@ -247,11 +249,11 @@ SocialDriveAction.defaultProps = {
   approvedPostCountActionId: null,
   approvedPostCountLabel: null,
   campaignId: null,
+  description: null,
   fullWidth: false,
   pageId: null,
   queryOptions: null,
-  shareCardDescription: null,
-  shareCardTitle: 'Your Online Drive',
+  title: 'Your Online Drive',
 };
 
 export default SocialDriveAction;

--- a/resources/assets/components/actions/VoterRegistrationDriveAction/VoterRegistrationDriveAction.js
+++ b/resources/assets/components/actions/VoterRegistrationDriveAction/VoterRegistrationDriveAction.js
@@ -62,8 +62,8 @@ const VoterRegistrationDriveAction = ({
         ).href
       }
       queryOptions={<QueryOptions />}
-      shareCardDescription={description}
-      shareCardTitle={title}
+      description={description}
+      title={title}
     />
   );
 };

--- a/resources/assets/components/pages/AccountPage/ReferFriends/ReferFriendsTab.js
+++ b/resources/assets/components/pages/AccountPage/ReferFriends/ReferFriendsTab.js
@@ -27,8 +27,8 @@ const ReferFriendsTab = () => {
         />
 
         <SocialDriveActionContainer
-          shareCardTitle="Refer a friend!"
-          shareCardDescription={
+          title="Refer a friend!"
+          description={
             referralIncentive
               ? 'When your friend signs up for their first DoSomething campaign, you’ll both enter for a chance to win a $10 gift card! Every 2 weeks, we’ll randomly select 25 winners. The more friends you refer, the more chances you have to win. (P.S. There’s no limit on how many friends you can refer!)'
               : 'Share the link below with a friend and invite them to sign up for their first DoSomething campaign! As soon as your friend signs up, you’ll see their name in the Your Referrals section below. Let’s Do This.'

--- a/resources/assets/components/pages/ReferralPage/Alpha/AlphaPage.js
+++ b/resources/assets/components/pages/ReferralPage/Alpha/AlphaPage.js
@@ -27,12 +27,12 @@ const AlphaPage = () => {
 
           <div className="my-6">
             <SocialDriveActionContainer
-              shareCardDescription={`${
+              description={`${
                 referralIncentive
                   ? "Invite your friends to join DoSomething. When your friend signs up for this campaign, you'll both enter for a chance to win a $10 gift card! Every 2 weeks, we’ll randomly select 25 winners. The more friends you refer, the more chances you have to win. (P.S. There’s no limit on how many friends you can refer!)"
                   : "Share the link below with a friend and invite them to sign up for their first DoSomething campaign! Let's Do This."
               }`}
-              shareCardTitle="Refer A Friend!"
+              title="Refer A Friend!"
               link={getReferFriendsLink()}
               fullWidth
             />


### PR DESCRIPTION
### What's this PR do?

This pull request pulls the title and description fields in from contentful if added, and updates the props for the `SocialDriveAction` to remove the `shareCardTitle` and `shareCardDescription`. these felt redundant to me and i decided we could use title and description in both cases. So I also updates the instances where we use the SocialDriveAction to reflect this change. 

### How should this be reviewed?

👀 

Made by pulling from Contentful:
<img width="697" alt="Screen Shot 2020-08-26 at 3 07 22 PM" src="https://user-images.githubusercontent.com/15236023/91346669-2ee0d100-e7af-11ea-9c65-cde4e205e9ca.png">

Existing RAF Tab with updated props (should be rendering same exact copy as before):
<img width="650" alt="Screen Shot 2020-08-26 at 3 07 45 PM" src="https://user-images.githubusercontent.com/15236023/91346739-461fbe80-e7af-11ea-9726-9ad876752494.png">

### Any background context you want to provide?

These updates are in preparation for using a RAF type action inside a new campaign with HRC.

### Relevant tickets

References [Pivotal #174263168](https://www.pivotaltracker.com/story/show/174263168).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [x] Added screenshots of front-end changes on small, medium, and large screens.
- [ ] Added appropriate feature/unit tests.
