### PR TITLE
Query GraphQL for SignupReferralsBlock content

### DIFF
--- a/contentful/content-types/signupReferralsBlock.js
+++ b/contentful/content-types/signupReferralsBlock.js
@@ -1,0 +1,38 @@
+module.exports = function(migration) {
+  const signupReferralsBlock = migration
+    .createContentType('signupReferralsBlock')
+    .name('Signup Referrals Block')
+    .description("Displays current user's signup referrals.")
+    .displayField('internalTitle');
+
+  signupReferralsBlock
+    .createField('internalTitle')
+    .name('Internal Title')
+    .type('Symbol')
+    .localized(false)
+    .required(true)
+    .validations([
+      {
+        unique: true,
+      },
+    ])
+    .disabled(false)
+    .omitted(false);
+
+  signupReferralsBlock
+    .createField('title')
+    .name('Title')
+    .type('Symbol')
+    .localized(false)
+    .required(false)
+    .validations([])
+    .disabled(false)
+    .omitted(false);
+  signupReferralsBlock.changeFieldControl(
+    'internalTitle',
+    'builtin',
+    'singleLine',
+    {},
+  );
+  signupReferralsBlock.changeFieldControl('title', 'builtin', 'singleLine', {});
+};

--- a/docs/development/content-types/signup-referrals-block.md
+++ b/docs/development/content-types/signup-referrals-block.md
@@ -1,0 +1,17 @@
+# Signup Referrals Block
+
+This block type displays the current user's signup referrals in a [`ReferralsGallery`](../features/referrals-gallery.md).
+
+![Signup Referrals Block](../../.gitbook/assets/referrals-gallery-truncated.png)
+
+**Note:** It will display the user's signup referrals for all campaigns.
+
+## Fields
+
+-   **Internal Title**
+
+-   **Title**: Optional `SectionHeader` text, defaults to "Your Referrals" if empty.
+
+## Notes
+
+All block content besides the `title` field is managed in code, e.g. "You have referred 3 people so far who have signed up for a campaign."

--- a/docs/development/content-types/voter-registration-referrals-block.md
+++ b/docs/development/content-types/voter-registration-referrals-block.md
@@ -1,14 +1,14 @@
 # Voter Registration Referrals Block
 
-This block type displays the current user's completed voter registration referrals in a [`ReferralsGallery`](../features/referrals-gallery.md).
+This block type displays the current user's completed voter registration referrals, as well as voter registration referrals that are still in progress.
 
-![Voter Registration Referrals Block](../../.gitbook/assets/voter-registration-referrals-block.png)
+**Note:** It will display the user's voter registration referrals for all voter registration actions (but we only began saving referrer users on `voter-reg` posts in 2020 for [action 954](https://activity.dosomething.org/actions/954).
 
 ## Fields
 
-- **Internal Title**
+-   **Internal Title**
 
-- **Title**: Optional `SectionHeader` text, e.g. "Get 3 friends to register!"
+-   **Title**: Optional `SectionHeader` text, e.g. "Get 3 friends to register!"
 
 ## Notes
 

--- a/resources/assets/components/ContentfulEntry/ContentfulEntry.js
+++ b/resources/assets/components/ContentfulEntry/ContentfulEntry.js
@@ -20,6 +20,7 @@ import ShareActionContainer from '../actions/ShareAction/ShareActionContainer';
 import CampaignDashboard from '../utilities/CampaignDashboard/CampaignDashboard';
 import SixpackExperiment from '../utilities/SixpackExperiment/SixpackExperiment';
 import PostGalleryBlockQuery from '../blocks/PostGalleryBlock/PostGalleryBlockQuery';
+import SignupReferralsBlock from '../blocks/SignupReferralsBlock/SignupReferralsBlock';
 import SocialDriveActionContainer from '../actions/SocialDriveAction/SocialDriveActionContainer';
 import CurrentSchoolBlockContainer from '../blocks/CurrentSchoolBlock/CurrentSchoolBlockContainer';
 import TextSubmissionActionContainer from '../actions/TextSubmissionAction/TextSubmissionActionContainer';
@@ -194,6 +195,9 @@ class ContentfulEntry extends React.Component {
 
       case 'ShareBlock':
         return <ShareActionContainer id={json.id} {...withoutNulls(json)} />;
+
+      case 'SignupReferralsBlock':
+        return <SignupReferralsBlock {...withoutNulls(json)} />;
 
       case 'SixpackExperimentBlock':
         return <SixpackExperiment id={json.id} {...withoutNulls(json)} />;

--- a/resources/assets/components/blocks/SignupReferralsBlock/SignupReferralsBlock.js
+++ b/resources/assets/components/blocks/SignupReferralsBlock/SignupReferralsBlock.js
@@ -2,6 +2,7 @@ import React from 'react';
 import gql from 'graphql-tag';
 import { uniqBy } from 'lodash';
 import pluralize from 'pluralize';
+import PropTypes from 'prop-types';
 
 import Query from '../../Query';
 import { getUserId } from '../../../helpers/auth';
@@ -9,6 +10,12 @@ import EmptyReferralIcon from './empty-referral.svg';
 import CompletedReferralIcon from './completed-referral.svg';
 import SectionHeader from '../../utilities/SectionHeader/SectionHeader';
 import ReferralsGallery from '../../utilities/ReferralsGallery/ReferralsGallery';
+
+export const SignupReferralsBlockFragment = gql`
+  fragment SignupReferralsBlockFragment on SignupReferralsBlock {
+    title
+  }
+`;
 
 export const SIGNUP_REFERRALS_QUERY = gql`
   query SignupReferrals($referrerUserId: String!) {
@@ -22,9 +29,9 @@ export const SIGNUP_REFERRALS_QUERY = gql`
   }
 `;
 
-const SignupReferralsBlock = () => (
+const SignupReferralsBlock = ({ title }) => (
   <>
-    <SectionHeader underlined title="Your Referrals" />
+    <SectionHeader underlined title={title} />
 
     <Query
       query={SIGNUP_REFERRALS_QUERY}
@@ -59,5 +66,13 @@ const SignupReferralsBlock = () => (
     </Query>
   </>
 );
+
+SignupReferralsBlock.propTypes = {
+  title: PropTypes.string,
+};
+
+SignupReferralsBlock.defaultProps = {
+  title: 'Your Referrals',
+};
 
 export default SignupReferralsBlock;

--- a/resources/assets/components/blocks/SignupReferralsBlock/SignupReferralsBlock.js
+++ b/resources/assets/components/blocks/SignupReferralsBlock/SignupReferralsBlock.js
@@ -39,8 +39,8 @@ const SignupReferralsBlock = ({ title }) => (
     >
       {data => {
         // Avoid passing duplicate referrals (multiple referral signups from the same user) to the referrals gallery.
-        const referralLabels = uniqBy(data.signups, 'userId').map(
-          signup => signup.user.displayName,
+        const referralLabels = uniqBy(data.signups, 'userId').map(signup =>
+          signup.user ? signup.user.displayName : 'DoSomething Member',
         );
         const numberOfReferrals = referralLabels.length;
 

--- a/resources/assets/components/utilities/ContentfulEntryLoader/ContentfulEntryLoader.js
+++ b/resources/assets/components/utilities/ContentfulEntryLoader/ContentfulEntryLoader.js
@@ -26,6 +26,7 @@ import { ActionStatsBlockFragment } from '../../blocks/ActionStatsBlock/ActionSt
 import { SocialDriveBlockFragment } from '../../actions/SocialDriveAction/SocialDriveAction';
 import { PostGalleryBlockFragment } from '../../blocks/PostGalleryBlock/PostGalleryBlockQuery';
 import { CurrentSchoolBlockFragment } from '../../blocks/CurrentSchoolBlock/CurrentSchoolBlock';
+import { SignupReferralsBlockFragment } from '../../blocks/SignupReferralsBlock/SignupReferralsBlock';
 import { TextSubmissionBlockFragment } from '../../actions/TextSubmissionAction/TextSubmissionAction';
 import { PhotoSubmissionBlockFragment } from '../../actions/PhotoSubmissionAction/PhotoSubmissionAction';
 import { VoterRegistrationBlockFragment } from '../../actions/VoterRegistrationAction/VoterRegistrationAction';
@@ -89,6 +90,9 @@ const CONTENTFUL_BLOCK_QUERY = gql`
       ... on PhotoSubmissionBlock {
         ...PhotoSubmissionBlockFragment
       }
+      ... on SignupReferralsBlock {
+        ...SignupReferralsBlockFragment
+      }
       ... on SixpackExperimentBlock {
         ...SixpackExperimentBlockFragment
       }
@@ -127,6 +131,7 @@ const CONTENTFUL_BLOCK_QUERY = gql`
   ${CampaignUpdateBlockFragment}
   ${TextSubmissionBlockFragment}
   ${PhotoSubmissionBlockFragment}
+  ${SignupReferralsBlockFragment}
   ${SixpackExperimentBlockFragment}
   ${VoterRegistrationBlockFragment}
   ${PetitionSubmissionBlockFragment}

--- a/schema.json
+++ b/schema.json
@@ -419,6 +419,60 @@
             "deprecationReason": null
           },
           {
+            "name": "clubs",
+            "description": "Get a list of clubs.",
+            "args": [
+              {
+                "name": "name",
+                "description": "The club name to filter clubs by.",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null
+              }
+            ],
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "Club",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "club",
+            "description": "Get a club by ID.",
+            "args": [
+              {
+                "name": "id",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null
+              }
+            ],
+            "type": {
+              "kind": "OBJECT",
+              "name": "Club",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "group",
             "description": "Get a group by ID.",
             "args": [
@@ -4371,6 +4425,11 @@
           },
           {
             "kind": "OBJECT",
+            "name": "CurrentClubBlock",
+            "ofType": null
+          },
+          {
+            "kind": "OBJECT",
             "name": "CurrentSchoolBlock",
             "ofType": null
           },
@@ -4427,6 +4486,11 @@
           {
             "kind": "OBJECT",
             "name": "ShareBlock",
+            "ofType": null
+          },
+          {
+            "kind": "OBJECT",
+            "name": "SignupReferralsBlock",
             "ofType": null
           },
           {
@@ -5192,6 +5256,18 @@
             "deprecationReason": null
           },
           {
+            "name": "clubId",
+            "description": "The user's current Club ID. Null if unauthorized.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "schoolId",
             "description": "The user's current School ID **This field contains personally-identifiable information, and access will be logged.**",
             "args": [],
@@ -5447,6 +5523,18 @@
             "deprecationReason": null
           },
           {
+            "name": "club",
+            "description": "The user's current club. Null if unauthorized.",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "Club",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "school",
             "description": "The user's current school. Note -- only works if user.schoolId is also returned",
             "args": [],
@@ -5502,6 +5590,12 @@
           },
           {
             "name": "LIFESTYLE",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "CLUBS",
             "description": null,
             "isDeprecated": false,
             "deprecationReason": null
@@ -7130,6 +7224,137 @@
             "ofType": null
           }
         ]
+      },
+      {
+        "kind": "OBJECT",
+        "name": "Club",
+        "description": "A DoSomething club.",
+        "fields": [
+          {
+            "name": "id",
+            "description": "The unique ID for this club.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "name",
+            "description": "The club name.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "leaderId",
+            "description": "The Northstar ID of the club leader.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "city",
+            "description": "The club city.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "location",
+            "description": "The club ISO-3166-2 location.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "schoolId",
+            "description": "The club school ID.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "updatedAt",
+            "description": "The time this club was last modified.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "DateTime",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "createdAt",
+            "description": "The time when this club was originally created.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "DateTime",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "leader",
+            "description": "The leader of the club.",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "User",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
       },
       {
         "kind": "OBJECT",
@@ -9444,6 +9669,47 @@
                     "name": "Boolean",
                     "ofType": null
                   }
+                },
+                "defaultValue": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "User",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "updateClubId",
+            "description": "Update the user's club ID.",
+            "args": [
+              {
+                "name": "id",
+                "description": "the ID of the user to update.",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "clubId",
+                "description": "the club ID to save to the user.",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
                 },
                 "defaultValue": null
               }
@@ -12559,6 +12825,79 @@
       },
       {
         "kind": "OBJECT",
+        "name": "CurrentClubBlock",
+        "description": null,
+        "fields": [
+          {
+            "name": "internalTitle",
+            "description": "The internal-facing title for this block.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "id",
+            "description": "The Contentful ID for this entry.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "updatedAt",
+            "description": "The time this entry was last modified.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "DateTime",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "createdAt",
+            "description": "The time when this entry was originally created.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "DateTime",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [
+          {
+            "kind": "INTERFACE",
+            "name": "Block",
+            "ofType": null
+          }
+        ],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
         "name": "CurrentSchoolBlock",
         "description": null,
         "fields": [
@@ -15204,6 +15543,91 @@
             "type": {
               "kind": "OBJECT",
               "name": "Action",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [
+          {
+            "kind": "INTERFACE",
+            "name": "Block",
+            "ofType": null
+          }
+        ],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "SignupReferralsBlock",
+        "description": null,
+        "fields": [
+          {
+            "name": "title",
+            "description": "The user-facing title for this signup referrals block.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "internalTitle",
+            "description": "The internal-facing title for this block.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "id",
+            "description": "The Contentful ID for this entry.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "updatedAt",
+            "description": "The time this entry was last modified.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "DateTime",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "createdAt",
+            "description": "The time when this entry was originally created.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "DateTime",
               "ofType": null
             },
             "isDeprecated": false,


### PR DESCRIPTION
### What's this PR do?

This pull request adds a Contentful migration for a new `signupReferralsBlock` content type (referenced in https://github.com/DoSomething/graphql/pull/274) and adds GraphQL support for the `SignupReferralsBlock` component (added in #2343) 

### How should this be reviewed?

👀 

### Any background context you want to provide?

* This PR also updates our `schema.json` with the `SignupReferralsBlock` type added in https://github.com/DoSomething/graphql/pull/274, but also includes the substantial Clubs updates added in https://github.com/DoSomething/graphql/pull/273 by @mendelB i- which is why there are so many additions in this PR.

* I plan to add tests in a future PR to help this reviewable. Also plan to update the `page` Contentful migration to allow adding a `signupReferralsBlock` entry to the multi-value `blocks` reference field.

* This PR changes the `SignupReferralsGallery` to default "DoSomething Member" as a referral label if the signup does not have a valid user (as often happens when working against your local Rogue  DB that's been seeded with northstar id's that don't match the local Northstar DB 😿 )

### Relevant tickets

References [Pivotal #174263179](https://www.pivotaltracker.com/n/projects/2417735/stories/174263179).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [x] Documentation added for new features/changed endpoints.
- [ ] Added screenshots of front-end changes on small, medium, and large screens.
- [ ] Added appropriate feature/unit tests.
