### PR TITLE
Current Club Block

### DIFF
--- a/resources/assets/components/ContentfulEntry/ContentfulEntry.js
+++ b/resources/assets/components/ContentfulEntry/ContentfulEntry.js
@@ -13,6 +13,7 @@ import CampaignUpdate from '../blocks/CampaignUpdate/CampaignUpdate';
 import AffirmationContainer from '../Affirmation/AffirmationContainer';
 import { parseContentfulType, report, withoutNulls } from '../../helpers';
 import ActionStatsBlock from '../blocks/ActionStatsBlock/ActionStatsBlock';
+import CurrentClubBlock from '../blocks/CurrentClubBlock/CurrentClubBlock';
 import EmbedBlockContainer from '../blocks/EmbedBlock/EmbedBlockContainer';
 import LinkActionContainer from '../actions/LinkAction/LinkActionContainer';
 import CallToActionBlock from '../blocks/CallToActionBlock/CallToActionBlock';
@@ -106,6 +107,9 @@ class ContentfulEntry extends React.Component {
             {...additionalCustomProps}
           />
         );
+
+      case 'CurrentClubBlock':
+        return <CurrentClubBlock {...withoutNulls(json)} />;
 
       case 'CurrentSchoolBlock':
         return <CurrentSchoolBlockContainer {...withoutNulls(json)} />;

--- a/resources/assets/components/blocks/CurrentClubBlock/ClubSelect.js
+++ b/resources/assets/components/blocks/CurrentClubBlock/ClubSelect.js
@@ -23,19 +23,17 @@ const ClubSelect = ({ onChange }) => {
    */
   const client = useApolloClient();
 
-  const fetchClubs = debounce(
-    (searchString, callback) =>
-      client
-        .query({
-          query: SEARCH_CLUBS_QUERY,
-          variables: {
-            name: searchString,
-          },
-        })
-        .then(result => callback(result.data.clubs))
-        .catch(error => callback(error)),
-    250,
-  );
+  const fetchClubs = debounce((searchString, callback) => {
+    client
+      .query({
+        query: SEARCH_CLUBS_QUERY,
+        variables: {
+          name: searchString,
+        },
+      })
+      .then(result => callback(result.data.clubs))
+      .catch(error => callback(error));
+  }, 250);
 
   return (
     <AsyncSelect

--- a/resources/assets/components/blocks/CurrentClubBlock/ClubSelect.js
+++ b/resources/assets/components/blocks/CurrentClubBlock/ClubSelect.js
@@ -1,0 +1,65 @@
+import React from 'react';
+import gql from 'graphql-tag';
+import { debounce } from 'lodash';
+import PropTypes from 'prop-types';
+import AsyncSelect from 'react-select/async';
+import { useApolloClient } from '@apollo/react-hooks';
+
+const SEARCH_CLUBS_QUERY = gql`
+  query SearchClubsQuery($name: String!) {
+    clubs(name: $name) {
+      id
+      name
+      city
+      location
+    }
+  }
+`;
+
+const ClubSelect = ({ onChange }) => {
+  /**
+   * This is copied by example from the blocks/CurrentSchoolBlock/SchoolSelect, which has comments
+   * detailing debouncing the useApolloClient hook (AsyncSelect loadOptions expects a Promise).
+   */
+  const client = useApolloClient();
+
+  const fetchClubs = debounce(
+    (searchString, callback) =>
+      client
+        .query({
+          query: SEARCH_CLUBS_QUERY,
+          variables: {
+            name: searchString,
+          },
+        })
+        .then(result => callback(result.data.clubs))
+        .catch(error => callback(error)),
+    250,
+  );
+
+  return (
+    <AsyncSelect
+      getOptionLabel={({ name, location, city }) =>
+        `${name} - ${location ? `${city}, ${location.substring(3)}` : ''}`
+      }
+      getOptionValue={club => club.id}
+      isClearable
+      loadOptions={(input, callback) =>
+        !input ? Promise.resolve([]) : fetchClubs(input, callback)
+      }
+      noOptionsMessage={({ inputValue }) =>
+        inputValue.length
+          ? `Oops, we can't find a club called "${inputValue}"`
+          : 'Enter your club name'
+      }
+      onChange={onChange}
+      placeholder="Enter your club name"
+    />
+  );
+};
+
+ClubSelect.propTypes = {
+  onChange: PropTypes.func.isRequired,
+};
+
+export default ClubSelect;

--- a/resources/assets/components/blocks/CurrentClubBlock/ClubSelect.js
+++ b/resources/assets/components/blocks/CurrentClubBlock/ClubSelect.js
@@ -44,15 +44,15 @@ const ClubSelect = ({ onChange }) => {
       }
       getOptionValue={club => club.id}
       isClearable
-      loadOptions={(input, callback) =>
-        !input ? Promise.resolve([]) : fetchClubs(input, callback)
-      }
+      loadOptions={(input, callback) => {
+        return !input ? Promise.resolve([]) : fetchClubs(input, callback);
+      }}
       noOptionsMessage={({ inputValue }) =>
         inputValue.length
           ? `Oops, we can't find a club called "${inputValue}"`
           : 'Enter your club name'
       }
-      onChange={onChange}
+      onChange={club => onChange(club.id)}
       placeholder="Enter your club name"
     />
   );

--- a/resources/assets/components/blocks/CurrentClubBlock/ClubSelect.js
+++ b/resources/assets/components/blocks/CurrentClubBlock/ClubSelect.js
@@ -50,7 +50,7 @@ const ClubSelect = ({ onChange }) => {
           ? `Oops, we can't find a club called "${inputValue}"`
           : 'Enter your club name'
       }
-      onChange={club => onChange(club.id)}
+      onChange={club => onChange(club ? club.id : null)}
       placeholder="Enter your club name"
     />
   );

--- a/resources/assets/components/blocks/CurrentClubBlock/ClubSelect.js
+++ b/resources/assets/components/blocks/CurrentClubBlock/ClubSelect.js
@@ -43,6 +43,10 @@ const ClubSelect = ({ onChange }) => {
       getOptionValue={club => club.id}
       isClearable
       loadOptions={(input, callback) => {
+        /**
+         * Avoid querying by empty club name on page load.
+         * @see https://github.com/JedWatson/react-select/issues/614#issuecomment-380763225
+         */
         return !input ? Promise.resolve([]) : fetchClubs(input, callback);
       }}
       noOptionsMessage={({ inputValue }) =>

--- a/resources/assets/components/blocks/CurrentClubBlock/CurrentClubBlock.js
+++ b/resources/assets/components/blocks/CurrentClubBlock/CurrentClubBlock.js
@@ -49,7 +49,7 @@ const CurrentClubBlock = () => {
           <>
             <p className="pt-2 pb-3">Hooray! You have joined the club for:</p>
 
-            <div className="border border-solid border-gray-400 rounded p-4">
+            <div className="border border-solid border-gray-400 rounded p-3">
               <p className="font-bold">{name}</p>
 
               {location ? (
@@ -58,14 +58,14 @@ const CurrentClubBlock = () => {
                 </span>
               ) : null}
             </div>
+
+            <p className="text-sm text-gray-500 pt-3">
+              Need help? Contact maddy@dosomething.org
+            </p>
           </>
         ) : (
           <CurrentClubForm />
         )}
-
-        <p className="text-sm text-gray-500 pt-3">
-          Need help? Email maddy@dosomething.org
-        </p>
       </div>
     </Card>
   );

--- a/resources/assets/components/blocks/CurrentClubBlock/CurrentClubBlock.js
+++ b/resources/assets/components/blocks/CurrentClubBlock/CurrentClubBlock.js
@@ -1,5 +1,43 @@
 import React from 'react';
+import { get } from 'lodash';
+import gql from 'graphql-tag';
+import { useQuery } from '@apollo/react-hooks';
 
-const CurrentClubBlock = () => <div>Current Club Block</div>;
+import { getUserId } from '../../../helpers/auth';
+import ErrorBlock from '../ErrorBlock/ErrorBlock';
+import Spinner from '../../artifacts/Spinner/Spinner';
+
+const USER_CLUB_QUERY = gql`
+  query UserClubQuery($userId: String!) {
+    user(id: $userId) {
+      id
+      clubId
+      club {
+        name
+      }
+    }
+  }
+`;
+
+const CurrentClubBlock = () => {
+  const userId = getUserId();
+
+  const { loading, error, data } = useQuery(USER_CLUB_QUERY, {
+    variables: { userId },
+    skip: !userId,
+  });
+
+  if (loading) {
+    return <Spinner className="flex justify-center p-3 pb-8" />;
+  }
+
+  if (error) {
+    return <ErrorBlock error={error} />;
+  }
+
+  const club = get(data, 'user.club');
+
+  return <div>{club ? club.name : 'Club Form'}</div>;
+};
 
 export default CurrentClubBlock;

--- a/resources/assets/components/blocks/CurrentClubBlock/CurrentClubBlock.js
+++ b/resources/assets/components/blocks/CurrentClubBlock/CurrentClubBlock.js
@@ -44,27 +44,29 @@ const CurrentClubBlock = () => {
 
   return (
     <Card className="rounded bordered" title="Your club">
-      {club ? (
-        <div className="p-3">
-          <p className="pt-2 pb-3">Hooray! You have joined the club for:</p>
+      <div className="p-3">
+        {club ? (
+          <>
+            <p className="pt-2 pb-3">Hooray! You have joined the club for:</p>
 
-          <div className="border border-solid border-gray-400 rounded p-4">
-            <p className="font-bold">{name}</p>
+            <div className="border border-solid border-gray-400 rounded p-4">
+              <p className="font-bold">{name}</p>
 
-            {location ? (
-              <span className="uppercase text-sm text-gray-600 font-bold">
-                {city}, {location.substring(3)}
-              </span>
-            ) : null}
-          </div>
-        </div>
-      ) : (
-        <CurrentClubForm />
-      )}
+              {location ? (
+                <span className="uppercase text-sm text-gray-600 font-bold">
+                  {city}, {location.substring(3)}
+                </span>
+              ) : null}
+            </div>
+          </>
+        ) : (
+          <CurrentClubForm />
+        )}
 
-      <p className="text-sm text-gray-500 p-3">
-        Need help? Email maddy@dosomething.org
-      </p>
+        <p className="text-sm text-gray-500 pt-3">
+          Need help? Email maddy@dosomething.org
+        </p>
+      </div>
     </Card>
   );
 };

--- a/resources/assets/components/blocks/CurrentClubBlock/CurrentClubBlock.js
+++ b/resources/assets/components/blocks/CurrentClubBlock/CurrentClubBlock.js
@@ -4,6 +4,7 @@ import gql from 'graphql-tag';
 import { useQuery } from '@apollo/react-hooks';
 
 import Card from '../../utilities/Card/Card';
+import CurrentClubForm from './CurrentClubForm';
 import { getUserId } from '../../../helpers/auth';
 import ErrorBlock from '../ErrorBlock/ErrorBlock';
 import Spinner from '../../artifacts/Spinner/Spinner';
@@ -12,7 +13,6 @@ const USER_CLUB_QUERY = gql`
   query UserClubQuery($userId: String!) {
     user(id: $userId) {
       id
-      clubId
       club {
         id
         name
@@ -57,14 +57,14 @@ const CurrentClubBlock = () => {
               </span>
             ) : null}
           </div>
-
-          <p className="text-sm text-gray-500 pt-3">
-            Need help? Email maddy@dosomething.org
-          </p>
         </div>
       ) : (
-        <div>Club Form</div>
+        <CurrentClubForm />
       )}
+
+      <p className="text-sm text-gray-500 p-3">
+        Need help? Email maddy@dosomething.org
+      </p>
     </Card>
   );
 };

--- a/resources/assets/components/blocks/CurrentClubBlock/CurrentClubBlock.js
+++ b/resources/assets/components/blocks/CurrentClubBlock/CurrentClubBlock.js
@@ -3,6 +3,7 @@ import { get } from 'lodash';
 import gql from 'graphql-tag';
 import { useQuery } from '@apollo/react-hooks';
 
+import Card from '../../utilities/Card/Card';
 import { getUserId } from '../../../helpers/auth';
 import ErrorBlock from '../ErrorBlock/ErrorBlock';
 import Spinner from '../../artifacts/Spinner/Spinner';
@@ -13,7 +14,10 @@ const USER_CLUB_QUERY = gql`
       id
       clubId
       club {
+        id
         name
+        city
+        location
       }
     }
   }
@@ -36,8 +40,33 @@ const CurrentClubBlock = () => {
   }
 
   const club = get(data, 'user.club');
+  const { name, city, location } = club || {};
 
-  return <div>{club ? club.name : 'Club Form'}</div>;
+  return (
+    <Card className="rounded bordered" title="Your club">
+      {club ? (
+        <div className="p-3">
+          <p className="pt-2 pb-3">Hooray! You have joined the club for:</p>
+
+          <div className="border border-solid border-gray-400 rounded p-4">
+            <p className="font-bold">{name}</p>
+
+            {location ? (
+              <span className="uppercase text-sm text-gray-600 font-bold">
+                {city}, {location.substring(3)}
+              </span>
+            ) : null}
+          </div>
+
+          <p className="text-sm text-gray-500 pt-3">
+            Need help? Email maddy@dosomething.org
+          </p>
+        </div>
+      ) : (
+        <div>Club Form</div>
+      )}
+    </Card>
+  );
 };
 
 export default CurrentClubBlock;

--- a/resources/assets/components/blocks/CurrentClubBlock/CurrentClubBlock.js
+++ b/resources/assets/components/blocks/CurrentClubBlock/CurrentClubBlock.js
@@ -1,0 +1,5 @@
+import React from 'react';
+
+const CurrentClubBlock = () => <div>Current Club Block</div>;
+
+export default CurrentClubBlock;

--- a/resources/assets/components/blocks/CurrentClubBlock/CurrentClubForm.js
+++ b/resources/assets/components/blocks/CurrentClubBlock/CurrentClubForm.js
@@ -1,0 +1,49 @@
+import gql from 'graphql-tag';
+import React, { useState } from 'react';
+import { useMutation } from '@apollo/react-hooks';
+
+import ClubSelect from './ClubSelect';
+import { getUserId } from '../../../helpers/auth';
+import PrimaryButton from '../../utilities/Button/PrimaryButton';
+
+const USER_CLUB_MUTATION = gql`
+  mutation UserClubMutation($userId: String!, $clubId: Int) {
+    updateClubId(id: $userId, clubId: $clubId) {
+      id
+      club {
+        id
+      }
+    }
+
+    updateEmailSubscriptionTopic(id: $userId, topic: CLUBS, subscribed: true) {
+      id
+      emailSubscriptionTopics
+      emailSubscriptionStatus
+    }
+  }
+`;
+
+const CurrentClubForm = () => {
+  const [club, setClub] = useState(null);
+  const [updateUserClub, { loading }] = useMutation(USER_CLUB_MUTATION, {
+    variables: { userId: getUserId() },
+  });
+
+  return (
+    <div className="p-3">
+      <strong>Club Name</strong>
+
+      <ClubSelect onChange={selected => setClub(selected)} />
+
+      <PrimaryButton
+        className="mt-3 text-lg w-full"
+        onClick={() => updateUserClub({ variables: { clubId: club.id } })}
+        isLoading={loading}
+        isDisabled={!club || loading}
+        text="join club"
+      />
+    </div>
+  );
+};
+
+export default CurrentClubForm;

--- a/resources/assets/components/blocks/CurrentClubBlock/CurrentClubForm.js
+++ b/resources/assets/components/blocks/CurrentClubBlock/CurrentClubForm.js
@@ -34,7 +34,7 @@ const CurrentClubForm = () => {
   }, []);
 
   return (
-    <div className="p-3">
+    <>
       <strong>Club Name</strong>
 
       <ClubSelect onChange={setClubId} />
@@ -52,7 +52,7 @@ const CurrentClubForm = () => {
         isDisabled={!clubId || loading}
         text="join club"
       />
-    </div>
+    </>
   );
 };
 

--- a/resources/assets/components/blocks/CurrentClubBlock/CurrentClubForm.js
+++ b/resources/assets/components/blocks/CurrentClubBlock/CurrentClubForm.js
@@ -3,6 +3,8 @@ import { useMutation } from '@apollo/react-hooks';
 import React, { useState, useEffect } from 'react';
 
 import ClubSelect from './ClubSelect';
+import ErrorBlock from '../ErrorBlock/ErrorBlock';
+import Spinner from '../../artifacts/Spinner/Spinner';
 import PrimaryButton from '../../utilities/Button/PrimaryButton';
 import { getUserId, isAuthenticated, useGate } from '../../../helpers/auth';
 
@@ -22,16 +24,29 @@ const CurrentClubForm = () => {
   const [flash, authenticate] = useGate('CurrentClubForm');
   const [clubId, setClubId] = useState();
 
-  const [updateUserClub, { loading }] = useMutation(USER_CLUB_MUTATION, {
-    variables: { userId: getUserId(), clubId: flash.clubId },
-    refetchQueries: ['UserClubQuery'],
-  });
+  const [updateUserClub, { loading, data, error }] = useMutation(
+    USER_CLUB_MUTATION,
+    {
+      variables: { userId: getUserId(), clubId: flash.clubId },
+      refetchQueries: ['UserClubQuery'],
+    },
+  );
 
   useEffect(() => {
     if (isAuthenticated() && flash.clubId) {
       updateUserClub();
     }
   }, []);
+
+  if (error) {
+    return <ErrorBlock error={error} />;
+  }
+
+  // If the mutation was successful, we'll hide the form while the CurrentClubBlock
+  // updates to display the user's current club.
+  if (data) {
+    return <Spinner className="flex justify-center p-6" />;
+  }
 
   return (
     <>

--- a/resources/assets/components/blocks/CurrentClubBlock/CurrentClubForm.js
+++ b/resources/assets/components/blocks/CurrentClubBlock/CurrentClubForm.js
@@ -33,6 +33,8 @@ const CurrentClubForm = () => {
   );
 
   useEffect(() => {
+    // If the user has been successfully redirected from the authentication flow after selecting their
+    // club anonymously, manually run the mutation to add them to the club.
     if (isAuthenticated() && flash.clubId) {
       updateUserClub();
     }
@@ -42,7 +44,7 @@ const CurrentClubForm = () => {
     return <ErrorBlock error={error} />;
   }
 
-  // If the mutation was successful, we'll hide the form while the CurrentClubBlock
+  // If the mutation was successful, hide the form while the CurrentClubBlock
   // updates to display the user's current club.
   if (data) {
     return <Spinner className="flex justify-center p-6" />;

--- a/schema.json
+++ b/schema.json
@@ -419,6 +419,60 @@
             "deprecationReason": null
           },
           {
+            "name": "clubs",
+            "description": "Get a list of clubs.",
+            "args": [
+              {
+                "name": "name",
+                "description": "The club name to filter clubs by.",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null
+              }
+            ],
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "Club",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "club",
+            "description": "Get a club by ID.",
+            "args": [
+              {
+                "name": "id",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null
+              }
+            ],
+            "type": {
+              "kind": "OBJECT",
+              "name": "Club",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "group",
             "description": "Get a group by ID.",
             "args": [
@@ -4371,6 +4425,11 @@
           },
           {
             "kind": "OBJECT",
+            "name": "CurrentClubBlock",
+            "ofType": null
+          },
+          {
+            "kind": "OBJECT",
             "name": "CurrentSchoolBlock",
             "ofType": null
           },
@@ -5192,6 +5251,18 @@
             "deprecationReason": null
           },
           {
+            "name": "clubId",
+            "description": "The user's current Club ID. Null if unauthorized.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "schoolId",
             "description": "The user's current School ID **This field contains personally-identifiable information, and access will be logged.**",
             "args": [],
@@ -5447,6 +5518,18 @@
             "deprecationReason": null
           },
           {
+            "name": "club",
+            "description": "The user's current club. Null if unauthorized.",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "Club",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "school",
             "description": "The user's current school. Note -- only works if user.schoolId is also returned",
             "args": [],
@@ -5502,6 +5585,12 @@
           },
           {
             "name": "LIFESTYLE",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "CLUBS",
             "description": null,
             "isDeprecated": false,
             "deprecationReason": null
@@ -7130,6 +7219,137 @@
             "ofType": null
           }
         ]
+      },
+      {
+        "kind": "OBJECT",
+        "name": "Club",
+        "description": "A DoSomething club.",
+        "fields": [
+          {
+            "name": "id",
+            "description": "The unique ID for this club.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "name",
+            "description": "The club name.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "leaderId",
+            "description": "The Northstar ID of the club leader.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "city",
+            "description": "The club city.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "location",
+            "description": "The club ISO-3166-2 location.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "schoolId",
+            "description": "The club school ID.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "updatedAt",
+            "description": "The time this club was last modified.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "DateTime",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "createdAt",
+            "description": "The time when this club was originally created.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "DateTime",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "leader",
+            "description": "The leader of the club.",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "User",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
       },
       {
         "kind": "OBJECT",
@@ -9444,6 +9664,47 @@
                     "name": "Boolean",
                     "ofType": null
                   }
+                },
+                "defaultValue": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "User",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "updateClubId",
+            "description": "Update the user's club ID.",
+            "args": [
+              {
+                "name": "id",
+                "description": "the ID of the user to update.",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "clubId",
+                "description": "the club ID to save to the user.",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
                 },
                 "defaultValue": null
               }
@@ -12555,6 +12816,79 @@
             "deprecationReason": null
           }
         ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "CurrentClubBlock",
+        "description": null,
+        "fields": [
+          {
+            "name": "internalTitle",
+            "description": "The internal-facing title for this block.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "id",
+            "description": "The Contentful ID for this entry.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "updatedAt",
+            "description": "The time this entry was last modified.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "DateTime",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "createdAt",
+            "description": "The time when this entry was originally created.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "DateTime",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [
+          {
+            "kind": "INTERFACE",
+            "name": "Block",
+            "ofType": null
+          }
+        ],
+        "enumValues": null,
         "possibleTypes": null
       },
       {


### PR DESCRIPTION
### What's this PR do?

This pull request adds a new `CurrentClubBlock` component rendered via embedded Current Club Block Contentful entries.

The Block - a la the [`CurrentSchoolBlock`](https://github.com/DoSomething/phoenix-next/blob/96183a8c9acbc289fe4662ca33212dba10777a4b/resources/assets/components/blocks/CurrentSchoolBlock/CurrentSchoolBlock.js) - displays an authenticated user's current club if they've joined one, or acts as a form selector for them to find and join their club. It supports lazy authentication thanks to our in-house `useGate` hook @DFurnes added in https://github.com/DoSomething/phoenix-next/pull/1854.

### How should this be reviewed?
I'd recommend commit-by-commit. If it's helpful, keep the [`CurrentSchoolBlock`](https://github.com/DoSomething/phoenix-next/blob/96183a8c9acbc289fe4662ca33212dba10777a4b/resources/assets/components/blocks/CurrentSchoolBlock) directory handy for quick references for where we're following by example.

Notice any holes in the logic, or oddities? You'll probably notice areas rife for DRY-ness between this, the School block & the Groups block, which I'm sure @aaronschachter has more good thoughts on. 

I don't think we've documented our `useGate` hook functionality, so happy to chat through that flow!

The designs [are here](https://app.abstract.com/projects/fadf0790-f1f9-11e6-9a30-b54ba7e8e705/branches/75907f4b-8dff-48c9-a076-58df31f0273e/commits/latest/files/05f5faae-3c13-4947-b624-f9e0ea97822c/layers/0868842E-5A4B-4936-B046-FB26B098EDC1?collectionId=f7ec00df-516b-4e9d-9243-19e82d1ff5fc&collectionLayerId=de6acd75-c101-4805-b312-71309adbf9c7&mode=build).

### Any background context you want to provide?
Documentation & Tests to follow!

Just noting that if a user has an existing club, even if they visit the form unauthenticated and pick a different club, upon redirect, they'll still see they're original club since the block always attempts to find the existing one when it loads and withholds the form if it finds one, so the pending mutation won't run.

### Relevant tickets

References [Pivotal #174340202](https://www.pivotaltracker.com/story/show/174340202).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [x] Added screenshots of front-end changes on small, medium, and large screens.
- [ ] Added appropriate feature/unit tests.

🎥 
- [Lazy auth flow for anonymous users](https://user-images.githubusercontent.com/12417657/91577049-2c4cbb80-e916-11ea-9f67-e4a1b521a1a3.gif)

- [Regular flow for authenticated users](https://user-images.githubusercontent.com/12417657/91577377-98c7ba80-e916-11ea-9f60-eb064d9e1eb3.gif)

