### PR TITLE
Fix issue building review apps.

### DIFF
--- a/app.json
+++ b/app.json
@@ -19,7 +19,7 @@
     },
     "APP_LOG": "errorlog",
     "APP_URL": "https://ds-phoenix-staging.herokuapp.com/",
-    "DB_CONNECTION": "heroku_mariadb",
+    "DB_CONNECTION": "jawsdb",
     "CONTENTFUL_CACHE": "false",
     "CONTENTFUL_CONTENT_API_KEY": {
       "required": true

--- a/config/database.php
+++ b/config/database.php
@@ -92,17 +92,6 @@ return [
             ]) : [],
         ],
 
-        'heroku_mysql' => [
-            'driver' => 'mysql',
-            'url' => env('CLEARDB_DATABASE_URL'),
-            'database' => env('DB_DATABASE', 'forge'),
-            'charset' => 'utf8mb4',
-            'collation' => 'utf8mb4_unicode_ci',
-            'prefix' => '',
-            'strict' => true,
-            'engine' => null,
-        ],
-
         'sqlsrv' => [
             'driver' => 'sqlsrv',
             'url' => env('DATABASE_URL'),

--- a/config/database.php
+++ b/config/database.php
@@ -84,8 +84,12 @@ return [
             'charset' => 'utf8mb4',
             'collation' => 'utf8mb4_unicode_ci',
             'prefix' => '',
+            'prefix_indexes' => true,
             'strict' => true,
             'engine' => null,
+            'options' => extension_loaded('pdo_mysql') ? array_filter([
+                PDO::MYSQL_ATTR_SSL_CA => env('MYSQL_ATTR_SSL_CA'),
+            ]) : [],
         ],
 
         'heroku_mysql' => [

--- a/config/database.php
+++ b/config/database.php
@@ -80,7 +80,6 @@ return [
 
         'jawsdb' => [
             'driver' => 'mysql',
-            'database' => env('DB_DATABASE', 'forge'),
             'url' => env('JAWSDB_MARIA_URL'),
             'charset' => 'utf8mb4',
             'collation' => 'utf8mb4_unicode_ci',

--- a/config/database.php
+++ b/config/database.php
@@ -78,10 +78,10 @@ return [
             'sslmode' => 'prefer',
         ],
 
-        'heroku_mariadb' => [
+        'jawsdb' => [
             'driver' => 'mysql',
-            'url' => env('JAWS_MARIA_URL'),
             'database' => env('DB_DATABASE', 'forge'),
+            'url' => env('JAWSDB_MARIA_URL'),
             'charset' => 'utf8mb4',
             'collation' => 'utf8mb4_unicode_ci',
             'prefix' => '',


### PR DESCRIPTION
### What's this PR do?

This pull request fixes an issue building review apps for Phoenix.

I'd accidentally typo'd the environment variable that is provided by the [JawsDB Heroku add-on](https://elements.heroku.com/addons/jawsdb-maria) as `JAWS_MARIA_URL` (instead of `JAWSDB_MARIA_URL`) when [upgrading this application to Laravel 6.0](https://github.com/DoSomething/phoenix-next/commit/37ebe61e275c6ccaccd3f43c581edf66e2c8a339#diff-8a025ad5d4f4fade612727b1bb0e974f). This caused review apps to stop functioning.

I've corrected this to use the right environment variable name, removed a redundant `database` configuration line, and added some options that we use on our production database config for closer dev/prod parity. I've also removed the unused [ClearDB](https://elements.heroku.com/addons/cleardb) connection, since it was unclear at a glance which we actively used.

### How should this be reviewed?

I've broken up the changes into atomic commits. And hopefully the review app works now! :v:

### Any background context you want to provide?

This makes it easier to test changes before merging code in!

### Relevant tickets

References [Pivotal #174579215](https://www.pivotaltracker.com/story/show/174579215).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added screenshots of front-end changes on small, medium, and large screens.
- [ ] Added appropriate feature/unit tests.
