### PR TITLE
Airtable Embeds in Company Pages

### DIFF
--- a/contentful/content-types/companyPage.js
+++ b/contentful/content-types/companyPage.js
@@ -133,6 +133,7 @@ module.exports = function(migration) {
                 'actionStatsBlock',
                 'callToAction',
                 'contentBlock',
+                'embed',
                 'galleryBlock',
                 'imagesBlock',
                 'linkAction',

--- a/contentful/content-types/embed.js
+++ b/contentful/content-types/embed.js
@@ -24,12 +24,12 @@ module.exports = function(migration) {
       {
         regexp: {
           pattern:
-            '^https:\\/\\/dosomething\\.(?:(?:carto\\.com\\/builder\\/[a-z0-9-]+\\/embed)|(?:typeform\\.com\\/to\\/[a-zA-Z0-9-]+))\\/?$',
+            '^(https:\\/\\/dosomething\\\\.(?:(?:carto\\\\.com\\/builder\\/[a-z0-9-]+\\/embed)|(?:typeform\\.com\\/to\\/[a-zA-Z0-9-]+)))|(https:\\/\\/airtable.com\\/embed\\/[a-zA-Z0-9-\\/]+)\\/?',
           flags: null,
         },
 
         message:
-          'Must be a valid Carto embeddable map URL from the DoSomething space (https://dosomething.carto.com/dashboard), or a valid Typeform embeddable URL (https://dosomething.typeform.com)',
+          'Must be a valid Carto embeddable map URL from the DoSomething space (https://dosomething.carto.com/dashboard), or a valid Typeform embeddable URL (https://dosomething.typeform.com), or a valid Airtable embeddable URL.',
       },
     ])
     .disabled(false)
@@ -55,17 +55,17 @@ module.exports = function(migration) {
     .omitted(false)
     .linkType('Asset');
 
-  embed.changeEditorInterface('internalTitle', 'singleLine', {
+  embed.changeFieldControl('internalTitle', 'builtin', 'singleLine', {
     helpText:
       'This title is used internally to help find this content. It will not be displayed anywhere on the rendered web page.',
   });
 
-  embed.changeEditorInterface('url', 'singleLine', {
+  embed.changeFieldControl('url', 'builtin', 'singleLine', {
     helpText:
       'The URL for the embed. (Currently only supporting Carto map embed URLs. (https://dosomething.carto.com/dashboard)).',
   });
 
-  embed.changeEditorInterface('previewImage', 'assetLinkEditor', {
+  embed.changeFieldControl('previewImage', 'builtin', 'assetLinkEditor', {
     helpText:
       'If set, replaces the embed on smaller screens as a preview of the embed content.',
   });

--- a/resources/assets/components/blocks/CurrentClubBlock/CurrentClubBlock.js
+++ b/resources/assets/components/blocks/CurrentClubBlock/CurrentClubBlock.js
@@ -47,7 +47,9 @@ const CurrentClubBlock = () => {
       <div className="p-3">
         {club ? (
           <div data-testid="current-club">
-            <p className="pt-2 pb-3">Hooray! You have joined the club for:</p>
+            <p className="pt-2 pb-3">
+              Hooray! You’re officially a member of your local DoSomething Club:
+            </p>
 
             <div className="border border-solid border-gray-400 rounded p-3">
               <p className="font-bold" data-testid="current-club-name">
@@ -62,7 +64,7 @@ const CurrentClubBlock = () => {
             </div>
 
             <p className="text-sm text-gray-500 pt-3">
-              Need help? Contact maddy@dosomething.org
+              Need help? Email Maddy at maddy@dosomething.org
             </p>
           </div>
         ) : (

--- a/resources/assets/components/blocks/CurrentClubBlock/CurrentClubForm.js
+++ b/resources/assets/components/blocks/CurrentClubBlock/CurrentClubForm.js
@@ -52,6 +52,11 @@ const CurrentClubForm = () => {
 
   return (
     <div data-testid="current-club-form">
+      <p className="pb-3">
+        Join an existing DoSomething club. Don’t forget to double check with
+        your leader that you’re selecting the right one!
+      </p>
+
       <strong>Club Name</strong>
 
       <ClubSelect onChange={setClubId} />
@@ -70,7 +75,7 @@ const CurrentClubForm = () => {
         }
         isLoading={loading}
         isDisabled={!clubId || loading}
-        text="join club"
+        text="Join Now"
       />
     </div>
   );

--- a/resources/assets/components/blocks/EmbedBlock/EmbedBlock.js
+++ b/resources/assets/components/blocks/EmbedBlock/EmbedBlock.js
@@ -5,8 +5,10 @@ import PropTypes from 'prop-types';
 import ErrorBlock from '../ErrorBlock/ErrorBlock';
 import CartoTemplate from './templates/CartoTemplate';
 import TypeFormTemplate from './templates/TypeFormTemplate';
+import IframeEmbed from '../../utilities/IframeEmbed/IframeEmbed';
 
 const PERMITTED_HOSTNAMES = {
+  'airtable.com': 'airtable',
   'dosomething.carto.com': 'carto',
   'dosomething.typeform.com': 'typeform',
 };
@@ -32,6 +34,9 @@ const EmbedBlock = props => {
 
     case 'carto':
       return <CartoTemplate {...props} />;
+
+    case 'airtable':
+      return <IframeEmbed {...props} />;
 
     default:
       return (


### PR DESCRIPTION
### What's this PR do?

This pull request adds `https://airtable.com/embed/...` as a valid URL for our Contentful Embed content type and `EmbedBlock` block in Phoenix. It also allows embedding an embed ( ♻️ ) in Company Page `content`.

### How should this be reviewed?
👀 

https://dosomething-phoenix-de-pr-2352.herokuapp.com/us/about/who-we-are

### Any background context you want to provide?
The regex for the Embed `url` field is officially out of control now lol. We should def revisit for a better way to validate this on the editor side.

This was more rapid POC then official feature PR, but this is technically ready to ship! It would be nice to have documentation + tests for this though at some point.

One additional bit of work that could be helpful if we so choose would be to allow customizing the `height` of the `IframeEmbed` via props so that we could extend the height of say Airtable embeds if we want it to be more spacious.

### Relevant tickets

References [Pivotal #174201121](https://www.pivotaltracker.com/story/show/174201121).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added screenshots of front-end changes on small, medium, and large screens.
- [ ] Added appropriate feature/unit tests.

![image](https://user-images.githubusercontent.com/12417657/92269000-528fcf80-eeb1-11ea-87c9-2c8fd8db35d0.png)
![image](https://user-images.githubusercontent.com/12417657/92269017-591e4700-eeb1-11ea-929e-dc998055c329.png)
