### PR TITLE
One click signup: Add loading state and use data rather than called

### DIFF
--- a/resources/assets/components/utilities/ScholarshipCard/GalleryBlockSignup.js
+++ b/resources/assets/components/utilities/ScholarshipCard/GalleryBlockSignup.js
@@ -15,14 +15,18 @@ export const CREATE_SIGNUP_MUTATION = gql`
   }
 `;
 const GalleryBlockSignup = ({ campaignId, path }) => {
-  const [handleSignup, { called, error }] = useMutation(
+  const [handleSignup, { loading, data, error }] = useMutation(
     CREATE_SIGNUP_MUTATION,
     {
       variables: { campaignId },
     },
   );
 
-  if (called && !error) {
+  if (loading) {
+    return <Spinner className="flex justify-center p-4" />;
+  }
+
+  if (data) {
     window.location = path;
 
     return <Spinner className="flex justify-center p-4" />;


### PR DESCRIPTION
### What's this PR do?

This pull request adds a loading state so we see the spinner before we get the mutation results, and only performs the "redirect" after the mutation has completed (aka, when we have `data`).

### How should this be reviewed?

Will this help with the issue where the campaign page doesn't register the signup? Does it mess up anything else?

### Any background context you want to provide?

[Slack thread](https://dosomething.slack.com/archives/CUQMU4Q6B/p1600965511003300)

### Relevant tickets

References [Pivotal #173228830](https://www.pivotaltracker.com/story/show/173228830).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added screenshots of front-end changes on small, medium, and large screens.
- [ ] Added appropriate feature/unit tests.
