### PR TITLE
Fix SocialShareTray styles on GeneralPage and StoryPage

### DIFF
--- a/resources/assets/components/pages/GeneralPage/GeneralPage.js
+++ b/resources/assets/components/pages/GeneralPage/GeneralPage.js
@@ -94,6 +94,7 @@ const GeneralPage = props => {
 
             {displaySocialShare ? (
               <SocialShareTray
+                className="text-center"
                 shareLink={window.location.href}
                 platforms={['facebook', 'twitter']}
                 title="found this useful?"

--- a/resources/assets/components/pages/StoryPage/StoryPage.js
+++ b/resources/assets/components/pages/StoryPage/StoryPage.js
@@ -51,6 +51,7 @@ const StoryPage = props => {
           </header>
 
           <SocialShareTray
+            className="text-center"
             // Pass through the current URL without the query parameters.
             shareLink={window.location.href.split('?')[0]}
             platforms={['facebook', 'twitter']}

--- a/resources/assets/components/utilities/SocialShareTray/SocialShareTray.js
+++ b/resources/assets/components/utilities/SocialShareTray/SocialShareTray.js
@@ -3,6 +3,7 @@
 import React from 'react';
 import Media from 'react-media';
 import PropTypes from 'prop-types';
+import classnames from 'classnames';
 
 import ShareButton from './ShareButton';
 import emailIcon from './emailIcon.svg';
@@ -133,11 +134,11 @@ class SocialShareTray extends React.Component {
   };
 
   render() {
-    const { shareLink, platforms, title } = this.props;
+    const { className, shareLink, platforms, title } = this.props;
     const trackLink = this.props.trackLink || this.props.shareLink;
 
     return (
-      <div className="p-3">
+      <div className={classnames('p-3', className)}>
         {title ? (
           <p
             data-test="social-share-tray-title"
@@ -215,6 +216,7 @@ class SocialShareTray extends React.Component {
 }
 
 SocialShareTray.propTypes = {
+  className: PropTypes.string,
   shareLink: PropTypes.string,
   trackLink: PropTypes.string,
   platforms: PropTypes.arrayOf(PropTypes.string),
@@ -222,6 +224,7 @@ SocialShareTray.propTypes = {
 };
 
 SocialShareTray.defaultProps = {
+  className: null,
   shareLink: null,
   trackLink: null,
   platforms: ['facebook', 'snapchat', 'twitter', 'messenger', 'email'],


### PR DESCRIPTION
### What's this PR do?

This pull request fixes the broken `SocialShareTray` alignment that @mendelB flagged in https://github.com/DoSomething/phoenix-next/pull/2364#issuecomment-698490426 (and fixed in https://github.com/DoSomething/phoenix-next/pull/2364#issuecomment-698491253)

<img width="450" alt="StoryPage" src="https://user-images.githubusercontent.com/1236811/94185625-6304eb80-fe5a-11ea-98ab-ee60c5aa31c8.png">

### How should this be reviewed?

Will link to example pages. 

### Any background context you want to provide?

🐞 

### Relevant tickets


References [Pivotal #174806681](https://www.pivotaltracker.com/story/show/174806681).


### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added screenshots of front-end changes on small, medium, and large screens.
- [ ] Added appropriate feature/unit tests.
