### PR TITLE
Add a '?chromeless' mode for embeds.

### DIFF
--- a/resources/assets/components/App.js
+++ b/resources/assets/components/App.js
@@ -9,11 +9,11 @@ import { Router, Route, Switch } from 'react-router-dom';
 import graphqlClient from '../graphql';
 import ErrorPage from './pages/ErrorPage';
 import Modal from './utilities/Modal/Modal';
-import { env, featureFlag } from '../helpers';
 import { initializeStore } from '../store/store';
 import HomePage from './pages/HomePage/HomePage';
 import BlockPage from './pages/BlockPage/BlockPage';
 import CausePage from './pages/CausePage/CausePage';
+import { env, featureFlag, query } from '../helpers';
 import NewHomePage from './pages/HomePage/NewHomePage';
 import CompanyPage from './pages/CompanyPage/CompanyPage';
 import CampaignContainer from './Campaign/CampaignContainer';
@@ -34,10 +34,15 @@ import VoterRegistrationDrivePage from './pages/VoterRegistrationDrivePage/Voter
 
 const App = ({ store, history }) => {
   initializeStore(store);
+
   return (
     <ReduxProvider store={store}>
       <ErrorBoundary FallbackComponent={ErrorPage}>
         <ApolloProvider client={graphqlClient(env('GRAPHQL_URL'))}>
+          {query('chromeless') ? (
+            /* If we're in "chromeless" mode, open all links in new windows: */
+            <base target="_blank" />
+          ) : null}
           <DismissableElement
             name="sitewide_banner_call_to_action"
             daysToReRender={7}

--- a/resources/assets/components/SiteNavigation/SiteNavigation.js
+++ b/resources/assets/components/SiteNavigation/SiteNavigation.js
@@ -11,6 +11,7 @@ import SiteNavigationFeature from './SiteNavigationFeature';
 import CloseButton from '../artifacts/CloseButton/CloseButton';
 import ProfileIcon from '../artifacts/ProfileIcon/ProfileIcon';
 import DoSomethingLogo from '../utilities/DoSomethingLogo/DoSomethingLogo';
+import { query } from '../../helpers';
 import {
   EVENT_CATEGORIES,
   getUtmContext,
@@ -169,6 +170,11 @@ class SiteNavigation extends React.Component {
   };
 
   render() {
+    // Hide navigation if we're in "chromeless" mode, e.g. for an embed:
+    if (query('chromeless')) {
+      return null;
+    }
+
     return (
       <nav role="navigation" id="nav" className="site-navigation">
         <div className="wrapper base-12-grid">

--- a/resources/assets/components/utilities/SiteFooter/SiteFooter.js
+++ b/resources/assets/components/utilities/SiteFooter/SiteFooter.js
@@ -1,153 +1,164 @@
 import React from 'react';
 
-const SiteFooter = () => (
-  <footer className="footer site-footer pb-32 md:pb-3">
-    <div className="footer__columns">
-      <div className="footer__column -social">
+import { query } from '../../../helpers';
+
+const SiteFooter = () => {
+  // Hide footer if we're in "chromeless" mode, e.g. for an embed:
+  if (query('chromeless')) {
+    return null;
+  }
+
+  return (
+    <footer className="footer site-footer pb-32 md:pb-3">
+      <div className="footer__columns">
+        <div className="footer__column -social">
+          <ul>
+            <li>
+              <a
+                href="https://www.facebook.com/dosomething"
+                className="social-icon -facebook"
+                title="dosomething on Facebook"
+              >
+                <span>dosomething on Facebook</span>
+              </a>
+            </li>
+            <li>
+              <a
+                href="https://twitter.com/dosomething"
+                className="social-icon -twitter"
+                title="@dosomething on Twitter"
+              >
+                <span>@dosomething on Twitter</span>
+              </a>
+            </li>
+            <li>
+              <a
+                href="http://instagram.com/dosomething"
+                className="social-icon -instagram"
+                title="@dosomething on Instagram"
+              >
+                <span>@dosomething on Instagram</span>
+              </a>
+            </li>
+            <li>
+              <a
+                href="http://dosomething.tumblr.com"
+                className="social-icon -tumblr"
+                title="dosomething on Tumblr"
+              >
+                <span>dosomething on Tumblr</span>
+              </a>
+            </li>
+            <li>
+              <a
+                href="https://www.snapchat.com/add/dosomething"
+                className="social-icon -snapchat"
+                title="dosomething on Snapchat"
+              >
+                <span>dosomething on Snapchat</span>
+              </a>
+            </li>
+            <li>
+              <a
+                href="http://weheartit.com/dosomething"
+                className="social-icon -weheartit"
+                title="dosomething on We Heart It"
+              >
+                <span>dosomething on We Heart It</span>
+              </a>
+            </li>
+            <li>
+              <a
+                href="http://www.youtube.com/user/DoSomething1"
+                className="social-icon -youtube"
+                title="dosomething1 on YouTube"
+              >
+                <span>dosomething1 on YouTube</span>
+              </a>
+            </li>
+          </ul>
+        </div>
+        <div className="footer__column -links">
+          <h4>Who We Are</h4>
+          <ul>
+            <li>
+              <a href="https://join.dosomething.org/">
+                What is DoSomething.org?
+              </a>
+            </li>
+            <li>
+              <a href="/us/about/our-people">Our Team</a>
+            </li>
+            <li>
+              <a href="/us/about/our-financials">Our Financials</a>
+            </li>
+            <li>
+              <a href="/us/about/our-press">Press</a>
+            </li>
+            <li>
+              <a href="https://lets.dosomething.org/">Articles</a>
+            </li>
+            <li>
+              <a href="/us/about/contact-us">Contact Us</a>
+            </li>
+          </ul>
+        </div>
+        <div className="footer__column -links">
+          <h4>Our Friends</h4>
+          <ul>
+            <li>
+              <a href="http://dosomethingstrategic.org/">
+                DoSomethingStrategic.org
+              </a>
+            </li>
+            <li>
+              <a href="/us/about/our-partners">Partners</a>
+            </li>
+            <li>
+              <a href="/us/about/hotline-list">Crisis Hotlines</a>
+            </li>
+          </ul>
+        </div>
+        <div className="footer__column -links">
+          <h4>Get Involved</h4>
+          <ul>
+            <li>
+              <a href="https://vote.dosomething.org/workwithus">
+                Get Out the Vote!
+              </a>
+            </li>
+            <li>
+              <a href="/us/about/easy-scholarships">Scholarships</a>
+            </li>
+            <li>
+              <a href="/us/about/join-our-team">Jobs</a>
+            </li>
+            <li>
+              <a href="/us/about/internships">Internships</a>
+            </li>
+            <li>
+              <a href="/us/articles/clubs-notify-me">DoSomething Clubs</a>
+            </li>
+            <li>
+              <a href="/us/about/donate">Donate</a>
+            </li>
+            <li>
+              <a href="https://help.dosomething.org/hc/en-us">Help Center</a>
+            </li>
+          </ul>
+        </div>
+      </div>
+      <div className="footer__subfooter border-gray-700">
         <ul>
           <li>
-            <a
-              href="https://www.facebook.com/dosomething"
-              className="social-icon -facebook"
-              title="dosomething on Facebook"
-            >
-              <span>dosomething on Facebook</span>
-            </a>
+            <a href="/us/about/terms-service">Terms of Service</a>
           </li>
           <li>
-            <a
-              href="https://twitter.com/dosomething"
-              className="social-icon -twitter"
-              title="@dosomething on Twitter"
-            >
-              <span>@dosomething on Twitter</span>
-            </a>
-          </li>
-          <li>
-            <a
-              href="http://instagram.com/dosomething"
-              className="social-icon -instagram"
-              title="@dosomething on Instagram"
-            >
-              <span>@dosomething on Instagram</span>
-            </a>
-          </li>
-          <li>
-            <a
-              href="http://dosomething.tumblr.com"
-              className="social-icon -tumblr"
-              title="dosomething on Tumblr"
-            >
-              <span>dosomething on Tumblr</span>
-            </a>
-          </li>
-          <li>
-            <a
-              href="https://www.snapchat.com/add/dosomething"
-              className="social-icon -snapchat"
-              title="dosomething on Snapchat"
-            >
-              <span>dosomething on Snapchat</span>
-            </a>
-          </li>
-          <li>
-            <a
-              href="http://weheartit.com/dosomething"
-              className="social-icon -weheartit"
-              title="dosomething on We Heart It"
-            >
-              <span>dosomething on We Heart It</span>
-            </a>
-          </li>
-          <li>
-            <a
-              href="http://www.youtube.com/user/DoSomething1"
-              className="social-icon -youtube"
-              title="dosomething1 on YouTube"
-            >
-              <span>dosomething1 on YouTube</span>
-            </a>
+            <a href="/us/about/privacy-policy">Privacy Policy</a>
           </li>
         </ul>
       </div>
-      <div className="footer__column -links">
-        <h4>Who We Are</h4>
-        <ul>
-          <li>
-            <a href="https://join.dosomething.org/">What is DoSomething.org?</a>
-          </li>
-          <li>
-            <a href="/us/about/our-people">Our Team</a>
-          </li>
-          <li>
-            <a href="/us/about/our-financials">Our Financials</a>
-          </li>
-          <li>
-            <a href="/us/about/our-press">Press</a>
-          </li>
-          <li>
-            <a href="https://lets.dosomething.org/">Articles</a>
-          </li>
-          <li>
-            <a href="/us/about/contact-us">Contact Us</a>
-          </li>
-        </ul>
-      </div>
-      <div className="footer__column -links">
-        <h4>Our Friends</h4>
-        <ul>
-          <li>
-            <a href="http://dosomethingstrategic.org/">
-              DoSomethingStrategic.org
-            </a>
-          </li>
-          <li>
-            <a href="/us/about/our-partners">Partners</a>
-          </li>
-          <li>
-            <a href="/us/about/hotline-list">Crisis Hotlines</a>
-          </li>
-        </ul>
-      </div>
-      <div className="footer__column -links">
-        <h4>Get Involved</h4>
-        <ul>
-          <li>
-            <a href="https://vote.dosomething.org/workwithus">
-              Get Out the Vote!
-            </a>
-          </li>
-          <li>
-            <a href="/us/about/easy-scholarships">Scholarships</a>
-          </li>
-          <li>
-            <a href="/us/about/join-our-team">Jobs</a>
-          </li>
-          <li>
-            <a href="/us/about/internships">Internships</a>
-          </li>
-          <li>
-            <a href="/us/articles/clubs-notify-me">DoSomething Clubs</a>
-          </li>
-          <li>
-            <a href="/us/about/donate">Donate</a>
-          </li>
-          <li>
-            <a href="https://help.dosomething.org/hc/en-us">Help Center</a>
-          </li>
-        </ul>
-      </div>
-    </div>
-    <div className="footer__subfooter border-gray-700">
-      <ul>
-        <li>
-          <a href="/us/about/terms-service">Terms of Service</a>
-        </li>
-        <li>
-          <a href="/us/about/privacy-policy">Privacy Policy</a>
-        </li>
-      </ul>
-    </div>
-  </footer>
-);
+    </footer>
+  );
+};
 export default SiteFooter;

--- a/resources/assets/components/utilities/SitewideBanner/SitewideBanner.js
+++ b/resources/assets/components/utilities/SitewideBanner/SitewideBanner.js
@@ -4,7 +4,7 @@ import { createPortal } from 'react-dom';
 import { useQuery } from '@apollo/react-hooks';
 import React, { useRef, useEffect } from 'react';
 
-import { isCurrentPathInPaths } from '../../../helpers';
+import { isCurrentPathInPaths, query } from '../../../helpers';
 import { getCampaign } from '../../../helpers/campaign';
 import SitewideBannerContent from './SitewideBannerContent';
 import { getUserId, isAuthenticated } from '../../../helpers/auth';
@@ -60,6 +60,11 @@ const SitewideBanner = props => {
   if (isCurrentPathInPaths(excludedPaths)) {
     target.setAttribute('data-testid', hiddenAttributeDataTestId);
 
+    return null;
+  }
+
+  // If we're in "chromeless" mode, e.g. an embed, hide this bar:
+  if (query('chromeless')) {
     return null;
   }
 


### PR DESCRIPTION
### What's this PR do?

This pull request adds a `?chromeless` query string that hides the navigation, footer, and HolaBar _and_ forces all links to open in new tabs. This fixes two issues with the embed at the end of the voter registration flow:
1. We should no longer need to whitelist any links someone could follow from that content page, since any links on the page (whether via Markdown, a component like the gallery, etc.) will be forced to open in a new tab.
2. We won't have the awkwardness of having a second navigation chrome within the tiny Rock The Vote embed, so things will look more like they belong! This is also a clear way to indicate the "chromeless" mode so we don't start abusing this functionality...

![Screen Shot 2020-09-24 at 2 33 28 PM](https://user-images.githubusercontent.com/583202/94185759-b5063b00-fe73-11ea-9069-780327316735.png)

(I'd show the embed within the actual Rock The Vote page but it doesn't like our non-secure `http://phoenix.test` or the self-signed Homestead certificate on `https://phoenix.test` – boo, security!!! But this should work there too! 😜)

### How should this be reviewed?

I'd recommend reviewing this [without whitespace](https://github.com/DoSomething/phoenix-next/pull/2366/files?w=1) since some of the indentation changes are distracting!

### Any background context you want to provide?

My goal here is to fix this issue with a priority flow in a way that allows us to work around this issue in the future without continuing to litter the codebase to references to specific one-off experiences.

### Relevant tickets

References [Pivotal #]().

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added screenshots of front-end changes on small, medium, and large screens.
- [ ] Added appropriate feature/unit tests.
