### PR TITLE
Update Contentful Embed migration script - remove regex validation

### DIFF
--- a/contentful/content-types/embed.js
+++ b/contentful/content-types/embed.js
@@ -13,25 +13,13 @@ module.exports = function(migration) {
     .validations([])
     .disabled(false)
     .omitted(false);
-
   embed
     .createField('url')
     .name('URL')
     .type('Symbol')
     .localized(false)
     .required(true)
-    .validations([
-      {
-        regexp: {
-          pattern:
-            '^(https:\\/\\/dosomething\\.(?:(?:carto\\.com\\/builder\\/[a-z0-9-]+\\/embed)|(?:typeform\\.com\\/to\\/[a-zA-Z0-9-]+)))|(https:\\/\\/airtable.com\\/embed\\/[a-zA-Z0-9-\\/]+)\\/?',
-          flags: null,
-        },
-
-        message:
-          'Must be a valid Carto embeddable map URL from the DoSomething space (https://dosomething.carto.com/dashboard), or a valid Typeform embeddable URL (https://dosomething.typeform.com), or a valid Airtable embeddable URL.',
-      },
-    ])
+    .validations([])
     .disabled(false)
     .omitted(false);
 
@@ -62,7 +50,7 @@ module.exports = function(migration) {
 
   embed.changeFieldControl('url', 'builtin', 'singleLine', {
     helpText:
-      'Must be a valid Carto embeddable map URL from the DoSomething space (https://dosomething.carto.com/dashboard), or a valid Typeform embeddable URL (https://dosomething.typeform.com)',
+      'The URL for the embed. Supports Carto map (https://dosomething.carto.com/dashboard) or Typeform (https://dosomething.typeform.com) embed URLs from our DoSomething spaces, or Airtable embed URLs (https://airtable.com/embed/abcd1234).',
   });
 
   embed.changeFieldControl('previewImage', 'builtin', 'assetLinkEditor', {


### PR DESCRIPTION
### What's this PR do?

This pull request removes the flabbergasting Regex validation from the Embed URL field on Contentful.

### How should this be reviewed?
👀 

### Any background context you want to provide?
We [filter per hostname](https://github.com/DoSomething/phoenix-next/blob/8a854e19bf8602c81c2caae7c941451b29cbcc49/resources/assets/components/blocks/EmbedBlock/EmbedBlock.js#L10-L14) on our end, and at this point, maintaining this Regex validation has proven more trouble then it's worth.

### Relevant tickets
This (ongoing) discussion https://github.com/DoSomething/phoenix-next/pull/2360#discussion_r494444901, and note #2352.