### PR TITLE
Adds data-testid's to SocialShareTray

### DIFF
--- a/cypress/integration/voter-registration-drive-action.js
+++ b/cypress/integration/voter-registration-drive-action.js
@@ -92,7 +92,7 @@ describe('Voter Registration Drive Action', () => {
       `${PHOENIX_URL}/us/my-voter-registration-drive?referrer_user_id=${user.id}`,
     );
     cy.get('[data-test=voting-reasons-query-options]').should('have.length', 1);
-    cy.get('[data-test=social-share-tray-title]').should('have.length', 0);
+    cy.findByTestId('social-share-tray-title').should('have.length', 0);
   });
 
   it('Appends group_id query to link if signed up with group', () => {

--- a/resources/assets/components/utilities/SocialShareTray/SocialShareTray.js
+++ b/resources/assets/components/utilities/SocialShareTray/SocialShareTray.js
@@ -138,10 +138,13 @@ class SocialShareTray extends React.Component {
     const trackLink = this.props.trackLink || this.props.shareLink;
 
     return (
-      <div className={classnames('p-3', className)}>
+      <div
+        className={classnames('p-3', className)}
+        data-testid="social-share-tray"
+      >
         {title ? (
           <p
-            data-test="social-share-tray-title"
+            data-testid="social-share-tray-title"
             className="title uppercase font-bold"
           >
             {title}


### PR DESCRIPTION
### What's this PR do?

This pull request adds a `data-testid` attribute to parent `div` returned in the `SocialShareTray` component, to be used for Ghost Inspector tests. Our [`StoryPage` test is currently failing](https://app.ghostinspector.com/results/5f6cf8d55a582c2e0f7cfe51) because it's checking for a `.social-share-tray` element -- that class was removed in #2364.

Also updates the title `data-test` attribute to be a `data-testid` attribute.

### How should this be reviewed?

👀 

### Any background context you want to provide?

🐦 

### Relevant tickets

References [Pivotal #174806681](https://www.pivotaltracker.com/story/show/174806681).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added screenshots of front-end changes on small, medium, and large screens.
- [ ] Added appropriate feature/unit tests.
