### PR TITLE
Social Drive Action Width Fix

### DIFF
--- a/resources/assets/components/actions/SocialDriveAction/SocialDriveAction.js
+++ b/resources/assets/components/actions/SocialDriveAction/SocialDriveAction.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import gql from 'graphql-tag';
 import PropTypes from 'prop-types';
+import classNames from 'classnames';
 
 import Card from '../../utilities/Card/Card';
 import ShortLinkShareContainer from '../../utilities/ShortLinkShare/ShortLinkShareContainer';
@@ -13,8 +14,8 @@ export const SocialDriveBlockFragment = gql`
   }
 `;
 
-const SocialDriveAction = ({ description, link, title }) => (
-  <div className="clearfix pb-6 lg:flex lg:w-2/3 lg:pr-3">
+const SocialDriveAction = ({ className, description, link, title }) => (
+  <div className={classNames('clearfix pb-6', className)}>
     <Card className="rounded bordered" title={title}>
       {description ? <p className="p-3">{description}</p> : null}
 
@@ -24,12 +25,14 @@ const SocialDriveAction = ({ description, link, title }) => (
 );
 
 SocialDriveAction.propTypes = {
+  className: PropTypes.string,
   description: PropTypes.string,
   link: PropTypes.string.isRequired,
   title: PropTypes.string,
 };
 
 SocialDriveAction.defaultProps = {
+  className: null,
   description: null,
   title: 'Your Online Drive',
 };

--- a/resources/assets/components/pages/CampaignPage/CampaignPageContent.js
+++ b/resources/assets/components/pages/CampaignPage/CampaignPageContent.js
@@ -58,7 +58,6 @@ const CampaignPageContent = props => {
                 PostGalleryBlock: wideSpan,
                 PhotoSubmissionBlock: wideSpan,
                 QuizBlock: wideSpan,
-                SocialDriveBlock: wideSpan,
                 VoterRegistrationDriveBlock: wideSpan,
                 VoterRegistrationReferralsBlock: wideSpan,
               }}


### PR DESCRIPTION
### What's this PR do?

This pull request removes the hardcoded two-thirds width styling classes, and instead uses a `className` prop to allow containing elements to control such things.

### How should this be reviewed?
👀 

Am I missing any scenarios?

### Any background context you want to provide?
#2372 removed the optionally applied two-thirds width styling which caused the RAF Account page to [erroneously apply it as well](https://dosomething.slack.com/archives/CUQMU4Q6B/p1601390263003300?thread_ts=1601389846.002400&cid=CUQMU4Q6B).

However this refactor actually put us in good stead to remove this hack entirely, in favor of `className`, wherein the `CampaignPageContent` which I believe is the only place we want the two-thirds width -- can apply this via `className`, and every other page can relax 😌 

### Relevant tickets
https://dosomething.slack.com/archives/CUQMU4Q6B/p1601390263003300?thread_ts=1601389846.002400&cid=CUQMU4Q6B

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added screenshots of front-end changes on small, medium, and large screens.
- [ ] Added appropriate feature/unit tests.


Campaign Page:
Before:
![image](https://user-images.githubusercontent.com/12417657/94577669-d2a51d00-0244-11eb-85bb-4e337df2977a.png)

After:
![image](https://user-images.githubusercontent.com/12417657/94577861-097b3300-0245-11eb-99dc-28fc20d17a49.png)


RAF Account page:
Before:
![image](https://user-images.githubusercontent.com/12417657/94577760-e94b7400-0244-11eb-9f32-98b0232758f2.png)

After:
![image](https://user-images.githubusercontent.com/12417657/94577803-f7999000-0244-11eb-8f95-ef6c952fb2d8.png)


Referral Alpha Page:
Before/After:
![image](https://user-images.githubusercontent.com/12417657/94578004-316a9680-0245-11eb-9cfc-6debdb27b6b3.png)
