### PR TITLE
Adds optional groupTypeId filter to ActionStatsBlock

### DIFF
--- a/contentful/content-types/actionStatsBlock.js
+++ b/contentful/content-types/actionStatsBlock.js
@@ -36,6 +36,15 @@ module.exports = function(migration) {
     .disabled(false)
     .omitted(false);
 
+  actionStatsBlock
+    .createField('groupTypeId')
+    .name('Group Type ID')
+    .type('Integer')
+    .localized(false)
+    .required(false)
+    .validations([])
+    .disabled(false)
+    .omitted(false);
   actionStatsBlock.changeFieldControl(
     'internalTitle',
     'builtin',
@@ -46,4 +55,14 @@ module.exports = function(migration) {
   actionStatsBlock.changeFieldControl('actionId', 'builtin', 'numberEditor', {
     helpText: 'The Rogue Action ID to display a leaderboard for.',
   });
+
+  actionStatsBlock.changeFieldControl(
+    'groupTypeId',
+    'builtin',
+    'numberEditor',
+    {
+      helpText:
+        'If set, filters stats to only show schools that have groups in this group type. See https://activity.dosomething.org/groups for list of group types.',
+    },
+  );
 };

--- a/docs/development/content-types/action-stats-block.md
+++ b/docs/development/content-types/action-stats-block.md
@@ -9,3 +9,5 @@ Displays a leaderboard and table of paginated school [action stats](https://gith
 -   **Internal Title**: This is for our internal Contentful organization and will be how the block shows up in search results, etc.
 
 -   **Action ID**: The ID of the [Action](https://github.com/DoSomething/rogue/blob/master/docs/endpoints/actions.md) to filter a `GET /action-stats` query by.
+
+-   **Group Type ID**: The ID of the [Group Type](https://github.com/DoSomething/rogue/blob/master/docs/endpoints/group-types.md) to filter a `GET /action-stats` query by. Only stats for schools that have groups within the group type will be displayed.

--- a/resources/assets/components/blocks/ActionStatsBlock/ActionStatsBlock.js
+++ b/resources/assets/components/blocks/ActionStatsBlock/ActionStatsBlock.js
@@ -10,16 +10,20 @@ import SchoolLocationSelect from '../../utilities/UsaStateSelect';
 export const ActionStatsBlockFragment = gql`
   fragment ActionStatsBlockFragment on ActionStatsBlock {
     filterByActionId: actionId
+    filterByGroupTypeId: groupTypeId
   }
 `;
 
-const ActionStatsBlock = ({ filterByActionId }) => {
+const ActionStatsBlock = ({ filterByActionId, filterByGroupTypeId }) => {
   const [schoolId, setSchoolId] = useState(null);
   const [schoolLocation, setSchoolLocation] = useState(null);
 
   return (
     <>
-      <ActionStatsLeaderboard actionId={filterByActionId} />
+      <ActionStatsLeaderboard
+        actionId={filterByActionId}
+        groupTypeId={filterByGroupTypeId}
+      />
 
       <div className="flex bg-gray-100 flex-wrap py-8 px-4 md:px-20 lg:px-4 border border-solid border-gray-200">
         <div className="w-full lg:w-1/5">
@@ -48,6 +52,7 @@ const ActionStatsBlock = ({ filterByActionId }) => {
 
       <ActionStatsTable
         actionId={filterByActionId}
+        groupTypeId={filterByGroupTypeId}
         schoolId={schoolId}
         schoolLocation={schoolLocation}
       />
@@ -57,6 +62,11 @@ const ActionStatsBlock = ({ filterByActionId }) => {
 
 ActionStatsBlock.propTypes = {
   filterByActionId: PropTypes.number.isRequired,
+  filterByGroupTypeId: PropTypes.number,
+};
+
+ActionStatsBlock.defaultProps = {
+  filterByGroupTypeId: null,
 };
 
 export default ActionStatsBlock;

--- a/resources/assets/components/blocks/ActionStatsBlock/ActionStatsLeaderboard.js
+++ b/resources/assets/components/blocks/ActionStatsBlock/ActionStatsLeaderboard.js
@@ -9,9 +9,14 @@ import ErrorBlock from '../ErrorBlock/ErrorBlock';
 import Spinner from '../../artifacts/Spinner/Spinner';
 
 const SCHOOL_ACTION_STATS_LEADER_QUERY = gql`
-  query SchoolActionStatsLeaderQuery($actionId: Int!, $count: Int) {
+  query SchoolActionStatsLeaderQuery(
+    $actionId: Int!
+    $groupTypeId: Int
+    $count: Int
+  ) {
     stats: schoolActionStats(
       actionId: $actionId
+      groupTypeId: $groupTypeId
       orderBy: "impact,desc"
       count: $count
     ) {
@@ -29,12 +34,18 @@ const SCHOOL_ACTION_STATS_LEADER_QUERY = gql`
   }
 `;
 
-const ActionStatsLeaderboard = ({ actionId, count }) => {
+const ActionStatsLeaderboard = ({ actionId, count, groupTypeId }) => {
+  const variables = {
+    actionId,
+    count,
+  };
+
+  if (groupTypeId) {
+    variables.groupTypeId = groupTypeId;
+  }
+
   const { loading, data, error } = useQuery(SCHOOL_ACTION_STATS_LEADER_QUERY, {
-    variables: {
-      actionId,
-      count,
-    },
+    variables,
   });
 
   let rank = 0;
@@ -115,11 +126,13 @@ const ActionStatsLeaderboard = ({ actionId, count }) => {
 
 ActionStatsLeaderboard.propTypes = {
   actionId: PropTypes.number.isRequired,
+  groupTypeId: PropTypes.number,
   count: PropTypes.number,
 };
 
 ActionStatsLeaderboard.defaultProps = {
   count: 3,
+  groupTypeId: null,
 };
 
 export default ActionStatsLeaderboard;

--- a/resources/assets/components/blocks/ActionStatsBlock/ActionStatsLeaderboard.js
+++ b/resources/assets/components/blocks/ActionStatsBlock/ActionStatsLeaderboard.js
@@ -1,8 +1,8 @@
 import React from 'react';
-import { get } from 'lodash';
 import gql from 'graphql-tag';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
+import { assign, get } from 'lodash';
 import { useQuery } from '@apollo/react-hooks';
 
 import ErrorBlock from '../ErrorBlock/ErrorBlock';
@@ -41,7 +41,7 @@ const ActionStatsLeaderboard = ({ actionId, count, groupTypeId }) => {
   };
 
   if (groupTypeId) {
-    variables.groupTypeId = groupTypeId;
+    assign(variables, { groupTypeId });
   }
 
   const { loading, data, error } = useQuery(SCHOOL_ACTION_STATS_LEADER_QUERY, {

--- a/resources/assets/components/blocks/ActionStatsBlock/ActionStatsTable.js
+++ b/resources/assets/components/blocks/ActionStatsBlock/ActionStatsTable.js
@@ -15,6 +15,7 @@ const PAGINATED_ACTION_STATS_QUERY = gql`
   query PaginatedActionStatsQuery(
     $actionId: Int
     $cursor: String
+    $groupTypeId: Int
     $location: String
     $schoolId: String
   ) {
@@ -22,6 +23,7 @@ const PAGINATED_ACTION_STATS_QUERY = gql`
       actionId: $actionId
       after: $cursor
       first: 10
+      groupTypeId: $groupTypeId
       location: $location
       orderBy: "impact,desc"
       schoolId: $schoolId
@@ -52,8 +54,17 @@ const Table = tw.table`w-full border border-solid border-gray-200`;
 const TableHeader = tw.thead`bg-blurple-500 font-bold p-4 pr-6 text-left text-white w-full`;
 const TableCell = tw.td`p-2 text-sm md:text-base`;
 
-const ActionStatsTable = ({ actionId, schoolId, schoolLocation }) => {
+const ActionStatsTable = ({
+  actionId,
+  groupTypeId,
+  schoolId,
+  schoolLocation,
+}) => {
   const variables = { actionId };
+
+  if (groupTypeId) {
+    assign(variables, { groupTypeId });
+  }
 
   if (schoolLocation) {
     assign(variables, { location: schoolLocation });
@@ -187,11 +198,13 @@ const ActionStatsTable = ({ actionId, schoolId, schoolLocation }) => {
 
 ActionStatsTable.propTypes = {
   actionId: PropTypes.number.isRequired,
+  groupTypeId: PropTypes.number,
   schoolId: PropTypes.string,
   schoolLocation: PropTypes.string,
 };
 
 ActionStatsTable.defaultProps = {
+  groupTypeId: null,
   schoolId: null,
   schoolLocation: null,
 };

--- a/schema.json
+++ b/schema.json
@@ -71,6 +71,33 @@
             "deprecationReason": null
           },
           {
+            "name": "locationVotingInformation",
+            "description": "Get voting information by location.",
+            "args": [
+              {
+                "name": "location",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null
+              }
+            ],
+            "type": {
+              "kind": "OBJECT",
+              "name": "LocationVotingInformation",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "embed",
             "description": null,
             "args": [
@@ -1190,6 +1217,16 @@
                 "defaultValue": null
               },
               {
+                "name": "groupTypeId",
+                "description": "The Group Type ID to filter action stats by.",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null
+              },
+              {
                 "name": "page",
                 "description": "The page of results to return.",
                 "type": {
@@ -1211,13 +1248,13 @@
               },
               {
                 "name": "orderBy",
-                "description": "How to order the results (e.g. 'id,desc').",
+                "description": "How to order the results (e.g. 'impact,desc').",
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
                   "ofType": null
                 },
-                "defaultValue": "\"id,desc\""
+                "defaultValue": "\"impact,desc\""
               }
             ],
             "type": {
@@ -1267,6 +1304,16 @@
                 "defaultValue": null
               },
               {
+                "name": "groupTypeId",
+                "description": "The Group Type ID to filter action stats by.",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null
+              },
+              {
                 "name": "first",
                 "description": "Get the first N results.",
                 "type": {
@@ -1294,7 +1341,7 @@
                   "name": "String",
                   "ofType": null
                 },
-                "defaultValue": "\"id,desc\""
+                "defaultValue": "\"impact,desc\""
               }
             ],
             "type": {
@@ -4710,6 +4757,121 @@
                 "name": "Boolean",
                 "ofType": null
               }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "LocationVotingInformation",
+        "description": "A set of voting information for a location.",
+        "fields": [
+          {
+            "name": "id",
+            "description": "The unique ID of this location voting information record.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "location",
+            "description": "The ISO-3166-2 location this voting information is for.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "voterRegistrationDeadline",
+            "description": "The deadline for voter registration, e.g. 10/31",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "earlyVotingStarts",
+            "description": "The start date for early voting, e.g. 10/5",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "earlyVotingEnds",
+            "description": "The end date for early voting, e.g. 10/20",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "absenteeBallotRequestDeadline",
+            "description": "The deadline for requesting an absentee ballot, e.g. 9/14",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "absenteeBallotReturnDeadline",
+            "description": "The deadline for returning an absentee ballot, e.g. 9/27",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "absenteeBallotReturnDeadlineType",
+            "description": "The type of deadline for returning an absentee ballot, e.g. received by, postmarked by",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -10927,6 +11089,18 @@
                 "name": "Int",
                 "ofType": null
               }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "groupTypeId",
+            "description": "The group type ID to filter stats by.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
             },
             "isDeprecated": false,
             "deprecationReason": null


### PR DESCRIPTION
### What's this PR do?

This pull request adds a `groupTypeId` field to our `ActionStatsBlock` content type, and uses it to filter the query for Action Stats if set, per https://github.com/DoSomething/graphql/pull/280.

Also updates our GraphQL schema, adding the new `LocationVotingInformation` type added in https://github.com/DoSomething/graphql/pull/275.  

### How should this be reviewed?

👀 

### Any background context you want to provide?

This will resolve the request to filter our voter registration leaderboard to NASSP groups (group type ID 5).


### Relevant tickets

References [Pivotal #175047229](https://www.pivotaltracker.com/story/show/175047229).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [x] Documentation added for new features/changed endpoints.
- [ ] Added screenshots of front-end changes on small, medium, and large screens.
- [ ] Added appropriate feature/unit tests.
