### PR TITLE
Hide leaderboard Load More Button for now

### DIFF
--- a/resources/assets/components/blocks/ActionStatsBlock/ActionStatsBlock.js
+++ b/resources/assets/components/blocks/ActionStatsBlock/ActionStatsBlock.js
@@ -18,6 +18,10 @@ const ActionStatsBlock = ({ filterByActionId, filterByGroupTypeId }) => {
   const [schoolId, setSchoolId] = useState(null);
   const [schoolLocation, setSchoolLocation] = useState(null);
 
+  // Hiding Load More Button as a quick fix until Rogue pagination errors are fixed.
+  // @see https://www.pivotaltracker.com/story/show/175102031
+  const hideLoadMoreButton = true;
+
   return (
     <>
       <ActionStatsLeaderboard
@@ -53,7 +57,7 @@ const ActionStatsBlock = ({ filterByActionId, filterByGroupTypeId }) => {
       <ActionStatsTable
         actionId={filterByActionId}
         groupTypeId={filterByGroupTypeId}
-        hideLoadMoreButton
+        hideLoadMoreButton={hideLoadMoreButton}
         schoolId={schoolId}
         schoolLocation={schoolLocation}
       />

--- a/resources/assets/components/blocks/ActionStatsBlock/ActionStatsBlock.js
+++ b/resources/assets/components/blocks/ActionStatsBlock/ActionStatsBlock.js
@@ -53,6 +53,7 @@ const ActionStatsBlock = ({ filterByActionId, filterByGroupTypeId }) => {
       <ActionStatsTable
         actionId={filterByActionId}
         groupTypeId={filterByGroupTypeId}
+        hideLoadMoreButton
         schoolId={schoolId}
         schoolLocation={schoolLocation}
       />

--- a/resources/assets/components/blocks/ActionStatsBlock/ActionStatsTable.js
+++ b/resources/assets/components/blocks/ActionStatsBlock/ActionStatsTable.js
@@ -57,6 +57,7 @@ const TableCell = tw.td`p-2 text-sm md:text-base`;
 const ActionStatsTable = ({
   actionId,
   groupTypeId,
+  hideLoadMoreButton,
   schoolId,
   schoolLocation,
 }) => {
@@ -180,7 +181,7 @@ const ActionStatsTable = ({
           </tr>
         ) : null}
 
-        {hasNextPage ? (
+        {hasNextPage && !hideLoadMoreButton ? (
           <tr>
             <td className="p-3" colSpan={colSpan}>
               <PrimaryButton
@@ -199,12 +200,14 @@ const ActionStatsTable = ({
 ActionStatsTable.propTypes = {
   actionId: PropTypes.number.isRequired,
   groupTypeId: PropTypes.number,
+  hideLoadMoreButton: PropTypes.bool,
   schoolId: PropTypes.string,
   schoolLocation: PropTypes.string,
 };
 
 ActionStatsTable.defaultProps = {
   groupTypeId: null,
+  hideLoadMoreButton: false,
   schoolId: null,
   schoolLocation: null,
 };


### PR DESCRIPTION
### What's this PR do?

This pull request hides the load more button until we fix pagination in a Rogue `GET /action-stats` API request when a group type filter is set, which [causes an integrity constraint violation](https://github.com/DoSomething/rogue/pull/1125#issuecomment-702849789):

```
production.ERROR: SQLSTATE[23000]: Integrity constraint violation: 1052 Column 'id' in where clause is ambiguous (SQL: select * from `action_stats` inner join `groups` on `action_stats`.`school_id` = `groups`.`school_id` where `action_id` = 954 and `groups`.`group_type_id` = 5 and (`impact` < 6 or (`impact` = 6 and `id` > 11955)) order by `impact` desc, `action_stats`.`id` asc limit 11 offset 0)
```

### How should this be reviewed?

👀 

### Any background context you want to provide?

🛺 

### Relevant tickets

References [Pivotal #175102031](https://www.pivotaltracker.com/story/show/175102031).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added screenshots of front-end changes on small, medium, and large screens.
- [ ] Added appropriate feature/unit tests.
