### PR TITLE
Update Holabar for self reported voter registrations

### DIFF
--- a/cypress/integration/sitewide-banner.js
+++ b/cypress/integration/sitewide-banner.js
@@ -73,6 +73,31 @@ describe('Site Wide Banner', () => {
     cy.findByTestId('sitewide-banner').should('have.length', 1);
   });
 
+  it('The Site Wide Banner is displayed with custom messaging for users with self reported VR status', () => {
+    const user = userFactory();
+
+    cy.mockGraphqlOp('CampaignBannerQuery', {
+      campaign: {
+        groupTypeId: null,
+      },
+    });
+
+    cy.mockGraphqlOp('UserSitewideBannerQuery', {
+      user: {
+        voterRegistrationStatus: 'CONFIRMED',
+      },
+    });
+
+    cy.authVisitCampaignWithoutSignup(user, exampleCampaign);
+
+    cy.findByTestId('sitewide-banner').should('have.length', 1);
+    cy.findByTestId('sitewide-banner-button').should(
+      'have.attr',
+      'href',
+      'https://am-i-registered-to-vote.org/dosomething/',
+    );
+  });
+
   it('The Site Wide Banner is not displayed on the beta voter registration (OVRD) drive page', () => {
     const user = userFactory();
 

--- a/resources/assets/components/utilities/SitewideBanner/SitewideBanner.js
+++ b/resources/assets/components/utilities/SitewideBanner/SitewideBanner.js
@@ -151,7 +151,6 @@ const SitewideBanner = props => {
     );
   }
 
-  console.log(userRegistrationStatus);
   return createPortal(<SitewideBannerContent {...props} />, target);
 };
 

--- a/resources/assets/components/utilities/SitewideBanner/SitewideBanner.js
+++ b/resources/assets/components/utilities/SitewideBanner/SitewideBanner.js
@@ -151,6 +151,7 @@ const SitewideBanner = props => {
     );
   }
 
+  console.log(userRegistrationStatus);
   return createPortal(<SitewideBannerContent {...props} />, target);
 };
 

--- a/resources/assets/components/utilities/SitewideBanner/SitewideBanner.js
+++ b/resources/assets/components/utilities/SitewideBanner/SitewideBanner.js
@@ -4,11 +4,15 @@ import { createPortal } from 'react-dom';
 import { useQuery } from '@apollo/react-hooks';
 import React, { useRef, useEffect } from 'react';
 
-import { isCurrentPathInPaths, query } from '../../../helpers';
 import { getCampaign } from '../../../helpers/campaign';
 import SitewideBannerContent from './SitewideBannerContent';
+import { isCurrentPathInPaths, query } from '../../../helpers';
 import { getUserId, isAuthenticated } from '../../../helpers/auth';
 import { excludedPaths, excludedVoterRegistrationStatuses } from './config';
+import {
+  isRegisteredStatus,
+  getCheckRegistrationStatusURL,
+} from '../../../helpers/voter-registration';
 
 const USER_QUERY = gql`
   query UserSitewideBannerQuery($userId: String!) {
@@ -120,6 +124,26 @@ const SitewideBanner = props => {
         cta="Start Now"
         link="/us/account/refer-friends"
         description="Want to build our youth-led movement? Refer a friend!"
+        handleClose={props.handleClose}
+        handleComplete={props.handleComplete}
+      />,
+      target,
+    );
+  }
+
+  if (
+    /**
+     * Checks for auth user and if the user is self reported to be registered to vote,
+     * Display a reminder to check their status
+     */
+    isAuthenticated() &&
+    isRegisteredStatus(userRegistrationStatus)
+  ) {
+    return createPortal(
+      <SitewideBannerContent
+        cta="Get Started"
+        link={getCheckRegistrationStatusURL()}
+        description="1 in 8 voter registrations are invalid. Take 2 minutes to make sure you're registered at your current address."
         handleClose={props.handleClose}
         handleComplete={props.handleComplete}
       />,

--- a/resources/assets/components/utilities/SitewideBanner/SitewideBanner.js
+++ b/resources/assets/components/utilities/SitewideBanner/SitewideBanner.js
@@ -142,6 +142,7 @@ const SitewideBanner = props => {
     return createPortal(
       <SitewideBannerContent
         cta="Get Started"
+        contextSource="voter_registration_lookup_tool"
         link={getCheckRegistrationStatusURL()}
         description="1 in 8 voter registrations are invalid. Take 2 minutes to make sure you're registered at your current address."
         handleClose={props.handleClose}

--- a/resources/assets/components/utilities/SitewideBanner/SitewideBannerContent.js
+++ b/resources/assets/components/utilities/SitewideBanner/SitewideBannerContent.js
@@ -10,6 +10,7 @@ import CloseButton from '../../artifacts/CloseButton/CloseButton';
 
 const SitewideBannerContent = ({
   cta,
+  contextSource,
   description,
   handleClose,
   handleComplete,
@@ -22,7 +23,7 @@ const SitewideBannerContent = ({
       action: 'button_clicked',
       category: EVENT_CATEGORIES.siteAction,
       label: 'sitewide_banner',
-      context: { contextSource: 'voter_registration' },
+      context: { contextSource },
     });
   };
   return (
@@ -58,10 +59,15 @@ const SitewideBannerContent = ({
 
 SitewideBannerContent.propTypes = {
   cta: PropTypes.string.isRequired,
+  contextSource: PropTypes.string,
   description: PropTypes.string.isRequired,
   handleClose: PropTypes.func.isRequired,
   handleComplete: PropTypes.func.isRequired,
   link: PropTypes.string.isRequired,
+};
+
+SitewideBannerContent.defaultProps = {
+  contextSource: 'voter_registration',
 };
 
 export default SitewideBannerContent;

--- a/resources/assets/components/utilities/SitewideBanner/config.js
+++ b/resources/assets/components/utilities/SitewideBanner/config.js
@@ -18,3 +18,8 @@ export const excludedVoterRegistrationStatuses = [
   'INELIGIBLE',
   'REGISTRATION_COMPLETE',
 ];
+
+export const selfReportedVoterRegistrationConfirmedStatuses = [
+  'CONFIRMED',
+  'UNCERTAIN',
+];

--- a/resources/assets/helpers/voter-registration.js
+++ b/resources/assets/helpers/voter-registration.js
@@ -41,3 +41,23 @@ export function getTrackingSource(sourceDetails, referrerUserId, groupId) {
 
   return getUserId() ? `user:${getUserId()},${result}` : result;
 }
+
+/**
+ * Returns boolean indicating whether user's registration status is considered "registered"
+ *
+ * @param {String} userRegistrationStatus
+ */
+export function isRegisteredStatus(userRegistrationStatus) {
+  if (userRegistrationStatus === ('confirmed' || 'uncertain')) {
+    return true;
+  }
+
+  return false;
+}
+
+/**
+ * Returns Url to use when checking voter registration status
+ */
+export function getCheckRegistrationStatusURL() {
+  return 'https://am-i-registered-to-vote.org/dosomething/';
+}

--- a/resources/assets/helpers/voter-registration.js
+++ b/resources/assets/helpers/voter-registration.js
@@ -47,17 +47,12 @@ export function getTrackingSource(sourceDetails, referrerUserId, groupId) {
  * Returns boolean indicating whether user's registration status is considered "registered"
  *
  * @param {String} userRegistrationStatus
+ * @return {Boolean}
  */
 export function isRegisteredStatus(userRegistrationStatus) {
-  if (
-    selfReportedVoterRegistrationConfirmedStatuses.includes(
-      userRegistrationStatus,
-    )
-  ) {
-    return true;
-  }
-
-  return false;
+  return selfReportedVoterRegistrationConfirmedStatuses.includes(
+    userRegistrationStatus,
+  );
 }
 
 /**

--- a/resources/assets/helpers/voter-registration.js
+++ b/resources/assets/helpers/voter-registration.js
@@ -1,4 +1,5 @@
 import { getUserId } from './auth';
+import { selfReportedVoterRegistrationConfirmedStatuses } from '../components/utilities/SitewideBanner/config';
 
 /**
  * Returns percentage completed and corresponding label.
@@ -48,7 +49,11 @@ export function getTrackingSource(sourceDetails, referrerUserId, groupId) {
  * @param {String} userRegistrationStatus
  */
 export function isRegisteredStatus(userRegistrationStatus) {
-  if (userRegistrationStatus === ('confirmed' || 'uncertain')) {
+  if (
+    selfReportedVoterRegistrationConfirmedStatuses.includes(
+      userRegistrationStatus,
+    )
+  ) {
     return true;
   }
 


### PR DESCRIPTION
### What's this PR do?

This pull request adds a specific check for users that have self reported either `confirmed` or `uncertain` when registering with DS. If they have either as their voter registration status, they'll see specific copy to encourage them to double check their status.

### How should this be reviewed?

👀 
<img width="419" alt="Screen Shot 2020-10-06 at 11 41 40 AM" src="https://user-images.githubusercontent.com/15236023/95226429-eb747c00-07ca-11eb-97d4-1c7d7017bdcd.png">

<img width="383" alt="Screen Shot 2020-10-06 at 11 41 01 AM" src="https://user-images.githubusercontent.com/15236023/95226435-ee6f6c80-07ca-11eb-98ee-f3e125e87f40.png">

<img width="1396" alt="Screen Shot 2020-10-06 at 11 40 43 AM" src="https://user-images.githubusercontent.com/15236023/95226446-f16a5d00-07ca-11eb-8cac-d72e6f5d0b1b.png">


### Any background context you want to provide?

I created two helpers that will also be helpful for a feature we're hoping to add in a users profile.

### Relevant tickets

References [Pivotal # 173807023](https://www.pivotaltracker.com/story/show/173807023).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added screenshots of front-end changes on small, medium, and large screens.
- [ ] Added appropriate feature/unit tests.
