### PR TITLE
Voter Widget style tweaks

### DIFF
--- a/resources/assets/components/blocks/ContentBlock/ContentBlock.js
+++ b/resources/assets/components/blocks/ContentBlock/ContentBlock.js
@@ -69,8 +69,7 @@ const ContentBlock = ({
               and thus the content width is confined to accommodate the image, whereas on 'Campaign Pages', we assign
               *extra* overlaying row space to Content Blocks, allowing the image to just optionally display within the extra space.
             */
-            'col-span-3':
-              (!image.url && fullWidth) || footerType === 'GetOutTheVoteBlock',
+            'col-span-3': (!image.url && fullWidth) || footerType,
           })}
         >
           {contentNode}

--- a/resources/assets/components/blocks/ContentBlock/ContentBlock.js
+++ b/resources/assets/components/blocks/ContentBlock/ContentBlock.js
@@ -68,6 +68,8 @@ const ContentBlock = ({
               This is necessary on 'General Pages' or in 'Modals' where the overlaying row width is more restricted,
               and thus the content width is confined to accommodate the image, whereas on 'Campaign Pages', we assign
               *extra* overlaying row space to Content Blocks, allowing the image to just optionally display within the extra space.
+
+              Additionally, if a footer is included, the content should span across the full view.
             */
             'col-span-3': (!image.url && fullWidth) || footerType,
           })}

--- a/resources/assets/components/utilities/CivicEngineVoterWidget/CivicEngineVoterWidget.js
+++ b/resources/assets/components/utilities/CivicEngineVoterWidget/CivicEngineVoterWidget.js
@@ -11,7 +11,7 @@ import React from 'react';
  */
 const CivicEngineVoterWidget = () => (
   <iframe
-    height="520"
+    height="180"
     src="https://app.requestballot.civicengine.com/w/address?utm_source=DST"
     title="Voter Widget"
     width="100%"


### PR DESCRIPTION
### What's this PR do?

This pull request decreases the `height` value of the iframe used to render the Voter Widget, and adjusts its width to be the full width of its parent `ContentBlock`.

<img width="600" alt="StoryPage example" src="https://user-images.githubusercontent.com/1236811/95385556-01557000-08a3-11eb-87c1-7cf96dbd7838.png">

### How should this be reviewed?

I've created a sample story page on dev, `/stories/voter-widget`, and will link to the review app upon building.

### Any background context you want to provide?

The addresses do get cut off with this height change, but seems better than having such a large vertical space in-between elements on the page. Anything smaller than this height change will begin to cut off the bottom of the red CTA button.

<img width="400" alt="Screen Shot 2020-10-07 at 1 24 02 PM" src="https://user-images.githubusercontent.com/1236811/95385243-88eeaf00-08a2-11eb-99a5-774d1790f5d7.png">


### Relevant tickets

References [Pivotal #175148561](https://www.pivotaltracker.com/story/show/175148561).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added screenshots of front-end changes on small, medium, and large screens.
- [ ] Added appropriate feature/unit tests.
