### PR TITLE
Appends utm_campaign values to voter registration source_details

### DIFF
--- a/resources/assets/helpers/voter-registration.js
+++ b/resources/assets/helpers/voter-registration.js
@@ -1,3 +1,4 @@
+import { query } from './index';
 import { getUserId } from './auth';
 import { selfReportedVoterRegistrationConfirmedStatuses } from '../components/utilities/SitewideBanner/config';
 
@@ -32,9 +33,10 @@ export function getGoalInfo(goalAmount, completedAmount) {
  * @return {String}
  */
 export function getTrackingSource(sourceDetails, referrerUserId, groupId) {
+  const utmCampaign = query('utm_campaign');
   const result = `source:web,source_details:${sourceDetails}${
-    groupId ? `,group_id=${groupId}` : ''
-  }`;
+    utmCampaign ? `_${utmCampaign}` : ''
+  }${groupId ? `,group_id=${groupId}` : ''}`;
 
   if (referrerUserId) {
     return `user:${referrerUserId},${result},referral=true`;

--- a/resources/assets/helpers/voter-registration.js
+++ b/resources/assets/helpers/voter-registration.js
@@ -1,4 +1,4 @@
-import { query } from './index';
+import { getUtms } from './utm';
 import { getUserId } from './auth';
 import { selfReportedVoterRegistrationConfirmedStatuses } from '../components/utilities/SitewideBanner/config';
 
@@ -33,7 +33,9 @@ export function getGoalInfo(goalAmount, completedAmount) {
  * @return {String}
  */
 export function getTrackingSource(sourceDetails, referrerUserId, groupId) {
-  const utmCampaign = query('utm_campaign');
+  const utmCampaign = getUtms().utm_campaign;
+
+  // If utmCampaign exists, append it to source details value.
   const result = `source:web,source_details:${sourceDetails}${
     utmCampaign ? `_${utmCampaign}` : ''
   }${groupId ? `,group_id=${groupId}` : ''}`;

--- a/resources/assets/helpers/voter-registration.test.js
+++ b/resources/assets/helpers/voter-registration.test.js
@@ -65,4 +65,18 @@ describe('getTrackingSource', () => {
       'user:5edfc80ecb4dbf2020580a76,source:web,source_details:abc,group_id=81,referral=true',
     );
   });
+
+  /** @test */
+  it('Appends utm_campaign to source_details if present', () => {
+    global.AUTH = {};
+    // Mock visiting with UTM parameters .
+    window.jsdom.reconfigure({
+      url:
+        'https://dev.dosomething.org/us/?utm_campaign=puppetsloth_youtube_s3e8',
+    });
+
+    expect(getTrackingSource('hellobar')).toEqual(
+      'source:web,source_details:hellobar_puppetsloth_youtube_s3e8',
+    );
+  });
 });


### PR DESCRIPTION
### What's this PR do?

This pull request uses our handy UTM helpers (courtesy of @weerd) to append `utm_campaign` values to the `source_details` of a voter registration tracking source, if UTMs are present.

Because the UTM helper persists the values, when the quiz campaign (/us/campaigns/ready-vote) redirects a user to a quiz result page (/us/quiz-results/:id) - the `utm_campaign` value is still present within the tracking source of the quiz result page.

### How should this be reviewed?

👀 

### Any background context you want to provide?

I manually tested the quiz in order to verify the `utm_campaign` was present within the `source_details` (by inspecting the page source after visiting the quiz with utms, and completing the quiz). It'd be ideal to add Cypress tests for the quiz, especially given its success in driving voter registrations... but it begs the question of whether we go all-in on supporting it as a feature. (If we do, it'd be worth a major rewrite to make it easier for editors configure)

### Relevant tickets

References [Pivotal #175101261](https://www.pivotaltracker.com/story/show/175101261).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added screenshots of front-end changes on small, medium, and large screens.
- [x] Added appropriate feature/unit tests.
