### PR TITLE
Change Voter Widget URL

### DIFF
--- a/docs/development/features/voter-registration.md
+++ b/docs/development/features/voter-registration.md
@@ -74,7 +74,7 @@ We host customized voter registration drives for influencers on our Instapage, b
 
 A [CivicEngine Voter Widget](https://developers.civicengine.com/docs/widget/) can be embedded in the footer of a [`ContentBlock`](development/content-types/content-block.md#content-type-fields).
 
-The Voter Widget is hosted on BallotReady - for 2020 we subscribed to maintain our own instance of the widget, instead of using the shared TMC instance (switch was made on October 13, 2020 from white-labelled to shared)
+The Voter Widget is hosted on BallotReady - for 2020 we subscribed to maintain our own instance of the widget, instead of using the shared TMC instance (switch was made on October 13, 2020 from shared to white-labelled)
 
 ![Content Block - CivicEngineVoterWidget footerType](../../.gitbook/assets/request-ballot-block.png)
 

--- a/docs/development/features/voter-registration.md
+++ b/docs/development/features/voter-registration.md
@@ -74,7 +74,7 @@ We host customized voter registration drives for influencers on our Instapage, b
 
 A [CivicEngine Voter Widget](https://developers.civicengine.com/docs/widget/) can be embedded in the footer of a [`ContentBlock`](development/content-types/content-block.md#content-type-fields).
 
-We share an instance of this Voter Widget on behalf The Movement Cooperative, who control its configuration. The Voter Widget will display a form to enter your address to a mail-in ballot until October 10, 2020. After October 10, it will display to enter your address to find your polling location.
+The Voter Widget is hosted on BallotReady - for 2020 we subscribed to maintain our own instance of the widget, instead of using the shared TMC instance (switch was made on October 13, 2020 from white-labelled to shared)
 
 ![Content Block - CivicEngineVoterWidget footerType](../../.gitbook/assets/request-ballot-block.png)
 

--- a/resources/assets/components/utilities/CivicEngineVoterWidget/CivicEngineVoterWidget.js
+++ b/resources/assets/components/utilities/CivicEngineVoterWidget/CivicEngineVoterWidget.js
@@ -1,24 +1,26 @@
 import React from 'react';
 
+import { getUtms } from '../../../helpers/utm';
+import { appendToQuery } from '../../../helpers';
+
 /*
- * Embeds a CivicEngine Voter Widget.
- * @see https://developers.civicengine.com/docs/widget
+ * Renders a CivicEngine Voter Widget via the Bronze Level embed.
+ * @see https://developers.civicengine.com/docs/widget/#bronze-level-widget-instructions
  *
- * A utm_source parameter is used to track a submission on behalf of DoSomething.
  * Although the docs claim bronze level (using an iframe) does not support UTM params, an email
- * from Ballot Ready to us says this should still send through the utm_source correctly.
+ * from Ballot Ready to us says this should still send through the UTM's correctly.
  * @see https://www.pivotaltracker.com/story/show/174199686
  */
-const CivicEngineVoterWidget = () => {
-  // TODO: Append UTM parameters to src URL
-  return (
-    <iframe
-      height="180"
-      src="https://app.dosomething.civicengine.com/w/address"
-      title="Voter Widget"
-      width="100%"
-    />
-  );
-};
+const CivicEngineVoterWidget = () => (
+  <iframe
+    height="180"
+    src={appendToQuery(
+      getUtms(),
+      'https://app.dosomething.civicengine.com/w/address',
+    )}
+    title="Voter Widget"
+    width="100%"
+  />
+);
 
 export default CivicEngineVoterWidget;

--- a/resources/assets/components/utilities/CivicEngineVoterWidget/CivicEngineVoterWidget.js
+++ b/resources/assets/components/utilities/CivicEngineVoterWidget/CivicEngineVoterWidget.js
@@ -9,13 +9,16 @@ import React from 'react';
  * from Ballot Ready to us says this should still send through the utm_source correctly.
  * @see https://www.pivotaltracker.com/story/show/174199686
  */
-const CivicEngineVoterWidget = () => (
-  <iframe
-    height="180"
-    src="https://app.requestballot.civicengine.com/w/address?utm_source=DST"
-    title="Voter Widget"
-    width="100%"
-  />
-);
+const CivicEngineVoterWidget = () => {
+  // TODO: Append UTM parameters to src URL
+  return (
+    <iframe
+      height="180"
+      src="https://app.dosomething.civicengine.com/w/address"
+      title="Voter Widget"
+      width="100%"
+    />
+  );
+};
 
 export default CivicEngineVoterWidget;


### PR DESCRIPTION
### What's this PR do?

This pull request changes iframe src to our white-labelled instance of the CivicEngine Voter Widget, instead of the shared TMC instance.

Because we're using our own white-labelled instance, we don't need to pass `DST` as the `utm_source` for TMC to filter out our submissions, and instead can send through any UTM's found in the URL.

### How should this be reviewed?

👀 

### Any background context you want to provide?

♻️ 

### Relevant tickets

References [Pivotal #175170981](https://www.pivotaltracker.com/story/show/175170981), [#175194203](https://www.pivotaltracker.com/story/show/175194203)

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [x] Documentation added for new features/changed endpoints.
- [ ] Added screenshots of front-end changes on small, medium, and large screens.
- [ ] Added appropriate feature/unit tests.
