### PR TITLE
Club Finder in Pages

### DIFF
--- a/contentful/content-types/page.js
+++ b/contentful/content-types/page.js
@@ -163,6 +163,7 @@ module.exports = function(migration) {
             'callToAction',
             'campaignUpdate',
             'contentBlock',
+            'currentClubBlock',
             'currentSchoolBlock',
             'customBlock',
             'embed',

--- a/contentful/content-types/page.js
+++ b/contentful/content-types/page.js
@@ -208,22 +208,6 @@ module.exports = function(migration) {
     .validations([])
     .disabled(false)
     .omitted(false);
-
-  page
-    .createField('socialOverride')
-    .name('Social Override')
-    .type('Link')
-    .localized(false)
-    .required(false)
-    .validations([
-      {
-        linkContentType: ['socialOverride'],
-      },
-    ])
-    .disabled(true)
-    .omitted(false)
-    .linkType('Entry');
-
   page
     .createField('additionalContent')
     .name('Additional Content')
@@ -248,13 +232,12 @@ module.exports = function(migration) {
   });
 
   page.changeFieldControl('metadata', 'builtin', 'entryLinkEditor', {});
-
-  page.changeFieldControl('authors', 'builtin', 'entryLinksEditor', {
-    bulkEditing: false,
-  });
+  page.changeFieldControl('authors', 'builtin', 'entryLinksEditor', {});
 
   page.changeFieldControl('coverImage', 'builtin', 'assetLinkEditor', {
     helpText: 'The cover image will display on the page before the content.',
+    showLinkEntityAction: true,
+    showCreateEntityAction: true,
   });
 
   page.changeFieldControl('content', 'builtin', 'markdown', {});
@@ -277,6 +260,5 @@ module.exports = function(migration) {
     falseLabel: 'No',
   });
 
-  page.changeFieldControl('socialOverride', 'builtin', 'entryLinkEditor', {});
   page.changeFieldControl('additionalContent', 'builtin', 'objectEditor', {});
 };


### PR DESCRIPTION
### What's this PR do?

This pull request adds the CurrentClubBlock as a valid referenced link in the `Page#blocks` field (for campaign pages & articles)

### How should this be reviewed?
👀 

### Any background context you want to provide?
This allows us to embed the club finder in campaigns.

### Relevant tickets

References [Pivotal #174958715](https://www.pivotaltracker.com/story/show/174958715).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [x] Added screenshots of front-end changes on small, medium, and large screens.
- [ ] Added appropriate feature/unit tests.


![image](https://user-images.githubusercontent.com/12417657/96301342-0dd57900-0fc5-11eb-8bb6-2868b8d8ea67.png)

![image](https://user-images.githubusercontent.com/12417657/96301369-1928a480-0fc5-11eb-9dc8-8d7f96469480.png)
