### PR TITLE
Removes sticky css on hellobar

### DIFF
--- a/resources/views/layouts/master.blade.php
+++ b/resources/views/layouts/master.blade.php
@@ -33,7 +33,7 @@
     @endif
 
     <div id="fb-root"></div>
-    <div id="banner-portal" class="top-0 left-0 w-full block sticky z-1000" role="presentation"></div>
+    <div id="banner-portal" class="top-0 left-0 w-full block z-1000" role="presentation"></div>
     <div id="chrome" class="chrome min-h-screen w-full">
         @yield('content')
     </div>


### PR DESCRIPTION
### What's this PR do?

This pull request removes the tailwind style that made the helloBar sticky. Now that VR is wrapping up, we don't need to continue keeping it visible as aggressively. 

### How should this be reviewed?

👀 

### Any background context you want to provide?

n/a

### Relevant tickets

References [Pivotal #175211031](https://www.pivotaltracker.com/story/show/175211031).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added screenshots of front-end changes on small, medium, and large screens.
- [ ] Added appropriate feature/unit tests.
