### PR TITLE
Update HomePage.js

### DIFF
--- a/resources/assets/components/pages/HomePage/HomePage.js
+++ b/resources/assets/components/pages/HomePage/HomePage.js
@@ -220,6 +220,12 @@ const HomePageTemplate = ({ articles, campaigns, coverImage, title }) => {
             >
               <div className="bg-blurple-500 py-4 grid-wide xl:grid xl:grid-cols-3">
                 <ImpactStatistic
+                  campaignName="We are The Voters"
+                  impactLabel="Voters Registered"
+                  impactValue="350,000"
+                />
+
+                <ImpactStatistic
                   campaignName="Teens for Jeans"
                   impactLabel="Jeans Donated"
                   impactValue="5 million"
@@ -229,12 +235,6 @@ const HomePageTemplate = ({ articles, campaigns, coverImage, title }) => {
                   campaignName="GTFO (Get The Filter Out)"
                   impactLabel="Cigarette Butts Collected"
                   impactValue="3.7 million"
-                />
-
-                <ImpactStatistic
-                  campaignName="Power to the Period"
-                  impactLabel="Period Products Donated"
-                  impactValue="585,965"
                 />
               </div>
             </div>


### PR DESCRIPTION
### What's this PR do?

This pull request updates the homepage impact banner with VR stats

### How should this be reviewed?
🔢 
...

### Any background context you want to provide?

Marketing wants to update the hard-coded Homepage stats bar with VR-related stats.
...

### Relevant tickets

References [Pivotal #175210939](https://www.pivotaltracker.com/n/projects/2401401/stories/175210939).

### Checklist
Current:
<img width="1289" alt="Screen Shot 2020-10-20 at 6 55 24 PM" src="https://user-images.githubusercontent.com/20409413/96654501-7300d580-1309-11eb-938a-830d5de54a41.png">

Suggested changes:
<img width="1334" alt="Screen Shot 2020-10-20 at 7 15 19 PM" src="https://user-images.githubusercontent.com/20409413/96654526-814ef180-1309-11eb-99dd-adcf3e33a77e.png">
Mobile: 
<img width="356" alt="Screen Shot 2020-10-20 at 7 20 00 PM" src="https://user-images.githubusercontent.com/20409413/96654567-a0e61a00-1309-11eb-991f-696fec139936.png">


- [ x  ] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ x  ] Added screenshots of front-end changes on small, medium, and large screens.
- [ ] Added appropriate feature/unit tests.
