### PR TITLE
Gallery Block "Content Block" gallery type

### DIFF
--- a/contentful/content-types/galleryBlock.js
+++ b/contentful/content-types/galleryBlock.js
@@ -24,6 +24,21 @@ module.exports = function(migration) {
     .omitted(false);
 
   galleryBlock
+    .createField('galleryType')
+    .name('Gallery Type')
+    .type('Symbol')
+    .localized(false)
+    .required(true)
+    .validations([
+      {
+        in: ['Campaign', 'Scholarship', 'Page', 'Person', 'External Link'],
+        message: 'Please choose a gallery type.',
+      },
+    ])
+    .disabled(false)
+    .omitted(false);
+
+  galleryBlock
     .createField('blocks')
     .name('Blocks')
     .type('Array')
@@ -37,7 +52,13 @@ module.exports = function(migration) {
 
       validations: [
         {
-          linkContentType: ['campaign', 'contentBlock', 'page', 'person'],
+          linkContentType: [
+            'campaign',
+            'contentBlock',
+            'page',
+            'person',
+            'storyPage',
+          ],
         },
       ],
 
@@ -89,8 +110,14 @@ module.exports = function(migration) {
   galleryBlock.changeFieldControl('internalTitle', 'builtin', 'singleLine', {});
   galleryBlock.changeFieldControl('title', 'builtin', 'singleLine', {});
 
+  galleryBlock.changeFieldControl('galleryType', 'builtin', 'dropdown', {
+    helpText: 'Choose a gallery type that matches your content.',
+  });
+
   galleryBlock.changeFieldControl('blocks', 'builtin', 'entryLinksEditor', {
     bulkEditing: false,
+    showLinkEntityAction: true,
+    showCreateEntityAction: true,
   });
 
   galleryBlock.changeFieldControl('itemsPerRow', 'builtin', 'radio', {

--- a/contentful/content-types/galleryBlock.js
+++ b/contentful/content-types/galleryBlock.js
@@ -111,10 +111,13 @@ module.exports = function(migration) {
   galleryBlock.changeFieldControl('title', 'builtin', 'singleLine', {});
 
   galleryBlock.changeFieldControl('galleryType', 'builtin', 'dropdown', {
-    helpText: 'Choose a gallery type that matches your content.',
+    helpText:
+      'Choose a gallery type that directly matches your referenced entry types. ("Scholarship": a list of Campaigns embellished with scholarship info. The "External Link" has been updated to "Content Block").',
   });
 
   galleryBlock.changeFieldControl('blocks', 'builtin', 'entryLinksEditor', {
+    helpText:
+      "The list of entries displayed in the gallery. These entries must all be of the *same type*, e.g. a list of Campaign entries. You shouldn't mix and match content types.",
     bulkEditing: false,
     showLinkEntityAction: true,
     showCreateEntityAction: true,

--- a/contentful/content-types/galleryBlock.js
+++ b/contentful/content-types/galleryBlock.js
@@ -31,7 +31,7 @@ module.exports = function(migration) {
     .required(true)
     .validations([
       {
-        in: ['Campaign', 'Scholarship', 'Page', 'Person', 'External Link'],
+        in: ['Campaign', 'Scholarship', 'Page', 'Person', 'Content Block'],
         message: 'Please choose a gallery type.',
       },
     ])

--- a/cypress/integration/gallery-block.js
+++ b/cypress/integration/gallery-block.js
@@ -1,0 +1,39 @@
+/// <reference types="Cypress" />
+import { userFactory } from '../fixtures/user';
+
+describe('Gallery Block', () => {
+  beforeEach(() => cy.configureMocks());
+
+  const blockId = 'abcdefghi123456789';
+
+  /** @test */
+  it.only('renders a ContentBlockGalleryItem component for "EXTERNAL_LINK" blocks', () => {
+    cy.mockGraphqlOp('ContentfulBlockQuery', {
+      block: {
+        __typename: 'GalleryBlock',
+        galleryType: 'EXTERNAL_LINK',
+        blocks: [{ __typename: 'ContentBlock' }],
+      },
+    });
+
+    cy.visit(`us/blocks/${blockId}`);
+
+    cy.findByTestId('content-block-gallery-item');
+  });
+
+  // @TODO: Activate this test once we've deployed https://git.io/JTuoE and pulled in the new schema.
+  // /** @test */
+  // it.only('renders a ContentBlockGalleryItem component for "CONTENT_BLOCK" blocks', () => {
+  //   cy.mockGraphqlOp('ContentfulBlockQuery', {
+  //     block: {
+  //       __typename: 'GalleryBlock',
+  //       galleryType: 'CONTENT_BLOCK',
+  //       blocks: [{ __typename: 'ContentBlock' }],
+  //     },
+  //   });
+
+  //   cy.visit(`us/blocks/${blockId}`);
+
+  //   cy.findByTestId('content-block-gallery-item');
+  // });
+});

--- a/resources/assets/components/blocks/GalleryBlock/GalleryBlock.js
+++ b/resources/assets/components/blocks/GalleryBlock/GalleryBlock.js
@@ -76,6 +76,8 @@ const renderBlock = (blockType, block, imageAlignment, imageFit) => {
         />
       );
 
+    // @TODO: Deprecate 'EXTERNAL_LINK' once we've deployed GraphQL schema updates in https://git.io/JTuoE.
+    case 'EXTERNAL_LINK':
     case 'CONTENT_BLOCK':
     case 'ContentBlock':
       return (
@@ -142,6 +144,7 @@ GalleryBlock.propTypes = {
     'SCHOLARSHIP',
     'PAGE',
     'CONTENT_BLOCK',
+    'EXTERNAL_LINK',
   ]),
   blocks: PropTypes.arrayOf(PropTypes.object).isRequired,
   itemsPerRow: PropTypes.oneOf([2, 3, 4, 5]).isRequired,

--- a/resources/assets/components/blocks/GalleryBlock/GalleryBlock.js
+++ b/resources/assets/components/blocks/GalleryBlock/GalleryBlock.js
@@ -76,7 +76,7 @@ const renderBlock = (blockType, block, imageAlignment, imageFit) => {
         />
       );
 
-    case 'EXTERNAL_LINK':
+    case 'CONTENT_BLOCK':
     case 'ContentBlock':
       return (
         <ContentBlockGalleryItem
@@ -141,7 +141,7 @@ GalleryBlock.propTypes = {
     'CAMPAIGN',
     'SCHOLARSHIP',
     'PAGE',
-    'EXTERNAL_LINK',
+    'CONTENT_BLOCK',
   ]),
   blocks: PropTypes.arrayOf(PropTypes.object).isRequired,
   itemsPerRow: PropTypes.oneOf([2, 3, 4, 5]).isRequired,

--- a/resources/assets/components/utilities/Figure/Figure.js
+++ b/resources/assets/components/utilities/Figure/Figure.js
@@ -8,6 +8,7 @@ import { modifiers } from '../../../helpers';
 import './figure.scss';
 
 export const BaseFigure = ({
+  attributes,
   alignment,
   verticalAlignment,
   media,
@@ -21,6 +22,7 @@ export const BaseFigure = ({
       className,
       modifiers(alignment, verticalAlignment, size),
     )}
+    {...attributes}
   >
     <div className="figure__media">{media}</div>
     <div className="figure__body">{children}</div>
@@ -28,6 +30,7 @@ export const BaseFigure = ({
 );
 
 BaseFigure.propTypes = {
+  attributes: PropTypes.object,
   className: PropTypes.string,
   children: PropTypes.node,
   alignment: PropTypes.oneOf([
@@ -42,6 +45,7 @@ BaseFigure.propTypes = {
 };
 
 BaseFigure.defaultProps = {
+  attributes: {},
   className: null,
   alignment: null,
   children: null,

--- a/resources/assets/components/utilities/Gallery/templates/ContentBlockGalleryItem.js
+++ b/resources/assets/components/utilities/Gallery/templates/ContentBlockGalleryItem.js
@@ -23,6 +23,7 @@ const ContentBlockGalleryItem = ({
 
   return (
     <Figure
+      attributes={{ 'data-testid': 'content-block-gallery-item' }}
       alt={showcaseImage.description || `${showcaseTitle}-photo`}
       image={contentfulImageUrl(
         get(showcaseImage, 'url'),


### PR DESCRIPTION
### What's this PR do?

This pull request adds a new `CONTENT_BLOCK` gallery type to the `GalleryBlock`. We'll retire the legacy `EXTERNAL_LINK` which this is replacing once we deploy https://github.com/DoSomething/graphql/pull/291 which will convert legacy blocks to the new format for backward compatibility.

It also adds a very basic Gallery Block test to cover this backward compatibility. I wanted to add a more robust suite and some documentation, but alas the relentless waves of time.

### How should this be reviewed?
👀 

### Any background context you want to provide?
This has been a point of confusion for editors!

### Relevant tickets

References [Pivotal #174048432](https://www.pivotaltracker.com/story/show/174048432).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added screenshots of front-end changes on small, medium, and large screens.
- [x] Added appropriate feature/unit tests.
