### PR TITLE
Retire Gallery Block "External Link" gallery type

### DIFF
--- a/cypress/integration/gallery-block.js
+++ b/cypress/integration/gallery-block.js
@@ -4,36 +4,18 @@ import { userFactory } from '../fixtures/user';
 describe('Gallery Block', () => {
   beforeEach(() => cy.configureMocks());
 
-  const blockId = 'abcdefghi123456789';
-
   /** @test */
-  it.only('renders a ContentBlockGalleryItem component for "EXTERNAL_LINK" blocks', () => {
+  it.only('renders a ContentBlockGalleryItem component for "CONTENT_BLOCK" blocks', () => {
     cy.mockGraphqlOp('ContentfulBlockQuery', {
       block: {
         __typename: 'GalleryBlock',
-        galleryType: 'EXTERNAL_LINK',
+        galleryType: 'CONTENT_BLOCK',
         blocks: [{ __typename: 'ContentBlock' }],
       },
     });
 
-    cy.visit(`us/blocks/${blockId}`);
+    cy.visit('us/blocks/abcdefghi123456789');
 
     cy.findByTestId('content-block-gallery-item');
   });
-
-  // @TODO: Activate this test once we've deployed https://git.io/JTuoE and pulled in the new schema.
-  // /** @test */
-  // it.only('renders a ContentBlockGalleryItem component for "CONTENT_BLOCK" blocks', () => {
-  //   cy.mockGraphqlOp('ContentfulBlockQuery', {
-  //     block: {
-  //       __typename: 'GalleryBlock',
-  //       galleryType: 'CONTENT_BLOCK',
-  //       blocks: [{ __typename: 'ContentBlock' }],
-  //     },
-  //   });
-
-  //   cy.visit(`us/blocks/${blockId}`);
-
-  //   cy.findByTestId('content-block-gallery-item');
-  // });
 });

--- a/resources/assets/components/blocks/GalleryBlock/GalleryBlock.js
+++ b/resources/assets/components/blocks/GalleryBlock/GalleryBlock.js
@@ -76,8 +76,6 @@ const renderBlock = (blockType, block, imageAlignment, imageFit) => {
         />
       );
 
-    // @TODO: Deprecate 'EXTERNAL_LINK' once we've deployed GraphQL schema updates in https://git.io/JTuoE.
-    case 'EXTERNAL_LINK':
     case 'CONTENT_BLOCK':
     case 'ContentBlock':
       return (
@@ -144,7 +142,6 @@ GalleryBlock.propTypes = {
     'SCHOLARSHIP',
     'PAGE',
     'CONTENT_BLOCK',
-    'EXTERNAL_LINK',
   ]),
   blocks: PropTypes.arrayOf(PropTypes.object).isRequired,
   itemsPerRow: PropTypes.oneOf([2, 3, 4, 5]).isRequired,

--- a/schema.json
+++ b/schema.json
@@ -13532,18 +13532,6 @@
             "deprecationReason": null
           },
           {
-            "name": "previewImage",
-            "description": "A preview image of the embed content. If set, replaces the embed on smaller screens.",
-            "args": [],
-            "type": {
-              "kind": "OBJECT",
-              "name": "Asset",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
             "name": "internalTitle",
             "description": "The internal-facing title for this block.",
             "args": [],
@@ -13897,7 +13885,7 @@
             "deprecationReason": null
           },
           {
-            "name": "EXTERNAL_LINK",
+            "name": "CONTENT_BLOCK",
             "description": null,
             "isDeprecated": false,
             "deprecationReason": null


### PR DESCRIPTION
### What's this PR do?

This pull request follows up on #2411 to retire the legacy `EXTERNAL_LINK` gallery type. It updates our schema per the new changes in GraphQL https://github.com/DoSomething/graphql/pull/291 and updates the test.

### How should this be reviewed?
👀 

### Any background context you want to provide?
We kept this alive to maintain backward compatibility with existing entries, but that's being resolved via GraphQL now. (Plus we've updated existing entries on Contentful, so we'll be sunsetting the GraphQL resolution shortly!)

### Relevant tickets

References [Pivotal #174048432](https://www.pivotaltracker.com/story/show/174048432).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added screenshots of front-end changes on small, medium, and large screens.
- [x] Added appropriate feature/unit tests.
