### PR TITLE
Customer.io Page View Tracking Script - Instapage Tracking

### DIFF
--- a/public/customer-io-page-views.js
+++ b/public/customer-io-page-views.js
@@ -1,0 +1,40 @@
+function parseQuery(queryString) {
+  var query = {};
+  var pairs = (queryString[0] === '?'
+    ? queryString.substr(1)
+    : queryString
+  ).split('&');
+  for (var i = 0; i < pairs.length; i++) {
+    var pair = pairs[i].split('=');
+    query[decodeURIComponent(pair[0])] = decodeURIComponent(pair[1] || '');
+  }
+  return query;
+}
+
+var query = parseQuery(window.location.search);
+
+if (query.test_cio_pageview && query.user_id) {
+  var _cio = _cio || [];
+
+  (function() {
+    var a, b, c;
+    a = function(f) {
+      return function() {
+        _cio.push([f].concat(Array.prototype.slice.call(arguments, 0)));
+      };
+    };
+    b = ['identify', 'track'];
+    for (c = 0; c < b.length; c++) {
+      _cio[b[c]] = a(b[c]);
+    }
+    var t = document.createElement('script'),
+      s = document.getElementsByTagName('script')[0];
+    t.async = true;
+    t.id = 'cio-tracker';
+    t.setAttribute('data-site-id', 'c4797aae91625d7068c9');
+    t.src = 'https://assets.customer.io/assets/track.js';
+    s.parentNode.insertBefore(t, s);
+  })();
+
+  _cio.identify({ id: query.user_id });
+}

--- a/public/customer-io-page-views.js
+++ b/public/customer-io-page-views.js
@@ -4,10 +4,12 @@ function parseQuery(queryString) {
     ? queryString.substr(1)
     : queryString
   ).split('&');
+
   for (var i = 0; i < pairs.length; i++) {
     var pair = pairs[i].split('=');
     query[decodeURIComponent(pair[0])] = decodeURIComponent(pair[1] || '');
   }
+ 
   return query;
 }
 

--- a/public/customer-io-page-views.js
+++ b/public/customer-io-page-views.js
@@ -29,8 +29,10 @@ if (query.test_cio_pageview && query.user_id) {
     for (c = 0; c < b.length; c++) {
       _cio[b[c]] = a(b[c]);
     }
+
     var t = document.createElement('script'),
       s = document.getElementsByTagName('script')[0];
+ 
     t.async = true;
     t.id = 'cio-tracker';
     t.setAttribute('data-site-id', 'c4797aae91625d7068c9');


### PR DESCRIPTION
### What's this PR do?

This pull request sets up a _beta_ tracking script in `/public`, to enable importing this file on Instapages to track pageviews from SMS broadcast links to customer.io.

"Feature flagged" behind a `test_cio_pageview` query parameter.

### How should this be reviewed?
👀 

### Any background context you want to provide?
- I copied the actual script from our existing c.io [tracking script](https://github.com/DoSomething/phoenix-next/blob/84d0010bbceb6c869f94457345b06349d4f24272/resources/views/partials/customer_io_script.blade.php)
- I copied the `parseQuery` method from an existing script on our ["member drive" instapage](https://app.instapage.com/dashboard2/pages/2929481(experience-settings:_/20183660)) which contains a script that similarly, parses out a `userId` param
- This is a test to ensure that the script will load properly on our instapages and track to c.io. I've tested with a local ngrok server successfully
- We'll need to add some logic to account for RTV friendly query params, where the user ID is encoded differently (and also add a conditional to filter for SMS broadcasts)

### Relevant tickets

References [Pivotal #175078913](https://www.pivotaltracker.com/story/show/175078913).
https://dosomething.slack.com/archives/CUQMU4Q6B/p1603484970011100

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added screenshots of front-end changes on small, medium, and large screens.
- [ ] Added appropriate feature/unit tests.
