### PR TITLE
Grab `affirmationContent` from `PhotoSubmissionAction`

### DIFF
--- a/resources/assets/components/pages/ShowSubmissionPage/ShowSubmissionPage.js
+++ b/resources/assets/components/pages/ShowSubmissionPage/ShowSubmissionPage.js
@@ -1,27 +1,24 @@
 import React from 'react';
 import gql from 'graphql-tag';
-import { useQuery } from '@apollo/react-hooks';
 
-import Card from '../../utilities/Card/Card';
-import Spinner from '../../artifacts/Spinner/Spinner';
+import { query } from '../../../helpers';
+import Query from '../../Query';
 import SiteFooter from '../../utilities/SiteFooter/SiteFooter';
 import SiteNavigationContainer from '../../SiteNavigation/SiteNavigationContainer';
 
 export const GET_AFFIRMATION_CONTENT = gql`
   query submissionActionIdQuery($id: String!) {
-    block(id: $submissionActionId)
+    block(id: $id) {
+      id
+      ... on PhotoSubmissionBlock {
+        affirmationContent
+      }
+    }
   }
 `;
 
-const ShowSubmissionPage = id => {
-  const { loading, error, data } = useQuery(GET_AFFIRMATION_CONTENT, {
-    variables: { id },
-    skip: !id,
-  });
-
-  <Card className="bordered rounded" title={title}>
-    {loading ? <Spinner className="flex justify-center p-16" /> : null}
-  </Card>;
+const ShowSubmissionPage = () => {
+  const id = query('submissionActionId');
 
   return (
     <>
@@ -32,11 +29,20 @@ const ShowSubmissionPage = id => {
           <h1 className="uppercase text-3xl md:text-4xl font-league-gothic font-normal">
             We Got Your Submission
           </h1>
-          <p>
-            Thanks for joining the movement! After we review your submission,
-            we&apos;ll add it to the public gallery alongside submissions from
-            all the other members taking action in this campaign.
-          </p>
+          <Query query={GET_AFFIRMATION_CONTENT} variables={{ id }}>
+            {data => {
+              return (
+                data.block.affirmationContent || (
+                  <p>
+                    Thanks for joining the movement! After we review your
+                    submission, we&apos;ll add it to the public gallery
+                    alongside submissions from all the other members taking
+                    action in this campaign.
+                  </p>
+                )
+              );
+            }}
+          </Query>
         </div>
       </main>
 

--- a/resources/assets/components/pages/ShowSubmissionPage/ShowSubmissionPage.js
+++ b/resources/assets/components/pages/ShowSubmissionPage/ShowSubmissionPage.js
@@ -11,6 +11,7 @@ const ShowSubmissionPage = () => {
   const id = query('submissionActionId');
   const defaultContent =
     'Thanks for joining the movement! After we review your submission, we&apos;ll add it to the public gallery alongside submissions from all the other members taking action in this campaign.';
+
   return (
     <>
       <SiteNavigationContainer />

--- a/resources/assets/components/pages/ShowSubmissionPage/ShowSubmissionPage.js
+++ b/resources/assets/components/pages/ShowSubmissionPage/ShowSubmissionPage.js
@@ -1,22 +1,11 @@
 import React from 'react';
-import gql from 'graphql-tag';
 
 import Query from '../../Query';
 import { query } from '../../../helpers';
 import SiteFooter from '../../utilities/SiteFooter/SiteFooter';
 import TextContent from '../../utilities/TextContent/TextContent';
 import SiteNavigationContainer from '../../SiteNavigation/SiteNavigationContainer';
-
-export const CONTENTFUL_BLOCK_QUERY = gql`
-  query ContentfulBlockQuery($id: String!) {
-    block(id: $id) {
-      id
-      ... on PhotoSubmissionBlock {
-        affirmationContent
-      }
-    }
-  }
-`;
+import { CONTENTFUL_BLOCK_QUERY } from '../../utilities/ContentfulEntryLoader/ContentfulEntryLoader';
 
 const ShowSubmissionPage = () => {
   const id = query('submissionActionId');
@@ -32,7 +21,10 @@ const ShowSubmissionPage = () => {
             We Got Your Submission
           </h1>
           {id ? (
-            <Query query={CONTENTFUL_BLOCK_QUERY} variables={{ id }}>
+            <Query
+              query={CONTENTFUL_BLOCK_QUERY}
+              variables={{ id, preview: false }}
+            >
               {data =>
                 data.block.affirmationContent ? (
                   <TextContent className="mb-6">

--- a/resources/assets/components/pages/ShowSubmissionPage/ShowSubmissionPage.js
+++ b/resources/assets/components/pages/ShowSubmissionPage/ShowSubmissionPage.js
@@ -1,7 +1,9 @@
 import React from 'react';
 import gql from 'graphql-tag';
+import { useQuery } from '@apollo/react-hooks';
 
-import { query } from '../../../helpers';
+import Card from '../../utilities/Card/Card';
+import Spinner from '../../artifacts/Spinner/Spinner';
 import SiteFooter from '../../utilities/SiteFooter/SiteFooter';
 import SiteNavigationContainer from '../../SiteNavigation/SiteNavigationContainer';
 
@@ -11,9 +13,15 @@ export const GET_AFFIRMATION_CONTENT = gql`
   }
 `;
 
-const ShowSubmissionPage = () => {
-  const submissionActionId = query('submissionActionId');
-  console.log(submissionActionId);
+const ShowSubmissionPage = id => {
+  const { loading, error, data } = useQuery(GET_AFFIRMATION_CONTENT, {
+    variables: { id },
+    skip: !id,
+  });
+
+  <Card className="bordered rounded" title={title}>
+    {loading ? <Spinner className="flex justify-center p-16" /> : null}
+  </Card>;
 
   return (
     <>

--- a/resources/assets/components/pages/ShowSubmissionPage/ShowSubmissionPage.js
+++ b/resources/assets/components/pages/ShowSubmissionPage/ShowSubmissionPage.js
@@ -1,9 +1,10 @@
 import React from 'react';
 import gql from 'graphql-tag';
 
-import { query } from '../../../helpers';
 import Query from '../../Query';
+import { query } from '../../../helpers';
 import SiteFooter from '../../utilities/SiteFooter/SiteFooter';
+import TextContent from '../../utilities/TextContent/TextContent';
 import SiteNavigationContainer from '../../SiteNavigation/SiteNavigationContainer';
 
 export const GET_AFFIRMATION_CONTENT = gql`
@@ -34,6 +35,9 @@ const ShowSubmissionPage = () => {
               return (
                 data.block.affirmationContent || (
                   <p>
+                    <TextContent className="mb-6">
+                      {data.block.affirmationContent}
+                    </TextContent>
                     Thanks for joining the movement! After we review your
                     submission, we&apos;ll add it to the public gallery
                     alongside submissions from all the other members taking

--- a/resources/assets/components/pages/ShowSubmissionPage/ShowSubmissionPage.js
+++ b/resources/assets/components/pages/ShowSubmissionPage/ShowSubmissionPage.js
@@ -32,18 +32,17 @@ const ShowSubmissionPage = () => {
           </h1>
           <Query query={GET_AFFIRMATION_CONTENT} variables={{ id }}>
             {data => {
-              return (
-                data.block.affirmationContent || (
-                  <p>
-                    <TextContent className="mb-6">
-                      {data.block.affirmationContent}
-                    </TextContent>
-                    Thanks for joining the movement! After we review your
-                    submission, we&apos;ll add it to the public gallery
-                    alongside submissions from all the other members taking
-                    action in this campaign.
-                  </p>
-                )
+              return data.block.affirmationContent ? (
+                <TextContent className="mb-6">
+                  {data.block.affirmationContent}
+                </TextContent>
+              ) : (
+                <p>
+                  Thanks for joining the movement! After we review your
+                  submission, we&apos;ll add it to the public gallery alongside
+                  submissions from all the other members taking action in this
+                  campaign.
+                </p>
               );
             }}
           </Query>

--- a/resources/assets/components/pages/ShowSubmissionPage/ShowSubmissionPage.js
+++ b/resources/assets/components/pages/ShowSubmissionPage/ShowSubmissionPage.js
@@ -1,9 +1,20 @@
 import React from 'react';
+import gql from 'graphql-tag';
 
+import { query } from '../../../helpers';
 import SiteFooter from '../../utilities/SiteFooter/SiteFooter';
 import SiteNavigationContainer from '../../SiteNavigation/SiteNavigationContainer';
 
+export const GET_AFFIRMATION_CONTENT = gql`
+  query submissionActionIdQuery($id: String!) {
+    block(id: $submissionActionId)
+  }
+`;
+
 const ShowSubmissionPage = () => {
+  const submissionActionId = query('submissionActionId');
+  console.log(submissionActionId);
+
   return (
     <>
       <SiteNavigationContainer />

--- a/resources/assets/components/pages/ShowSubmissionPage/ShowSubmissionPage.js
+++ b/resources/assets/components/pages/ShowSubmissionPage/ShowSubmissionPage.js
@@ -7,8 +7,8 @@ import SiteFooter from '../../utilities/SiteFooter/SiteFooter';
 import TextContent from '../../utilities/TextContent/TextContent';
 import SiteNavigationContainer from '../../SiteNavigation/SiteNavigationContainer';
 
-export const GET_AFFIRMATION_CONTENT = gql`
-  query submissionActionIdQuery($id: String!) {
+export const CONTENTFUL_BLOCK_QUERY = gql`
+  query ContentfulBlockQuery($id: String!) {
     block(id: $id) {
       id
       ... on PhotoSubmissionBlock {
@@ -20,7 +20,8 @@ export const GET_AFFIRMATION_CONTENT = gql`
 
 const ShowSubmissionPage = () => {
   const id = query('submissionActionId');
-
+  const defaultContent =
+    'Thanks for joining the movement! After we review your submission, we&apos;ll add it to the public gallery alongside submissions from all the other members taking action in this campaign.';
   return (
     <>
       <SiteNavigationContainer />
@@ -30,25 +31,23 @@ const ShowSubmissionPage = () => {
           <h1 className="uppercase text-3xl md:text-4xl font-league-gothic font-normal">
             We Got Your Submission
           </h1>
-          <Query query={GET_AFFIRMATION_CONTENT} variables={{ id }}>
-            {data => {
-              return data.block.affirmationContent ? (
-                <TextContent className="mb-6">
-                  {data.block.affirmationContent}
-                </TextContent>
-              ) : (
-                <p>
-                  Thanks for joining the movement! After we review your
-                  submission, we&apos;ll add it to the public gallery alongside
-                  submissions from all the other members taking action in this
-                  campaign.
-                </p>
-              );
-            }}
-          </Query>
+          {id ? (
+            <Query query={CONTENTFUL_BLOCK_QUERY} variables={{ id }}>
+              {data =>
+                data.block.affirmationContent ? (
+                  <TextContent className="mb-6">
+                    {data.block.affirmationContent}
+                  </TextContent>
+                ) : null
+              }
+            </Query>
+          ) : (
+            <p>
+              <TextContent className="mb-6">{defaultContent}</TextContent>
+            </p>
+          )}
         </div>
       </main>
-
       <SiteFooter />
     </>
   );

--- a/resources/assets/components/utilities/ContentfulEntryLoader/ContentfulEntryLoader.js
+++ b/resources/assets/components/utilities/ContentfulEntryLoader/ContentfulEntryLoader.js
@@ -35,7 +35,7 @@ import { SelectionSubmissionBlockFragment } from '../../actions/SelectionSubmiss
 import { VoterRegistrationDriveBlockFragment } from '../../actions/VoterRegistrationDriveAction/VoterRegistrationDriveAction';
 import { VoterRegistrationReferralsBlockFragment } from '../../blocks/VoterRegistrationReferralsBlock/VoterRegistrationReferralsBlock';
 
-const CONTENTFUL_BLOCK_QUERY = gql`
+export const CONTENTFUL_BLOCK_QUERY = gql`
   query ContentfulBlockQuery($id: String!, $preview: Boolean!) {
     block(id: $id, preview: $preview) {
       id


### PR DESCRIPTION
### What's this PR do?

This pull request will allow affirmation copy to be editable in Contentful by providing a `submissionActionId`and allowing content to be queried according to the Id

### How should this be reviewed?

👀

### Any background context you want to provide?

This is part 1b of the Related Campaigns work

### Relevant tickets

References [Pivotal #174885003](https://www.pivotaltracker.com/story/show/174885003).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added screenshots of front-end changes on small, medium, and large screens.
- [ ] Added appropriate feature/unit tests.
