### PR TITLE
Track customer.io page view for SMS links

### DIFF
--- a/app/helpers.php
+++ b/app/helpers.php
@@ -473,3 +473,36 @@ function generate_streamed_csv($columns, $records)
 
     return fclose($file);
 }
+
+/**
+ * Determine if we should track a Customer.io page view.
+ *
+ * @return bool
+ */
+function should_track_customer_io_page_view()
+{
+    // Ensure we have a Customer.io space ID.
+    if !(config('services.analytics.customer_io_id')) {
+        return false;
+    }
+
+    // If the user is authenticated, we'll want to track their page view.
+    if (auth()->check()) {
+        return true;
+    }
+
+    // Otherwise, we'll only track the page view if we determine that they're visting a link recieved via a DoSomething SMS.
+    return request()->query('user_id') && request()->query('utm_medium') === 'sms';
+}
+
+/**
+ * Get the user ID to identify the user for a customer.io pageview event.
+ *
+ * @return string
+ */
+function get_user_id_for_customer_io()
+{
+    // We'll either grab the authenticated user's ID,
+    // or rely on the user_id query parameter for SMS links.
+    return auth()->id() ?: request()->query('user_id');
+}

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -482,7 +482,7 @@ function generate_streamed_csv($columns, $records)
 function should_track_customer_io_page_view()
 {
     // Ensure we have a Customer.io space ID.
-    if !(config('services.analytics.customer_io_id')) {
+    if (! config('services.analytics.customer_io_id')) {
         return false;
     }
 

--- a/docs/development/data-and-performance/analytics.md
+++ b/docs/development/data-and-performance/analytics.md
@@ -6,9 +6,11 @@ We track a series of analytics events and user interactions throughout the user 
 
 We use a few analytics services in Phoenix to track our events:
 
-- [Google Tag Manager](https://marketingplatform.google.com/about/tag-manager/). Events are also dispatched to GTM via the [Data Layer](https://support.google.com/tagmanager/answer/6164391?hl=en), and are dispatched over to Google Analytics).
+-   [Google Tag Manager](https://marketingplatform.google.com/about/tag-manager/). Events are also dispatched to GTM via the [Data Layer](https://support.google.com/tagmanager/answer/6164391?hl=en), and are dispatched over to Google Analytics).
 
-- [Snowplow](https://snowplowanalytics.com/). We dispatch events using the [Snowplow JS Tracker](https://github.com/snowplow/snowplow-javascript-tracker), which pushes events to our Snowplow config & data warehouse via [Fivetran](https://fivetran.com/).
+-   [Snowplow](https://snowplowanalytics.com/). We dispatch events using the [Snowplow JS Tracker](https://github.com/snowplow/snowplow-javascript-tracker), which pushes events to our Snowplow config & data warehouse via [Fivetran](https://fivetran.com/).
+
+-   [Customer.io](customer.io). We embed a [customer.io JS tracking snippet](https://git.io/JTdzk) to track [page views](https://customer.io/docs/pageviews) for authenticated users or users visiting a DoSomething SMS link (containing `utm_medium=sms` and `user_id` query parameters). _This excludes pages loaded without a full page refresh (e.g. switching tabs on the Account page), since the script is rendered from the server side on the initial page load_.
 
 ## Tracking an Event
 
@@ -16,9 +18,9 @@ _@TODO: Update this with the new naming conventions based on the assorted `metad
 
 To track a new event, simply import the `trackAnalyticsEvent` method from `/resources/assets/helpers/analytics.js` and pass it an object containing the following fields:
 
-- `metadata`: an object containing the `noun`, `verb`, optional `adjective`, `category`, `target`, and optional `label`.
-- `context` _(optional)_: an object containing contextual event information e.g. the `pageId` where the event took place.
-- `service` _optional_: define the singular service to track the event (e.g. `ga`). (The event will be dispatched to _all_ services by default).
+-   `metadata`: an object containing the `noun`, `verb`, optional `adjective`, `category`, `target`, and optional `label`.
+-   `context` _(optional)_: an object containing contextual event information e.g. the `pageId` where the event took place.
+-   `service` _optional_: define the singular service to track the event (e.g. `ga`). (The event will be dispatched to _all_ services by default).
 
 See listed events below for some examples.
 
@@ -69,15 +71,15 @@ We also track a Google Analytics [Pageview event](https://support.google.com/ana
 
 Here's a list of active [waypoint events]('../features/analytics-waypoint.md') labeled by their respective `context.name`s:
 
-- `petition_submission_action-top`, `petition_submission_action-bottom`
-- `text_submission_action-top`, `text_submission_action-top`
-- `section_block-top`, `section_block-bottom`
-- `voter_registration_action-top`, `voter_registration_action-bottom`
-- `share_action-top`, `share_action-bottom`
-- `link_action-top`, `link_action-bottom`
-- `photo_submission_action-top`, `photo_submission_action-bottom`
-- `landing_page_cta-top`, `landing_page_cta-bottom`
-- `embed-top`, `embed-bottom`
+-   `petition_submission_action-top`, `petition_submission_action-bottom`
+-   `text_submission_action-top`, `text_submission_action-top`
+-   `section_block-top`, `section_block-bottom`
+-   `voter_registration_action-top`, `voter_registration_action-bottom`
+-   `share_action-top`, `share_action-bottom`
+-   `link_action-top`, `link_action-bottom`
+-   `photo_submission_action-top`, `photo_submission_action-bottom`
+-   `landing_page_cta-top`, `landing_page_cta-bottom`
+-   `embed-top`, `embed-bottom`
 
 ### Events tracked by [Northstar](https://github.com/DoSomething/northstar)
 

--- a/resources/views/partials/customer_io_script.blade.php
+++ b/resources/views/partials/customer_io_script.blade.php
@@ -1,4 +1,4 @@
-@if(config('services.analytics.customer_io_id') && auth()->check())
+@if(should_track_customer_io_page_view())
     <script type="text/javascript">
         var _cio = _cio || [];
 
@@ -15,6 +15,6 @@
             s.parentNode.insertBefore(t, s);
         })();
 
-        _cio.identify({id: '{{ auth()->id() }}'});
+        _cio.identify({id: '{{ get_user_id_for_customer_io() }}' });
     </script>
 @endif

--- a/resources/views/partials/customer_io_script.blade.php
+++ b/resources/views/partials/customer_io_script.blade.php
@@ -1,5 +1,6 @@
 @if(should_track_customer_io_page_view())
     <script type="text/javascript">
+        {{-- https://customer.io/docs/javascript-quick-start --}}
         var _cio = _cio || [];
 
         (function() {


### PR DESCRIPTION
### What's this PR do?

This pull request updates our `customer_io__script` file to include [customer.io Page View](https://customer.io/docs/pageviews) tracking for URL visits determined to be links received via DoSomething SMS.

### How should this be reviewed?
Does the logic check out, is it clear?

### Any background context you want to provide?
Previously, we were only rendering the tracking snippet for _authenticated_ users whom we can identify via Northstar ID. Now, we'd be including URLs containing a `utm_medium=sms` determining this as an SMS link, and including a `user_id` query parameter (which these links typically will include) which we can use to identify the user for customer.io.

### Relevant tickets

References [Pivotal #175078023](https://www.pivotaltracker.com/story/show/175078023).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [x] Documentation added for new features/changed endpoints.
- [ ] Added screenshots of front-end changes on small, medium, and large screens.
- [ ] Added appropriate feature/unit tests.
