### PR TITLE
Cypress tests for SignupReferralsBlock

### DIFF
--- a/cypress/integration/signup-referrals-block.js
+++ b/cypress/integration/signup-referrals-block.js
@@ -72,6 +72,10 @@ describe('Signup Referrals Block', () => {
         'You have referred 1 person so far who has signed up for a campaign.',
       );
       cy.findAllByTestId('referrals-gallery').should('have.length', 1);
+      cy.findAllByTestId('referral-list-item-completed').should(
+        'have.length',
+        1,
+      );
     });
 
     it('Displays singular text if one unique referrerd user was found', () => {
@@ -90,6 +94,10 @@ describe('Signup Referrals Block', () => {
         'You have referred 1 person so far who has signed up for a campaign.',
       );
       cy.findAllByTestId('referrals-gallery').should('have.length', 1);
+      cy.findAllByTestId('referral-list-item-completed').should(
+        'have.length',
+        1,
+      );
     });
 
     it('Displays plural text if signup referrals were found for more than 1 unique referred user', () => {
@@ -108,6 +116,10 @@ describe('Signup Referrals Block', () => {
         'You have referred 2 people so far who have signed up for a campaign.',
       );
       cy.findAllByTestId('referrals-gallery').should('have.length', 1);
+      cy.findAllByTestId('referral-list-item-completed').should(
+        'have.length',
+        2,
+      );
     });
   });
 });

--- a/cypress/integration/signup-referrals-block.js
+++ b/cypress/integration/signup-referrals-block.js
@@ -78,7 +78,7 @@ describe('Signup Referrals Block', () => {
       );
     });
 
-    it('Displays singular text if one unique referrerd user was found', () => {
+    it('Displays singular text if one unique referred user was found', () => {
       const user = userFactory();
 
       cy.mockGraphqlOp('SignupReferrals', {

--- a/cypress/integration/signup-referrals-block.js
+++ b/cypress/integration/signup-referrals-block.js
@@ -16,23 +16,98 @@ const contentfulBlockQueryResult = {
 describe('Signup Referrals Block', () => {
   beforeEach(() => {
     cy.configureMocks();
-    cy.mockGraphqlOp('ContentfulBlockQuery', contentfulBlockQueryResult);
   });
 
-  it('Displays singular text if one signup referral was found', () => {
-    const user = userFactory();
-
-    cy.mockGraphqlOp('SignupReferrals', {
-      signups: [{ id: 11122016, group: null }],
+  describe('Section Header', () => {
+    beforeEach(() => {
+      cy.mockGraphqlOp('SignupReferrals', {
+        signups: [{ id: 11122016, group: null }],
+      });
     });
 
-    cy.authVisitBlockPermalink(user, blockId);
+    it('Displays default text if title null', () => {
+      const user = userFactory();
 
-    cy.get('.section-header__title').contains(
-      contentfulBlockQueryResult.block.title,
-    );
-    cy.findAllByTestId('referrals-count-description').contains(
-      'You have referred 1 person so far who has signed up for a campaign.',
-    );
+      cy.mockGraphqlOp('ContentfulBlockQuery', {
+        block: {
+          id: blockId,
+          __typename: 'SignupReferralsBlock',
+          title: null,
+        },
+      });
+
+      cy.authVisitBlockPermalink(user, blockId);
+
+      cy.get('.section-header__title').contains('Your Referrals');
+    });
+
+    it('Displays title field if present', () => {
+      const user = userFactory();
+
+      cy.mockGraphqlOp('ContentfulBlockQuery', contentfulBlockQueryResult);
+
+      cy.authVisitBlockPermalink(user, blockId);
+
+      cy.get('.section-header__title').contains(
+        contentfulBlockQueryResult.block.title,
+      );
+    });
+  });
+
+  describe('Referrals description', () => {
+    beforeEach(() => {
+      cy.mockGraphqlOp('ContentfulBlockQuery', contentfulBlockQueryResult);
+    });
+
+    it('Displays singular text if one signup referral was found', () => {
+      const user = userFactory();
+
+      cy.mockGraphqlOp('SignupReferrals', {
+        signups: [{ id: 11122016, group: null }],
+      });
+
+      cy.authVisitBlockPermalink(user, blockId);
+
+      cy.findAllByTestId('referrals-count-description').contains(
+        'You have referred 1 person so far who has signed up for a campaign.',
+      );
+      cy.findAllByTestId('referrals-gallery').should('have.length', 1);
+    });
+
+    it('Displays singular text if one unique referrerd user was found', () => {
+      const user = userFactory();
+
+      cy.mockGraphqlOp('SignupReferrals', {
+        signups: [
+          { id: 11122016, group: null, userId: '5554eac1a59dbf117e8b4567' },
+          { id: 11122019, group: null, userId: '5554eac1a59dbf117e8b4567' },
+        ],
+      });
+
+      cy.authVisitBlockPermalink(user, blockId);
+
+      cy.findAllByTestId('referrals-count-description').contains(
+        'You have referred 1 person so far who has signed up for a campaign.',
+      );
+      cy.findAllByTestId('referrals-gallery').should('have.length', 1);
+    });
+
+    it('Displays plural text if signup referrals were found for more than 1 unique referred user', () => {
+      const user = userFactory();
+
+      cy.mockGraphqlOp('SignupReferrals', {
+        signups: [
+          { id: 11122018, group: null, userId: '5554eac1a59dbf117e8b4567' },
+          { id: 13122016, group: null, userId: '557775e9a59dbf3b7a8b457b' },
+        ],
+      });
+
+      cy.authVisitBlockPermalink(user, blockId);
+
+      cy.findAllByTestId('referrals-count-description').contains(
+        'You have referred 2 people so far who have signed up for a campaign.',
+      );
+      cy.findAllByTestId('referrals-gallery').should('have.length', 1);
+    });
   });
 });

--- a/cypress/integration/signup-referrals-block.js
+++ b/cypress/integration/signup-referrals-block.js
@@ -1,0 +1,38 @@
+/// <reference types="Cypress" />
+import faker from 'faker';
+
+import { userFactory } from '../fixtures/user';
+
+const blockId = '2eDT9YCur8YhK0LskcFXNF';
+
+const contentfulBlockQueryResult = {
+  block: {
+    id: blockId,
+    __typename: 'SignupReferralsBlock',
+    title: faker.company.catchPhrase(),
+  },
+};
+
+describe('Signup Referrals Block', () => {
+  beforeEach(() => {
+    cy.configureMocks();
+    cy.mockGraphqlOp('ContentfulBlockQuery', contentfulBlockQueryResult);
+  });
+
+  it('Displays singular text if one signup referral was found', () => {
+    const user = userFactory();
+
+    cy.mockGraphqlOp('SignupReferrals', {
+      signups: [{ id: 11122016, group: null }],
+    });
+
+    cy.authVisitBlockPermalink(user, blockId);
+
+    cy.get('.section-header__title').contains(
+      contentfulBlockQueryResult.block.title,
+    );
+    cy.findAllByTestId('referrals-count-description').contains(
+      'You have referred 1 person so far who has signed up for a campaign.',
+    );
+  });
+});

--- a/resources/assets/components/blocks/SignupReferralsBlock/SignupReferralsBlock.js
+++ b/resources/assets/components/blocks/SignupReferralsBlock/SignupReferralsBlock.js
@@ -46,7 +46,7 @@ const SignupReferralsBlock = ({ title }) => (
 
         return (
           <>
-            <p className="mb-3">
+            <p className="mb-3" data-testid="referrals-count-description">
               You have referred{' '}
               <strong>
                 {numberOfReferrals} {pluralize('person', numberOfReferrals)}


### PR DESCRIPTION
### What's this PR do?

This pull request adds test coverage for the[ `SignupReferralsBlock`](https://github.com/DoSomething/phoenix-next/blob/master/resources/assets/components/blocks/SignupReferralsBlock/SignupReferralsBlock.js) component. We skipped tests for this because it had a go-live deadline at the time we developed it. 

### How should this be reviewed?

👀 

### Any background context you want to provide?

There's a start of [Jest tests](https://github.com/DoSomething/phoenix-next/blob/master/resources/assets/components/blocks/SignupReferralsBlock/SignupReferralsBlock.test.js) for this component, but this catches a few more scenarios (testing for the default `SectionHeader` text if a `title` prop is null, variations of the GraphQL query results). Should I just scrap the jest test completely?

### Relevant tickets

References [Pivotal #175278295](https://www.pivotaltracker.com/story/show/175278295).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added screenshots of front-end changes on small, medium, and large screens.
- [x] Added appropriate feature/unit tests.
