### PR TITLE
Make helper text conditional for photo submission quantity

### DIFF
--- a/resources/assets/components/actions/PhotoSubmissionAction/PhotoSubmissionAction.js
+++ b/resources/assets/components/actions/PhotoSubmissionAction/PhotoSubmissionAction.js
@@ -440,12 +440,14 @@ class PhotoSubmissionAction extends PostForm {
                             required
                             min={Number(quantity) + 1}
                           />
-                          <p className="text-sm text-gray-600">
-                            This is the total items number above plus the new
-                            number you are adding. For instance, if you
-                            currently have 1 total item and are adding 1 more,
-                            you would enter 2 here.
-                          </p>
+                          {quantity ? (
+                            <p className="text-sm text-gray-600">
+                              This is the total items number above plus the new
+                              number you are adding. For instance, if you
+                              currently have 1 total item and are adding 1 more,
+                              you would enter 2 here.
+                            </p>
+                          ) : null}
                         </div>
                       ) : null}
 


### PR DESCRIPTION
### What's this PR do?

This pull request adds a ternary to check whether the user has a quantity they've associated with a photo submission action. If so we display helper text to provide guidance on how to update the quantity. Otherwise, we hide the helper text as it's irrelevant on the initial upload.

### How should this be reviewed?

**Initial Upload:**
<img width="1134" alt="Screen Shot 2020-11-02 at 3 25 28 PM" src="https://user-images.githubusercontent.com/15236023/97915994-5e1c3d00-1d20-11eb-899b-82aaff8efb07.png">

**Second Upload:**
<img width="1123" alt="Screen Shot 2020-11-02 at 3 25 44 PM" src="https://user-images.githubusercontent.com/15236023/97916047-6ffde000-1d20-11eb-9519-c972c0c0fe8d.png">

### Any background context you want to provide?

Bug ticket opened by Leah and high priority for campaign that started Nov 1

### Relevant tickets

References [Pivotal #175405884](https://www.pivotaltracker.com/n/projects/2401401/stories/175405884).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [x] Added screenshots of front-end changes on small, medium, and large screens.
- [ ] Added appropriate feature/unit tests.
