### PR TITLE
Cypress tests for ActionStatsBlock

### DIFF
--- a/cypress/integration/action-stats-block.js
+++ b/cypress/integration/action-stats-block.js
@@ -15,25 +15,47 @@ const contentfulBlockQueryResult = {
   },
 };
 
+/**
+ * @param {Number} impact
+ * @return {Object}
+ */
+function schoolActionStat(impact) {
+  const schoolId = faker.random.uuid();
+
+  return {
+    actionId,
+    impact,
+    location: `US-${faker.address.stateAbbr()}`,
+    schoolId,
+    school: {
+      id: schoolId,
+      city: faker.address.city(),
+      name: faker.company.companyName(),
+    },
+  };
+}
+
+const topThreeStats = [
+  schoolActionStat(200),
+  schoolActionStat(140),
+  schoolActionStat(78),
+];
+
 describe('Action Stats Block', () => {
   beforeEach(() => {
     cy.configureMocks();
     cy.mockGraphqlOp('ContentfulBlockQuery', contentfulBlockQueryResult);
   });
 
-  it('Displays leaderboard and table with load more if more than 10 records', () => {
+  it('Displays leaderboard and table with load more button if first page has more results', () => {
     cy.mockGraphqlOp('SchoolActionStatsLeaderQuery', {
-      schoolActionStats: [
-        { actionId, schoolId: '11122016', impact: 20 },
-        { actionId, schoolId: '21022010', impact: 14 },
-      ],
+      schoolActionStats: topThreeStats,
     });
     cy.mockGraphqlOp('PaginatedActionStatsQuery', {
       paginatedSchoolActionStats: {
-        edges: [
-          { actionId, schoolId: '11122016' },
-          { actionId, schoolId: '21022010' },
-        ],
+        edges: topThreeStats.map(stat => {
+          return { node: stat };
+        }),
         pageInfo: {
           hasNextPage: true,
         },
@@ -42,6 +64,6 @@ describe('Action Stats Block', () => {
 
     cy.authVisitBlockPermalink(user, blockId);
 
-    cy.contains('leaderboard');
+    cy.findAllByTestId('load-more-stats-button').should('have.length', 1);
   });
 });

--- a/cypress/integration/action-stats-block.js
+++ b/cypress/integration/action-stats-block.js
@@ -5,6 +5,7 @@ import { userFactory } from '../fixtures/user';
 
 const actionId = faker.random.number();
 const blockId = '51SWUaRvyhsJsTWHRGGfjK';
+const url = `us/blocks/${blockId}`;
 
 const contentfulBlockQueryResult = {
   block: {
@@ -46,12 +47,12 @@ describe('Action Stats Block', () => {
   beforeEach(() => {
     cy.configureMocks();
     cy.mockGraphqlOp('ContentfulBlockQuery', contentfulBlockQueryResult);
-  });
-
-  it('Displays leaderboard and table that paginates through results', () => {
     cy.mockGraphqlOp('SchoolActionStatsLeaderQuery', {
       schoolActionStats: topThreeStats,
     });
+  });
+
+  it('Displays leaderboard and table that paginates through results', () => {
     cy.mockGraphqlOp('PaginatedActionStatsQuery', {
       paginatedSchoolActionStats: {
         edges: topThreeStats.map(stat => {
@@ -63,7 +64,7 @@ describe('Action Stats Block', () => {
       },
     });
 
-    cy.visit(`/us/blocks/${blockId}`);
+    cy.visit(url);
 
     cy.nth('[data-testid=action-stats-leaderboard-rank]', 0).should(
       'have.class',
@@ -98,5 +99,86 @@ describe('Action Stats Block', () => {
     cy.findAllByTestId('load-more-stats-button').click();
 
     cy.findAllByTestId('load-more-stats-button').should('have.length', 0);
+  });
+
+  describe('Location filter', () => {
+    it('Filters results by location if location selected', () => {
+      cy.mockGraphqlOp('PaginatedActionStatsQuery', {
+        paginatedSchoolActionStats: {
+          edges: topThreeStats.map(stat => {
+            return { node: stat };
+          }),
+          pageInfo: {
+            hasNextPage: true,
+          },
+        },
+      });
+
+      cy.visit(url);
+
+      let firstRow = cy
+        .findAllByTestId('action-stats-table-body')
+        .children()
+        .first();
+
+      // Four cells present when not filtering by location.
+      firstRow.children().should('have.length', 4);
+
+      const stat = schoolActionStat(23);
+
+      cy.mockGraphqlOp('PaginatedActionStatsQuery', {
+        paginatedSchoolActionStats: {
+          edges: [stat].map(stat => {
+            return { node: stat };
+          }),
+          pageInfo: {
+            hasNextPage: false,
+          },
+        },
+      });
+
+      cy.get('#react-select-select-state--input').type('A', { force: true });
+      cy.get('#react-select-select-state--option-0').click({ force: true });
+
+      cy.findAllByTestId('action-stats-table-body')
+        .children()
+        .should('have.length', 1);
+
+      firstRow = cy
+        .findAllByTestId('action-stats-table-body')
+        .children()
+        .first();
+      // Only three cells present when filtering by location.
+      firstRow.children().should('have.length', 3);
+    });
+
+    it('Displays no results content if no stats found for selected location', () => {
+      cy.mockGraphqlOp('PaginatedActionStatsQuery', {
+        paginatedSchoolActionStats: {
+          edges: topThreeStats.map(stat => {
+            return { node: stat };
+          }),
+          pageInfo: {
+            hasNextPage: true,
+          },
+        },
+      });
+      cy.visit(url);
+
+      cy.mockGraphqlOp('PaginatedActionStatsQuery', {
+        paginatedSchoolActionStats: {
+          edges: [],
+          pageInfo: {
+            hasNextPage: false,
+          },
+        },
+      });
+
+      cy.get('#react-select-select-state--input').type('A', { force: true });
+      cy.get('#react-select-select-state--option-0').click({ force: true });
+
+      cy.findAllByTestId('action-stats-table-body').should('have.length', 0);
+      cy.findAllByTestId('action-stats-not-found').should('have.length', 1);
+    });
   });
 });

--- a/cypress/integration/action-stats-block.js
+++ b/cypress/integration/action-stats-block.js
@@ -1,0 +1,47 @@
+/// <reference types="Cypress" />
+import faker from 'faker';
+
+import { userFactory } from '../fixtures/user';
+
+const actionId = faker.random.number();
+const blockId = '51SWUaRvyhsJsTWHRGGfjK';
+const user = userFactory();
+
+const contentfulBlockQueryResult = {
+  block: {
+    id: blockId,
+    __typename: 'ActionStatsBlock',
+    actionId,
+  },
+};
+
+describe('Action Stats Block', () => {
+  beforeEach(() => {
+    cy.configureMocks();
+    cy.mockGraphqlOp('ContentfulBlockQuery', contentfulBlockQueryResult);
+  });
+
+  it('Displays leaderboard and table with load more if more than 10 records', () => {
+    cy.mockGraphqlOp('SchoolActionStatsLeaderQuery', {
+      schoolActionStats: [
+        { actionId, schoolId: '11122016', impact: 20 },
+        { actionId, schoolId: '21022010', impact: 14 },
+      ],
+    });
+    cy.mockGraphqlOp('PaginatedActionStatsQuery', {
+      paginatedSchoolActionStats: {
+        edges: [
+          { actionId, schoolId: '11122016' },
+          { actionId, schoolId: '21022010' },
+        ],
+        pageInfo: {
+          hasNextPage: true,
+        },
+      },
+    });
+
+    cy.authVisitBlockPermalink(user, blockId);
+
+    cy.contains('leaderboard');
+  });
+});

--- a/cypress/integration/action-stats-block.js
+++ b/cypress/integration/action-stats-block.js
@@ -1,7 +1,6 @@
 /// <reference types="Cypress" />
-import faker from 'faker';
 
-import { userFactory } from '../fixtures/user';
+import faker from 'faker';
 
 const actionId = faker.random.number();
 const blockId = '51SWUaRvyhsJsTWHRGGfjK';

--- a/cypress/integration/action-stats-block.js
+++ b/cypress/integration/action-stats-block.js
@@ -5,7 +5,6 @@ import { userFactory } from '../fixtures/user';
 
 const actionId = faker.random.number();
 const blockId = '51SWUaRvyhsJsTWHRGGfjK';
-const user = userFactory();
 
 const contentfulBlockQueryResult = {
   block: {
@@ -16,6 +15,8 @@ const contentfulBlockQueryResult = {
 };
 
 /**
+ * Returns an mock instance of the SchoolActionStat type.
+ *
  * @param {Number} impact
  * @return {Object}
  */
@@ -62,7 +63,20 @@ describe('Action Stats Block', () => {
       },
     });
 
-    cy.authVisitBlockPermalink(user, blockId);
+    cy.visit(`/us/blocks/${blockId}`);
+
+    cy.nth('[data-testid=action-stats-leaderboard-rank]', 0).should(
+      'have.class',
+      'bg-yellow-500',
+    );
+    cy.nth('[data-testid=action-stats-leaderboard-rank]', 1).should(
+      'have.class',
+      'bg-purple-500',
+    );
+    cy.nth('[data-testid=action-stats-leaderboard-rank]', 2).should(
+      'have.class',
+      'bg-blurple-500',
+    );
 
     cy.findAllByTestId('load-more-stats-button').should('have.length', 1);
 

--- a/cypress/integration/action-stats-block.js
+++ b/cypress/integration/action-stats-block.js
@@ -47,7 +47,7 @@ describe('Action Stats Block', () => {
     cy.mockGraphqlOp('ContentfulBlockQuery', contentfulBlockQueryResult);
   });
 
-  it('Displays leaderboard and table with load more button if first page has more results', () => {
+  it('Displays leaderboard and table that paginates through results', () => {
     cy.mockGraphqlOp('SchoolActionStatsLeaderQuery', {
       schoolActionStats: topThreeStats,
     });
@@ -65,5 +65,24 @@ describe('Action Stats Block', () => {
     cy.authVisitBlockPermalink(user, blockId);
 
     cy.findAllByTestId('load-more-stats-button').should('have.length', 1);
+
+    cy.mockGraphqlOp('PaginatedActionStatsQuery', {
+      paginatedSchoolActionStats: {
+        edges: [
+          schoolActionStat(43),
+          schoolActionStat(23),
+          schoolActionStat(12),
+        ].map(stat => {
+          return { node: stat };
+        }),
+        pageInfo: {
+          hasNextPage: false,
+        },
+      },
+    });
+
+    cy.findAllByTestId('load-more-stats-button').click();
+
+    cy.findAllByTestId('load-more-stats-button').should('have.length', 0);
   });
 });

--- a/resources/assets/components/blocks/ActionStatsBlock/ActionStatsLeaderboard.js
+++ b/resources/assets/components/blocks/ActionStatsBlock/ActionStatsLeaderboard.js
@@ -57,7 +57,7 @@ const ActionStatsLeaderboard = ({ actionId, count, groupTypeId }) => {
   }
 
   return (
-    <>
+    <div data-testid="action-stats-leaderboard">
       {loading ? (
         <Spinner className="flex justify-center" />
       ) : (
@@ -65,6 +65,7 @@ const ActionStatsLeaderboard = ({ actionId, count, groupTypeId }) => {
           {leaders.map(leader => {
             const { impact, school, location, id } = leader;
             let circleBgColor;
+
             rank += 1;
 
             switch (rank) {
@@ -90,6 +91,7 @@ const ActionStatsLeaderboard = ({ actionId, count, groupTypeId }) => {
                 key={id}
               >
                 <div
+                  data-testid="action-stats-leaderboard-rank"
                   className={classnames(
                     'mx-auto md:mr-4 rounded-full h-20 w-20 flex items-center justify-center',
                     circleBgColor,
@@ -102,6 +104,7 @@ const ActionStatsLeaderboard = ({ actionId, count, groupTypeId }) => {
 
                 <div className="md:w-3/5 mt-6 md:mt-0 text-center md:text-left md:pr-4">
                   <h2 className="text-lg">{school.name}</h2>
+
                   <h3 className="font-bold text-sm text-gray-600 uppercase">
                     {school.city}, {location.substring(3)}
                   </h3>
@@ -111,6 +114,7 @@ const ActionStatsLeaderboard = ({ actionId, count, groupTypeId }) => {
                   <h2 className="font-normal font-league-gothic pr-3 text-3xl md:w-1/4">
                     {impact}
                   </h2>
+
                   <span className="font-bold text-gray-600 text-base uppercase md:w-3/4">
                     Registrations
                   </span>
@@ -120,7 +124,7 @@ const ActionStatsLeaderboard = ({ actionId, count, groupTypeId }) => {
           })}
         </div>
       )}
-    </>
+    </div>
   );
 };
 

--- a/resources/assets/components/blocks/ActionStatsBlock/ActionStatsTable.js
+++ b/resources/assets/components/blocks/ActionStatsBlock/ActionStatsTable.js
@@ -123,7 +123,10 @@ const ActionStatsTable = ({
         <tbody>
           <tr>
             <td className="bg-gray-100 px-10 pt-10 pb-32" colSpan={colSpan}>
-              <div className="bg-white p-6 rounded">
+              <div
+                className="bg-white p-6 rounded"
+                data-testid="action-stats-not-found"
+              >
                 <h3>No Schools Found</h3>
 
                 <p>
@@ -144,7 +147,7 @@ const ActionStatsTable = ({
     <Table>
       {header}
 
-      <tbody>
+      <tbody data-testid="action-stats-table-body">
         {stats.map(({ node, cursor }) => {
           const { impact, location, school } = node;
 

--- a/resources/assets/components/blocks/ActionStatsBlock/ActionStatsTable.js
+++ b/resources/assets/components/blocks/ActionStatsBlock/ActionStatsTable.js
@@ -184,6 +184,7 @@ const ActionStatsTable = ({
           <tr>
             <td className="p-3" colSpan={colSpan}>
               <PrimaryButton
+                attributes={{ 'data-testid': 'load-more-stats-button' }}
                 onClick={handleViewMore}
                 isDisabled={loading}
                 text="Load More"


### PR DESCRIPTION
### What's this PR do?

This pull request adds test coverage for the`ActionStatsBlock` component, which powers the school leaderboards used for voter registration. Similar to #2421, we skipped tests for this because it had a go-live deadline at the time we developed it.

### How should this be reviewed?

👀 

### Any background context you want to provide?

These are basic tests for:

* Leaderboard and view more button displaying in the table
* Filtering by location when data exists, and when it doesn't

### Relevant tickets

References [Pivotal #175278294](https://www.pivotaltracker.com/story/show/175278294).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added screenshots of front-end changes on small, medium, and large screens.
- [x] Added appropriate feature/unit tests.
