### PR TITLE
Fix Embed Block Cypress Test - Use data-testid

### DIFF
--- a/cypress/integration/embed-block.js
+++ b/cypress/integration/embed-block.js
@@ -40,9 +40,11 @@ describe('Embed Block', () => {
 
     cy.visit(`us/blocks/${blockId}`);
 
-    cy.get('iframe')
-      .should('have.attr', 'src')
-      .and('include', cartoUrl);
+    cy.findByTestId('iframe-embed').within(() => {
+      cy.get('iframe')
+        .should('have.attr', 'src')
+        .and('include', cartoUrl);
+    });
   });
 
   /** @test */
@@ -59,9 +61,11 @@ describe('Embed Block', () => {
 
     cy.visit(`us/blocks/${blockId}`);
 
-    cy.get('iframe')
-      .should('have.attr', 'src')
-      .and('include', cartoUrl);
+    cy.findByTestId('iframe-embed').within(() => {
+      cy.get('iframe')
+        .should('have.attr', 'src')
+        .and('include', cartoUrl);
+    });
   });
 
   /** @test */
@@ -77,9 +81,11 @@ describe('Embed Block', () => {
 
     cy.visit(`us/blocks/${blockId}`);
 
-    cy.get('iframe')
-      .should('have.attr', 'src')
-      .and('include', airtable);
+    cy.findByTestId('iframe-embed').within(() => {
+      cy.get('iframe')
+        .should('have.attr', 'src')
+        .and('include', airtable);
+    });
   });
 
   context('Default URLs', () => {

--- a/resources/assets/components/utilities/IframeEmbed/IframeEmbed.js
+++ b/resources/assets/components/utilities/IframeEmbed/IframeEmbed.js
@@ -5,7 +5,11 @@ import classnames from 'classnames';
 import AnalyticsWaypoint from '../AnalyticsWaypoint/AnalyticsWaypoint';
 
 const IframeEmbed = ({ className, id, url }) => (
-  <div id={id} className={classnames('embed', className)}>
+  <div
+    id={id}
+    className={classnames('embed', className)}
+    data-testid="iframe-embed"
+  >
     <AnalyticsWaypoint name="embed-top" context={{ blockId: id }} />
 
     <iframe title={`embed ${id}`} src={url} width="100%" height="520" />


### PR DESCRIPTION
### What's this PR do?

This pull request adds a `data-testid` to the `IframeEmbed` component and uses it for querying within our Cypress tests to ensure we're pulling in the accurate `iframe`.

### How should this be reviewed?
👀 

### Any background context you want to provide?
[We discovered](https://dosomething.slack.com/archives/CUQMU4Q6B/p1604434861011300) this test failing on the cloud, presumably due to finding some other `iframe` in the DOM.

### Relevant tickets
https://dosomething.slack.com/archives/CUQMU4Q6B/p1604434861011300