### PR TITLE
Add 'id' to queried fields for cache key.

### DIFF
--- a/resources/assets/components/actions/SoftEdgeBlock.js
+++ b/resources/assets/components/actions/SoftEdgeBlock.js
@@ -24,6 +24,7 @@ const CONGRESSWEB_SDK =
 const SOFT_EDGE_AUTOFILL_QUERY = gql`
   query SoftEdgeAutofillQuery($userId: String!) {
     user(id: $userId) {
+      id
       memberId: id
       firstName
       lastName


### PR DESCRIPTION
### What's this PR do?

This pull request fixes an issue pre-filling the form fields on our SoftEdge widget. The `SoftEdgeAutofillQuery` was not able to be cached in Apollo's in-memory store because it didn't have an `id` field (to use as the cache key):

```
Network error: Error writing result to store for query: (app-c2b30f4019354c72735f.js, line 9948)
 {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"SoftEdgeAutofillQuery"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"userId"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}},"directives":[]}],"directives":[],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"user"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"id"},"value":{"kind":"Variable","name":{"kind":"Name","value":"userId"}}}],"directives":[],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","alias":{"kind":"Name","value":"memberId"},"name":{"kind":"Name","value":"id"},"arguments":[],"directives":[]},{"kind":"Field","name":{"kind":"Name","value":"firstName"},"arguments":[],"directives":[]},{"kind":"Field","name":{"kind":"Name","value":"lastName"},"arguments":[],"directives":[]},{"kind":"Field","name":{"kind":"Name","value":"email"},"arguments":[],"directives":[]},{"kind":"Field","name":{"kind":"Name","value":"mobile"},"arguments":[],"directives":[]},{"kind":"Field","alias":{"kind":"Name","value":"address"},"name":{"kind":"Name","value":"addrStreet1"},"arguments":[],"directives":[]},{"kind":"Field","alias":{"kind":"Name","value":"city"},"name":{"kind":"Name","value":"addrCity"},"arguments":[],"directives":[]},{"kind":"Field","alias":{"kind":"Name","value":"state"},"name":{"kind":"Name","value":"addrState"},"arguments":[],"directives":[]},{"kind":"Field","alias":{"kind":"Name","value":"zip"},"name":{"kind":"Name","value":"addrZip"},"arguments":[],"directives":[]},{"kind":"Field","name":{"kind":"Name","value":"__typename"}}]}}]}}],"loc":{"start":0,"end":250,"source":{"body":"\n  query SoftEdgeAutofillQuery($userId: String!) {\n    user(id: $userId) {\n      memberId: id\n      firstName\n      lastName\n      email\n      mobile\n      address: addrStreet1\n      city: addrCity\n      state: addrState\n      zip: addrZip\n    }\n  }\n","name":"GraphQL request","locationOffset":{"line":1,"column":1}}}}
Store error: the application attempted to write an object with no provided id but the store already contains an id of User:5543dfd6469c64ec7d8b46b3 for this object. The selectionSet that was trying to be written is:
{"kind":"Field","name":{"kind":"Name","value":"user"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"id"},"value":{"kind":"Variable","name":{"kind":"Name","value":"userId"}}}],"directives":[],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","alias":{"kind":"Name","value":"memberId"},"name":{"kind":"Name","value":"id"},"arguments":[],"directives":[]},{"kind":"Field","name":{"kind":"Name","value":"firstName"},"arguments":[],"directives":[]},{"kind":"Field","name":{"kind":"Name","value":"lastName"},"arguments":[],"directives":[]},{"kind":"Field","name":{"kind":"Name","value":"email"},"arguments":[],"directives":[]},{"kind":"Field","name":{"kind":"Name","value":"mobile"},"arguments":[],"directives":[]},{"kind":"Field","alias":{"kind":"Name","value":"address"},"name":{"kind":"Name","value":"addrStreet1"},"arguments":[],"directives":[]},{"kind":"Field","alias":{"kind":"Name","value":"city"},"name":{"kind":"Name","value":"addrCity"},"arguments":[],"directives":[]},{"kind":"Field","alias":{"kind":"Name","value":"state"},"name":{"kind":"Name","value":"addrState"},"arguments":[],"directives":[]},{"kind":"Field","alias":{"kind":"Name","value":"zip"},"name":{"kind":"Name","value":"addrZip"},"arguments":[],"directives":[]},{"kind":"Field","name":{"kind":"Name","value":"__typename"}}]}}
ApolloError — bundle.esm.js:63
```

### How should this be reviewed?

👀

### Any background context you want to provide?

More details on how we uncovered this problem in [this thread](https://dosomething.slack.com/archives/C02BBP0CU/p1604589443002300).

### Relevant tickets

Making a ticket now!

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added screenshots of front-end changes on small, medium, and large screens.
- [ ] Added appropriate feature/unit tests.
