### PR TITLE
Click Tracking badges page

### DIFF
--- a/resources/assets/components/pages/AccountPage/Badges/BadgesTab.js
+++ b/resources/assets/components/pages/AccountPage/Badges/BadgesTab.js
@@ -5,6 +5,11 @@ import gql from 'graphql-tag';
 import Badge from './Badge';
 import Query from '../../../Query';
 import BadgeModal from './BadgeModal';
+import {
+  EVENT_CATEGORIES,
+  trackAnalyticsEvent,
+} from '../../../../helpers/analytics';
+
 import './badges-tab.scss';
 
 const SIGNUP_COUNT_BADGE = gql`
@@ -129,13 +134,42 @@ class BadgesTab extends React.Component {
   }
 
   showModal(name, earned) {
+    const modalEarned = earned ? 'earned' : 'unearned';
+    // Track modal open event.
+    trackAnalyticsEvent(`opened_modal_${modalEarned}_badge_${name}`, {
+      action: 'modal_opened',
+      category: EVENT_CATEGORIES.modal,
+      label: type,
+      context: {
+        actionId,
+        blockId,
+        campaignId,
+        pageId,
+      },
+    });
+
     this.setState({
       modalName: name,
       modalEarned: earned,
     });
   }
 
-  closeModal() {
+  closeModal(name, earned) {
+    const modalEarned = earned ? 'earned' : 'unearned';
+
+    // Track modal closed event.
+    trackAnalyticsEvent(`closed_modal_${modalEarned}_badge_${name}`, {
+      action: 'modal_closed',
+      category: EVENT_CATEGORIES.modal,
+      label: type,
+      context: {
+        actionId,
+        blockId,
+        campaignId,
+        pageId,
+      },
+    });
+
     this.setState({
       modalName: '',
     });
@@ -336,7 +370,10 @@ class BadgesTab extends React.Component {
         </ul>
         {this.state.modalName ? (
           <BadgeModal
-            onClose={this.closeModal}
+            onClose={this.closeModal(
+              this.state.modalName,
+              this.state.modalEarned,
+            )}
             earned={this.state.modalEarned}
             name={this.state.modalName}
           >

--- a/resources/assets/components/pages/AccountPage/Badges/BadgesTab.js
+++ b/resources/assets/components/pages/AccountPage/Badges/BadgesTab.js
@@ -7,6 +7,7 @@ import Query from '../../../Query';
 import BadgeModal from './BadgeModal';
 import {
   EVENT_CATEGORIES,
+  getPageContext,
   trackAnalyticsEvent,
 } from '../../../../helpers/analytics';
 
@@ -139,12 +140,10 @@ class BadgesTab extends React.Component {
     trackAnalyticsEvent(`opened_modal_${modalEarned}_badge_${name}`, {
       action: 'modal_opened',
       category: EVENT_CATEGORIES.modal,
-      label: type,
+      label: 'BADGES_MODAL',
       context: {
-        actionId,
-        blockId,
-        campaignId,
-        pageId,
+        url: window.location.href,
+        ...getPageContext(),
       },
     });
 
@@ -154,21 +153,22 @@ class BadgesTab extends React.Component {
     });
   }
 
-  closeModal(name, earned) {
-    const modalEarned = earned ? 'earned' : 'unearned';
+  closeModal() {
+    const modalEarned = this.state.modalEarned ? 'earned' : 'unearned';
 
     // Track modal closed event.
-    trackAnalyticsEvent(`closed_modal_${modalEarned}_badge_${name}`, {
-      action: 'modal_closed',
-      category: EVENT_CATEGORIES.modal,
-      label: type,
-      context: {
-        actionId,
-        blockId,
-        campaignId,
-        pageId,
+    trackAnalyticsEvent(
+      `closed_modal_${modalEarned}_badge_${this.state.modalName}`,
+      {
+        action: 'modal_closed',
+        category: EVENT_CATEGORIES.modal,
+        label: 'BADGES_MODAL',
+        context: {
+          url: window.location.href,
+          ...getPageContext(),
+        },
       },
-    });
+    );
 
     this.setState({
       modalName: '',
@@ -370,10 +370,7 @@ class BadgesTab extends React.Component {
         </ul>
         {this.state.modalName ? (
           <BadgeModal
-            onClose={this.closeModal(
-              this.state.modalName,
-              this.state.modalEarned,
-            )}
+            onClose={this.closeModal}
             earned={this.state.modalEarned}
             name={this.state.modalName}
           >


### PR DESCRIPTION
### What's this PR do?

This pull request adds tracking for opening and closing the modals for badges in a user's account page! We're tracking open and close for earned and unearned badges.

### How should this be reviewed?

👀 

### Any background context you want to provide?

Since we will be removing the feature flag on badges and showing for all users, we want to make sure we're keeping track of users interactions with them in their profiles.

### Relevant tickets

References [Pivotal #175415974](https://www.pivotaltracker.com/story/show/175415974).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added screenshots of front-end changes on small, medium, and large screens.
- [ ] Added appropriate feature/unit tests.
