### PR TITLE
Removes Badges Flag Check

### DIFF
--- a/docs/development/features/badges.md
+++ b/docs/development/features/badges.md
@@ -4,13 +4,6 @@
 
 Badges are awarded to users based on actions they have taken.
 
-## Who Gets Badges
-
-The following users will NOT have a chance to be opted-in to the badges experience:
-
--   Users who have `utm_source:clubs` in their `source_detail`
--   Users who have particular campaigns in their `source_detail` (these excluded campaigns come from the `DS_CONTENTFUL_IDS_FOR_CAMPAIGNS_WITH_NO_BADGES` feature flag in _Northstar_) - currently the only excluded campaign is for teachers, who do not need badges
-
 ## Current Badges
 
 Unless specified, badges will only show up in the Badges tab of the user profile.
@@ -46,13 +39,30 @@ If a user earns a badge upon submitting a post, it will show up in the `PostCrea
 
 ## Iterations
 
-### Badges Version 1 (current version)
+### Badges Version 1
 
 This verions opts 70% of _new_ users into the badge experience, unless excluded (club referrals are excluded as are users from certain campaigns).
+
+The "badges" experience is still a test, and only [a subset of new users](#who-gets-badges) are opted-in.
+
+#### Who Gets Badges
+
+Only new users get the badge experience, but there are some exceptions. All of the following logic takes place in _Northstar_.
+
+The following users will NOT have a chance to be opted-in to the badges experience:
+
+-   Users who have `utm_source:clubs` in their `source_detail`
+-   Users who have particular campaigns in their `source_detail` (these excluded campaigns come from the `DS_CONTENTFUL_IDS_FOR_CAMPAIGNS_WITH_NO_BADGES` feature flag in _Northstar_) - currently the only excluded campaign is for teachers, who do not need badges
+
+The `DS_BADGES_TEST` feature flag in _Northstar_ is what toggles the currently running badge _test_ on and off, it does _not_ toggle the badge feature itself. The badge feature is controlled by the `badges` feature flag that lives on a user in Northstar. When `DS_BADGES_TEST` is `true`, that means that some users in Northstar are getting `badges` added to their `feature_flags`. Users who have the badges feature flag will _always_ get the badges experience. _Phoenix_ checks if a user has the badges feature flag before displaying any badge related content.
 
 In this version _badges are not stored anywhere_. Each time we display a badge, we are calculating on the fly if the user has earned that badge. The good thing about this is that we don't have to worry about revoking badges (like if someone unsubscribes from The Breakdown) because that will happen automatically. The bad thing is that there is no easy way to answer questions like "How many badges does this user have?"
 
 There is currently no easy way for an admin to see which badges a user has, though they can see if users are getting the badges experience or not.
+
+### Badges Version 1.2 (current version)
+
+In this version all users are able to see badges within their profile, but the other aspects of version 1 remain in tact (calculating on the fly, etc).
 
 ### Badges Version 2
 

--- a/docs/development/features/badges.md
+++ b/docs/development/features/badges.md
@@ -2,20 +2,14 @@
 
 ## Overview
 
-Badges are awarded to users based on actions they have taken. The "badges" experience is still a test, and only [a subset of new users](#who-gets-badges) are opted-in.
-
-The `DS_BADGES_TEST` feature flag in _Northstar_ is what toggles the currently running badge _test_ on and off, it does _not_ toggle the badge feature itself. The badge feature is controlled by the `badges` feature flag that lives on a user in Northstar. When `DS_BADGES_TEST` is `true`, that means that some users in Northstar are getting `badges` added to their `feature_flags`. Users who have the badges feature flag will _always_ get the badges experience. _Phoenix_ checks if a user has the badges feature flag before displaying any badge related content.
+Badges are awarded to users based on actions they have taken.
 
 ## Who Gets Badges
-
-Only new users get the badge experience, but there are some exceptions. All of the following logic takes place in _Northstar_.
 
 The following users will NOT have a chance to be opted-in to the badges experience:
 
 -   Users who have `utm_source:clubs` in their `source_detail`
 -   Users who have particular campaigns in their `source_detail` (these excluded campaigns come from the `DS_CONTENTFUL_IDS_FOR_CAMPAIGNS_WITH_NO_BADGES` feature flag in _Northstar_) - currently the only excluded campaign is for teachers, who do not need badges
-
-All other new users will have a 70% chance of being opted-in to the badge experience.
 
 ## Current Badges
 
@@ -34,7 +28,7 @@ Unless specified, badges will only show up in the Badges tab of the user profile
 
 ### Profile
 
-Users with the badge experience will have a "Badges" tab in their profile. Clicking on a badge pulls up a modal which gives more information on how a badge was earned or how to earn it.
+Users will have a "Badges" tab in their profile. Clicking on a badge pulls up a modal which gives more information on how a badge was earned or how to earn it.
 
 ![Badges Tab In Profile Example](../../.gitbook/assets/badges-tab.png)
 

--- a/resources/assets/components/Affirmation/Affirmation.js
+++ b/resources/assets/components/Affirmation/Affirmation.js
@@ -34,7 +34,6 @@ const USER_QUERY = gql`
   query UserAccountAndSignupsCountQuery($userId: String!) {
     user(id: $userId) {
       id
-      hasBadgesFlag: hasFeatureFlag(feature: "badges")
     }
     signupsCount(userId: $userId, limit: 2)
   }
@@ -60,7 +59,7 @@ const Affirmation = ({
       <Query query={USER_QUERY} variables={{ userId }}>
         {res => (
           <React.Fragment>
-            {get(res, 'user.hasBadgesFlag', false) && res.signupsCount === 1 ? (
+            {res.signupsCount === 1 ? (
               <Badge
                 earned
                 className="badge p-3"

--- a/resources/assets/components/actions/PostCreatedModal.js
+++ b/resources/assets/components/actions/PostCreatedModal.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import { get } from 'lodash';
 import gql from 'graphql-tag';
 import PropTypes from 'prop-types';
 
@@ -8,15 +7,6 @@ import Card from '../utilities/Card/Card';
 import Modal from '../utilities/Modal/Modal';
 import Badge from '../pages/AccountPage/Badges/Badge';
 import TextContent from '../utilities/TextContent/TextContent';
-
-const BADGE_QUERY = gql`
-  query PostCreatedModalBadgeQuery($userId: String!) {
-    user(id: $userId) {
-      id
-      hasBadgesFlag: hasFeatureFlag(feature: "badges")
-    }
-  }
-`;
 
 const POST_COUNT_BADGE = gql`
   query PostsCreatedModalCountQuery($userId: String!) {
@@ -28,58 +18,47 @@ const PostCreatedModal = ({ affirmationContent, onClose, title, userId }) => (
   <Modal onClose={onClose} trackingId="REPORTBACK_AFFIRMATION_MODAL">
     <Card className="bordered rounded" title={title}>
       {userId ? (
-        <Query query={BADGE_QUERY} variables={{ userId }} hideSpinner>
-          {badgeData =>
-            get(badgeData, 'user.hasBadgesFlag', false) ? (
-              <Query
-                query={POST_COUNT_BADGE}
-                variables={{ userId }}
-                hideSpinner
+        <Query query={POST_COUNT_BADGE} variables={{ userId }} hideSpinner>
+          {postData => {
+            const count = postData.postsCount;
+
+            if (count > 3) {
+              return null;
+            }
+
+            const config = {
+              1: {
+                className: 'onePostBadge',
+                descriptor: 'first',
+              },
+              2: {
+                className: 'twoPostsBadge',
+                descriptor: 'second',
+              },
+              3: {
+                className: 'threePostsBadge',
+                descriptor: 'third',
+              },
+            };
+
+            return (
+              <Badge
+                earned
+                className="badge p-3"
+                size="medium"
+                name={config[count].className}
               >
-                {postData => {
-                  const count = postData.postsCount;
-
-                  if (count > 3) {
-                    return null;
-                  }
-
-                  const config = {
-                    1: {
-                      className: 'onePostBadge',
-                      descriptor: 'first',
-                    },
-                    2: {
-                      className: 'twoPostsBadge',
-                      descriptor: 'second',
-                    },
-                    3: {
-                      className: 'threePostsBadge',
-                      descriptor: 'third',
-                    },
-                  };
-
-                  return (
-                    <Badge
-                      earned
-                      className="badge p-3"
-                      size="medium"
-                      name={config[count].className}
-                    >
-                      <h4>
-                        {count} Action{count > 1 ? 's' : null}
-                      </h4>
-                      <p>
-                        Ohhh HECK yes! You just earned a new badge for
-                        completing your {config[count].descriptor} campaign.
-                        Congratulations!
-                      </p>
-                      <a href="/us/account/badges">View all my badges</a>
-                    </Badge>
-                  );
-                }}
-              </Query>
-            ) : null
-          }
+                <h4>
+                  {count} Action{count > 1 ? 's' : null}
+                </h4>
+                <p>
+                  Ohhh HECK yes! You just earned a new badge for completing your{' '}
+                  {config[count].descriptor} campaign. Congratulations!
+                </p>
+                <a href="/us/account/badges">View all my badges</a>
+              </Badge>
+            );
+          }}
         </Query>
       ) : null}
 

--- a/resources/assets/components/pages/AccountPage/Account/AccountNavigation.js
+++ b/resources/assets/components/pages/AccountPage/Account/AccountNavigation.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 import { featureFlag } from '../../../../helpers';
 import NavigationLink from '../../../utilities/NavigationLink/NavigationLink';
@@ -16,7 +15,7 @@ const handleAccountNavTabClick = tabName => {
   });
 };
 
-const AccountNavigation = props => (
+const AccountNavigation = () => (
   <nav className="base-12-grid page-navigation py-3 md:py-6 -no-fade">
     <div className="grid-wide nav-items -mx-3">
       <NavigationLink
@@ -32,14 +31,12 @@ const AccountNavigation = props => (
       >
         Campaigns
       </NavigationLink>
-      {props.user.hasBadgesFlag ? (
-        <NavigationLink
-          to="/us/account/badges"
-          onClick={() => handleAccountNavTabClick('badges')}
-        >
-          Badges
-        </NavigationLink>
-      ) : null}
+      <NavigationLink
+        to="/us/account/badges"
+        onClick={() => handleAccountNavTabClick('badges')}
+      >
+        Badges
+      </NavigationLink>
       {featureFlag('volunteer_credits') ? (
         <NavigationLink
           to="/us/account/credits"
@@ -71,11 +68,5 @@ const AccountNavigation = props => (
     </div>
   </nav>
 );
-
-AccountNavigation.propTypes = {
-  user: PropTypes.shape({
-    hasBadgesFlag: PropTypes.bool,
-  }).isRequired,
-};
 
 export default AccountNavigation;

--- a/resources/assets/components/pages/AccountPage/Account/AccountQuery.js
+++ b/resources/assets/components/pages/AccountPage/Account/AccountQuery.js
@@ -18,7 +18,6 @@ const ACCOUNT_QUERY = gql`
       birthdate
       email
       emailSubscriptionTopics
-      hasBadgesFlag: hasFeatureFlag(feature: "badges")
     }
   }
 `;

--- a/resources/assets/components/pages/AccountPage/Account/AccountRoute.js
+++ b/resources/assets/components/pages/AccountPage/Account/AccountRoute.js
@@ -18,12 +18,7 @@ const AccountRoute = props => (
       path="/us/account/campaigns"
       render={() => <UserPostsQuery userId={props.userId} />}
     />
-    {props.user.hasBadgesFlag ? (
-      <Route
-        path="/us/account/badges"
-        render={() => <BadgesTab {...props} />}
-      />
-    ) : null}
+    <Route path="/us/account/badges" render={() => <BadgesTab {...props} />} />
     {featureFlag('volunteer_credits') ? (
       <Route path="/us/account/credits" component={Credits} />
     ) : null}
@@ -45,9 +40,11 @@ const AccountRoute = props => (
 
 AccountRoute.propTypes = {
   userId: PropTypes.string.isRequired,
-  user: PropTypes.shape({
-    hasBadgesFlag: PropTypes.bool,
-  }).isRequired,
+  user: PropTypes.object,
+};
+
+AccountRoute.defaultProps = {
+  user: {},
 };
 
 export default AccountRoute;


### PR DESCRIPTION
### What's this PR do?

This pull request "turns on" the badges feature for all users! We're removing any checks for the `badges` feature flag on a user within their account as well as on the `PostCreateModal` and the `Affirmation` modal. It also updates the documentation to no longer reference needing the flag or any users being excluded from seeing badges in their profile.

### How should this be reviewed?

👀 

### Any background context you want to provide?

We're moving forward with badges for all users after testing it out on a subset throughout this year!

### Relevant tickets

References [Pivotal #172623689](https://www.pivotaltracker.com/story/show/172623689).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added screenshots of front-end changes on small, medium, and large screens.
- [ ] Added appropriate feature/unit tests.
