### PR TITLE
Order campaigns gallery in cause pages by start date

### DIFF
--- a/docs/development/content-types/cause-page.md
+++ b/docs/development/content-types/cause-page.md
@@ -8,51 +8,51 @@ Displays a collection of (optional) stats, campaigns and article content revolvi
 
 ## Content Type Fields
 
-- **Internal Title**: This is for our internal Contentful organization and will be how the block shows up in search results, etc. (does _not_ display to the user on the page).
+-   **Internal Title**: This is for our internal Contentful organization and will be how the block shows up in search results, etc. (does _not_ display to the user on the page).
 
-- **Slug**: The URL slug, which we prefix with `/causes/`. e.g. `dosomething.org/causes/environment`. _This must be a [valid cause name](https://github.com/DoSomething/rogue/blob/78cfb1abcdd590afd253fb4e9b8d9e83831bbb1f/app/Types/Cause.php) on Rogue since we use this value to query campaign content via Rogue._
+-   **Slug**: The URL slug, which we prefix with `/causes/`. e.g. `dosomething.org/causes/environment`. _This must be a [valid cause name](https://github.com/DoSomething/rogue/blob/78cfb1abcdd590afd253fb4e9b8d9e83831bbb1f/app/Types/Cause.php) on Rogue since we use this value to query campaign content via Rogue._
 
-- **Cover Image**: Displays as the background image of the banner at the top of the page.
+-   **Cover Image**: Displays as the background image of the banner at the top of the page.
 
-- **Supertitle**: Shows up atop the title in the banner (can be used as a nice prefix to the title) e.g. "Let's do something about the".
+-   **Supertitle**: Shows up atop the title in the banner (can be used as a nice prefix to the title) e.g. "Let's do something about the".
 
-- **Title**: Displays right under the Supertitle. This is the title of the page. e.g. "Environment".
+-   **Title**: Displays right under the Supertitle. This is the title of the page. e.g. "Environment".
 
-- **Description**: The Rich Text description (information/introduction) for this cause page. Displays in the banner below the title.
+-   **Description**: The Rich Text description (information/introduction) for this cause page. Displays in the banner below the title.
 
-- **Content**: The Rich Text content of the page. This can be content in markdown format, embedded Assets, or valid embedded entry blocks (preferabely Gallery Blocks).
+-   **Content**: The Rich Text content of the page. This can be content in markdown format, embedded Assets, or valid embedded entry blocks (preferabely Gallery Blocks).
 
-- **Additional Content** _(optional)_: Supports displaying a triad gallery of 'Stats' under the **Description** in the Cause Page banner. Stats are rendered in a triad gallery of [`StatCard`s](../features/stat-card.md). There should be at least three Stats. The properties necessary for the `FactCard`s are required in an array of `stats`, along with a `statsBackgroundColor` to be assigned their `backgroundColor` CSS property. Example:
+-   **Additional Content** _(optional)_: Supports displaying a triad gallery of 'Stats' under the **Description** in the Cause Page banner. Stats are rendered in a triad gallery of [`StatCard`s](../features/stat-card.md). There should be at least three Stats. The properties necessary for the `FactCard`s are required in an array of `stats`, along with a `statsBackgroundColor` to be assigned their `backgroundColor` CSS property. Example:
 
 ```json
 {
-  "statsBackgroundColor": "#3D9CB1",
-  "stats": [
-    {
-      "link": {
-        "url": "https://www.dosomething.org/us/campaigns/company-student-debt",
-        "text": "Invest In Us"
-      },
-      "title": "actions taken about student debt",
-      "number": 59077
-    },
-    {
-      "link": {
-        "url": "https://www.dosomething.org/us/stories/legacy-donor-admissions",
-        "text": "Merit Over Money"
-      },
-      "title": "signatures for fairer admissions",
-      "number": 27711
-    },
-    {
-      "link": {
-        "url": "https://www.dosomething.org/us/campaigns/fed/community",
-        "text": "Fed Up"
-      },
-      "title": "votes for better school lunches",
-      "number": 576846
-    }
-  ]
+    "statsBackgroundColor": "#3D9CB1",
+    "stats": [
+        {
+            "link": {
+                "url": "https://www.dosomething.org/us/campaigns/company-student-debt",
+                "text": "Invest In Us"
+            },
+            "title": "actions taken about student debt",
+            "number": 59077
+        },
+        {
+            "link": {
+                "url": "https://www.dosomething.org/us/stories/legacy-donor-admissions",
+                "text": "Merit Over Money"
+            },
+            "title": "signatures for fairer admissions",
+            "number": 27711
+        },
+        {
+            "link": {
+                "url": "https://www.dosomething.org/us/campaigns/fed/community",
+                "text": "Fed Up"
+            },
+            "title": "votes for better school lunches",
+            "number": 576846
+        }
+    ]
 }
 ```
 
@@ -60,7 +60,7 @@ Displays a collection of (optional) stats, campaigns and article content revolvi
 
 ## Campaign Gallery
 
-The cause page will automatically pull _open_ campaigns from Rogue associated with this cause space (via the campaign's _cause_ field).
+The cause page will automatically pull _open_, website campaigns from Rogue associated with this cause space (via the campaign's _cause_ field), ordered by start date.
 
 It'll display a paginated gallery of these campaigns atop the content section. (Using the [Paginated Campaign Gallery](../features/paginated-campaign-gallery.md) utility).
 

--- a/resources/assets/components/pages/CausePage/CausePage.js
+++ b/resources/assets/components/pages/CausePage/CausePage.js
@@ -57,7 +57,12 @@ const CausePageTemplate = ({
               className="grid-full"
               itemsPerRow={4}
               title="Campaigns"
-              variables={{ isOpen: true, first: 12, causes: [slug] }}
+              variables={{
+                isOpen: true,
+                first: 12,
+                causes: [slug],
+                orderBy: 'start_date,desc',
+              }}
             />
           </div>
 


### PR DESCRIPTION
### What's this PR do?

This pull request adds an `orderBy: 'start_date,desc'` parameter to the `PaginatedCampaignsGallery` on the `CausePage` to sort these campaigns by their starting date in descending order.

### How should this be reviewed?
👀 

### Any background context you want to provide?
We [recently noticed](https://dosomething.slack.com/archives/CUQMU4Q6B/p1605541419000600?thread_ts=1605540664.000400&cid=CUQMU4Q6B) a different sorting order on this gallery. Rogue sorts by the Campaign ID in ascending order by default, though previously these were being sorted in _descending_ order, we know not why. We figured in any case, that we should be ordering these campaigns by start date as is our standard convention cross-site (e.g. the [Campaigns index page](https://github.com/DoSomething/phoenix-next/blob/28ad9fea0f88f418fd72386fdcf19e8bd313566b/resources/assets/components/pages/CampaignsPage/CampaignsIndexPage.js#L32)).

### Relevant tickets

References [Pivotal #175582776](https://www.pivotaltracker.com/story/show/175582776).
https://dosomething.slack.com/archives/CUQMU4Q6B/p1605542050001300?thread_ts=1605540664.000400&cid=CUQMU4Q6B

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [x] Documentation added for new features/changed endpoints.
- [ ] Added screenshots of front-end changes on small, medium, and large screens.
- [ ] Added appropriate feature/unit tests.
