### PR TITLE
Fixes issue rendering unpublished Call To Action blocks.

### DIFF
--- a/resources/assets/components/blocks/CallToActionBlock/CallToActionBlock.js
+++ b/resources/assets/components/blocks/CallToActionBlock/CallToActionBlock.js
@@ -5,13 +5,13 @@ import PropTypes from 'prop-types';
 import { css } from '@emotion/core';
 import { useQuery } from '@apollo/react-hooks';
 
-import { tailwind } from '../../../helpers';
+import { env, tailwind } from '../../../helpers';
 import Spinner from '../../artifacts/Spinner/Spinner';
 import PrimaryButton from '../../utilities/Button/PrimaryButton';
 
 const CALL_TO_ACTION_QUERY = gql`
-  query CallToActionBlockQuery($id: String!) {
-    block(id: $id) {
+  query CallToActionBlockQuery($id: String!, $preview: Boolean!) {
+    block(id: $id, preview: $preview) {
       id
       ... on CallToActionBlock {
         superTitle
@@ -28,7 +28,7 @@ const CALL_TO_ACTION_QUERY = gql`
 
 const CallToActionBlock = ({ id }) => {
   const { data, loading, error } = useQuery(CALL_TO_ACTION_QUERY, {
-    variables: { id },
+    variables: { id, preview: env('CONTENTFUL_USE_PREVIEW_API', false) },
   });
 
   if (error) {

--- a/resources/assets/components/blocks/CallToActionBlock/CallToActionBlock.js
+++ b/resources/assets/components/blocks/CallToActionBlock/CallToActionBlock.js
@@ -40,6 +40,10 @@ const CallToActionBlock = ({ id }) => {
     return <Spinner className="flex justify-center p-2" />;
   }
 
+  if (!data.block) {
+    return <ErrorBlock error="Block does not exist." />;
+  }
+
   const {
     superTitle,
     title,

--- a/resources/assets/components/blocks/CallToActionBlock/CallToActionBlock.js
+++ b/resources/assets/components/blocks/CallToActionBlock/CallToActionBlock.js
@@ -5,6 +5,7 @@ import PropTypes from 'prop-types';
 import { css } from '@emotion/core';
 import { useQuery } from '@apollo/react-hooks';
 
+import ErrorBlock from '../ErrorBlock/ErrorBlock';
 import { env, tailwind } from '../../../helpers';
 import Spinner from '../../artifacts/Spinner/Spinner';
 import PrimaryButton from '../../utilities/Button/PrimaryButton';
@@ -32,7 +33,7 @@ const CallToActionBlock = ({ id }) => {
   });
 
   if (error) {
-    return <p>Something went wrong!</p>;
+    return <ErrorBlock error={error} />;
   }
 
   if (loading) {


### PR DESCRIPTION
### What's this PR do?

This pull request fixes an issue rendering unpublished Call To Action blocks on [preview.dosomething.org](https://preview.dosomething.org/us).

### How should this be reviewed?

Here's an example of an unpublished block that does not render on preview:

<img width="1220" alt="Screen Shot 2020-11-24 at 3 28 26 PM" src="https://user-images.githubusercontent.com/583202/100148324-9a981000-2e6a-11eb-959d-e57bcfe5ebe4.png">

After making this change, it does!

<img width="1220" alt="Screen Shot 2020-11-24 at 3 31 36 PM" src="https://user-images.githubusercontent.com/583202/100148347-a4217800-2e6a-11eb-8a60-7aed5529527c.png">

### Any background context you want to provide?

Since GraphQL is able to query either Contentful's standard or "preview" APIs from the same endpoint, we choose which to read from using an argument passed to the `block()` query. In the future, this could allow us to enable admins to preview items within the normal "production" site...!

### Relevant tickets

References [Pivotal #173016057](https://www.pivotaltracker.com/story/show/173016057).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added screenshots of front-end changes on small, medium, and large screens.
- [ ] Added appropriate feature/unit tests.
