### PR TITLE
Disable ElementButton when loading.

### DIFF
--- a/resources/assets/components/utilities/Button/ElementButton.js
+++ b/resources/assets/components/utilities/Button/ElementButton.js
@@ -22,7 +22,7 @@ const ElementButton = ({
   return (
     <button
       className={classnames('btn', className, { 'is-loading': isLoading })}
-      disabled={isDisabled}
+      disabled={isDisabled || isLoading}
       onClick={onClick}
       type={type}
       {...attributes}


### PR DESCRIPTION
### What's this PR do?

This pull request disables buttons when they're "loading", which prevents accidental double-submissions:

![Kapture 2020-11-24 at 16 27 47](https://user-images.githubusercontent.com/583202/100153491-337e5980-2e72-11eb-8f5b-7b459ab3ad4c.gif)

(Ignore the funny cursor glitch. I'm not sure why [Kap](https://getkap.co) has trouble recording the spinner.)

### How should this be reviewed?

👁️ 

### Any background context you want to provide?

There's still a little delay while we transition from the `POST_SUBMISSION_RESET_ITEM` upon click into the `POST_SUBMISSION_PENDING` state (after the request is sent off & awaiting a response). Since the `POST_SUBMISSION_RESET_ITEM` action is _also_ fired after successful submission, I don't think there's an easy way to _immediately_ enter a loading state...

Still, this makes it a lot more apparent to the user that _something_ is happening!

### Relevant tickets

References [Pivotal #173015832](https://www.pivotaltracker.com/story/show/173015832).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added screenshots of front-end changes on small, medium, and large screens.
- [ ] Added appropriate feature/unit tests.
