### PR TITLE
Update GalleryBlockSignup.js

### DIFF
--- a/resources/assets/components/utilities/ScholarshipCard/GalleryBlockSignup.js
+++ b/resources/assets/components/utilities/ScholarshipCard/GalleryBlockSignup.js
@@ -105,7 +105,7 @@ const GalleryBlockSignup = ({ campaignId, path }) => {
   return (
     <SecondaryButton
       className="w-full"
-      text={textToDisplay(campaignData.signups[0].campaignId)}
+      text={textToDisplay(campaignData.signups.length)}
       href={path}
       onClick={handleScholarshipCardShareClick}
     />

--- a/resources/assets/components/utilities/ScholarshipCard/GalleryBlockSignup.js
+++ b/resources/assets/components/utilities/ScholarshipCard/GalleryBlockSignup.js
@@ -40,6 +40,7 @@ const GalleryBlockSignup = ({ campaignId, path }) => {
       userId: window.AUTH.id.toString(),
       campaignId: campaignId.toString(),
     },
+    skip: !window.AUTH.id,
   });
 
   const [handleSignup, { loading, data, error }] = useMutation(
@@ -54,8 +55,6 @@ const GalleryBlockSignup = ({ campaignId, path }) => {
   const [flash, authenticate] = useGate(
     `OneClickSignupCampaignId:${campaignId}`,
   );
-
-  console.log('campaignData.signups.campaignId :', campaignData);
 
   const textToDisplay = userSignedUpForThisCampaign => {
     return userSignedUpForThisCampaign ? 'View Application' : 'Apply Now';

--- a/resources/assets/components/utilities/ScholarshipCard/GalleryBlockSignup.js
+++ b/resources/assets/components/utilities/ScholarshipCard/GalleryBlockSignup.js
@@ -37,8 +37,8 @@ const GalleryBlockSignup = ({ campaignId, path }) => {
     error: errorCampaign,
   } = useQuery(SEARCH_USER_CAMPAIGN_QUERY, {
     variables: {
-      userId: window.AUTH.id.toString(),
-      campaignId: campaignId.toString(),
+      userId: window.AUTH.id,
+      campaignId: campaignId,
     },
     skip: !window.AUTH.id,
   });

--- a/resources/assets/components/utilities/ScholarshipCard/GalleryBlockSignup.js
+++ b/resources/assets/components/utilities/ScholarshipCard/GalleryBlockSignup.js
@@ -38,7 +38,7 @@ const GalleryBlockSignup = ({ campaignId, path }) => {
   } = useQuery(SEARCH_USER_CAMPAIGN_QUERY, {
     variables: {
       userId: window.AUTH.id,
-      campaignId: campaignId,
+      campaignId,
     },
     skip: !window.AUTH.id,
   });


### PR DESCRIPTION
### What's this PR do?

This pull request adds a query to determine the text displayed on the scholarship buttons. If a user hasn't signed up for a campaign the button will display the text `Apply Now`, if they signed up for the campaign already it will say `View Application`

### How should this be reviewed?
🔢 
...

### Any background context you want to provide?

...

### Relevant tickets

References [Pivotal #173454908](https://www.pivotaltracker.com/n/projects/2401401/stories/173454908).

### Checklist

- [ x ] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ x ] Added screenshots of front-end changes on small, medium, and large screens.
- [ ] Added appropriate feature/unit tests.

Not signed up:
<img width="840" alt="Screen Shot 2020-11-25 at 12 25 23 PM" src="https://user-images.githubusercontent.com/20409413/100261958-7f380e00-2f19-11eb-9f3b-5050885597c0.png">

Campaigns associated with this user:
<img width="777" alt="Screen Shot 2020-11-25 at 12 24 08 PM" src="https://user-images.githubusercontent.com/20409413/100262037-9d9e0980-2f19-11eb-9002-8446c86770e6.png">
