### PR TITLE
Remove textToDisplay in favor of inline

### DIFF
--- a/resources/assets/components/utilities/ScholarshipCard/GalleryBlockSignup.js
+++ b/resources/assets/components/utilities/ScholarshipCard/GalleryBlockSignup.js
@@ -37,8 +37,8 @@ const GalleryBlockSignup = ({ campaignId, path }) => {
     error: errorCampaign,
   } = useQuery(SEARCH_USER_CAMPAIGN_QUERY, {
     variables: {
-      userId: window.AUTH.id,
-      campaignId,
+      userId: window.AUTH.id.toString(),
+      campaignId: campaignId.toString(),
     },
     skip: !window.AUTH.id,
   });
@@ -55,10 +55,6 @@ const GalleryBlockSignup = ({ campaignId, path }) => {
   const [flash, authenticate] = useGate(
     `OneClickSignupCampaignId:${campaignId}`,
   );
-
-  const textToDisplay = userSignedUpForThisCampaign => {
-    return userSignedUpForThisCampaign ? 'View Application' : 'Apply Now';
-  };
 
   const handleScholarshipCardShareClick = event => {
     event.preventDefault();
@@ -105,7 +101,11 @@ const GalleryBlockSignup = ({ campaignId, path }) => {
   return (
     <SecondaryButton
       className="w-full"
-      text={textToDisplay(campaignData.signups.length)}
+      text={
+        campaignData && campaignData.signups.length
+          ? 'View Application'
+          : 'Apply Now'
+      }
       href={path}
       onClick={handleScholarshipCardShareClick}
     />

--- a/resources/assets/components/utilities/ScholarshipCard/GalleryBlockSignup.js
+++ b/resources/assets/components/utilities/ScholarshipCard/GalleryBlockSignup.js
@@ -37,7 +37,7 @@ const GalleryBlockSignup = ({ campaignId, path }) => {
     error: errorCampaign,
   } = useQuery(SEARCH_USER_CAMPAIGN_QUERY, {
     variables: {
-      userId: getUserId,
+      userId: getUserId(),
       campaignId: campaignId.toString(),
     },
     skip: !window.AUTH.id,

--- a/resources/assets/components/utilities/ScholarshipCard/GalleryBlockSignup.js
+++ b/resources/assets/components/utilities/ScholarshipCard/GalleryBlockSignup.js
@@ -6,7 +6,7 @@ import { useQuery, useMutation } from '@apollo/react-hooks';
 import SecondaryButton from '../Button/SecondaryButton';
 import Spinner from '../../artifacts/Spinner/Spinner';
 import ErrorBlock from '../../blocks/ErrorBlock/ErrorBlock';
-import { useGate, isAuthenticated } from '../../../helpers/auth';
+import { useGate, isAuthenticated, getUserId } from '../../../helpers/auth';
 import {
   EVENT_CATEGORIES,
   trackAnalyticsEvent,
@@ -37,7 +37,7 @@ const GalleryBlockSignup = ({ campaignId, path }) => {
     error: errorCampaign,
   } = useQuery(SEARCH_USER_CAMPAIGN_QUERY, {
     variables: {
-      userId: window.AUTH.id.toString(),
+      userId: getUserId,
       campaignId: campaignId.toString(),
     },
     skip: !window.AUTH.id,


### PR DESCRIPTION
Remove textToDisplay in favor of inline
add toSting() to `campaignId` and  `userId`

### What's this PR do?

This pull request fixes an error message when viewing the scholarship page
graphql requires both `campaignId` and  `userId`, added toString() to fix the error

Also switched to an inline code for the `text` prop and checked if the data is available before evaluating what to be presented 
### How should this be reviewed?
![Screen Shot 2020-12-01 at 12 42 20 PM](https://user-images.githubusercontent.com/20409413/100806893-47403780-33ff-11eb-8e02-d716855f715a.png)

<img width="726" alt="Screen Shot 2020-12-01 at 5 55 17 PM" src="https://user-images.githubusercontent.com/20409413/100806912-53c49000-33ff-11eb-8494-ef557eaae8d2.png">

...

### Any background context you want to provide?

...

### Relevant tickets

References [Pivotal #173454908](https://www.pivotaltracker.com/n/projects/2401401/stories/173454908/comments/220130129).

### Checklist

- [ x ] This PR has been added to the relevant Pivotal card.
- [ x  ] Added screenshots of front-end changes on small, medium, and large screens.
