### PR TITLE
Adding Photo to Submission Page

### DIFF
--- a/resources/assets/components/pages/ShowSubmissionPage/ShowSubmissionPage.js
+++ b/resources/assets/components/pages/ShowSubmissionPage/ShowSubmissionPage.js
@@ -46,8 +46,8 @@ const ShowSubmissionPage = ({ match }) => {
     <>
       <SiteNavigationContainer />
 
-      <div className="base-12-grid bg-white">
-        <main className="grid-wide lg:flex">
+      <main className="base-12-grid">
+        <div className="grid-wide lg:flex bg-white">
           {postImageUrl ? (
             <div className="w-1/2 md:w-1/4 pt-6 lg:p-6">
               {loading ? (
@@ -86,11 +86,13 @@ const ShowSubmissionPage = ({ match }) => {
               <TextContent className="mb-6">{defaultContent}</TextContent>
             )}
           </div>
-        
+        </div>
 
-        <RecommendedCampaignsGallery />
+        <div className="grid-wide">
+          <RecommendedCampaignsGallery />
+        </div>
       </main>
-      </div>
+
       <SiteFooter />
     </>
   );

--- a/resources/assets/components/pages/ShowSubmissionPage/ShowSubmissionPage.js
+++ b/resources/assets/components/pages/ShowSubmissionPage/ShowSubmissionPage.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { get } from 'lodash';
 import gql from 'graphql-tag';
+import classnames from 'classnames';
 import { useQuery } from '@apollo/react-hooks';
 import ReactRouterPropTypes from 'react-router-prop-types';
 
@@ -56,7 +57,11 @@ const ShowSubmissionPage = ({ match }) => {
               )}
             </div>
           ) : null}
-          <div className="lg:w-2/3 p-6">
+          <div
+            className={classnames('p-6', {
+              'lg:w-2/3 ': postImageUrl,
+            })}
+          >
             <h1 className="uppercase text-3xl md:text-4xl font-league-gothic font-normal">
               We Got Your Submission
             </h1>

--- a/resources/assets/components/pages/ShowSubmissionPage/ShowSubmissionPage.js
+++ b/resources/assets/components/pages/ShowSubmissionPage/ShowSubmissionPage.js
@@ -6,8 +6,7 @@ import { useQuery } from '@apollo/react-hooks';
 import ReactRouterPropTypes from 'react-router-prop-types';
 
 import Query from '../../Query';
-import { query } from '../../../helpers';
-import Spinner from '../../artifacts/Spinner/Spinner';
+import { env, query } from '../../../helpers';
 import ErrorBlock from '../../blocks/ErrorBlock/ErrorBlock';
 import SiteFooter from '../../utilities/SiteFooter/SiteFooter';
 import TextContent from '../../utilities/TextContent/TextContent';
@@ -15,8 +14,8 @@ import RecommendedCampaignsGallery from './RecommendedCampaignsGallery';
 import SiteNavigationContainer from '../../SiteNavigation/SiteNavigationContainer';
 import { CONTENTFUL_BLOCK_QUERY } from '../../utilities/ContentfulEntryLoader/ContentfulEntryLoader';
 
-const CAMPAIGN_POST_QUERY = gql`
-  query CampaignInfoQuery($postId: Int!) {
+const POST_QUERY = gql`
+  query PostQuery($postId: Int!) {
     post(id: $postId) {
       id
       url
@@ -30,7 +29,7 @@ const ShowSubmissionPage = ({ match }) => {
     'Thanks for joining the movement! After we review your submission, we&apos;ll add it to the public gallery alongside submissions from all the other members taking action in this campaign.';
   const postId = Number(match.params.post_id);
 
-  const { loading, error, data: postData } = useQuery(CAMPAIGN_POST_QUERY, {
+  const { loading, error, data: postData } = useQuery(POST_QUERY, {
     variables: {
       postId,
     },
@@ -48,17 +47,13 @@ const ShowSubmissionPage = ({ match }) => {
 
       <main className="base-12-grid">
         <div className="grid-wide lg:flex bg-white">
-          {postImageUrl ? (
+          {postImageUrl && !loading ? (
             <div className="w-1/2 md:w-1/4 pt-6 lg:p-6">
-              {loading ? (
-                <Spinner />
-              ) : (
-                <img
-                  className="border-2 border-gray-400 border-solid"
-                  alt="Reportback submission"
-                  src={postImageUrl}
-                />
-              )}
+              <img
+                className="border-2 border-gray-400 border-solid"
+                alt="Reportback submission"
+                src={postImageUrl}
+              />
             </div>
           ) : null}
           <div
@@ -72,7 +67,10 @@ const ShowSubmissionPage = ({ match }) => {
             {id ? (
               <Query
                 query={CONTENTFUL_BLOCK_QUERY}
-                variables={{ id, preview: false }}
+                variables={{
+                  id,
+                  preview: env('CONTENTFUL_USE_PREVIEW_API', false),
+                }}
               >
                 {data =>
                   data.block.affirmationContent ? (

--- a/resources/assets/components/pages/ShowSubmissionPage/ShowSubmissionPage.js
+++ b/resources/assets/components/pages/ShowSubmissionPage/ShowSubmissionPage.js
@@ -49,17 +49,21 @@ const ShowSubmissionPage = ({ match }) => {
       <div className="base-12-grid bg-white">
         <main className="grid-wide lg:flex">
           {postImageUrl ? (
-            <div className="lg:w-1/3 p-6">
+            <div className="w-1/2 md:w-1/4 pt-6 md:p-6">
               {loading ? (
                 <Spinner />
               ) : (
-                <img alt="Reportback submission" src={postImageUrl} />
+                <img
+                  className="border-2 border-gray-400 border-solid"
+                  alt="Reportback submission"
+                  src={postImageUrl}
+                />
               )}
             </div>
           ) : null}
           <div
-            className={classnames('p-6', {
-              'lg:w-2/3 ': postImageUrl,
+            className={classnames('py-3 lg:p-6', {
+              'lg:w-3/4 ': postImageUrl,
             })}
           >
             <h1 className="uppercase text-3xl md:text-4xl font-league-gothic font-normal">

--- a/resources/assets/components/pages/ShowSubmissionPage/ShowSubmissionPage.js
+++ b/resources/assets/components/pages/ShowSubmissionPage/ShowSubmissionPage.js
@@ -46,9 +46,9 @@ const ShowSubmissionPage = ({ match }) => {
       <SiteNavigationContainer />
 
       <main className="base-12-grid">
-        <div className="grid-wide lg:flex bg-white">
+        <div className="grid-wide lg:flex bg-white px-6">
           {postImageUrl && !loading ? (
-            <div className="w-1/2 md:w-1/4 pt-6 lg:p-6">
+            <div className="w-1/2 md:w-1/4 pt-6">
               <img
                 className="border-2 border-gray-400 border-solid"
                 alt="Reportback submission"
@@ -64,6 +64,7 @@ const ShowSubmissionPage = ({ match }) => {
             <h1 className="uppercase text-3xl md:text-4xl font-league-gothic font-normal">
               We Got Your Submission
             </h1>
+
             {id ? (
               <Query
                 query={CONTENTFUL_BLOCK_QUERY}
@@ -86,7 +87,11 @@ const ShowSubmissionPage = ({ match }) => {
           </div>
         </div>
 
-        <div className="grid-wide">
+        <div className="grid-wide m-6">
+          <h1 className="uppercase text-3xl md:text-4xl font-league-gothic font-normal">
+            More Scholarship Opportunities
+          </h1>
+
           <RecommendedCampaignsGallery />
         </div>
       </main>

--- a/resources/assets/components/pages/ShowSubmissionPage/ShowSubmissionPage.js
+++ b/resources/assets/components/pages/ShowSubmissionPage/ShowSubmissionPage.js
@@ -35,7 +35,7 @@ const ShowSubmissionPage = ({ match }) => {
     },
   });
 
-  const postImageURL = get(postData, 'post.url', null);
+  const postImageUrl = get(postData, 'post.url', null);
 
   if (loading) {
     return <Spinner />;
@@ -49,27 +49,34 @@ const ShowSubmissionPage = ({ match }) => {
     <>
       <SiteNavigationContainer />
 
-      <main>
-        <div>
-          <h1 className="uppercase text-3xl md:text-4xl font-league-gothic font-normal">
-            We Got Your Submission
-          </h1>
-          {id ? (
-            <Query
-              query={CONTENTFUL_BLOCK_QUERY}
-              variables={{ id, preview: false }}
-            >
-              {data =>
-                data.block.affirmationContent ? (
-                  <TextContent className="mb-6">
-                    {data.block.affirmationContent}
-                  </TextContent>
-                ) : null
-              }
-            </Query>
-          ) : (
-            <TextContent className="mb-6">{defaultContent}</TextContent>
-          )}
+      <main className="base-12-grid">
+        <div className="grid-wide flex">
+          {postImageUrl ? (
+            <div className="w-1/3">
+              <img alt="Reportback submission" src={postImageUrl} />
+            </div>
+          ) : null}
+          <div className="w-2/3">
+            <h1 className="uppercase text-3xl md:text-4xl font-league-gothic font-normal">
+              We Got Your Submission
+            </h1>
+            {id ? (
+              <Query
+                query={CONTENTFUL_BLOCK_QUERY}
+                variables={{ id, preview: false }}
+              >
+                {data =>
+                  data.block.affirmationContent ? (
+                    <TextContent className="mb-6">
+                      {data.block.affirmationContent}
+                    </TextContent>
+                  ) : null
+                }
+              </Query>
+            ) : (
+              <TextContent className="mb-6">{defaultContent}</TextContent>
+            )}
+          </div>
         </div>
 
         <RecommendedCampaignsGallery />

--- a/resources/assets/components/pages/ShowSubmissionPage/ShowSubmissionPage.js
+++ b/resources/assets/components/pages/ShowSubmissionPage/ShowSubmissionPage.js
@@ -49,7 +49,7 @@ const ShowSubmissionPage = ({ match }) => {
       <div className="base-12-grid bg-white">
         <main className="grid-wide lg:flex">
           {postImageUrl ? (
-            <div className="w-1/2 md:w-1/4 pt-6 md:p-6">
+            <div className="w-1/2 md:w-1/4 pt-6 lg:p-6">
               {loading ? (
                 <Spinner />
               ) : (

--- a/resources/assets/components/pages/ShowSubmissionPage/ShowSubmissionPage.js
+++ b/resources/assets/components/pages/ShowSubmissionPage/ShowSubmissionPage.js
@@ -1,17 +1,50 @@
 import React from 'react';
+import gql from 'graphql-tag';
+import { useQuery } from '@apollo/react-hooks';
+import ReactRouterPropTypes from 'react-router-prop-types';
 
 import Query from '../../Query';
 import { query } from '../../../helpers';
+import Spinner from '../../artifacts/Spinner/Spinner';
+import ErrorBlock from '../../blocks/ErrorBlock/ErrorBlock';
 import SiteFooter from '../../utilities/SiteFooter/SiteFooter';
 import TextContent from '../../utilities/TextContent/TextContent';
 import RecommendedCampaignsGallery from './RecommendedCampaignsGallery';
 import SiteNavigationContainer from '../../SiteNavigation/SiteNavigationContainer';
 import { CONTENTFUL_BLOCK_QUERY } from '../../utilities/ContentfulEntryLoader/ContentfulEntryLoader';
 
-const ShowSubmissionPage = () => {
+const CAMPAIGN_POST_QUERY = gql`
+  query CampaignInfoQuery($postId: Int!) {
+    post(id: $postId) {
+      id
+      url
+    }
+  }
+`;
+
+const ShowSubmissionPage = ({ match }) => {
   const id = query('submissionActionId');
   const defaultContent =
     'Thanks for joining the movement! After we review your submission, we&apos;ll add it to the public gallery alongside submissions from all the other members taking action in this campaign.';
+  const postId = Number(match.params.post_id);
+
+  const { loading, error, postData } = useQuery(CAMPAIGN_POST_QUERY, {
+    variables: {
+      postId,
+    },
+  });
+
+  // const post = postData
+
+  if (loading) {
+    return <Spinner />;
+  }
+
+  if (error) {
+    return <ErrorBlock error={error} />;
+  }
+
+  console.log('this is the post', postData);
 
   return (
     <>
@@ -36,9 +69,7 @@ const ShowSubmissionPage = () => {
               }
             </Query>
           ) : (
-            <p>
-              <TextContent className="mb-6">{defaultContent}</TextContent>
-            </p>
+            <TextContent className="mb-6">{defaultContent}</TextContent>
           )}
         </div>
 
@@ -47,6 +78,10 @@ const ShowSubmissionPage = () => {
       <SiteFooter />
     </>
   );
+};
+
+ShowSubmissionPage.propTypes = {
+  match: ReactRouterPropTypes.match.isRequired,
 };
 
 export default ShowSubmissionPage;

--- a/resources/assets/components/pages/ShowSubmissionPage/ShowSubmissionPage.js
+++ b/resources/assets/components/pages/ShowSubmissionPage/ShowSubmissionPage.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { get } from 'lodash';
 import gql from 'graphql-tag';
 import { useQuery } from '@apollo/react-hooks';
 import ReactRouterPropTypes from 'react-router-prop-types';
@@ -28,13 +29,13 @@ const ShowSubmissionPage = ({ match }) => {
     'Thanks for joining the movement! After we review your submission, we&apos;ll add it to the public gallery alongside submissions from all the other members taking action in this campaign.';
   const postId = Number(match.params.post_id);
 
-  const { loading, error, postData } = useQuery(CAMPAIGN_POST_QUERY, {
+  const { loading, error, data: postData } = useQuery(CAMPAIGN_POST_QUERY, {
     variables: {
       postId,
     },
   });
 
-  // const post = postData
+  const postImageURL = get(postData, 'post.url', null);
 
   if (loading) {
     return <Spinner />;
@@ -43,8 +44,6 @@ const ShowSubmissionPage = ({ match }) => {
   if (error) {
     return <ErrorBlock error={error} />;
   }
-
-  console.log('this is the post', postData);
 
   return (
     <>

--- a/resources/assets/components/pages/ShowSubmissionPage/ShowSubmissionPage.js
+++ b/resources/assets/components/pages/ShowSubmissionPage/ShowSubmissionPage.js
@@ -37,10 +37,6 @@ const ShowSubmissionPage = ({ match }) => {
 
   const postImageUrl = get(postData, 'post.url', null);
 
-  if (loading) {
-    return <Spinner />;
-  }
-
   if (error) {
     return <ErrorBlock error={error} />;
   }
@@ -49,14 +45,18 @@ const ShowSubmissionPage = ({ match }) => {
     <>
       <SiteNavigationContainer />
 
-      <main className="base-12-grid">
-        <div className="grid-wide flex">
+      <div className="base-12-grid bg-white">
+        <main className="grid-wide lg:flex">
           {postImageUrl ? (
-            <div className="w-1/3">
-              <img alt="Reportback submission" src={postImageUrl} />
+            <div className="lg:w-1/3 p-6">
+              {loading ? (
+                <Spinner />
+              ) : (
+                <img alt="Reportback submission" src={postImageUrl} />
+              )}
             </div>
           ) : null}
-          <div className="w-2/3">
+          <div className="lg:w-2/3 p-6">
             <h1 className="uppercase text-3xl md:text-4xl font-league-gothic font-normal">
               We Got Your Submission
             </h1>
@@ -77,10 +77,11 @@ const ShowSubmissionPage = ({ match }) => {
               <TextContent className="mb-6">{defaultContent}</TextContent>
             )}
           </div>
-        </div>
+        
 
         <RecommendedCampaignsGallery />
       </main>
+      </div>
       <SiteFooter />
     </>
   );


### PR DESCRIPTION
### What's this PR do?

This pull request adds a query for the post's photo URL if it exists! We want to add the photo from the post so that users who completed a photo report back can see what they submitted.

### How should this be reviewed?

👀 

I have two questions I'd like feedback on.

1. Is there a better way to size the photos based on screensize? I went with width in TW because it's easy and seems to work well enough, but not sure if we should be more explicit in defining width etc.

2. On medium screens, when the related campaigns are displayed one per row, I feel like it looks wonky compared to the size of the reportback photo. Thoughts?

### Any background context you want to provide?

Large:
<img width="828" alt="Screen Shot 2020-12-03 at 12 02 10 PM" src="https://user-images.githubusercontent.com/15236023/101062630-e2502300-355f-11eb-9edd-12a4d63c2301.png">

Small:
<img width="379" alt="Screen Shot 2020-12-03 at 12 03 33 PM" src="https://user-images.githubusercontent.com/15236023/101062648-e7ad6d80-355f-11eb-8cf3-d42168b5de25.png">

Medium:
<img width="388" alt="Screen Shot 2020-12-03 at 12 03 45 PM" src="https://user-images.githubusercontent.com/15236023/101062654-e9773100-355f-11eb-8c8e-c65be8e9f7d3.png">


This is only relevant for photo submission reportbacks

### Relevant tickets

References [Pivotal #173236812](https://www.pivotaltracker.com/story/show/173236812).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added screenshots of front-end changes on small, medium, and large screens.
- [ ] Added appropriate feature/unit tests.
