### PR TITLE
Update Query component to useQuery hook

### DIFF
--- a/resources/assets/components/Query.js
+++ b/resources/assets/components/Query.js
@@ -1,32 +1,27 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Query as ApolloQuery } from 'react-apollo';
+import { useQuery } from '@apollo/react-hooks';
 
-import { NetworkStatus } from '../constants';
-import ErrorBlock from './blocks/ErrorBlock/ErrorBlock';
 import Spinner from './artifacts/Spinner/Spinner';
+import ErrorBlock from './blocks/ErrorBlock/ErrorBlock';
 
 /**
- * Fetch results via GraphQL using a query component.
+ * Fetch results via GraphQL using the useQuery hook.
  */
-const Query = ({ query, variables, children, hideSpinner }) => (
-  <ApolloQuery query={query} variables={variables} notifyOnNetworkStatusChange>
-    {result => {
-      // On initial load, just display a loading spinner.
-      if (result.networkStatus === NetworkStatus.LOADING) {
-        return hideSpinner ? null : (
-          <Spinner className="flex justify-center p-6" />
-        );
-      }
+const Query = ({ query, variables, children, hideSpinner }) => {
+  const { error, loading, data } = useQuery(query, { variables });
 
-      if (result.error) {
-        return <ErrorBlock error={result.error} />;
-      }
+  // On initial load, just display a loading spinner.
+  if (loading) {
+    return hideSpinner ? null : <Spinner className="flex justify-center p-6" />;
+  }
 
-      return children(result.data);
-    }}
-  </ApolloQuery>
-);
+  if (error) {
+    return <ErrorBlock error={error} />;
+  }
+
+  return children(data);
+};
 
 Query.propTypes = {
   query: PropTypes.object.isRequired,


### PR DESCRIPTION
### What's this PR do?

This pull request updates the in-house `Query` component to use the `useQuery` hook instead of the older Apollo `Query` component

### How should this be reviewed?
👀 

I don't think we need the detailed `networkStatus` right? I swapped that for the `loading` variable which I'm pretty sure is the updated equivalent of the status code we were using here (`loading: 1`).

### Any background context you want to provide?
I used this component in #2446 and felt like this might be a nice time to update.

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added screenshots of front-end changes on small, medium, and large screens.
- [ ] Added appropriate feature/unit tests.
