### PR TITLE
Update PaginatedQuery component to use the useQuery hook

### DIFF
--- a/resources/assets/components/PaginatedQuery.js
+++ b/resources/assets/components/PaginatedQuery.js
@@ -1,63 +1,62 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Query } from 'react-apollo';
+import { useQuery } from '@apollo/react-hooks';
 
 import { NetworkStatus } from '../constants';
-import ErrorBlock from './blocks/ErrorBlock/ErrorBlock';
 import Spinner from './artifacts/Spinner/Spinner';
+import ErrorBlock from './blocks/ErrorBlock/ErrorBlock';
 
 /**
- * Fetch results via GraphQL using a query component.
+ * Fetch results via GraphQL using a useQuery hook.
  */
-const PaginatedQuery = ({ query, queryName, variables, count, children }) => (
-  <Query
-    query={query}
-    variables={{ ...variables, count, page: 1 }}
-    notifyOnNetworkStatusChange
-  >
-    {result => {
-      // On initial load, just display a loading spinner.
-      if (result.networkStatus === NetworkStatus.LOADING) {
-        return <Spinner className="flex justify-center p-6" />;
-      }
+const PaginatedQuery = ({ query, queryName, variables, count, children }) => {
+  const { error, loading, data, fetchMore, networkStatus } = useQuery(query, {
+    variables: {
+      ...variables,
+      count,
+      page: 1,
+    },
+    notifyOnNetworkStatusChange: true,
+  });
 
-      if (result.error) {
-        console.error(`${queryName} ERROR: ${result.error}`);
-        return <ErrorBlock error={result.error} />;
-      }
+  // On initial load, just display a loading spinner.
+  if (networkStatus === NetworkStatus.LOADING) {
+    return <Spinner className="flex justify-center p-6" />;
+  }
 
-      return children({
-        result: result.data[queryName],
-        fetching: result.networkStatus === NetworkStatus.FETCH_MORE,
-        fetchMore: () =>
-          result.fetchMore({
-            variables: {
-              // The value in `variables.page` doesn't get updated here on
-              // subsequent clicks, so we have to recalculate each time...
-              page:
-                // Use ceil to force an integer in case we have less results data than the count!
-                Math.ceil(
-                  result.data[queryName].length / result.variables.count,
-                ) + 1,
-            },
-            updateQuery: (previousResult, { fetchMoreResult }) => {
-              if (!fetchMoreResult[queryName]) {
-                return previousResult;
-              }
+  if (error) {
+    console.error(`${queryName} ERROR: ${error}`);
+    return <ErrorBlock error={error} />;
+  }
 
-              return {
-                ...previousResult,
-                [queryName]: [
-                  ...previousResult[queryName],
-                  ...fetchMoreResult[queryName],
-                ],
-              };
-            },
-          }),
-      });
-    }}
-  </Query>
-);
+  return children({
+    result: data[queryName],
+    fetching: networkStatus === NetworkStatus.FETCH_MORE,
+    fetchMore: () =>
+      fetchMore({
+        variables: {
+          // The value in `variables.page` doesn't get updated here on
+          // subsequent clicks, so we have to recalculate each time...
+          page:
+            // Use ceil to force an integer in case we have less results data than the count!
+            Math.ceil(data[queryName].length / count) + 1,
+        },
+        updateQuery: (previousResult, { fetchMoreResult }) => {
+          if (!fetchMoreResult[queryName]) {
+            return previousResult;
+          }
+
+          return {
+            ...previousResult,
+            [queryName]: [
+              ...previousResult[queryName],
+              ...fetchMoreResult[queryName],
+            ],
+          };
+        },
+      }),
+  });
+};
 
 PaginatedQuery.propTypes = {
   query: PropTypes.any.isRequired, // eslint-disable-line react/forbid-prop-types

--- a/resources/assets/components/PaginatedQuery.js
+++ b/resources/assets/components/PaginatedQuery.js
@@ -10,7 +10,7 @@ import ErrorBlock from './blocks/ErrorBlock/ErrorBlock';
  * Fetch results via GraphQL using a useQuery hook.
  */
 const PaginatedQuery = ({ query, queryName, variables, count, children }) => {
-  const { error, loading, data, fetchMore, networkStatus } = useQuery(query, {
+  const { error, data, fetchMore, networkStatus } = useQuery(query, {
     variables: {
       ...variables,
       count,

--- a/resources/assets/components/PaginatedQuery.js
+++ b/resources/assets/components/PaginatedQuery.js
@@ -2,10 +2,10 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { useQuery } from '@apollo/react-hooks';
 
+import { updateQuery } from '../helpers';
 import { NetworkStatus } from '../constants';
 import Spinner from './artifacts/Spinner/Spinner';
 import ErrorBlock from './blocks/ErrorBlock/ErrorBlock';
-import { updateQuery } from '../helpers';
 
 /**
  * Fetch results via GraphQL using a useQuery hook.

--- a/resources/assets/components/PaginatedQuery.js
+++ b/resources/assets/components/PaginatedQuery.js
@@ -5,6 +5,7 @@ import { useQuery } from '@apollo/react-hooks';
 import { NetworkStatus } from '../constants';
 import Spinner from './artifacts/Spinner/Spinner';
 import ErrorBlock from './blocks/ErrorBlock/ErrorBlock';
+import { updateQuery } from '../helpers';
 
 /**
  * Fetch results via GraphQL using a useQuery hook.
@@ -41,19 +42,7 @@ const PaginatedQuery = ({ query, queryName, variables, count, children }) => {
             // Use ceil to force an integer in case we have less results data than the count!
             Math.ceil(data[queryName].length / count) + 1,
         },
-        updateQuery: (previousResult, { fetchMoreResult }) => {
-          if (!fetchMoreResult[queryName]) {
-            return previousResult;
-          }
-
-          return {
-            ...previousResult,
-            [queryName]: [
-              ...previousResult[queryName],
-              ...fetchMoreResult[queryName],
-            ],
-          };
-        },
+        updateQuery,
       }),
   });
 };


### PR DESCRIPTION
### What's this PR do?

This pull request updates the `PaginatedQuery` component to utilize the newer `useQuery` React hook.

### How should this be reviewed?
👀 

### Any background context you want to provide?
Following up on #2447 

This admittedly doesn't clean much.... Though it doesn't hurt to be hooked into the hook.

I initially wanted to tackle this here to see if we could scrap the network status mapping constant per https://github.com/DoSomething/phoenix-next/pull/2447#discussion_r534649070, but turns out we actually still need it here to differentiate between the initial data fetch and the subsequent "fetch more" requests to either render a plain spinner or just notify the child that we're in loading state.

