### PR TITLE
Show Submission Page - Slight Style Adjustment

### DIFF
--- a/resources/assets/components/pages/ShowSubmissionPage/ShowSubmissionPage.js
+++ b/resources/assets/components/pages/ShowSubmissionPage/ShowSubmissionPage.js
@@ -49,7 +49,7 @@ const ShowSubmissionPage = ({ match }) => {
         <div className="base-12-grid bg-white">
           <div className="grid-wide lg:flex px-2 md:px-4 lg:px-6">
             {postImageUrl && !loading ? (
-              <div className="w-1/2 md:w-1/4 pt-6">
+              <div className="w-1/2 md:w-1/4 pt-6 lg:pb-4">
                 <img
                   className="border-2 border-gray-400 border-solid"
                   alt="Reportback submission"

--- a/resources/assets/components/pages/ShowSubmissionPage/ShowSubmissionPage.js
+++ b/resources/assets/components/pages/ShowSubmissionPage/ShowSubmissionPage.js
@@ -45,54 +45,58 @@ const ShowSubmissionPage = ({ match }) => {
     <>
       <SiteNavigationContainer />
 
-      <main className="base-12-grid">
-        <div className="grid-wide lg:flex bg-white px-6">
-          {postImageUrl && !loading ? (
-            <div className="w-1/2 md:w-1/4 pt-6">
-              <img
-                className="border-2 border-gray-400 border-solid"
-                alt="Reportback submission"
-                src={postImageUrl}
-              />
-            </div>
-          ) : null}
-          <div
-            className={classnames('py-3 lg:p-6', {
-              'lg:w-3/4 ': postImageUrl,
-            })}
-          >
-            <h1 className="uppercase text-3xl md:text-4xl font-league-gothic font-normal">
-              We Got Your Submission
-            </h1>
+      <main>
+        <div className="base-12-grid bg-white">
+          <div className="grid-wide lg:flex px-2 md:px-4 lg:px-6">
+            {postImageUrl && !loading ? (
+              <div className="w-1/2 md:w-1/4 pt-6">
+                <img
+                  className="border-2 border-gray-400 border-solid"
+                  alt="Reportback submission"
+                  src={postImageUrl}
+                />
+              </div>
+            ) : null}
+            <div
+              className={classnames('py-3 lg:p-6', {
+                'lg:w-3/4 ': postImageUrl,
+              })}
+            >
+              <h1 className="uppercase text-3xl md:text-4xl font-league-gothic font-normal">
+                We Got Your Submission
+              </h1>
 
-            {id ? (
-              <Query
-                query={CONTENTFUL_BLOCK_QUERY}
-                variables={{
-                  id,
-                  preview: env('CONTENTFUL_USE_PREVIEW_API', false),
-                }}
-              >
-                {data =>
-                  data.block.affirmationContent ? (
-                    <TextContent className="mb-6">
-                      {data.block.affirmationContent}
-                    </TextContent>
-                  ) : null
-                }
-              </Query>
-            ) : (
-              <TextContent className="mb-6">{defaultContent}</TextContent>
-            )}
+              {id ? (
+                <Query
+                  query={CONTENTFUL_BLOCK_QUERY}
+                  variables={{
+                    id,
+                    preview: env('CONTENTFUL_USE_PREVIEW_API', false),
+                  }}
+                >
+                  {data =>
+                    data.block.affirmationContent ? (
+                      <TextContent className="mb-6">
+                        {data.block.affirmationContent}
+                      </TextContent>
+                    ) : null
+                  }
+                </Query>
+              ) : (
+                <TextContent className="mb-6">{defaultContent}</TextContent>
+              )}
+            </div>
           </div>
         </div>
 
-        <div className="grid-wide m-6">
-          <h1 className="uppercase text-3xl md:text-4xl font-league-gothic font-normal">
-            More Scholarship Opportunities
-          </h1>
+        <div className="base-12-grid">
+          <div className="grid-wide mt-6 mx-2 md:mx-4 lg:mx-6">
+            <h2 className="uppercase text-2xl md:text-3xl font-league-gothic font-normal">
+              More Scholarship Opportunities
+            </h2>
 
-          <RecommendedCampaignsGallery />
+            <RecommendedCampaignsGallery />
+          </div>
         </div>
       </main>
 


### PR DESCRIPTION
### What's this PR do?

This pull request tweaks the styling a tad for the Gallery and general layout on the Show Submission page.

### How should this be reviewed?
👀 
It's a bit tricky to see the actual changes but they're minor. Just a couple of little tweaks per the [designs](https://app.abstract.com/projects/fadf0790-f1f9-11e6-9a30-b54ba7e8e705/branches/1c5535e5-7433-4778-9107-9ce6dc3bd74f/commits/latest/files/05f5faae-3c13-4947-b624-f9e0ea97822c/layers/283AA542-4DAB-42D1-9EE3-D1D171BBB36C?collectionId=b9242790-e891-4704-933e-fca6b5bf1e37&collectionLayerId=f8b892a4-f800-47cc-afb1-12e7ed301395):
- added a surrounding base-12-grid `<div>` around the submission section and gallery section to get the full white background
- adjusted padding / margin on both sections for small/medium/large
- updated the gallery `<h1>` title to an `<h2>`

### Relevant tickets

References [Pivotal #173236860](https://www.pivotaltracker.com/story/show/173236860).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [x] Added screenshots of front-end changes on small, medium, and large screens.
- [ ] Added appropriate feature/unit tests.

**Before**
- [Small](https://user-images.githubusercontent.com/12417657/101196593-f31b9a00-362e-11eb-9bd1-71318ce743d0.png)
- [Medium](https://user-images.githubusercontent.com/12417657/101196596-f3b43080-362e-11eb-9c73-19b8710a5958.png)
- [Large](https://user-images.githubusercontent.com/12417657/101196597-f3b43080-362e-11eb-816e-82bf228aefd8.png)


**After**
- [Small](https://user-images.githubusercontent.com/12417657/101196512-d1221780-362e-11eb-9a42-cc4f43dadddb.png)
- [Medium](https://user-images.githubusercontent.com/12417657/101196514-d1baae00-362e-11eb-9c78-074787b04fa5.png)
- [Large](https://user-images.githubusercontent.com/12417657/101196516-d2534480-362e-11eb-8aa4-d14abc1c8f1f.png)
