### PR TITLE
Quick Styling Tweak - Show Submission Page

### DIFF
--- a/resources/assets/components/pages/ShowSubmissionPage/ShowSubmissionPage.js
+++ b/resources/assets/components/pages/ShowSubmissionPage/ShowSubmissionPage.js
@@ -87,7 +87,7 @@ const ShowSubmissionPage = ({ match }) => {
           </div>
         </div>
 
-        <div className="grid-wide m-6">
+        <div className="grid-wide m-6 mb-16">
           <h1 className="uppercase text-3xl md:text-4xl font-league-gothic font-normal">
             More Scholarship Opportunities
           </h1>

--- a/resources/assets/components/pages/ShowSubmissionPage/ShowSubmissionPage.js
+++ b/resources/assets/components/pages/ShowSubmissionPage/ShowSubmissionPage.js
@@ -89,7 +89,7 @@ const ShowSubmissionPage = ({ match }) => {
           </div>
         </div>
 
-        <div className="base-12-grid">
+        <div className="base-12-grid mb-16">
           <div className="grid-wide mt-6 mx-2 md:mx-4 lg:mx-6">
             <h2 className="uppercase text-2xl md:text-3xl font-league-gothic font-normal">
               More Scholarship Opportunities


### PR DESCRIPTION
### What's this PR do?

This pull request adds a quick styling tweak to the Show Submission Page per Design QA to add some more bottom margin to the Gallery. (The request was for `60px` and the `mb-16` was pretty darn close so I opted for that!)

### How should this be reviewed?
👀 

### Relevant tickets

References [Pivotal #173236860/comments/220251091](https://www.pivotaltracker.com/story/show/173236860/comments/220251091).

**Before**
![image](https://user-images.githubusercontent.com/12417657/101211856-d3dc3700-3645-11eb-88b0-29887d94dab5.png)

**After**
![image](https://user-images.githubusercontent.com/12417657/101211595-6af4bf00-3645-11eb-82ad-60b222027288.png)
