### PR TITLE
Rename rewards tab

### DIFF
--- a/config/feature-flags.php
+++ b/config/feature-flags.php
@@ -23,4 +23,5 @@ return [
     'refer_friends_incentive' => env('DS_ENABLE_REFER_FRIENDS_INCENTIVE', false),
     'sitewide_nps_survey' => env('DS_ENABLE_SITEWIDE_NPS_SURVEY', false),
     'volunteer_credits' => env('DS_ENABLE_VOLUNTEER_CREDITS', false),
+    'rewards_levels' => env('DS_ENABLE_REWARDS_LEVELS', false),
 ];

--- a/resources/assets/components/pages/AccountPage/Account/AccountNavigation.js
+++ b/resources/assets/components/pages/AccountPage/Account/AccountNavigation.js
@@ -35,7 +35,7 @@ const AccountNavigation = () => (
         to="/us/account/badges"
         onClick={() => handleAccountNavTabClick('badges')}
       >
-        Badges
+        {featureFlag('rewards_levels') ? 'Rewards' : 'Badges'}
       </NavigationLink>
       {featureFlag('volunteer_credits') ? (
         <NavigationLink

--- a/resources/assets/components/pages/AccountPage/Account/AccountNavigation.js
+++ b/resources/assets/components/pages/AccountPage/Account/AccountNavigation.js
@@ -35,7 +35,7 @@ const AccountNavigation = () => (
         to="/us/account/badges"
         onClick={() =>
           handleAccountNavTabClick(
-            featureFlag('rewards_levels') ? 'rewards' : 'radges',
+            featureFlag('rewards_levels') ? 'rewards' : 'badges',
           )
         }
       >

--- a/resources/assets/components/pages/AccountPage/Account/AccountNavigation.js
+++ b/resources/assets/components/pages/AccountPage/Account/AccountNavigation.js
@@ -33,7 +33,11 @@ const AccountNavigation = () => (
       </NavigationLink>
       <NavigationLink
         to="/us/account/badges"
-        onClick={() => handleAccountNavTabClick('badges')}
+        onClick={() =>
+          handleAccountNavTabClick(
+            featureFlag('rewards_levels') ? 'rewards' : 'radges',
+          )
+        }
       >
         {featureFlag('rewards_levels') ? 'Rewards' : 'Badges'}
       </NavigationLink>

--- a/resources/assets/components/pages/AccountPage/Badges/BadgesTab.js
+++ b/resources/assets/components/pages/AccountPage/Badges/BadgesTab.js
@@ -11,9 +11,9 @@ import {
   getPageContext,
   trackAnalyticsEvent,
 } from '../../../../helpers/analytics';
+import { featureFlag } from '../../../../helpers';
 
 import './badges-tab.scss';
-import { featureFlag } from '../../../../helpers';
 
 const SIGNUP_COUNT_BADGE = gql`
   query SignupsCountQuery($userId: String!) {

--- a/resources/assets/components/pages/AccountPage/Badges/BadgesTab.js
+++ b/resources/assets/components/pages/AccountPage/Badges/BadgesTab.js
@@ -5,6 +5,7 @@ import gql from 'graphql-tag';
 import Badge from './Badge';
 import Query from '../../../Query';
 import BadgeModal from './BadgeModal';
+import RewardsFaq from './RewardsFaq';
 import {
   EVENT_CATEGORIES,
   getPageContext,
@@ -12,6 +13,7 @@ import {
 } from '../../../../helpers/analytics';
 
 import './badges-tab.scss';
+import { featureFlag } from '../../../../helpers';
 
 const SIGNUP_COUNT_BADGE = gql`
   query SignupsCountQuery($userId: String!) {
@@ -384,6 +386,8 @@ class BadgesTab extends React.Component {
             </p>
           </BadgeModal>
         ) : null}
+
+        {featureFlag('rewards_levels') ? <RewardsFaq /> : null}
       </div>
     );
   }

--- a/resources/assets/components/pages/AccountPage/Badges/RewardsFaq.js
+++ b/resources/assets/components/pages/AccountPage/Badges/RewardsFaq.js
@@ -1,0 +1,49 @@
+import React from 'react';
+import tw from 'twin.macro';
+
+import SectionHeader from '../../../utilities/SectionHeader/SectionHeader';
+
+const Details = tw.details`pb-4`;
+const Summary = tw.summary`font-bold text-base cursor-pointer`;
+const DetailsParagraph = tw.p`pt-2`;
+
+const RewardsFaq = () => (
+  <>
+    <div className="col-span-4 md:col-span-8 lg:col-start-2 lg:col-span-7 xxl:col-start-2 xxl:col-span-6 pt-10">
+      <SectionHeader title="faqs" />
+
+      <Details>
+        <Summary>How does DoSomething&apos;s Rewards program work?</Summary>
+
+        <DetailsParagraph>
+          Share the link above with your friend, either via text, email, or
+          social media. Using that link, your friend will create a DoSomething
+          account and then sign up for a campaign. When they sign up, you’ll see
+          their name in the “Your Referrals” section. Yep, that easy.
+        </DetailsParagraph>
+      </Details>
+
+      <Details>
+        <Summary>How do the additional scholarship entries work?</Summary>
+
+        <DetailsParagraph>
+          We’ll email it to you using the same email address used to create your
+          DoSomething account.
+        </DetailsParagraph>
+      </Details>
+
+      <Details>
+        <Summary>What are the terms and conditions?</Summary>
+
+        <DetailsParagraph>
+          This offer is for a limited time only. See the{' '}
+          <a href="/us/refer-a-friend-official-rules" target="_blank">
+            Refer A Friend Official Rules.
+          </a>
+        </DetailsParagraph>
+      </Details>
+    </div>
+  </>
+);
+
+export default RewardsFaq;


### PR DESCRIPTION
### What's this PR do?

This pull request adds a new 🎉 feature flag 🎉  for our Rewards tab!! Behind the feature flag, we're renaming the tab rewards, updating the click tracking analytics, and adding an FAQ section regarding the rewards program. (the copy is not finalized there, will need a follow up PR to update)

### How should this be reviewed?

👀 

**Large:**
<img width="1398" alt="Screen Shot 2020-12-04 at 4 23 07 PM" src="https://user-images.githubusercontent.com/15236023/101216841-389b8f80-364e-11eb-9897-5c2707497238.png">

**Medium:**
<img width="771" alt="Screen Shot 2020-12-04 at 4 23 56 PM" src="https://user-images.githubusercontent.com/15236023/101216876-49e49c00-364e-11eb-9a0b-678b11abaa55.png">

**Small:**
<img width="377" alt="Screen Shot 2020-12-04 at 4 23 21 PM" src="https://user-images.githubusercontent.com/15236023/101216923-5ec12f80-364e-11eb-9f2b-09eee81ba692.png">

<img width="378" alt="Screen Shot 2020-12-04 at 4 23 33 PM" src="https://user-images.githubusercontent.com/15236023/101216928-61238980-364e-11eb-871e-8c6a8cf7a2e2.png">



### Any background context you want to provide?

Getting in some front end work for Levels while we figure out the backend functionality timeline.

### Relevant tickets

References [Pivotal #175856446](https://www.pivotaltracker.com/story/show/175856446).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added screenshots of front-end changes on small, medium, and large screens.
- [ ] Added appropriate feature/unit tests.
