### PR TITLE
Update Levels FAQ Copy and Componentize FAQ structure

### DIFF
--- a/resources/assets/components/pages/AccountPage/Badges/RewardsFaq.js
+++ b/resources/assets/components/pages/AccountPage/Badges/RewardsFaq.js
@@ -7,6 +7,8 @@ const Details = tw.details`pb-4`;
 const Summary = tw.summary`font-bold text-base cursor-pointer`;
 const DetailsParagraph = tw.p`pt-2`;
 
+// needs terms and conditions link
+
 const RewardsFaq = () => (
   <>
     <div className="col-span-4 md:col-span-8 lg:col-start-2 lg:col-span-7 xxl:col-start-2 xxl:col-span-6 pt-10">
@@ -16,10 +18,13 @@ const RewardsFaq = () => (
         <Summary>How does DoSomething&apos;s Rewards program work?</Summary>
 
         <DetailsParagraph>
-          Share the link above with your friend, either via text, email, or
-          social media. Using that link, your friend will create a DoSomething
-          account and then sign up for a campaign. When they sign up, you’ll see
-          their name in the “Your Referrals” section. Yep, that easy.
+          Earn badges to level up. Enjoy your rewards. Let’s Do This!
+        </DetailsParagraph>
+        <DetailsParagraph>
+          (The fine print, because our lawyers said so: Under the current terms
+          and conditions of our program, rewards do not reset. DoSomething
+          reserves the right to reset rewards in the future. See the terms and
+          conditions.)
         </DetailsParagraph>
       </Details>
 
@@ -27,8 +32,29 @@ const RewardsFaq = () => (
         <Summary>How do the additional scholarship entries work?</Summary>
 
         <DetailsParagraph>
-          We’ll email it to you using the same email address used to create your
-          DoSomething account.
+          Once you reach a new level, you will earn the additional scholarship
+          entries for all future campaigns that you complete. For instance, if
+          you become a Doer and complete a DoSomething campaign, you’ll earn 2
+          chances to win that campaign’s scholarship instead of one. As a
+          SuperDoer, you’ll earn 3 scholarship entries instead of 1 entry. And
+          as a Legend you’ll earn 4 scholarship entries instead of 1. This
+          applies to all campaigns you complete.
+        </DetailsParagraph>
+        <DetailsParagraph>
+          For most campaigns, simply completing the campaign earns you a
+          scholarship entry. For campaigns where the impact you make determines
+          your entries into the scholarship contest, your chances to win will be
+          multiplied by your impact. For example, take a campaign that offers a
+          scholarship entry for each pair of jeans you donate. If you’re a
+          SuperDoer (3x scholarship entries) and donate 10 pairs of jeans, your
+          impact will be multiplied by 3 and you’ll earn 30 entries into the
+          scholarship contest.
+        </DetailsParagraph>
+        <DetailsParagraph>
+          <a href="/us/about/easy-scholarships" target="_blank">
+            Learn more about DoSomething scholarships
+          </a>
+          .
         </DetailsParagraph>
       </Details>
 
@@ -36,10 +62,7 @@ const RewardsFaq = () => (
         <Summary>What are the terms and conditions?</Summary>
 
         <DetailsParagraph>
-          This offer is for a limited time only. See the{' '}
-          <a href="/us/refer-a-friend-official-rules" target="_blank">
-            Refer A Friend Official Rules.
-          </a>
+          See DoSomething Rewards terms and conditions.
         </DetailsParagraph>
       </Details>
     </div>

--- a/resources/assets/components/pages/AccountPage/Badges/RewardsFaq.js
+++ b/resources/assets/components/pages/AccountPage/Badges/RewardsFaq.js
@@ -1,13 +1,12 @@
 import React from 'react';
-import tw from 'twin.macro';
+// import tw from 'twin.macro';
 
+import Details from '../../../utilities/FaqElements/Details';
+import Summary from '../../../utilities/FaqElements/Summary';
 import SectionHeader from '../../../utilities/SectionHeader/SectionHeader';
+import DetailsParagraph from '../../../utilities/FaqElements/DetailsParagraph';
 
-const Details = tw.details`pb-4`;
-const Summary = tw.summary`font-bold text-base cursor-pointer`;
-const DetailsParagraph = tw.p`pt-2`;
-
-// needs terms and conditions link
+// @TODO : get feedback on styling for FAQ section and add new terms and conditions link
 
 const RewardsFaq = () => (
   <>
@@ -15,55 +14,53 @@ const RewardsFaq = () => (
       <SectionHeader title="faqs" />
 
       <Details>
-        <Summary>How does DoSomething&apos;s Rewards program work?</Summary>
+        <Summary summaryText="How does DoSomething's Rewards program work?" />
 
-        <DetailsParagraph>
-          Earn badges to level up. Enjoy your rewards. Let’s Do This!
-        </DetailsParagraph>
-        <DetailsParagraph>
-          (The fine print, because our lawyers said so: Under the current terms
-          and conditions of our program, rewards do not reset. DoSomething
-          reserves the right to reset rewards in the future. See the terms and
-          conditions.)
-        </DetailsParagraph>
+        <DetailsParagraph detailsText="Earn badges to level up. Enjoy your rewards. Let’s Do This!" />
+
+        <DetailsParagraph
+          className="mt-0"
+          detailsText="(The fine print, because our lawyers said so: Under the current terms
+            and conditions of our program, rewards do not reset. DoSomething
+            reserves the right to reset rewards in the future. See the terms and
+            conditions.)"
+        />
       </Details>
 
       <Details>
-        <Summary>How do the additional scholarship entries work?</Summary>
+        <Summary summaryText="How do the additional scholarship entries work?" />
 
-        <DetailsParagraph>
-          Once you reach a new level, you will earn the additional scholarship
+        <DetailsParagraph
+          detailsText="Once you reach a new level, you will earn the additional scholarship
           entries for all future campaigns that you complete. For instance, if
           you become a Doer and complete a DoSomething campaign, you’ll earn 2
           chances to win that campaign’s scholarship instead of one. As a
           SuperDoer, you’ll earn 3 scholarship entries instead of 1 entry. And
           as a Legend you’ll earn 4 scholarship entries instead of 1. This
-          applies to all campaigns you complete.
-        </DetailsParagraph>
-        <DetailsParagraph>
-          For most campaigns, simply completing the campaign earns you a
+          applies to all campaigns you complete."
+        />
+        <DetailsParagraph
+          className="mt-0"
+          detailsText="For most campaigns, simply completing the campaign earns you a
           scholarship entry. For campaigns where the impact you make determines
           your entries into the scholarship contest, your chances to win will be
           multiplied by your impact. For example, take a campaign that offers a
           scholarship entry for each pair of jeans you donate. If you’re a
           SuperDoer (3x scholarship entries) and donate 10 pairs of jeans, your
           impact will be multiplied by 3 and you’ll earn 30 entries into the
-          scholarship contest.
-        </DetailsParagraph>
-        <DetailsParagraph>
+          scholarship contest."
+        />
+        <DetailsParagraph className="mt-0">
           <a href="/us/about/easy-scholarships" target="_blank">
-            Learn more about DoSomething scholarships
+            Learn more about DoSomething scholarships.
           </a>
-          .
         </DetailsParagraph>
       </Details>
 
       <Details>
-        <Summary>What are the terms and conditions?</Summary>
+        <Summary summaryText="What are the terms and conditions?" />
 
-        <DetailsParagraph>
-          See DoSomething Rewards terms and conditions.
-        </DetailsParagraph>
+        <DetailsParagraph detailsText="See DoSomething Rewards terms and conditions." />
       </Details>
     </div>
   </>

--- a/resources/assets/components/pages/AccountPage/Badges/RewardsFaq.js
+++ b/resources/assets/components/pages/AccountPage/Badges/RewardsFaq.js
@@ -1,5 +1,4 @@
 import React from 'react';
-// import tw from 'twin.macro';
 
 import Details from '../../../utilities/FaqElements/Details';
 import Summary from '../../../utilities/FaqElements/Summary';
@@ -14,42 +13,44 @@ const RewardsFaq = () => (
       <SectionHeader title="faqs" />
 
       <Details>
-        <Summary summaryText="How does DoSomething's Rewards program work?" />
+        <Summary text="How does DoSomething's Rewards program work?" />
 
-        <DetailsParagraph detailsText="Earn badges to level up. Enjoy your rewards. Let’s Do This!" />
+        <DetailsParagraph>
+          Earn badges to level up. Enjoy your rewards. Let’s Do This!
+        </DetailsParagraph>
 
-        <DetailsParagraph
-          className="mt-0"
-          detailsText="(The fine print, because our lawyers said so: Under the current terms
-            and conditions of our program, rewards do not reset. DoSomething
-            reserves the right to reset rewards in the future. See the terms and
-            conditions.)"
-        />
+        <DetailsParagraph className="mt-0">
+          (The fine print, because our lawyers said so: Under the current terms
+          and conditions of our program, rewards do not reset. DoSomething
+          reserves the right to reset rewards in the future. See the terms and
+          conditions.)
+        </DetailsParagraph>
       </Details>
 
       <Details>
-        <Summary summaryText="How do the additional scholarship entries work?" />
+        <Summary text="How do the additional scholarship entries work?" />
 
-        <DetailsParagraph
-          detailsText="Once you reach a new level, you will earn the additional scholarship
+        <DetailsParagraph>
+          Once you reach a new level, you will earn the additional scholarship
           entries for all future campaigns that you complete. For instance, if
           you become a Doer and complete a DoSomething campaign, you’ll earn 2
           chances to win that campaign’s scholarship instead of one. As a
           SuperDoer, you’ll earn 3 scholarship entries instead of 1 entry. And
           as a Legend you’ll earn 4 scholarship entries instead of 1. This
-          applies to all campaigns you complete."
-        />
-        <DetailsParagraph
-          className="mt-0"
-          detailsText="For most campaigns, simply completing the campaign earns you a
+          applies to all campaigns you complete.
+        </DetailsParagraph>
+
+        <DetailsParagraph className="mt-0">
+          For most campaigns, simply completing the campaign earns you a
           scholarship entry. For campaigns where the impact you make determines
           your entries into the scholarship contest, your chances to win will be
           multiplied by your impact. For example, take a campaign that offers a
           scholarship entry for each pair of jeans you donate. If you’re a
           SuperDoer (3x scholarship entries) and donate 10 pairs of jeans, your
           impact will be multiplied by 3 and you’ll earn 30 entries into the
-          scholarship contest."
-        />
+          scholarship contest.
+        </DetailsParagraph>
+
         <DetailsParagraph className="mt-0">
           <a href="/us/about/easy-scholarships" target="_blank">
             Learn more about DoSomething scholarships.
@@ -58,9 +59,11 @@ const RewardsFaq = () => (
       </Details>
 
       <Details>
-        <Summary summaryText="What are the terms and conditions?" />
+        <Summary text="What are the terms and conditions?" />
 
-        <DetailsParagraph detailsText="See DoSomething Rewards terms and conditions." />
+        <DetailsParagraph>
+          See DoSomething Rewards terms and conditions.
+        </DetailsParagraph>
       </Details>
     </div>
   </>

--- a/resources/assets/components/pages/AccountPage/ReferFriends/ReferFriendsTab.js
+++ b/resources/assets/components/pages/AccountPage/ReferFriends/ReferFriendsTab.js
@@ -55,56 +55,56 @@ const ReferFriendsTab = () => {
 
         {referralIncentive ? (
           <Details>
-            <Summary summaryText="Who can I refer?" />
+            <Summary text="Who can I refer?" />
 
-            <DetailsParagraph
-              detailsText="To earn the chance to win a $10 gift card, you need to refer NEW
-              members to DoSomething!"
-            />
+            <DetailsParagraph>
+              {' '}
+              To earn the chance to win a $10 gift card, you need to refer NEW
+              members to DoSomething!
+            </DetailsParagraph>
 
-            <DetailsParagraph
-              className="mt-0"
-              detailsText="Referring someone who already has a DoSomething account is an
+            <DetailsParagraph className="mt-0">
+              Referring someone who already has a DoSomething account is an
               awesome way to build our movement, but unfortunately, referring
-              them won’t enter you for a chance at the gift card."
-            />
+              them won’t enter you for a chance at the gift card.
+            </DetailsParagraph>
           </Details>
         ) : (
           <Details>
-            <Summary summaryText="Why should I refer a friend?" />
+            <Summary text="Why should I refer a friend?" />
 
-            <DetailsParagraph
-              detailsText="You’ll help your friend join our youth-led movement for good, make
+            <DetailsParagraph>
+              You’ll help your friend join our youth-led movement for good, make
               an impact on the causes they care about, and have the chance to
-              earn scholarships for volunteering."
-            />
+              earn scholarships for volunteering.
+            </DetailsParagraph>
           </Details>
         )}
 
         <Details>
-          <Summary summaryText="How do I know that I’ve referred a friend?" />
+          <Summary text="How do I know that I’ve referred a friend?" />
 
-          <DetailsParagraph
-            detailsText="Share the link above with your friend, either via text, email, or
+          <DetailsParagraph>
+            Share the link above with your friend, either via text, email, or
             social media. Using that link, your friend will create a DoSomething
             account and then sign up for a campaign. When they sign up, you’ll
-            see their name in the “Your Referrals” section. Yep, that easy."
-          />
+            see their name in the “Your Referrals” section. Yep, that easy.
+          </DetailsParagraph>
         </Details>
 
         {referralIncentive ? (
           <Details>
-            <Summary summaryText="How will I receive my gift card if I win?" />
+            <Summary text="How will I receive my gift card if I win?" />
 
-            <DetailsParagraph
-              detailsText="We’ll email it to you using the same email address used to create
-              your DoSomething account."
-            />
+            <DetailsParagraph>
+              We’ll email it to you using the same email address used to create
+              your DoSomething account.
+            </DetailsParagraph>
           </Details>
         ) : null}
 
         <Details>
-          <Summary summaryText="Where can I find the full rules?" />
+          <Summary text="Where can I find the full rules?" />
 
           <DetailsParagraph>
             This offer is for a limited time only. See the{' '}

--- a/resources/assets/components/pages/AccountPage/ReferFriends/ReferFriendsTab.js
+++ b/resources/assets/components/pages/AccountPage/ReferFriends/ReferFriendsTab.js
@@ -1,16 +1,14 @@
 import React from 'react';
-import tw from 'twin.macro';
 
 import { featureFlag } from '../../../../helpers';
+import Details from '../../../utilities/FaqElements/Details';
+import Summary from '../../../utilities/FaqElements/Summary';
 import ErrorBlock from '../../../blocks/ErrorBlock/ErrorBlock';
 import { getReferFriendsLink } from '../../../../helpers/refer-friends';
 import SectionHeader from '../../../utilities/SectionHeader/SectionHeader';
+import DetailsParagraph from '../../../utilities/FaqElements/DetailsParagraph';
 import SocialDriveAction from '../../../actions/SocialDriveAction/SocialDriveAction';
 import SignupReferralsBlock from '../../../blocks/SignupReferralsBlock/SignupReferralsBlock';
-
-const Details = tw.details`pb-4`;
-const Summary = tw.summary`font-bold text-base cursor-pointer`;
-const DetailsParagraph = tw.p`pt-2`;
 
 const ReferFriendsTab = () => {
   const referralIncentive = featureFlag('refer_friends_incentive');
@@ -57,55 +55,56 @@ const ReferFriendsTab = () => {
 
         {referralIncentive ? (
           <Details>
-            <Summary>Who can I refer?</Summary>
+            <Summary summaryText="Who can I refer?" />
 
-            <p className="pt-2">
-              To earn the chance to win a $10 gift card, you need to refer NEW
-              members to DoSomething!
-            </p>
+            <DetailsParagraph
+              detailsText="To earn the chance to win a $10 gift card, you need to refer NEW
+              members to DoSomething!"
+            />
 
-            <p className="mt-0 pt-2">
-              Referring someone who already has a DoSomething account is an
+            <DetailsParagraph
+              className="mt-0"
+              detailsText="Referring someone who already has a DoSomething account is an
               awesome way to build our movement, but unfortunately, referring
-              them won’t enter you for a chance at the gift card.
-            </p>
+              them won’t enter you for a chance at the gift card."
+            />
           </Details>
         ) : (
           <Details>
-            <Summary>Why should I refer a friend?</Summary>
+            <Summary summaryText="Why should I refer a friend?" />
 
-            <DetailsParagraph>
-              You’ll help your friend join our youth-led movement for good, make
+            <DetailsParagraph
+              detailsText="You’ll help your friend join our youth-led movement for good, make
               an impact on the causes they care about, and have the chance to
-              earn scholarships for volunteering.
-            </DetailsParagraph>
+              earn scholarships for volunteering."
+            />
           </Details>
         )}
 
         <Details>
-          <Summary>How do I know that I’ve referred a friend?</Summary>
+          <Summary summaryText="How do I know that I’ve referred a friend?" />
 
-          <DetailsParagraph>
-            Share the link above with your friend, either via text, email, or
+          <DetailsParagraph
+            detailsText="Share the link above with your friend, either via text, email, or
             social media. Using that link, your friend will create a DoSomething
             account and then sign up for a campaign. When they sign up, you’ll
-            see their name in the “Your Referrals” section. Yep, that easy.
-          </DetailsParagraph>
+            see their name in the “Your Referrals” section. Yep, that easy."
+          />
         </Details>
 
         {referralIncentive ? (
           <Details>
-            <Summary>How will I receive my gift card if I win?</Summary>
+            <Summary summaryText="How will I receive my gift card if I win?" />
 
-            <DetailsParagraph>
-              We’ll email it to you using the same email address used to create
-              your DoSomething account.
-            </DetailsParagraph>
+            <DetailsParagraph
+              detailsText="We’ll email it to you using the same email address used to create
+              your DoSomething account."
+            />
           </Details>
         ) : null}
 
         <Details>
-          <Summary>Where can I find the full rules?</Summary>
+          <Summary summaryText="Where can I find the full rules?" />
 
           <DetailsParagraph>
             This offer is for a limited time only. See the{' '}

--- a/resources/assets/components/utilities/FaqElements/Details.js
+++ b/resources/assets/components/utilities/FaqElements/Details.js
@@ -1,0 +1,18 @@
+import React from 'react';
+import PropTypes, { object } from 'prop-types';
+import classnames from 'classnames';
+
+const Details = ({ children, className }) => (
+  <details className={classnames(className, 'pb-4')}>{children}</details>
+);
+
+Details.propTypes = {
+  children: PropTypes.arrayOf(object).isRequired,
+  className: PropTypes.string,
+};
+
+Details.defaultProps = {
+  className: null,
+};
+
+export default Details;

--- a/resources/assets/components/utilities/FaqElements/DetailsParagraph.js
+++ b/resources/assets/components/utilities/FaqElements/DetailsParagraph.js
@@ -2,8 +2,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 
-const DetailsParagraph = ({ children, className, detailsText }) => (
-  <p className={classnames(className, 'pt-2')}>{children || detailsText}</p>
+const DetailsParagraph = ({ children, className }) => (
+  <p className={classnames(className, 'pt-2')}>{children}</p>
 );
 
 DetailsParagraph.propTypes = {
@@ -11,13 +11,11 @@ DetailsParagraph.propTypes = {
     PropTypes.string,
     PropTypes.arrayOf(PropTypes.string),
     PropTypes.object,
-  ]),
+  ]).isRequired,
   className: PropTypes.string,
-  detailsText: PropTypes.string.isRequired,
 };
 
 DetailsParagraph.defaultProps = {
-  children: null,
   className: null,
 };
 

--- a/resources/assets/components/utilities/FaqElements/DetailsParagraph.js
+++ b/resources/assets/components/utilities/FaqElements/DetailsParagraph.js
@@ -1,0 +1,24 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import classnames from 'classnames';
+
+const DetailsParagraph = ({ children, className, detailsText }) => (
+  <p className={classnames(className, 'pt-2')}>{children || detailsText}</p>
+);
+
+DetailsParagraph.propTypes = {
+  children: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.arrayOf(PropTypes.string),
+    PropTypes.object,
+  ]),
+  className: PropTypes.string,
+  detailsText: PropTypes.string.isRequired,
+};
+
+DetailsParagraph.defaultProps = {
+  children: null,
+  className: null,
+};
+
+export default DetailsParagraph;

--- a/resources/assets/components/utilities/FaqElements/Summary.js
+++ b/resources/assets/components/utilities/FaqElements/Summary.js
@@ -1,0 +1,22 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import classnames from 'classnames';
+
+const Summary = ({ className, summaryText }) => (
+  <summary
+    className={classnames(className, 'font-bold text-base cursor-pointer')}
+  >
+    {summaryText}
+  </summary>
+);
+
+Summary.propTypes = {
+  className: PropTypes.string,
+  summaryText: PropTypes.string.isRequired,
+};
+
+Summary.defaultProps = {
+  className: null,
+};
+
+export default Summary;

--- a/resources/assets/components/utilities/FaqElements/Summary.js
+++ b/resources/assets/components/utilities/FaqElements/Summary.js
@@ -2,17 +2,17 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 
-const Summary = ({ className, summaryText }) => (
+const Summary = ({ className, text }) => (
   <summary
     className={classnames(className, 'font-bold text-base cursor-pointer')}
   >
-    {summaryText}
+    {text}
   </summary>
 );
 
 Summary.propTypes = {
   className: PropTypes.string,
-  summaryText: PropTypes.string.isRequired,
+  text: PropTypes.string.isRequired,
 };
 
 Summary.defaultProps = {


### PR DESCRIPTION
### What's this PR do?

This pull request updates the details copy for the rewards tab FAQs. We are still missing a couple of links but we have a [follow up ticket](https://www.pivotaltracker.com/n/projects/2401401/stories/176020117) when that's ready. This also componentizes a few structural pieces from the FAQ section that were repeated between Refer a friend and Rewards! (per suggestions from @mendelB on #2454)

### How should this be reviewed?

Does this make sense as the best way to re structure? Everything should look exactly the same!

### Any background context you want to provide?

Now that we're repeating elements, it made sense to make them re usable.

### Relevant tickets

References [Pivotal #175856446](https://www.pivotaltracker.com/story/show/175856446).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added screenshots of front-end changes on small, medium, and large screens.
- [ ] Added appropriate feature/unit tests.
