### PR TITLE
Update Recommend Campaigns Gallery Filters

### DIFF
--- a/cypress/integration/show-submission-page.js
+++ b/cypress/integration/show-submission-page.js
@@ -1,13 +1,51 @@
 /// <reference types="Cypress" />
 
+import { MockList } from '../fixtures/graphql';
+
 describe('Show Submission Page', () => {
   beforeEach(() => cy.configureMocks());
 
   /** @test */
-  it('Displays the post image and a gallery block for the recommended campaigns', () => {
+  it('Displays the post image, default affirmation content, and a gallery block for the recommended campaigns', () => {
+    cy.mockGraphqlOp('PostQuery', {
+      post: {
+        campaignId: 1,
+      },
+    });
+
+    cy.mockGraphqlOp('ScholarshipCampaignsQuery', {
+      searchCampaigns: {
+        edges: MockList(3),
+      },
+    });
+
     cy.withFeatureFlags({ post_confirmation_page: true }).visit('/us/posts/1');
 
     cy.findByTestId('post-submission-image').should('have.length', 1);
-    cy.findByTestId('gallery-block').should('have.length', 1);
+
+    cy.contains('Thanks for joining the movement!');
+
+    cy.findByTestId('gallery-block')
+      .should('have.length', 1)
+      .within(() => {
+        cy.findAllByTestId('scholarship-card').should('have.length', 3);
+      });
+  });
+
+  it.only('Displays the custom affirmation content if Contentful ID query parameter is provided', () => {
+    const affirmationContent = "Here's some custom affirmation content for ya!";
+
+    cy.mockGraphqlOp('ContentfulBlockQuery', {
+      block: {
+        __typename: 'PhotoSubmissionBlock',
+        affirmationContent,
+      },
+    });
+
+    cy.withFeatureFlags({ post_confirmation_page: true }).visit(
+      '/us/posts/1?submissionActionId=abc',
+    );
+
+    cy.contains(affirmationContent);
   });
 });

--- a/cypress/integration/show-submission-page.js
+++ b/cypress/integration/show-submission-page.js
@@ -1,0 +1,13 @@
+/// <reference types="Cypress" />
+
+describe('Show Submission Page', () => {
+  beforeEach(() => cy.configureMocks());
+
+  /** @test */
+  it('Displays the post image and a gallery block for the recommended campaigns', () => {
+    cy.withFeatureFlags({ post_confirmation_page: true }).visit('/us/posts/1');
+
+    cy.findByTestId('post-submission-image').should('have.length', 1);
+    cy.findByTestId('gallery-block').should('have.length', 1);
+  });
+});

--- a/resources/assets/components/blocks/GalleryBlock/GalleryBlock.js
+++ b/resources/assets/components/blocks/GalleryBlock/GalleryBlock.js
@@ -105,7 +105,7 @@ const GalleryBlock = props => {
   const galleryLayout = galleryLayouts[itemsPerRow];
 
   return (
-    <div className="gallery-block">
+    <div className="gallery-block" data-testid="gallery-block">
       {title ? <SectionHeader underlined title={title} /> : null}
 
       <Gallery type={galleryLayout} className="-mx-3 mt-3">

--- a/resources/assets/components/pages/ShowSubmissionPage/RecommendedCampaignsGallery.js
+++ b/resources/assets/components/pages/ShowSubmissionPage/RecommendedCampaignsGallery.js
@@ -1,19 +1,22 @@
 import React from 'react';
 import { get } from 'lodash';
 import gql from 'graphql-tag';
+import PropTypes from 'prop-types';
 
 import Query from '../../Query';
+import { siteConfig } from '../../../helpers';
 import GalleryBlock from '../../blocks/GalleryBlock/GalleryBlock';
 import { scholarshipCardFragment } from '../../utilities/ScholarshipCard/ScholarshipCard';
 
 const SCHOLARSHIP_CAMPAIGNS_QUERY = gql`
-  query ScholarshipCampaignsQuery {
+  query ScholarshipCampaignsQuery($excludeIds: [Int]) {
     campaigns: searchCampaigns(
       perPage: 3
       hasWebsite: true
       hasScholarship: true
       isOpen: true
       orderBy: "start_date,desc"
+      excludeIds: $excludeIds
     ) {
       edges {
         node {
@@ -29,8 +32,16 @@ const SCHOLARSHIP_CAMPAIGNS_QUERY = gql`
   ${scholarshipCardFragment}
 `;
 
-const RecommendedCampaignsGallery = () => (
-  <Query query={SCHOLARSHIP_CAMPAIGNS_QUERY}>
+const RecommendedCampaignsGallery = ({ variables }) => (
+  <Query
+    query={SCHOLARSHIP_CAMPAIGNS_QUERY}
+    variables={{
+      excludeIds: [
+        ...(variables.excludeIds || []),
+        ...siteConfig('hide_campaign_ids', []).map(id => Number(id)),
+      ],
+    }}
+  >
     {result => (
       <GalleryBlock
         blocks={(get(result, 'campaigns.edges') || []).map(
@@ -43,5 +54,15 @@ const RecommendedCampaignsGallery = () => (
     )}
   </Query>
 );
+
+RecommendedCampaignsGallery.propTypes = {
+  variables: PropTypes.shape({
+    excludeIds: PropTypes.arrayOf(PropTypes.number),
+  }),
+};
+
+RecommendedCampaignsGallery.defaultProps = {
+  variables: {},
+};
 
 export default RecommendedCampaignsGallery;

--- a/resources/assets/components/pages/ShowSubmissionPage/RecommendedCampaignsGallery.js
+++ b/resources/assets/components/pages/ShowSubmissionPage/RecommendedCampaignsGallery.js
@@ -14,6 +14,7 @@ const SCHOLARSHIP_CAMPAIGNS_QUERY = gql`
       perPage: 3
       hasWebsite: true
       hasScholarship: true
+      isGroupCampaign: false
       isOpen: true
       orderBy: "start_date,desc"
       excludeIds: $excludeIds

--- a/resources/assets/components/pages/ShowSubmissionPage/RecommendedCampaignsGallery.js
+++ b/resources/assets/components/pages/ShowSubmissionPage/RecommendedCampaignsGallery.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { get } from 'lodash';
 import gql from 'graphql-tag';
 
 import Query from '../../Query';
@@ -32,7 +33,9 @@ const RecommendedCampaignsGallery = () => (
   <Query query={SCHOLARSHIP_CAMPAIGNS_QUERY}>
     {result => (
       <GalleryBlock
-        blocks={result.campaigns.edges.map(edge => edge.node.campaignWebsite)}
+        blocks={(get(result, 'campaigns.edges') || []).map(
+          edge => edge.node.campaignWebsite,
+        )}
         galleryType="SCHOLARSHIP"
         itemsPerRow={3}
         imageAlignment="LEFT"

--- a/resources/assets/components/pages/ShowSubmissionPage/ShowSubmissionPage.js
+++ b/resources/assets/components/pages/ShowSubmissionPage/ShowSubmissionPage.js
@@ -18,6 +18,7 @@ const POST_QUERY = gql`
   query PostQuery($postId: Int!) {
     post(id: $postId) {
       id
+      campaignId
       url
     }
   }
@@ -35,7 +36,7 @@ const ShowSubmissionPage = ({ match }) => {
     },
   });
 
-  const postImageUrl = get(postData, 'post.url', null);
+  const { url: postImageUrl, campaignId } = get(postData, 'post') || {};
 
   if (error) {
     return <ErrorBlock error={error} />;
@@ -98,7 +99,11 @@ const ShowSubmissionPage = ({ match }) => {
               More Scholarship Opportunities
             </h2>
 
-            <RecommendedCampaignsGallery />
+            <RecommendedCampaignsGallery
+              variables={{
+                excludeIds: campaignId ? [Number(campaignId)] : [],
+              }}
+            />
           </div>
         </div>
       </main>

--- a/resources/assets/components/pages/ShowSubmissionPage/ShowSubmissionPage.js
+++ b/resources/assets/components/pages/ShowSubmissionPage/ShowSubmissionPage.js
@@ -49,7 +49,10 @@ const ShowSubmissionPage = ({ match }) => {
         <div className="base-12-grid bg-white">
           <div className="grid-wide lg:flex px-2 md:px-4 lg:px-6">
             {postImageUrl && !loading ? (
-              <div className="w-1/2 md:w-1/4 pt-6 lg:pb-4">
+              <div
+                className="w-1/2 md:w-1/4 pt-6 lg:pb-4"
+                data-testid="post-submission-image"
+              >
                 <img
                   className="border-2 border-gray-400 border-solid"
                   alt="Reportback submission"

--- a/resources/assets/components/utilities/ScholarshipCard/ScholarshipCard.js
+++ b/resources/assets/components/utilities/ScholarshipCard/ScholarshipCard.js
@@ -62,7 +62,10 @@ const ScholarshipCard = ({ campaign }) => {
   ]);
 
   return (
-    <article className="flex flex-col h-full relative text-left">
+    <article
+      className="flex flex-col h-full relative text-left"
+      data-testid="scholarship-card"
+    >
       <a className="block cursor-pointer" href={path}>
         <img
           alt={showcaseImage.description || `Cover photo for ${showcaseTitle}`}

--- a/schema.json
+++ b/schema.json
@@ -38,6 +38,16 @@
                 "defaultValue": null
               },
               {
+                "name": "isGroupCampaign",
+                "description": "Search for only group or non-group campaigns.",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                },
+                "defaultValue": null
+              },
+              {
                 "name": "hasScholarship",
                 "description": "Search for campaigns that have or do not have a scholarship.",
                 "type": {
@@ -98,6 +108,20 @@
                   "kind": "SCALAR",
                   "name": "String",
                   "ofType": null
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "excludeIds",
+                "description": "Exclude campaigns with specified IDs",
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  }
                 },
                 "defaultValue": null
               }


### PR DESCRIPTION
### What's this PR do?

This pull request adds new filtering to the `RecommendedCampaignsGallery` used by the `ShowSubmissionPage` to exclude 
- env-variable-configured campaigns to hide
- the pages submission post's campaign ID (we don't want to recommend the campaign they've just completed!)
- group campaigns (which we typically want to exclude from site galleries)

It also adds some basic integration tests. I know we anticipate gating this page which could cause Cypress issues, but I'm hoping that we can address [Pivotal #175313574](https://www.pivotaltracker.com/n/projects/2401401/stories/175313574) as we add the gate so this test will still work.

### How should this be reviewed?
commit-by-commit if you so fancy!
Perhaps keep an eye on the logic we're using to exclude the campaign IDs, I think that's the most interesting bit!

### Any background context you want to provide?
We've added these new filters to our Algolia `searchCampaigns` query (see [here](https://git.io/JI48K)). A follow up task is to add these filters to the `PaginatedCampaignGallery` as well.


### Relevant tickets

References [Pivotal #175358477](https://www.pivotaltracker.com/story/show/175358477).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [x] Added appropriate feature/unit tests.
