### PR TITLE
Go Greener Holabar copy

### DIFF
--- a/cypress/integration/popover-dispatcher.js
+++ b/cypress/integration/popover-dispatcher.js
@@ -109,7 +109,7 @@ describe('Site Wide Banner', () => {
     cy.findByTestId('sitewide-banner-button').should(
       'have.attr',
       'href',
-      '/us/account/refer-friends',
+      '/us/campaigns/go-there-greener',
     );
   });
 });

--- a/docs/development/features/sitewide-banner.md
+++ b/docs/development/features/sitewide-banner.md
@@ -4,7 +4,7 @@
 
 This is a banner feature that is displayed site wide when turned on. In the past, we partnered with a 3rd party service to achieve this (HelloBar), but ran into some unforeseen and hard to troubleshoot bugs. And so, HowdyBar was born!
 
-We use this feature to display important info to our users in a prominent banner across the top of the site. It is currently hardcoded to link to our [refer a friend page](/development/features/referral-pages.md).
+We use this feature to display important info to our users in a prominent banner across the top of the site. It is currently hardcoded to link to our [go greener campaign](https://www.dosomething.org/us/campaigns/go-there-greener).
 
 The `SitewideBanner` can be used in conjunction with a `DismissableElement` or other wrapper components. We currently display the `SitewideBanner` via the `PopoverDispatcher`, which keeps track of what kind of banner or popover should be displayed on different pages.
 

--- a/resources/assets/components/utilities/PopoverDispatcher/PopoverDispatcher.js
+++ b/resources/assets/components/utilities/PopoverDispatcher/PopoverDispatcher.js
@@ -129,14 +129,14 @@ const PopoverDispatcher = () => {
 
   return createPortal(
     <DismissableElement
-      name="sitewide_banner_refer_friends"
+      name="sitewide_banner_go_greener_campaign"
       daysToReRender={7}
       render={(handleClose, handleComplete) => (
         <SitewideBanner
-          contextSource="refer_friends"
-          cta="Start Now"
-          link="/us/account/refer-friends"
-          description="Want to build our youth-led movement? Refer a friend!"
+          contextSource="go_greener_campaign"
+          cta="Get Started"
+          link="/us/campaigns/go-there-greener"
+          description="Travel more sustainably for a day. You’ll earn a chance to win a $1,500 scholarship"
           handleClose={handleClose}
           handleComplete={handleComplete}
         />

--- a/resources/assets/components/utilities/PopoverDispatcher/PopoverDispatcher.js
+++ b/resources/assets/components/utilities/PopoverDispatcher/PopoverDispatcher.js
@@ -129,7 +129,10 @@ const PopoverDispatcher = () => {
 
   return createPortal(
     <DismissableElement
-      name="sitewide_banner_go_greener_campaign"
+      name="sitewide_banner"
+      context={{
+        contextSource: 'go_greener_campaign',
+      }}
       daysToReRender={7}
       render={(handleClose, handleComplete) => (
         <SitewideBanner


### PR DESCRIPTION
### What's this PR do?

This pull request updates the default copy and link for the holabar to the go greener campaign. It also updates the tracking for dismissal of the site wide banner to include a context source.

### How should this be reviewed?

👀 

### Any background context you want to provide?

Updates to the analytics naming came out of a discussion on the pivotal ticket and [on slack](https://dosomething.slack.com/archives/C03T8SDJG/p1607461142005600).

### Relevant tickets

References [Pivotal #175957725](https://www.pivotaltracker.com/story/show/175957725).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added screenshots of front-end changes on small, medium, and large screens.
- [x] Added appropriate feature/unit tests.
