### PR TITLE
Refactor Campaign ID Gallery Filtering

### DIFF
--- a/config/site.php
+++ b/config/site.php
@@ -19,5 +19,5 @@ return [
     'default_referral_campaign_id' => env('DS_DEFAULT_REFERRAL_CAMPAIGN_ID'),
     'go_greener_campaign_goal' => env('DS_GO_GREENER_GOAL'),
     'go_greener_campaign_quantity' => env('DS_GO_GREENER_QUANTITY'),
-    'hide_campaign_ids' => array_map('intval', array_filter(explode(',', env('DS_HIDE_CAMPAIGN_IDS')))),
+    'hide_campaign_ids' => array_map('intval', array_filter(explode(',', env('DS_HIDE_CAMPAIGN_IDS', [])))),
 ];

--- a/config/site.php
+++ b/config/site.php
@@ -19,5 +19,5 @@ return [
     'default_referral_campaign_id' => env('DS_DEFAULT_REFERRAL_CAMPAIGN_ID'),
     'go_greener_campaign_goal' => env('DS_GO_GREENER_GOAL'),
     'go_greener_campaign_quantity' => env('DS_GO_GREENER_QUANTITY'),
-    'hide_campaign_ids' => explode(',', env('DS_HIDE_CAMPAIGN_IDS')),
+    'hide_campaign_ids' => array_map('intval', array_filter(explode(',', env('DS_HIDE_CAMPAIGN_IDS')))),
 ];

--- a/cypress/integration/cause-page.js
+++ b/cypress/integration/cause-page.js
@@ -211,9 +211,7 @@ describe('Cause Page', () => {
       },
     });
 
-    cy.withSiteConfig({ hide_campaign_ids: ['1'] }).visit(
-      '/us/causes/education',
-    );
+    cy.withSiteConfig({ hide_campaign_ids: [1] }).visit('/us/causes/education');
 
     cy.findAllByTestId('campaign-card').should('have.length', 1);
   });

--- a/cypress/integration/show-submission-page.js
+++ b/cypress/integration/show-submission-page.js
@@ -9,7 +9,7 @@ describe('Show Submission Page', () => {
   it('Displays the post image, default affirmation content, and a gallery block for the recommended campaigns', () => {
     cy.mockGraphqlOp('PostQuery', {
       post: {
-        campaignId: 1,
+        campaignId: '1',
       },
     });
 

--- a/resources/assets/components/pages/ShowSubmissionPage/RecommendedCampaignsGallery.js
+++ b/resources/assets/components/pages/ShowSubmissionPage/RecommendedCampaignsGallery.js
@@ -37,7 +37,10 @@ const RecommendedCampaignsGallery = ({ excludeCampaignIds }) => (
   <Query
     query={SCHOLARSHIP_CAMPAIGNS_QUERY}
     variables={{
-      excludeIds: [...excludeCampaignIds, ...siteConfig('hide_campaign_ids')],
+      excludeIds: [
+        ...excludeCampaignIds,
+        ...siteConfig('hide_campaign_ids', []),
+      ],
     }}
   >
     {result => (

--- a/resources/assets/components/pages/ShowSubmissionPage/RecommendedCampaignsGallery.js
+++ b/resources/assets/components/pages/ShowSubmissionPage/RecommendedCampaignsGallery.js
@@ -33,14 +33,11 @@ const SCHOLARSHIP_CAMPAIGNS_QUERY = gql`
   ${scholarshipCardFragment}
 `;
 
-const RecommendedCampaignsGallery = ({ variables }) => (
+const RecommendedCampaignsGallery = ({ excludeCampaignIds }) => (
   <Query
     query={SCHOLARSHIP_CAMPAIGNS_QUERY}
     variables={{
-      excludeIds: [
-        ...(variables.excludeIds || []),
-        ...siteConfig('hide_campaign_ids'),
-      ],
+      excludeIds: [...excludeCampaignIds, ...siteConfig('hide_campaign_ids')],
     }}
   >
     {result => (
@@ -57,13 +54,11 @@ const RecommendedCampaignsGallery = ({ variables }) => (
 );
 
 RecommendedCampaignsGallery.propTypes = {
-  variables: PropTypes.shape({
-    excludeIds: PropTypes.arrayOf(PropTypes.number),
-  }),
+  excludeCampaignIds: PropTypes.arrayOf(PropTypes.number),
 };
 
 RecommendedCampaignsGallery.defaultProps = {
-  variables: {},
+  excludeCampaignIds: [],
 };
 
 export default RecommendedCampaignsGallery;

--- a/resources/assets/components/pages/ShowSubmissionPage/RecommendedCampaignsGallery.js
+++ b/resources/assets/components/pages/ShowSubmissionPage/RecommendedCampaignsGallery.js
@@ -39,7 +39,7 @@ const RecommendedCampaignsGallery = ({ variables }) => (
     variables={{
       excludeIds: [
         ...(variables.excludeIds || []),
-        ...siteConfig('hide_campaign_ids', []).map(id => Number(id)),
+        ...siteConfig('hide_campaign_ids'),
       ],
     }}
   >

--- a/resources/assets/components/pages/ShowSubmissionPage/ShowSubmissionPage.js
+++ b/resources/assets/components/pages/ShowSubmissionPage/ShowSubmissionPage.js
@@ -100,9 +100,7 @@ const ShowSubmissionPage = ({ match }) => {
             </h2>
 
             <RecommendedCampaignsGallery
-              variables={{
-                excludeIds: campaignId ? [Number(campaignId)] : [],
-              }}
+              excludeCampaignIds={campaignId ? [Number(campaignId)] : []}
             />
           </div>
         </div>

--- a/resources/assets/components/utilities/PaginatedCampaignGallery/PaginatedCampaignGallery.js
+++ b/resources/assets/components/utilities/PaginatedCampaignGallery/PaginatedCampaignGallery.js
@@ -95,7 +95,7 @@ const PaginatedCampaignGallery = ({
   title,
   variables,
 }) => {
-  const excludeIds = siteConfig('hide_campaign_ids');
+  const excludeIds = siteConfig('hide_campaign_ids', []);
 
   const { error, loading, data, fetchMore } = useQuery(
     featureFlag('algolia_campaigns_search')

--- a/resources/assets/components/utilities/PaginatedCampaignGallery/PaginatedCampaignGallery.js
+++ b/resources/assets/components/utilities/PaginatedCampaignGallery/PaginatedCampaignGallery.js
@@ -95,9 +95,7 @@ const PaginatedCampaignGallery = ({
   title,
   variables,
 }) => {
-  const excludeIds = (siteConfig('hide_campaign_ids') || []).map(id =>
-    Number(id),
-  );
+  const excludeIds = siteConfig('hide_campaign_ids');
 
   const { error, loading, data, fetchMore } = useQuery(
     featureFlag('algolia_campaigns_search')


### PR DESCRIPTION
### What's this PR do?

This pull request follows up on #2456 to cast the `DS_HIDE_CAMPAIGN_IDS` list to numbers straight from the config file and to simplify the prop used to exclude campaign IDs in the `RecommenedCampaignsGallery` per PR feedback.

### How should this be reviewed?
👀 

### Relevant tickets

References [Pivotal #175358477](https://www.pivotaltracker.com/story/show/175358477).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added screenshots of front-end changes on small, medium, and large screens.
- [ ] Added appropriate feature/unit tests.
