### PR TITLE
Add Show Submission Page Redirect Following Photo Post Submission

### DIFF
--- a/cypress/integration/campaign-post.js
+++ b/cypress/integration/campaign-post.js
@@ -109,4 +109,47 @@ describe('Campaign Post', () => {
     // We should see the affirmation modal after submitting a post:
     cy.contains('We got your photo!');
   });
+
+  context('When the post_confirmation_page feature flag is on', () => {
+    it('Redirects to the show submission page after a successful photo post submission', () => {
+      const user = userFactory();
+
+      cy.mockGraphqlOp('ActionAndUserByIdQuery', {
+        action: {
+          collectSchoolId: false,
+        },
+        user: {
+          schoolId: null,
+        },
+      });
+
+      // Log in & visit the campaign action page:
+      cy.withFeatureFlags({
+        post_confirmation_page: true,
+      }).authVisitCampaignWithSignup(user, exampleCampaign);
+
+      cy.get('.photo-submission-action').within(() => {
+        // Choose an image to upload as a photo post:
+        cy.get('input[type="file"]').attachFile('upload.jpg');
+
+        // Fill out other fields:
+        cy.get('[name="caption"]').type("Let's do this!");
+        cy.get('[name="quantity"]').type('1');
+        cy.get('[name="whyParticipated"]').type('Testing');
+
+        // Mock the backend response:
+        const response = newPhotoPost(campaignId, user);
+        cy.route('POST', POSTS_API, response).as('submitPost');
+
+        // Submit the form, and assert we made the API request:
+        cy.contains('Submit a new photo').click();
+        cy.wait('@submitPost');
+
+        // We should be redirected to the show submission page after submitting a post.
+        cy.location('pathname').should('eq', `/us/posts/${response.data.id}`);
+        // We should have appended the Photo Submission Action ID as a query parameter.
+        cy.location('search').should('eq', '?submissionActionId=id');
+      });
+    });
+  });
 });

--- a/resources/assets/components/actions/PhotoSubmissionAction/PhotoSubmissionAction.js
+++ b/resources/assets/components/actions/PhotoSubmissionAction/PhotoSubmissionAction.js
@@ -4,6 +4,7 @@ import React from 'react';
 import gql from 'graphql-tag';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
+import { Redirect } from 'react-router-dom';
 import { get, has, invert, mapValues } from 'lodash';
 
 import PostForm from '../PostForm';
@@ -66,15 +67,13 @@ class PhotoSubmissionAction extends PostForm {
       // Resetting the submission item so that this won't be triggered continually for further renders.
       nextProps.resetPostSubmissionItem(nextProps.id);
 
-      if (featureFlag('post_confirmation_page')) {
-        // Redirect the user to the post submission page.
-        window.location = `/us/posts/${response.data.id}?submissionActionId=${nextProps.id}`;
-      }
+      // If the feature is toggled on, we'll redirect to the show submission page instead of displaying the affirmation modal.
+      const redirectToSubmissionPage = featureFlag('post_confirmation_page');
 
       return {
         shouldResetForm: true,
-        // Don't display the modal if we're redirecting the user to the post submission page.
-        showModal: !featureFlag('post_confirmation_page'),
+        redirectToSubmissionPage,
+        showModal: !redirectToSubmissionPage,
       };
     }
 
@@ -294,6 +293,18 @@ class PhotoSubmissionAction extends PostForm {
    */
   render() {
     const submissionItem = this.props.submissions.items[this.props.id];
+
+    if (this.state.redirectToSubmissionPage) {
+      return (
+        <Redirect
+          push
+          to={{
+            pathname: `/us/posts/${submissionItem.data.id}`,
+            search: `submissionActionId=${this.props.id}`,
+          }}
+        />
+      );
+    }
 
     const formResponse = has(submissionItem, 'status') ? submissionItem : null;
 

--- a/resources/assets/components/actions/PhotoSubmissionAction/PhotoSubmissionAction.js
+++ b/resources/assets/components/actions/PhotoSubmissionAction/PhotoSubmissionAction.js
@@ -14,9 +14,9 @@ import MediaUploader from '../../utilities/MediaUploader';
 import { getUserCampaignSignups } from '../../../helpers/api';
 import FormValidation from '../../utilities/Form/FormValidation';
 import PrimaryButton from '../../utilities/Button/PrimaryButton';
-import { withoutUndefined, withoutNulls } from '../../../helpers';
 import CharacterLimit from '../../utilities/CharacterLimit/CharacterLimit';
 import PrivacyLanguage from '../../utilities/PrivacyLanguage/PrivacyLanguage';
+import { withoutUndefined, withoutNulls, featureFlag } from '../../../helpers';
 import AnalyticsWaypoint from '../../utilities/AnalyticsWaypoint/AnalyticsWaypoint';
 import {
   calculateDifference,
@@ -66,9 +66,15 @@ class PhotoSubmissionAction extends PostForm {
       // Resetting the submission item so that this won't be triggered continually for further renders.
       nextProps.resetPostSubmissionItem(nextProps.id);
 
+      if (featureFlag('post_confirmation_page')) {
+        // Redirect the user to the post submission page.
+        window.location = `/us/posts/${response.data.id}?submissionActionId=${nextProps.id}`;
+      }
+
       return {
         shouldResetForm: true,
-        showModal: true,
+        // Don't display the modal if we're redirecting the user to the post submission page.
+        showModal: !featureFlag('post_confirmation_page'),
       };
     }
 


### PR DESCRIPTION
### What's this PR do?

This pull request adds a redirect to the Show Submission Page (`/us/posts/:id`) following a successful photo-post submission.

### How should this be reviewed?
👀 

### Any background context you want to provide?
I toyed with using a `<Redirect />` instead of the full page refresh but the UX win was dampened by the window scroll not being adjusted on the next page, and it also complicated the logic a little bit. (I also wasn't sure about the analytics ramifications).

I didn't DRY up the photo post logic in the tests (we're running the photo post submission logic twice now) since we'll be combining the two once this launches.

### Relevant tickets

References [Pivotal #176056956](https://www.pivotaltracker.com/story/show/176056956).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added screenshots of front-end changes on small, medium, and large screens.
- [x] Added appropriate feature/unit tests.

![Kapture 2020-12-09 at 15 30 36](https://user-images.githubusercontent.com/12417657/101684002-b9ce9a00-3a33-11eb-81c2-0a6a8ed839e6.gif)

