### PR TITLE
Gate the Show Submission Page to Authenticated Users & Post's Author

### DIFF
--- a/cypress/integration/show-submission-page.js
+++ b/cypress/integration/show-submission-page.js
@@ -1,15 +1,44 @@
 /// <reference types="Cypress" />
 
 import { MockList } from '../fixtures/graphql';
+import { userFactory } from '../fixtures/user';
 
 describe('Show Submission Page', () => {
   beforeEach(() => cy.configureMocks());
 
   /** @test */
+  it('Is gated to authenticated users', () => {
+    cy.withFeatureFlags({ post_confirmation_page: true }).visit('/us/posts/1');
+
+    cy.get('[data-test="redirect"]').should('have.length', 1);
+    cy.findByTestId('show-submission-page').should('have.length', 0);
+  });
+
+  /** @test */
+  it("Is gated to the post's author, and redirects others to their account submissions page", () => {
+    const user = userFactory();
+
+    cy.mockGraphqlOp('PostQuery', {
+      post: {
+        userId: "Not the post's ID that's for sure!",
+      },
+    });
+
+    cy.withFeatureFlags({ post_confirmation_page: true })
+      .login(user)
+      .visit('/us/posts/1');
+
+    cy.location('pathname').should('eq', `/us/account/campaigns`);
+  });
+
+  /** @test */
   it('Displays the post image, default affirmation content, and a gallery block for the recommended campaigns', () => {
+    const user = userFactory();
+
     cy.mockGraphqlOp('PostQuery', {
       post: {
         campaignId: 1,
+        userId: user.id,
       },
     });
 
@@ -19,7 +48,9 @@ describe('Show Submission Page', () => {
       },
     });
 
-    cy.withFeatureFlags({ post_confirmation_page: true }).visit('/us/posts/1');
+    cy.withFeatureFlags({ post_confirmation_page: true })
+      .login(user)
+      .visit('/us/posts/1');
 
     cy.findByTestId('post-submission-image').should('have.length', 1);
 
@@ -32,8 +63,16 @@ describe('Show Submission Page', () => {
       });
   });
 
-  it.only('Displays the custom affirmation content if Contentful ID query parameter is provided', () => {
+  it('Displays the custom affirmation content if Contentful ID query parameter is provided', () => {
+    const user = userFactory();
+
     const affirmationContent = "Here's some custom affirmation content for ya!";
+
+    cy.mockGraphqlOp('PostQuery', {
+      post: {
+        userId: user.id,
+      },
+    });
 
     cy.mockGraphqlOp('ContentfulBlockQuery', {
       block: {
@@ -42,9 +81,9 @@ describe('Show Submission Page', () => {
       },
     });
 
-    cy.withFeatureFlags({ post_confirmation_page: true }).visit(
-      '/us/posts/1?submissionActionId=abc',
-    );
+    cy.withFeatureFlags({ post_confirmation_page: true })
+      .login(user)
+      .visit('/us/posts/1?submissionActionId=abc');
 
     cy.contains(affirmationContent);
   });

--- a/resources/assets/components/App.js
+++ b/resources/assets/components/App.js
@@ -8,6 +8,7 @@ import { Router, Route, Switch } from 'react-router-dom';
 
 import graphqlClient from '../graphql';
 import ErrorPage from './pages/ErrorPage';
+import AuthGate from './utilities/AuthGate';
 import Modal from './utilities/Modal/Modal';
 import { initializeStore } from '../store/store';
 import HomePage from './pages/HomePage/HomePage';
@@ -78,7 +79,11 @@ const App = ({ store, history }) => {
               {featureFlag('post_confirmation_page') ? (
                 <Route
                   path="/us/posts/:post_id"
-                  component={ShowSubmissionPage}
+                  render={routeProps => (
+                    <AuthGate>
+                      <ShowSubmissionPage match={routeProps.match} />
+                    </AuthGate>
+                  )}
                 />
               ) : null}
 

--- a/resources/assets/components/pages/ShowSubmissionPage/ShowSubmissionPage.js
+++ b/resources/assets/components/pages/ShowSubmissionPage/ShowSubmissionPage.js
@@ -2,11 +2,14 @@ import React from 'react';
 import { get } from 'lodash';
 import gql from 'graphql-tag';
 import classnames from 'classnames';
+import { Redirect } from 'react-router-dom';
 import { useQuery } from '@apollo/react-hooks';
 import ReactRouterPropTypes from 'react-router-prop-types';
 
 import Query from '../../Query';
 import { env, query } from '../../../helpers';
+import { getUserId } from '../../../helpers/auth';
+import Placeholder from '../../utilities/Placeholder';
 import ErrorBlock from '../../blocks/ErrorBlock/ErrorBlock';
 import SiteFooter from '../../utilities/SiteFooter/SiteFooter';
 import TextContent from '../../utilities/TextContent/TextContent';
@@ -19,6 +22,7 @@ const POST_QUERY = gql`
     post(id: $postId) {
       id
       campaignId
+      userId
       url
     }
   }
@@ -36,10 +40,19 @@ const ShowSubmissionPage = ({ match }) => {
     },
   });
 
-  const { url: postImageUrl, campaignId } = get(postData, 'post') || {};
+  const { url: postImageUrl, campaignId, userId } = get(postData, 'post') || {};
+
+  if (loading) {
+    return <Placeholder />;
+  }
 
   if (error) {
     return <ErrorBlock error={error} />;
+  }
+
+  // This page is gated to the post's author.
+  if (getUserId() !== userId) {
+    return <Redirect to="/us/account/campaigns" />;
   }
 
   return (
@@ -49,7 +62,7 @@ const ShowSubmissionPage = ({ match }) => {
       <main>
         <div className="base-12-grid bg-white">
           <div className="grid-wide lg:flex px-2 md:px-4 lg:px-6">
-            {postImageUrl && !loading ? (
+            {postImageUrl ? (
               <div
                 className="w-1/2 md:w-1/4 pt-6 lg:pb-4"
                 data-testid="post-submission-image"

--- a/resources/assets/components/pages/ShowSubmissionPage/ShowSubmissionPage.js
+++ b/resources/assets/components/pages/ShowSubmissionPage/ShowSubmissionPage.js
@@ -60,7 +60,10 @@ const ShowSubmissionPage = ({ match }) => {
       <SiteNavigationContainer />
 
       <main>
-        <div className="base-12-grid bg-white">
+        <div
+          className="base-12-grid bg-white"
+          data-testid="show-submission-page"
+        >
           <div className="grid-wide lg:flex px-2 md:px-4 lg:px-6">
             {postImageUrl ? (
               <div

--- a/resources/assets/components/utilities/AuthGate.js
+++ b/resources/assets/components/utilities/AuthGate.js
@@ -1,0 +1,33 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import Placeholder from './Placeholder';
+import { isAuthenticated, buildAuthRedirectUrl } from '../../helpers/auth';
+
+const AuthGate = ({ children }) => {
+  if (isAuthenticated()) {
+    return children;
+  }
+
+  const redirect = buildAuthRedirectUrl();
+
+  // If we're running our test suite, don't automatically initiate
+  // the login redirect flow & leave something to assert on.
+  if (window.Cypress) {
+    document.body.innerHTML = `<div data-test="redirect" data-url="${redirect}" />`;
+    return null;
+  }
+
+  window.location.href = redirect;
+  return <Placeholder />;
+};
+
+AuthGate.propTypes = {
+  children: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.array,
+    PropTypes.object,
+  ]).isRequired,
+};
+
+export default AuthGate;

--- a/resources/assets/components/utilities/PopoverDispatcher/PopoverDispatcher.js
+++ b/resources/assets/components/utilities/PopoverDispatcher/PopoverDispatcher.js
@@ -40,7 +40,9 @@ const PopoverDispatcher = () => {
     useEffect(() => {
       const mainContainer = document.getElementById(id);
 
-      mainContainer.prepend(rootElem.current);
+      if (mainContainer) {
+        mainContainer.prepend(rootElem.current);
+      }
     }, []);
 
     return rootElem.current;


### PR DESCRIPTION
### What's this PR do?

This pull request adds a new `AuthGate` component which wraps the `ShowSubmissionPage`, gating it to authenticated users, and redirecting anonymous users to Northstar. It also updates the `ShowSubmissionPage` to ensure that the user is the post's author, otherwise, we redirect them to their account posts page per [Pivotal #176056956/comments/220370164](https://www.pivotaltracker.com/story/show/176056956/comments/220370164).

### How should this be reviewed?
👀 

How's the `AuthGate` name?

You can test the flow locally to ensure the redirect to NS & back post-auth works correctly, and that you cannot see someone else's post. (I'll set up the review app once it builds).

### Any background context you want to provide?
I followed @DFurnes recommendation in [the thread](https://dosomething.slack.com/archives/CUQMU4Q6B/p1602881724011500?thread_ts=1602876723.008600&cid=CUQMU4Q6B) linked from [Pivotal #175313574](https://www.pivotaltracker.com/n/projects/2401401/stories/175313574). (And hopefully, we can apply this easily to the Account page as well when we get to that ticket).

### Relevant tickets

References [Pivotal #176056956](https://www.pivotaltracker.com/story/show/176056956).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints. _I'll add some documentation if this is approved_
- [ ] Added screenshots of front-end changes on small, medium, and large screens.
- [x] Added appropriate feature/unit tests.
