### PR TITLE
Bug fix - default value on hide campaign IDs config

### DIFF
--- a/config/site.php
+++ b/config/site.php
@@ -19,5 +19,5 @@ return [
     'default_referral_campaign_id' => env('DS_DEFAULT_REFERRAL_CAMPAIGN_ID'),
     'go_greener_campaign_goal' => env('DS_GO_GREENER_GOAL'),
     'go_greener_campaign_quantity' => env('DS_GO_GREENER_QUANTITY'),
-    'hide_campaign_ids' => array_map('intval', array_filter(explode(',', env('DS_HIDE_CAMPAIGN_IDS', [])))),
+    'hide_campaign_ids' => array_map('intval', array_filter(explode(',', env('DS_HIDE_CAMPAIGN_IDS', '')))),
 ];


### PR DESCRIPTION
### What's this PR do?

This pull request fixes a bug flagged by @lindsayrmaher where if the `DS_HIDE_CAMPAIGN_IDS` is not in the `.env`, it'll explode since `explode` is expecting a String not an Array.

### How should this be reviewed?
💥 


### Relevant tickets
https://dosomething.slack.com/archives/CUQMU4Q6B/p1607619687006200

