### PR TITLE
Define arrayOf for prop types triggering linter warning

### DIFF
--- a/resources/assets/components/pages/AccountPage/Subscriptions/EmailSubscriptions.js
+++ b/resources/assets/components/pages/AccountPage/Subscriptions/EmailSubscriptions.js
@@ -39,7 +39,7 @@ const EmailSubscriptions = () => (
 
 EmailSubscriptions.propTypes = {
   user: PropTypes.shape({
-    emailSubscriptionTopics: PropTypes.array,
+    emailSubscriptionTopics: PropTypes.arrayOf(PropTypes.string),
     id: PropTypes.string,
   }).isRequired,
 };

--- a/resources/assets/components/pages/AccountPage/Subscriptions/Subscriptions.js
+++ b/resources/assets/components/pages/AccountPage/Subscriptions/Subscriptions.js
@@ -21,7 +21,7 @@ const Subscriptions = props => (
 
 Subscriptions.propTypes = {
   user: PropTypes.shape({
-    emailSubscriptionTopics: PropTypes.array,
+    emailSubscriptionTopics: PropTypes.arrayOf(PropTypes.string),
     userId: PropTypes.string,
   }).isRequired,
 };

--- a/resources/assets/components/pages/CausePage/CausePage.js
+++ b/resources/assets/components/pages/CausePage/CausePage.js
@@ -94,7 +94,7 @@ CausePageTemplate.propTypes = {
   description: PropTypes.object.isRequired,
   content: PropTypes.object.isRequired,
   additionalContent: PropTypes.shape({
-    stats: PropTypes.array,
+    stats: PropTypes.arrayOf(PropTypes.object),
     statsBackgroundColor: PropTypes.string,
   }),
 };

--- a/resources/assets/components/pages/CollectionPage/CollectionPage.js
+++ b/resources/assets/components/pages/CollectionPage/CollectionPage.js
@@ -93,7 +93,7 @@ CollectionPageTemplate.propTypes = {
   affiliates: PropTypes.arrayOf(PropTypes.object),
   content: PropTypes.object.isRequired,
   additionalContent: PropTypes.shape({
-    stats: PropTypes.array,
+    stats: PropTypes.arrayOf(PropTypes.object),
     statsBackgroundColor: PropTypes.string,
   }),
 };


### PR DESCRIPTION
### What's this PR do?

This pull request fixes the linter warning `warning  Prop type `array` is forbidden  react/forbid-prop-types` for a few components.

### How should this be reviewed?
👁️ 

### Any background context you want to provide?
This has been annoying the living crud out of me. 