### PR TITLE
Remove Progress bar Experiment

### DIFF
--- a/resources/assets/components/CampaignBanner/CampaignBanner.js
+++ b/resources/assets/components/CampaignBanner/CampaignBanner.js
@@ -106,7 +106,7 @@ const CampaignBanner = ({
             className="grid-wide-7/10 mb-6"
           >
             {numCampaignId === 9109 || numCampaignId === 9001 ? (
-              <div className="mb-6" testName="Progress Bar Visible">
+              <div className="mb-6">
                 <ProgressBar percentage={percentage} />
                 <p className="text-lg">
                   <span className="font-bold">

--- a/resources/assets/components/CampaignBanner/CampaignBanner.js
+++ b/resources/assets/components/CampaignBanner/CampaignBanner.js
@@ -107,22 +107,16 @@ const CampaignBanner = ({
             className="grid-wide-7/10 mb-6"
           >
             {numCampaignId === 9109 || numCampaignId === 9001 ? (
-              <SixpackExperiment
-                internalTitle="Campaign Progress Bar Experiment"
-                convertableActions={['signup']}
-                alternatives={[
-                  <div className="mb-6" testName="Progress Bar Visible">
-                    <ProgressBar percentage={percentage} />
-                    <p className="text-lg">
-                      <span className="font-bold">
-                        {`${currentImpactTotal.toLocaleString()}`} lbs of CO2
-                        saved so far.
-                      </span>
-                      {` `}Help us get to {`${goal.toLocaleString()}`}!
-                    </p>
-                  </div>,
-                ]}
-              />
+              <div className="mb-6" testName="Progress Bar Visible">
+                <ProgressBar percentage={percentage} />
+                <p className="text-lg">
+                  <span className="font-bold">
+                    {`${currentImpactTotal.toLocaleString()}`} lbs of CO2 saved
+                    so far.
+                  </span>
+                  {` `}Help us get to {`${goal.toLocaleString()}`}!
+                </p>
+              </div>
             ) : null}
             <TextContent>{content}</TextContent>
 

--- a/resources/assets/components/CampaignBanner/CampaignBanner.js
+++ b/resources/assets/components/CampaignBanner/CampaignBanner.js
@@ -24,7 +24,6 @@ import ProgressBar from '../utilities/ProgressBar/ProgressBar';
 import TextContent from '../utilities/TextContent/TextContent';
 import { SCHOLARSHIP_SIGNUP_BUTTON_TEXT } from '../../constants';
 import CampaignInfoBlock from '../blocks/CampaignInfoBlock/CampaignInfoBlock';
-import SixpackExperiment from '../utilities/SixpackExperiment/SixpackExperiment';
 import AffiliatePromotion from '../utilities/AffiliatePromotion/AffiliatePromotion';
 import ScholarshipInfoBlock from '../blocks/ScholarshipInfoBlock/ScholarshipInfoBlock';
 import CampaignSignupFormContainer from '../CampaignSignupForm/CampaignSignupFormContainer';


### PR DESCRIPTION
### What's this PR do?

This pull request removes the experiment for the progress bar from the `CampaignBanner` we deemed this experiment a success and determined we wanted to keep the progress bar on the `Go Greener Campaign`. So this PR just removes the experiment so it shows for all users.

### How should this be reviewed?

👀 

### Any background context you want to provide?

We already chose this as the winner via Sixpack, so this is more of a cleanup item.

### Relevant tickets

References [Pivotal #176079268](https://www.pivotaltracker.com/story/show/176079268).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added screenshots of front-end changes on small, medium, and large screens.
- [ ] Added appropriate feature/unit tests.
