### PR TITLE
sixpack

### DIFF
--- a/resources/assets/components/Campaign/CampaignRoute/CampaignRoute.js
+++ b/resources/assets/components/Campaign/CampaignRoute/CampaignRoute.js
@@ -106,7 +106,7 @@ const CampaignRoute = props => {
               return (
                 <SixpackExperiment
                   internalTitle="ungated or gated campaign"
-                  convertableActions={['reportback']}
+                  convertableActions={['reportbackPost']}
                   control={
                     <LandingPage
                       testName="gated campaign"

--- a/resources/assets/components/CampaignBanner/CampaignBanner.js
+++ b/resources/assets/components/CampaignBanner/CampaignBanner.js
@@ -1,6 +1,7 @@
 import { get } from 'lodash';
 import gql from 'graphql-tag';
 import PropTypes from 'prop-types';
+import classnames from 'classnames';
 import { useQuery } from '@apollo/react-hooks';
 import React, { useState, useEffect } from 'react';
 
@@ -142,26 +143,37 @@ const CampaignBanner = ({
             data-testid="campaign-banner-secondary-content"
             className="grid-wide-3/10 mb-6 xxl:row-start-1 xxl:row-span-3"
           >
-            {!loading ? (
-              <CampaignSignupFormContainer
-                className="block md:mb-3 p-6 text-lg w-full"
-                groupType={groupType}
-                text={
-                  isScholarshipAffiliateReferral()
-                    ? SCHOLARSHIP_SIGNUP_BUTTON_TEXT
-                    : undefined
-                }
-                contextSource="campaign_landing_page"
-              />
-            ) : (
-              <Spinner className="flex justify-center p-6 mb-3" />
-            )}
+            {!isAffiliated &&
+            !window.sessionStorage.getItem('ungated_session') ? (
+              <div
+                data-testid="campaign-banner-signup-button"
+                className={classnames(
+                  'bg-white bottom-0 md:bottom-auto left-0 md:left-auto p-3 md:static md:p-0 w-full md:w-auto z-10 md:z-auto',
+                  { fixed: !groupType },
+                )}
+              >
+                {!loading ? (
+                  <CampaignSignupFormContainer
+                    className="block md:mb-3 p-6 text-lg w-full"
+                    groupType={groupType}
+                    text={
+                      isScholarshipAffiliateReferral()
+                        ? SCHOLARSHIP_SIGNUP_BUTTON_TEXT
+                        : undefined
+                    }
+                    contextSource="campaign_landing_page"
+                  />
+                ) : (
+                  <Spinner className="flex justify-center p-6 mb-3" />
+                )}
 
-            {/* TODO: Move this into the CampaignSignupForm */}
-            {affiliateOptInContent ? (
-              <AffiliateOptInToggleContainer
-                affiliateOptInContent={affiliateOptInContent}
-              />
+                {/* TODO: Move this into the CampaignSignupForm */}
+                {affiliateOptInContent ? (
+                  <AffiliateOptInToggleContainer
+                    affiliateOptInContent={affiliateOptInContent}
+                  />
+                ) : null}
+              </div>
             ) : null}
 
             <CampaignInfoBlock

--- a/resources/assets/components/CampaignBanner/CampaignBanner.js
+++ b/resources/assets/components/CampaignBanner/CampaignBanner.js
@@ -11,7 +11,6 @@ import {
   isCurrentPathInPaths,
   siteConfig,
 } from '../../helpers';
-import SixpackExperiment from '../utilities/SixpackExperiment/SixpackExperiment';
 import Modal from '../utilities/Modal/Modal';
 import ContentfulEntry from '../ContentfulEntry';
 import partnerScholarshipQuizPaths from './config';
@@ -24,6 +23,7 @@ import ProgressBar from '../utilities/ProgressBar/ProgressBar';
 import TextContent from '../utilities/TextContent/TextContent';
 import { SCHOLARSHIP_SIGNUP_BUTTON_TEXT } from '../../constants';
 import CampaignInfoBlock from '../blocks/CampaignInfoBlock/CampaignInfoBlock';
+import SixpackExperiment from '../utilities/SixpackExperiment/SixpackExperiment';
 import AffiliatePromotion from '../utilities/AffiliatePromotion/AffiliatePromotion';
 import ScholarshipInfoBlock from '../blocks/ScholarshipInfoBlock/ScholarshipInfoBlock';
 import CampaignSignupFormContainer from '../CampaignSignupForm/CampaignSignupFormContainer';

--- a/resources/assets/components/CampaignBanner/CampaignBanner.js
+++ b/resources/assets/components/CampaignBanner/CampaignBanner.js
@@ -1,7 +1,6 @@
 import { get } from 'lodash';
 import gql from 'graphql-tag';
 import PropTypes from 'prop-types';
-import classnames from 'classnames';
 import { useQuery } from '@apollo/react-hooks';
 import React, { useState, useEffect } from 'react';
 
@@ -11,6 +10,7 @@ import {
   isCurrentPathInPaths,
   siteConfig,
 } from '../../helpers';
+import SixpackExperiment from '../utilities/SixpackExperiment/SixpackExperiment';
 import Modal from '../utilities/Modal/Modal';
 import ContentfulEntry from '../ContentfulEntry';
 import partnerScholarshipQuizPaths from './config';
@@ -96,6 +96,15 @@ const CampaignBanner = ({
     <>
       <CoverImage coverImage={coverImage} />
 
+      {numCampaignId === 9108 || numCampaignId === 9001 ? (
+        <SixpackExperiment
+          internalTitle="ungated or gated campaign"
+          convertableActions={['reportbackPost']}
+          control={<></>}
+          alternatives={[<span testName="ungated campaign" />]}
+        />
+      ) : null}
+
       <div className="clearfix bg-gray-100">
         <div className="base-12-grid py-3 md:py-6">
           <CampaignHeader title={title} subtitle={subtitle} />
@@ -133,37 +142,26 @@ const CampaignBanner = ({
             data-testid="campaign-banner-secondary-content"
             className="grid-wide-3/10 mb-6 xxl:row-start-1 xxl:row-span-3"
           >
-            {!isAffiliated &&
-            !window.sessionStorage.getItem('ungated_session') ? (
-              <div
-                data-testid="campaign-banner-signup-button"
-                className={classnames(
-                  'bg-white bottom-0 md:bottom-auto left-0 md:left-auto p-3 md:static md:p-0 w-full md:w-auto z-10 md:z-auto',
-                  { fixed: !groupType },
-                )}
-              >
-                {!loading ? (
-                  <CampaignSignupFormContainer
-                    className="block md:mb-3 p-6 text-lg w-full"
-                    groupType={groupType}
-                    text={
-                      isScholarshipAffiliateReferral()
-                        ? SCHOLARSHIP_SIGNUP_BUTTON_TEXT
-                        : undefined
-                    }
-                    contextSource="campaign_landing_page"
-                  />
-                ) : (
-                  <Spinner className="flex justify-center p-6 mb-3" />
-                )}
+            {!loading ? (
+              <CampaignSignupFormContainer
+                className="block md:mb-3 p-6 text-lg w-full"
+                groupType={groupType}
+                text={
+                  isScholarshipAffiliateReferral()
+                    ? SCHOLARSHIP_SIGNUP_BUTTON_TEXT
+                    : undefined
+                }
+                contextSource="campaign_landing_page"
+              />
+            ) : (
+              <Spinner className="flex justify-center p-6 mb-3" />
+            )}
 
-                {/* TODO: Move this into the CampaignSignupForm */}
-                {affiliateOptInContent ? (
-                  <AffiliateOptInToggleContainer
-                    affiliateOptInContent={affiliateOptInContent}
-                  />
-                ) : null}
-              </div>
+            {/* TODO: Move this into the CampaignSignupForm */}
+            {affiliateOptInContent ? (
+              <AffiliateOptInToggleContainer
+                affiliateOptInContent={affiliateOptInContent}
+              />
             ) : null}
 
             <CampaignInfoBlock

--- a/resources/assets/services/Sixpack.js
+++ b/resources/assets/services/Sixpack.js
@@ -47,6 +47,7 @@ class Sixpack {
    * @return {Promise}
    */
   convert(experimentName) {
+    console.log('convert:', experimentName);
     const kpi = this.experiments[experimentName].kpi;
 
     return new Promise((resolve, reject) => {
@@ -74,6 +75,8 @@ class Sixpack {
    * @return {Void}
    */
   convertOnAction(action) {
+    console.log('convertOnAction:', action);
+    console.log('this.experiments:', this.experiments);
     const matchingExperiments = Object.keys(this.experiments).filter(
       experimentName =>
         this.experiments[experimentName].convertableActions.includes(action),
@@ -91,6 +94,9 @@ class Sixpack {
    * @return {Promise}
    */
   participate(experimentName, testAlternatives = [], options = {}) {
+    console.log('participate:', experimentName);
+    console.log('testAlternatives:', testAlternatives);
+
     return new Promise((resolve, reject) => {
       this.client.participate(
         experimentName,

--- a/resources/assets/services/Sixpack.js
+++ b/resources/assets/services/Sixpack.js
@@ -47,7 +47,6 @@ class Sixpack {
    * @return {Promise}
    */
   convert(experimentName) {
-    console.log('convert:', experimentName);
     const kpi = this.experiments[experimentName].kpi;
 
     return new Promise((resolve, reject) => {
@@ -75,8 +74,6 @@ class Sixpack {
    * @return {Void}
    */
   convertOnAction(action) {
-    console.log('convertOnAction:', action);
-    console.log('this.experiments:', this.experiments);
     const matchingExperiments = Object.keys(this.experiments).filter(
       experimentName =>
         this.experiments[experimentName].convertableActions.includes(action),


### PR DESCRIPTION
### What's this PR do?

This pull request corrects the `convertableActions ` to `reportbackPost`, removes duplication of adding a button, as well as adding a second sixpack test to capture conversion when users are redirected away from the campaign.

### How should this be reviewed?

...

### Any background context you want to provide?
We can see conversions now:
<img width="1184" alt="Screen Shot 2020-12-15 at 1 21 12 PM" src="https://user-images.githubusercontent.com/20409413/102255776-83cc6280-3ed8-11eb-87de-f5d623e23a1e.png">

...

### Relevant tickets

References [Pivotal #175560547](https://www.pivotaltracker.com/n/projects/2401401/stories/175560547).

### Checklist

- [  x ] This PR has been added to the relevant Pivotal card.