### PR TITLE
Fix Show Submission Page Redirect Bug

### DIFF
--- a/resources/assets/components/actions/PhotoSubmissionAction/PhotoSubmissionAction.js
+++ b/resources/assets/components/actions/PhotoSubmissionAction/PhotoSubmissionAction.js
@@ -70,6 +70,7 @@ class PhotoSubmissionAction extends PostForm {
       const redirectToSubmissionPage = featureFlag('post_confirmation_page');
 
       if (redirectToSubmissionPage) {
+        // @TODO: Use <Redirect> once https://git.io/JL3Bc is resolved.
         window.location = `/us/posts/${response.data.id}?submissionActionId=${nextProps.id}`;
       }
 

--- a/resources/assets/components/actions/PhotoSubmissionAction/PhotoSubmissionAction.js
+++ b/resources/assets/components/actions/PhotoSubmissionAction/PhotoSubmissionAction.js
@@ -4,7 +4,6 @@ import React from 'react';
 import gql from 'graphql-tag';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
-import { Redirect } from 'react-router-dom';
 import { get, has, invert, mapValues } from 'lodash';
 
 import PostForm from '../PostForm';

--- a/resources/assets/components/actions/PhotoSubmissionAction/PhotoSubmissionAction.js
+++ b/resources/assets/components/actions/PhotoSubmissionAction/PhotoSubmissionAction.js
@@ -70,9 +70,12 @@ class PhotoSubmissionAction extends PostForm {
       // If the feature is toggled on, we'll redirect to the show submission page instead of displaying the affirmation modal.
       const redirectToSubmissionPage = featureFlag('post_confirmation_page');
 
+      if (redirectToSubmissionPage) {
+        window.location = `/us/posts/${response.data.id}?submissionActionId=${nextProps.id}`;
+      }
+
       return {
         shouldResetForm: true,
-        redirectToSubmissionPage,
         showModal: !redirectToSubmissionPage,
       };
     }
@@ -293,18 +296,6 @@ class PhotoSubmissionAction extends PostForm {
    */
   render() {
     const submissionItem = this.props.submissions.items[this.props.id];
-
-    if (this.state.redirectToSubmissionPage) {
-      return (
-        <Redirect
-          push
-          to={{
-            pathname: `/us/posts/${submissionItem.data.id}`,
-            search: `submissionActionId=${this.props.id}`,
-          }}
-        />
-      );
-    }
 
     const formResponse = has(submissionItem, 'status') ? submissionItem : null;
 


### PR DESCRIPTION
### What's this PR do?

This pull request fixes a - bit of an edge case - bug wherein because we were redirecting with React `Redirect` to the show submission page, users on the show submission page who would navigate to a new refreshed page - e.g. a campaign in the recommended gallery - and then use the browser back button to go back to the campaign would face an error because the Redux campaign state was missing and the browser didn't force a redirect.

### How should this be reviewed?
👀 

### Any background context you want to provide?
There are probably other alternative ways we can solve this, but this seems like the easiest quickest fix so we can deploy before the code freeze and maintain this new feature.

### Relevant tickets
https://dosomething.slack.com/archives/CP2D7UGAU/p1608052149017300?thread_ts=1608051501.016800&cid=CP2D7UGAU
https://github.com/DoSomething/phoenix-next/pull/2460#discussion_r539683322

![Kapture 2020-12-15 at 14 17 25](https://user-images.githubusercontent.com/12417657/102261889-508dd180-3ee0-11eb-9796-d23c0cf413d4.gif)
