### PR TITLE
Text Post Affirmation Page Redirect

### DIFF
--- a/cypress/integration/campaign-post.js
+++ b/cypress/integration/campaign-post.js
@@ -181,6 +181,12 @@ describe('Campaign Post', () => {
         const response = newPhotoPost(campaignId, user);
         cy.route('POST', POSTS_API, response).as('submitPost');
 
+        cy.mockGraphqlOp('PostQuery', {
+          post: {
+            userId: user.id,
+          },
+        });
+
         // Submit the form, and assert we made the API request:
         cy.contains('Submit a new photo').click();
         cy.wait('@submitPost');
@@ -190,6 +196,8 @@ describe('Campaign Post', () => {
         // We should have appended the Photo Submission Action ID as a query parameter.
         cy.location('search').should('eq', '?submissionActionId=id');
       });
+
+      cy.contains('We Got Your Submission');
     });
   });
 });

--- a/cypress/integration/campaign-post.js
+++ b/cypress/integration/campaign-post.js
@@ -111,6 +111,46 @@ describe('Campaign Post', () => {
   });
 
   context('When the post_confirmation_page feature flag is on', () => {
+    it('Redirects to the show submission page after a successful text post submission', () => {
+      const user = userFactory();
+
+      cy.mockGraphqlOp('ActionAndUserByIdQuery', {
+        action: {
+          collectSchoolId: false,
+        },
+        user: {
+          schoolId: null,
+        },
+      });
+
+      // Log in & visit the campaign action page:
+      cy.withFeatureFlags({
+        post_confirmation_page: true,
+      }).authVisitCampaignWithSignup(user, exampleCampaign);
+
+      const text =
+        'I made my cat a full English breakfast, with coffee & cream.';
+      const response = newTextPost(campaignId, user, text);
+      cy.route('POST', POSTS_API, response).as('submitPost');
+
+      cy.mockGraphqlOp('PostQuery', {
+        post: {
+          userId: user.id,
+        },
+      });
+
+      cy.get('.text-submission-action textarea').type(text);
+      cy.get('.text-submission-action button[type="submit"]').click();
+      cy.wait('@submitPost');
+
+      // We should be redirected to the show submission page after submitting a post.
+      cy.location('pathname').should('eq', `/us/posts/${response.data.id}`);
+      // We should have appended the Photo Submission Action ID as a query parameter.
+      cy.location('search').should('eq', '?submissionActionId=id');
+
+      cy.contains('We Got Your Submission');
+    });
+
     it('Redirects to the show submission page after a successful photo post submission', () => {
       const user = userFactory();
 

--- a/resources/assets/components/actions/TextSubmissionAction/TextSubmissionAction.js
+++ b/resources/assets/components/actions/TextSubmissionAction/TextSubmissionAction.js
@@ -10,10 +10,10 @@ import PostCreatedModal from '../PostCreatedModal';
 import ActionInformation from '../ActionInformation';
 import FormValidation from '../../utilities/Form/FormValidation';
 import PrimaryButton from '../../utilities/Button/PrimaryButton';
-import { withoutUndefined, withoutNulls } from '../../../helpers';
 import { getFieldErrors, formatPostPayload } from '../../../helpers/forms';
 import CharacterLimit from '../../utilities/CharacterLimit/CharacterLimit';
 import PrivacyLanguage from '../../utilities/PrivacyLanguage/PrivacyLanguage';
+import { featureFlag, withoutUndefined, withoutNulls } from '../../../helpers';
 import AnalyticsWaypoint from '../../utilities/AnalyticsWaypoint/AnalyticsWaypoint';
 import {
   EVENT_CATEGORIES,
@@ -45,8 +45,16 @@ class TextSubmissionAction extends PostForm {
       // Resetting the submission item so that this won't be triggered continually for further renders.
       nextProps.resetPostSubmissionItem(nextProps.id);
 
+      // If the feature is toggled on, we'll redirect to the show submission page instead of displaying the affirmation modal.
+      const redirectToSubmissionPage = featureFlag('post_confirmation_page');
+
+      if (redirectToSubmissionPage) {
+        // @TODO: Use <Redirect> once https://git.io/JL3Bc is resolved.
+        window.location = `/us/posts/${response.data.id}?submissionActionId=${nextProps.id}`;
+      }
+
       return {
-        showModal: true,
+        showModal: !redirectToSubmissionPage,
         textValue: '',
       };
     }

--- a/resources/assets/components/pages/ShowSubmissionPage/ShowSubmissionPage.js
+++ b/resources/assets/components/pages/ShowSubmissionPage/ShowSubmissionPage.js
@@ -79,7 +79,8 @@ const ShowSubmissionPage = ({ match }) => {
             ) : null}
             <div
               className={classnames('py-3 lg:p-6', {
-                'lg:w-3/4 ': postImageUrl,
+                'lg:w-3/4': postImageUrl,
+                'lg:pl-0': !postImageUrl,
               })}
             >
               <h1 className="uppercase text-3xl md:text-4xl font-league-gothic font-normal">


### PR DESCRIPTION
### What's this PR do?

This pull request redirects users to the show submission page following a successful text post submission (feature flagged).

It also updates the tests & fixes a small visual bug with padding-left on non-photo show submission pages.

### How should this be reviewed?
👀 

### Relevant tickets

References [Pivotal #176180310](https://www.pivotaltracker.com/story/show/176180310).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added screenshots of front-end changes on small, medium, and large screens.
- [x] Added appropriate feature/unit tests.


**Before**
![image](https://user-images.githubusercontent.com/12417657/102523551-afc91e80-4065-11eb-8735-4053827a5b10.png)

**After**
![image](https://user-images.githubusercontent.com/12417657/102523561-b5266900-4065-11eb-96e5-70c38492b530.png)

![Kapture 2020-12-17 at 12 46 25](https://user-images.githubusercontent.com/12417657/102523714-ed2dac00-4065-11eb-869e-2577fe43822b.gif)
