### PR TITLE
Petition Post Show Submission Page Redirect

### DIFF
--- a/cypress/fixtures/contentful/exampleCampaign.js
+++ b/cypress/fixtures/contentful/exampleCampaign.js
@@ -123,6 +123,10 @@ export default {
               },
             },
             {
+              id: '74LtFv1QWIvW67MtzDnzwA',
+              type: 'petitionSubmissionAction',
+            },
+            {
               id: '6orwgSeryEmhc5G40QShBh',
               type: 'contentBlock',
               fields: {

--- a/cypress/fixtures/graphql.js
+++ b/cypress/fixtures/graphql.js
@@ -29,6 +29,7 @@ const blocks = {
   '7qT9bG21eOhu9svaFL3rJ6': 'LinkAction',
   o9Le9daUHn0McdCdTRMMq: 'ContentBlock',
   '4ti6d4kQ80JRrkAmvltkm': 'PostGalleryBlock',
+  '74LtFv1QWIvW67MtzDnzwA': 'PetitionSubmissionBlock',
 };
 
 /**

--- a/cypress/integration/campaign-post.js
+++ b/cypress/integration/campaign-post.js
@@ -65,6 +65,31 @@ describe('Campaign Post', () => {
     );
   });
 
+  it.only('Create a petition-text post', () => {
+    const user = userFactory();
+
+    cy.mockGraphqlOp('ActionAndUserByIdQuery', {
+      action: {
+        collectSchoolId: false,
+      },
+      user: {
+        schoolId: null,
+      },
+    });
+
+    // Log in & visit the campaign action page:
+    cy.authVisitCampaignWithSignup(user, exampleCampaign);
+
+    const text = 'I made my cat a full English breakfast, with coffee & cream.';
+    const response = newTextPost(campaignId, user, text);
+    cy.route('POST', POSTS_API, response).as('submitPost');
+
+    cy.get('.petition-submission-action textarea').type(text);
+    cy.get('.petition-submission-action button[type="submit"]').click();
+
+    cy.contains('Thanks for signing the petition!');
+  });
+
   it('Create a photo post', () => {
     const user = userFactory();
 

--- a/cypress/integration/campaign-post.js
+++ b/cypress/integration/campaign-post.js
@@ -65,7 +65,7 @@ describe('Campaign Post', () => {
     );
   });
 
-  it.only('Create a petition-text post', () => {
+  it('Create a petition-text post', () => {
     const user = userFactory();
 
     cy.mockGraphqlOp('ActionAndUserByIdQuery', {

--- a/resources/assets/components/actions/PetitionSubmissioncAction/PetitionSubmissionAction.js
+++ b/resources/assets/components/actions/PetitionSubmissioncAction/PetitionSubmissionAction.js
@@ -7,6 +7,7 @@ import { Query as ApolloQuery } from 'react-apollo';
 
 import PostForm from '../PostForm';
 import Card from '../../utilities/Card/Card';
+import { featureFlag } from '../../../helpers';
 import PostCreatedModal from '../PostCreatedModal';
 import ActionInformation from '../ActionInformation';
 import FormValidation from '../../utilities/Form/FormValidation';
@@ -63,9 +64,17 @@ class PetitionSubmissionAction extends PostForm {
       // Resetting the submission item so that this won't be triggered continually for further renders.
       nextProps.resetPostSubmissionItem(nextProps.id);
 
+      // If the feature is toggled on, we'll redirect to the show submission page instead of displaying the affirmation modal.
+      const redirectToSubmissionPage = featureFlag('post_confirmation_page');
+
+      if (redirectToSubmissionPage) {
+        // @TODO: Use <Redirect> once https://git.io/JL3Bc is resolved.
+        window.location = `/us/posts/${response.data.id}?submissionActionId=${nextProps.id}`;
+      }
+
       return {
         submitted: true,
-        showModal: true,
+        showModal: !redirectToSubmissionPage,
         textValue: '',
       };
     }

--- a/resources/assets/components/pages/ShowSubmissionPage/ShowSubmissionPage.js
+++ b/resources/assets/components/pages/ShowSubmissionPage/ShowSubmissionPage.js
@@ -95,15 +95,11 @@ const ShowSubmissionPage = ({ match }) => {
                     preview: env('CONTENTFUL_USE_PREVIEW_API', false),
                   }}
                 >
-                  {data =>
-                    data.block.affirmationContent ? (
-                      <TextContent className="mb-6">
-                        {data.block.affirmationContent}
-                      </TextContent>
-                    ) : (
-                      defaultContent
-                    )
-                  }
+                  {data => (
+                    <TextContent className="mb-6">
+                      {data.block.affirmationContent || defaultContent}
+                    </TextContent>
+                  )}
                 </Query>
               ) : (
                 <TextContent className="mb-6">{defaultContent}</TextContent>

--- a/resources/assets/components/pages/ShowSubmissionPage/ShowSubmissionPage.js
+++ b/resources/assets/components/pages/ShowSubmissionPage/ShowSubmissionPage.js
@@ -100,7 +100,9 @@ const ShowSubmissionPage = ({ match }) => {
                       <TextContent className="mb-6">
                         {data.block.affirmationContent}
                       </TextContent>
-                    ) : null
+                    ) : (
+                      defaultContent
+                    )
                   }
                 </Query>
               ) : (


### PR DESCRIPTION
### What's this PR do?

This pull request adds a redirect to the show submission page following successful petition post submission (feature flagged).

It also resolves a bug where if a `submissionActionId` was specified in the show submission page URL, but no `affirmationContent` was specified in Contentful, we wouldn't show any message. Now we'll display the default affirmation content.



### How should this be reviewed?
👀 

### Relevant tickets

References [Pivotal #176180310](https://www.pivotaltracker.com/story/show/176180310).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added screenshots of front-end changes on small, medium, and large screens.
- [x] Added appropriate feature/unit tests.

![Kapture 2020-12-17 at 13 47 35](https://user-images.githubusercontent.com/12417657/102529836-76e17780-406e-11eb-9b5c-564a5307ca18.gif)