### PR TITLE
Updating Authentication to Front End for Account Pages

### DIFF
--- a/cypress/integration/profile-page.js
+++ b/cypress/integration/profile-page.js
@@ -1,0 +1,18 @@
+import { userFactory } from '../fixtures/user';
+
+describe('User Profile Page', () => {
+  beforeEach(() => cy.configureMocks());
+  /** @test */
+  it('Renders Voter Registration Call to Action in Registration Status', () => {
+    const user = userFactory();
+    cy.mockGraphqlOp('UserVoterRegistrationStatusQuery', {
+      user: {
+        voterRegistrationStatus: 'UNREGISTERED',
+      },
+    });
+    cy.login(user);
+    cy.visit(`/us/account`);
+    // cy.findByTestId('unregistered-status').should('have.length', 1);
+    // cy.findByTestId('quiz-result-page').should('have.length', 0);
+  });
+});

--- a/cypress/integration/profile-page.js
+++ b/cypress/integration/profile-page.js
@@ -3,11 +3,14 @@ import { userFactory } from '../fixtures/user';
 describe('User Profile Page', () => {
   beforeEach(() => cy.configureMocks());
   /** @test */
-  it('Renders Voter Registration Call to Action in Registration Status', () => {
+  it('Renders User Account Page if that User is Logged In', () => {
     const user = userFactory();
-    cy.mockGraphqlOp('UserVoterRegistrationStatusQuery', {
+    cy.mockGraphqlOp('AccountQuery', {
       user: {
-        voterRegistrationStatus: 'UNREGISTERED',
+        lastName: 'Tester',
+        birthdate: Date(),
+        email: 'tester@mail.com',
+        emailSubscriptionTopics: ['COMMUNITY'],
       },
     });
     cy.login(user);

--- a/cypress/integration/profile-page.js
+++ b/cypress/integration/profile-page.js
@@ -3,7 +3,7 @@ import { userFactory } from '../fixtures/user';
 describe('User Profile Page', () => {
   beforeEach(() => cy.configureMocks());
   /** @test */
-  it('Renders User Account Page if that User is Logged In', () => {
+  it('Renders user Account Page if that user is logged in', () => {
     const user = userFactory();
     cy.mockGraphqlOp('AccountQuery', {
       user: {
@@ -15,7 +15,12 @@ describe('User Profile Page', () => {
     });
     cy.login(user);
     cy.visit(`/us/account`);
-    // cy.findByTestId('unregistered-status').should('have.length', 1);
-    // cy.findByTestId('quiz-result-page').should('have.length', 0);
+    cy.findByTestId('user-email').should('contain', 'tester@mail.com');
+  });
+
+  /** @test */
+  it('Does not render user Account Page if not logged in', () => {
+    cy.visit(`/us/account`);
+    cy.findByTestId('user-email').should('have.length', 0);
   });
 });

--- a/resources/assets/components/App.js
+++ b/resources/assets/components/App.js
@@ -73,7 +73,14 @@ const App = ({ store, history }) => {
             <Switch>
               <Route exact path="/us" component={HomePage} />
 
-              <Route path="/us/account" component={AccountQuery} />
+              <Route
+                path="/us/account"
+                render={() => (
+                  <AuthGate>
+                    <AccountQuery />
+                  </AuthGate>
+                )}
+              />
 
               <Route path="/us/blocks/:id" component={BlockPage} />
 

--- a/resources/assets/components/pages/AccountPage/Profile/FormItem.js
+++ b/resources/assets/components/pages/AccountPage/Profile/FormItem.js
@@ -4,17 +4,19 @@ import PropTypes from 'prop-types';
 const FormItem = props => (
   <div className="mt-4">
     <h5 className="text-gray-700">{props.title}</h5>
-    <p>{props.value}</p>
+    <p data-testid={props.dataTestId}>{props.value}</p>
   </div>
 );
 
 export default FormItem;
 
 FormItem.propTypes = {
+  dataTestId: PropTypes.string,
   title: PropTypes.string.isRequired,
   value: PropTypes.string,
 };
 
 FormItem.defaultProps = {
   value: '-',
+  dataTestId: null,
 };

--- a/resources/assets/components/pages/AccountPage/Profile/Profile.js
+++ b/resources/assets/components/pages/AccountPage/Profile/Profile.js
@@ -33,7 +33,11 @@ const Profile = props => (
         title="Password"
         value="&#9679; &#9679; &#9679; &#9679; &#9679; &#9679;"
       />
-      <FormItem title="Email" value={props.user.email} />
+      <FormItem
+        dataTestId="user-email"
+        title="Email"
+        value={props.user.email}
+      />
       {props.user.mobile ? (
         <FormItem title="Phone Number" value={props.user.mobile} />
       ) : null}

--- a/resources/assets/components/pages/AccountPage/VoterReg/VoterRegStatusBlock.js
+++ b/resources/assets/components/pages/AccountPage/VoterReg/VoterRegStatusBlock.js
@@ -84,7 +84,7 @@ const VoterRegStatusBlock = ({ userId }) => {
 
   return (
     <div className="voter-reg flex items-center">
-      <div className="m-3">
+      <div className="m-3" data-testid="unregistered-status">
         <p>We don&#39;t have your voter registration.</p>
         <a
           href={`https://vote.dosomething.org/?r=${getTrackingSource(

--- a/routes/web.php
+++ b/routes/web.php
@@ -33,8 +33,7 @@ Route::redirect('/next/logout', '/deauthorize', 302);
 // Profile
 Route::redirect('/northstar/{id}', '/us/account');
 Route::view('/us/account/{clientRoute?}', 'app')
-    ->where('clientRoute', '.*')
-    ->middleware('auth');
+    ->where('clientRoute', '.*');
 
 // Campaigns index
 Route::view('us/campaigns', 'app');


### PR DESCRIPTION
### What's this PR do?

This pull request removes middleware from a php route and adds an authentication gate around the "account" route. This should allow us to check whether a user is logged in before navigating to their account page successfully.

### How should this be reviewed?

Am I missing anything here? It seems to work as expected. Does it makes sense to create a couple of tests just to see that we can visit the page if we're logged in and we get redirected if we don't? I'm guessing the answer to this Q is yes lol

### Any background context you want to provide?

In order to add Cypress tests for _any_ of the account pages, we need to be able to authenticate via the front end so that cypress can mock that behavior. this is something we really wanted to update since we have quite a few tabs now in the account page.

### Relevant tickets

References [Pivotal #](https://www.pivotaltracker.com/story/show/175313574).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added screenshots of front-end changes on small, medium, and large screens.
- [ ] Added appropriate feature/unit tests.
