### PR TITLE
Moving straggling campaign helpers into dedicated file.

### DIFF
--- a/resources/assets/components/Campaign/CampaignRoute/CampaignRoute.js
+++ b/resources/assets/components/Campaign/CampaignRoute/CampaignRoute.js
@@ -6,8 +6,8 @@ import ReactRouterPropTypes from 'react-router-prop-types';
 import { Switch, Route, Redirect } from 'react-router-dom';
 
 import Modal from '../../utilities/Modal/Modal';
-import { isCampaignClosed } from '../../../helpers';
 import BlockPage from '../../pages/BlockPage/BlockPage';
+import { isCampaignClosed } from '../../../helpers/campaign';
 import LandingPage from '../../pages/LandingPage/LandingPage';
 import PostSignupModal from '../../pages/PostSignupModal/PostSignupModal';
 import CampaignClosedPage from '../../pages/CampaignPage/CampaignClosedPage';

--- a/resources/assets/components/CampaignPageNavigation/CampaignPageNavigation.js
+++ b/resources/assets/components/CampaignPageNavigation/CampaignPageNavigation.js
@@ -1,9 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import { isActionPage } from '../../helpers';
-import { prepareCampaignPageSlug } from '../../helpers/campaign';
 import PageNavigation from '../utilities/PageNavigation/PageNavigation';
+import { isActionPage, prepareCampaignPageSlug } from '../../helpers/campaign';
 import CampaignSignupFormContainer from '../CampaignSignupForm/CampaignSignupFormContainer';
 
 const CampaignPageNavigation = ({

--- a/resources/assets/components/CampaignPageNavigation/CampaignPageNavigationContainer.js
+++ b/resources/assets/components/CampaignPageNavigation/CampaignPageNavigationContainer.js
@@ -1,8 +1,8 @@
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router-dom';
 
-import { isCampaignClosed } from '../../helpers';
 import { isSignedUp } from '../../selectors/signup';
+import { isCampaignClosed } from '../../helpers/campaign';
 import CampaignPageNavigation from './CampaignPageNavigation';
 
 const mapStateToProps = state => ({

--- a/resources/assets/components/CampaignSignupForm/CampaignSignupForm.js
+++ b/resources/assets/components/CampaignSignupForm/CampaignSignupForm.js
@@ -2,11 +2,12 @@ import PropTypes from 'prop-types';
 import React, { useState } from 'react';
 
 import Card from '../utilities/Card/Card';
+import { withoutNulls } from '../../helpers';
 import { siteConfig } from '../../helpers/env';
 import { getUtms, query } from '../../helpers/url';
 import GroupFinder from './GroupFinder/GroupFinder';
+import { isCampaignClosed } from '../../helpers/campaign';
 import PrimaryButton from '../utilities/Button/PrimaryButton';
-import { isCampaignClosed, withoutNulls } from '../../helpers';
 import { EVENT_CATEGORIES, trackAnalyticsEvent } from '../../helpers/analytics';
 
 const CampaignSignupForm = props => {

--- a/resources/assets/components/ContentfulEntry/ContentfulEntryContainer.js
+++ b/resources/assets/components/ContentfulEntry/ContentfulEntryContainer.js
@@ -1,7 +1,7 @@
 import { connect } from 'react-redux';
 
 import ContentfulEntry from './ContentfulEntry';
-import { findContentfulEntry } from '../../helpers';
+import { findContentfulEntryInCampaign } from '../../helpers/campaign';
 
 /**
  * Provide state from the Redux store as props for this component.
@@ -9,7 +9,7 @@ import { findContentfulEntry } from '../../helpers';
  * @return {Object}
  */
 const mapStateToProps = (state, { id }) => ({
-  json: findContentfulEntry(state, id),
+  json: findContentfulEntryInCampaign(state, id),
 });
 
 export default connect(mapStateToProps)(ContentfulEntry);

--- a/resources/assets/components/pages/CampaignPage/CampaignPageContainer.js
+++ b/resources/assets/components/pages/CampaignPage/CampaignPageContainer.js
@@ -1,7 +1,7 @@
 import { connect } from 'react-redux';
 
 import CampaignPage from './CampaignPage';
-import { isCampaignClosed } from '../../../helpers';
+import { isCampaignClosed } from '../../../helpers/campaign';
 
 /**
  * Provide state from the Redux store as props for this component.

--- a/resources/assets/helpers/campaign.js
+++ b/resources/assets/helpers/campaign.js
@@ -1,3 +1,5 @@
+/* global window */
+
 import { join } from 'path';
 import { find, get } from 'lodash';
 import gql from 'graphql-tag';

--- a/resources/assets/helpers/index.js
+++ b/resources/assets/helpers/index.js
@@ -1,9 +1,8 @@
 /* global window, document, Blob */
 
-import { format, getTime, isBefore, isWithinInterval } from 'date-fns';
+import { format, getTime, isWithinInterval } from 'date-fns';
 import {
   get,
-  find,
   isArray,
   isEmpty,
   isNil,
@@ -334,21 +333,6 @@ export function getFormattedScreenSize(screenWidth = window.innerWidth) {
 }
 
 /**
- * Check if the given campaign is closed.
- *
- * @param  {String}  endDate
- * @return {Boolean}
- * @todo move to helpers/campaign.js
- */
-export function isCampaignClosed(endDate) {
-  if (!endDate) {
-    return false;
-  }
-
-  return isBefore(endDate, new Date());
-}
-
-/**
  * Check if specified date occurred within the last specified minutes.
  *
  * @param  {Date|String|Number}  date
@@ -414,27 +398,6 @@ export function openDialog(href, callback, width = 550, height = 420) {
   if (callback) {
     interval = setInterval(check, 1000);
   }
-}
-
-/**
- * Find an entry from within the campaign by given ID or Slug param.
- * (Returns false if not found).
- *
- * @param  {Object} state
- * @param  {String} identifier
- * @return {Object|Undefined}
- * @todo rename to findContentfulEntryInCampaign and move to helpers/campaign.js
- */
-export function findContentfulEntry(state, identifier) {
-  const campaign = state.campaign;
-
-  const contentfulEntries = [].concat(campaign.pages, campaign.quizzes);
-
-  return find(
-    contentfulEntries,
-    entry =>
-      entry.id === identifier || get(entry, 'fields.slug') === identifier,
-  );
 }
 
 /**
@@ -508,16 +471,6 @@ export function stringifyNestedObjects(data) {
 
     return value;
   });
-}
-
-/**
- * Determine if a page is an 'Action' page.
- *
- * @param  {Object} page
- * @return {Boolean}
- */
-export function isActionPage(page) {
-  return page.type === 'page' && page.fields.slug.endsWith('action');
 }
 
 /**


### PR DESCRIPTION
### What's this PR do?

This pull request continues the work from the following PRs to clean up the **helpers/index.js** file. 
- #2483
- #2484
- #2487 
- #2488
- #2490 

It separates out any helper functions that deal with campaigns. A **helpers/campaign.js** already existed but there were a few straggling helper functions in the **helpers/index.js** that needed to be moved as well.

### How should this be reviewed?

👀 

### Relevant tickets

References [Pivotal #173019917](https://www.pivotaltracker.com/story/show/173019917).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.