### PR TITLE
Helper cleanup display

### DIFF
--- a/cypress/integration/site-navigation.js
+++ b/cypress/integration/site-navigation.js
@@ -1,6 +1,6 @@
 /// <reference types="Cypress" />
 
-import { tailwind } from '../../resources/assets/helpers';
+import { tailwind } from '../../resources/assets/helpers/display';
 import exampleFactPage from '../fixtures/contentful/exampleFactPage';
 
 // Return array of viewport sizes based on Tailwind configuration.

--- a/resources/assets/components/Flex/index.js
+++ b/resources/assets/components/Flex/index.js
@@ -2,7 +2,8 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import classnames from 'classnames';
 
-import { modifiers } from '../../helpers';
+import { modifiers } from '../../helpers/display';
+
 import './flex.scss';
 
 export const Flex = ({ id, className = null, children }) => (

--- a/resources/assets/components/blocks/CallToActionBlock/CallToActionBlock.js
+++ b/resources/assets/components/blocks/CallToActionBlock/CallToActionBlock.js
@@ -6,8 +6,8 @@ import { css } from '@emotion/core';
 import { useQuery } from '@apollo/react-hooks';
 
 import { env } from '../../../helpers/env';
-import { tailwind } from '../../../helpers';
 import ErrorBlock from '../ErrorBlock/ErrorBlock';
+import { tailwind } from '../../../helpers/display';
 import Spinner from '../../artifacts/Spinner/Spinner';
 import PrimaryButton from '../../utilities/Button/PrimaryButton';
 

--- a/resources/assets/components/blocks/VoterRegistrationReferralsBlock/VoterRegistrationReferral.js
+++ b/resources/assets/components/blocks/VoterRegistrationReferralsBlock/VoterRegistrationReferral.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { css } from '@emotion/core';
 
-import { tailwind } from '../../../helpers';
+import { tailwind } from '../../../helpers/display';
 import StartedRegistrationImage from './started-registration.svg';
 import CompletedRegistrationImage from './completed-registration.svg';
 

--- a/resources/assets/components/pages/AccountPage/Credits/VolunteerCreditsTable.js
+++ b/resources/assets/components/pages/AccountPage/Credits/VolunteerCreditsTable.js
@@ -4,7 +4,7 @@ import Media from 'react-media';
 import PropTypes from 'prop-types';
 import { css } from '@emotion/core';
 
-import { tailwind } from '../../../../helpers';
+import { tailwind } from '../../../../helpers/display';
 import { certificatePostType } from './CertificateTemplate';
 import VolunteerCreditsTableRow from './VolunteerCreditsTableRow';
 

--- a/resources/assets/components/pages/AccountPage/Credits/VolunteerCreditsTableRow.js
+++ b/resources/assets/components/pages/AccountPage/Credits/VolunteerCreditsTableRow.js
@@ -3,8 +3,8 @@ import tw from 'twin.macro';
 import Media from 'react-media';
 import PropTypes from 'prop-types';
 
-import { tailwind } from '../../../../helpers';
 import CampaignPreview from './CampaignPreview';
+import { tailwind } from '../../../../helpers/display';
 import { certificatePostType } from './CertificateTemplate';
 import CertificateDownloadButton from './CertificateDownloadButton';
 

--- a/resources/assets/components/pages/HomePage/HomePage.js
+++ b/resources/assets/components/pages/HomePage/HomePage.js
@@ -6,9 +6,9 @@ import { React, Fragment } from 'react';
 
 import PageQuery from '../PageQuery';
 import sponsorList from './sponsor-list';
-import { tailwind } from '../../../helpers';
 import Modal from '../../utilities/Modal/Modal';
 import { featureFlag } from '../../../helpers/env';
+import { tailwind } from '../../../helpers/display';
 import * as NewsletterImages from './NewsletterImages';
 import { isAuthenticated } from '../../../helpers/auth';
 import HomePageArticleGallery from './HomePageArticleGallery';

--- a/resources/assets/components/pages/HomePage/HomePageCampaignGallery.js
+++ b/resources/assets/components/pages/HomePage/HomePageCampaignGallery.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { css } from '@emotion/core';
 
-import { tailwind } from '../../../helpers';
+import { tailwind } from '../../../helpers/display';
 import CampaignCard from '../../utilities/CampaignCard/CampaignCard';
 import CampaignCardFeatured from '../../utilities/CampaignCard/CampaignCardFeatured';
 

--- a/resources/assets/components/pages/LandingPage/LandingPage.js
+++ b/resources/assets/components/pages/LandingPage/LandingPage.js
@@ -5,7 +5,7 @@ import tw from 'twin.macro';
 import PropTypes from 'prop-types';
 import { css } from '@emotion/core';
 
-import { tailwind } from '../../../helpers';
+import { tailwind } from '../../../helpers/display';
 import TextContent from '../../utilities/TextContent/TextContent';
 import PageInfoBarContainer from '../../PageInfoBar/PageInfoBarContainer';
 import CampaignBannerContainer from '../../CampaignBanner/CampaignBannerContainer';

--- a/resources/assets/components/utilities/CampaignCard/CampaignCardFeatured.js
+++ b/resources/assets/components/utilities/CampaignCard/CampaignCardFeatured.js
@@ -3,7 +3,7 @@ import gql from 'graphql-tag';
 import { css } from '@emotion/core';
 import { propType } from 'graphql-anywhere';
 
-import { tailwind } from '../../../helpers';
+import { tailwind } from '../../../helpers/display';
 import PrimaryButton from '../Button/PrimaryButton';
 import {
   contentfulImageUrl,

--- a/resources/assets/components/utilities/CtaReferralPageBanner/CtaReferralPageBanner.js
+++ b/resources/assets/components/utilities/CtaReferralPageBanner/CtaReferralPageBanner.js
@@ -4,9 +4,10 @@ import PropTypes from 'prop-types';
 import { css } from '@emotion/core';
 import { useQuery } from '@apollo/react-hooks';
 
+import { report } from '../../../helpers';
 import { query } from '../../../helpers/url';
 import { featureFlag } from '../../../helpers/env';
-import { tailwind, report } from '../../../helpers';
+import { tailwind } from '../../../helpers/display';
 import GiftCardHandLargeImage from './gift-card-hand-large.svg';
 import GiftCardHandSmallImage from './gift-card-hand-small.svg';
 import { REFERRAL_USER_QUERY } from '../../pages/ReferralPage/Beta/BetaPage';

--- a/resources/assets/components/utilities/CuratedPageBanner.js
+++ b/resources/assets/components/utilities/CuratedPageBanner.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { css } from '@emotion/core';
 
-import { tailwind } from '../../helpers';
+import { tailwind } from '../../helpers/display';
 import TextContent from './TextContent/TextContent';
 import StatCard, { STAT_PROPS } from './StatCard/StatCard';
 import { contentfulImageUrl } from '../../helpers/contentful';

--- a/resources/assets/components/utilities/Figure/Figure.js
+++ b/resources/assets/components/utilities/Figure/Figure.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import classnames from 'classnames';
 
 import LazyImage from '../LazyImage';
-import { modifiers } from '../../../helpers';
+import { modifiers } from '../../../helpers/display';
 
 import './figure.scss';
 

--- a/resources/assets/components/utilities/FormMessage/index.js
+++ b/resources/assets/components/utilities/FormMessage/index.js
@@ -3,7 +3,8 @@ import { has } from 'lodash';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 
-import { makeHash, modifiers } from '../../../helpers';
+import { makeHash } from '../../../helpers';
+import { modifiers } from '../../../helpers/display';
 
 import './form-message.scss';
 

--- a/resources/assets/components/utilities/LazyImage.js
+++ b/resources/assets/components/utilities/LazyImage.js
@@ -4,7 +4,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import requiredIf from 'react-required-if';
 
-import { EMPTY_IMAGE } from '../../helpers';
+import { EMPTY_IMAGE } from '../../helpers/display';
 
 class LazyImage extends React.Component {
   constructor(props) {

--- a/resources/assets/components/utilities/PlaceholderText/PlaceholderText.js
+++ b/resources/assets/components/utilities/PlaceholderText/PlaceholderText.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { css, keyframes } from '@emotion/core';
 
-import { tailwind } from '../../../helpers';
+import { tailwind } from '../../../helpers/display';
 
 const shimmer = keyframes`
   0% {

--- a/resources/assets/components/utilities/ProgressBar/ProgressBar.js
+++ b/resources/assets/components/utilities/ProgressBar/ProgressBar.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { css } from '@emotion/core';
 
-import { tailwind } from '../../../helpers';
+import { tailwind } from '../../../helpers/display';
 
 const ProgressBar = ({ percentage }) => {
   const tailwindYellow = tailwind('colors.yellow');

--- a/resources/assets/helpers/admin-dashboard.js
+++ b/resources/assets/helpers/admin-dashboard.js
@@ -1,6 +1,6 @@
 /* global document */
 
-import { toggleClassHandler } from '.';
+import { toggleClassHandler } from './display';
 
 export function bindAdminDashboardEvents() {
   const adminDashboard = document.getElementById('admin-dashboard');

--- a/resources/assets/helpers/display.js
+++ b/resources/assets/helpers/display.js
@@ -1,0 +1,122 @@
+/* global document */
+
+import { get, isString } from 'lodash';
+
+import tailwindVariables from '../../../tailwind.variables';
+
+// Helper Constants
+export const EMPTY_IMAGE =
+  'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7';
+
+/**
+ * Prefix a class name or array of class names.
+ * @param {String|Array} names
+ */
+export function modifiers(...names) {
+  let classes = names;
+
+  if (!Array.isArray(classes)) {
+    classes = [classes];
+  }
+
+  return classes
+    .filter(className => className)
+    .map(className => `-${className}`);
+}
+
+/**
+ * Open a dialog and run a callback when it closes.
+ *
+ * @param {String} href
+ * @param {Function} callback
+ * @param {Number} height
+ * @param {Number} width
+ */
+export function openDialog(href, callback, width = 550, height = 420) {
+  const winHeight = window.screen.height;
+  const winWidth = window.screen.width;
+
+  const left = Math.round(winWidth / 2 - width / 2);
+  let top = 0;
+
+  if (winHeight > height) {
+    top = Math.round(winHeight / 2 - height / 2);
+  }
+
+  const dialog = window.open(
+    href,
+    'intent',
+    `scrollbars=yes,resizable=yes,toolbar=no,location=yes,width=${width},height=${height},left=${left},top=${top}`,
+  );
+
+  let interval;
+
+  const check = () => {
+    if (dialog.closed) {
+      clearInterval(interval);
+      callback();
+    }
+  };
+
+  if (callback) {
+    interval = setInterval(check, 1000);
+  }
+}
+
+/**
+ * Wait until the DOM is ready.
+ *
+ * @param {Function} fn
+ */
+export function ready(fn) {
+  if (document.readyState !== 'loading') {
+    fn();
+  } else {
+    document.addEventListener('DOMContentLoaded', fn);
+  }
+}
+
+/**
+ * Get specified theme setting from the resolved Tailwind configuration object.
+ *
+ * @param {String} themeSetting
+ */
+export function tailwind(themeSetting) {
+  if (!isString(themeSetting)) {
+    throw new Error(
+      'Please specify a theme setting as a string to retrieve from Tailwind.',
+    );
+  }
+
+  const setting = get(tailwindVariables, themeSetting, null);
+
+  if (!setting) {
+    console.error(
+      `The ${themeSetting} setting specified was not found in the Tailwind theme configuration.`,
+    );
+  }
+
+  return setting;
+}
+
+/**
+ * Toggle the specified class on the given target element
+ * when the button element is clicked or touched.
+ *
+ * @param  {Element} button
+ * @param  {Element} target
+ * @param  {String} toggleClass
+ */
+export function toggleClassHandler(button, target, toggleClass) {
+  if (!button || !target) {
+    return;
+  }
+
+  function clickHandler() {
+    target.classList.toggle(toggleClass);
+  }
+
+  button.addEventListener('mousedown', clickHandler, false);
+}
+
+export default null;

--- a/resources/assets/helpers/facebook.js
+++ b/resources/assets/helpers/facebook.js
@@ -1,8 +1,8 @@
 /* global window, document */
 
 import { env } from './env';
-import { openDialog } from '.';
 import { makeUrl } from './url';
+import { openDialog } from './display';
 import { EVENT_CATEGORIES, trackAnalyticsEvent } from './analytics';
 
 /**

--- a/resources/assets/helpers/flash-message.js
+++ b/resources/assets/helpers/flash-message.js
@@ -1,7 +1,7 @@
 /* global document */
 /* eslint-disable import/prefer-default-export */
 
-import { toggleClassHandler } from '.';
+import { toggleClassHandler } from './display';
 
 export function bindFlashMessageEvents() {
   const flashMessage = document.getElementById('flash-message');

--- a/resources/assets/helpers/index.js
+++ b/resources/assets/helpers/index.js
@@ -1,4 +1,4 @@
-/* global window, document, Blob */
+/* global window, Blob */
 
 import { format, getTime, isWithinInterval } from 'date-fns';
 import {
@@ -18,11 +18,6 @@ import {
 import { query } from './url';
 import Debug from '../services/Debug';
 import Sixpack from '../services/Sixpack';
-import tailwindVariables from '../../../tailwind.variables';
-
-// Helper Constants
-export const EMPTY_IMAGE =
-  'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7';
 
 /**
  * Return a boolean indicating whether the provided argument is an empty string.
@@ -109,35 +104,6 @@ export function withoutTokens(string) {
   const regex = new RegExp(`{[A-Za-z]*}`, 'g');
 
   return string.replace(regex, 'x');
-}
-
-/**
- * Wait until the DOM is ready.
- *
- * @param {Function} fn
- */
-export function ready(fn) {
-  if (document.readyState !== 'loading') {
-    fn();
-  } else {
-    document.addEventListener('DOMContentLoaded', fn);
-  }
-}
-
-/**
- * Prefix a class name or array of class names.
- * @param {String|Array} names
- */
-export function modifiers(...names) {
-  let classes = names;
-
-  if (!Array.isArray(classes)) {
-    classes = [classes];
-  }
-
-  return classes
-    .filter(className => className)
-    .map(className => `-${className}`);
 }
 
 /**
@@ -362,45 +328,6 @@ export function findById(array, compareId) {
 }
 
 /**
- * Open a dialog and run a callback when it closes.
- *
- * @param {String} href
- * @param {Function} callback
- * @param {Number} height
- * @param {Number} width
- */
-export function openDialog(href, callback, width = 550, height = 420) {
-  const winHeight = window.screen.height;
-  const winWidth = window.screen.width;
-
-  const left = Math.round(winWidth / 2 - width / 2);
-  let top = 0;
-
-  if (winHeight > height) {
-    top = Math.round(winHeight / 2 - height / 2);
-  }
-
-  const dialog = window.open(
-    href,
-    'intent',
-    `scrollbars=yes,resizable=yes,toolbar=no,location=yes,width=${width},height=${height},left=${left},top=${top}`,
-  );
-
-  let interval;
-
-  const check = () => {
-    if (dialog.closed) {
-      clearInterval(interval);
-      callback();
-    }
-  };
-
-  if (callback) {
-    interval = setInterval(check, 1000);
-  }
-}
-
-/**
  * Report a caught error to New Relic.
  *
  * @param {Error|string}  error
@@ -498,49 +425,6 @@ export function getScholarshipAffiliateLabel() {
   // If the utm_source contains 'scholarship', we assume this visit to be a referral from a
   // scholarship affiliate and return the affiliate's UTM label.
   return isScholarshipAffiliateReferral() ? utmLabel : null;
-}
-
-/**
- * Get specified theme setting from the resolved Tailwind configuration object.
- *
- * @param {String} themeSetting
- */
-export function tailwind(themeSetting) {
-  if (!isString(themeSetting)) {
-    throw new Error(
-      'Please specify a theme setting as a string to retrieve from Tailwind.',
-    );
-  }
-
-  const setting = get(tailwindVariables, themeSetting, null);
-
-  if (!setting) {
-    console.error(
-      `The ${themeSetting} setting specified was not found in the Tailwind theme configuration.`,
-    );
-  }
-
-  return setting;
-}
-
-/**
- * Toggle the specified class on the given target element
- * when the button element is clicked or touched.
- *
- * @param  {Element} button
- * @param  {Element} target
- * @param  {String} toggleClass
- */
-export function toggleClassHandler(button, target, toggleClass) {
-  if (!button || !target) {
-    return;
-  }
-
-  function clickHandler() {
-    target.classList.toggle(toggleClass);
-  }
-
-  button.addEventListener('mousedown', clickHandler, false);
 }
 
 /**

--- a/resources/assets/helpers/test.js
+++ b/resources/assets/helpers/test.js
@@ -1,4 +1,5 @@
-import { makeHash, modifiers, pluralize, dynamicString } from './index';
+import { modifiers } from './display';
+import { makeHash, pluralize, dynamicString } from './index';
 
 /**
  * Test dynamicString()

--- a/resources/assets/helpers/twitter.js
+++ b/resources/assets/helpers/twitter.js
@@ -1,5 +1,5 @@
-import { openDialog } from '.';
 import { makeUrl } from './url';
+import { openDialog } from './display';
 import { EVENT_CATEGORIES, trackAnalyticsEvent } from './analytics';
 
 /**

--- a/resources/assets/init.js
+++ b/resources/assets/init.js
@@ -37,7 +37,8 @@ import App from './components/App';
 import NavApp from './components/NavApp';
 
 // DOM Helpers
-import { ready, debug } from './helpers';
+import { debug } from './helpers';
+import { ready } from './helpers/display';
 import { persistUtms } from './helpers/url';
 import { init as historyInit } from './history';
 import { bindFlashMessageEvents } from './helpers/flash-message';


### PR DESCRIPTION
### What's this PR do?

This pull request continues the work from the following PRs to clean up the **helpers/index.js** file. 
- #2483
- #2484
- #2487 
- #2488
- #2490 
- #2492 

It separates out any helper functions that deal with display related needs into a **helpers/display.js** file. I debated what to call this... I originally thought **ui.js**, but figured **display.js** is more obvious. Lemme know if you have thoughts.

### How should this be reviewed?

👀 

### Relevant tickets

References [Pivotal #173019917](https://www.pivotaltracker.com/story/show/173019917).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.