### PR TITLE
Helper cleanup File and Analytics

### DIFF
--- a/resources/assets/components/utilities/MediaUploader/index.js
+++ b/resources/assets/components/utilities/MediaUploader/index.js
@@ -4,7 +4,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 
-import { processFile } from '../../../helpers';
+import { processFile } from '../../../helpers/file';
 
 import './media-uploader.scss';
 

--- a/resources/assets/components/utilities/SixpackExperiment/SixpackExperiment.js
+++ b/resources/assets/components/utilities/SixpackExperiment/SixpackExperiment.js
@@ -5,7 +5,7 @@ import { get, snakeCase } from 'lodash';
 
 import Empty from '../Empty';
 import Placeholder from '../Placeholder';
-import { sixpack } from '../../../helpers';
+import { sixpack } from '../../../helpers/analytics';
 import ContentfulEntryLoader from '../ContentfulEntryLoader/ContentfulEntryLoader';
 
 export const SixpackExperimentBlockFragment = gql`

--- a/resources/assets/helpers/analytics.js
+++ b/resources/assets/helpers/analytics.js
@@ -10,6 +10,7 @@ import {
 } from 'lodash';
 
 import { getUtms } from './url';
+import Sixpack from '../services/Sixpack';
 import { debug, stringifyNestedObjects, withoutValueless } from '.';
 
 /**
@@ -125,31 +126,6 @@ export function analyzeWithSnowplow(name, category, action, label, data) {
 }
 
 /**
- * Dispatch analytics event to specified service, or all services by default.
- *
- * @param  {String}      category
- * @param  {String}      name
- * @param  {Object|Null} [data]
- * @param  {String|Null} [service]
- * @return {void}
- */
-const sendToServices = (name, category, action, label, data, service) => {
-  switch (service) {
-    case 'google':
-      analyzeWithGoogle(name, category, action, label, data);
-      break;
-
-    case 'snowplow':
-      analyzeWithSnowplow(name, category, action, label, data);
-      break;
-
-    default:
-      analyzeWithGoogle(name, category, action, label, data);
-      analyzeWithSnowplow(name, category, action, label, data);
-  }
-};
-
-/**
  * Format analytics event noun string.
  *
  * @param  {String} string
@@ -202,6 +178,49 @@ export function getUtmContext() {
 
   // For analytics, we prefer camelCased keys:
   return mapKeys(utms, (value, key) => camelCase(key));
+}
+
+/**
+ * Dispatch analytics event to specified service, or all services by default.
+ *
+ * @param  {String}      category
+ * @param  {String}      name
+ * @param  {Object|Null} [data]
+ * @param  {String|Null} [service]
+ * @return {void}
+ */
+const sendToServices = (name, category, action, label, data, service) => {
+  switch (service) {
+    case 'google':
+      analyzeWithGoogle(name, category, action, label, data);
+      break;
+
+    case 'snowplow':
+      analyzeWithSnowplow(name, category, action, label, data);
+      break;
+
+    default:
+      analyzeWithGoogle(name, category, action, label, data);
+      analyzeWithSnowplow(name, category, action, label, data);
+  }
+};
+
+/*
+ * Variable that stores single instance of Sixpack.
+ */
+let sixpackInstance = null;
+
+/**
+ * Get instance of Sixpack class.
+ *
+ * @return {Sixpack}
+ */
+export function sixpack() {
+  if (!sixpackInstance) {
+    sixpackInstance = new Sixpack();
+  }
+
+  return sixpackInstance;
 }
 
 /**

--- a/resources/assets/helpers/file.js
+++ b/resources/assets/helpers/file.js
@@ -1,0 +1,54 @@
+/* global Blob, DataView */
+
+import { get } from 'lodash';
+
+/**
+ * Get the type for a specified file.
+ *
+ * @param  {ArrayBuffer} file
+ * @return {String|null}
+ * @todo Eventually deal with other file types.
+ */
+function getFileType(file) {
+  const dv = new DataView(file, 0, 5);
+  const byte1 = dv.getUint8(0, true);
+  const byte2 = dv.getUint8(1, true);
+  const hex = byte1.toString(16) + byte2.toString(16);
+
+  return get(
+    {
+      '8950': 'image/png',
+      '4749': 'image/gif',
+      '424d': 'image/bmp',
+      ffd8: 'image/jpeg',
+    },
+    hex,
+    null,
+  );
+}
+
+/**
+ * Process file (provided as an ArrayBuffer) depending
+ * on its type.
+ *
+ * @param  {ArrayBuffer} file
+ * @return {Blob}
+ *
+ * @todo Eventually deal with other file types.
+ */
+export function processFile(file) {
+  const fileType = getFileType(file);
+  const dataView = new DataView(file);
+
+  if (fileType === 'image/png') {
+    return new Blob([dataView], { type: fileType });
+  }
+
+  if (fileType === 'image/jpeg') {
+    return new Blob([dataView], { type: 'image/jpeg' });
+  }
+
+  throw new Error('Unsupported file type.');
+}
+
+export default null;

--- a/resources/assets/helpers/index.js
+++ b/resources/assets/helpers/index.js
@@ -1,8 +1,7 @@
-/* global window, Blob */
+/* global window */
 
 import { format, getTime, isWithinInterval } from 'date-fns';
 import {
-  get,
   isArray,
   isEmpty,
   isNil,
@@ -17,7 +16,6 @@ import {
 
 import { query } from './url';
 import Debug from '../services/Debug';
-import Sixpack from '../services/Sixpack';
 
 /**
  * Return a boolean indicating whether the provided argument is an empty string.
@@ -115,54 +113,6 @@ export function withoutTokens(string) {
  */
 export function pluralize(quantity, singular, plural) {
   return quantity === 1 ? singular : plural;
-}
-
-/**
- * Get the type for a specified file.
- *
- * @param  {ArrayBuffer} file
- * @return {String|null}
- * @todo Eventually deal with other file types.
- */
-function getFileType(file) {
-  const dv = new DataView(file, 0, 5);
-  const byte1 = dv.getUint8(0, true);
-  const byte2 = dv.getUint8(1, true);
-  const hex = byte1.toString(16) + byte2.toString(16);
-
-  return get(
-    {
-      '8950': 'image/png',
-      '4749': 'image/gif',
-      '424d': 'image/bmp',
-      ffd8: 'image/jpeg',
-    },
-    hex,
-    null,
-  );
-}
-
-/**
- * Process file (provided as an ArrayBuffer) depending
- * on its type.
- *
- * @param  {ArrayBuffer} file
- * @return {Blob}
- * @todo Eventually deal with other file types.
- */
-export function processFile(file) {
-  const fileType = getFileType(file);
-  const dataView = new DataView(file);
-
-  if (fileType === 'image/png') {
-    return new Blob([dataView], { type: fileType });
-  }
-
-  if (fileType === 'image/jpeg') {
-    return new Blob([dataView], { type: 'image/jpeg' });
-  }
-
-  throw new Error('Unsupported file type.');
 }
 
 /**
@@ -354,24 +304,6 @@ export function report(error, customAttributes = null) {
   }
 
   window.newrelic.noticeError(errorInstance, customAttributes);
-}
-
-/*
- * Variable that stores single instance of Sixpack.
- */
-let sixpackInstance = null;
-
-/**
- * Get instance of Sixpack class.
- *
- * @return {Sixpack}
- */
-export function sixpack() {
-  if (!sixpackInstance) {
-    sixpackInstance = new Sixpack();
-  }
-
-  return sixpackInstance;
 }
 
 let debugInstance = null;

--- a/resources/assets/middleware/sixpackExperiments.js
+++ b/resources/assets/middleware/sixpackExperiments.js
@@ -1,6 +1,6 @@
 import { get } from 'lodash';
 
-import { sixpack } from '../helpers';
+import { sixpack } from '../helpers/analytics';
 
 const sixpackExperimentsMiddleware = () => next => action => {
   const convertableActionName = get(


### PR DESCRIPTION
### What's this PR do?

This pull request continues the work from the following PRs to clean up the **helpers/index.js** file. 
- #2483
- #2484
- #2487 
- #2488
- #2490 
- #2492 
- #2493 

It separates out any helper functions that deal with file/image manipulation into the **helpers/file.js** and the Sixpack related helper into the **helpers/analytics.js**.

### How should this be reviewed?

👀 

### Relevant tickets

References [Pivotal #173019917](https://www.pivotaltracker.com/story/show/173019917).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.