### PR TITLE
Helper cleanup for data manipulation helpers

### DIFF
--- a/resources/assets/components/AffiliateOptInToggle/AffiliateOptInToggle.js
+++ b/resources/assets/components/AffiliateOptInToggle/AffiliateOptInToggle.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import { withoutNulls } from '../../helpers';
+import { withoutNulls } from '../../helpers/data';
 import TextContent from '../utilities/TextContent/TextContent';
 
 import './affiliate-opt-in-toggle.scss';

--- a/resources/assets/components/CampaignSignupForm/CampaignSignupForm.js
+++ b/resources/assets/components/CampaignSignupForm/CampaignSignupForm.js
@@ -2,8 +2,8 @@ import PropTypes from 'prop-types';
 import React, { useState } from 'react';
 
 import Card from '../utilities/Card/Card';
-import { withoutNulls } from '../../helpers';
 import { siteConfig } from '../../helpers/env';
+import { withoutNulls } from '../../helpers/data';
 import { getUtms, query } from '../../helpers/url';
 import GroupFinder from './GroupFinder/GroupFinder';
 import { isCampaignClosed } from '../../helpers/campaign';

--- a/resources/assets/components/ContentfulEntry/ContentfulEntry.js
+++ b/resources/assets/components/ContentfulEntry/ContentfulEntry.js
@@ -1,8 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
+import { report } from '../../helpers';
 import Loader from '../utilities/Loader';
-import { report, withoutNulls } from '../../helpers';
+import { withoutNulls } from '../../helpers/data';
 import Affirmation from '../Affirmation/Affirmation';
 import SoftEdgeBlock from '../actions/SoftEdgeBlock';
 import EmbedBlock from '../blocks/EmbedBlock/EmbedBlock';

--- a/resources/assets/components/Quiz/QuizQuestion.js
+++ b/resources/assets/components/Quiz/QuizQuestion.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import QuizChoice from './QuizChoice';
-import { convertNumberToWord } from '../../helpers';
+import { convertNumberToWord } from '../../helpers/data';
 import SectionHeader from '../utilities/SectionHeader/SectionHeader';
 
 const QuizQuestion = props => {

--- a/resources/assets/components/actions/LinkAction/LinkActionContainer.js
+++ b/resources/assets/components/actions/LinkAction/LinkActionContainer.js
@@ -1,7 +1,7 @@
 import { connect } from 'react-redux';
 
 import LinkAction from './LinkAction';
-import { withoutNulls } from '../../../helpers';
+import { withoutNulls } from '../../../helpers/data';
 
 /**
  * Provide state from the Redux store as props for this component.

--- a/resources/assets/components/actions/LinkAction/templates/CtaTemplate.js
+++ b/resources/assets/components/actions/LinkAction/templates/CtaTemplate.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import Card from '../../../utilities/Card/Card';
-import { dynamicString } from '../../../../helpers';
+import { dynamicString } from '../../../../helpers/data';
 import PrimaryButton from '../../../utilities/Button/PrimaryButton';
 import TextContent from '../../../utilities/TextContent/TextContent';
 import {

--- a/resources/assets/components/actions/LinkAction/templates/DefaultTemplate.js
+++ b/resources/assets/components/actions/LinkAction/templates/DefaultTemplate.js
@@ -3,8 +3,8 @@ import PropTypes from 'prop-types';
 
 import Card from '../../../utilities/Card/Card';
 import Embed from '../../../utilities/Embed/Embed';
-import { dynamicString } from '../../../../helpers';
 import { getUserId } from '../../../../helpers/auth';
+import { dynamicString } from '../../../../helpers/data';
 import PrimaryButton from '../../../utilities/Button/PrimaryButton';
 import TextContent from '../../../utilities/TextContent/TextContent';
 import AffiliatePromotion from '../../../utilities/AffiliatePromotion/AffiliatePromotion';

--- a/resources/assets/components/actions/PhotoSubmissionAction/PhotoSubmissionAction.js
+++ b/resources/assets/components/actions/PhotoSubmissionAction/PhotoSubmissionAction.js
@@ -17,7 +17,7 @@ import MediaUploader from '../../utilities/MediaUploader';
 import { getUserCampaignSignups } from '../../../helpers/api';
 import FormValidation from '../../utilities/Form/FormValidation';
 import PrimaryButton from '../../utilities/Button/PrimaryButton';
-import { withoutUndefined, withoutNulls } from '../../../helpers';
+import { withoutUndefined, withoutNulls } from '../../../helpers/data';
 import CharacterLimit from '../../utilities/CharacterLimit/CharacterLimit';
 import PrivacyLanguage from '../../utilities/PrivacyLanguage/PrivacyLanguage';
 import AnalyticsWaypoint from '../../utilities/AnalyticsWaypoint/AnalyticsWaypoint';

--- a/resources/assets/components/actions/ShareAction/ShareAction.js
+++ b/resources/assets/components/actions/ShareAction/ShareAction.js
@@ -13,6 +13,7 @@ import PrimaryButton from '../../utilities/Button/PrimaryButton';
 import { showTwitterSharePrompt } from '../../../helpers/twitter';
 import { SOCIAL_SHARE_TYPE } from '../../../constants/post-types';
 import TextContent from '../../utilities/TextContent/TextContent';
+import { dynamicString, withoutNulls } from '../../../helpers/data';
 import AnalyticsWaypoint from '../../utilities/AnalyticsWaypoint/AnalyticsWaypoint';
 import ContentfulEntryLoader from '../../utilities/ContentfulEntryLoader/ContentfulEntryLoader';
 import {
@@ -23,7 +24,6 @@ import {
   loadFacebookSDK,
   showFacebookShareDialog,
 } from '../../../helpers/facebook';
-import { dynamicString, withoutNulls } from '../../../helpers';
 
 export const ShareBlockFragment = gql`
   fragment ShareBlockFragment on ShareBlock {

--- a/resources/assets/components/actions/SoftEdgeBlock.js
+++ b/resources/assets/components/actions/SoftEdgeBlock.js
@@ -7,7 +7,7 @@ import useScript, { ScriptStatus } from '@charlietango/use-script';
 
 import Card from '../utilities/Card/Card';
 import { makeUrl } from '../../helpers/url';
-import { withoutNulls } from '../../helpers';
+import { withoutNulls } from '../../helpers/data';
 import Spinner from '../artifacts/Spinner/Spinner';
 import ErrorBlock from '../blocks/ErrorBlock/ErrorBlock';
 

--- a/resources/assets/components/actions/TextSubmissionAction/TextSubmissionAction.js
+++ b/resources/assets/components/actions/TextSubmissionAction/TextSubmissionAction.js
@@ -12,7 +12,7 @@ import PostCreatedModal from '../PostCreatedModal';
 import ActionInformation from '../ActionInformation';
 import FormValidation from '../../utilities/Form/FormValidation';
 import PrimaryButton from '../../utilities/Button/PrimaryButton';
-import { withoutUndefined, withoutNulls } from '../../../helpers';
+import { withoutUndefined, withoutNulls } from '../../../helpers/data';
 import { getFieldErrors, formatPostPayload } from '../../../helpers/forms';
 import CharacterLimit from '../../utilities/CharacterLimit/CharacterLimit';
 import PrivacyLanguage from '../../utilities/PrivacyLanguage/PrivacyLanguage';

--- a/resources/assets/components/actions/VoterRegistrationAction/VoterRegistrationAction.js
+++ b/resources/assets/components/actions/VoterRegistrationAction/VoterRegistrationAction.js
@@ -3,8 +3,8 @@ import gql from 'graphql-tag';
 import PropTypes from 'prop-types';
 
 import Card from '../../utilities/Card/Card';
-import { dynamicString } from '../../../helpers';
 import { getUserId } from '../../../helpers/auth';
+import { dynamicString } from '../../../helpers/data';
 import PrimaryButton from '../../utilities/Button/PrimaryButton';
 import TextContent from '../../utilities/TextContent/TextContent';
 import AnalyticsWaypoint from '../../utilities/AnalyticsWaypoint/AnalyticsWaypoint';

--- a/resources/assets/components/blocks/GalleryBlock/GalleryBlock.js
+++ b/resources/assets/components/blocks/GalleryBlock/GalleryBlock.js
@@ -2,8 +2,8 @@ import React from 'react';
 import gql from 'graphql-tag';
 import PropTypes from 'prop-types';
 
-import { withoutNulls } from '../../../helpers';
 import Person from '../../utilities/Person/Person';
+import { withoutNulls } from '../../../helpers/data';
 import Gallery from '../../utilities/Gallery/Gallery';
 import SectionHeader from '../../utilities/SectionHeader/SectionHeader';
 import CampaignCard, {

--- a/resources/assets/components/blocks/PostGalleryBlock/PostGalleryBlockQuery.js
+++ b/resources/assets/components/blocks/PostGalleryBlock/PostGalleryBlockQuery.js
@@ -7,7 +7,7 @@ import classnames from 'classnames';
 import { query } from '../../../helpers/url';
 import PaginatedQuery from '../../PaginatedQuery';
 import ScrollConcierge from '../../ScrollConcierge';
-import { withoutValueless } from '../../../helpers';
+import { withoutValueless } from '../../../helpers/data';
 import PostGallery from '../../utilities/PostGallery/PostGallery';
 import { postCardFragment } from '../../utilities/PostCard/PostCard';
 import { reactionButtonFragment } from '../../utilities/ReactionButton/ReactionButton';

--- a/resources/assets/components/blocks/SubmissionGalleryBlock/SubmissionGalleryBlockQuery.js
+++ b/resources/assets/components/blocks/SubmissionGalleryBlock/SubmissionGalleryBlockQuery.js
@@ -2,9 +2,9 @@ import React from 'react';
 import gql from 'graphql-tag';
 import PropTypes from 'prop-types';
 
-import { withoutNulls } from '../../../helpers';
 import { getUserId } from '../../../helpers/auth';
 import PaginatedQuery from '../../PaginatedQuery';
+import { withoutNulls } from '../../../helpers/data';
 import PostGallery from '../../utilities/PostGallery/PostGallery';
 import { postCardFragment } from '../../utilities/PostCard/PostCard';
 import { reactionButtonFragment } from '../../utilities/ReactionButton/ReactionButton';

--- a/resources/assets/components/pages/AccountPage/Credits/CampaignPreview.js
+++ b/resources/assets/components/pages/AccountPage/Credits/CampaignPreview.js
@@ -2,8 +2,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import LazyImage from '../../../utilities/LazyImage';
-import { getFormattedScreenSize } from '../../../../helpers';
 import { contentfulImageUrl } from '../../../../helpers/contentful';
+import { getFormattedScreenSize } from '../../../../helpers/display';
 
 const CampaignPreview = ({ campaignWebsite }) => {
   const {

--- a/resources/assets/components/pages/CampaignsPage/FilterNavigation/FilterSubNav.js
+++ b/resources/assets/components/pages/CampaignsPage/FilterNavigation/FilterSubNav.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
-import { withoutNulls } from '../../../../helpers';
+import { withoutNulls } from '../../../../helpers/data';
 import CauseFilter from '../CampaignFilters/CauseFilter/CauseFilter';
 
 const renderedFilterMenu = props => {

--- a/resources/assets/components/pages/CollectionPage/CollectionPage.js
+++ b/resources/assets/components/pages/CollectionPage/CollectionPage.js
@@ -3,7 +3,7 @@ import gql from 'graphql-tag';
 import PropTypes from 'prop-types';
 
 import PageQuery from '../PageQuery';
-import { withoutNulls } from '../../../helpers';
+import { withoutNulls } from '../../../helpers/data';
 import SiteFooter from '../../utilities/SiteFooter/SiteFooter';
 import CuratedPageBanner from '../../utilities/CuratedPageBanner';
 import TextContent from '../../utilities/TextContent/TextContent';

--- a/resources/assets/components/pages/CompanyPage/CompanyPage.js
+++ b/resources/assets/components/pages/CompanyPage/CompanyPage.js
@@ -3,8 +3,8 @@ import gql from 'graphql-tag';
 import PropTypes from 'prop-types';
 
 import PageQuery from '../PageQuery';
-import { withoutNulls } from '../../../helpers';
 import LazyImage from '../../utilities/LazyImage';
+import { withoutNulls } from '../../../helpers/data';
 import SiteFooter from '../../utilities/SiteFooter/SiteFooter';
 import { contentfulImageUrl } from '../../../helpers/contentful';
 import TextContent from '../../utilities/TextContent/TextContent';

--- a/resources/assets/components/pages/GeneralPage/GeneralPage.js
+++ b/resources/assets/components/pages/GeneralPage/GeneralPage.js
@@ -4,9 +4,9 @@ import React from 'react';
 import get from 'lodash/get';
 import PropTypes from 'prop-types';
 
-import { withoutNulls } from '../../../helpers';
 import LazyImage from '../../utilities/LazyImage';
 import Byline from '../../utilities/Byline/Byline';
+import { withoutNulls } from '../../../helpers/data';
 import { REGISTER_CTA_COPY } from '../../../constants';
 import AuthorBio from '../../utilities/Author/AuthorBio';
 import ArticleHeader from '../../utilities/ArticleHeader';

--- a/resources/assets/components/pages/PostSignupModal/PostSignupModal.js
+++ b/resources/assets/components/pages/PostSignupModal/PostSignupModal.js
@@ -2,8 +2,8 @@ import React from 'react';
 import { get } from 'lodash';
 import PropTypes from 'prop-types';
 
-import { withoutNulls } from '../../../helpers';
 import SlideshowContainer from '../../Slideshow';
+import { withoutNulls } from '../../../helpers/data';
 import Affirmation from '../../Affirmation/Affirmation';
 import ContentfulEntryLoader from '../../utilities/ContentfulEntryLoader/ContentfulEntryLoader';
 

--- a/resources/assets/components/pages/StoryPage/StoryPage.js
+++ b/resources/assets/components/pages/StoryPage/StoryPage.js
@@ -3,8 +3,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import { withoutNulls } from '../../../helpers';
 import ContentfulEntry from '../../ContentfulEntry';
+import { withoutNulls } from '../../../helpers/data';
 import { isAuthenticated } from '../../../helpers/auth';
 import PageInfoBar from '../../PageInfoBar/PageInfoBar';
 import SiteFooter from '../../utilities/SiteFooter/SiteFooter';

--- a/resources/assets/components/utilities/FormMessage/index.js
+++ b/resources/assets/components/utilities/FormMessage/index.js
@@ -3,7 +3,7 @@ import { has } from 'lodash';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 
-import { makeHash } from '../../../helpers';
+import { makeHash } from '../../../helpers/data';
 import { modifiers } from '../../../helpers/display';
 
 import './form-message.scss';

--- a/resources/assets/components/utilities/ShortLinkShare/ShortLinkShare.js
+++ b/resources/assets/components/utilities/ShortLinkShare/ShortLinkShare.js
@@ -8,8 +8,8 @@ import { env } from '../../../helpers/env';
 import { getUserId } from '../../../helpers/auth';
 import { postRequest } from '../../../helpers/api';
 import { appendToQuery } from '../../../helpers/url';
-import { dynamicString, withoutTokens } from '../../../helpers';
 import SocialShareTray from '../SocialShareTray/SocialShareTray';
+import { dynamicString, withoutTokens } from '../../../helpers/data';
 import {
   EVENT_CATEGORIES,
   trackAnalyticsEvent,

--- a/resources/assets/components/utilities/SocialShareTray/SocialShareTray.js
+++ b/resources/assets/components/utilities/SocialShareTray/SocialShareTray.js
@@ -26,7 +26,7 @@ import {
   showFacebookSendDialog,
   showFacebookShareDialog,
 } from '../../../helpers/facebook';
-import { getFormattedScreenSize } from '../../../helpers';
+import { getFormattedScreenSize } from '../../../helpers/display';
 
 class SocialShareTray extends React.Component {
   componentDidMount() {

--- a/resources/assets/components/utilities/TypeFormEmbed/TypeFormEmbed.js
+++ b/resources/assets/components/utilities/TypeFormEmbed/TypeFormEmbed.js
@@ -3,7 +3,7 @@ import * as typeformEmbed from '@typeform/embed';
 import React, { useRef, useEffect } from 'react';
 
 import { makeUrl } from '../../../helpers/url';
-import { withoutNulls } from '../../../helpers';
+import { withoutNulls } from '../../../helpers/data';
 
 const DISPLAY_STYLES = {
   block: {

--- a/resources/assets/helpers/analytics.js
+++ b/resources/assets/helpers/analytics.js
@@ -9,9 +9,10 @@ import {
   startCase,
 } from 'lodash';
 
+import { debug } from '.';
 import { getUtms } from './url';
 import Sixpack from '../services/Sixpack';
-import { debug, stringifyNestedObjects, withoutValueless } from '.';
+import { stringifyNestedObjects, withoutValueless } from './data';
 
 /**
  * App name prefix used for event naming.

--- a/resources/assets/helpers/auth.js
+++ b/resources/assets/helpers/auth.js
@@ -3,7 +3,7 @@
 import { get, isEmpty } from 'lodash';
 import queryString from 'query-string';
 
-import { withoutValueless } from '.';
+import { withoutValueless } from './data';
 import { EVENT_CATEGORIES, trackAnalyticsEvent } from './analytics';
 
 /**

--- a/resources/assets/helpers/contentful.js
+++ b/resources/assets/helpers/contentful.js
@@ -1,6 +1,6 @@
 import { get } from 'lodash';
 
-import { withoutNulls } from '.';
+import { withoutNulls } from './data';
 import { appendToQuery } from './url';
 
 /**

--- a/resources/assets/helpers/data.js
+++ b/resources/assets/helpers/data.js
@@ -78,7 +78,7 @@ export function generateUniqueId() {
 /**
  * Return a boolean indicating whether the provided argument is an empty array.
  *
- * @param  {Mixed}  data
+ * @param  {*} data
  * @return {Boolean}
  */
 export function isEmptyArray(data) {
@@ -92,7 +92,7 @@ export function isEmptyArray(data) {
 /**
  * Return a boolean indicating whether the provided argument is an empty string.
  *
- * @param  {Mixed}  data
+ * @param  {*} data
  * @return {Boolean}
  */
 export function isEmptyString(data) {

--- a/resources/assets/helpers/data.js
+++ b/resources/assets/helpers/data.js
@@ -12,8 +12,8 @@ import {
 } from 'lodash';
 
 /**
- * Convert an int to a string. (Supports 0-10)
- * @param  {int} number
+ * Convert an number to a string. (Supports 0-10)
+ * @param  {Number} number
  * @return {String}
  */
 export function convertNumberToWord(number) {

--- a/resources/assets/helpers/data.js
+++ b/resources/assets/helpers/data.js
@@ -1,3 +1,5 @@
+/* global Date, JSON, Math, Object */
+
 import {
   isArray,
   isEmpty,

--- a/resources/assets/helpers/data.js
+++ b/resources/assets/helpers/data.js
@@ -1,0 +1,198 @@
+import {
+  isArray,
+  isEmpty,
+  isNil,
+  isNull,
+  isObjectLike,
+  isUndefined,
+  mapValues,
+  omitBy,
+} from 'lodash';
+
+/**
+ * Convert an int to a string. (Supports 0-10)
+ * @param  {int} number
+ * @return {String}
+ */
+export function convertNumberToWord(number) {
+  switch (number) {
+    case 0:
+      return 'zero';
+    case 1:
+      return 'one';
+    case 2:
+      return 'two';
+    case 3:
+      return 'three';
+    case 4:
+      return 'four';
+    case 5:
+      return 'five';
+    case 6:
+      return 'six';
+    case 7:
+      return 'seven';
+    case 8:
+      return 'eight';
+    case 9:
+      return 'nine';
+    case 10:
+      return 'ten';
+    default:
+      throw new Error('Number out of range');
+  }
+}
+
+/**
+ * Return a string with tokens replaced by specified values.
+ *
+ * @param  {String} string
+ * @param  {Object} tokens
+ * @return {String}
+ */
+export function dynamicString(string, tokens = {}) {
+  let updatedString = string;
+
+  Object.keys(tokens).forEach(key => {
+    const regex = new RegExp(`{${key}}`, 'g');
+
+    updatedString = updatedString.replace(regex, tokens[key]);
+  });
+
+  return updatedString;
+}
+
+/**
+ * Generate a random unique id based on the current time
+ * and a random 5 digit number.
+ *
+ * @return {String}
+ */
+export function generateUniqueId() {
+  const salt = Math.floor(Math.random() * 90000) + 10000;
+  return `${Date.now()}${salt}`;
+}
+
+/**
+ * Return a boolean indicating whether the provided argument is an empty array.
+ *
+ * @param  {Mixed}  data
+ * @return {Boolean}
+ */
+export function isEmptyArray(data) {
+  if (!isArray(data)) {
+    return false;
+  }
+
+  return isEmpty(data);
+}
+
+/**
+ * Return a boolean indicating whether the provided argument is an empty string.
+ *
+ * @param  {Mixed}  data
+ * @return {Boolean}
+ */
+export function isEmptyString(data) {
+  return data === '';
+}
+
+/**
+ * Make a hash from a specified string.
+ * @see  http://werxltd.com/wp/2010/05/13/javascript-implementation-of-javas-string-hashcode-method/
+ *
+ * @param  {String} string
+ * @return {String}
+ */
+export function makeHash(string) {
+  if (string === undefined || string === null) {
+    throw new Error('Cannot make hash from undefined or null value.');
+  }
+
+  let hash = 0;
+
+  if (!string.length) {
+    return hash;
+  }
+
+  string.split('').forEach((char, index) => {
+    const charCode = string.charCodeAt(index);
+    hash = (hash << 5) - hash + charCode; // eslint-disable-line no-bitwise
+    hash = hash & hash; // eslint-disable-line no-bitwise, operator-assignment
+  });
+
+  return Math.abs(hash);
+}
+
+/**
+ * Pluralize a noun.
+ *
+ * @param {Number} quantity
+ * @param {String} singular
+ * @param {String} plural
+ */
+export function pluralize(quantity, singular, plural) {
+  return quantity === 1 ? singular : plural;
+}
+
+/**
+ * Stringify all properties on an object whose value is object with properties.
+ *
+ * @param  {Object} data
+ * @return {Object}
+ */
+export function stringifyNestedObjects(data) {
+  return mapValues(data, value => {
+    if (isObjectLike(value)) {
+      return JSON.stringify(value);
+    }
+
+    return value;
+  });
+}
+
+/**
+ * Remove items with null properties.
+ * Helps with React defaultProps.
+ *
+ * @param  {Object} data
+ * @return {Object}
+ */
+export function withoutNulls(data) {
+  return omitBy(data, isNull);
+}
+
+/**
+ * Return a string with tokens removed.
+ *
+ * @param  {String} string
+ * @param  {Object} tokens
+ * @return {String}
+ */
+export function withoutTokens(string) {
+  const regex = new RegExp(`{[A-Za-z]*}`, 'g');
+
+  return string.replace(regex, 'x');
+}
+
+/**
+ * Remove items with undefined properties.
+ *
+ * @param  {Object} data
+ * @return {Object}
+ */
+export function withoutUndefined(data) {
+  return omitBy(data, isUndefined);
+}
+
+/**
+ * Remove items from object with null, undefined, or empty string values.
+ *
+ * @param  {Object} data
+ * @return {Object}
+ */
+export function withoutValueless(data) {
+  return omitBy(omitBy(omitBy(data, isNil), isEmptyArray), isEmptyString);
+}
+
+export default null;

--- a/resources/assets/helpers/display.js
+++ b/resources/assets/helpers/display.js
@@ -9,6 +9,32 @@ export const EMPTY_IMAGE =
   'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7';
 
 /**
+ * Get a formatted name (small, medium, large)
+ * of the current display size.
+ *
+ * @param  {int} width - Defaults to the screen width
+ * @return {String}
+ */
+export function getFormattedScreenSize(screenWidth = window.innerWidth) {
+  const breakpoints = [
+    {
+      name: 'small',
+      test: width => width <= 759,
+    },
+    {
+      name: 'medium',
+      test: width => width >= 760 && width <= 959,
+    },
+    {
+      name: 'large',
+      test: width => width >= 960,
+    },
+  ];
+
+  return breakpoints.find(breakpoint => breakpoint.test(screenWidth)).name;
+}
+
+/**
  * Prefix a class name or array of class names.
  * @param {String|Array} names
  */

--- a/resources/assets/helpers/forms.js
+++ b/resources/assets/helpers/forms.js
@@ -2,8 +2,8 @@
 
 import { forEach, get, isInteger } from 'lodash';
 
-import { withoutValueless } from '.';
 import { getUtms, query } from './url';
+import { withoutValueless } from './data';
 
 /**
  * Calculate the difference between a total value and a submitted value.

--- a/resources/assets/helpers/index.js
+++ b/resources/assets/helpers/index.js
@@ -1,130 +1,10 @@
 /* global window */
 
 import { format, getTime, isWithinInterval } from 'date-fns';
-import {
-  isArray,
-  isEmpty,
-  isNil,
-  isNull,
-  isString,
-  isObjectLike,
-  isUndefined,
-  mapValues,
-  mergeWith,
-  omitBy,
-} from 'lodash';
+import { isArray, isNull, isString, mergeWith } from 'lodash';
 
 import { query } from './url';
 import Debug from '../services/Debug';
-
-/**
- * Return a boolean indicating whether the provided argument is an empty string.
- *
- * @param  {Mixed}  string
- * @return {Boolean}
- */
-export function isEmptyString(string) {
-  return string === '';
-}
-
-/**
- * Return a boolean indicating whether the provided argument is an empty array.
- *
- * @param  {Mixed}  data
- * @return {Boolean}
- */
-export function isEmptyArray(data) {
-  if (!isArray(data)) {
-    return false;
-  }
-
-  return isEmpty(data);
-}
-
-/**
- * Remove items with null properties.
- * Helps with React defaultProps.
- *
- * @param  {Object} data
- * @return {Object}
- */
-export function withoutNulls(data) {
-  return omitBy(data, isNull);
-}
-
-/**
- * Remove items with undefined properties.
- *
- * @param  {Object} data
- * @return {Object}
- */
-export function withoutUndefined(data) {
-  return omitBy(data, isUndefined);
-}
-
-/**
- * Remove items from object with null, undefined, or empty string values.
- *
- * @param  {Object} data
- * @return {Object}
- */
-export function withoutValueless(data) {
-  return omitBy(omitBy(omitBy(data, isNil), isEmptyArray), isEmptyString);
-}
-
-/**
- * Return a string with tokens replaced by specified values.
- *
- * @param  {String} string
- * @param  {Object} tokens
- * @return {String}
- */
-export function dynamicString(string, tokens = {}) {
-  let updatedString = string;
-
-  Object.keys(tokens).forEach(key => {
-    const regex = new RegExp(`{${key}}`, 'g');
-
-    updatedString = updatedString.replace(regex, tokens[key]);
-  });
-
-  return updatedString;
-}
-
-/**
- * Return a string with tokens removed.
- *
- * @param  {String} string
- * @param  {Object} tokens
- * @return {String}
- */
-export function withoutTokens(string) {
-  const regex = new RegExp(`{[A-Za-z]*}`, 'g');
-
-  return string.replace(regex, 'x');
-}
-
-/**
- * Pluralize a noun.
- *
- * @param {Number} quantity
- * @param {String} singular
- * @param {String} plural
- */
-export function pluralize(quantity, singular, plural) {
-  return quantity === 1 ? singular : plural;
-}
-
-/**
- * Generate a random unique id based on the current time
- * and a random 5 digit number.
- *
- * @return {String}
- */
-export function generateUniqueId() {
-  const salt = Math.floor(Math.random() * 90000) + 10000;
-  return `${Date.now()}${salt}`;
-}
 
 /**
  * Check if the given timestamp has exceeded its lifespan of max time.
@@ -135,67 +15,6 @@ export function generateUniqueId() {
  */
 export function isTimestampValid(timestamp, maxTime) {
   return timestamp + maxTime > Date.now();
-}
-
-/**
- * Convert an int to a string. (Supports 0-10)
- * @param  {int} number
- * @return {String}
- */
-export function convertNumberToWord(number) {
-  switch (number) {
-    case 0:
-      return 'zero';
-    case 1:
-      return 'one';
-    case 2:
-      return 'two';
-    case 3:
-      return 'three';
-    case 4:
-      return 'four';
-    case 5:
-      return 'five';
-    case 6:
-      return 'six';
-    case 7:
-      return 'seven';
-    case 8:
-      return 'eight';
-    case 9:
-      return 'nine';
-    case 10:
-      return 'ten';
-    default:
-      throw new Error('Number out of range');
-  }
-}
-
-/**
- * Make a hash from a specified string.
- * @see  http://werxltd.com/wp/2010/05/13/javascript-implementation-of-javas-string-hashcode-method/
- *
- * @param  {String} string
- * @return {String}
- */
-export function makeHash(string) {
-  if (string === undefined || string === null) {
-    throw new Error('Cannot make hash from undefined or null value.');
-  }
-
-  let hash = 0;
-
-  if (!string.length) {
-    return hash;
-  }
-
-  string.split('').forEach((char, index) => {
-    const charCode = string.charCodeAt(index);
-    hash = (hash << 5) - hash + charCode; // eslint-disable-line no-bitwise
-    hash = hash & hash; // eslint-disable-line no-bitwise, operator-assignment
-  });
-
-  return Math.abs(hash);
 }
 
 /**
@@ -223,32 +42,6 @@ export function getDaysBetween(dateOne, dateTwo) {
 }
 
 /**
- * Get a formatted name (small, medium, large)
- * of the current display size.
- *
- * @param  {int} width - Defaults to the screen width
- * @return {String}
- */
-export function getFormattedScreenSize(screenWidth = window.innerWidth) {
-  const breakpoints = [
-    {
-      name: 'small',
-      test: width => width <= 759,
-    },
-    {
-      name: 'medium',
-      test: width => width >= 760 && width <= 959,
-    },
-    {
-      name: 'large',
-      test: width => width >= 960,
-    },
-  ];
-
-  return breakpoints.find(breakpoint => breakpoint.test(screenWidth)).name;
-}
-
-/**
  * Check if specified date occurred within the last specified minutes.
  *
  * @param  {Date|String|Number}  date
@@ -264,17 +57,6 @@ export function isWithinMinutes(date, minutes = 2) {
     start: Date.now() - minutes * 60 * 1000,
     end: Date.now(),
   });
-}
-
-/**
- * Search an array of objects for the given id.
- *
- * @param  {Array}  array
- * @param  {String} compareId
- * @return {Object}
- */
-export function findById(array, compareId) {
-  return array.find(({ id }) => id === compareId);
 }
 
 /**
@@ -314,22 +96,6 @@ export function debug() {
   }
 
   return debugInstance;
-}
-
-/**
- * Stringify all properties on an object whose value is object with properties.
- *
- * @param  {Object} data
- * @return {Object}
- */
-export function stringifyNestedObjects(data) {
-  return mapValues(data, value => {
-    if (isObjectLike(value)) {
-      return JSON.stringify(value);
-    }
-
-    return value;
-  });
 }
 
 /**

--- a/resources/assets/helpers/test.js
+++ b/resources/assets/helpers/test.js
@@ -1,5 +1,5 @@
 import { modifiers } from './display';
-import { makeHash, pluralize, dynamicString } from './index';
+import { makeHash, pluralize, dynamicString } from './data';
 
 /**
  * Test dynamicString()

--- a/resources/assets/helpers/url.js
+++ b/resources/assets/helpers/url.js
@@ -3,7 +3,7 @@
 import queryString from 'query-string';
 import { merge, isEmpty } from 'lodash';
 
-import { withoutValueless } from '.';
+import { withoutValueless } from './data';
 
 const UTM_SESSION_KEY = 'ds_utm_params';
 

--- a/resources/assets/selectors/index.js
+++ b/resources/assets/selectors/index.js
@@ -1,5 +1,5 @@
-import { withoutValueless } from '../helpers';
 import { getUtms, query } from '../helpers/url';
+import { withoutValueless } from '../helpers/data';
 import { getCampaignDataForNorthstar } from './campaign';
 import { getStoryPageDataForNorthstar } from './storyPage';
 


### PR DESCRIPTION
### What's this PR do?

This pull request continues the work from the following PRs to clean up the **helpers/index.js** file. 
- #2483
- #2484
- #2487 
- #2488
- #2490 
- #2492 
- #2493 
- #2495 

It separates out any helper functions that deal with data manipulation into a dedicated **helpers/data.js** file. Initially I added the helpers that dealt more with objects and their properties but ended up including ones that also manipulate strings because they technically are manipulating data and would keep us from having a separate **string.js** as well for a small number of methods.

### How should this be reviewed?

👀 

### Relevant tickets

References [Pivotal #173019917](https://www.pivotaltracker.com/story/show/173019917).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.