### PR TITLE
Moving monitoring related helpers to dedicated file.

### DIFF
--- a/resources/assets/components/ContentfulEntry/ContentfulEntry.js
+++ b/resources/assets/components/ContentfulEntry/ContentfulEntry.js
@@ -1,8 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import { report } from '../../helpers';
 import Loader from '../utilities/Loader';
+import { report } from '../../helpers/monitoring';
 import { withoutNulls } from '../../helpers/data';
 import Affirmation from '../Affirmation/Affirmation';
 import SoftEdgeBlock from '../actions/SoftEdgeBlock';

--- a/resources/assets/components/blocks/ErrorBlock/ErrorBlock.js
+++ b/resources/assets/components/blocks/ErrorBlock/ErrorBlock.js
@@ -2,8 +2,8 @@ import PropTypes from 'prop-types';
 import React, { useEffect } from 'react';
 
 import errorIcon from './error_icon.svg';
-import { report } from '../../../helpers';
 import Card from '../../utilities/Card/Card';
+import { report } from '../../../helpers/monitoring';
 import ErrorDetails from '../../utilities/ErrorDetails';
 
 const ErrorBlock = ({ error }) => {

--- a/resources/assets/components/blocks/ScholarshipInfoBlock/ScholarshipInfoBlock.js
+++ b/resources/assets/components/blocks/ScholarshipInfoBlock/ScholarshipInfoBlock.js
@@ -6,9 +6,9 @@ import { css } from '@emotion/core';
 import { useQuery } from 'react-apollo';
 import React, { Fragment, useState } from 'react';
 
-import { report } from '../../../helpers';
 import Card from '../../utilities/Card/Card';
 import ErrorBlock from '../ErrorBlock/ErrorBlock';
+import { report } from '../../../helpers/monitoring';
 import ScholarshipActionType from './ScholarshipActionType';
 import MenuCarat from '../../artifacts/MenuCarat/MenuCarat';
 import ScholarshipRequirements from './ScholarshipRequirements';

--- a/resources/assets/components/pages/ErrorPage.js
+++ b/resources/assets/components/pages/ErrorPage.js
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React, { useEffect } from 'react';
 
-import { report } from '../../helpers';
+import { report } from '../../helpers/monitoring';
 import ErrorDetails from '../utilities/ErrorDetails';
 import SiteFooter from '../utilities/SiteFooter/SiteFooter';
 import SiteNavigationContainer from '../SiteNavigation/SiteNavigationContainer';

--- a/resources/assets/components/utilities/CtaReferralPageBanner/CtaReferralPageBanner.js
+++ b/resources/assets/components/utilities/CtaReferralPageBanner/CtaReferralPageBanner.js
@@ -4,10 +4,10 @@ import PropTypes from 'prop-types';
 import { css } from '@emotion/core';
 import { useQuery } from '@apollo/react-hooks';
 
-import { report } from '../../../helpers';
 import { query } from '../../../helpers/url';
 import { featureFlag } from '../../../helpers/env';
 import { tailwind } from '../../../helpers/display';
+import { report } from '../../../helpers/monitoring';
 import GiftCardHandLargeImage from './gift-card-hand-large.svg';
 import GiftCardHandSmallImage from './gift-card-hand-small.svg';
 import { REFERRAL_USER_QUERY } from '../../pages/ReferralPage/Beta/BetaPage';

--- a/resources/assets/components/utilities/PopoverDispatcher/CtaPopover/CtaPopoverEmailForm.js
+++ b/resources/assets/components/utilities/PopoverDispatcher/CtaPopover/CtaPopoverEmailForm.js
@@ -4,9 +4,9 @@ import { get, isString, first } from 'lodash';
 import { RestApiClient } from '@dosomething/gateway';
 
 import { env } from '../../../../helpers/env';
-import { report } from '../../../../helpers/index';
 import { tabularLog } from '../../../../helpers/api';
 import PrimaryButton from '../../Button/PrimaryButton';
+import { report } from '../../../../helpers/monitoring';
 import {
   EVENT_CATEGORIES,
   trackAnalyticsEvent,

--- a/resources/assets/components/utilities/ScholarshipInfoBlockTitle/ScholarshipInfoBlockTitle.js
+++ b/resources/assets/components/utilities/ScholarshipInfoBlockTitle/ScholarshipInfoBlockTitle.js
@@ -4,8 +4,8 @@ import gql from 'graphql-tag';
 import PropTypes from 'prop-types';
 import { useQuery } from 'react-apollo';
 
-import { report } from '../../../helpers';
 import { env } from '../../../helpers/env';
+import { report } from '../../../helpers/monitoring';
 import ErrorBlock from '../../blocks/ErrorBlock/ErrorBlock';
 import PlaceholderText from '../PlaceholderText/PlaceholderText';
 

--- a/resources/assets/components/utilities/ZendeskForm/ZendeskForm.js
+++ b/resources/assets/components/utilities/ZendeskForm/ZendeskForm.js
@@ -3,10 +3,10 @@ import classNames from 'classnames';
 import React, { useState } from 'react';
 
 import Card from '../Card/Card';
-import { report } from '../../../helpers';
 import { postRequest } from '../../../helpers/api';
 import PrimaryButton from '../Button/PrimaryButton';
 import { getUserToken } from '../../../helpers/auth';
+import { report } from '../../../helpers/monitoring';
 import { HELP_LINK, HELP_REQUEST_LINK } from '../../../constants';
 
 const ZendeskForm = ({ campaignId, campaignName, faqLink }) => {

--- a/resources/assets/helpers/analytics.js
+++ b/resources/assets/helpers/analytics.js
@@ -9,8 +9,8 @@ import {
   startCase,
 } from 'lodash';
 
-import { debug } from '.';
 import { getUtms } from './url';
+import { debug } from './monitoring';
 import Sixpack from '../services/Sixpack';
 import { stringifyNestedObjects, withoutValueless } from './data';
 

--- a/resources/assets/helpers/index.js
+++ b/resources/assets/helpers/index.js
@@ -1,48 +1,6 @@
-/* global window */
-
-import { isArray, isNull, isString, mergeWith } from 'lodash';
+import { isArray, mergeWith } from 'lodash';
 
 import { query } from './url';
-import Debug from '../services/Debug';
-
-/**
- * Report a caught error to New Relic.
- *
- * @param {Error|string}  error
- * @param {Object} customAttributes
- */
-export function report(error, customAttributes = null) {
-  let errorInstance;
-
-  // Print to the console for devs:
-  console.error(`[report] ${error}`);
-
-  // If we're not running New Relic here, don't report:
-  if (!window.newrelic) {
-    return;
-  }
-
-  // New Relic's 'noticeError' expects an Error instance:
-  if (isString(error)) {
-    errorInstance = new Error(error);
-  }
-
-  if (isNull(error)) {
-    errorInstance = new Error('Unknown error');
-  }
-
-  window.newrelic.noticeError(errorInstance, customAttributes);
-}
-
-let debugInstance = null;
-
-export function debug() {
-  if (!debugInstance) {
-    debugInstance = new Debug();
-  }
-
-  return debugInstance;
-}
 
 /**
  * Determine if the user is a scholarship affiliate referral.

--- a/resources/assets/helpers/monitoring.js
+++ b/resources/assets/helpers/monitoring.js
@@ -1,0 +1,49 @@
+/* global window */
+
+import { isNull, isString } from 'lodash';
+
+import Debug from '../services/Debug';
+
+/**
+ * Report a caught error to New Relic.
+ *
+ * @param {Error|string}  error
+ * @param {Object} customAttributes
+ */
+export function report(error, customAttributes = null) {
+  let errorInstance;
+
+  // Print to the console for devs:
+  console.error(`[report] ${error}`);
+
+  // If we're not running New Relic here, don't report:
+  if (!window.newrelic) {
+    return;
+  }
+
+  // New Relic's 'noticeError' expects an Error instance:
+  if (isString(error)) {
+    errorInstance = new Error(error);
+  }
+
+  if (isNull(error)) {
+    errorInstance = new Error('Unknown error');
+  }
+
+  window.newrelic.noticeError(errorInstance, customAttributes);
+}
+
+/**
+ * Create single instance of the Debug class.
+ */
+let debugInstance = null;
+
+export function debug() {
+  if (!debugInstance) {
+    debugInstance = new Debug();
+  }
+
+  return debugInstance;
+}
+
+export default null;

--- a/resources/assets/init.js
+++ b/resources/assets/init.js
@@ -37,9 +37,9 @@ import App from './components/App';
 import NavApp from './components/NavApp';
 
 // DOM Helpers
-import { debug } from './helpers';
 import { ready } from './helpers/display';
 import { persistUtms } from './helpers/url';
+import { debug } from './helpers/monitoring';
 import { init as historyInit } from './history';
 import { bindFlashMessageEvents } from './helpers/flash-message';
 import { bindAdminDashboardEvents } from './helpers/admin-dashboard';

--- a/resources/assets/middleware/api.js
+++ b/resources/assets/middleware/api.js
@@ -3,8 +3,8 @@
 import { get } from 'lodash';
 import { RestApiClient } from '@dosomething/gateway';
 
-import { report } from '../helpers';
 import { PHOENIX_URL } from '../constants';
+import { report } from '../helpers/monitoring';
 import { API } from '../constants/action-types';
 import { getUserToken } from '../selectors/user';
 import { isWithinMinutes } from '../helpers/datetime';


### PR DESCRIPTION
### What's this PR do?

This pull request continues the work from the following PRs to clean up the **helpers/index.js** file. 
- #2483
- #2484
- #2487 
- #2488
- #2490 
- #2492 
- #2493 
- #2495 
- #2496
- #2498

It separates out any helper functions that deal with error reporting and debuggin into a dedicated *helpers/monitoring.js* file. I had a bit of trouble deciding on what to name this file since it's not just for error helpers and not just debugging helpers. Since it dealt with functions that monitor the app to show debug info or reporting an error, "monitoring" seemed like an 🆗  fit.

### How should this be reviewed?

👀 

### Relevant tickets

References [Pivotal #173019917](https://www.pivotaltracker.com/story/show/173019917).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.