### PR TITLE
Subscription center cypress tests

### DIFF
--- a/cypress/integration/account-subscriptions-tab.js
+++ b/cypress/integration/account-subscriptions-tab.js
@@ -12,20 +12,32 @@ describe('User Account Email Subscriptions Tab', () => {
 
     cy.mockGraphqlOp('AccountQuery', {
       // Get back a particular user and subscription topics
-      user: root => ({
+      user: {
         firstName: 'Delilah',
         emailSubscriptionTopics: ['COMMUNITY', 'NEWS', 'LIFESTYLE'],
-      }),
+      },
     });
 
     // Log in & visit the subscription center:
-    cy.login(user).visit('/us/account/profile/subscriptions');
+    cy.login(user).visit('/us/account/subscriptions');
 
     // We should see the user's name and the correct subscription topics checked
     cy.contains('Welcome, Delilah!');
-    cy.get('input[name=COMMUNITY]').should('be.checked');
-    cy.get('input[name=NEWS]').should('be.checked');
-    cy.get('input[name=LIFESTYLE]').should('be.checked');
-    cy.get('input[name=SCHOLARSHIPS]').should('not.be.checked');
+    cy.findByTestId('community-newsletter-subscription').should(
+      'contain',
+      'Unsubscribe',
+    );
+    cy.findByTestId('news-newsletter-subscription').should(
+      'contain',
+      'Unsubscribe',
+    );
+    cy.findByTestId('lifestyle-newsletter-subscription').should(
+      'contain',
+      'Unsubscribe',
+    );
+    cy.findByTestId('scholarships-newsletter-subscription').should(
+      'contain',
+      'Subscribe',
+    );
   });
 });

--- a/cypress/integration/account-subscriptions-tab.js
+++ b/cypress/integration/account-subscriptions-tab.js
@@ -1,0 +1,31 @@
+/// <reference types="Cypress" />
+
+import { userFactory } from '../fixtures/user';
+
+describe('User Account Email Subscriptions Tab', () => {
+  // Configure a new "mock" server before each test:
+  beforeEach(() => cy.configureMocks());
+
+  it('View existing subscriptions', () => {
+    // This user is just for auth purposes
+    const user = userFactory();
+
+    cy.mockGraphqlOp('AccountQuery', {
+      // Get back a particular user and subscription topics
+      user: root => ({
+        firstName: 'Delilah',
+        emailSubscriptionTopics: ['COMMUNITY', 'NEWS', 'LIFESTYLE'],
+      }),
+    });
+
+    // Log in & visit the subscription center:
+    cy.login(user).visit('/us/account/profile/subscriptions');
+
+    // We should see the user's name and the correct subscription topics checked
+    cy.contains('Welcome, Delilah!');
+    cy.get('input[name=COMMUNITY]').should('be.checked');
+    cy.get('input[name=NEWS]').should('be.checked');
+    cy.get('input[name=LIFESTYLE]').should('be.checked');
+    cy.get('input[name=SCHOLARSHIPS]').should('not.be.checked');
+  });
+});

--- a/resources/assets/components/pages/AccountPage/Subscriptions/EmailSubscriptionItem.js
+++ b/resources/assets/components/pages/AccountPage/Subscriptions/EmailSubscriptionItem.js
@@ -33,6 +33,7 @@ const EMAIL_SUBSCRIPTION_MUTATION = gql`
   }
 `;
 const EmailSubscriptionItem = ({
+  attributes,
   topic,
   name,
   image,
@@ -74,6 +75,7 @@ const EmailSubscriptionItem = ({
             <Spinner className="flex justify-center p-2" />
           ) : (
             <ToggleButton
+              attributes={attributes}
               activateText="Subscribe"
               deactivateText="Unsubscribe"
               isDisabled={modifying}
@@ -97,11 +99,16 @@ const EmailSubscriptionItem = ({
 };
 
 EmailSubscriptionItem.propTypes = {
+  attributes: PropTypes.object,
   topic: PropTypes.string.isRequired,
   name: PropTypes.string.isRequired,
   image: PropTypes.string.isRequired,
   description: PropTypes.string.isRequired,
   descriptionHeader: PropTypes.string.isRequired,
+};
+
+EmailSubscriptionItem.defaultProps = {
+  attributes: null,
 };
 
 export default EmailSubscriptionItem;

--- a/resources/assets/components/pages/AccountPage/Subscriptions/EmailSubscriptions.js
+++ b/resources/assets/components/pages/AccountPage/Subscriptions/EmailSubscriptions.js
@@ -7,6 +7,7 @@ import EmailSubscriptionItem from './EmailSubscriptionItem';
 const EmailSubscriptions = () => (
   <div className="gallery-grid gallery-grid-quartet my-6 -mx-3">
     <EmailSubscriptionItem
+      attributes={{ 'data-testid': 'community-newsletter-subscription' }}
       topic="COMMUNITY"
       name="What You're Doing"
       image={NewsletterImages.CommunityNewsletter}
@@ -14,6 +15,7 @@ const EmailSubscriptions = () => (
       description="A roundup of photos, writing, and stories of impact from the DoSomething community and members like you."
     />
     <EmailSubscriptionItem
+      attributes={{ 'data-testid': 'news-newsletter-subscription' }}
       topic="NEWS"
       name="The Breakdown"
       image={NewsletterImages.NewsNewsletter}
@@ -21,6 +23,7 @@ const EmailSubscriptions = () => (
       description="Don’t just read the news…*change* the news. Our current events newsletter has headlines, along with immediate ways to impact them."
     />
     <EmailSubscriptionItem
+      attributes={{ 'data-testid': 'lifestyle-newsletter-subscription' }}
       topic="LIFESTYLE"
       name="The Boost"
       image={NewsletterImages.LifestyleNewsletter}
@@ -28,6 +31,7 @@ const EmailSubscriptions = () => (
       description="Stories of incredible young people, actionable how-tos, inspirational playlists, and other content to live your best life and help others do the same."
     />
     <EmailSubscriptionItem
+      attributes={{ 'data-testid': 'scholarships-newsletter-subscription' }}
       topic="SCHOLARSHIPS"
       name="Pays to Do Good"
       image={NewsletterImages.ScholarshipNewsletter}


### PR DESCRIPTION
### What's this PR do?

This pull request adds a test to make sure our subscription center displays the correct status for a users choices. I think we should be able to close #1657 since it is essentially an older version of this! (and also maybe #1733 which was covered in #2502 - although i like the idea of testing multiple posts so maybe we should port that over).

### How should this be reviewed?

👀 


### Any background context you want to provide?

Ongoing testing updates

### Relevant tickets

References [Pivotal #176438356](https://www.pivotaltracker.com/story/show/176438356).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [x] Added appropriate feature/unit tests.
