### PR TITLE
Link Action Script + Docs quick update

### DIFF
--- a/contentful/content-types/linkAction.js
+++ b/contentful/content-types/linkAction.js
@@ -34,15 +34,25 @@ module.exports = function(migration) {
     .validations([])
     .disabled(false)
     .omitted(false);
+
   linkAction
     .createField('link')
     .name('Link')
     .type('Symbol')
     .localized(false)
     .required(true)
-    .validations([])
+    .validations([
+      {
+        regexp: {
+          pattern:
+            '^((ftp|http|https):\\/\\/(\\w+:{0,1}\\w*@)?(\\S+)(:[0-9]+)?(\\/|\\/([\\w#!:.?+=&%@!\\-\\/]))?$|tel\\:?\\d[ -.]?\\(?\\d\\d\\d\\)?[ -.]?\\d\\d\\d[ -.]?\\d\\d\\d\\d$)',
+          flags: null,
+        },
+      },
+    ])
     .disabled(false)
     .omitted(false);
+
   linkAction
     .createField('buttonText')
     .name('Button Text')
@@ -125,6 +135,8 @@ module.exports = function(migration) {
     'additionalContent',
     'builtin',
     'objectEditor',
-    {},
+    {
+      helpText: 'Used for quiz results (set "sourceDetails" property)',
+    },
   );
 };

--- a/docs/development/content-types/link-action.md
+++ b/docs/development/content-types/link-action.md
@@ -10,6 +10,8 @@ Displays a card with a customizable title, Markdown content, and button link. Us
 
 -   Legacy Link Action can render as a Call To Action card if the `template` field is set to `cta`.
 
+-   Link Actions can be used to control the content on the [Quiz Results](../features/voter-registration.md#Quiz) page for Voter Registration quizzes.
+
 ## Content Type Fields
 
 -   **Internal Title**: This is for our internal Contentful organization and will be how the block shows up in search results, etc. (does _not_ display to the user on the page).
@@ -21,3 +23,6 @@ Displays a card with a customizable title, Markdown content, and button link. Us
 -   **Link**: A valid Absolute URL or [Tel link](https://www.elegantthemes.com/blog/wordpress/call-link-html-phone-number) usedas the button destination. Supported the `userId` & `northstarId` (assigned to the current user's ID), `campaignId` (assigned to the current Campaign's Campaign ID), `campaignRunId` (assigned to `0`), and `source` (derived from the `utm_source` query parameter defaulting to `web`) tokens (within {} e.g. `https://dosomething.org?userId={userId}`).
 
 -   **Button Text** _(optional)_: The text displayed in the button (defaults to "Visit link").
+
+-   **Additional Content**: _(optional)_: Any custom settings for this page in JSON format:
+    -   `sourceDetails`: See [Voter Registration Quiz](../features/voter-registration.md#Quiz)


### PR DESCRIPTION
### What's this PR do?

This pull request follows up on #2517 with a new migration generation per updates that were on `master` but not on `dev`, and doc reference to the Link Action's ability to function as a Quiz Results page content block.

### How should this be reviewed?
👀 


### Relevant tickets

References [Pivotal #175380207](https://www.pivotaltracker.com/story/show/175380207).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [x] Documentation added for new features/changed endpoints.
