### PR TITLE
Rewards Progress Bar

### DIFF
--- a/resources/assets/components/pages/AccountPage/Badges/BadgesTab.js
+++ b/resources/assets/components/pages/AccountPage/Badges/BadgesTab.js
@@ -48,7 +48,7 @@ const exploreCampaignsLink = text => {
 };
 
 // @TODO: when we are ready to bring in real data from users earned badges, we will replace this variable
-const badges = query('badges') || 4;
+const badges = Number(query('badges')) || 0;
 
 const badgeModalContent = {
   signupBadge: {

--- a/resources/assets/components/pages/AccountPage/Badges/BadgesTab.js
+++ b/resources/assets/components/pages/AccountPage/Badges/BadgesTab.js
@@ -6,7 +6,9 @@ import Badge from './Badge';
 import Query from '../../../Query';
 import BadgeModal from './BadgeModal';
 import RewardsFaq from './RewardsFaq';
+import { query } from '../../../../helpers/url';
 import RewardLevelsTable from './RewardLevelsTable';
+import RewardsProgressBar from './RewardsProgressBar';
 import { featureFlag } from '../../../../helpers/env';
 import {
   EVENT_CATEGORIES,
@@ -44,6 +46,9 @@ const NEWSLETTER_BADGE = gql`
 const exploreCampaignsLink = text => {
   return <a href="/us/campaigns">{text}</a>;
 };
+
+// @TODO: when we are ready to bring in real data from users earned badges, we will replace this variable
+const badges = query('badges') || 4;
 
 const badgeModalContent = {
   signupBadge: {
@@ -183,6 +188,10 @@ class BadgesTab extends React.Component {
 
     return (
       <div className="grid-wide bg-gray pb-6 wrapper">
+        {featureFlag('rewards_levels') ? (
+          <RewardsProgressBar totalBadges={badges} />
+        ) : null}
+
         <h1 className="text-xl">Badges</h1>
         <p className="text-gray-600">
           Earn badges and rewards for making a difference.
@@ -395,7 +404,9 @@ class BadgesTab extends React.Component {
           </BadgeModal>
         ) : null}
 
-        {featureFlag('rewards_levels') ? <RewardLevelsTable /> : null}
+        {featureFlag('rewards_levels') ? (
+          <RewardLevelsTable badges={badges} />
+        ) : null}
 
         {featureFlag('rewards_levels') ? <RewardsFaq /> : null}
       </div>

--- a/resources/assets/components/pages/AccountPage/Badges/BadgesTab.js
+++ b/resources/assets/components/pages/AccountPage/Badges/BadgesTab.js
@@ -405,7 +405,7 @@ class BadgesTab extends React.Component {
         ) : null}
 
         {featureFlag('rewards_levels') ? (
-          <RewardLevelsTable badges={badges} />
+          <RewardLevelsTable totalBadges={badges} />
         ) : null}
 
         {featureFlag('rewards_levels') ? <RewardsFaq /> : null}

--- a/resources/assets/components/pages/AccountPage/Badges/RewardLevelsTable.js
+++ b/resources/assets/components/pages/AccountPage/Badges/RewardLevelsTable.js
@@ -13,20 +13,19 @@ const TableCellCenter = tw.td`p-2 text-sm text-center md:text-base border-solid 
 const TableCellCenterBottom = tw.td`p-2 text-sm text-center md:text-base border-solid border-l border-gray-400 align-middle`;
 const TableMarker = tw.div`bg-black rounded-full h-3 w-3 flex mx-auto`;
 
+export const userLevelLabel = badgeNumber => {
+  let userLevel;
+  if (badgeNumber >= 6) {
+    userLevel = 'Legend';
+  } else if (badgeNumber > 3) {
+    userLevel = 'SuperDoer';
+  } else if (badgeNumber >= 2) {
+    userLevel = 'Doer';
+  }
+
+  return userLevel;
+};
 const RewardLevelsTable = ({ badges }) => {
-  const userLevelLabel = badgeNumber => {
-    let userLevel;
-    if (badgeNumber >= 6) {
-      userLevel = 'Legend';
-    } else if (badgeNumber > 3) {
-      userLevel = 'SuperDoer';
-    } else if (badgeNumber >= 2) {
-      userLevel = 'Doer';
-    }
-
-    return userLevel;
-  };
-
   const doerHighlight = css`
     background-color: rgba(47, 227, 218, 0.15);
   `;

--- a/resources/assets/components/pages/AccountPage/Badges/RewardLevelsTable.js
+++ b/resources/assets/components/pages/AccountPage/Badges/RewardLevelsTable.js
@@ -14,7 +14,7 @@ const TableCellCenterBottom = tw.td`p-2 text-sm text-center md:text-base border-
 const TableMarker = tw.div`bg-black rounded-full h-3 w-3 flex mx-auto`;
 
 export const userLevelLabel = badgeNumber => {
-  let userLevel;
+  let userLevel = 'member';
   if (badgeNumber >= 6) {
     userLevel = 'Legend';
   } else if (badgeNumber > 3) {

--- a/resources/assets/components/pages/AccountPage/Badges/RewardLevelsTable.js
+++ b/resources/assets/components/pages/AccountPage/Badges/RewardLevelsTable.js
@@ -1,8 +1,8 @@
 import React from 'react';
 import tw from 'twin.macro';
+import PropTypes from 'prop-types';
 import { css } from '@emotion/core';
 
-import { query } from '../../../../helpers/url';
 import SectionHeader from '../../../utilities/SectionHeader/SectionHeader';
 
 const Table = tw.table`my-6 w-full lg:w-3/4`;
@@ -13,10 +13,7 @@ const TableCellCenter = tw.td`p-2 text-sm text-center md:text-base border-solid 
 const TableCellCenterBottom = tw.td`p-2 text-sm text-center md:text-base border-solid border-l border-gray-400 align-middle`;
 const TableMarker = tw.div`bg-black rounded-full h-3 w-3 flex mx-auto`;
 
-const RewardLevelsTable = () => {
-  // @TODO: when we are ready to bring in real data from users earned badges, we will replace this variable
-  const badges = query('badges') || 4;
-
+const RewardLevelsTable = ({ badges }) => {
   const userLevelLabel = badgeNumber => {
     let userLevel;
     if (badgeNumber >= 6) {
@@ -132,6 +129,10 @@ const RewardLevelsTable = () => {
       </Table>
     </div>
   );
+};
+
+RewardLevelsTable.propTypes = {
+  badges: PropTypes.number.isRequired,
 };
 
 export default RewardLevelsTable;

--- a/resources/assets/components/pages/AccountPage/Badges/RewardLevelsTable.js
+++ b/resources/assets/components/pages/AccountPage/Badges/RewardLevelsTable.js
@@ -14,10 +14,10 @@ const TableCellCenterBottom = tw.td`p-2 text-sm text-center md:text-base border-
 const TableMarker = tw.div`bg-black rounded-full h-3 w-3 flex mx-auto`;
 
 export const userLevelLabel = badgeNumber => {
-  let userLevel = 'member';
+  let userLevel = 'Member';
   if (badgeNumber >= 6) {
     userLevel = 'Legend';
-  } else if (badgeNumber > 3) {
+  } else if (badgeNumber >= 4) {
     userLevel = 'SuperDoer';
   } else if (badgeNumber >= 2) {
     userLevel = 'Doer';
@@ -25,7 +25,7 @@ export const userLevelLabel = badgeNumber => {
 
   return userLevel;
 };
-const RewardLevelsTable = ({ badges }) => {
+const RewardLevelsTable = ({ totalBadges }) => {
   const doerHighlight = css`
     background-color: rgba(47, 227, 218, 0.15);
   `;
@@ -66,23 +66,29 @@ const RewardLevelsTable = ({ badges }) => {
       <SectionHeader title="my rewards" />
 
       <p className="text-gray-600">
-        You currently enjoy all the perks of a {userLevelLabel(badges)}!
+        You currently enjoy all the perks of a {userLevelLabel(totalBadges)}!
       </p>
 
       <Table>
         <colgroup>
           <col />
 
-          <col css={userLevelLabel(badges) === 'Doer' ? doerHighlight : null} />
+          <col
+            css={userLevelLabel(totalBadges) === 'Doer' ? doerHighlight : null}
+          />
 
           <col
             css={
-              userLevelLabel(badges) === 'SuperDoer' ? superDoerHighlight : null
+              userLevelLabel(totalBadges) === 'SuperDoer'
+                ? superDoerHighlight
+                : null
             }
           />
 
           <col
-            css={userLevelLabel(badges) === 'Legend' ? legendHighlight : null}
+            css={
+              userLevelLabel(totalBadges) === 'Legend' ? legendHighlight : null
+            }
           />
         </colgroup>
 
@@ -131,7 +137,7 @@ const RewardLevelsTable = ({ badges }) => {
 };
 
 RewardLevelsTable.propTypes = {
-  badges: PropTypes.number.isRequired,
+  totalBadges: PropTypes.number.isRequired,
 };
 
 export default RewardLevelsTable;

--- a/resources/assets/components/pages/AccountPage/Badges/RewardsProgressBar.js
+++ b/resources/assets/components/pages/AccountPage/Badges/RewardsProgressBar.js
@@ -12,9 +12,9 @@ const RewardsProgressBar = ({ totalBadges }) => {
     <>
       <SectionHeader title={`You're a ${userLevelLabel(totalBadges)}`} />
 
-      <p>
-        You earned <em>${totalBadges} out of 6 badges</em>, which makes you a $
-        {userLevelLabel(totalBadges)}. You're almost there!
+      <p className="pt-6 pb-3 text-lg">
+        You earned <b>{totalBadges} out of 6 badges</b>, which makes you a{' '}
+        {userLevelLabel(totalBadges)}. You&apos;re almost there!
       </p>
       <ProgressBar percentage={percentage} />
     </>

--- a/resources/assets/components/pages/AccountPage/Badges/RewardsProgressBar.js
+++ b/resources/assets/components/pages/AccountPage/Badges/RewardsProgressBar.js
@@ -48,6 +48,7 @@ const RewardsProgressBar = ({ totalBadges }) => {
           : "You're almost there"}
         !
       </p>
+
       <MultiLevelProgressBar
         levelOneProgress={doerProgress(totalBadges)}
         levelTwoProgress={superDoerProgress(totalBadges)}

--- a/resources/assets/components/pages/AccountPage/Badges/RewardsProgressBar.js
+++ b/resources/assets/components/pages/AccountPage/Badges/RewardsProgressBar.js
@@ -6,16 +6,50 @@ import SectionHeader from '../../../utilities/SectionHeader/SectionHeader';
 import MultiLevelProgressBar from '../../../utilities/ProgressBar/MultiLevelProgressBar';
 
 const RewardsProgressBar = ({ totalBadges }) => {
+  const doerProgress = badges => {
+    let doerPercentage = '0%';
+    if (badges >= 2) {
+      doerPercentage = '100%';
+    } else if (badges > 0 && badges < 2) {
+      doerPercentage = '50%';
+    }
+    return doerPercentage;
+  };
+
+  const superDoerProgress = badges => {
+    let superDoerPercentage = '0%';
+    if (badges >= 4) {
+      superDoerPercentage = '100%';
+    } else if (badges > 2 && badges < 4) {
+      superDoerPercentage = '50%';
+    }
+    return superDoerPercentage;
+  };
+
+  const legendProgress = badges => {
+    let legendPercentage = '0%';
+    if (badges >= 6) {
+      legendPercentage = '100%';
+    } else if (badges > 4 && badges < 6) {
+      legendPercentage = '50%';
+    }
+    return legendPercentage;
+  };
+
   return (
-    <>
+    <div className="pb-12">
       <SectionHeader title={`You're a ${userLevelLabel(totalBadges)}`} />
 
       <p className="pt-6 pb-3 text-lg">
         You earned <b>{totalBadges} out of 6 badges</b>, which makes you a{' '}
         {userLevelLabel(totalBadges)}. You&apos;re almost there!
       </p>
-      <MultiLevelProgressBar currentAmount={totalBadges} />
-    </>
+      <MultiLevelProgressBar
+        levelOneProgress={doerProgress(totalBadges)}
+        levelTwoProgress={superDoerProgress(totalBadges)}
+        levelThreeProgress={legendProgress(totalBadges)}
+      />
+    </div>
   );
 };
 

--- a/resources/assets/components/pages/AccountPage/Badges/RewardsProgressBar.js
+++ b/resources/assets/components/pages/AccountPage/Badges/RewardsProgressBar.js
@@ -42,7 +42,11 @@ const RewardsProgressBar = ({ totalBadges }) => {
 
       <p className="pt-6 pb-3 text-lg">
         You earned <b>{totalBadges} out of 6 badges</b>, which makes you a{' '}
-        {userLevelLabel(totalBadges)}. You&apos;re almost there!
+        {userLevelLabel(totalBadges)}.{' '}
+        {userLevelLabel(totalBadges) === 'Legend'
+          ? 'Congrats'
+          : "You're almost there"}
+        !
       </p>
       <MultiLevelProgressBar
         levelOneProgress={doerProgress(totalBadges)}

--- a/resources/assets/components/pages/AccountPage/Badges/RewardsProgressBar.js
+++ b/resources/assets/components/pages/AccountPage/Badges/RewardsProgressBar.js
@@ -1,13 +1,11 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import { getGoalInfo } from '../../../../helpers/voter-registration';
-import ProgressBar from '../../../utilities/ProgressBar/ProgressBar';
-import SectionHeader from '../../../utilities/SectionHeader/SectionHeader';
 import { userLevelLabel } from './RewardLevelsTable';
+import SectionHeader from '../../../utilities/SectionHeader/SectionHeader';
+import MultiLevelProgressBar from '../../../utilities/ProgressBar/MultiLevelProgressBar';
 
 const RewardsProgressBar = ({ totalBadges }) => {
-  const { percentage } = getGoalInfo(6, totalBadges);
   return (
     <>
       <SectionHeader title={`You're a ${userLevelLabel(totalBadges)}`} />
@@ -16,7 +14,7 @@ const RewardsProgressBar = ({ totalBadges }) => {
         You earned <b>{totalBadges} out of 6 badges</b>, which makes you a{' '}
         {userLevelLabel(totalBadges)}. You&apos;re almost there!
       </p>
-      <ProgressBar percentage={percentage} multiLevel levelCount={3} />
+      <MultiLevelProgressBar currentAmount={totalBadges} />
     </>
   );
 };

--- a/resources/assets/components/pages/AccountPage/Badges/RewardsProgressBar.js
+++ b/resources/assets/components/pages/AccountPage/Badges/RewardsProgressBar.js
@@ -3,11 +3,19 @@ import PropTypes from 'prop-types';
 
 import { getGoalInfo } from '../../../../helpers/voter-registration';
 import ProgressBar from '../../../utilities/ProgressBar/ProgressBar';
+import SectionHeader from '../../../utilities/SectionHeader/SectionHeader';
+import { userLevelLabel } from './RewardLevelsTable';
 
 const RewardsProgressBar = ({ totalBadges }) => {
   const { percentage } = getGoalInfo(6, totalBadges);
   return (
     <>
+      <SectionHeader title={`You're a ${userLevelLabel(totalBadges)}`} />
+
+      <p>
+        You earned <em>${totalBadges} out of 6 badges</em>, which makes you a $
+        {userLevelLabel(totalBadges)}. You're almost there!
+      </p>
       <ProgressBar percentage={percentage} />
     </>
   );

--- a/resources/assets/components/pages/AccountPage/Badges/RewardsProgressBar.js
+++ b/resources/assets/components/pages/AccountPage/Badges/RewardsProgressBar.js
@@ -1,0 +1,20 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import { getGoalInfo } from '../../../../helpers/voter-registration';
+import ProgressBar from '../../../utilities/ProgressBar/ProgressBar';
+
+const RewardsProgressBar = ({ totalBadges }) => {
+  const { percentage } = getGoalInfo(6, totalBadges);
+  return (
+    <>
+      <ProgressBar percentage={percentage} />
+    </>
+  );
+};
+
+RewardsProgressBar.propTypes = {
+  totalBadges: PropTypes.number.isRequired,
+};
+
+export default RewardsProgressBar;

--- a/resources/assets/components/pages/AccountPage/Badges/RewardsProgressBar.js
+++ b/resources/assets/components/pages/AccountPage/Badges/RewardsProgressBar.js
@@ -16,7 +16,7 @@ const RewardsProgressBar = ({ totalBadges }) => {
         You earned <b>{totalBadges} out of 6 badges</b>, which makes you a{' '}
         {userLevelLabel(totalBadges)}. You&apos;re almost there!
       </p>
-      <ProgressBar percentage={percentage} />
+      <ProgressBar percentage={percentage} multiLevel levelCount={3} />
     </>
   );
 };

--- a/resources/assets/components/pages/AccountPage/Badges/RewardsProgressBar.js
+++ b/resources/assets/components/pages/AccountPage/Badges/RewardsProgressBar.js
@@ -37,7 +37,7 @@ const RewardsProgressBar = ({ totalBadges }) => {
   };
 
   return (
-    <div className="pb-12">
+    <div>
       <SectionHeader title={`You're a ${userLevelLabel(totalBadges)}`} />
 
       <p className="pt-6 pb-3 text-lg">

--- a/resources/assets/components/utilities/ProgressBar/MultiLevelProgressBar.js
+++ b/resources/assets/components/utilities/ProgressBar/MultiLevelProgressBar.js
@@ -15,7 +15,10 @@ const MultiLevelProgressBar = ({
   // mobile sizing
   // verbiage for when you have 1 badge??
   return (
-    <div className="grid grid-cols-3 bg-gray-300" css={progressBarContainer}>
+    <div
+      className="grid grid-cols-3 bg-gray-300 pr-4 lg:pr-0 mb-10"
+      css={progressBarContainer}
+    >
       <div className="relative">
         <div
           className="bg-teal-500 h-full"

--- a/resources/assets/components/utilities/ProgressBar/MultiLevelProgressBar.js
+++ b/resources/assets/components/utilities/ProgressBar/MultiLevelProgressBar.js
@@ -1,0 +1,86 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { css } from '@emotion/core';
+
+const MultiLevelProgressBar = ({ currentAmount }) => {
+  const progressBarContainer = css`
+    height: 25px;
+    width: 100%;
+    border-radius: 50px;
+  `;
+
+  const doerProgress = badges => {
+    let doerPercentage = '0%';
+    if (badges >= 2) {
+      doerPercentage = '100%';
+    } else if (badges > 0 && badges < 2) {
+      doerPercentage = '50%';
+    }
+    return doerPercentage;
+  };
+
+  const superDoerProgress = badges => {
+    let superDoerPercentage = '0%';
+    if (badges >= 4) {
+      superDoerPercentage = '100%';
+    } else if (badges > 2 && badges < 4) {
+      superDoerPercentage = '50%';
+    }
+    return superDoerPercentage;
+  };
+
+  const legendProgress = badges => {
+    let legendPercentage = '0%';
+    if (badges >= 6) {
+      legendPercentage = '100%';
+    } else if (badges > 4 && badges < 6) {
+      legendPercentage = '50%';
+    }
+    return legendPercentage;
+  };
+
+  // 3 inner divs with the container
+  // each inner div
+  // create a multilevel helper / new component to make it work better for this type of calc
+  // for the circle marker, it is a sibling of the color linear div and it's absolutely positioned/top-right
+  return (
+    // <div className="relative bg-gray-200" css={progressBarContainer}>
+    //   <div
+    //     css={progressBar}
+    //     style={{ width: `${percentage > 100 ? 100 : percentage}%` }}
+    //   />
+    // </div>
+    <div className="grid grid-cols-3 bg-gray-300" css={progressBarContainer}>
+      <div className="relative">
+        <div
+          className="bg-teal-500 h-full"
+          style={{ width: doerProgress(currentAmount) }}
+        />
+
+        <div className="bg-teal-500 h-8 w-8 absolute top-0 right-0 border border-solid border-white rounded-full" />
+      </div>
+      <div className="relative">
+        <div
+          className="bg-purple-400 h-full"
+          style={{ width: superDoerProgress(currentAmount) }}
+        />
+
+        <div className="bg-purple-400 h-8 w-8 absolute top-0 right-0 border border-solid border-white rounded-full" />
+      </div>
+      <div className="relative">
+        <div
+          className="bg-yellow-400 h-full"
+          style={{ width: legendProgress(currentAmount) }}
+        />
+
+        <div className="bg-yellow-400 h-8 w-8 absolute top-0 right-0 border border-solid border-white rounded-full" />
+      </div>
+    </div>
+  );
+};
+
+MultiLevelProgressBar.propTypes = {
+  currentAmount: PropTypes.number.isRequired,
+};
+
+export default MultiLevelProgressBar;

--- a/resources/assets/components/utilities/ProgressBar/MultiLevelProgressBar.js
+++ b/resources/assets/components/utilities/ProgressBar/MultiLevelProgressBar.js
@@ -2,85 +2,83 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { css } from '@emotion/core';
 
-const MultiLevelProgressBar = ({ currentAmount }) => {
+const MultiLevelProgressBar = ({
+  levelOneProgress,
+  levelTwoProgress,
+  levelThreeProgress,
+}) => {
   const progressBarContainer = css`
-    height: 25px;
+    height: 15px;
     width: 100%;
     border-radius: 50px;
   `;
-
-  const doerProgress = badges => {
-    let doerPercentage = '0%';
-    if (badges >= 2) {
-      doerPercentage = '100%';
-    } else if (badges > 0 && badges < 2) {
-      doerPercentage = '50%';
-    }
-    return doerPercentage;
-  };
-
-  const superDoerProgress = badges => {
-    let superDoerPercentage = '0%';
-    if (badges >= 4) {
-      superDoerPercentage = '100%';
-    } else if (badges > 2 && badges < 4) {
-      superDoerPercentage = '50%';
-    }
-    return superDoerPercentage;
-  };
-
-  const legendProgress = badges => {
-    let legendPercentage = '0%';
-    if (badges >= 6) {
-      legendPercentage = '100%';
-    } else if (badges > 4 && badges < 6) {
-      legendPercentage = '50%';
-    }
-    return legendPercentage;
-  };
-
-  // 3 inner divs with the container
-  // each inner div
-  // create a multilevel helper / new component to make it work better for this type of calc
-  // for the circle marker, it is a sibling of the color linear div and it's absolutely positioned/top-right
+  // mobile sizing
+  // verbiage for when you have 1 badge??
   return (
-    // <div className="relative bg-gray-200" css={progressBarContainer}>
-    //   <div
-    //     css={progressBar}
-    //     style={{ width: `${percentage > 100 ? 100 : percentage}%` }}
-    //   />
-    // </div>
     <div className="grid grid-cols-3 bg-gray-300" css={progressBarContainer}>
       <div className="relative">
         <div
           className="bg-teal-500 h-full"
-          style={{ width: doerProgress(currentAmount) }}
+          style={{
+            width: levelOneProgress,
+            'border-radius': '50px',
+          }}
         />
 
-        <div className="bg-teal-500 h-8 w-8 absolute top-0 right-0 border border-solid border-white rounded-full" />
+        <div
+          className="bg-teal-500 h-8 w-8 absolute border border-solid border-white rounded-full z-10"
+          style={{
+            top: '-8px',
+            right: '-16px',
+          }}
+        />
       </div>
+
       <div className="relative">
         <div
           className="bg-purple-400 h-full"
-          style={{ width: superDoerProgress(currentAmount) }}
+          style={{
+            width: levelTwoProgress,
+            'border-top-right-radius': '50px',
+            'border-bottom-right-radius': '50px',
+          }}
         />
 
-        <div className="bg-purple-400 h-8 w-8 absolute top-0 right-0 border border-solid border-white rounded-full" />
+        <div
+          className="bg-purple-400 h-8 w-8 absolute top-0 right-0 border border-solid border-white rounded-full z-10"
+          style={{
+            top: '-8px',
+            right: '-16px',
+          }}
+        />
       </div>
+
       <div className="relative">
         <div
           className="bg-yellow-400 h-full"
-          style={{ width: legendProgress(currentAmount) }}
+          style={{
+            width: levelThreeProgress,
+            'border-top-right-radius': '50px',
+            'border-bottom-right-radius': '50px',
+          }}
         />
 
-        <div className="bg-yellow-400 h-8 w-8 absolute top-0 right-0 border border-solid border-white rounded-full" />
+        <div
+          className="bg-yellow-400 h-8 w-8 absolute top-0 right-0 border border-solid border-white rounded-full"
+          style={{
+            top: '-8px',
+            right: '-16px',
+          }}
+        />
       </div>
     </div>
   );
 };
 
 MultiLevelProgressBar.propTypes = {
-  currentAmount: PropTypes.number.isRequired,
+  levelOneProgress: PropTypes.string.isRequired,
+  levelTwoProgress: PropTypes.string.isRequired,
+  levelThreeProgress: PropTypes.string.isRequired,
 };
 
 export default MultiLevelProgressBar;

--- a/resources/assets/components/utilities/ProgressBar/MultiLevelProgressBar.js
+++ b/resources/assets/components/utilities/ProgressBar/MultiLevelProgressBar.js
@@ -2,6 +2,31 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { css } from '@emotion/core';
 
+const SingleLevel = ({ levelProgress, color }) => (
+  <div className="relative">
+    <div
+      className={`${color} h-full`}
+      css={css`
+        width: ${levelProgress};
+        border-radius: 50px;
+      `}
+    />
+
+    <div
+      className={`${color} h-8 w-8 absolute border border-solid border-white rounded-full z-10`}
+      css={css`
+        top: -8px;
+        right: -16px;
+      `}
+    />
+  </div>
+);
+
+SingleLevel.propTypes = {
+  color: PropTypes.string.isRequired,
+  levelProgress: PropTypes.string.isRequired,
+};
+
 const MultiLevelProgressBar = ({
   levelOneProgress,
   levelTwoProgress,
@@ -17,61 +42,11 @@ const MultiLevelProgressBar = ({
       className="grid grid-cols-3 bg-gray-300 pr-4 lg:pr-0 mb-10 w-full"
       css={progressBarContainer}
     >
-      <div className="relative">
-        <div
-          className="bg-teal-500 h-full"
-          style={{
-            width: levelOneProgress,
-            'border-radius': '50px',
-          }}
-        />
+      <SingleLevel levelProgress={levelOneProgress} color="bg-teal-500" />
 
-        <div
-          className="bg-teal-500 h-8 w-8 absolute border border-solid border-white rounded-full z-10"
-          style={{
-            top: '-8px',
-            right: '-16px',
-          }}
-        />
-      </div>
+      <SingleLevel levelProgress={levelTwoProgress} color="bg-purple-400" />
 
-      <div className="relative">
-        <div
-          className="bg-purple-400 h-full"
-          style={{
-            width: levelTwoProgress,
-            'border-top-right-radius': '50px',
-            'border-bottom-right-radius': '50px',
-          }}
-        />
-
-        <div
-          className="bg-purple-400 h-8 w-8 absolute top-0 right-0 border border-solid border-white rounded-full z-10"
-          style={{
-            top: '-8px',
-            right: '-16px',
-          }}
-        />
-      </div>
-
-      <div className="relative">
-        <div
-          className="bg-yellow-400 h-full"
-          style={{
-            width: levelThreeProgress,
-            'border-top-right-radius': '50px',
-            'border-bottom-right-radius': '50px',
-          }}
-        />
-
-        <div
-          className="bg-yellow-400 h-8 w-8 absolute top-0 right-0 border border-solid border-white rounded-full"
-          style={{
-            top: '-8px',
-            right: '-16px',
-          }}
-        />
-      </div>
+      <SingleLevel levelProgress={levelThreeProgress} color="bg-yellow-400" />
     </div>
   );
 };

--- a/resources/assets/components/utilities/ProgressBar/MultiLevelProgressBar.js
+++ b/resources/assets/components/utilities/ProgressBar/MultiLevelProgressBar.js
@@ -9,14 +9,12 @@ const MultiLevelProgressBar = ({
 }) => {
   const progressBarContainer = css`
     height: 15px;
-    width: 100%;
     border-radius: 50px;
   `;
-  // mobile sizing
-  // verbiage for when you have 1 badge??
+
   return (
     <div
-      className="grid grid-cols-3 bg-gray-300 pr-4 lg:pr-0 mb-10"
+      className="grid grid-cols-3 bg-gray-300 pr-4 lg:pr-0 mb-10 w-full"
       css={progressBarContainer}
     >
       <div className="relative">

--- a/resources/assets/components/utilities/ProgressBar/ProgressBar.js
+++ b/resources/assets/components/utilities/ProgressBar/ProgressBar.js
@@ -4,7 +4,7 @@ import { css } from '@emotion/core';
 
 import { tailwind } from '../../../helpers/display';
 
-const ProgressBar = ({ percentage, multiLevel, levelCount }) => {
+const ProgressBar = ({ percentage, multiLevel }) => {
   const tailwindYellow = tailwind('colors.yellow');
 
   const progressBarContainer = css`
@@ -19,13 +19,23 @@ const ProgressBar = ({ percentage, multiLevel, levelCount }) => {
     border-radius: inherit;
   `;
 
+  // 3 inner divs with the container
+  // set the container to 100% and 1fr x3
+  // each inner div
+  // create a multilevel helper / new component to make it work better for this type of calc
+  // for the circle marker, it is a sibling of the color linear div and it's absolutely positioned/top-right
   if (multiLevel) {
     return (
-      <div className="relative bg-gray-200" css={progressBarContainer}>
-        <div
-          css={progressBar}
-          style={{ width: `${percentage > 100 ? 100 : percentage}%` }}
-        />
+      // <div className="relative bg-gray-200" css={progressBarContainer}>
+      //   <div
+      //     css={progressBar}
+      //     style={{ width: `${percentage > 100 ? 100 : percentage}%` }}
+      //   />
+      // </div>
+      <div className="w-full grid grid-cols-3 bg-gray-300">
+        <div className="bg-purple-400">hello</div>
+        <div className="bg-teal-100">hi</div>
+        <div className="bg-yellow-300 w-1/2">ciao</div>
       </div>
     );
   }
@@ -41,13 +51,13 @@ const ProgressBar = ({ percentage, multiLevel, levelCount }) => {
 };
 
 ProgressBar.propTypes = {
-  levelCount: PropTypes.number,
+  // levelCount: PropTypes.number,
   multiLevel: PropTypes.bool,
   percentage: PropTypes.number.isRequired,
 };
 
 ProgressBar.defaultProps = {
-  levelCount: null,
+  // levelCount: null,
   multiLevel: null,
 };
 

--- a/resources/assets/components/utilities/ProgressBar/ProgressBar.js
+++ b/resources/assets/components/utilities/ProgressBar/ProgressBar.js
@@ -4,7 +4,7 @@ import { css } from '@emotion/core';
 
 import { tailwind } from '../../../helpers/display';
 
-const ProgressBar = ({ percentage, multiLevel }) => {
+const ProgressBar = ({ percentage }) => {
   const tailwindYellow = tailwind('colors.yellow');
 
   const progressBarContainer = css`
@@ -19,27 +19,6 @@ const ProgressBar = ({ percentage, multiLevel }) => {
     border-radius: inherit;
   `;
 
-  // 3 inner divs with the container
-  // set the container to 100% and 1fr x3
-  // each inner div
-  // create a multilevel helper / new component to make it work better for this type of calc
-  // for the circle marker, it is a sibling of the color linear div and it's absolutely positioned/top-right
-  if (multiLevel) {
-    return (
-      // <div className="relative bg-gray-200" css={progressBarContainer}>
-      //   <div
-      //     css={progressBar}
-      //     style={{ width: `${percentage > 100 ? 100 : percentage}%` }}
-      //   />
-      // </div>
-      <div className="w-full grid grid-cols-3 bg-gray-300">
-        <div className="bg-purple-400">hello</div>
-        <div className="bg-teal-100">hi</div>
-        <div className="bg-yellow-300 w-1/2">ciao</div>
-      </div>
-    );
-  }
-
   return (
     <div className="relative bg-gray-200" css={progressBarContainer}>
       <div
@@ -51,14 +30,7 @@ const ProgressBar = ({ percentage, multiLevel }) => {
 };
 
 ProgressBar.propTypes = {
-  // levelCount: PropTypes.number,
-  multiLevel: PropTypes.bool,
   percentage: PropTypes.number.isRequired,
-};
-
-ProgressBar.defaultProps = {
-  // levelCount: null,
-  multiLevel: null,
 };
 
 export default ProgressBar;

--- a/resources/assets/components/utilities/ProgressBar/ProgressBar.js
+++ b/resources/assets/components/utilities/ProgressBar/ProgressBar.js
@@ -4,7 +4,7 @@ import { css } from '@emotion/core';
 
 import { tailwind } from '../../../helpers/display';
 
-const ProgressBar = ({ percentage }) => {
+const ProgressBar = ({ percentage, multiLevel, levelCount }) => {
   const tailwindYellow = tailwind('colors.yellow');
 
   const progressBarContainer = css`
@@ -19,6 +19,17 @@ const ProgressBar = ({ percentage }) => {
     border-radius: inherit;
   `;
 
+  if (multiLevel) {
+    return (
+      <div className="relative bg-gray-200" css={progressBarContainer}>
+        <div
+          css={progressBar}
+          style={{ width: `${percentage > 100 ? 100 : percentage}%` }}
+        />
+      </div>
+    );
+  }
+
   return (
     <div className="relative bg-gray-200" css={progressBarContainer}>
       <div
@@ -30,7 +41,14 @@ const ProgressBar = ({ percentage }) => {
 };
 
 ProgressBar.propTypes = {
+  levelCount: PropTypes.number,
+  multiLevel: PropTypes.bool,
   percentage: PropTypes.number.isRequired,
+};
+
+ProgressBar.defaultProps = {
+  levelCount: null,
+  multiLevel: null,
 };
 
 export default ProgressBar;


### PR DESCRIPTION
### What's this PR do?

This pull request adds the progress bar for levels!!! It's using similar structure to the original `progressBar`, with some new details and multiple levels 😎 

### How should this be reviewed?

Let me know if you spot anything I could DRY up.

Large Screen:
![Screen Shot 2021-01-26 at 5 09 07 PM](https://user-images.githubusercontent.com/15236023/105913834-6f14db80-5ffb-11eb-9655-d4cdcd9c5ae8.png)


Medium Screen:
![Screen Shot 2021-01-26 at 5 09 27 PM](https://user-images.githubusercontent.com/15236023/105913844-73d98f80-5ffb-11eb-9a52-f4bea8ec144a.png)

Small Screen: 
![Screen Shot 2021-01-26 at 5 09 38 PM](https://user-images.githubusercontent.com/15236023/105913863-7a680700-5ffb-11eb-9cd2-0fd5faffab39.png)

Mid Tier:
![Screen Shot 2021-01-26 at 5 10 24 PM](https://user-images.githubusercontent.com/15236023/105913919-8e136d80-5ffb-11eb-9e7a-a2092d9693fc.png)


Low Tier:
![Screen Shot 2021-01-26 at 5 10 04 PM](https://user-images.githubusercontent.com/15236023/105913879-80f67e80-5ffb-11eb-8b62-e9132ca3b274.png)



### Any background context you want to provide?

This is more pre work for the eventual launch of Levels, hence the hardcoded badges number etc

### Relevant tickets

References [Pivotal #175855256](https://www.pivotaltracker.com/story/show/175855256).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [x] Added screenshots of front-end changes on small, medium, and large screens.
- [ ] Added appropriate feature/unit tests.
