### PR TITLE
Remove clubs from footer

### DIFF
--- a/resources/assets/components/utilities/SiteFooter/SiteFooter.js
+++ b/resources/assets/components/utilities/SiteFooter/SiteFooter.js
@@ -209,16 +209,6 @@ const SiteFooter = () => {
           <ul>
             <li>
               <a
-                href="/us/articles/clubs-notify-me"
-                onClick={event =>
-                  handleFooterTracking('dosomething_clubs', event.target.href)
-                }
-              >
-                DoSomething Clubs
-              </a>
-            </li>
-            <li>
-              <a
                 href="/us/about/volunteer-hours"
                 onClick={event =>
                   handleFooterTracking('volunteer_hours', event.target.href)

--- a/resources/views/partials/footer.blade.php
+++ b/resources/views/partials/footer.blade.php
@@ -47,7 +47,6 @@
     <div class="footer__column -links">
         <h4>Get Involved</h4>
         <ul>
-          <li><a href="{{ config('app.url') }}/us/articles/clubs-notify-me">DoSomething Clubs</a></li>
           <li><a href="{{ config('app.url') }}/us/about/volunteer-hours">Volunteer Hours</a></li>
           <li><a href="{{ config('app.url') }}/us/about/join-our-team">Jobs</a></li>
           <li><a href="{{ config('app.url') }}/us/about/internships">Internships</a></li>


### PR DESCRIPTION
### What's this PR do?

This pull request removes the "DoSomething Clubs" link in the footer as we are not doing clubs right now.

<img width="134" alt="image" src="https://user-images.githubusercontent.com/4240292/106020502-b3928c80-6078-11eb-9ce7-c0f2cee973bb.png">


### How should this be reviewed?

Maybe poke around in the review app and make sure it's really gone everywhere!

### Any background context you want to provide?

All in the card.

### Relevant tickets

References [Pivotal #176665589](https://www.pivotaltracker.com/story/show/176665589).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Added appropriate feature/unit tests.
