### PR TITLE
Adds labels to progress bar, updates some sizing

### DIFF
--- a/resources/assets/components/pages/AccountPage/Badges/RewardsProgressBar.js
+++ b/resources/assets/components/pages/AccountPage/Badges/RewardsProgressBar.js
@@ -51,8 +51,14 @@ const RewardsProgressBar = ({ totalBadges }) => {
 
       <MultiLevelProgressBar
         levelOneProgress={doerProgress(totalBadges)}
+        levelOneLabel="Doer"
+        levelOneSubLabel="2 Badges"
         levelTwoProgress={superDoerProgress(totalBadges)}
+        levelTwoLabel="SuperDoer"
+        levelTwoSubLabel="4 Badges"
         levelThreeProgress={legendProgress(totalBadges)}
+        levelThreeLabel="Legend"
+        levelThreeSubLabel="6 Badges"
       />
     </div>
   );

--- a/resources/assets/components/pages/AccountPage/Badges/RewardsProgressBar.js
+++ b/resources/assets/components/pages/AccountPage/Badges/RewardsProgressBar.js
@@ -3,7 +3,9 @@ import PropTypes from 'prop-types';
 
 import { userLevelLabel } from './RewardLevelsTable';
 import SectionHeader from '../../../utilities/SectionHeader/SectionHeader';
-import MultiLevelProgressBar from '../../../utilities/ProgressBar/MultiLevelProgressBar';
+import MultiLevelProgressBar, {
+  SingleLevel,
+} from '../../../utilities/ProgressBar/MultiLevelProgressBar';
 
 const RewardsProgressBar = ({ totalBadges }) => {
   const doerProgress = badges => {
@@ -50,16 +52,34 @@ const RewardsProgressBar = ({ totalBadges }) => {
       </p>
 
       <MultiLevelProgressBar
-        levelOneProgress={doerProgress(totalBadges)}
-        levelOneLabel="Doer"
-        levelOneSubLabel="2 Badges"
-        levelTwoProgress={superDoerProgress(totalBadges)}
-        levelTwoLabel="SuperDoer"
-        levelTwoSubLabel="4 Badges"
-        levelThreeProgress={legendProgress(totalBadges)}
-        levelThreeLabel="Legend"
-        levelThreeSubLabel="6 Badges"
-      />
+        levelLabels={[
+          {
+            label: 'Doer',
+            subLabel: '2 Badges',
+          },
+          {
+            label: 'SuperDoer',
+            subLabel: '4 Badges',
+          },
+          {
+            label: 'Legend',
+            subLabel: '6 Badges',
+          },
+        ]}
+      >
+        <SingleLevel
+          levelProgress={doerProgress(totalBadges)}
+          color="bg-teal-500"
+        />
+        <SingleLevel
+          levelProgress={superDoerProgress(totalBadges)}
+          color="bg-purple-400"
+        />
+        <SingleLevel
+          levelProgress={legendProgress(totalBadges)}
+          color="bg-yellow-400"
+        />
+      </MultiLevelProgressBar>
     </div>
   );
 };

--- a/resources/assets/components/utilities/ProgressBar/MultiLevelProgressBar.js
+++ b/resources/assets/components/utilities/ProgressBar/MultiLevelProgressBar.js
@@ -51,7 +51,7 @@ const MultiLevelProgressBar = ({ children, levelLabels }) => {
           return (
             <div className="text-right">
               <span className="font-bold">{level.label}</span> <br />{' '}
-              {level.subLevel || null}
+              {level.subLabel || null}
             </div>
           );
         })}

--- a/resources/assets/components/utilities/ProgressBar/MultiLevelProgressBar.js
+++ b/resources/assets/components/utilities/ProgressBar/MultiLevelProgressBar.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { css } from '@emotion/core';
 
-const SingleLevel = ({ color, levelProgress }) => (
+export const SingleLevel = ({ color, levelProgress }) => (
   <div className="relative">
     <div
       className={`${color} h-full`}
@@ -27,71 +27,47 @@ SingleLevel.propTypes = {
   levelProgress: PropTypes.string.isRequired,
 };
 
-const MultiLevelProgressBar = ({
-  levelOneProgress,
-  levelOneLabel,
-  levelOneSubLabel,
-  levelTwoProgress,
-  levelTwoLabel,
-  levelTwoSubLabel,
-  levelThreeProgress,
-  levelThreeLabel,
-  levelThreeSubLabel,
-}) => {
+const MultiLevelProgressBar = ({ children, levelLabels }) => {
   const progressBarContainer = css`
     height: 12px;
     border-radius: 50px;
   `;
 
+  // add a children prop and a levels props
+  // replace the multiple props with a levelLabels prop
+  // map through the levelLabels to display the labels
+  // display the child prop inside the first grid div
   return (
     <div>
       <div
         className="grid grid-cols-3 bg-gray-300 pr-4 lg:pr-0 mb-3 w-full"
         css={progressBarContainer}
       >
-        <SingleLevel levelProgress={levelOneProgress} color="bg-teal-500" />
-
-        <SingleLevel levelProgress={levelTwoProgress} color="bg-purple-400" />
-
-        <SingleLevel levelProgress={levelThreeProgress} color="bg-yellow-400" />
+        {children}
       </div>
 
       <div className="grid grid-cols-3 pr-4 lg:pr-0 mb-10 w-full">
-        <div className="text-right">
-          <span className="font-bold">{levelOneLabel}</span> <br />{' '}
-          {levelOneSubLabel}
-        </div>
-
-        <div className="text-right">
-          <span className="font-bold">{levelTwoLabel}</span> <br />{' '}
-          {levelTwoSubLabel}
-        </div>
-
-        <div className="text-right">
-          <span className="font-bold">{levelThreeLabel}</span> <br />{' '}
-          {levelThreeSubLabel}
-        </div>
+        {levelLabels.map(level => {
+          return (
+            <div className="text-right">
+              <span className="font-bold">{level.label}</span> <br />{' '}
+              {level.subLevel || null}
+            </div>
+          );
+        })}
       </div>
     </div>
   );
 };
 
 MultiLevelProgressBar.propTypes = {
-  levelOneProgress: PropTypes.string.isRequired,
-  levelOneLabel: PropTypes.string.isRequired,
-  levelOneSubLabel: PropTypes.string,
-  levelTwoProgress: PropTypes.string.isRequired,
-  levelTwoLabel: PropTypes.string.isRequired,
-  levelTwoSubLabel: PropTypes.string,
-  levelThreeProgress: PropTypes.string.isRequired,
-  levelThreeLabel: PropTypes.string.isRequired,
-  levelThreeSubLabel: PropTypes.string,
-};
-
-MultiLevelProgressBar.defaultProps = {
-  levelOneSubLabel: null,
-  levelTwoSubLabel: null,
-  levelThreeSubLabel: null,
+  children: PropTypes.object.isRequired,
+  levelLabels: PropTypes.arrayOf(
+    PropTypes.shape({
+      label: PropTypes.string.isRequired,
+      subLabel: PropTypes.string,
+    }),
+  ).isRequired,
 };
 
 export default MultiLevelProgressBar;

--- a/resources/assets/components/utilities/ProgressBar/MultiLevelProgressBar.js
+++ b/resources/assets/components/utilities/ProgressBar/MultiLevelProgressBar.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { css } from '@emotion/core';
 
-const SingleLevel = ({ levelProgress, color }) => (
+const SingleLevel = ({ color, levelProgress }) => (
   <div className="relative">
     <div
       className={`${color} h-full`}
@@ -15,7 +15,7 @@ const SingleLevel = ({ levelProgress, color }) => (
     <div
       className={`${color} h-8 w-8 absolute border border-solid border-white rounded-full z-10`}
       css={css`
-        top: -8px;
+        top: -10px;
         right: -16px;
       `}
     />
@@ -29,32 +29,69 @@ SingleLevel.propTypes = {
 
 const MultiLevelProgressBar = ({
   levelOneProgress,
+  levelOneLabel,
+  levelOneSubLabel,
   levelTwoProgress,
+  levelTwoLabel,
+  levelTwoSubLabel,
   levelThreeProgress,
+  levelThreeLabel,
+  levelThreeSubLabel,
 }) => {
   const progressBarContainer = css`
-    height: 15px;
+    height: 12px;
     border-radius: 50px;
   `;
 
   return (
-    <div
-      className="grid grid-cols-3 bg-gray-300 pr-4 lg:pr-0 mb-10 w-full"
-      css={progressBarContainer}
-    >
-      <SingleLevel levelProgress={levelOneProgress} color="bg-teal-500" />
+    <div>
+      <div
+        className="grid grid-cols-3 bg-gray-300 pr-4 lg:pr-0 mb-3 w-full"
+        css={progressBarContainer}
+      >
+        <SingleLevel levelProgress={levelOneProgress} color="bg-teal-500" />
 
-      <SingleLevel levelProgress={levelTwoProgress} color="bg-purple-400" />
+        <SingleLevel levelProgress={levelTwoProgress} color="bg-purple-400" />
 
-      <SingleLevel levelProgress={levelThreeProgress} color="bg-yellow-400" />
+        <SingleLevel levelProgress={levelThreeProgress} color="bg-yellow-400" />
+      </div>
+
+      <div className="grid grid-cols-3 pr-4 lg:pr-0 mb-10 w-full">
+        <div className="text-right">
+          <span className="font-bold">{levelOneLabel}</span> <br />{' '}
+          {levelOneSubLabel}
+        </div>
+
+        <div className="text-right">
+          <span className="font-bold">{levelTwoLabel}</span> <br />{' '}
+          {levelTwoSubLabel}
+        </div>
+
+        <div className="text-right">
+          <span className="font-bold">{levelThreeLabel}</span> <br />{' '}
+          {levelThreeSubLabel}
+        </div>
+      </div>
     </div>
   );
 };
 
 MultiLevelProgressBar.propTypes = {
   levelOneProgress: PropTypes.string.isRequired,
+  levelOneLabel: PropTypes.string.isRequired,
+  levelOneSubLabel: PropTypes.string,
   levelTwoProgress: PropTypes.string.isRequired,
+  levelTwoLabel: PropTypes.string.isRequired,
+  levelTwoSubLabel: PropTypes.string,
   levelThreeProgress: PropTypes.string.isRequired,
+  levelThreeLabel: PropTypes.string.isRequired,
+  levelThreeSubLabel: PropTypes.string,
+};
+
+MultiLevelProgressBar.defaultProps = {
+  levelOneSubLabel: null,
+  levelTwoSubLabel: null,
+  levelThreeSubLabel: null,
 };
 
 export default MultiLevelProgressBar;

--- a/resources/assets/components/utilities/ProgressBar/MultiLevelProgressBar.js
+++ b/resources/assets/components/utilities/ProgressBar/MultiLevelProgressBar.js
@@ -33,10 +33,6 @@ const MultiLevelProgressBar = ({ children, levelLabels }) => {
     border-radius: 50px;
   `;
 
-  // add a children prop and a levels props
-  // replace the multiple props with a levelLabels prop
-  // map through the levelLabels to display the labels
-  // display the child prop inside the first grid div
   return (
     <div>
       <div


### PR DESCRIPTION
### What's this PR do?

This pull request adds labels underneath the progress bar for clarity as to what each marker is referencing. It also adds some minor styling adjustments 

### How should this be reviewed?

👀 

Large:
![Screen Shot 2021-01-28 at 10 48 31 AM](https://user-images.githubusercontent.com/15236023/106164987-9af9a380-6158-11eb-8417-3f0dc004f741.png)

Medium:
![Screen Shot 2021-01-28 at 10 49 08 AM](https://user-images.githubusercontent.com/15236023/106165009-9f25c100-6158-11eb-87dc-2819ceee6dac.png)

Small:
![Screen Shot 2021-01-28 at 10 49 32 AM](https://user-images.githubusercontent.com/15236023/106165026-a351de80-6158-11eb-861e-5d94b748c930.png)


### Any background context you want to provide?

These were on the updated designs and I didn't see them originally :)

### Relevant tickets

References [Pivotal #175855256](https://www.pivotaltracker.com/story/show/175855256).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [x] Added screenshots of front-end changes on small, medium, and large screens.
- [ ] Added appropriate feature/unit tests.
