### PR TITLE
Matching Gallery Block Header to HomePage

### DIFF
--- a/resources/assets/components/blocks/GalleryBlock/GalleryBlock.js
+++ b/resources/assets/components/blocks/GalleryBlock/GalleryBlock.js
@@ -3,20 +3,20 @@ import gql from 'graphql-tag';
 import PropTypes from 'prop-types';
 
 import Person from '../../utilities/Person/Person';
-import { withoutNulls } from '../../../helpers/data';
-import Gallery from '../../utilities/Gallery/Gallery';
-import SectionHeader from '../../utilities/SectionHeader/SectionHeader';
 import CampaignCard, {
   campaignCardFragment,
 } from '../../utilities/CampaignCard/CampaignCard';
+import { withoutNulls } from '../../../helpers/data';
+import Gallery from '../../utilities/Gallery/Gallery';
 import ScholarshipCard, {
   scholarshipCardFragment,
 } from '../../utilities/ScholarshipCard/ScholarshipCard';
-import PageCard, { pageCardFragment } from '../../utilities/PageCard/PageCard';
-import ContentBlockGalleryItem from '../../utilities/Gallery/templates/ContentBlockGalleryItem';
 import ExternalLinkCard, {
   ExternalLinkBlockFragment,
 } from '../../utilities/ExternalLinkCard/ExternalLinkCard';
+import PageCard, { pageCardFragment } from '../../utilities/PageCard/PageCard';
+import GalleryBlockHeader from '../../utilities/SectionHeader/GalleryBlockHeader';
+import ContentBlockGalleryItem from '../../utilities/Gallery/templates/ContentBlockGalleryItem';
 
 export const GalleryBlockFragment = gql`
   fragment GalleryBlockFragment on GalleryBlock {
@@ -120,7 +120,7 @@ const GalleryBlock = props => {
 
   return (
     <div className="gallery-block" data-testid="gallery-block">
-      {title ? <SectionHeader underlined title={title} /> : null}
+      {title ? <GalleryBlockHeader title={title} /> : null}
 
       <Gallery type={galleryLayout} className="-mx-3 mt-3">
         {blocks.map(block =>

--- a/resources/assets/components/pages/HomePage/HomePage.js
+++ b/resources/assets/components/pages/HomePage/HomePage.js
@@ -23,6 +23,7 @@ import { campaignCardFragment } from '../../utilities/CampaignCard/CampaignCard'
 import SiteNavigationContainer from '../../SiteNavigation/SiteNavigationContainer';
 import AnalyticsWaypoint from '../../utilities/AnalyticsWaypoint/AnalyticsWaypoint';
 import DismissableElement from '../../utilities/DismissableElement/DismissableElement';
+import { centerHorizontalRule } from '../../utilities/SectionHeader/GalleryBlockHeader';
 import TrafficDistribution from '../../utilities/TrafficDistribution/TrafficDistribution';
 import { campaignCardFeaturedFragment } from '../../utilities/CampaignCard/CampaignCardFeatured';
 
@@ -129,13 +130,6 @@ NewsletterItem.propTypes = {
 const HomePageTemplate = ({ articles, campaigns, coverImage, title }) => {
   const tailwindGray = tailwind('colors.gray');
   const tailwindScreens = tailwind('screens');
-
-  const centerHorizontalRule = css`
-    @media (min-width: ${tailwindScreens.md}) {
-      margin-top: -2px;
-      top: 50%;
-    }
-  `;
 
   const headerBackgroundStyles = coverImage
     ? css`

--- a/resources/assets/components/pages/HomePage/HomePage.js
+++ b/resources/assets/components/pages/HomePage/HomePage.js
@@ -20,10 +20,10 @@ import { pageCardFragment } from '../../utilities/PageCard/PageCard';
 import TypeFormEmbed from '../../utilities/TypeFormEmbed/TypeFormEmbed';
 import DelayedElement from '../../utilities/DelayedElement/DelayedElement';
 import { campaignCardFragment } from '../../utilities/CampaignCard/CampaignCard';
+import GalleryBlockHeader from '../../utilities/SectionHeader/GalleryBlockHeader';
 import SiteNavigationContainer from '../../SiteNavigation/SiteNavigationContainer';
 import AnalyticsWaypoint from '../../utilities/AnalyticsWaypoint/AnalyticsWaypoint';
 import DismissableElement from '../../utilities/DismissableElement/DismissableElement';
-import { centerHorizontalRule } from '../../utilities/SectionHeader/GalleryBlockHeader';
 import TrafficDistribution from '../../utilities/TrafficDistribution/TrafficDistribution';
 import { campaignCardFeaturedFragment } from '../../utilities/CampaignCard/CampaignCardFeatured';
 
@@ -246,19 +246,11 @@ const HomePageTemplate = ({ articles, campaigns, coverImage, title }) => {
               `}
               data-test="campaigns-section"
             >
+              <AnalyticsWaypoint name="campaign_section_top" />
+
+              <GalleryBlockHeader title="Take Action!" bgColor="bg-white" />
+
               <div className="grid-wide text-center">
-                <AnalyticsWaypoint name="campaign_section_top" />
-
-                <h2 className="mb-6 relative">
-                  <span className="bg-white font-league-gothic font-normal leading-tight inline-block px-6 relative text-3xl md:text-4xl uppercase z-10">
-                    Take Action!
-                  </span>
-                  <span
-                    className="absolute bg-purple-500 block h-1 w-full z-0"
-                    css={centerHorizontalRule}
-                  />
-                </h2>
-
                 <p className="mb-3 text-lg">
                   Choose a campaign below to make an impact,{' '}
                   <a
@@ -394,19 +386,11 @@ const HomePageTemplate = ({ articles, campaigns, coverImage, title }) => {
               className="base-12-grid bg-gray-100 py-8"
               data-test="articles-section"
             >
+              <AnalyticsWaypoint name="article_section_top" />
+
+              <GalleryBlockHeader title="Read About It" />
+
               <div className="grid-wide text-center">
-                <AnalyticsWaypoint name="article_section_top" />
-
-                <h2 className="mb-6 relative">
-                  <span className="bg-gray-100 font-league-gothic font-normal leading-tight inline-block px-6 relative text-3xl md:text-4xl uppercase z-10">
-                    Read About It
-                  </span>
-                  <span
-                    className="absolute bg-purple-500 block h-1 w-full z-0"
-                    css={centerHorizontalRule}
-                  />
-                </h2>
-
                 <HomePageArticleGallery articles={articles} />
 
                 <PrimaryButton

--- a/resources/assets/components/utilities/SectionHeader/GalleryBlockHeader.js
+++ b/resources/assets/components/utilities/SectionHeader/GalleryBlockHeader.js
@@ -13,28 +13,29 @@ export const centerHorizontalRule = css`
   }
 `;
 
-const GalleryBlockHeader = ({ title }) => (
+const GalleryBlockHeader = ({ bgColor, title }) => (
   <div className="grid-wide text-center">
-    {title ? (
-      <h2 className="mb-6 relative">
-        <span className="bg-gray-100 font-league-gothic font-normal leading-tight inline-block px-6 relative text-3xl md:text-4xl uppercase z-10">
-          {title}
-        </span>
-        <span
-          className="absolute bg-purple-500 block h-1 w-full z-0"
-          css={centerHorizontalRule}
-        />
-      </h2>
-    ) : null}
+    <h2 className="mb-6 relative">
+      <span
+        className={`${bgColor} font-league-gothic font-normal leading-tight inline-block px-6 relative text-3xl md:text-4xl uppercase z-10`}
+      >
+        {title}
+      </span>
+      <span
+        className="absolute bg-purple-500 block h-1 w-full z-0"
+        css={centerHorizontalRule}
+      />
+    </h2>
   </div>
 );
 
 GalleryBlockHeader.propTypes = {
-  title: PropTypes.string,
+  bgColor: PropTypes.string,
+  title: PropTypes.string.isRequired,
 };
 
 GalleryBlockHeader.defaultProps = {
-  title: null,
+  bgColor: 'bg-gray-100',
 };
 
 export default GalleryBlockHeader;

--- a/resources/assets/components/utilities/SectionHeader/GalleryBlockHeader.js
+++ b/resources/assets/components/utilities/SectionHeader/GalleryBlockHeader.js
@@ -1,0 +1,40 @@
+import React from 'react';
+import { css } from '@emotion/core';
+import PropTypes from 'prop-types';
+
+import { tailwind } from '../../../helpers/display';
+
+const tailwindScreens = tailwind('screens');
+
+export const centerHorizontalRule = css`
+  @media (min-width: ${tailwindScreens.md}) {
+    margin-top: -2px;
+    top: 50%;
+  }
+`;
+
+const GalleryBlockHeader = ({ title }) => (
+  <div className="grid-wide text-center">
+    {title ? (
+      <h2 className="mb-6 relative">
+        <span className="bg-gray-100 font-league-gothic font-normal leading-tight inline-block px-6 relative text-3xl md:text-4xl uppercase z-10">
+          {title}
+        </span>
+        <span
+          className="absolute bg-purple-500 block h-1 w-full z-0"
+          css={centerHorizontalRule}
+        />
+      </h2>
+    ) : null}
+  </div>
+);
+
+GalleryBlockHeader.propTypes = {
+  title: PropTypes.string,
+};
+
+GalleryBlockHeader.defaultProps = {
+  title: null,
+};
+
+export default GalleryBlockHeader;


### PR DESCRIPTION
### What's this PR do?

This pull request updates the header of the `GalleryBlock` component to match the homepage!

### How should this be reviewed?

I tried to keep things DRY, but i didn't want to entirely eliminate the current `SectionHeader` or the styling of the Homepage because there were specific differences between them all. (ie, homepage uses AnalyticsWayPoints and the `SectionHeader` is used in other places). That being said, are there other ways we could make this more reusable?

### Any background context you want to provide?

Request from the design team!
Current:
![Screen Shot 2021-02-01 at 11 24 05 AM](https://user-images.githubusercontent.com/15236023/106486788-022c9600-6480-11eb-883d-657bea63749a.png)

Large Screen:
![Screen Shot 2021-02-01 at 11 18 13 AM](https://user-images.githubusercontent.com/15236023/106486689-e7f2b800-647f-11eb-91a1-762d87d46f1f.png)

Small Screen:
![Screen Shot 2021-02-01 at 11 18 42 AM](https://user-images.githubusercontent.com/15236023/106486710-ef19c600-647f-11eb-92b8-0fb593adb2ba.png)


### Relevant tickets

References [Pivotal #174220566](https://www.pivotaltracker.com/story/show/174220566).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [x] Added screenshots of front-end changes on small, medium, and large screens.
