### PR TITLE
Fix Campaign Link for RAF Beta Page

### DIFF
--- a/resources/assets/components/pages/ReferralPage/Beta/BetaPageCampaignLink.js
+++ b/resources/assets/components/pages/ReferralPage/Beta/BetaPageCampaignLink.js
@@ -44,7 +44,7 @@ const ReferralPageCampaignLink = ({ campaignId, userId }) => (
         <CampaignCard
           campaign={{
             ...data,
-            path: `${data.url}?referrer_user_id=${userId}`,
+            path: `${data.path}?referrer_user_id=${userId}`,
             // Suppress the 'featured' badge.
             staffPick: undefined,
           }}


### PR DESCRIPTION
Quick fix per #2525 where I mistakenly used the `url` property (which we aren't even querying via GraphQL) instead of the `path`.


https://www.pivotaltracker.com/story/show/176641967/comments/221606907