### PR TITLE
Updates for StrikeThrough Header

### DIFF
--- a/resources/assets/components/blocks/GalleryBlock/GalleryBlock.js
+++ b/resources/assets/components/blocks/GalleryBlock/GalleryBlock.js
@@ -15,7 +15,7 @@ import ExternalLinkCard, {
   ExternalLinkBlockFragment,
 } from '../../utilities/ExternalLinkCard/ExternalLinkCard';
 import PageCard, { pageCardFragment } from '../../utilities/PageCard/PageCard';
-import GalleryBlockHeader from '../../utilities/SectionHeader/GalleryBlockHeader';
+import StrikeThroughHeader from '../../utilities/SectionHeader/StrikeThroughHeader';
 import ContentBlockGalleryItem from '../../utilities/Gallery/templates/ContentBlockGalleryItem';
 
 export const GalleryBlockFragment = gql`
@@ -120,16 +120,7 @@ const GalleryBlock = props => {
 
   return (
     <div className="gallery-block" data-testid="gallery-block">
-      {title ? (
-        <GalleryBlockHeader
-          title={title}
-          bgColor={
-            window.location.pathname.includes('/about/')
-              ? 'bg-white'
-              : undefined
-          }
-        />
-      ) : null}
+      {title ? <StrikeThroughHeader title={title} /> : null}
 
       <Gallery type={galleryLayout} className="-mx-3 mt-3">
         {blocks.map(block =>

--- a/resources/assets/components/blocks/GalleryBlock/GalleryBlock.js
+++ b/resources/assets/components/blocks/GalleryBlock/GalleryBlock.js
@@ -120,7 +120,16 @@ const GalleryBlock = props => {
 
   return (
     <div className="gallery-block" data-testid="gallery-block">
-      {title ? <GalleryBlockHeader title={title} /> : null}
+      {title ? (
+        <GalleryBlockHeader
+          title={title}
+          bgColor={
+            window.location.pathname.includes('/about/')
+              ? 'bg-white'
+              : undefined
+          }
+        />
+      ) : null}
 
       <Gallery type={galleryLayout} className="-mx-3 mt-3">
         {blocks.map(block =>

--- a/resources/assets/components/pages/HomePage/HomePage.js
+++ b/resources/assets/components/pages/HomePage/HomePage.js
@@ -20,7 +20,7 @@ import { pageCardFragment } from '../../utilities/PageCard/PageCard';
 import TypeFormEmbed from '../../utilities/TypeFormEmbed/TypeFormEmbed';
 import DelayedElement from '../../utilities/DelayedElement/DelayedElement';
 import { campaignCardFragment } from '../../utilities/CampaignCard/CampaignCard';
-import GalleryBlockHeader from '../../utilities/SectionHeader/GalleryBlockHeader';
+import StrikeThroughHeader from '../../utilities/SectionHeader/StrikeThroughHeader';
 import SiteNavigationContainer from '../../SiteNavigation/SiteNavigationContainer';
 import AnalyticsWaypoint from '../../utilities/AnalyticsWaypoint/AnalyticsWaypoint';
 import DismissableElement from '../../utilities/DismissableElement/DismissableElement';
@@ -248,7 +248,7 @@ const HomePageTemplate = ({ articles, campaigns, coverImage, title }) => {
             >
               <AnalyticsWaypoint name="campaign_section_top" />
 
-              <GalleryBlockHeader title="Take Action!" bgColor="bg-white" />
+              <StrikeThroughHeader title="Take Action!" />
 
               <div className="grid-wide text-center">
                 <p className="mb-3 text-lg">
@@ -388,7 +388,7 @@ const HomePageTemplate = ({ articles, campaigns, coverImage, title }) => {
             >
               <AnalyticsWaypoint name="article_section_top" />
 
-              <GalleryBlockHeader title="Read About It" />
+              <StrikeThroughHeader title="Read About It" />
 
               <div className="grid-wide text-center">
                 <HomePageArticleGallery articles={articles} />

--- a/resources/assets/components/utilities/SectionHeader/GalleryBlockHeader.js
+++ b/resources/assets/components/utilities/SectionHeader/GalleryBlockHeader.js
@@ -1,41 +1,22 @@
 import React from 'react';
-import { css } from '@emotion/core';
 import PropTypes from 'prop-types';
 
-import { tailwind } from '../../../helpers/display';
-
-const tailwindScreens = tailwind('screens');
-
-export const centerHorizontalRule = css`
-  @media (min-width: ${tailwindScreens.md}) {
-    margin-top: -2px;
-    top: 50%;
-  }
-`;
-
-const GalleryBlockHeader = ({ bgColor, title }) => (
-  <div className="grid-wide text-center">
-    <h2 className="mb-6 relative">
-      <span
-        className={`${bgColor} font-league-gothic font-normal leading-tight inline-block px-6 relative text-3xl md:text-4xl uppercase z-10`}
-      >
-        {title}
-      </span>
-      <span
-        className="absolute bg-purple-500 block h-1 w-full z-0"
-        css={centerHorizontalRule}
-      />
+const GalleryBlockHeader = ({ title }) => (
+  <div className="grid-wide flex flex-wrap md:flex-no-wrap text-center w-full mb-6 justify-center">
+    <div className="w-0 md:w-full md:flex-shrink my-auto">
+      <div className=" bg-purple-500 h-1 w-full z-0" />
+    </div>
+    <h2 className="font-league-gothic font-normal leading-tight px-6 text-3xl md:text-4xl uppercase z-10 md:flex-shrink-0">
+      {title}
     </h2>
+    <div className="w-full md:flex-shrink my-auto">
+      <div className=" bg-purple-500 h-1 w-full z-0" />
+    </div>
   </div>
 );
 
 GalleryBlockHeader.propTypes = {
-  bgColor: PropTypes.string,
   title: PropTypes.string.isRequired,
-};
-
-GalleryBlockHeader.defaultProps = {
-  bgColor: 'bg-gray-100',
 };
 
 export default GalleryBlockHeader;

--- a/resources/assets/components/utilities/SectionHeader/StrikeThroughHeader.js
+++ b/resources/assets/components/utilities/SectionHeader/StrikeThroughHeader.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-const GalleryBlockHeader = ({ title }) => (
+const StrikeThroughHeader = ({ title }) => (
   <div className="grid-wide flex flex-wrap md:flex-no-wrap text-center w-full mb-6 justify-center">
     <div className="w-0 md:w-full md:flex-shrink my-auto">
       <div className=" bg-purple-500 h-1 w-full z-0" />
@@ -15,8 +15,8 @@ const GalleryBlockHeader = ({ title }) => (
   </div>
 );
 
-GalleryBlockHeader.propTypes = {
+StrikeThroughHeader.propTypes = {
   title: PropTypes.string.isRequired,
 };
 
-export default GalleryBlockHeader;
+export default StrikeThroughHeader;

--- a/resources/assets/components/utilities/SectionHeader/StrikeThroughHeader.js
+++ b/resources/assets/components/utilities/SectionHeader/StrikeThroughHeader.js
@@ -2,7 +2,10 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const StrikeThroughHeader = ({ title }) => (
-  <div className="grid-wide flex flex-wrap md:flex-no-wrap text-center w-full mb-6 justify-center">
+  <div
+    className="grid-wide flex flex-wrap md:flex-no-wrap text-center w-full mb-6 justify-center"
+    data-testid="strike-through-header"
+  >
     <div className="w-0 md:w-full md:flex-shrink my-auto">
       <div className=" bg-purple-500 h-1 w-full z-0" />
     </div>


### PR DESCRIPTION
### What's this PR do?

This pull request refactors the galleryblock (now `StrikeThroughHeader`) to use flex box rather than rely on background color!!

### How should this be reviewed?

👀 

Before:
![Screen Shot 2021-02-01 at 4 02 50 PM](https://user-images.githubusercontent.com/15236023/106517813-fc967680-64a6-11eb-96f9-c5b61745a38a.png)

After (bg-white):
![Screen Shot 2021-02-02 at 11 46 14 AM](https://user-images.githubusercontent.com/15236023/106633203-93693e80-654c-11eb-907c-13cb6d8fcd3f.png)

(bg gray):
![Screen Shot 2021-02-02 at 11 46 45 AM](https://user-images.githubusercontent.com/15236023/106633253-9f550080-654c-11eb-88b5-44718b3ebe76.png)

(bg gray) Medium:
![Screen Shot 2021-02-02 at 11 47 04 AM](https://user-images.githubusercontent.com/15236023/106633277-a714a500-654c-11eb-8636-00a5e0d3e25d.png)

(bg-gray) Small:
![Screen Shot 2021-02-02 at 11 46 56 AM](https://user-images.githubusercontent.com/15236023/106633295-aed44980-654c-11eb-97aa-2bddce536e44.png)




### Any background context you want to provide?

We discussed possibly creating 3 components side by side rather than positioning the blurple line underneath the headline [in slack](https://dosomething.slack.com/archives/CUQMU4Q6B/p1612209479013800), and this is a much more future proofed option! I made sure that it looked the same as the current homepage styling on all screen sizes as well to be consistent.

### Relevant tickets

References [Pivotal #174220566](https://www.pivotaltracker.com/story/show/174220566).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [x] Added screenshots of front-end changes on small, medium, and large screens.
