### PR TITLE
Update photo uploader title 

### DIFF
--- a/resources/assets/components/utilities/MediaUploader/index.js
+++ b/resources/assets/components/utilities/MediaUploader/index.js
@@ -55,7 +55,7 @@ class MediaUploader extends React.Component {
       );
     } else {
       content = (
-        <div className="media-uploader__content media-uploader--action">
+        <div className="media-uploader__content media-uploader--action underline">
           <span>{this.props.label}</span>
         </div>
       );


### PR DESCRIPTION
### What's this PR do?

This pull request adds an underline for the photo uploader title `Add your photo here`

### How should this be reviewed?

...

### Any background context you want to provide?

...
Previous: 
<img width="368" alt="Screen Shot 2021-02-01 at 7 45 35 PM" src="https://user-images.githubusercontent.com/20409413/106532484-a46f6c80-64c6-11eb-9dfe-700395e21e42.png">

Current:
<img width="372" alt="Screen Shot 2021-02-01 at 7 46 05 PM" src="https://user-images.githubusercontent.com/20409413/106532510-ae916b00-64c6-11eb-8cdd-34cd33dc4c5c.png">


### Relevant tickets

References [Pivotal #176179259](https://www.pivotaltracker.com/n/projects/2401401/stories/176179259).

### Checklist

- [ x ] This PR has been added to the relevant Pivotal card.
- [ x ] Added screenshots of front-end changes on small, medium, and large screens.

