### PR TITLE
Add test debugger for show submission page auth

### DIFF
--- a/resources/assets/components/pages/ShowSubmissionPage/ShowSubmissionPage.js
+++ b/resources/assets/components/pages/ShowSubmissionPage/ShowSubmissionPage.js
@@ -53,6 +53,12 @@ const ShowSubmissionPage = ({ match }) => {
 
   // This page is gated to the post's author.
   if (getUserId() !== userId) {
+    if (window.Cypress) {
+      document.querySelector(
+        '#cypress-test-debug',
+      ).innerHTML = `AUTH ID: ${getUserId()}. Post ID: ${userId}`;
+    }
+
     return <Redirect to="/us/account/campaigns" />;
   }
 

--- a/resources/views/layouts/master.blade.php
+++ b/resources/views/layouts/master.blade.php
@@ -35,6 +35,8 @@
     <div id="fb-root"></div>
     <div id="popover-portal" class="top-0 left-0 w-full block z-1000" role="presentation"></div>
     <div id="chrome" class="chrome min-h-screen w-full">
+        <h1 id="cypress-test-debug"/>
+
         @yield('content')
     </div>
 


### PR DESCRIPTION
This PR is an attempt to debug [the flakey](https://dashboard.cypress.io/projects/ayzqmy/analytics/flaky-tests/454c2b0f-5a38-fe89-a84a-bbc00e6d5387-0f359aac-7fa0-d111-e223-5b92622e93bc) submission page redirect tests. What seems to be happening is that [the authorization gate](https://github.com/DoSomething/phoenix-next/blob/b2b71fd652305b449c1c8dcac91786789448993a/resources/assets/components/pages/ShowSubmissionPage/ShowSubmissionPage.js#L54-L57) is failing, causing a redirect to /campaigns. I've tried some other debugging methods in vain, and can't seem to replicate locally (not by running locally on electron either). Logging via Cypress doesn't seem to be viewable in the test output, so this is hopefully a way to catch an ID discrepancy in the test video (🤷‍♂️ 🤞 🙏)