### PR TITLE
Unbold the Site! Better way to debug the flakey cypress test

### DIFF
--- a/resources/assets/components/pages/ShowSubmissionPage/ShowSubmissionPage.js
+++ b/resources/assets/components/pages/ShowSubmissionPage/ShowSubmissionPage.js
@@ -56,7 +56,7 @@ const ShowSubmissionPage = ({ match }) => {
     if (window.Cypress) {
       const h1 = document.createElement('h1');
 
-      h1.innerHTML = `AUTH ID: ${getUserId()}. Post ID: ${userId}`;
+      h1.innerText = `AUTH ID: ${getUserId()}. Post ID: ${userId}`;
 
       document.querySelector('#chrome').prepend(h1);
     }

--- a/resources/assets/components/pages/ShowSubmissionPage/ShowSubmissionPage.js
+++ b/resources/assets/components/pages/ShowSubmissionPage/ShowSubmissionPage.js
@@ -54,9 +54,11 @@ const ShowSubmissionPage = ({ match }) => {
   // This page is gated to the post's author.
   if (getUserId() !== userId) {
     if (window.Cypress) {
-      document.querySelector(
-        '#cypress-test-debug',
-      ).innerHTML = `AUTH ID: ${getUserId()}. Post ID: ${userId}`;
+      const h1 = document.createElement('h1');
+
+      h1.innerHTML = `AUTH ID: ${getUserId()}. Post ID: ${userId}`;
+
+      document.querySelector('#chrome').prepend(h1);
     }
 
     return <Redirect to="/us/account/campaigns" />;

--- a/resources/views/layouts/master.blade.php
+++ b/resources/views/layouts/master.blade.php
@@ -34,9 +34,8 @@
 
     <div id="fb-root"></div>
     <div id="popover-portal" class="top-0 left-0 w-full block z-1000" role="presentation"></div>
-    <div id="chrome" class="chrome min-h-screen w-full">
-        <h1 id="cypress-test-debug"/>
 
+    <div id="chrome" class="chrome min-h-screen w-full">
         @yield('content')
     </div>
 


### PR DESCRIPTION
### What's this PR do?

This pull request removes the `h1` used to inject Cypress test information since it was causing the entire site chrome content to be nested inside an `h1`!!

#2535 
https://dosomething.slack.com/archives/CUQMU4Q6B/p1612309316008600