### PR TITLE
Actions Campaign Filter

### DIFF
--- a/resources/assets/components/pages/CampaignsPage/CampaignFilters/ActionFilter/ActionFilter.js
+++ b/resources/assets/components/pages/CampaignsPage/CampaignFilters/ActionFilter/ActionFilter.js
@@ -19,8 +19,8 @@ const ActionFilter = ({ filters, setFilters }) => {
 
   const handleActionTypeSelect = event => {
     if (actionTypes.includes(event.target.value)) {
-      const newActionTypes = actionTypes.filter(cause => {
-        return cause !== event.target.value;
+      const newActionTypes = actionTypes.filter(actionType => {
+        return actionType !== event.target.value;
       });
       setFilters({ actionTypes: [...newActionTypes] });
     } else {
@@ -33,7 +33,7 @@ const ActionFilter = ({ filters, setFilters }) => {
       setFilters({ actionTypes: [] });
     }
   };
-
+  console.log('hello?');
   return (
     <form>
       <div className="cause-filter w-full p-4 flex flex-col flex-wrap">

--- a/resources/assets/components/pages/CampaignsPage/CampaignFilters/ActionFilter/ActionFilter.js
+++ b/resources/assets/components/pages/CampaignsPage/CampaignFilters/ActionFilter/ActionFilter.js
@@ -1,0 +1,127 @@
+import React from 'react';
+import { get } from 'lodash';
+import PropTypes from 'prop-types';
+
+import ElementButton from '../../../../utilities/Button/ElementButton';
+import {
+  EVENT_CATEGORIES,
+  trackAnalyticsEvent,
+} from '../../../../../helpers/analytics';
+
+const causeLabels = {
+  'animal-welfare': 'Animal Welfare',
+  bullying: 'Bullying',
+  education: 'Education',
+  environment: 'Environment',
+  'gender-rights': 'Gender Rights & Equality',
+  'homelessness-and-poverty': 'Homelessness & Poverty',
+  immigration: 'Immigration & Refugees',
+  'lgbtq-rights': 'LGBTQ+ Rights & Equality',
+  'mental-health': 'Mental Health',
+  'physical-health': 'Physical Health',
+  'racial-justice': 'Racial Justice & Equity',
+  'sexual-harassment': 'Sexual Harassment & Assault',
+};
+
+/**
+ * Checkbox input component.
+ *
+ * @param {Object}
+ */
+const CauseInput = ({ causeName, causeValue, handleSelect, isChecked }) => (
+  <label className="flex items-start justify-start pb-2" htmlFor={causeValue}>
+    <input
+      id={causeValue}
+      checked={isChecked}
+      className="mt-1"
+      name={causeValue}
+      onChange={handleSelect}
+      type="checkbox"
+      value={causeValue}
+    />
+    <span className="pl-4">{causeName}</span>
+  </label>
+);
+
+CauseInput.propTypes = {
+  isChecked: PropTypes.bool,
+  causeName: PropTypes.string.isRequired,
+  causeValue: PropTypes.string.isRequired,
+  handleSelect: PropTypes.func.isRequired,
+};
+
+CauseInput.defaultProps = {
+  isChecked: false,
+};
+
+/**
+ * Filter menu form with series of checkbox inputs.
+ *
+ * @param {Object}
+ */
+const ActionFilter = ({ filters, setFilters }) => {
+  const causes = get(filters, 'causes', []);
+
+  const handleCauseSelect = event => {
+    trackAnalyticsEvent('clicked_filter_options_cause', {
+      action: 'button_clicked',
+      category: EVENT_CATEGORIES.filter,
+      label: event.target.value,
+      context: { value: event.target.value },
+    });
+
+    if (causes.includes(event.target.value)) {
+      const newCauses = causes.filter(cause => {
+        return cause !== event.target.value;
+      });
+      setFilters({ causes: [...newCauses] });
+    } else {
+      setFilters({ causes: [...causes, event.target.value] });
+    }
+  };
+
+  const clearAllSelected = () => {
+    trackAnalyticsEvent('clicked_filter_clear_options_cause', {
+      action: 'link_clicked',
+      category: EVENT_CATEGORIES.filter,
+      label: 'cause',
+    });
+
+    if (causes) {
+      setFilters({ causes: [] });
+    }
+  };
+
+  return (
+    <form>
+      <div className="cause-filter w-full p-4 flex flex-col flex-wrap">
+        {Object.keys(causeLabels).map(cause => {
+          return (
+            <CauseInput
+              key={cause}
+              handleSelect={handleCauseSelect}
+              causeName={causeLabels[cause]}
+              causeValue={cause}
+              isChecked={causes.includes(cause)}
+            />
+          );
+        })}
+      </div>
+
+      <div className="w-full flex justify-start py-2 px-4">
+        <ElementButton
+          className="font-bold p-2 text-blue-500 hover:text-blue-300"
+          text="clear"
+          onClick={clearAllSelected}
+        />
+      </div>
+    </form>
+  );
+};
+
+ActionFilter.propTypes = {
+  filters: PropTypes.object.isRequired,
+  setFilters: PropTypes.func.isRequired,
+};
+
+export default ActionFilter;

--- a/resources/assets/components/pages/CampaignsPage/CampaignFilters/ActionFilter/ActionFilter.js
+++ b/resources/assets/components/pages/CampaignsPage/CampaignFilters/ActionFilter/ActionFilter.js
@@ -27,6 +27,7 @@ const ActionFilter = ({ filters, setFilters }) => {
         ...filters.actions,
         actionTypes: [...newActionTypes],
       };
+
       setFilters({
         ...filters,
         actions: { ...actionsRemoved },
@@ -36,6 +37,7 @@ const ActionFilter = ({ filters, setFilters }) => {
         ...filters.actions,
         actionTypes: [...actionTypes, event.target.value],
       };
+
       setFilters({
         ...filters,
         actions: {

--- a/resources/assets/components/pages/CampaignsPage/CampaignFilters/ActionFilter/ActionFilter.js
+++ b/resources/assets/components/pages/CampaignsPage/CampaignFilters/ActionFilter/ActionFilter.js
@@ -104,7 +104,7 @@ const ActionFilter = ({ filters, setFilters }) => {
         </div>
         <div className="col-span-2">
           <h2 className="font-bold text-base pb-3">Type</h2>
-          <div className="lg:grid lg:grid-cols-2 flex flex-col flex-wrap w-full">
+          <div className="lg:grid lg:grid-cols-2">
             {Object.keys(actionTypeLabels).map(actionType => {
               return (
                 <ActionTypeInput

--- a/resources/assets/components/pages/CampaignsPage/CampaignFilters/ActionFilter/ActionFilter.js
+++ b/resources/assets/components/pages/CampaignsPage/CampaignFilters/ActionFilter/ActionFilter.js
@@ -15,11 +15,8 @@ import ElementButton from '../../../../utilities/Button/ElementButton';
  */
 const ActionFilter = ({ filters, setFilters }) => {
   const actionTypes = get(filters, 'actions.actionTypes', []);
-  const actionIsOnline = get(filters, 'actions.isOnline', null);
 
   const [actionLocation, setActionLocation] = useState('');
-  console.log('is online', actionIsOnline);
-  console.log('location', actionLocation);
 
   const handleActionTypeSelect = event => {
     if (actionTypes.includes(event.target.value)) {
@@ -63,8 +60,19 @@ const ActionFilter = ({ filters, setFilters }) => {
         },
       });
       setActionLocation(event.target.value);
+    } else if (
+      (event.target.value === 'in-person' && actionLocation === 'in-person') ||
+      (event.target.value === 'online' && actionLocation === 'online')
+    ) {
+      setFilters({
+        ...filters,
+        actions: {
+          ...filters.actions,
+          isOnline: null,
+        },
+      });
+      setActionLocation('');
     }
-    setActionLocation('');
   };
 
   const clearAllSelected = () => {

--- a/resources/assets/components/pages/CampaignsPage/CampaignFilters/ActionFilter/ActionFilter.js
+++ b/resources/assets/components/pages/CampaignsPage/CampaignFilters/ActionFilter/ActionFilter.js
@@ -1,10 +1,10 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { get } from 'lodash';
 import PropTypes from 'prop-types';
 
-// import ActionLocationInput, {
-//   actionLocationLabels,
-// } from './ActionLocationInput';
+import ActionLocationInput, {
+  actionLocationLabels,
+} from './ActionLocationInput';
 import ActionTypeInput, { actionTypeLabels } from './ActionTypeInput';
 import ElementButton from '../../../../utilities/Button/ElementButton';
 
@@ -14,8 +14,12 @@ import ElementButton from '../../../../utilities/Button/ElementButton';
  * @param {Object}
  */
 const ActionFilter = ({ filters, setFilters }) => {
-  //   const actionLocation = get(filters, 'actionLocation', false);
   const actionTypes = get(filters, 'actions.actionTypes', []);
+  const actionIsOnline = get(filters, 'actions.isOnline', null);
+
+  const [actionLocation, setActionLocation] = useState('');
+  console.log('is online', actionIsOnline);
+  console.log('location', actionLocation);
 
   const handleActionTypeSelect = event => {
     if (actionTypes.includes(event.target.value)) {
@@ -37,14 +41,42 @@ const ActionFilter = ({ filters, setFilters }) => {
     }
   };
 
+  const handleActionLocationSelect = event => {
+    if (event.target.value === 'online' && actionLocation !== 'online') {
+      setFilters({
+        ...filters,
+        actions: {
+          ...filters.actions,
+          isOnline: true,
+        },
+      });
+      setActionLocation(event.target.value);
+    } else if (
+      event.target.value === 'in-person' &&
+      actionLocation !== 'in-person'
+    ) {
+      setFilters({
+        ...filters,
+        actions: {
+          ...filters.actions,
+          isOnline: false,
+        },
+      });
+      setActionLocation(event.target.value);
+    }
+    setActionLocation('');
+  };
+
   const clearAllSelected = () => {
     if (actionTypes) {
       setFilters({
         ...filters,
-        actions: { ...filters.actions, actionTypes: [] },
+        actions: { actionTypes: [], isOnline: null },
       });
     }
+    setActionLocation('');
   };
+
   return (
     <form>
       <div className="cause-filter w-full p-4 flex flex-col flex-wrap">
@@ -56,6 +88,19 @@ const ActionFilter = ({ filters, setFilters }) => {
               actionTypeName={actionTypeLabels[actionType]}
               actionTypeValue={actionType}
               isChecked={actionTypes.includes(actionType)}
+            />
+          );
+        })}
+      </div>
+      <div className="cause-filter w-full p-4 flex flex-col flex-wrap">
+        {Object.keys(actionLocationLabels).map(actionLocationLabel => {
+          return (
+            <ActionLocationInput
+              key={actionLocationLabel}
+              handleSelect={handleActionLocationSelect}
+              actionLocationName={actionLocationLabels[actionLocationLabel]}
+              actionLocationValue={actionLocationLabel}
+              isChecked={actionLocationLabel === actionLocation}
             />
           );
         })}

--- a/resources/assets/components/pages/CampaignsPage/CampaignFilters/ActionFilter/ActionFilter.js
+++ b/resources/assets/components/pages/CampaignsPage/CampaignFilters/ActionFilter/ActionFilter.js
@@ -15,25 +15,36 @@ import ElementButton from '../../../../utilities/Button/ElementButton';
  */
 const ActionFilter = ({ filters, setFilters }) => {
   //   const actionLocation = get(filters, 'actionLocation', false);
-  const actionTypes = get(filters, 'actionTypes', []);
+  const actionTypes = get(filters, 'actions.actionTypes', []);
 
   const handleActionTypeSelect = event => {
     if (actionTypes.includes(event.target.value)) {
       const newActionTypes = actionTypes.filter(actionType => {
         return actionType !== event.target.value;
       });
-      setFilters({ actionTypes: [...newActionTypes] });
+      setFilters({
+        ...filters,
+        actions: { ...filters.actions, actionTypes: [...newActionTypes] },
+      });
     } else {
-      setFilters({ actionTypes: [...actionTypes, event.target.value] });
+      setFilters({
+        ...filters,
+        actions: {
+          ...filters.actions,
+          actionTypes: [...actionTypes, event.target.value],
+        },
+      });
     }
   };
 
   const clearAllSelected = () => {
     if (actionTypes) {
-      setFilters({ actionTypes: [] });
+      setFilters({
+        ...filters,
+        actions: { ...filters.actions, actionTypes: [] },
+      });
     }
   };
-  console.log('hello?');
   return (
     <form>
       <div className="cause-filter w-full p-4 flex flex-col flex-wrap">

--- a/resources/assets/components/pages/CampaignsPage/CampaignFilters/ActionFilter/ActionFilter.js
+++ b/resources/assets/components/pages/CampaignsPage/CampaignFilters/ActionFilter/ActionFilter.js
@@ -2,57 +2,11 @@ import React from 'react';
 import { get } from 'lodash';
 import PropTypes from 'prop-types';
 
+// import ActionLocationInput, {
+//   actionLocationLabels,
+// } from './ActionLocationInput';
+import ActionTypeInput, { actionTypeLabels } from './ActionTypeInput';
 import ElementButton from '../../../../utilities/Button/ElementButton';
-import {
-  EVENT_CATEGORIES,
-  trackAnalyticsEvent,
-} from '../../../../../helpers/analytics';
-
-const causeLabels = {
-  'animal-welfare': 'Animal Welfare',
-  bullying: 'Bullying',
-  education: 'Education',
-  environment: 'Environment',
-  'gender-rights': 'Gender Rights & Equality',
-  'homelessness-and-poverty': 'Homelessness & Poverty',
-  immigration: 'Immigration & Refugees',
-  'lgbtq-rights': 'LGBTQ+ Rights & Equality',
-  'mental-health': 'Mental Health',
-  'physical-health': 'Physical Health',
-  'racial-justice': 'Racial Justice & Equity',
-  'sexual-harassment': 'Sexual Harassment & Assault',
-};
-
-/**
- * Checkbox input component.
- *
- * @param {Object}
- */
-const CauseInput = ({ causeName, causeValue, handleSelect, isChecked }) => (
-  <label className="flex items-start justify-start pb-2" htmlFor={causeValue}>
-    <input
-      id={causeValue}
-      checked={isChecked}
-      className="mt-1"
-      name={causeValue}
-      onChange={handleSelect}
-      type="checkbox"
-      value={causeValue}
-    />
-    <span className="pl-4">{causeName}</span>
-  </label>
-);
-
-CauseInput.propTypes = {
-  isChecked: PropTypes.bool,
-  causeName: PropTypes.string.isRequired,
-  causeValue: PropTypes.string.isRequired,
-  handleSelect: PropTypes.func.isRequired,
-};
-
-CauseInput.defaultProps = {
-  isChecked: false,
-};
 
 /**
  * Filter menu form with series of checkbox inputs.
@@ -60,49 +14,37 @@ CauseInput.defaultProps = {
  * @param {Object}
  */
 const ActionFilter = ({ filters, setFilters }) => {
-  const causes = get(filters, 'causes', []);
+  //   const actionLocation = get(filters, 'actionLocation', false);
+  const actionTypes = get(filters, 'actionTypes', []);
 
-  const handleCauseSelect = event => {
-    trackAnalyticsEvent('clicked_filter_options_cause', {
-      action: 'button_clicked',
-      category: EVENT_CATEGORIES.filter,
-      label: event.target.value,
-      context: { value: event.target.value },
-    });
-
-    if (causes.includes(event.target.value)) {
-      const newCauses = causes.filter(cause => {
+  const handleActionTypeSelect = event => {
+    if (actionTypes.includes(event.target.value)) {
+      const newActionTypes = actionTypes.filter(cause => {
         return cause !== event.target.value;
       });
-      setFilters({ causes: [...newCauses] });
+      setFilters({ actionTypes: [...newActionTypes] });
     } else {
-      setFilters({ causes: [...causes, event.target.value] });
+      setFilters({ actionTypes: [...actionTypes, event.target.value] });
     }
   };
 
   const clearAllSelected = () => {
-    trackAnalyticsEvent('clicked_filter_clear_options_cause', {
-      action: 'link_clicked',
-      category: EVENT_CATEGORIES.filter,
-      label: 'cause',
-    });
-
-    if (causes) {
-      setFilters({ causes: [] });
+    if (actionTypes) {
+      setFilters({ actionTypes: [] });
     }
   };
 
   return (
     <form>
       <div className="cause-filter w-full p-4 flex flex-col flex-wrap">
-        {Object.keys(causeLabels).map(cause => {
+        {Object.keys(actionTypeLabels).map(actionType => {
           return (
-            <CauseInput
-              key={cause}
-              handleSelect={handleCauseSelect}
-              causeName={causeLabels[cause]}
-              causeValue={cause}
-              isChecked={causes.includes(cause)}
+            <ActionTypeInput
+              key={actionType}
+              handleSelect={handleActionTypeSelect}
+              actionTypeName={actionTypeLabels[actionType]}
+              actionTypeValue={actionType}
+              isChecked={actionTypes.includes(actionType)}
             />
           );
         })}

--- a/resources/assets/components/pages/CampaignsPage/CampaignFilters/ActionFilter/ActionFilter.js
+++ b/resources/assets/components/pages/CampaignsPage/CampaignFilters/ActionFilter/ActionFilter.js
@@ -15,7 +15,6 @@ import ElementButton from '../../../../utilities/Button/ElementButton';
  */
 const ActionFilter = ({ filters, setFilters }) => {
   const actionTypes = get(filters, 'actions.actionTypes', []);
-  console.log('actions added', actionTypes);
 
   const [actionLocation, setActionLocation] = useState('');
 

--- a/resources/assets/components/pages/CampaignsPage/CampaignFilters/ActionFilter/ActionFilter.js
+++ b/resources/assets/components/pages/CampaignsPage/CampaignFilters/ActionFilter/ActionFilter.js
@@ -87,34 +87,40 @@ const ActionFilter = ({ filters, setFilters }) => {
 
   return (
     <form>
-      <div className="cause-filter w-full p-4 flex flex-col flex-wrap">
-        {Object.keys(actionTypeLabels).map(actionType => {
-          return (
-            <ActionTypeInput
-              key={actionType}
-              handleSelect={handleActionTypeSelect}
-              actionTypeName={actionTypeLabels[actionType]}
-              actionTypeValue={actionType}
-              isChecked={actionTypes.includes(actionType)}
-            />
-          );
-        })}
-      </div>
-      <div className="cause-filter w-full p-4 flex flex-col flex-wrap">
-        {Object.keys(actionLocationLabels).map(actionLocationLabel => {
-          return (
-            <ActionLocationInput
-              key={actionLocationLabel}
-              handleSelect={handleActionLocationSelect}
-              actionLocationName={actionLocationLabels[actionLocationLabel]}
-              actionLocationValue={actionLocationLabel}
-              isChecked={actionLocationLabel === actionLocation}
-            />
-          );
-        })}
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 w-full p-4">
+        <div className="mb-6 lg:mb-0">
+          <h2 className="font-bold text-base pb-3">Location</h2>
+          {Object.keys(actionLocationLabels).map(actionLocationLabel => {
+            return (
+              <ActionLocationInput
+                key={actionLocationLabel}
+                handleSelect={handleActionLocationSelect}
+                actionLocationName={actionLocationLabels[actionLocationLabel]}
+                actionLocationValue={actionLocationLabel}
+                isChecked={actionLocationLabel === actionLocation}
+              />
+            );
+          })}
+        </div>
+        <div className="col-span-2">
+          <h2 className="font-bold text-base pb-3">Type</h2>
+          <div className="lg:grid lg:grid-cols-2 flex flex-col flex-wrap w-full">
+            {Object.keys(actionTypeLabels).map(actionType => {
+              return (
+                <ActionTypeInput
+                  key={actionType}
+                  handleSelect={handleActionTypeSelect}
+                  actionTypeName={actionTypeLabels[actionType]}
+                  actionTypeValue={actionType}
+                  isChecked={actionTypes.includes(actionType)}
+                />
+              );
+            })}
+          </div>
+        </div>
       </div>
 
-      <div className="w-full flex justify-start py-2 px-4">
+      <div className="w-full flex justify-start py-2">
         <ElementButton
           className="font-bold p-2 text-blue-500 hover:text-blue-300"
           text="clear"

--- a/resources/assets/components/pages/CampaignsPage/CampaignFilters/ActionFilter/ActionFilter.js
+++ b/resources/assets/components/pages/CampaignsPage/CampaignFilters/ActionFilter/ActionFilter.js
@@ -15,6 +15,7 @@ import ElementButton from '../../../../utilities/Button/ElementButton';
  */
 const ActionFilter = ({ filters, setFilters }) => {
   const actionTypes = get(filters, 'actions.actionTypes', []);
+  console.log('actions added', actionTypes);
 
   const [actionLocation, setActionLocation] = useState('');
 
@@ -23,56 +24,48 @@ const ActionFilter = ({ filters, setFilters }) => {
       const newActionTypes = actionTypes.filter(actionType => {
         return actionType !== event.target.value;
       });
+      const actionsRemoved = {
+        ...filters.actions,
+        actionTypes: [...newActionTypes],
+      };
       setFilters({
         ...filters,
-        actions: { ...filters.actions, actionTypes: [...newActionTypes] },
+        actions: { ...actionsRemoved },
       });
     } else {
+      const actionsAdded = {
+        ...filters.actions,
+        actionTypes: [...actionTypes, event.target.value],
+      };
       setFilters({
         ...filters,
         actions: {
-          ...filters.actions,
-          actionTypes: [...actionTypes, event.target.value],
+          ...actionsAdded,
         },
       });
     }
   };
 
   const handleActionLocationSelect = event => {
-    if (event.target.value === 'online' && actionLocation !== 'online') {
+    const selection = event.target.value;
+
+    if (actionLocation === selection) {
       setFilters({
         ...filters,
-        actions: {
-          ...filters.actions,
-          isOnline: true,
-        },
+        actions: { ...filters.actions, isOnline: null },
       });
-      setActionLocation(event.target.value);
-    } else if (
-      event.target.value === 'in-person' &&
-      actionLocation !== 'in-person'
-    ) {
-      setFilters({
-        ...filters,
-        actions: {
-          ...filters.actions,
-          isOnline: false,
-        },
-      });
-      setActionLocation(event.target.value);
-    } else if (
-      (event.target.value === 'in-person' && actionLocation === 'in-person') ||
-      (event.target.value === 'online' && actionLocation === 'online')
-    ) {
-      setFilters({
-        ...filters,
-        actions: {
-          ...filters.actions,
-          isOnline: null,
-        },
-      });
+
       setActionLocation('');
+
+      return;
     }
+
+    setFilters({
+      ...filters,
+      actions: { ...filters.actions, isOnline: selection === 'online' },
+    });
+
+    setActionLocation(selection);
   };
 
   const clearAllSelected = () => {
@@ -90,6 +83,7 @@ const ActionFilter = ({ filters, setFilters }) => {
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 w-full p-4">
         <div className="mb-6 lg:mb-0">
           <h2 className="font-bold text-base pb-3">Location</h2>
+
           {Object.keys(actionLocationLabels).map(actionLocationLabel => {
             return (
               <ActionLocationInput
@@ -102,8 +96,10 @@ const ActionFilter = ({ filters, setFilters }) => {
             );
           })}
         </div>
+
         <div className="col-span-2">
           <h2 className="font-bold text-base pb-3">Type</h2>
+
           <div className="lg:grid lg:grid-cols-2">
             {Object.keys(actionTypeLabels).map(actionType => {
               return (

--- a/resources/assets/components/pages/CampaignsPage/CampaignFilters/ActionFilter/ActionLocationInput.js
+++ b/resources/assets/components/pages/CampaignsPage/CampaignFilters/ActionFilter/ActionLocationInput.js
@@ -2,18 +2,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 export const actionLocationLabels = {
-  'animal-welfare': 'Animal Welfare',
-  bullying: 'Bullying',
-  education: 'Education',
-  environment: 'Environment',
-  'gender-rights': 'Gender Rights & Equality',
-  'homelessness-and-poverty': 'Homelessness & Poverty',
-  immigration: 'Immigration & Refugees',
-  'lgbtq-rights': 'LGBTQ+ Rights & Equality',
-  'mental-health': 'Mental Health',
-  'physical-health': 'Physical Health',
-  'racial-justice': 'Racial Justice & Equity',
-  'sexual-harassment': 'Sexual Harassment & Assault',
+  'in-person': 'In Person',
+  online: 'Online',
 };
 
 /**
@@ -22,29 +12,32 @@ export const actionLocationLabels = {
  * @param {Object}
  */
 const ActionLocationInput = ({
-  causeName,
-  causeValue,
+  actionLocationName,
+  actionLocationValue,
   handleSelect,
   isChecked,
 }) => (
-  <label className="flex items-start justify-start pb-2" htmlFor={causeValue}>
+  <label
+    className="flex items-start justify-start pb-2"
+    htmlFor={actionLocationValue}
+  >
     <input
-      id={causeValue}
+      id={actionLocationValue}
       checked={isChecked}
       className="mt-1"
-      name={causeValue}
+      name={actionLocationValue}
       onChange={handleSelect}
       type="checkbox"
-      value={causeValue}
+      value={actionLocationValue}
     />
-    <span className="pl-4">{causeName}</span>
+    <span className="pl-4">{actionLocationName}</span>
   </label>
 );
 
 ActionLocationInput.propTypes = {
   isChecked: PropTypes.bool,
-  causeName: PropTypes.string.isRequired,
-  causeValue: PropTypes.string.isRequired,
+  actionLocationName: PropTypes.string.isRequired,
+  actionLocationValue: PropTypes.string.isRequired,
   handleSelect: PropTypes.func.isRequired,
 };
 

--- a/resources/assets/components/pages/CampaignsPage/CampaignFilters/ActionFilter/ActionLocationInput.js
+++ b/resources/assets/components/pages/CampaignsPage/CampaignFilters/ActionFilter/ActionLocationInput.js
@@ -1,0 +1,55 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+export const actionLocationLabels = {
+  'animal-welfare': 'Animal Welfare',
+  bullying: 'Bullying',
+  education: 'Education',
+  environment: 'Environment',
+  'gender-rights': 'Gender Rights & Equality',
+  'homelessness-and-poverty': 'Homelessness & Poverty',
+  immigration: 'Immigration & Refugees',
+  'lgbtq-rights': 'LGBTQ+ Rights & Equality',
+  'mental-health': 'Mental Health',
+  'physical-health': 'Physical Health',
+  'racial-justice': 'Racial Justice & Equity',
+  'sexual-harassment': 'Sexual Harassment & Assault',
+};
+
+/**
+ * Checkbox input component.
+ *
+ * @param {Object}
+ */
+const ActionLocationInput = ({
+  causeName,
+  causeValue,
+  handleSelect,
+  isChecked,
+}) => (
+  <label className="flex items-start justify-start pb-2" htmlFor={causeValue}>
+    <input
+      id={causeValue}
+      checked={isChecked}
+      className="mt-1"
+      name={causeValue}
+      onChange={handleSelect}
+      type="checkbox"
+      value={causeValue}
+    />
+    <span className="pl-4">{causeName}</span>
+  </label>
+);
+
+ActionLocationInput.propTypes = {
+  isChecked: PropTypes.bool,
+  causeName: PropTypes.string.isRequired,
+  causeValue: PropTypes.string.isRequired,
+  handleSelect: PropTypes.func.isRequired,
+};
+
+ActionLocationInput.defaultProps = {
+  isChecked: false,
+};
+
+export default ActionLocationInput;

--- a/resources/assets/components/pages/CampaignsPage/CampaignFilters/ActionFilter/ActionTypeInput.js
+++ b/resources/assets/components/pages/CampaignsPage/CampaignFilters/ActionFilter/ActionTypeInput.js
@@ -2,18 +2,16 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 export const actionTypeLabels = {
-  'animal-welfare': 'Animal Welfare',
-  bullying: 'Bullying',
-  education: 'Education',
-  environment: 'Environment',
-  'gender-rights': 'Gender Rights & Equality',
-  'homelessness-and-poverty': 'Homelessness & Poverty',
-  immigration: 'Immigration & Refugees',
-  'lgbtq-rights': 'LGBTQ+ Rights & Equality',
-  'mental-health': 'Mental Health',
-  'physical-health': 'Physical Health',
-  'racial-justice': 'Racial Justice & Equity',
-  'sexual-harassment': 'Sexual Harassment & Assault',
+  'attend-event': 'Attend an Event',
+  'collect-something': 'Collect Something',
+  'contact-decisionmaker': 'Contact a Decision-Maker',
+  'donate-something': 'Donate Something',
+  'flag-content': 'Flag Content',
+  'have-a-conversation': 'Have A Conversation',
+  'host-event': 'Host An Event',
+  'make-something': 'Make Something',
+  'share-something': 'Share Something',
+  'sign-petition': 'Sign A Petition',
 };
 
 /**

--- a/resources/assets/components/pages/CampaignsPage/CampaignFilters/ActionFilter/ActionTypeInput.js
+++ b/resources/assets/components/pages/CampaignsPage/CampaignFilters/ActionFilter/ActionTypeInput.js
@@ -1,0 +1,58 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+export const actionTypeLabels = {
+  'animal-welfare': 'Animal Welfare',
+  bullying: 'Bullying',
+  education: 'Education',
+  environment: 'Environment',
+  'gender-rights': 'Gender Rights & Equality',
+  'homelessness-and-poverty': 'Homelessness & Poverty',
+  immigration: 'Immigration & Refugees',
+  'lgbtq-rights': 'LGBTQ+ Rights & Equality',
+  'mental-health': 'Mental Health',
+  'physical-health': 'Physical Health',
+  'racial-justice': 'Racial Justice & Equity',
+  'sexual-harassment': 'Sexual Harassment & Assault',
+};
+
+/**
+ * Checkbox input component.
+ *
+ * @param {Object}
+ */
+const ActionTypeInput = ({
+  actionTypeName,
+  actionTypeValue,
+  handleSelect,
+  isChecked,
+}) => (
+  <label
+    className="flex items-start justify-start pb-2"
+    htmlFor={actionTypeValue}
+  >
+    <input
+      id={actionTypeValue}
+      checked={isChecked}
+      className="mt-1"
+      name={actionTypeValue}
+      onChange={handleSelect}
+      type="checkbox"
+      value={actionTypeValue}
+    />
+    <span className="pl-4">{actionTypeName}</span>
+  </label>
+);
+
+ActionTypeInput.propTypes = {
+  isChecked: PropTypes.bool,
+  actionTypeName: PropTypes.string.isRequired,
+  actionTypeValue: PropTypes.string.isRequired,
+  handleSelect: PropTypes.func.isRequired,
+};
+
+ActionTypeInput.defaultProps = {
+  isChecked: false,
+};
+
+export default ActionTypeInput;

--- a/resources/assets/components/pages/CampaignsPage/CampaignFilters/CauseFilter/CauseFilter.js
+++ b/resources/assets/components/pages/CampaignsPage/CampaignFilters/CauseFilter/CauseFilter.js
@@ -74,9 +74,9 @@ const CauseFilter = ({ filters, setFilters }) => {
       const newCauses = causes.filter(cause => {
         return cause !== event.target.value;
       });
-      setFilters({ causes: [...newCauses] });
+      setFilters({ ...filters, causes: [...newCauses] });
     } else {
-      setFilters({ causes: [...causes, event.target.value] });
+      setFilters({ ...filters, causes: [...causes, event.target.value] });
     }
   };
 
@@ -88,7 +88,7 @@ const CauseFilter = ({ filters, setFilters }) => {
     });
 
     if (causes) {
-      setFilters({ causes: [] });
+      setFilters({ ...filters, causes: [] });
     }
   };
 

--- a/resources/assets/components/pages/CampaignsPage/CampaignsIndexPage.js
+++ b/resources/assets/components/pages/CampaignsPage/CampaignsIndexPage.js
@@ -11,7 +11,7 @@ import './campaigns-page.scss';
 const CampaignsIndexPage = () => {
   const [filters, setFilters] = useState({
     causes: [],
-    actions: { actionTypes: [], actionLocation: null },
+    actions: { actionTypes: [], isOnline: null },
   });
 
   return (
@@ -30,6 +30,7 @@ const CampaignsIndexPage = () => {
             className="grid-full px-6 md:px-0"
             itemsPerRow={4}
             variables={{
+              isOnline: get(filters, 'actions.isOnline', null),
               isOpen: true,
               first: 36,
               orderBy: 'start_date,desc',

--- a/resources/assets/components/pages/CampaignsPage/CampaignsIndexPage.js
+++ b/resources/assets/components/pages/CampaignsPage/CampaignsIndexPage.js
@@ -9,7 +9,10 @@ import PaginatedCampaignGallery from '../../utilities/PaginatedCampaignGallery/P
 import './campaigns-page.scss';
 
 const CampaignsIndexPage = () => {
-  const [filters, setFilters] = useState({ causes: [], actionTypes: [] });
+  const [filters, setFilters] = useState({
+    causes: [],
+    actions: { actionTypes: [], actionLocation: null },
+  });
 
   return (
     <>
@@ -33,7 +36,7 @@ const CampaignsIndexPage = () => {
               // @TODO depending on future implementation of filters in rogue,
               // potentially concatenate all filters to single array 🤔
               causes: get(filters, 'causes', []),
-              actionTypes: get(filters, 'actionTypes', []),
+              actionTypes: get(filters, 'actions.actionTypes', []),
             }}
           />
         </div>

--- a/resources/assets/components/pages/CampaignsPage/CampaignsIndexPage.js
+++ b/resources/assets/components/pages/CampaignsPage/CampaignsIndexPage.js
@@ -33,6 +33,7 @@ const CampaignsIndexPage = () => {
               // @TODO depending on future implementation of filters in rogue,
               // potentially concatenate all filters to single array 🤔
               causes: get(filters, 'causes', []),
+              actionTypes: get(filters, 'actionTypes', []),
             }}
           />
         </div>

--- a/resources/assets/components/pages/CampaignsPage/CampaignsIndexPage.js
+++ b/resources/assets/components/pages/CampaignsPage/CampaignsIndexPage.js
@@ -1,6 +1,7 @@
 import { get } from 'lodash';
 import React, { useState } from 'react';
 
+import { featureFlag } from '../../../helpers/env';
 import SiteFooter from '../../utilities/SiteFooter/SiteFooter';
 import FilterNavigation from './FilterNavigation/FilterNavigation';
 import SiteNavigationContainer from '../../SiteNavigation/SiteNavigationContainer';
@@ -9,10 +10,16 @@ import PaginatedCampaignGallery from '../../utilities/PaginatedCampaignGallery/P
 import './campaigns-page.scss';
 
 const CampaignsIndexPage = () => {
-  const [filters, setFilters] = useState({
-    causes: [],
-    actions: { actionTypes: [], isOnline: null },
-  });
+  const [filters, setFilters] = useState(
+    featureFlag('algolia_campaigns_search')
+      ? {
+          causes: [],
+          actions: { actionTypes: [], isOnline: null },
+        }
+      : {
+          causes: [],
+        },
+  );
 
   return (
     <>

--- a/resources/assets/components/pages/CampaignsPage/CampaignsIndexPage.js
+++ b/resources/assets/components/pages/CampaignsPage/CampaignsIndexPage.js
@@ -9,7 +9,7 @@ import PaginatedCampaignGallery from '../../utilities/PaginatedCampaignGallery/P
 import './campaigns-page.scss';
 
 const CampaignsIndexPage = () => {
-  const [filters, setFilters] = useState({ causes: [] });
+  const [filters, setFilters] = useState({ causes: [], actionTypes: [] });
 
   return (
     <>

--- a/resources/assets/components/pages/CampaignsPage/FilterNavigation/FilterSubNav.js
+++ b/resources/assets/components/pages/CampaignsPage/FilterNavigation/FilterSubNav.js
@@ -4,6 +4,7 @@ import classNames from 'classnames';
 
 import { withoutNulls } from '../../../../helpers/data';
 import CauseFilter from '../CampaignFilters/CauseFilter/CauseFilter';
+import ActionFilter from '../CampaignFilters/ActionFilter/ActionFilter';
 
 const renderedFilterMenu = props => {
   const fields = withoutNulls(props);
@@ -11,6 +12,10 @@ const renderedFilterMenu = props => {
     case 'cause':
       return (
         <CauseFilter filters={fields.filters} setFilters={fields.setFilters} />
+      );
+    case 'actionType':
+      return (
+        <ActionFilter filters={fields.filters} setFilters={fields.setFilters} />
       );
 
     default:

--- a/resources/assets/components/pages/CampaignsPage/FilterNavigation/FilterSubNav.js
+++ b/resources/assets/components/pages/CampaignsPage/FilterNavigation/FilterSubNav.js
@@ -13,7 +13,7 @@ const renderedFilterMenu = props => {
       return (
         <CauseFilter filters={fields.filters} setFilters={fields.setFilters} />
       );
-    case 'actionType':
+    case 'action':
       return (
         <ActionFilter filters={fields.filters} setFilters={fields.setFilters} />
       );

--- a/resources/assets/components/utilities/PaginatedCampaignGallery/PaginatedCampaignGallery.js
+++ b/resources/assets/components/utilities/PaginatedCampaignGallery/PaginatedCampaignGallery.js
@@ -54,20 +54,24 @@ const PAGINATED_CAMPAIGNS_QUERY = gql`
 
 const SEARCH_CAMPAIGNS_QUERY = gql`
   query SearchCampaignQuery(
+    $actionTypes: [String]
     $causes: [String]
     $cursor: String
     $excludeIds: [Int]
     $first: Int
+    $isOnline: Boolean
     $isOpen: Boolean
     $orderBy: String
   ) {
     campaigns: searchCampaigns(
+      actionTypes: $actionTypes
       cursor: $cursor
       causes: $causes
       excludeIds: $excludeIds
       perPage: $first
       hasWebsite: true
       isGroupCampaign: false
+      isOnline: $isOnline
       isOpen: $isOpen
       orderBy: $orderBy
     ) {


### PR DESCRIPTION
### What's this PR do?

This pull request adds a new filter option to the campaign page and two new query options for the `SEARCH CAMPAIGNS` query. We are using new facets in algolia to search for campaigns whose actions are of a specific type are are online/in-person. 

### How should this be reviewed?

Definitely interested in feedback around making the `handleLocationTypeSelect` a little cleaner? Maybe it's fine, but it feels a bit clunky to me. Idk! 

### Any background context you want to provide?

The action button is set to only show up for user when the algolia feature flag is on for PROD. 

Large Screen:
<img width="1383" alt="Screen Shot 2021-02-08 at 12 27 44 PM" src="https://user-images.githubusercontent.com/15236023/107258744-281ae300-6a0a-11eb-88cd-f852300f76f2.png">

Medium Screen: 
<img width="581" alt="Screen Shot 2021-02-08 at 12 28 13 PM" src="https://user-images.githubusercontent.com/15236023/107258772-2fda8780-6a0a-11eb-967d-691808a3574b.png">

Small Screen:
<img width="379" alt="Screen Shot 2021-02-08 at 12 28 30 PM" src="https://user-images.githubusercontent.com/15236023/107258783-349f3b80-6a0a-11eb-868c-3ab7a17b6bcf.png">



### Relevant tickets

References [Pivotal #173713718](https://www.pivotaltracker.com/story/show/173713718).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [x] Added screenshots of front-end changes on small, medium, and large screens.
- [ ] Added appropriate feature/unit tests.
