### PR TITLE
Re-arrange mock query on petition post-submission cypress test to hopefully fix the flakiness

### DIFF
--- a/cypress/integration/campaign-post.js
+++ b/cypress/integration/campaign-post.js
@@ -333,14 +333,14 @@ describe('Campaign Post', () => {
       const response = newTextPost(campaignId, user, text);
       cy.route('POST', POSTS_API, response).as('submitPost');
 
-      cy.get('.petition-submission-action textarea').type(text);
-      cy.get('.petition-submission-action button[type="submit"]').click();
-
       cy.mockGraphqlOp('PostQuery', {
         post: {
           userId: user.id,
         },
       });
+
+      cy.get('.petition-submission-action textarea').type(text);
+      cy.get('.petition-submission-action button[type="submit"]').click();
 
       cy.wait('@submitPost');
 


### PR DESCRIPTION
### What's this PR do?

This pull request attempts to address the flakey errors we keep seeing from the Petition post-submission redirect Cypress test by re-arranging where we setup the mock GraphQL query to align with the other tests.

### How should this be reviewed?
👀 

### Any background context you want to provide?
#2535 confirmed that the issue here is the post's `user.id` which is stubbed to match the authed user is _not_ yielding the stubbed result.
![image](https://user-images.githubusercontent.com/12417657/107534678-12cec180-6b8e-11eb-8672-38d9030edd16.png)
