### PR TITLE
wraps variables in withoutNulls to avoid graphql error

### DIFF
--- a/resources/assets/components/pages/CampaignsPage/CampaignsIndexPage.js
+++ b/resources/assets/components/pages/CampaignsPage/CampaignsIndexPage.js
@@ -2,7 +2,6 @@ import { get } from 'lodash';
 import React, { useState } from 'react';
 
 import { featureFlag } from '../../../helpers/env';
-import { withoutNulls } from '../../../helpers/data';
 import SiteFooter from '../../utilities/SiteFooter/SiteFooter';
 import FilterNavigation from './FilterNavigation/FilterNavigation';
 import SiteNavigationContainer from '../../SiteNavigation/SiteNavigationContainer';
@@ -37,7 +36,7 @@ const CampaignsIndexPage = () => {
           <PaginatedCampaignGallery
             className="grid-full px-6 md:px-0"
             itemsPerRow={4}
-            variables={withoutNulls({
+            variables={{
               isOnline: get(filters, 'actions.isOnline', null),
               isOpen: true,
               first: 36,
@@ -46,7 +45,7 @@ const CampaignsIndexPage = () => {
               // potentially concatenate all filters to single array 🤔
               causes: get(filters, 'causes', []),
               actionTypes: get(filters, 'actions.actionTypes', []),
-            })}
+            }}
           />
         </div>
       </main>

--- a/resources/assets/components/pages/CampaignsPage/CampaignsIndexPage.js
+++ b/resources/assets/components/pages/CampaignsPage/CampaignsIndexPage.js
@@ -2,6 +2,7 @@ import { get } from 'lodash';
 import React, { useState } from 'react';
 
 import { featureFlag } from '../../../helpers/env';
+import { withoutNulls } from '../../../helpers/data';
 import SiteFooter from '../../utilities/SiteFooter/SiteFooter';
 import FilterNavigation from './FilterNavigation/FilterNavigation';
 import SiteNavigationContainer from '../../SiteNavigation/SiteNavigationContainer';
@@ -36,7 +37,7 @@ const CampaignsIndexPage = () => {
           <PaginatedCampaignGallery
             className="grid-full px-6 md:px-0"
             itemsPerRow={4}
-            variables={{
+            variables={withoutNulls({
               isOnline: get(filters, 'actions.isOnline', null),
               isOpen: true,
               first: 36,
@@ -45,7 +46,7 @@ const CampaignsIndexPage = () => {
               // potentially concatenate all filters to single array 🤔
               causes: get(filters, 'causes', []),
               actionTypes: get(filters, 'actions.actionTypes', []),
-            }}
+            })}
           />
         </div>
       </main>

--- a/resources/assets/components/utilities/PaginatedCampaignGallery/PaginatedCampaignGallery.js
+++ b/resources/assets/components/utilities/PaginatedCampaignGallery/PaginatedCampaignGallery.js
@@ -6,6 +6,7 @@ import { useQuery } from '@apollo/react-hooks';
 
 import { updateQuery } from '../../../helpers';
 import ElementButton from '../Button/ElementButton';
+import { withoutNulls } from '../../../helpers/data';
 import Spinner from '../../artifacts/Spinner/Spinner';
 import ErrorBlock from '../../blocks/ErrorBlock/ErrorBlock';
 import { featureFlag, siteConfig } from '../../../helpers/env';
@@ -107,7 +108,7 @@ const PaginatedCampaignGallery = ({
       ? SEARCH_CAMPAIGNS_QUERY
       : PAGINATED_CAMPAIGNS_QUERY,
     {
-      variables: { ...variables, excludeIds },
+      variables: withoutNulls({ ...variables, excludeIds }),
       notifyOnNetworkStatusChange: true,
     },
   );


### PR DESCRIPTION
### What's this PR do?

This pull request wraps the variables passed to the search query for the campaigns page in our `withoutNulls` helper to avoid errors thrown by algolia.

### How should this be reviewed?

👀 

### Any background context you want to provide?

@mendelB flagged as an issue with a failing ghosty test and an issue he's seen before with other algolia searches.

### Relevant tickets

References [Pivotal #173713718](https://www.pivotaltracker.com/story/show/173713718).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
