### PR TITLE
Add 'sponsors' field to the Home Page content type.

### DIFF
--- a/contentful/content-types/homePage.js
+++ b/contentful/content-types/homePage.js
@@ -97,6 +97,27 @@ module.exports = function(migration) {
     });
 
   homePage
+    .createField('sponsors')
+    .name('Sponsors')
+    .type('Array')
+    .localized(false)
+    .required(false)
+    .validations([])
+    .disabled(false)
+    .omitted(false)
+    .items({
+      type: 'Link',
+
+      validations: [
+        {
+          linkContentType: ['affiliates'],
+        },
+      ],
+
+      linkType: 'Entry',
+    });
+
+  homePage
     .createField('additionalContent')
     .name('Additional Content')
     .type('Object')
@@ -130,6 +151,7 @@ module.exports = function(migration) {
     showCreateEntityAction: true,
   });
 
+  homePage.changeFieldControl('sponsors', 'builtin', 'entryLinksEditor', {});
   homePage.changeFieldControl(
     'additionalContent',
     'builtin',

--- a/contentful/content-types/homePage.js
+++ b/contentful/content-types/homePage.js
@@ -35,7 +35,6 @@ module.exports = function(migration) {
       },
       {
         assetFileSize: {
-          min: null,
           max: 20971520,
         },
       },
@@ -50,7 +49,16 @@ module.exports = function(migration) {
     .type('Array')
     .localized(false)
     .required(false)
-    .validations([])
+    .validations([
+      {
+        size: {
+          min: 7,
+          max: 7,
+        },
+
+        message: 'Please add exactly seven campaigns',
+      },
+    ])
     .disabled(false)
     .omitted(false)
     .items({
@@ -99,7 +107,13 @@ module.exports = function(migration) {
     .omitted(false);
   homePage.changeFieldControl('internalTitle', 'builtin', 'singleLine', {});
   homePage.changeFieldControl('title', 'builtin', 'singleLine', {});
-  homePage.changeFieldControl('coverImage', 'builtin', 'assetLinkEditor', {});
+
+  homePage.changeFieldControl('coverImage', 'builtin', 'assetLinkEditor', {
+    helpText:
+      'Cover image to display as background for the top banner on the home page.',
+    showLinkEntityAction: true,
+    showCreateEntityAction: true,
+  });
 
   homePage.changeFieldControl('campaigns', 'builtin', 'entryLinksEditor', {
     helpText:
@@ -112,6 +126,8 @@ module.exports = function(migration) {
   homePage.changeFieldControl('articles', 'builtin', 'entryLinksEditor', {
     helpText: 'Add articles (Page entries) to showcase on the home page.',
     bulkEditing: false,
+    showLinkEntityAction: true,
+    showCreateEntityAction: true,
   });
 
   homePage.changeFieldControl(


### PR DESCRIPTION
### What's this PR do?

This pull request adds the `sponsors` field to our homepage, which we'll use to let staffers edit this via the web!

### How should this be reviewed?

We saw some changes on QA that hadn't yet been committed here, and included them in 04c6d86.

Our changes for this feature are in 0cbd646.

### Any background context you want to provide?

📄 

### Relevant tickets

References [Pivotal #176745829](https://www.pivotaltracker.com/story/show/176745829).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added screenshots of front-end changes on small, medium, and large screens.
- [ ] Added appropriate feature/unit tests.
