### PR TITLE
Updates Order of Options for Time Commitment

### DIFF
--- a/resources/assets/components/pages/CampaignsPage/CampaignFilters/TimeFilter/TimeFilter.js
+++ b/resources/assets/components/pages/CampaignsPage/CampaignFilters/TimeFilter/TimeFilter.js
@@ -10,10 +10,10 @@ import ElementButton from '../../../../utilities/Button/ElementButton';
 
 const timeCommitmentLabels = {
   "'<0.083'": '< 5 minutes',
-  "'<0.5'": '< 30 minutes',
-  '0.5-1.0': '30 minutes - 1 hour',
   '1.0-3.0': '1 - 3 hours',
+  "'<0.5'": '< 30 minutes',
   '3.0+': '3+ hours',
+  '0.5-1.0': '30 minutes - 1 hour',
 };
 
 /**


### PR DESCRIPTION
### What's this PR do?

This pull request updates the order the options display on the time commitment filter.

### How should this be reviewed?

OLD:
<img width="513" alt="Screen Shot 2021-02-18 at 3 30 27 PM" src="https://user-images.githubusercontent.com/15236023/108417828-76946280-71fe-11eb-828c-1bae23ca1687.png">

NEW:
<img width="444" alt="Screen Shot 2021-02-18 at 3 29 52 PM" src="https://user-images.githubusercontent.com/15236023/108417856-7e540700-71fe-11eb-8a70-b419aed1badf.png">


### Any background context you want to provide?

Design feedback!

### Relevant tickets

References [Pivotal #173713859](https://www.pivotaltracker.com/story/show/173713859).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [x] Added screenshots of front-end changes on small, medium, and large screens.
