### PR TITLE
Update StartVoterRegistrationForm for usage in VR Marketing Page

### DIFF
--- a/resources/assets/components/blocks/ScholarshipReferralVoterRegistrationBlock/ScholarshipReferralVoterRegistrationBlock.js
+++ b/resources/assets/components/blocks/ScholarshipReferralVoterRegistrationBlock/ScholarshipReferralVoterRegistrationBlock.js
@@ -55,12 +55,16 @@ const ScholarshipReferralVoterRegistrationBlock = ({
         </div>
       </div>
       <div className="md:w-1/2 p-6 md:py-6 md:px-16 text-base scholarship-info-block">
-        <StartVoterRegistrationForm
-          campaignId={campaignId}
-          className="my-6"
-          contextSource="voter-registration-quiz-ungated-signup-modal"
-          sourceDetails="VoterRegQuiz_ScholarshipReferral"
-        />
+        <Card
+          title="Register to Vote"
+          className="my-6 bg-gray-100 border-none rounded"
+        >
+          <StartVoterRegistrationForm
+            campaignId={campaignId}
+            contextSource="voter-registration-quiz-ungated-signup-modal"
+            sourceDetails="VoterRegQuiz_ScholarshipReferral"
+          />
+        </Card>
       </div>
     </Card>
   );

--- a/resources/assets/components/pages/AccountPage/VoterReg/VoterRegStatusBlock.js
+++ b/resources/assets/components/pages/AccountPage/VoterReg/VoterRegStatusBlock.js
@@ -93,6 +93,7 @@ const VoterRegStatusBlock = ({ userId }) => {
         <p>We don&#39;t have your voter registration.</p>
         <a
           href={`https://vote.dosomething.org/?r=${getTrackingSource(
+            'web',
             'profile',
           )}`}
           target="_blank"

--- a/resources/assets/components/pages/QuizResultPage/QuizResultPage.js
+++ b/resources/assets/components/pages/QuizResultPage/QuizResultPage.js
@@ -7,6 +7,7 @@ import ErrorPage from '../ErrorPage';
 import triangle from './triangle.svg';
 import gqlVariables from './config';
 import NotFoundPage from '../NotFoundPage';
+import Card from '../../utilities/Card/Card';
 import Placeholder from '../../utilities/Placeholder';
 import { isDevEnvironment } from '../../../helpers/env';
 import SiteFooter from '../../utilities/SiteFooter/SiteFooter';
@@ -104,11 +105,16 @@ const QuizResultPage = ({ id }) => {
                 <p className="mb-6 text-lg text-center">
                   Take 2 minutes and register online now with your state.
                 </p>
-                <StartVoterRegistrationForm
-                  contextSource="voter-registration-quiz-results-page"
-                  className="md:mx-auto xl:w-4/5 pb-3"
-                  sourceDetails={additionalContent.sourceDetails}
-                />
+                <Card
+                  title="Register to Vote"
+                  className="pb-3 md:mx-auto xl:w-4/5 bg-gray-100 border-none rounded"
+                >
+                  <StartVoterRegistrationForm
+                    className="mx-auto xl:w-4/5"
+                    contextSource="voter-registration-quiz-results-page"
+                    sourceDetails={additionalContent.sourceDetails}
+                  />
+                </Card>
               </div>
             ) : null}
 

--- a/resources/assets/components/pages/VoterRegistrationDrivePage/VoterRegistrationDrivePage.js
+++ b/resources/assets/components/pages/VoterRegistrationDrivePage/VoterRegistrationDrivePage.js
@@ -127,7 +127,6 @@ const VoterRegistrationDrivePage = () => {
             customProps={{ ContentBlock: { fullWidth: true } }}
           />
           <StartVoterRegistrationForm
-            betaPage
             className="grid-wide-3/10"
             campaignId={campaignId}
             contextSource="beta-voter-registration-drive-page"

--- a/resources/assets/components/pages/VoterRegistrationMarketingPage/VoterRegistrationMarketingPage.js
+++ b/resources/assets/components/pages/VoterRegistrationMarketingPage/VoterRegistrationMarketingPage.js
@@ -3,6 +3,7 @@ import React from 'react';
 import SiteFooter from '../../utilities/SiteFooter/SiteFooter';
 import SocialShareTray from '../../utilities/SocialShareTray/SocialShareTray';
 import SiteNavigationContainer from '../../SiteNavigation/SiteNavigationContainer';
+import StartVoterRegistrationForm from '../../utilities/StartVoterRegistrationForm/StartVoterRegistrationForm';
 import {
   contentfulImageUrl,
   contentfulImageSrcset,
@@ -19,6 +20,9 @@ const srcset = contentfulImageSrcset(coverImage, [
 
 const logo =
   'https://images.ctfassets.net/81iqaqpfd8fy/SeD5JGpeLfF9BDoDPwwEu/1969bd8c18a1dc67720d9e10e3d4640b/Niche-logo---Horizontal-white.png';
+
+const source = 'marketing-partner';
+const sourceDetails = 'niche';
 
 const VoterRegistrationMarketingPage = () => (
   <>
@@ -58,6 +62,14 @@ const VoterRegistrationMarketingPage = () => (
           >
             Take 2 minutes to register to vote at your current address.
           </h2>
+
+          <StartVoterRegistrationForm
+            className="max-w-lg m-auto"
+            contextSource="voter-registration-marketing-page"
+            buttonText="Get Started"
+            source={source}
+            sourceDetails={sourceDetails}
+          />
         </div>
 
         <SocialShareTray

--- a/resources/assets/components/utilities/StartVoterRegistrationForm/StartVoterRegistrationForm.js
+++ b/resources/assets/components/utilities/StartVoterRegistrationForm/StartVoterRegistrationForm.js
@@ -13,6 +13,7 @@ import { getTrackingSource } from '../../../helpers/voter-registration';
 
 const StartVoterRegistrationForm = ({
   betaPage,
+  buttonText,
   campaignId,
   className,
   contextSource,
@@ -105,16 +106,16 @@ const StartVoterRegistrationForm = ({
 
           <PrimaryButton
             attributes={{ 'data-testid': 'voter-registration-submit-button' }}
-            className="w-full"
+            className="w-full flex justify-center"
             isDisabled={isDisabled}
             text={
               submitted ? (
-                <div className="flex justify-center">
+                <>
                   <Spinner />
                   <span className="pl-1 pt-1">Processing...</span>
-                </div>
+                </>
               ) : (
-                'Start Registration'
+                buttonText
               )
             }
             type="submit"
@@ -127,6 +128,7 @@ const StartVoterRegistrationForm = ({
 
 StartVoterRegistrationForm.propTypes = {
   betaPage: PropTypes.bool,
+  buttonText: PropTypes.string,
   campaignId: PropTypes.number,
   className: PropTypes.string,
   contextSource: PropTypes.string.isRequired,
@@ -138,6 +140,7 @@ StartVoterRegistrationForm.propTypes = {
 
 StartVoterRegistrationForm.defaultProps = {
   betaPage: false,
+  buttonText: 'Start Registration',
   campaignId: null,
   className: null,
   groupId: null,

--- a/resources/assets/components/utilities/StartVoterRegistrationForm/StartVoterRegistrationForm.js
+++ b/resources/assets/components/utilities/StartVoterRegistrationForm/StartVoterRegistrationForm.js
@@ -2,7 +2,6 @@ import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import React, { useState } from 'react';
 
-import Card from '../Card/Card';
 import {
   EVENT_CATEGORIES,
   trackAnalyticsEvent,
@@ -12,7 +11,6 @@ import Spinner from '../../artifacts/Spinner/Spinner';
 import { getTrackingSource } from '../../../helpers/voter-registration';
 
 const StartVoterRegistrationForm = ({
-  betaPage,
   buttonText,
   campaignId,
   className,
@@ -48,86 +46,77 @@ const StartVoterRegistrationForm = ({
   };
 
   return (
-    <>
-      <Card
-        attributes={{ 'data-testid': 'voter-registration-form-card' }}
-        className={classnames(className, 'bg-gray-100 border-none')}
-        title={!betaPage ? 'Register to Vote' : ''}
-      >
-        <form
-          data-testid="voter-registration-form"
-          action="https://register.rockthevote.com/registrants/new"
-          method="GET"
-          onSubmit={handleSubmit}
-          className={classnames('form p-3', className)}
-        >
-          <input type="hidden" name="partner" value="37187" />
+    <form
+      data-testid="voter-registration-form"
+      action="https://register.rockthevote.com/registrants/new"
+      method="GET"
+      onSubmit={handleSubmit}
+      className={classnames('form p-3', className)}
+    >
+      <input type="hidden" name="partner" value="37187" />
 
-          <input
-            type="hidden"
-            name="source"
-            value={getTrackingSource(
-              source,
-              sourceDetails,
-              referrerUserId,
-              groupId,
-            )}
-            data-testid="voter-registration-tracking-source"
-          />
+      <input
+        type="hidden"
+        name="source"
+        value={getTrackingSource(
+          source,
+          sourceDetails,
+          referrerUserId,
+          groupId,
+        )}
+        data-testid="voter-registration-tracking-source"
+      />
 
-          <div className="form-item stretched">
-            <input
-              className="text-field"
-              required
-              aria-label="Email"
-              type="email"
-              name="email_address"
-              value={email}
-              onChange={handleChange}
-              data-testid="voter-registration-email-field"
-              placeholder="Email"
-            />
-          </div>
+      <div className="form-item stretched">
+        <input
+          className="text-field"
+          required
+          aria-label="Email"
+          type="email"
+          name="email_address"
+          value={email}
+          onChange={handleChange}
+          data-testid="voter-registration-email-field"
+          placeholder="Email"
+        />
+      </div>
 
-          <div className="form-item stretched">
-            <input
-              className="text-field"
-              aria-label="Zip Code"
-              type="text"
-              name="home_zip_code"
-              value={zip}
-              onChange={handleChange}
-              required
-              pattern="^\s*?\d{5}(?:[-\s]\d{4})?\s*?$"
-              data-testid="voter-registration-zip-field"
-              placeholder="Zip Code"
-            />
-          </div>
+      <div className="form-item stretched">
+        <input
+          className="text-field"
+          aria-label="Zip Code"
+          type="text"
+          name="home_zip_code"
+          value={zip}
+          onChange={handleChange}
+          required
+          pattern="^\s*?\d{5}(?:[-\s]\d{4})?\s*?$"
+          data-testid="voter-registration-zip-field"
+          placeholder="Zip Code"
+        />
+      </div>
 
-          <PrimaryButton
-            attributes={{ 'data-testid': 'voter-registration-submit-button' }}
-            className="w-full flex justify-center"
-            isDisabled={isDisabled}
-            text={
-              submitted ? (
-                <>
-                  <Spinner />
-                  <span className="pl-1 pt-1">Processing...</span>
-                </>
-              ) : (
-                buttonText
-              )
-            }
-            type="submit"
-          />
-        </form>
-      </Card>
-    </>
+      <PrimaryButton
+        attributes={{ 'data-testid': 'voter-registration-submit-button' }}
+        className="w-full flex justify-center"
+        isDisabled={isDisabled}
+        text={
+          submitted ? (
+            <>
+              <Spinner />
+              <span className="pl-1 pt-1">Processing...</span>
+            </>
+          ) : (
+            buttonText
+          )
+        }
+        type="submit"
+      />
+    </form>
   );
 };
 
 StartVoterRegistrationForm.propTypes = {
-  betaPage: PropTypes.bool,
   buttonText: PropTypes.string,
   campaignId: PropTypes.number,
   className: PropTypes.string,
@@ -139,7 +128,6 @@ StartVoterRegistrationForm.propTypes = {
 };
 
 StartVoterRegistrationForm.defaultProps = {
-  betaPage: false,
   buttonText: 'Start Registration',
   campaignId: null,
   className: null,

--- a/resources/assets/components/utilities/StartVoterRegistrationForm/StartVoterRegistrationForm.js
+++ b/resources/assets/components/utilities/StartVoterRegistrationForm/StartVoterRegistrationForm.js
@@ -18,6 +18,7 @@ const StartVoterRegistrationForm = ({
   contextSource,
   groupId,
   referrerUserId,
+  source,
   sourceDetails,
 }) => {
   const [email, setEmail] = useState('');
@@ -64,7 +65,12 @@ const StartVoterRegistrationForm = ({
           <input
             type="hidden"
             name="source"
-            value={getTrackingSource(sourceDetails, referrerUserId, groupId)}
+            value={getTrackingSource(
+              source,
+              sourceDetails,
+              referrerUserId,
+              groupId,
+            )}
             data-testid="voter-registration-tracking-source"
           />
 
@@ -126,6 +132,7 @@ StartVoterRegistrationForm.propTypes = {
   contextSource: PropTypes.string.isRequired,
   groupId: PropTypes.number,
   referrerUserId: PropTypes.string,
+  source: PropTypes.string,
   sourceDetails: PropTypes.string.isRequired,
 };
 
@@ -135,6 +142,7 @@ StartVoterRegistrationForm.defaultProps = {
   className: null,
   groupId: null,
   referrerUserId: null,
+  source: null,
 };
 
 export default StartVoterRegistrationForm;

--- a/resources/assets/components/utilities/StartVoterRegistrationForm/StartVoterRegistrationForm.js
+++ b/resources/assets/components/utilities/StartVoterRegistrationForm/StartVoterRegistrationForm.js
@@ -145,7 +145,7 @@ StartVoterRegistrationForm.defaultProps = {
   className: null,
   groupId: null,
   referrerUserId: null,
-  source: null,
+  source: 'web',
 };
 
 export default StartVoterRegistrationForm;

--- a/resources/assets/helpers/voter-registration.js
+++ b/resources/assets/helpers/voter-registration.js
@@ -40,16 +40,22 @@ export function getGoalInfo(goalAmount, completedAmount) {
  * Returns tracking source query value to send for Voter Registration URLs.
  * @see /docs/development/features/voter-registration#tracking-source
  *
+ * @param {String} source
  * @param {String} sourceDetails
  * @param {String} referrerUserId
  * @param {Number} groupId
  * @return {String}
  */
-export function getTrackingSource(sourceDetails, referrerUserId, groupId) {
+export function getTrackingSource(
+  source,
+  sourceDetails,
+  referrerUserId,
+  groupId,
+) {
   const utms = getUtms();
 
   // Append UTMs to source_details value if they exist.
-  const result = `source:web,source_details:${sourceDetails}${
+  const result = `source:${source},source_details:${sourceDetails}${
     utms.utm_source ? `_${utms.utm_source}` : ''
   }${utms.utm_campaign ? `_${utms.utm_campaign}` : ''}${
     groupId ? `,group_id=${groupId}` : ''

--- a/resources/assets/helpers/voter-registration.test.js
+++ b/resources/assets/helpers/voter-registration.test.js
@@ -31,37 +31,39 @@ describe('getGoalInfo', () => {
 
 describe('getTrackingSource', () => {
   /** @test */
-  it('Returns source,source_details if only sourceDetails provided and AUTH is empty', () => {
+  it('Returns source,source_details if only source & sourceDetails provided and AUTH is empty', () => {
     global.AUTH = {};
 
-    expect(getTrackingSource('abc', null, null)).toEqual(
+    expect(getTrackingSource('web', 'abc', null, null)).toEqual(
       'source:web,source_details:abc',
     );
   });
 
   /** @test */
-  it('Returns user,source,source_details if only sourceDetails provided and AUTH id set', () => {
+  it('Returns user,source,source_details if only source & sourceDetails provided and AUTH id set', () => {
     global.AUTH = { id: '5f11b692b5892469df438d64' };
 
-    expect(getTrackingSource('abc', null, null)).toEqual(
+    expect(getTrackingSource('web', 'abc', null, null)).toEqual(
       'user:5f11b692b5892469df438d64,source:web,source_details:abc',
     );
   });
 
   /** @test */
-  it('Returns source,source_details,group_id if sourceDetails,groupId provided and AUTH is empty', () => {
+  it('Returns source,source_details,group_id if source, sourceDetails, groupId provided and AUTH is empty', () => {
     global.AUTH = {};
 
-    expect(getTrackingSource('abc', null, 81)).toEqual(
+    expect(getTrackingSource('web', 'abc', null, 81)).toEqual(
       'source:web,source_details:abc,group_id=81',
     );
   });
 
   /** @test */
-  it('Returns user,source,source_details,group_id,referral if sourceDetails,referrerUserId,groupId provided', () => {
+  it('Returns user,source,source_details,group_id,referral if source, sourceDetails, referrerUserId, groupId provided', () => {
     global.AUTH = { id: '5f11b692b5892469df438d64' };
 
-    expect(getTrackingSource('abc', '5edfc80ecb4dbf2020580a76', 81)).toEqual(
+    expect(
+      getTrackingSource('web', 'abc', '5edfc80ecb4dbf2020580a76', 81),
+    ).toEqual(
       'user:5edfc80ecb4dbf2020580a76,source:web,source_details:abc,group_id=81,referral=true',
     );
   });
@@ -75,7 +77,7 @@ describe('getTrackingSource', () => {
         'https://dev.dosomething.org/us/?utm_source=scholarship_listing&utm_campaign=fastweb_2020',
     });
 
-    expect(getTrackingSource('hellobar')).toEqual(
+    expect(getTrackingSource('web', 'hellobar')).toEqual(
       'source:web,source_details:hellobar_scholarship_listing_fastweb_2020',
     );
   });


### PR DESCRIPTION
### What's this PR do?

This pull request updates the `StartVoterRegistrationForm` component to be used from the VR Marketing page which required a few tweaks:
- https://github.com/DoSomething/phoenix-next/commit/2fe29f5531f949fa71f3219ff59c8dff4690b471, https://github.com/DoSomething/phoenix-next/commit/a433574eb48d8e076cf22ec75e0985c9e0e9549f allowing a custom `source` parameter for our generated RTV VR link since we'll need this customizable per page via Contentful.
- https://github.com/DoSomething/phoenix-next/commit/e92ac295c1fb6795305f5002a1d979608f3571b6 allowing custom button text - also editable via Contentful per page. (And centering the text in the button).
- https://github.com/DoSomething/phoenix-next/commit/02093bc987f610e98fef7796fbb4a8bd66d0b89f Extracting the `<Card>` functionality from within the component itself. Since we only want the raw form in the banner, the Card is unnecessary. The trick was that we also need the banners custom bg-color to apply within the form, but this was being overridden via the `<Card>`s background. Instead of finessing in some `css` or `attributes`, it felt cleaner, for now, to just manually embed the form from within a `<Card>` in the two places that actually make use of it. (We could always add a `StartVoterRegistrationFormCard` if need be).
- https://github.com/DoSomething/phoenix-next/commit/7e5f640bb3e6bda4a157c019f399899b63227ca7 finally, render the `StartVoterRegistrationForm` from the VR Marketing page 

### How should this be reviewed?
👀 

### Any background context you want to provide?
There might be more to come in terms of [button color customization](https://www.pivotaltracker.com/story/show/176905654/comments/222091036).
### Relevant tickets

References [Pivotal #176905654](https://www.pivotaltracker.com/story/show/176905654).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [x] Added screenshots of front-end changes on small, medium, and large screens.
- [ ] Added appropriate feature/unit tests. - tests in a follow-up PR


📸 
- [Small](https://user-images.githubusercontent.com/12417657/108431057-5a99bc80-7210-11eb-93e7-f21042bb9fff.png)
- [Medium](https://user-images.githubusercontent.com/12417657/108431058-5b325300-7210-11eb-9998-2804cc53dbd2.png)
![Screen Shot 2021-02-18 at 17 39 42](https://user-images.githubusercontent.com/12417657/108431061-5bcae980-7210-11eb-8a62-41dc6ddf75d7.png)
