### PR TITLE
Center Button Text on ElementButtons

### DIFF
--- a/resources/assets/components/utilities/Button/ElementButton.js
+++ b/resources/assets/components/utilities/Button/ElementButton.js
@@ -22,7 +22,7 @@ const ElementButton = ({
 }) => {
   return (
     <button
-      className={classnames('btn flex', className, {
+      className={classnames('btn flex justify-center', className, {
         'is-loading': isLoading,
       })}
       disabled={isDisabled || isLoading}


### PR DESCRIPTION
### What's this PR do?

This pull request fixes a quick UI bug which had our button text uncentered.

### How should this be reviewed?
👀 

### Any background context you want to provide?
We recently added `flex` to this component to allow a decoration prop to live side by side with the text which nudged the text to the left.



![image](https://user-images.githubusercontent.com/12417657/108533825-6ab0ab00-72a7-11eb-920d-c85d78e6314a.png)
![image](https://user-images.githubusercontent.com/12417657/108533839-71d7b900-72a7-11eb-8f81-146b1bcc23b8.png)
