### PR TITLE
Updates to show two badges for small screens

### DIFF
--- a/resources/assets/components/pages/AccountPage/Badges/BadgesTab.js
+++ b/resources/assets/components/pages/AccountPage/Badges/BadgesTab.js
@@ -196,7 +196,10 @@ class BadgesTab extends React.Component {
         <p className="text-gray-600">
           Earn badges and rewards for making a difference.
         </p>
-        <ul data-testid="badges-list" className="gallery-grid-sextet -mx-3">
+        <ul
+          data-testid="badges-list"
+          className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-6 gap-6 -mx-3 px-2"
+        >
           <Query query={SIGNUP_COUNT_BADGE} variables={{ userId }}>
             {data => (
               <li>


### PR DESCRIPTION
### What's this PR do?

This pull request updates the grid display of badges on small screens per feedback from design!

### How should this be reviewed?

OLD:
<img width="383" alt="Screen Shot 2021-02-19 at 3 49 46 PM" src="https://user-images.githubusercontent.com/15236023/108560981-82018f80-72cb-11eb-9f18-c85559425aad.png">

NEW:
<img width="382" alt="Screen Shot 2021-02-19 at 3 50 01 PM" src="https://user-images.githubusercontent.com/15236023/108561001-875eda00-72cb-11eb-9f48-ac056fdf73d5.png">


### Any background context you want to provide?

Feedback shared when working on an update for the rewards progress bar.

### Relevant tickets

References [Pivotal #176701256](https://www.pivotaltracker.com/story/show/176701256).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [x] Added screenshots of front-end changes on small, medium, and large screens.
