### PR TITLE
Start Voter Registration Form - Customizable Button Color

### DIFF
--- a/resources/assets/components/pages/VoterRegistrationMarketingPage/VoterRegistrationMarketingPage.js
+++ b/resources/assets/components/pages/VoterRegistrationMarketingPage/VoterRegistrationMarketingPage.js
@@ -24,6 +24,8 @@ const logo =
 const source = 'marketing-partner';
 const sourceDetails = 'niche';
 
+const buttonColor = '#f2714c';
+
 const VoterRegistrationMarketingPage = () => (
   <>
     <SiteNavigationContainer />
@@ -67,6 +69,7 @@ const VoterRegistrationMarketingPage = () => (
             className="max-w-lg m-auto"
             contextSource="voter-registration-marketing-page"
             buttonText="Get Started"
+            buttonColor={buttonColor}
             source={source}
             sourceDetails={sourceDetails}
           />

--- a/resources/assets/components/utilities/StartVoterRegistrationForm/StartVoterRegistrationForm.js
+++ b/resources/assets/components/utilities/StartVoterRegistrationForm/StartVoterRegistrationForm.js
@@ -7,6 +7,7 @@ import {
   EVENT_CATEGORIES,
   trackAnalyticsEvent,
 } from '../../../helpers/analytics';
+import ElementButton from '../Button/ElementButton';
 import Spinner from '../../artifacts/Spinner/Spinner';
 import { tailwind, colorLuminance } from '../../../helpers/display';
 import { getTrackingSource } from '../../../helpers/voter-registration';
@@ -98,28 +99,31 @@ const StartVoterRegistrationForm = ({
         />
       </div>
 
-      <button
+      <ElementButton
+        className="w-full"
         data-testid="voter-registration-submit-button"
-        className="btn w-full flex justify-center"
-        css={css`
-          background-color: ${buttonColor};
+        attributes={{
+          css: css`
+            background-color: ${buttonColor};
 
-          :hover {
-            background-color: ${colorLuminance(buttonColor, 10)};
-          }
-        `}
+            :hover {
+              background-color: ${colorLuminance(buttonColor, 10)};
+            }
+          `,
+        }}
         disabled={isDisabled || submitted}
         type="submit"
-      >
-        {submitted ? (
-          <>
-            <Spinner />
-            <span className="pl-1 pt-1">Processing...</span>
-          </>
-        ) : (
-          buttonText
-        )}
-      </button>
+        text={
+          submitted ? (
+            <>
+              <Spinner />
+              <span className="pl-1 pt-1">Processing...</span>
+            </>
+          ) : (
+            buttonText
+          )
+        }
+      />
     </form>
   );
 };

--- a/resources/assets/components/utilities/StartVoterRegistrationForm/StartVoterRegistrationForm.js
+++ b/resources/assets/components/utilities/StartVoterRegistrationForm/StartVoterRegistrationForm.js
@@ -101,7 +101,6 @@ const StartVoterRegistrationForm = ({
 
       <ElementButton
         className="w-full"
-        data-testid="voter-registration-submit-button"
         attributes={{
           css: css`
             background-color: ${buttonColor};
@@ -110,8 +109,9 @@ const StartVoterRegistrationForm = ({
               background-color: ${colorLuminance(buttonColor, 10)};
             }
           `,
+          'data-testid': 'voter-registration-submit-button',
         }}
-        disabled={isDisabled || submitted}
+        isDisabled={isDisabled || submitted}
         type="submit"
         text={
           submitted ? (

--- a/resources/assets/components/utilities/StartVoterRegistrationForm/StartVoterRegistrationForm.js
+++ b/resources/assets/components/utilities/StartVoterRegistrationForm/StartVoterRegistrationForm.js
@@ -105,7 +105,7 @@ const StartVoterRegistrationForm = ({
           background-color: ${buttonColor};
 
           :hover {
-            background-color: ${colorLuminance(buttonColor, '0.1')};
+            background-color: ${colorLuminance(buttonColor, 10)};
           }
         `}
         disabled={isDisabled || submitted}

--- a/resources/assets/components/utilities/StartVoterRegistrationForm/StartVoterRegistrationForm.js
+++ b/resources/assets/components/utilities/StartVoterRegistrationForm/StartVoterRegistrationForm.js
@@ -1,16 +1,18 @@
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
+import { css } from '@emotion/core';
 import React, { useState } from 'react';
 
 import {
   EVENT_CATEGORIES,
   trackAnalyticsEvent,
 } from '../../../helpers/analytics';
-import PrimaryButton from '../Button/PrimaryButton';
 import Spinner from '../../artifacts/Spinner/Spinner';
+import { tailwind, colorLuminance } from '../../../helpers/display';
 import { getTrackingSource } from '../../../helpers/voter-registration';
 
 const StartVoterRegistrationForm = ({
+  buttonColor,
   buttonText,
   campaignId,
   className,
@@ -96,27 +98,34 @@ const StartVoterRegistrationForm = ({
         />
       </div>
 
-      <PrimaryButton
-        attributes={{ 'data-testid': 'voter-registration-submit-button' }}
-        className="w-full flex justify-center"
-        isDisabled={isDisabled}
-        text={
-          submitted ? (
-            <>
-              <Spinner />
-              <span className="pl-1 pt-1">Processing...</span>
-            </>
-          ) : (
-            buttonText
-          )
-        }
+      <button
+        data-testid="voter-registration-submit-button"
+        className="btn w-full flex justify-center"
+        css={css`
+          background-color: ${buttonColor};
+
+          :hover {
+            background-color: ${colorLuminance(buttonColor, '0.1')};
+          }
+        `}
+        disabled={isDisabled || submitted}
         type="submit"
-      />
+      >
+        {submitted ? (
+          <>
+            <Spinner />
+            <span className="pl-1 pt-1">Processing...</span>
+          </>
+        ) : (
+          buttonText
+        )}
+      </button>
     </form>
   );
 };
 
 StartVoterRegistrationForm.propTypes = {
+  buttonColor: PropTypes.string,
   buttonText: PropTypes.string,
   campaignId: PropTypes.number,
   className: PropTypes.string,
@@ -128,6 +137,7 @@ StartVoterRegistrationForm.propTypes = {
 };
 
 StartVoterRegistrationForm.defaultProps = {
+  buttonColor: tailwind('colors.blurple')['500'],
   buttonText: 'Start Registration',
   campaignId: null,
   className: null,

--- a/resources/assets/helpers/display.js
+++ b/resources/assets/helpers/display.js
@@ -145,4 +145,30 @@ export function toggleClassHandler(button, target, toggleClass) {
   button.addEventListener('mousedown', clickHandler, false);
 }
 
+/**
+ * Alters luminosity for provided hex color by specified percentage.
+ * https://www.sitepoint.com/javascript-generate-lighter-darker-color/
+ *
+ * @param   {String} hex — a valid six character hex color value such as “#123456”.
+ * @param   {String} luminosity — the luminosity factor, i.e. -0.1 is 10% darker, 0.2 is 20% lighter, etc.
+ * @return  {String}
+ */
+export function colorLuminance(hex, luminosity = 0) {
+  const hashlessHex = hex.replace('#', '');
+
+  let luminatedValue = '#';
+
+  for (let i = 0; i < 3; i += 1) {
+    const colorAsInt = parseInt(hashlessHex.substr(i * 2, 2), 16);
+
+    const colorLuminated = Math.round(
+      Math.min(Math.max(0, colorAsInt + colorAsInt * luminosity), 255),
+    ).toString(16);
+
+    luminatedValue += `00${colorLuminated}`.substr(colorLuminated.length);
+  }
+
+  return luminatedValue;
+}
+
 export default null;

--- a/resources/assets/helpers/display.js
+++ b/resources/assets/helpers/display.js
@@ -150,7 +150,7 @@ export function toggleClassHandler(button, target, toggleClass) {
  * https://www.sitepoint.com/javascript-generate-lighter-darker-color/
  *
  * @param   {String} hex — a valid six character hex color value such as “#FF00FF".
- * @param   {String} luminosity — the luminosity factor, i.e. -10 is 10% darker, 20 is 20% lighter, etc.
+ * @param   {String} luminosity — the luminosity factor (from -100 to 100), i.e. -10 is 10% darker, 20 is 20% lighter, etc.
  * @return  {String}
  */
 export function colorLuminance(hex, luminosity = 0) {

--- a/resources/assets/helpers/display.js
+++ b/resources/assets/helpers/display.js
@@ -149,7 +149,7 @@ export function toggleClassHandler(button, target, toggleClass) {
  * Alters luminosity for provided hex color by specified percentage.
  * https://www.sitepoint.com/javascript-generate-lighter-darker-color/
  *
- * @param   {String} hex — a valid six character hex color value such as “#123456”.
+ * @param   {String} hex — a valid six character hex color value such as “#FF00FF".
  * @param   {String} luminosity — the luminosity factor, i.e. -0.1 is 10% darker, 0.2 is 20% lighter, etc.
  * @return  {String}
  */

--- a/resources/assets/helpers/display.js
+++ b/resources/assets/helpers/display.js
@@ -150,7 +150,7 @@ export function toggleClassHandler(button, target, toggleClass) {
  * https://www.sitepoint.com/javascript-generate-lighter-darker-color/
  *
  * @param   {String} hex — a valid six character hex color value such as “#FF00FF".
- * @param   {String} luminosity — the luminosity factor, i.e. -0.1 is 10% darker, 0.2 is 20% lighter, etc.
+ * @param   {String} luminosity — the luminosity factor, i.e. -10 is 10% darker, 20 is 20% lighter, etc.
  * @return  {String}
  */
 export function colorLuminance(hex, luminosity = 0) {
@@ -162,7 +162,7 @@ export function colorLuminance(hex, luminosity = 0) {
     const colorAsInt = parseInt(hashlessHex.substr(i * 2, 2), 16);
 
     const colorLuminated = Math.round(
-      Math.min(Math.max(0, colorAsInt + colorAsInt * luminosity), 255),
+      Math.min(Math.max(0, colorAsInt + colorAsInt * (luminosity * 0.01)), 255),
     ).toString(16);
 
     luminatedValue += `00${colorLuminated}`.substr(colorLuminated.length);


### PR DESCRIPTION
### What's this PR do?

This pull request allows a `buttonColor` prop in the `StartVoterRegistrationForm` component to customize the button color.

### How should this be reviewed?
👀  commit-by-commit
Does this approach make sense?

### Any background context you want to provide?
A requirement for the Voter Registration Marketing Page is to customize the button color. The challenge was to dynamically 'tint' the color on hover state. This would have been a cinch with Tailwind's [opacity utility](https://tailwindcss.com/docs/background-color#changing-opacity), but that wouldn't work with non Tailwind colors assigned via the `bg-[color]`. 

I found [this article](https://www.sitepoint.com/javascript-generate-lighter-darker-color/) that maps out a really neat way to do this though, so pasted over a simplified version as a helper method and we should be golden!

### Relevant tickets

References [Pivotal #176905654](https://www.pivotaltracker.com/story/show/176905654/comments/222091036).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added screenshots of front-end changes on small, medium, and large screens.
- [ ] Added appropriate feature/unit tests.

**Default**
![image](https://user-images.githubusercontent.com/12417657/108543409-0b589800-72b3-11eb-8877-d26acb0cb440.png)
**Hovered**
![image](https://user-images.githubusercontent.com/12417657/108543517-2cb98400-72b3-11eb-8996-a6c074a4e604.png)
