### PR TITLE
Defaults affiliate opt in to null in campaign signup form

### DIFF
--- a/resources/assets/components/CampaignSignupForm/CampaignSignupForm.js
+++ b/resources/assets/components/CampaignSignupForm/CampaignSignupForm.js
@@ -85,7 +85,7 @@ const CampaignSignupForm = props => {
     },
   );
 
-  const [affiliateMessagingOptIn, setAffiliateMessagingOptIn] = useState(false);
+  const [affiliateMessagingOptIn, setAffiliateMessagingOptIn] = useState(null);
 
   // We'll set up some state to store the selected Group ID if applicable on this form.
   const [groupId, setGroupId] = useState(null);


### PR DESCRIPTION
### What's this PR do?

This pull request is a quick tweak to #2539 to assign the default `affiliateMessagingOptIn` state value to `null` so that we can exclude it from our Signup mutation payload by default instead of including `affiliateOptIn: false` in our `source_details` which seems lame.

https://github.com/DoSomething/phoenix-next/blob/acd285898e101e6a3702ad34a12e235577ab11a0/resources/assets/components/CampaignSignupForm/CampaignSignupForm.js#L182-L186