### PR TITLE
Campaign Signup Form - Check Authentication Before Running Flashed Mutation

### DIFF
--- a/resources/assets/components/CampaignSignupForm/CampaignSignupForm.js
+++ b/resources/assets/components/CampaignSignupForm/CampaignSignupForm.js
@@ -148,6 +148,7 @@ const CampaignSignupForm = props => {
     // If we're returning from the authentication flow with "flashed" data
     // (and the user isn't already signed up for this campaign!), complete the signup:
     if (
+      isAuthenticated() &&
       !loading &&
       flash.signupData &&
       !get(campaignSignupData, 'signups', []).length &&


### PR DESCRIPTION
### What's this PR do?

This pull request adds a condition to ensure the user is authenticated before running the signup mutation for users ostensibly returning from the auth flow (using the flashed data).

### How should this be reviewed?
👀 

### Any background context you want to provide?
When spot checking this on the Apollo Studio app, [I see](https://studio.apollographql.com/graph/dosomething-graphql-lambda/operations?query=bea1d614135f336d05256365646004275f4a9425&queryName=CampaignSignupFormMutation&range=lastWeek&search=campaign&tab=traces&trace=dosomething-graphql-lambda~2021%3A03%3A11~7897174ce678e71ad8885c32de4d5e8e797e601cd52a4377962b2761c0602f98&traceBucket&variant=current) a bunch of failed mutations with the error:
`An access token is required for this query/mutation.`

My hunch is that these are users coming back from the auth flow without completing it, causing the mutation to fire off with a missing access token.

### Relevant tickets

References [Pivotal #175291206](https://www.pivotaltracker.com/story/show/175291206).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added screenshots of front-end changes on small, medium, and large screens.
- [ ] Added appropriate feature/unit tests.
