### PR TITLE
Questionnaire Action via GraphQL / Contentful

### DIFF
--- a/contentful/content-types/questionnaire-action.js
+++ b/contentful/content-types/questionnaire-action.js
@@ -1,0 +1,158 @@
+module.exports = function(migration) {
+  const questionnaireAction = migration
+    .createContentType('questionnaireAction')
+    .name('Questionnaire Action')
+    .description(
+      'A multi-question submission form. Create a custom range of questions which will appear in a single questionnaire card. Submission will create a separate post per question. Each question should be associated with a unique Action ID in Rogue.',
+    )
+    .displayField('internalTitle');
+
+  questionnaireAction
+    .createField('internalTitle')
+    .name('Internal Title')
+    .type('Symbol')
+    .localized(false)
+    .required(true)
+    .validations([])
+    .disabled(false)
+    .omitted(false);
+
+  questionnaireAction
+    .createField('title')
+    .name('Title')
+    .type('Symbol')
+    .localized(false)
+    .required(false)
+    .validations([
+      {
+        size: {
+          max: 65,
+        },
+      },
+    ])
+    .disabled(false)
+    .omitted(false);
+
+  questionnaireAction
+    .createField('questions')
+    .name('Questions')
+    .type('Object')
+    .localized(false)
+    .required(false)
+    .validations([])
+    .disabled(false)
+    .omitted(false);
+
+  questionnaireAction
+    .createField('buttonText')
+    .name('Button Text')
+    .type('Symbol')
+    .localized(false)
+    .required(false)
+    .validations([
+      {
+        size: {
+          max: 25,
+        },
+      },
+    ])
+    .disabled(false)
+    .omitted(false);
+
+  questionnaireAction
+    .createField('informationTitle')
+    .name('Information Title')
+    .type('Symbol')
+    .localized(false)
+    .required(false)
+    .validations([
+      {
+        size: {
+          max: 65,
+        },
+      },
+    ])
+    .disabled(false)
+    .omitted(false);
+
+  questionnaireAction
+    .createField('informationContent')
+    .name('Information Content')
+    .type('Text')
+    .localized(false)
+    .required(false)
+    .validations([])
+    .disabled(false)
+    .omitted(false);
+  questionnaireAction
+    .createField('affirmationContent')
+    .name('Affirmation Content')
+    .type('Text')
+    .localized(false)
+    .required(false)
+    .validations([])
+    .disabled(false)
+    .omitted(false);
+
+  questionnaireAction.changeFieldControl(
+    'internalTitle',
+    'builtin',
+    'singleLine',
+    {
+      helpText:
+        'This title is used internally to help find this content. It will not be displayed anywhere on the rendered web page.',
+    },
+  );
+
+  questionnaireAction.changeFieldControl('title', 'builtin', 'singleLine', {
+    helpText:
+      'The Questionnaire title. This will appear at the top of the card. Defaults to "Questionnaire".',
+  });
+
+  questionnaireAction.changeFieldControl(
+    'questions',
+    'app',
+    '3ays4DQCxsEfKdGs6YqUpB',
+    {},
+  );
+
+  questionnaireAction.changeFieldControl(
+    'buttonText',
+    'builtin',
+    'singleLine',
+    {
+      helpText:
+        'The text appearing in the form submission button. Defaults to "Submit Answers".',
+    },
+  );
+
+  questionnaireAction.changeFieldControl(
+    'informationTitle',
+    'builtin',
+    'singleLine',
+    {
+      helpText:
+        'Title displayed atop the information card adjacent to the form. Defaults to "More Info".',
+    },
+  );
+
+  questionnaireAction.changeFieldControl(
+    'informationContent',
+    'builtin',
+    'markdown',
+    {
+      helpText:
+        'Content displayed in the information card adjacent to the form. The card will be hidden unless this field is populated.',
+    },
+  );
+
+  questionnaireAction.changeFieldControl(
+    'affirmationContent',
+    'builtin',
+    'markdown',
+    {
+      helpText:
+        "The content displayed in the Show Submission page where the user is redirected once they've successfully submitted the form.",
+    },
+  );
+};

--- a/cypress/integration/questionnaire-action.js
+++ b/cypress/integration/questionnaire-action.js
@@ -5,22 +5,106 @@ import faker from 'faker';
 describe('Questionnaire Action', () => {
   beforeEach(() => cy.configureMocks());
 
+  const title = 'Register to vote';
+  const buttonText = 'Submit!';
+  const informationTitle = 'Much more info!';
+  const informationContent = 'So much information, oh my!';
+
+  const questions = [
+    {
+      title: "Who's your biggest inspiration?",
+      placeholder: 'My pet snail, Agnes.',
+      actionId: 1,
+    },
+    {
+      title: 'Why?',
+      placeholder: 'They have an inspired sense of Zen.',
+      actionId: 2,
+    },
+  ];
+
   /** @test */
-  it('does not enable submission until all questions are answered with valid character count', () => {
-    cy.visit('/us/questionnaire');
+  it('Displays the expected content with required fields.', () => {
+    cy.mockGraphqlOp('ContentfulBlockQuery', {
+      block: {
+        __typename: 'QuestionnaireBlock',
+        title: null,
+        questions,
+        buttonText: null,
+        informationTitle: null,
+        informationContent: null,
+      },
+    });
+
+    cy.visit('/us/blocks/123');
+
+    cy.findByTestId('questionnaire-action').within(() => {
+      questions.forEach((question, index) => {
+        cy.findByTestId(`question-${index + 1}`).within(() => {
+          cy.findByTestId(`question-${index + 1}-title`).contains(
+            questions[index].title,
+          );
+
+          cy.findByTestId(`question-${index + 1}-input`).should(
+            'have.attr',
+            'placeholder',
+            questions[index].placeholder,
+          );
+        });
+      });
+
+      cy.findByTestId('questionnaire-submit-button').contains('Submit Answers');
+      cy.findByTestId('action-information').should('have.length', 0);
+    });
+  });
+
+  /** @test */
+  it('Displays the expected content with customized fields.', () => {
+    cy.mockGraphqlOp('ContentfulBlockQuery', {
+      block: {
+        __typename: 'QuestionnaireBlock',
+        title,
+        questions,
+        buttonText,
+        informationTitle,
+        informationContent,
+      },
+    });
+
+    cy.visit('/us/blocks/123');
+
+    cy.findByTestId('questionnaire-action').within(() => {
+      cy.findByTestId('questionnaire-submit-button').contains(buttonText);
+
+      cy.findByTestId('action-information').contains(informationTitle);
+
+      cy.findByTestId('action-information').contains(informationContent);
+    });
+  });
+
+  /** @test */
+  it('Does not enable submission until all questions are answered with valid character count', () => {
+    cy.mockGraphqlOp('ContentfulBlockQuery', {
+      block: {
+        __typename: 'QuestionnaireBlock',
+        questions,
+      },
+    });
+
+    cy.visit('/us/blocks/123');
 
     cy.findByTestId('questionnaire-action').within(() => {
       cy.findByTestId('questionnaire-submit-button').should('be.disabled');
 
-      cy.findByTestId('question-1').type(faker.lorem.words());
+      cy.findByTestId('question-1-input').type(faker.lorem.words());
 
       cy.findByTestId('questionnaire-submit-button').should('be.disabled');
 
-      cy.findByTestId('question-2').type(faker.random.alphaNumeric(501));
+      cy.findByTestId('question-2-input').type(faker.random.alphaNumeric(501));
 
       cy.findByTestId('questionnaire-submit-button').should('be.disabled');
 
-      cy.findByTestId('question-2')
+      cy.findByTestId('question-2-input')
         .clear()
         .type(faker.lorem.words());
 

--- a/resources/assets/components/App.js
+++ b/resources/assets/components/App.js
@@ -31,7 +31,6 @@ import ShowSubmissionPage from './pages/ShowSubmissionPage/ShowSubmissionPage';
 import PageDispatcherContainer from './PageDispatcher/PageDispatcherContainer';
 import PopoverDispatcher from './utilities/PopoverDispatcher/PopoverDispatcher';
 import DismissableElement from './utilities/DismissableElement/DismissableElement';
-import QuestionnaireAction from './actions/QuestionnaireAction/QuestionnaireAction';
 import TrafficDistribution from './utilities/TrafficDistribution/TrafficDistribution';
 import VoterRegistrationDrivePage from './pages/VoterRegistrationDrivePage/VoterRegistrationDrivePage';
 import VoterRegistrationLandingPage from './pages/VoterRegistrationLandingPage/VoterRegistrationLandingPage';
@@ -160,17 +159,6 @@ const App = ({ store, history }) => {
               />
 
               <Route path="/us/refer-friends" component={AlphaReferralPage} />
-
-              <Route
-                path="/us/questionnaire"
-                render={() => (
-                  <main className="clearfix">
-                    <div className="md:w-3/4 mx-auto my-16 px-3">
-                      <QuestionnaireAction />
-                    </div>
-                  </main>
-                )}
-              />
 
               <Route path="/us/:slug" component={PageDispatcherContainer} />
             </Switch>

--- a/resources/assets/components/ContentfulEntry/ContentfulEntry.js
+++ b/resources/assets/components/ContentfulEntry/ContentfulEntry.js
@@ -26,6 +26,7 @@ import CampaignDashboard from '../utilities/CampaignDashboard/CampaignDashboard'
 import CurrentSchoolBlock from '../blocks/CurrentSchoolBlock/CurrentSchoolBlock';
 import SixpackExperiment from '../utilities/SixpackExperiment/SixpackExperiment';
 import PostGalleryBlockQuery from '../blocks/PostGalleryBlock/PostGalleryBlockQuery';
+import QuestionnaireAction from '../actions/QuestionnaireAction/QuestionnaireAction';
 import SignupReferralsBlock from '../blocks/SignupReferralsBlock/SignupReferralsBlock';
 import TextSubmissionActionContainer from '../actions/TextSubmissionAction/TextSubmissionActionContainer';
 import PhotoSubmissionActionContainer from '../actions/PhotoSubmissionAction/PhotoSubmissionActionContainer';
@@ -181,6 +182,10 @@ class ContentfulEntry extends React.Component {
             />
           </React.Fragment>
         );
+
+      case 'QuestionnaireBlock': {
+        return <QuestionnaireAction {...withoutNulls(json)} />;
+      }
 
       case 'QuizBlock': {
         const QuizBlock = Loader(import('../Quiz/QuizBlock'));

--- a/resources/assets/components/actions/ActionInformation.js
+++ b/resources/assets/components/actions/ActionInformation.js
@@ -5,7 +5,7 @@ import Card from '../utilities/Card/Card';
 import TextContent from '../utilities/TextContent/TextContent';
 
 const ActionInformation = ({ className, content, title }) => (
-  <div className={className}>
+  <div data-testid="action-information" className={className}>
     <Card title={title} className="bordered rounded">
       <TextContent className="p-3">{content}</TextContent>
     </Card>

--- a/resources/assets/components/actions/QuestionnaireAction/QuestionnaireAction.js
+++ b/resources/assets/components/actions/QuestionnaireAction/QuestionnaireAction.js
@@ -120,7 +120,7 @@ QuestionnaireAction.propTypes = {
 };
 
 QuestionnaireAction.defaultProps = {
-  title: null,
+  title: 'Questionnaire',
   buttonText: 'Submit Answers',
   informationTitle: 'More Info',
   informationContent: null,

--- a/resources/assets/components/actions/QuestionnaireAction/QuestionnaireAction.js
+++ b/resources/assets/components/actions/QuestionnaireAction/QuestionnaireAction.js
@@ -1,3 +1,4 @@
+import gql from 'graphql-tag';
 import { every } from 'lodash';
 import React, { useState } from 'react';
 
@@ -6,6 +7,16 @@ import ActionInformation from '../ActionInformation';
 import PrimaryButton from '../../utilities/Button/PrimaryButton';
 import CharacterLimit from '../../utilities/CharacterLimit/CharacterLimit';
 import PrivacyLanguage from '../../utilities/PrivacyLanguage/PrivacyLanguage';
+
+export const QuestionnaireBlockFragment = gql`
+  fragment QuestionnaireBlockFragment on QuestionnaireBlock {
+    title
+    questions
+    buttonText
+    informationTitle
+    informationContent
+  }
+`;
 
 const CHARACTER_LIMIT = 500;
 

--- a/resources/assets/components/actions/QuestionnaireAction/QuestionnaireAction.js
+++ b/resources/assets/components/actions/QuestionnaireAction/QuestionnaireAction.js
@@ -1,5 +1,6 @@
 import gql from 'graphql-tag';
 import { every } from 'lodash';
+import PropTypes from 'prop-types';
 import React, { useState } from 'react';
 
 import Card from '../../utilities/Card/Card';
@@ -20,25 +21,13 @@ export const QuestionnaireBlockFragment = gql`
 
 const CHARACTER_LIMIT = 500;
 
-const QUESTIONS = [
-  {
-    actionId: 1,
-    label: 'Are you going to school in person?',
-    placeholder: 'Neither',
-  },
-  {
-    actionId: 2,
-    label: "What's helping you cope?",
-    placeholder: 'Herbs and grasses',
-  },
-];
-
-const TITLE = 'Submit your tips';
-const INFORMATION_TITLE = 'more info';
-const INFORMATION_CONTENT = 'more information here.';
-const BUTTON_TEXT = 'Submit Answers';
-
-const QuestionnaireAction = () => {
+const QuestionnaireAction = ({
+  title,
+  questions,
+  buttonText,
+  informationTitle,
+  informationContent,
+}) => {
   const [answers, updateAnswers] = useState({});
 
   const onChange = (questionId, updatedAnswer) => {
@@ -46,7 +35,7 @@ const QuestionnaireAction = () => {
   };
 
   const finishedQuestionnaire = every(
-    QUESTIONS,
+    questions,
     question =>
       !!answers[question.actionId] &&
       answers[question.actionId].length < CHARACTER_LIMIT,
@@ -57,20 +46,24 @@ const QuestionnaireAction = () => {
       className="lg:grid grid-cols-12 gap-6"
       data-testid="questionnaire-action"
     >
-      <Card className="bordered rounded col-span-8" title={TITLE}>
+      <Card className="bordered rounded col-span-8" title={title}>
         <form className="p-3">
-          {QUESTIONS.map((question, index) => {
+          {questions.map((question, index) => {
             const questionId = `question-${question.actionId}`;
 
             return (
-              <div key={question.actionId}>
-                <label className="block mb-1 font-bold" htmlFor={questionId}>
-                  {index + 1}. {question.label}
+              <div key={question.actionId} data-testid={questionId}>
+                <label
+                  data-testid={`${questionId}-title`}
+                  className="block mb-1 font-bold"
+                  htmlFor={questionId}
+                >
+                  {index + 1}. {question.title}
                 </label>
 
                 <textarea
                   className="block mb-1 h-24 text-field"
-                  data-testid={questionId}
+                  data-testid={`${questionId}-input`}
                   id={questionId}
                   name={questionId}
                   placeholder={question.placeholder}
@@ -93,7 +86,7 @@ const QuestionnaireAction = () => {
             className="block mt-3 text-lg w-full"
             attributes={{ 'data-testid': 'questionnaire-submit-button' }}
             isDisabled={!finishedQuestionnaire}
-            text={BUTTON_TEXT}
+            text={buttonText}
             type="submit"
           />
 
@@ -101,13 +94,36 @@ const QuestionnaireAction = () => {
         </form>
       </Card>
 
-      <ActionInformation
-        className="col-span-4 mt-6 lg:mt-0"
-        title={INFORMATION_TITLE}
-        content={INFORMATION_CONTENT}
-      />
+      {informationContent ? (
+        <ActionInformation
+          className="col-span-4 mt-6 lg:mt-0"
+          title={informationTitle}
+          content={informationContent}
+        />
+      ) : null}
     </div>
   );
+};
+
+QuestionnaireAction.propTypes = {
+  title: PropTypes.string,
+  questions: PropTypes.arrayOf(
+    PropTypes.shape({
+      title: PropTypes.string,
+      placeholder: PropTypes.string,
+      actionId: PropTypes.number,
+    }),
+  ).isRequired,
+  buttonText: PropTypes.string,
+  informationTitle: PropTypes.string,
+  informationContent: PropTypes.string,
+};
+
+QuestionnaireAction.defaultProps = {
+  title: null,
+  buttonText: 'Submit Answers',
+  informationTitle: 'More Info',
+  informationContent: null,
 };
 
 export default QuestionnaireAction;

--- a/resources/assets/components/utilities/ContentfulEntryLoader/ContentfulEntryLoader.js
+++ b/resources/assets/components/utilities/ContentfulEntryLoader/ContentfulEntryLoader.js
@@ -27,6 +27,7 @@ import { ActionStatsBlockFragment } from '../../blocks/ActionStatsBlock/ActionSt
 import { SocialDriveBlockFragment } from '../../actions/SocialDriveAction/SocialDriveAction';
 import { PostGalleryBlockFragment } from '../../blocks/PostGalleryBlock/PostGalleryBlockQuery';
 import { CurrentSchoolBlockFragment } from '../../blocks/CurrentSchoolBlock/CurrentSchoolBlock';
+import { QuestionnaireBlockFragment } from '../../actions/QuestionnaireAction/QuestionnaireAction';
 import { SignupReferralsBlockFragment } from '../../blocks/SignupReferralsBlock/SignupReferralsBlock';
 import { TextSubmissionBlockFragment } from '../../actions/TextSubmissionAction/TextSubmissionAction';
 import { PhotoSubmissionBlockFragment } from '../../actions/PhotoSubmissionAction/PhotoSubmissionAction';
@@ -91,6 +92,9 @@ export const CONTENTFUL_BLOCK_QUERY = gql`
       ... on TextSubmissionBlock {
         ...TextSubmissionBlockFragment
       }
+      ... on QuestionnaireBlock {
+        ...QuestionnaireBlockFragment
+      }
       ... on PhotoSubmissionBlock {
         ...PhotoSubmissionBlockFragment
       }
@@ -133,6 +137,7 @@ export const CONTENTFUL_BLOCK_QUERY = gql`
   ${CampaignDashboardFragment}
   ${ExternalLinkBlockFragment}
   ${CurrentSchoolBlockFragment}
+  ${QuestionnaireBlockFragment}
   ${CampaignUpdateBlockFragment}
   ${TextSubmissionBlockFragment}
   ${PhotoSubmissionBlockFragment}

--- a/routes/web.php
+++ b/routes/web.php
@@ -88,10 +88,6 @@ Route::get('us/my-voter-registration-drive', 'VoterRegistrationDrivePageControll
 // Quiz Results
 Route::view('us/quiz-results/{id}', 'app');
 
-// Stubbed Questionnaire Action route for testing.
-// @TODO: Remove this when we formalize this feature.
-Route::view('us/questionnaire', 'app');
-
 // Pages
 Route::get('us/{slug}', 'PageController@show');
 Route::get('{slug}', function ($slug) {

--- a/schema.json
+++ b/schema.json
@@ -4744,6 +4744,11 @@
           },
           {
             "kind": "OBJECT",
+            "name": "QuestionnaireBlock",
+            "ofType": null
+          },
+          {
+            "kind": "OBJECT",
             "name": "QuizBlock",
             "ofType": null
           },
@@ -5561,7 +5566,7 @@
           },
           {
             "name": "emailSubscriptionTopics",
-            "description": "The user's email subscription status.",
+            "description": "The user's email subscription choices.",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -5864,6 +5869,22 @@
               "ofType": {
                 "kind": "ENUM",
                 "name": "CauseIdentifier",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "badges",
+            "description": "The badges a user has earned.",
+            "args": [],
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "BadgeIdentifier",
                 "ofType": null
               }
             },
@@ -6228,6 +6249,65 @@
           },
           {
             "name": "SEXUAL_HARASSMENT_ASSAULT",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "BadgeIdentifier",
+        "description": "The user's earned badges.",
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "SIGNUP",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "ONE_POST",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "TWO_POSTS",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "THREE_POSTS",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "BREAKDOWN",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "ONE_STAFF_FAVE",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "TWO_STAFF_FAVES",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "THREE_STAFF_FAVES",
             "description": null,
             "isDeprecated": false,
             "deprecationReason": null
@@ -15922,6 +16002,151 @@
             "type": {
               "kind": "SCALAR",
               "name": "Boolean",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "internalTitle",
+            "description": "The internal-facing title for this block.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "id",
+            "description": "The Contentful ID for this entry.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "updatedAt",
+            "description": "The time this entry was last modified.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "DateTime",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "createdAt",
+            "description": "The time when this entry was originally created.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "DateTime",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [
+          {
+            "kind": "INTERFACE",
+            "name": "Block",
+            "ofType": null
+          }
+        ],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "QuestionnaireBlock",
+        "description": null,
+        "fields": [
+          {
+            "name": "title",
+            "description": "Title of the questionnaire.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "questions",
+            "description": "List of questions.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "JSON",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "buttonText",
+            "description": "Text displayed on the questionnnaire submission button.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "informationTitle",
+            "description": "Title of the information card displayed next to the questionnaire.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "informationContent",
+            "description": "Content of the information card displayed next to the questionnaire.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "affirmationContent",
+            "description": "Content displayed in the affirmation page once the questionnaire is submitted.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
               "ofType": null
             },
             "isDeprecated": false,


### PR DESCRIPTION
### What's this PR do?

This pull request fleshes out the `QuestionnaireAction` to load as a standard block via GraphQL -> Contentful. Includes the generated Contentful migration script & updated tests.

### How should this be reviewed?
👀 

### Any background context you want to provide?
The tests won't pass until the updated schema is pulled in from GraphQL once we add the new block type (https://github.com/DoSomething/graphql/pull/327).

### Relevant tickets

References [Pivotal #176852206](https://www.pivotaltracker.com/story/show/176852206).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
~- [ ] Added screenshots of front-end changes on small, medium, and large screens.~
- [x] Added appropriate feature/unit tests.
