### PR TITLE
Update Company Page Cypress test Stub to use intercept

### DIFF
--- a/cypress/integration/company-page.js
+++ b/cypress/integration/company-page.js
@@ -44,11 +44,14 @@ describe('Company Page', () => {
 
     cy.visit(`/us/about/easy-scholarships`);
 
-    cy.route({
-      method: 'POST',
-      url: 'https://identity-dev.dosomething.org/v2/subscriptions',
-      status: 200,
-    });
+    cy.intercept(
+      'POST',
+      'https://identity-dev.dosomething.org/v2/subscriptions',
+      {
+        statusCode: 200,
+        body: { id: '123' },
+      },
+    );
 
     cy.get('[data-test="cta-popover-email-form"] input[type="text"]').type(
       'vmack@dosomething.org',
@@ -68,11 +71,14 @@ describe('Company Page', () => {
 
     cy.visit(`/us/about/easy-scholarships`);
 
-    cy.route({
-      method: 'POST',
-      url: 'https://identity-dev.dosomething.org/v2/subscriptions',
-      status: 422,
-    });
+    cy.intercept(
+      'POST',
+      'https://identity-dev.dosomething.org/v2/subscriptions',
+      {
+        statusCode: 422,
+        body: {},
+      },
+    );
 
     cy.get('[data-test="cta-popover-email-form"] input[type="text"]').type(
       'hsjadcusdcg',

--- a/cypress/integration/company-page.js
+++ b/cypress/integration/company-page.js
@@ -76,7 +76,14 @@ describe('Company Page', () => {
       'https://identity-dev.dosomething.org/v2/subscriptions',
       {
         statusCode: 422,
-        body: {},
+        body: {
+          error: {
+            message: 'Failed validation.',
+            fields: {
+              email: ['The email must be a valid email address.'],
+            },
+          },
+        },
       },
     );
 

--- a/resources/assets/components/utilities/PopoverDispatcher/CtaPopover/CtaPopoverEmailForm.js
+++ b/resources/assets/components/utilities/PopoverDispatcher/CtaPopover/CtaPopoverEmailForm.js
@@ -79,7 +79,11 @@ const CtaPopoverEmailForm = ({ handleComplete }) => {
   };
 
   return !showAffirmation ? (
-    <div className="pt-4" data-test="cta-popover-email-form">
+    <div
+      className="pt-4"
+      data-test="cta-popover-email-form"
+      data-testid="cta-popover-email-form"
+    >
       {errorResponse ? (
         <div className="text-red-500">{errorResponse}</div>
       ) : null}
@@ -115,7 +119,10 @@ const CtaPopoverEmailForm = ({ handleComplete }) => {
       </p>
     </div>
   ) : (
-    <div className="text-white mt-3 italic">
+    <div
+      className="text-white mt-3 italic"
+      data-testid="cta-popover-email-form-affirmation"
+    >
       Thank You For Submitting Your Email
     </div>
   );


### PR DESCRIPTION
### What's this PR do?

This pull request updates the stubbed POST requests in the company-page Cypress tests which were using the [deprecated](https://docs.cypress.io/api/commands/route.html) `cy.route()` and thus actually hitting our API (which was resulting in errors per an open issue discussed in [Slack](https://dosomething.slack.com/archives/CUQMTP0RM/p1615483885001600)) to use [`cy.intercept()`](https://docs.cypress.io/api/commands/intercept.html).

### How should this be reviewed?
👀 

### Any background context you want to provide?
TL;DR: due to an unrelated update in Northstar, these scholarship POST requests started failing due to a CORS issue. This caused this test to fail (which seemed strange https://github.com/DoSomething/phoenix-next/pull/2570#issuecomment-796910304) but turns out it's bc it's actually hitting our API!


I'll add a Ghost Inspector test to cover this submission so that we have live test coverage. This one should be stubbed since it's solely testing the Phoenix functionality. 