### PR TITLE
Add submission functionality to the Questionnaire action

### DIFF
--- a/resources/assets/components/actions/QuestionnaireAction/QuestionnaireAction.js
+++ b/resources/assets/components/actions/QuestionnaireAction/QuestionnaireAction.js
@@ -1,13 +1,24 @@
 import gql from 'graphql-tag';
-import { every } from 'lodash';
 import PropTypes from 'prop-types';
+import classNames from 'classnames';
+import { every, get } from 'lodash';
 import React, { useState } from 'react';
+import { RestApiClient } from '@dosomething/gateway';
 
+import { env } from '../../../helpers/env';
 import Card from '../../utilities/Card/Card';
+import { tabularLog } from '../../../helpers/api';
 import ActionInformation from '../ActionInformation';
+import { report } from '../../../helpers/monitoring';
+import { formatPostPayload } from '../../../helpers/forms';
 import PrimaryButton from '../../utilities/Button/PrimaryButton';
 import CharacterLimit from '../../utilities/CharacterLimit/CharacterLimit';
 import PrivacyLanguage from '../../utilities/PrivacyLanguage/PrivacyLanguage';
+import {
+  EVENT_CATEGORIES,
+  trackAnalyticsEvent,
+  getPageContext,
+} from '../../../helpers/analytics';
 
 export const QuestionnaireBlockFragment = gql`
   fragment QuestionnaireBlockFragment on QuestionnaireBlock {
@@ -21,7 +32,30 @@ export const QuestionnaireBlockFragment = gql`
 
 const CHARACTER_LIMIT = 500;
 
+/**
+ * Parse the question index from a validation error field name. ('questions.1.answer' -> 1).
+ *
+ * @param  {Object} errorField
+ * @return {Number}
+ */
+const getQuestionIndex = errorField => Number(errorField.match(/[0-9]/)[0]);
+
+/**
+ * Format a question field's error message into something more human friendly.
+ * ('The question.0.answer is required.' -> 'The question #1 answer is required.').
+ *
+ * @param  {Object} errorField
+ * @param  {Object} errorMessage
+ * @return {Number}
+ */
+const formatQuestionErrorMessage = (errorField, errorMessage) =>
+  errorMessage.replace(
+    /questions\.[0-9]\./,
+    `question #${getQuestionIndex(errorField) + 1} `,
+  );
+
 const QuestionnaireAction = ({
+  id,
   title,
   questions,
   buttonText,
@@ -29,9 +63,82 @@ const QuestionnaireAction = ({
   informationContent,
 }) => {
   const [answers, updateAnswers] = useState({});
+  const [loading, setLoading] = useState(false);
+  const [errors, setErrors] = useState(null);
 
   const onChange = (questionId, updatedAnswer) => {
     updateAnswers({ ...answers, [questionId]: updatedAnswer });
+  };
+
+  const onSubmit = event => {
+    event.preventDefault();
+
+    setLoading(true);
+
+    trackAnalyticsEvent('submitted_questionnaire_action', {
+      action: 'form_submitted',
+      category: EVENT_CATEGORIES.campaignAction,
+      label: 'questionnaire',
+      context: {
+        blockId: id,
+        ...getPageContext(),
+      },
+    });
+
+    const client = new RestApiClient(`${env('NORTHSTAR_URL')}`, {
+      headers: {
+        Authorization: `Bearer ${window.AUTH.token}`,
+        'Content-Type': 'application/json',
+      },
+    });
+
+    const data = formatPostPayload({
+      questions: questions.map(question => ({
+        title: question.title,
+        answer: answers[question.actionId],
+        action_id: question.actionId,
+      })),
+      contentful_id: id,
+    });
+
+    client
+      .post('/api/v3/questionnaires', data)
+      .then(response => {
+        tabularLog(get(response, 'data', null));
+
+        trackAnalyticsEvent('completed_questionnaire_action', {
+          action: 'questionnaire_completed',
+          category: EVENT_CATEGORIES.campaignAction,
+          label: 'questionnaire',
+          context: {
+            blockId: id,
+            ...getPageContext(),
+          },
+        });
+
+        window.location = `/us/posts/${response.data[0].id}?submissionActionId=${id}`;
+      })
+      .catch(error => {
+        report(error);
+
+        trackAnalyticsEvent('failed_questionnaire_action', {
+          action: 'questionnaire_failed',
+          category: EVENT_CATEGORIES.campaignAction,
+          label: 'questionnaire',
+          context: {
+            blockId: id,
+            ...getPageContext(),
+            error,
+          },
+        });
+
+        setLoading(false);
+
+        setErrors({
+          errorMessage: get(error, 'response.error.message'),
+          fieldErrors: get(error, 'response.errors'),
+        });
+      });
   };
 
   const finishedQuestionnaire = every(
@@ -47,22 +154,54 @@ const QuestionnaireAction = ({
       data-testid="questionnaire-action"
     >
       <Card className="bordered rounded col-span-8" title={title}>
-        <form className="p-3">
+        {errors ? (
+          <p className="p-3 text-red-500 font-bold">
+            {errors.errorMessage ||
+              'Hmm, there were some issues with your submission.'}
+          </p>
+        ) : null}
+
+        {get(errors, 'fieldErrors') ? (
+          <ul className="p-3 mt-0">
+            {Object.keys(errors.fieldErrors).map(errorField => (
+              <li key={errorField} className="text-red-500">
+                {errors.fieldErrors[errorField].map(errorMessage =>
+                  formatQuestionErrorMessage(errorField, errorMessage),
+                )}
+              </li>
+            ))}
+          </ul>
+        ) : null}
+
+        <form className="p-3" onSubmit={onSubmit}>
           {questions.map((question, index) => {
             const questionId = `question-${question.actionId}`;
+
+            const hasError = Object.keys(get(errors, 'fieldErrors', {})).find(
+              error =>
+                error.startsWith('questions') &&
+                getQuestionIndex(error) === index,
+            );
 
             return (
               <div key={question.actionId} data-testid={questionId}>
                 <label
                   data-testid={`${questionId}-title`}
-                  className="block mb-1 font-bold"
+                  className={classNames('block mb-1 font-bold', {
+                    'text-red-500': hasError,
+                  })}
                   htmlFor={questionId}
                 >
                   {index + 1}. {question.title}
                 </label>
 
                 <textarea
-                  className="block mb-1 h-24 text-field"
+                  className={classNames(
+                    'block mb-1 h-24 w-full text-base p-3 bg-clip-padding border border-gray-400 rounded',
+                    {
+                      'shake border border-red-500': hasError,
+                    },
+                  )}
                   data-testid={`${questionId}-input`}
                   id={questionId}
                   name={questionId}
@@ -71,6 +210,7 @@ const QuestionnaireAction = ({
                     onChange(question.actionId, event.target.value)
                   }
                   value={answers[question.actionId]}
+                  disabled={loading}
                 />
 
                 <CharacterLimit
@@ -86,6 +226,7 @@ const QuestionnaireAction = ({
             className="block mt-3 text-lg w-full"
             attributes={{ 'data-testid': 'questionnaire-submit-button' }}
             isDisabled={!finishedQuestionnaire}
+            isLoading={loading}
             text={buttonText}
             type="submit"
           />
@@ -106,12 +247,13 @@ const QuestionnaireAction = ({
 };
 
 QuestionnaireAction.propTypes = {
+  id: PropTypes.string.isRequired,
   title: PropTypes.string,
   questions: PropTypes.arrayOf(
     PropTypes.shape({
       title: PropTypes.string,
       placeholder: PropTypes.string,
-      actionId: PropTypes.number,
+      actionId: PropTypes.string,
     }),
   ).isRequired,
   buttonText: PropTypes.string,

--- a/resources/assets/helpers/api.js
+++ b/resources/assets/helpers/api.js
@@ -41,7 +41,7 @@ export function tabularLog(data) {
   // Console log response Data for debugging.
   if (window.ENV.APP_ENV !== 'production') {
     console.groupCollapsed(
-      '%c API Middleware Response: ',
+      '%c API Response: ',
       'background-color: rgba(137,161,188,0.5); color: rgba(33,70,112,1); display: block; font-weight: bold; line-height: 1.5;',
     );
     console.table(data);


### PR DESCRIPTION
### What's this PR do?

This pull request adds submission functionality to the `QuestionnaireAction` POSTing the user submission to Northstar.

Documentation & testing to come in a follow-up PR!

### How should this be reviewed?
👀 

The primary complexity revolves around the error state. Since we're not using a Phoenix proxy to talk with the ~Rogue~ Northstar API (unlike the other `_SubmissionActions` in Phoenix) which formats the API errors [on the backend](https://github.com/DoSomething/phoenix-next/blob/79bb0ea248177410d26365ba2f1d82646817a2f2/app/Exceptions/Handler.php#L102-L151), we needed to work with the errors without the various helpers used for the other components. (Hopefully, we'll swap to using GraphQL soon [per this thread](https://dosomething.slack.com/archives/CUQMU4Q6B/p1616093765009800)).
 
### Any background context you want to provide?
See above re error states, most of said complexity revolves around parsing the rather confusing looking error field labels e.g. `questions.1.title` into something more human friendly, and mapping these labels to the respective question fields for UI formatting. I don't anticipate any user input errors really....since we're validating on the front end, so this should really only pop up with machine errors / token errors, or admin misconfiguration (like an invalid Action ID).

### Relevant tickets

References [Pivotal #176852206](https://www.pivotaltracker.com/story/show/176852206).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [x] Added screenshots of front-end changes on small, medium, and large screens.
- [ ] Added appropriate feature/unit tests.

**Really the only type of error I'd anticipate**
![image](https://user-images.githubusercontent.com/12417657/111835876-eb28f280-88cb-11eb-9af4-6347ccb927ed.png)

**But if you hack around with the DOM then heck....**
![image](https://user-images.githubusercontent.com/12417657/111836883-69d25f80-88cd-11eb-9d2a-4dcd6768148e.png)
