### PR TITLE
About Page Member Spotlights

### DIFF
--- a/resources/assets/components/pages/AboutPage/AboutPage.js
+++ b/resources/assets/components/pages/AboutPage/AboutPage.js
@@ -72,9 +72,9 @@ const AboutPageTemplate = () => {
             <div className="grid-main">
               <p className="text-lg">
                 A DoSomething member is any young person who signs up for one of
-                our volunteer, social change, or civic action campaigns. We've
-                got *millions* of members making change in every US area code
-                and 131 countries. Get to know some of them!
+                our volunteer, social change, or civic action campaigns.
+                We&apos;ve got *millions* of members making change in every US
+                area code and 131 countries. Get to know some of them!
               </p>
             </div>
 

--- a/resources/assets/components/pages/AboutPage/AboutPage.js
+++ b/resources/assets/components/pages/AboutPage/AboutPage.js
@@ -5,10 +5,12 @@ import { isAuthenticated } from '../../../helpers/auth';
 import SiteFooter from '../../utilities/SiteFooter/SiteFooter';
 import PrimaryButton from '../../utilities/Button/PrimaryButton';
 import CampaignGallery from '../../utilities/Gallery/CampaignGallery';
+import SpotlightGallery from '../../utilities/Gallery/SpotlightGallery';
 import SiteNavigationContainer from '../../SiteNavigation/SiteNavigationContainer';
 import AnalyticsWaypoint from '../../utilities/AnalyticsWaypoint/AnalyticsWaypoint';
 import StrikeThroughHeader from '../../utilities/SectionHeader/StrikeThroughHeader';
 import NewsletterSubscriptionForm from '../../utilities/NewsletterSubscription/NewsletterSubscriptionForm';
+import { tailwind } from '../../../helpers/display';
 
 const AboutPageTemplate = () => {
   return (
@@ -27,7 +29,7 @@ const AboutPageTemplate = () => {
 
           {/* Campaign Gallery Section */}
           <section
-            className="base-12-grid bg-gray-100 py-8"
+            className="base-12-grid bg-gray-100 py-12"
             data-test="campaigns-section"
           >
             <AnalyticsWaypoint name="campaign_section_top" />
@@ -50,13 +52,58 @@ const AboutPageTemplate = () => {
 
           {/* Newsletter Signup Section */}
           <section
-            className="base-12-grid bg-gray-100 py-8"
+            className="base-12-grid bg-gray-100 py-12"
             data-test="newsletter-section"
           >
             <StrikeThroughHeader title="Get Inspired. Get Entertained. Get Active." />
 
             <div className="grid-wide text-center">
               <NewsletterSubscriptionForm />
+            </div>
+          </section>
+
+          {/* Member Highlight Section */}
+          <section
+            className="base-12-grid bg-white py-12"
+            data-test="member-highlight-section"
+          >
+            <StrikeThroughHeader title="Meet Our Members" />
+
+            <div className="grid-main">
+              <p className="text-lg">
+                A DoSomething member is any young person who signs up for one of
+                our volunteer, social change, or civic action campaigns. We've
+                got *millions* of members making change in every US area code
+                and 131 countries. Get to know some of them!
+              </p>
+            </div>
+
+            <div className="grid-wide">
+              <SpotlightGallery
+                type="memberSpotlight"
+                className="mt-8 text-center"
+                colors={{ background: tailwind('colors.purple.700') }}
+                items={content.memberHighlights}
+              />
+            </div>
+          </section>
+
+          {/* Scholarship Winners Section */}
+          <section
+            className="base-12-grid bg-white py-12"
+            data-test="scholarship-winners-section"
+          >
+            <StrikeThroughHeader title="Scholarship Winners" />
+
+            <div className="grid-wide text-center">
+              <SpotlightGallery
+                type="memberSpotlight"
+                colors={{
+                  background: tailwind('colors.blurple.500'),
+                  title: tailwind('colors.teal.500'),
+                }}
+                items={content.scholarshipWinners}
+              />
             </div>
           </section>
 

--- a/resources/assets/components/pages/AboutPage/AboutPage.js
+++ b/resources/assets/components/pages/AboutPage/AboutPage.js
@@ -1,6 +1,7 @@
 import { Fragment, React } from 'react';
 
 import content from './about-page-content.json';
+import { tailwind } from '../../../helpers/display';
 import { isAuthenticated } from '../../../helpers/auth';
 import SiteFooter from '../../utilities/SiteFooter/SiteFooter';
 import PrimaryButton from '../../utilities/Button/PrimaryButton';
@@ -10,7 +11,6 @@ import SiteNavigationContainer from '../../SiteNavigation/SiteNavigationContaine
 import AnalyticsWaypoint from '../../utilities/AnalyticsWaypoint/AnalyticsWaypoint';
 import StrikeThroughHeader from '../../utilities/SectionHeader/StrikeThroughHeader';
 import NewsletterSubscriptionForm from '../../utilities/NewsletterSubscription/NewsletterSubscriptionForm';
-import { tailwind } from '../../../helpers/display';
 
 const AboutPageTemplate = () => {
   return (

--- a/resources/assets/components/pages/AboutPage/about-page-content.json
+++ b/resources/assets/components/pages/AboutPage/about-page-content.json
@@ -57,5 +57,75 @@
   ],
   "coverImage": {
     "url": "https://images.ctfassets.net/81iqaqpfd8fy/HAghDe3KYoaSmgYEyoiYg/6cd32485fed6b640aa8b14441bdd33b2/Homepage_header_40.jpg"
-  }
+  },
+  "memberHighlights": [
+    {
+      "age": 20,
+      "campaignTitle": "Grandparents Gone Wired",
+      "content": "Caesar helped his grandma stay connected by teaching her emojis!",
+      "firstName": "Caesar",
+      "id": 1,
+      "image": {
+        "url": "https://images.ctfassets.net/81iqaqpfd8fy/HAghDe3KYoaSmgYEyoiYg/6cd32485fed6b640aa8b14441bdd33b2/Homepage_header_40.jpg"
+      },
+      "memberQuote": "Knowledge is power."
+    },
+    {
+      "age": 16,
+      "campaignTitle": "Teens for Jeans",
+      "content": "Jordyn and her friends donated 500 pairs of jeans to benefit a local homeless shelter.",
+      "firstName": "Jordyn",
+      "id": 2,
+      "image": {
+        "url": "https://images.ctfassets.net/81iqaqpfd8fy/HAghDe3KYoaSmgYEyoiYg/6cd32485fed6b640aa8b14441bdd33b2/Homepage_header_40.jpg"
+      },
+      "memberQuote": "We love giving back to the community! It is a great way to contribute to an important cause."
+    },
+    {
+      "age": 21,
+      "campaignTitle": "Give a Spit About Cancer",
+      "content": "Zachary swabbed his cheek to join the national bone marrow registry.",
+      "firstName": "Zachary",
+      "id": 3,
+      "image": {
+        "url": "https://images.ctfassets.net/81iqaqpfd8fy/HAghDe3KYoaSmgYEyoiYg/6cd32485fed6b640aa8b14441bdd33b2/Homepage_header_40.jpg"
+      },
+      "memberQuote": "I ran a give a spit drive on my campus. This campaign is LITERALLY saving lives!!!"
+    }
+  ],
+  "scholarshipWinners": [
+    {
+      "campaignTitle": "Not-So-Secret Admirer",
+      "content": "Keyla shared a V-Day card with her s/o to give them the confidence to pursue their dreams.",
+      "firstName": "Keyla",
+      "id": 1,
+      "image": {
+        "url": "https://images.ctfassets.net/81iqaqpfd8fy/HAghDe3KYoaSmgYEyoiYg/6cd32485fed6b640aa8b14441bdd33b2/Homepage_header_40.jpg"
+      },
+      "memberQuote": "This campaign allowed me to understand how important it is to show the person I am with how much I’m appreciative of them.",
+      "scholarshipAmount": 5000
+    },
+    {
+      "campaignTitle": "Let’s Stress Less",
+      "content": "Darren scored a scholarship for adding tips to our crowdsourced stress-busting guide.",
+      "firstName": "Darren",
+      "id": 2,
+      "image": {
+        "url": "https://images.ctfassets.net/81iqaqpfd8fy/HAghDe3KYoaSmgYEyoiYg/6cd32485fed6b640aa8b14441bdd33b2/Homepage_header_40.jpg"
+      },
+      "memberQuote": "I want to rest my head on my pillow at night knowing that I did the best I could to follow my calling of helping people.",
+      "scholarshipAmount": 2000
+    },
+    {
+      "campaignTitle": "Take Back the Prom: Outfit Donations",
+      "content": "Ricardo donated prom formal wear to make sure everyone could look and feel good at prom.",
+      "firstName": "Ricardo",
+      "id": 3,
+      "image": {
+        "url": "https://images.ctfassets.net/81iqaqpfd8fy/HAghDe3KYoaSmgYEyoiYg/6cd32485fed6b640aa8b14441bdd33b2/Homepage_header_40.jpg"
+      },
+      "memberQuote": "This campaign is important to me because I believe that everyone should be able to have an amazing prom filled with great memories.",
+      "scholarshipAmount": 2000
+    }
+  ]
 }

--- a/resources/assets/components/pages/AboutPage/about-page-content.json
+++ b/resources/assets/components/pages/AboutPage/about-page-content.json
@@ -66,7 +66,7 @@
       "firstName": "Caesar",
       "id": 1,
       "image": {
-        "url": "https://images.ctfassets.net/81iqaqpfd8fy/HAghDe3KYoaSmgYEyoiYg/6cd32485fed6b640aa8b14441bdd33b2/Homepage_header_40.jpg"
+        "url": "https://images.ctfassets.net/81iqaqpfd8fy/2zlEXv3peyZ1igkFLSuj1X/cad0cb1a0d78ab133ba06b4477e7a4e7/Caesar.png"
       },
       "memberQuote": "Knowledge is power."
     },
@@ -77,7 +77,7 @@
       "firstName": "Jordyn",
       "id": 2,
       "image": {
-        "url": "https://images.ctfassets.net/81iqaqpfd8fy/HAghDe3KYoaSmgYEyoiYg/6cd32485fed6b640aa8b14441bdd33b2/Homepage_header_40.jpg"
+        "url": "https://images.ctfassets.net/81iqaqpfd8fy/3G4nVbFnrjvYGG3kOo80wg/09acaee58919ebcd74b347ddec3cfa98/Jordyn.png"
       },
       "memberQuote": "We love giving back to the community! It is a great way to contribute to an important cause."
     },
@@ -88,7 +88,7 @@
       "firstName": "Zachary",
       "id": 3,
       "image": {
-        "url": "https://images.ctfassets.net/81iqaqpfd8fy/HAghDe3KYoaSmgYEyoiYg/6cd32485fed6b640aa8b14441bdd33b2/Homepage_header_40.jpg"
+        "url": "https://images.ctfassets.net/81iqaqpfd8fy/5gQ8bCGb2G68qgeHRKj1Sf/5f9b3b4f5bd0850227c47ea471671544/Zachary.png"
       },
       "memberQuote": "I ran a give a spit drive on my campus. This campaign is LITERALLY saving lives!!!"
     }
@@ -100,7 +100,7 @@
       "firstName": "Keyla",
       "id": 1,
       "image": {
-        "url": "https://images.ctfassets.net/81iqaqpfd8fy/HAghDe3KYoaSmgYEyoiYg/6cd32485fed6b640aa8b14441bdd33b2/Homepage_header_40.jpg"
+        "url": "https://images.ctfassets.net/81iqaqpfd8fy/1w35vrIZx2UaPQLvxnBXbF/81f3a9e5080cd61944c097633976d555/Keyla.png"
       },
       "memberQuote": "This campaign allowed me to understand how important it is to show the person I am with how much I’m appreciative of them.",
       "scholarshipAmount": 5000
@@ -111,7 +111,7 @@
       "firstName": "Darren",
       "id": 2,
       "image": {
-        "url": "https://images.ctfassets.net/81iqaqpfd8fy/HAghDe3KYoaSmgYEyoiYg/6cd32485fed6b640aa8b14441bdd33b2/Homepage_header_40.jpg"
+        "url": "https://images.ctfassets.net/81iqaqpfd8fy/5d6eAjeMqBAG9EtYuxj5d9/8a40997503fb7fe03393f6d65c4e2356/Darren.png"
       },
       "memberQuote": "I want to rest my head on my pillow at night knowing that I did the best I could to follow my calling of helping people.",
       "scholarshipAmount": 2000
@@ -122,7 +122,7 @@
       "firstName": "Ricardo",
       "id": 3,
       "image": {
-        "url": "https://images.ctfassets.net/81iqaqpfd8fy/HAghDe3KYoaSmgYEyoiYg/6cd32485fed6b640aa8b14441bdd33b2/Homepage_header_40.jpg"
+        "url": "https://images.ctfassets.net/81iqaqpfd8fy/1NXYHdwA74ztZCYZxxI1yQ/39cdc1acbe6a13c240619fd303d1b870/Ricardo.png"
       },
       "memberQuote": "This campaign is important to me because I believe that everyone should be able to have an amazing prom filled with great memories.",
       "scholarshipAmount": 2000

--- a/resources/assets/components/utilities/Gallery/SpotlightGallery.js
+++ b/resources/assets/components/utilities/Gallery/SpotlightGallery.js
@@ -1,0 +1,60 @@
+import React from 'react';
+import { get, startCase } from 'lodash';
+import PropTypes from 'prop-types';
+import classnames from 'classnames';
+
+import MemberSpotlight from '../MemberSpotlight/MemberSpotlight';
+import ErrorBlock from '../../blocks/ErrorBlock/ErrorBlock';
+
+const SpotlightGallery = ({ className, colors, items, type }) => (
+  <ul
+    className={classnames(
+      'spotlight-gallery gap-8 grid grid-cols-1 md:grid-cols-2 xxl:grid-cols-3',
+      className,
+    )}
+  >
+    {items.map(itemData => {
+      switch (type) {
+        case 'memberSpotlight':
+          return (
+            <li key={`${itemData.id}_member_spotlight`}>
+              <MemberSpotlight
+                age={get(itemData, 'age')}
+                campaignTitle={get(itemData, 'campaignTitle')}
+                colors={colors}
+                content={get(itemData, 'content')}
+                data={itemData}
+                firstName={get(itemData, 'firstName')}
+                image={get(itemData, 'image')}
+                memberQuote={get(itemData, 'memberQuote')}
+                scholarshipAmount={get(itemData, 'scholarshipAmount')}
+              />
+            </li>
+          );
+
+        default:
+          return (
+            <ErrorBlock
+              error={`${startCase(type)} gallery item component not found.`}
+            />
+          );
+      }
+    })}
+  </ul>
+);
+
+SpotlightGallery.propTypes = {
+  className: PropTypes.string,
+  colors: PropTypes.shape({
+    background: PropTypes.string,
+    title: PropTypes.string,
+  }),
+  items: PropTypes.arrayOf(PropTypes.object).isRequired,
+};
+
+SpotlightGallery.defaultProps = {
+  className: null,
+  colors: {},
+};
+
+export default SpotlightGallery;

--- a/resources/assets/components/utilities/Gallery/SpotlightGallery.js
+++ b/resources/assets/components/utilities/Gallery/SpotlightGallery.js
@@ -50,11 +50,13 @@ SpotlightGallery.propTypes = {
     title: PropTypes.string,
   }),
   items: PropTypes.arrayOf(PropTypes.object).isRequired,
+  type: PropTypes.string,
 };
 
 SpotlightGallery.defaultProps = {
   className: null,
   colors: {},
+  type: null,
 };
 
 export default SpotlightGallery;

--- a/resources/assets/components/utilities/MemberSpotlight/MemberSpotlight.js
+++ b/resources/assets/components/utilities/MemberSpotlight/MemberSpotlight.js
@@ -1,0 +1,99 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { css } from '@emotion/core';
+
+import { tailwind } from '../../../helpers/display';
+
+const MemberSpotlight = ({
+  age,
+  campaignTitle,
+  colors,
+  content,
+  firstName,
+  image,
+  memberQuote,
+  scholarshipAmount,
+}) => {
+  return (
+    <article
+      className="flex flex-col h-full relative text-center text-white bg-transparent"
+      css={css`
+        padding-top: 125px;
+      `}
+    >
+      <img
+        className="absolute rounded-full top-0"
+        css={css`
+          height: 250px;
+          left: 50%;
+          transform: translate(-50%);
+          width: 250px;
+        `}
+        src={image.url}
+        alt="DoSomething member"
+      />
+
+      <div
+        className="bg-orange-300 flex flex-col flex-grow px-4 pb-6 rounded"
+        css={css`
+          padding-top: 141px;
+        `}
+        style={{
+          backgroundColor: colors.background || tailwind('colors.blurple.500'),
+        }}
+      >
+        <h2
+          className="font-league-gothic font-normal mb-0 text-5xl uppercase"
+          style={{ color: colors.title || tailwind('colors.white') }}
+        >
+          {firstName}
+          {age ? `, ${age}` : null}
+        </h2>
+
+        <p className="mt-2 text-lg text-white">
+          Campaign: <span className="font-bold">{campaignTitle}</span>
+        </p>
+
+        {scholarshipAmount ? (
+          <p className="mt-1 text-lg text-white">
+            Amount:{' '}
+            <span className="font-bold">
+              ${scholarshipAmount.toLocaleString()}
+            </span>
+          </p>
+        ) : null}
+
+        <p className="mt-6 italic text-normal text-white">{content}</p>
+
+        <blockquote className="mt-6 italic">
+          &ldquo;{memberQuote}&rdquo;
+        </blockquote>
+      </div>
+    </article>
+  );
+};
+
+MemberSpotlight.propTypes = {
+  age: PropTypes.number,
+  campaignTitle: PropTypes.string.isRequired,
+  content: PropTypes.string.isRequired,
+  colors: PropTypes.shape({
+    background: PropTypes.string,
+    title: PropTypes.string,
+  }),
+  firstName: PropTypes.string.isRequired,
+  image: PropTypes.shape({
+    url: PropTypes.string,
+  }).isRequired,
+  memberQuote: PropTypes.string,
+  scholarshipAmount: PropTypes.number,
+};
+
+MemberSpotlight.defaultProps = {
+  age: null,
+  colors: {},
+  memberQuote: null,
+  scholarshipAmount: null,
+};
+
+export default MemberSpotlight;


### PR DESCRIPTION
### What's this PR do?

This pull request builds the "Meet Our Members" and "Scholarship Winners" section of the About page.

### How should this be reviewed?

While these sections contain all hardcoded content, my aim was to still create a reusable component which I essentially called a `*Spotlight` component and in this case, the `MemberSpotlight` component so it can be re-used in the future.

Along with this component I created a new `SpotlightGallery` component that accepts a `type` prop and then renders that type of spotlight component for the supplied data as a gallery (right now only the `MemberSpotlight` exists).

Here's what the "Meet Our Members" section looks like:
![Meet Our Members](https://user-images.githubusercontent.com/105849/112219048-debdd600-8bfa-11eb-99c1-ae6334bed5f2.png)

### Any background context you want to provide?

Here's a clip of how the sections behave responsively:

https://user-images.githubusercontent.com/105849/112218858-a1594880-8bfa-11eb-84a5-95f550971920.mp4

### Relevant tickets

References [Pivotal #177168906](https://www.pivotaltracker.com/story/show/177168906).

### Checklist

- [X] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [x] Added screenshots of front-end changes on small, medium, and large screens.
- [ ] Added appropriate feature/unit tests.
