### PR TITLE
Call To Action Banner component

### DIFF
--- a/resources/assets/components/pages/AboutPage/AboutPage.js
+++ b/resources/assets/components/pages/AboutPage/AboutPage.js
@@ -146,17 +146,13 @@ const AboutPageTemplate = () => {
           </section>
 
           <BannerCallToAction
-            colorClasses={{
-              background: 'bg-purple-500',
-              text: 'text-teal-500',
-            }}
             message="Earn scholarships through community service"
             title="Easy Scholarships"
             stacked
           >
             <PrimaryButton
               attributes={{ 'data-label': 'scholarships_cta_authorize' }}
-              className="mt-8 xl:m-0 py-4 px-16 text-lg xl:ml-auto"
+              className="mt-4 md:mt-8 py-4 px-16 text-lg"
               href="/authorize"
               text="See Scholarship Campaigns"
             />

--- a/resources/assets/components/pages/AboutPage/AboutPage.js
+++ b/resources/assets/components/pages/AboutPage/AboutPage.js
@@ -11,6 +11,7 @@ import { contentfulImageUrl } from '../../../helpers/contentful';
 import PrimaryButton from '../../utilities/Button/PrimaryButton';
 import CampaignGallery from '../../utilities/Gallery/CampaignGallery';
 import SpotlightGallery from '../../utilities/Gallery/SpotlightGallery';
+import BannerCallToAction from '../../utilities/CallToAction/BannerCallToAction';
 import SiteNavigationContainer from '../../SiteNavigation/SiteNavigationContainer';
 import AnalyticsWaypoint from '../../utilities/AnalyticsWaypoint/AnalyticsWaypoint';
 import StrikeThroughHeader from '../../utilities/SectionHeader/StrikeThroughHeader';
@@ -144,6 +145,23 @@ const AboutPageTemplate = () => {
             <AnalyticsWaypoint name="campaign_section_bottom" />
           </section>
 
+          <BannerCallToAction
+            colorClasses={{
+              background: 'bg-purple-500',
+              text: 'text-teal-500',
+            }}
+            message="Earn scholarships through community service"
+            title="Easy Scholarships"
+            stacked
+          >
+            <PrimaryButton
+              attributes={{ 'data-label': 'scholarships_cta_authorize' }}
+              className="mt-8 xl:m-0 py-4 px-16 text-lg xl:ml-auto"
+              href="/authorize"
+              text="See Scholarship Campaigns"
+            />
+          </BannerCallToAction>
+
           {/* Newsletter Signup Section */}
           <section
             className="base-12-grid bg-gray-100 py-12"
@@ -203,35 +221,18 @@ const AboutPageTemplate = () => {
 
           {/* Join Us Call To Action Banner */}
           {isAuthenticated() ? null : (
-            <article
-              className="base-12-grid bg-yellow-500 py-16"
-              data-test="signup-cta"
+            <BannerCallToAction
+              title="Join our youth-led movement for good"
+              message="Make an impact with millions of young people, and earn a chance to
+              win scholarships."
             >
-              <div className="xl:flex grid-wide xl:items-center text-center">
-                <AnalyticsWaypoint name="join_cta_top" />
-
-                <div className="text-left xl:w-8/12">
-                  <h1 className="font-bold text-2xl">
-                    Join our youth-led movement for good
-                  </h1>
-                  <p className="text-lg">
-                    Make an impact with millions of young people, and earn a
-                    chance to win scholarships.
-                  </p>
-                </div>
-
-                <div className="flex-grow">
-                  <PrimaryButton
-                    attributes={{ 'data-label': 'signup_cta_authorize' }}
-                    className="mt-8 xl:m-0 py-4 px-16 text-lg xl:ml-auto"
-                    href="/authorize"
-                    text="Join Now"
-                  />
-                </div>
-
-                <AnalyticsWaypoint name="join_cta_bottom" />
-              </div>
-            </article>
+              <PrimaryButton
+                attributes={{ 'data-label': 'signup_cta_authorize' }}
+                className="mt-8 xl:m-0 py-4 px-16 text-lg xl:ml-auto"
+                href="/authorize"
+                text="Join Now"
+              />
+            </BannerCallToAction>
           )}
         </article>
       </main>

--- a/resources/assets/components/pages/AboutPage/about-page-content.json
+++ b/resources/assets/components/pages/AboutPage/about-page-content.json
@@ -63,7 +63,7 @@
     }
   },
   "coverImage": {
-    "url": "https://images.ctfassets.net/81iqaqpfd8fy/HAghDe3KYoaSmgYEyoiYg/6cd32485fed6b640aa8b14441bdd33b2/Homepage_header_40.jpg"
+    "url": "https://images.ctfassets.net/81iqaqpfd8fy/OWhB5AP5YOEq1m7GTqSAn/2a12bfd0bf5bcbf0b9c15635b09a24fe/GettyImages-973270810.jpg"
   },
   "memberHighlights": [
     {

--- a/resources/assets/components/utilities/AnalyticsWaypoint/AnalyticsWaypoint.js
+++ b/resources/assets/components/utilities/AnalyticsWaypoint/AnalyticsWaypoint.js
@@ -7,7 +7,7 @@ import {
   trackAnalyticsEvent,
 } from '../../../helpers/analytics';
 
-const AnalyticsWaypoint = ({ name, context }) => {
+const AnalyticsWaypoint = ({ className, context, name }) => {
   const [ref, inView] = useInView({
     triggerOnce: true,
   });
@@ -26,15 +26,24 @@ const AnalyticsWaypoint = ({ name, context }) => {
     }
   }, [inView]);
 
-  return <div ref={ref} data-test="waypoint" data-testid="waypoint" />;
+  return (
+    <div
+      className={className}
+      ref={ref}
+      data-test="waypoint"
+      data-testid="waypoint"
+    />
+  );
 };
 
 AnalyticsWaypoint.propTypes = {
-  name: PropTypes.string.isRequired,
+  className: PropTypes.string,
   context: PropTypes.object,
+  name: PropTypes.string.isRequired,
 };
 
 AnalyticsWaypoint.defaultProps = {
+  className: null,
   context: {},
 };
 

--- a/resources/assets/components/utilities/CallToAction/BannerCallToAction.js
+++ b/resources/assets/components/utilities/CallToAction/BannerCallToAction.js
@@ -1,0 +1,86 @@
+import { React } from 'react';
+import PropTypes from 'prop-types';
+import { snakeCase } from 'lodash';
+import classnames from 'classnames';
+
+import AnalyticsWaypoint from '../AnalyticsWaypoint/AnalyticsWaypoint';
+
+const BannerCallToAction = ({
+  attributes,
+  children,
+  colorClasses,
+  message,
+  stacked,
+  title,
+  waypointName,
+}) => {
+  return (
+    <article
+      className={classnames(
+        'base-12-grid py-16 relative',
+        colorClasses.background || 'bg-yellow-500',
+      )}
+      {...attributes}
+    >
+      <AnalyticsWaypoint
+        className="absolute top-0 w-full"
+        name={snakeCase(`${waypointName} top`)}
+      />
+
+      <div
+        className={classnames('grid-wide text-center', {
+          'xl:flex xl:items-center': !stacked,
+        })}
+      >
+        <div className={classnames({ 'text-left xl:w-8/12': !stacked })}>
+          <h1
+            className={classnames(
+              'font-bold text-2xl',
+              colorClasses.text || 'text-gray-900',
+            )}
+          >
+            {title}
+          </h1>
+
+          <p
+            className={classnames(
+              'text-lg',
+              colorClasses.text || 'text-gray-900',
+            )}
+          >
+            {message}
+          </p>
+        </div>
+
+        <div className={classnames({ 'flex-grow': !stacked })}>{children}</div>
+      </div>
+
+      <AnalyticsWaypoint
+        className="absolute bottom-0 w-full"
+        name={snakeCase(`${waypointName} bottom`)}
+      />
+    </article>
+  );
+};
+
+BannerCallToAction.propTypes = {
+  attributes: PropTypes.object,
+  children: PropTypes.node.isRequired,
+  colorClasses: PropTypes.shape({
+    background: PropTypes.string,
+    text: PropTypes.string,
+  }),
+  message: PropTypes.string.isRequired,
+  stacked: PropTypes.bool,
+  title: PropTypes.string.isRequired,
+  waypointName: PropTypes.string,
+};
+
+BannerCallToAction.defaultProps = {
+  attributes: {},
+  colorClasses: {},
+  stacked: false,
+  waypointName: 'banner cta',
+};
+
+export default BannerCallToAction;

--- a/resources/assets/components/utilities/CallToAction/BannerCallToAction.js
+++ b/resources/assets/components/utilities/CallToAction/BannerCallToAction.js
@@ -35,7 +35,10 @@ const BannerCallToAction = ({
         <div className={classnames({ 'text-left xl:w-8/12': !stacked })}>
           <h1
             className={classnames(
-              'font-bold text-2xl',
+              'tracking-wide',
+              stacked
+                ? 'font-league-gothic font-normal text-4xl uppercase'
+                : 'text-2xl',
               colorClasses.text || 'text-gray-900',
             )}
           >
@@ -45,6 +48,7 @@ const BannerCallToAction = ({
           <p
             className={classnames(
               'text-lg',
+              { 'mt-4': stacked },
               colorClasses.text || 'text-gray-900',
             )}
           >


### PR DESCRIPTION
### What's this PR do?

This pull request creates a new utility component directory called `CallToAction` which will house the different call to action components needed (similar to the pattern established by the `Gallery` component directory).

First up is the new `BannerCallToAction`, which is a full width page banner CTA. There's some flexibility built into the component:

- Use the `stacked` prop to indicate that even on large screens, the alignment of the text and button should remain stacked in the center; otherwise it will have the message text on the left and button on the right.
- The button is passed as a child component to the `BannerCallToAction`, so that any kind of button can be used and does not have to be predefined by this component; the button can define its own colors, url, etc...
- Lastly, the background and text colors can be customized via class names using the `colorClasses` object prop, with `background` and `text` keys.

I also switched out the page cover image URL with the new one from Creative!

### How should this be reviewed?

👀 

Stacked Banner CTA:
![image](https://user-images.githubusercontent.com/105849/112563905-a06a1780-8db0-11eb-8917-f10b361311c0.png)

Side-by-side Banner CTA:
![image](https://user-images.githubusercontent.com/105849/112563983-c42d5d80-8db0-11eb-8291-0ce25d939c24.png)


Random Colors Stacked Banner CTA Example:
![image](https://user-images.githubusercontent.com/105849/112563840-83cddf80-8db0-11eb-93ce-086b8d5a7cd0.png)



### Any background context you want to provide?

This should help @lindsayrmaher with the upcoming Articles page work!

@mendelB I also made an update to the `AnalyticsWaypoint` component to allow passing classes. I ended up using this to better position the waypoint both in the markup and via styling to avoid conflicts we've seen before with it conflicting with the grid and taking up a spot in a column. Essentially I aboslutely positioned them with utility classes at the top & bottom of the component they are working in. I tested using the DS Analytics Debugger and had the waypoints fire exactly as expected! 🎉 

### Relevant tickets

References [Pivotal #177468614](https://www.pivotaltracker.com/story/show/177468614).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added screenshots of front-end changes on small, medium, and large screens.
- [ ] Added appropriate feature/unit tests.
