### PR TITLE
Fix Flakey Questionnaire Test

### DIFF
--- a/cypress/integration/questionnaire-action.js
+++ b/cypress/integration/questionnaire-action.js
@@ -285,14 +285,14 @@ describe('Questionnaire Action', () => {
     cy.findByTestId('question-1-input').type(faker.lorem.words());
     cy.findByTestId('question-2-input').type(faker.lorem.words());
 
-    cy.findByTestId('questionnaire-submit-button')
-      .click()
-      .handleLogin(user);
-
     cy.intercept('POST', QUESTIONNAIRES_API, {
       statusCode: 200,
       body: { data: [{ id: 1 }] },
     }).as('submitQuestionnaire');
+
+    cy.findByTestId('questionnaire-submit-button')
+      .click()
+      .handleLogin(user);
 
     cy.mockGraphqlOp('PostQuery', {
       post: {


### PR DESCRIPTION
### What's this PR do?

This pull request - hopefully - fixes what seems to be a flakey test in the Questionnaire Action Cypress suite. I think the issue is that we're stubbing the POST request after the login flow which might be too late for the triggered POST request that happens after the login.

### How should this be reviewed?
👀 
