### PR TITLE
Create Articles Page content type

### DIFF
--- a/contentful/content-types/articlesPage.js
+++ b/contentful/content-types/articlesPage.js
@@ -13,15 +13,6 @@ module.exports = function(migration) {
     .validations([])
     .disabled(false)
     .omitted(false);
-  articlesPage
-    .createField('title')
-    .name('Title')
-    .type('Symbol')
-    .localized(true)
-    .required(true)
-    .validations([])
-    .disabled(false)
-    .omitted(false);
 
   articlesPage
     .createField('coverImage')
@@ -234,7 +225,6 @@ module.exports = function(migration) {
     .disabled(false)
     .omitted(false);
   articlesPage.changeFieldControl('internalTitle', 'builtin', 'singleLine', {});
-  articlesPage.changeFieldControl('title', 'builtin', 'singleLine', {});
 
   articlesPage.changeFieldControl('coverImage', 'builtin', 'assetLinkEditor', {
     helpText:

--- a/contentful/content-types/articlesPage.js
+++ b/contentful/content-types/articlesPage.js
@@ -36,8 +36,8 @@ module.exports = function(migration) {
     .linkType('Asset');
 
   articlesPage
-    .createField('latestArticlesGalleryTitle')
-    .name('Latest Articles Gallery Title')
+    .createField('featuredArticlesGalleryTopTitle')
+    .name('Featured Articles Gallery Top Title')
     .type('Symbol')
     .localized(false)
     .required(true)
@@ -46,16 +46,16 @@ module.exports = function(migration) {
     .omitted(false);
 
   articlesPage
-    .createField('latestArticlesGallery')
-    .name('Latest Articles Gallery')
+    .createField('featuredArticlesGalleryTop')
+    .name('Featured Articles Gallery Top')
     .type('Array')
     .localized(false)
     .required(true)
     .validations([
       {
         size: {
-          min: 7,
-          max: 7,
+          min: 6,
+          max: 6,
         },
       },
     ])
@@ -67,7 +67,7 @@ module.exports = function(migration) {
       validations: [
         {
           linkContentType: ['page'],
-          message: 'Only Page entries are valid.',
+          message: 'Only Page entries are valid in this gallery.',
         },
       ],
 
@@ -157,8 +157,8 @@ module.exports = function(migration) {
     });
 
   articlesPage
-    .createField('elevenFactsGalleryTitle')
-    .name('Eleven Facts Gallery Title')
+    .createField('featuredArticlesGalleryBottomTitle')
+    .name('Featured Articles Gallery Bottom Title')
     .type('Symbol')
     .localized(false)
     .required(false)
@@ -167,8 +167,8 @@ module.exports = function(migration) {
     .omitted(false);
 
   articlesPage
-    .createField('elevenFactsGallery')
-    .name('Eleven Facts Gallery')
+    .createField('featuredArticlesGalleryBottom')
+    .name('Featured Articles Gallery Bottom')
     .type('Array')
     .localized(false)
     .required(false)
@@ -178,8 +178,6 @@ module.exports = function(migration) {
           min: 3,
           max: 6,
         },
-
-        message: 'Please add 3 or 6 articles to this gallery.',
       },
     ])
     .disabled(false)
@@ -190,7 +188,7 @@ module.exports = function(migration) {
       validations: [
         {
           linkContentType: ['page'],
-          message: 'Only Page entries are valid.',
+          message: 'Only Page entries are valid in this gallery.',
         },
       ],
 
@@ -234,20 +232,19 @@ module.exports = function(migration) {
   });
 
   articlesPage.changeFieldControl(
-    'latestArticlesGalleryTitle',
+    'featuredArticlesGalleryTopTitle',
     'builtin',
     'singleLine',
-    {
-      helpText: 'Add the title for our latest articles gallery',
-    },
+    {},
   );
 
   articlesPage.changeFieldControl(
-    'latestArticlesGallery',
+    'featuredArticlesGalleryTop',
     'builtin',
     'entryLinksEditor',
     {
-      helpText: 'Add articles (Page entries) to showcase on the articles page.',
+      helpText:
+        "Add stories you'd like to feature (latest articles, etc) here.",
       bulkEditing: false,
       showLinkEntityAction: true,
       showCreateEntityAction: true,
@@ -301,18 +298,19 @@ module.exports = function(migration) {
   );
 
   articlesPage.changeFieldControl(
-    'elevenFactsGalleryTitle',
+    'featuredArticlesGalleryBottomTitle',
     'builtin',
     'singleLine',
     {},
   );
 
   articlesPage.changeFieldControl(
-    'elevenFactsGallery',
+    'featuredArticlesGalleryBottom',
     'builtin',
     'entryLinksEditor',
     {
-      helpText: 'Add 11 facts articles to feature on the articles page.',
+      helpText:
+        'Use this gallery to feature 11 facts articles on the articles page.',
       bulkEditing: false,
       showLinkEntityAction: true,
       showCreateEntityAction: true,

--- a/contentful/content-types/articlesPage.js
+++ b/contentful/content-types/articlesPage.js
@@ -47,7 +47,7 @@ module.exports = function(migration) {
 
   articlesPage
     .createField('headerArticle')
-    .name('HeaderArticle')
+    .name('Header Article')
     .type('Link')
     .localized(false)
     .required(true)

--- a/contentful/content-types/articlesPage.js
+++ b/contentful/content-types/articlesPage.js
@@ -1,0 +1,335 @@
+module.exports = function(migration) {
+  const articlesPage = migration
+    .createContentType('articlesPage')
+    .name('Articles Page')
+    .description('The page for us to showcase articles on DoSomething.org')
+    .displayField('internalTitle');
+  articlesPage
+    .createField('internalTitle')
+    .name('Internal Title')
+    .type('Symbol')
+    .localized(false)
+    .required(true)
+    .validations([])
+    .disabled(false)
+    .omitted(false);
+  articlesPage
+    .createField('title')
+    .name('Title')
+    .type('Symbol')
+    .localized(true)
+    .required(true)
+    .validations([])
+    .disabled(false)
+    .omitted(false);
+
+  articlesPage
+    .createField('coverImage')
+    .name('Cover Image')
+    .type('Link')
+    .localized(false)
+    .required(false)
+    .validations([
+      {
+        linkMimetypeGroup: ['image'],
+      },
+      {
+        assetFileSize: {
+          min: null,
+          max: 20971520,
+        },
+      },
+    ])
+    .disabled(false)
+    .omitted(false)
+    .linkType('Asset');
+
+  articlesPage
+    .createField('latestArticlesGalleryTitle')
+    .name('Latest Articles Gallery Title')
+    .type('Symbol')
+    .localized(false)
+    .required(true)
+    .validations([])
+    .disabled(false)
+    .omitted(false);
+
+  articlesPage
+    .createField('latestArticlesGallery')
+    .name('Latest Articles Gallery')
+    .type('Array')
+    .localized(false)
+    .required(true)
+    .validations([
+      {
+        size: {
+          min: 7,
+          max: 7,
+        },
+      },
+    ])
+    .disabled(false)
+    .omitted(false)
+    .items({
+      type: 'Link',
+
+      validations: [
+        {
+          linkContentType: ['page'],
+          message: 'Only Page entries are valid.',
+        },
+      ],
+
+      linkType: 'Entry',
+    });
+
+  articlesPage
+    .createField('topicArticlesGalleryOneTitle')
+    .name('Topic Articles Gallery One Title')
+    .type('Symbol')
+    .localized(false)
+    .required(false)
+    .validations([])
+    .disabled(false)
+    .omitted(false);
+
+  articlesPage
+    .createField('topicArticlesGalleryOne')
+    .name('Topic Articles Gallery One')
+    .type('Array')
+    .localized(false)
+    .required(false)
+    .validations([
+      {
+        size: {
+          min: 3,
+          max: 6,
+        },
+
+        message: 'Please add 3 or 6 articles to this gallery.',
+      },
+    ])
+    .disabled(false)
+    .omitted(false)
+    .items({
+      type: 'Link',
+
+      validations: [
+        {
+          linkContentType: ['page'],
+          message: 'Only Page entries are valid.',
+        },
+      ],
+
+      linkType: 'Entry',
+    });
+
+  articlesPage
+    .createField('topicArticlesGalleryTwoTitle')
+    .name('Topic Articles Gallery Two Title')
+    .type('Symbol')
+    .localized(false)
+    .required(false)
+    .validations([])
+    .disabled(false)
+    .omitted(false);
+
+  articlesPage
+    .createField('topicArticlesGalleryTwo')
+    .name('Topic Articles Gallery Two')
+    .type('Array')
+    .localized(false)
+    .required(false)
+    .validations([
+      {
+        size: {
+          min: 3,
+          max: 6,
+        },
+
+        message: 'Please add 3 or 6 articles to this gallery.',
+      },
+    ])
+    .disabled(false)
+    .omitted(false)
+    .items({
+      type: 'Link',
+
+      validations: [
+        {
+          linkContentType: ['page'],
+          message: 'Only Page entries are valid.',
+        },
+      ],
+
+      linkType: 'Entry',
+    });
+
+  articlesPage
+    .createField('elevenFactsGalleryTitle')
+    .name('Eleven Facts Gallery Title')
+    .type('Symbol')
+    .localized(false)
+    .required(false)
+    .validations([])
+    .disabled(false)
+    .omitted(false);
+
+  articlesPage
+    .createField('elevenFactsGallery')
+    .name('Eleven Facts Gallery')
+    .type('Array')
+    .localized(false)
+    .required(false)
+    .validations([
+      {
+        size: {
+          min: 3,
+          max: 6,
+        },
+
+        message: 'Please add 3 or 6 articles to this gallery.',
+      },
+    ])
+    .disabled(false)
+    .omitted(false)
+    .items({
+      type: 'Link',
+
+      validations: [
+        {
+          linkContentType: ['page'],
+          message: 'Only Page entries are valid.',
+        },
+      ],
+
+      linkType: 'Entry',
+    });
+
+  articlesPage
+    .createField('ctaTitle')
+    .name('CTA Title')
+    .type('Symbol')
+    .localized(false)
+    .required(false)
+    .validations([])
+    .disabled(false)
+    .omitted(false);
+  articlesPage
+    .createField('ctaText')
+    .name('CTA Text')
+    .type('Symbol')
+    .localized(false)
+    .required(false)
+    .validations([])
+    .disabled(false)
+    .omitted(false);
+  articlesPage
+    .createField('ctaButtonText')
+    .name('CTA Button Text')
+    .type('Symbol')
+    .localized(false)
+    .required(false)
+    .validations([])
+    .disabled(false)
+    .omitted(false);
+  articlesPage.changeFieldControl('internalTitle', 'builtin', 'singleLine', {});
+  articlesPage.changeFieldControl('title', 'builtin', 'singleLine', {});
+
+  articlesPage.changeFieldControl('coverImage', 'builtin', 'assetLinkEditor', {
+    helpText:
+      'Cover image to display as background for the top banner on the articles page.',
+    showLinkEntityAction: true,
+    showCreateEntityAction: true,
+  });
+
+  articlesPage.changeFieldControl(
+    'latestArticlesGalleryTitle',
+    'builtin',
+    'singleLine',
+    {
+      helpText: 'Add the title for our latest articles gallery',
+    },
+  );
+
+  articlesPage.changeFieldControl(
+    'latestArticlesGallery',
+    'builtin',
+    'entryLinksEditor',
+    {
+      helpText: 'Add articles (Page entries) to showcase on the articles page.',
+      bulkEditing: false,
+      showLinkEntityAction: true,
+      showCreateEntityAction: true,
+    },
+  );
+
+  articlesPage.changeFieldControl(
+    'topicArticlesGalleryOneTitle',
+    'builtin',
+    'singleLine',
+    {
+      helpText:
+        'Add a title for first gallery of articles on a featured topic.',
+    },
+  );
+
+  articlesPage.changeFieldControl(
+    'topicArticlesGalleryOne',
+    'builtin',
+    'entryLinksEditor',
+    {
+      helpText:
+        'Add articles about the same topic to showcase on the articles page.',
+      bulkEditing: false,
+      showLinkEntityAction: true,
+      showCreateEntityAction: true,
+    },
+  );
+
+  articlesPage.changeFieldControl(
+    'topicArticlesGalleryTwoTitle',
+    'builtin',
+    'singleLine',
+    {
+      helpText:
+        'Add a title for the second gallery of articles on a specific topic.',
+    },
+  );
+
+  articlesPage.changeFieldControl(
+    'topicArticlesGalleryTwo',
+    'builtin',
+    'entryLinksEditor',
+    {
+      helpText:
+        'Add articles on the same topic to showcase on the articles page.',
+      bulkEditing: false,
+      showLinkEntityAction: true,
+      showCreateEntityAction: true,
+    },
+  );
+
+  articlesPage.changeFieldControl(
+    'elevenFactsGalleryTitle',
+    'builtin',
+    'singleLine',
+    {},
+  );
+
+  articlesPage.changeFieldControl(
+    'elevenFactsGallery',
+    'builtin',
+    'entryLinksEditor',
+    {
+      helpText: 'Add 11 facts articles to feature on the articles page.',
+      bulkEditing: false,
+      showLinkEntityAction: true,
+      showCreateEntityAction: true,
+    },
+  );
+
+  articlesPage.changeFieldControl('ctaTitle', 'builtin', 'singleLine', {});
+  articlesPage.changeFieldControl('ctaText', 'builtin', 'singleLine', {});
+  articlesPage.changeFieldControl('ctaButtonText', 'builtin', 'singleLine', {});
+};

--- a/contentful/content-types/articlesPage.js
+++ b/contentful/content-types/articlesPage.js
@@ -36,6 +36,32 @@ module.exports = function(migration) {
     .linkType('Asset');
 
   articlesPage
+    .createField('headerTitle')
+    .name('Header Title')
+    .type('Symbol')
+    .localized(false)
+    .required(false)
+    .validations([])
+    .disabled(false)
+    .omitted(false);
+
+  articlesPage
+    .createField('headerArticle')
+    .name('HeaderArticle')
+    .type('Link')
+    .localized(false)
+    .required(true)
+    .validations([
+      {
+        linkContentType: ['page'],
+        message: 'Only Page entries (articles) are valid for this field.',
+      },
+    ])
+    .disabled(false)
+    .omitted(false)
+    .linkType('Entry');
+
+  articlesPage
     .createField('featuredArticlesGalleryTopTitle')
     .name('Featured Articles Gallery Top Title')
     .type('Symbol')
@@ -231,6 +257,16 @@ module.exports = function(migration) {
     showCreateEntityAction: true,
   });
 
+  articlesPage.changeFieldControl('headerTitle', 'builtin', 'singleLine', {
+    helpText: 'Add a Title here to showcase the header article content.',
+  });
+
+  articlesPage.changeFieldControl(
+    'headerArticle',
+    'builtin',
+    'entryLinkEditor',
+    {},
+  );
   articlesPage.changeFieldControl(
     'featuredArticlesGalleryTopTitle',
     'builtin',

--- a/contentful/content-types/articlesPage.js
+++ b/contentful/content-types/articlesPage.js
@@ -62,6 +62,15 @@ module.exports = function(migration) {
     .linkType('Entry');
 
   articlesPage
+    .createField('headerLinkText')
+    .name('Header Link Text')
+    .type('Symbol')
+    .localized(false)
+    .required(false)
+    .validations([])
+    .disabled(false)
+    .omitted(false);
+  articlesPage
     .createField('featuredArticlesGalleryTopTitle')
     .name('Featured Articles Gallery Top Title')
     .type('Symbol')
@@ -267,6 +276,11 @@ module.exports = function(migration) {
     'entryLinkEditor',
     {},
   );
+
+  articlesPage.changeFieldControl('headerLinkText', 'builtin', 'singleLine', {
+    helpText: 'Add custom text for the article link ie. "Read More" etc.',
+  });
+
   articlesPage.changeFieldControl(
     'featuredArticlesGalleryTopTitle',
     'builtin',

--- a/docs/development/content-types/articles-page.md
+++ b/docs/development/content-types/articles-page.md
@@ -1,0 +1,31 @@
+# Articles Page
+
+## Overview
+
+This content type is an in-house replacement for the page we formerly housed on Instapage. It features articles from our site on a variety of topics.
+
+## Content Type Fields
+
+-   **Internal Title**: This is for our internal Contentful organization and will be how the block shows up in search results, etc. (does _not_ display to the user on the company page).
+
+-   **Title**:
+
+-   **Cover Image**: Displays at the top of the page and links to a featured Article.
+
+-   **Title**: The title of the page.
+
+-   **Subtitle**: The subtitle of the page
+
+-   **Content**: The Rich Text content of the page. This can be content in markdown format, embedded Assets, or valid embedded entry blocks.
+
+## Technical Notes
+
+<!-- Important information regarding how this content type behaves on the platform and code flow. -->
+
+## Additional Information
+
+<!-- Extra information that could be helpful. -->
+
+## Resources
+
+<!-- Links or information on additional resources that could be useful. -->

--- a/docs/development/content-types/articles-page.md
+++ b/docs/development/content-types/articles-page.md
@@ -8,24 +8,34 @@ This content type is an in-house replacement for the page we formerly housed on 
 
 -   **Internal Title**: This is for our internal Contentful organization and will be how the block shows up in search results, etc. (does _not_ display to the user on the company page).
 
--   **Title**:
-
 -   **Cover Image**: Displays at the top of the page and links to a featured Article.
 
--   **Title**: The title of the page.
+-   **Latest Articles Gallery Title**: The title above the first gallery of articles.
 
--   **Subtitle**: The subtitle of the page
+-   **Latest Articles Gallery**: Collection of 7 articles, the first will be the featured article displayed at the top of the page, and the other six in a gallery below.
 
--   **Content**: The Rich Text content of the page. This can be content in markdown format, embedded Assets, or valid embedded entry blocks.
+-   **Topic Articles Gallery One Title**: The title above the first gallery of articles on a specific topic.
+
+-   **Topic Articles Gallery One**: Collection of 3 or 6 articles all on a related topic.
+
+-   **Topic Articles Gallery Two Title**: The title above the second gallery of articles on a specific topic.
+
+-   **Topic Articles Gallery Two**: Collection of 3 or 6 articles all on a related topic.
+
+-   **Eleven Facts Gallery Title**: The title above the gallery showcasing all 11 Facts Articles.
+
+-   **Eleven Facts Gallery**: Collection of 3 or 6 11 Facts articles.
+
+-   **CTA Title**: Main CTA text for CTA banner at the bottom of the page.
+
+-   **CTA Text**: Sub CTA text for CTA banner at the bottom of the page.
+
+-   **CTA Button Text**: Custom text for the CTA button.
 
 ## Technical Notes
 
-<!-- Important information regarding how this content type behaves on the platform and code flow. -->
+Page entries are the currently the only type of entry we are validating for in the galleries since this is an articles specific page.
 
 ## Additional Information
 
-<!-- Extra information that could be helpful. -->
-
-## Resources
-
-<!-- Links or information on additional resources that could be useful. -->
+We chose to define each block of articles explicitly vs a rich text content field because of clarity for editors and being able to work in a stand alone component on the page itself.

--- a/docs/development/content-types/articles-page.md
+++ b/docs/development/content-types/articles-page.md
@@ -10,9 +10,15 @@ This content type is an in-house replacement for the page we formerly housed on 
 
 -   **Cover Image**: Displays at the top of the page and links to a featured Article.
 
--   **Latest Articles Gallery Title**: The title above the first gallery of articles.
+-   **Header Title**: Custom Title for the featured header article (alternative to headline in article page itself).
 
--   **Latest Articles Gallery**: Collection of 7 articles, the first will be the featured article displayed at the top of the page, and the other six in a gallery below.
+-   **Header Article**: Article that should be displayed and linked to at the top of the Articles page.
+
+-   **Header Link Text**: Optional custom text for the link out to the header article.
+
+-   **Featured Articles Gallery Top Title**: The title above the first gallery of articles.
+
+-   **Featured Articles Gallery Top**: Collection of 6 articles, for launch these will be the latest articles published on the site.
 
 -   **Topic Articles Gallery One Title**: The title above the first gallery of articles on a specific topic.
 
@@ -22,9 +28,9 @@ This content type is an in-house replacement for the page we formerly housed on 
 
 -   **Topic Articles Gallery Two**: Collection of 3 or 6 articles all on a related topic.
 
--   **Eleven Facts Gallery Title**: The title above the gallery showcasing all 11 Facts Articles.
+-   **Featured Articles Gallery Bottom Title**: The title above the gallery showcasing all 11 Facts Articles.
 
--   **Eleven Facts Gallery**: Collection of 3 or 6 11 Facts articles.
+-   **Featured Articles Gallery Bottom**: Collection of 3 or 6 11 Facts articles.
 
 -   **CTA Title**: Main CTA text for CTA banner at the bottom of the page.
 


### PR DESCRIPTION
### What's this PR do?

This pull request creates a new content type in Contentful called `articlesPage` with fields that editors will use to build out the new in house articles page to replace Instapage!

### How should this be reviewed?

Anything to add in documentation? Anything required that doesn't need to be? Anything missing that needs to be added?

### Any background context you want to provide?

I removed having an explicit `title` field because I felt like we could pull the title from the article itself. The featured article should be in the latest articles gallery similar to how we have the homepage setup, and it felt duplicative to have editors add a title there. I'm wondering if the same would be true about the cover image. [Here are the designs](https://app.abstract.com/projects/fadf0790-f1f9-11e6-9a30-b54ba7e8e705/branches/a9688e06-15bd-4d39-92e8-a7e688f9645c/commits/c50a405cb08fdf5bb6d367c44c554ebedf46d9af/files/c8cfdbb7-44da-408d-adeb-c88499272f2a/layers/CE85B7FC-0F17-4677-AD1B-6674A676E6F2?collectionId=e7dc0263-183e-47eb-890a-ac94286d2f94&collectionLayerId=684f5031-d92e-490f-b22a-6c899fd844c4) if that's helpful to reference.

### Relevant tickets

References [Pivotal #177518391](https://www.pivotaltracker.com/story/show/177518391).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [x] Documentation added for new features/changed endpoints.
