### PR TITLE
Articles Page Component

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -79,6 +79,7 @@ DS_ENABLE_REFER_FRIENDS_INCENTIVE=
 DS_ENABLE_SITEWIDE_NPS_SURVEY=
 DS_ENABLE_POST_CONFIRMATION_PAGE=
 DS_ENABLE_GRAPHQL_CAMPAIGN_SIGNUP=
+DS_ENABLE_NEW_ARTICLES_PAGE=
 
 # ==============================================================================
 # Site Config

--- a/config/feature-flags.php
+++ b/config/feature-flags.php
@@ -23,4 +23,5 @@ return [
     'sitewide_nps_survey' => env('DS_ENABLE_SITEWIDE_NPS_SURVEY', false),
     'rewards_levels' => env('DS_ENABLE_REWARDS_LEVELS', false),
     'graphql_campaign_signup' => env('DS_ENABLE_GRAPHQL_CAMPAIGN_SIGNUP', false),
+    'new_articles_page' => env('DS_ENABLE_NEW_ARTICLES_PAGE', false),
 ];

--- a/resources/assets/components/App.js
+++ b/resources/assets/components/App.js
@@ -22,6 +22,7 @@ import CampaignContainer from './Campaign/CampaignContainer';
 import BetaReferralPage from './pages/ReferralPage/Beta/BetaPage';
 import CollectionPage from './pages/CollectionPage/CollectionPage';
 import QuizResultPage from './pages/QuizResultPage/QuizResultPage';
+import ArticlesLandingPage from './pages/ArticlesPage/ArticlesPage';
 import AccountQuery from './pages/AccountPage/Account/AccountQuery';
 import TypeFormEmbed from './utilities/TypeFormEmbed/TypeFormEmbed';
 import AlphaReferralPage from './pages/ReferralPage/Alpha/AlphaPage';
@@ -84,6 +85,10 @@ const App = ({ store, history }) => {
                   </AuthGate>
                 )}
               />
+
+              {featureFlag('new_articles_page') ? (
+                <Route path="/us/articles" component={ArticlesLandingPage} />
+              ) : null}
 
               <Route path="/us/blocks/:id" component={BlockPage} />
 

--- a/resources/assets/components/App.js
+++ b/resources/assets/components/App.js
@@ -22,7 +22,7 @@ import CampaignContainer from './Campaign/CampaignContainer';
 import BetaReferralPage from './pages/ReferralPage/Beta/BetaPage';
 import CollectionPage from './pages/CollectionPage/CollectionPage';
 import QuizResultPage from './pages/QuizResultPage/QuizResultPage';
-import ArticlesLandingPage from './pages/ArticlesPage/ArticlesPage';
+import ArticlesPage from './pages/ArticlesPage/ArticlesPage';
 import AccountQuery from './pages/AccountPage/Account/AccountQuery';
 import TypeFormEmbed from './utilities/TypeFormEmbed/TypeFormEmbed';
 import AlphaReferralPage from './pages/ReferralPage/Alpha/AlphaPage';
@@ -78,7 +78,7 @@ const App = ({ store, history }) => {
               <Route exact path="/us" component={HomePage} />
 
               {featureFlag('new_articles_page') ? (
-                <Route path="/us/articles" component={ArticlesLandingPage} />
+                <Route path="/us/articles" component={ArticlesPage} />
               ) : null}
 
               <Route

--- a/resources/assets/components/App.js
+++ b/resources/assets/components/App.js
@@ -86,10 +86,6 @@ const App = ({ store, history }) => {
                 )}
               />
 
-              {featureFlag('new_articles_page') ? (
-                <Route path="/us/articles" component={ArticlesLandingPage} />
-              ) : null}
-
               <Route path="/us/blocks/:id" component={BlockPage} />
 
               {featureFlag('post_confirmation_page') ? (
@@ -164,6 +160,10 @@ const App = ({ store, history }) => {
               />
 
               <Route path="/us/refer-friends" component={AlphaReferralPage} />
+
+              {featureFlag('new_articles_page') ? (
+                <Route path="/us/articles" component={ArticlesLandingPage} />
+              ) : null}
 
               <Route path="/us/:slug" component={PageDispatcherContainer} />
             </Switch>

--- a/resources/assets/components/App.js
+++ b/resources/assets/components/App.js
@@ -77,6 +77,10 @@ const App = ({ store, history }) => {
             <Switch>
               <Route exact path="/us" component={HomePage} />
 
+              {featureFlag('new_articles_page') ? (
+                <Route path="/us/articles" component={ArticlesLandingPage} />
+              ) : null}
+
               <Route
                 path="/us/account"
                 render={() => (
@@ -160,10 +164,6 @@ const App = ({ store, history }) => {
               />
 
               <Route path="/us/refer-friends" component={AlphaReferralPage} />
-
-              {featureFlag('new_articles_page') ? (
-                <Route path="/us/articles" component={ArticlesLandingPage} />
-              ) : null}
 
               <Route path="/us/:slug" component={PageDispatcherContainer} />
             </Switch>

--- a/resources/assets/components/pages/ArticlesPage/ArticlesPage.js
+++ b/resources/assets/components/pages/ArticlesPage/ArticlesPage.js
@@ -1,15 +1,167 @@
-import React from 'react';
+import React, { Fragment } from 'react';
+import { css } from '@emotion/core';
 
+import LinkButton from '../../utilities/Button/LinkButton';
 import SiteFooter from '../../utilities/SiteFooter/SiteFooter';
+import PrimaryButton from '../../utilities/Button/PrimaryButton';
+import BannerCallToAction from '../../utilities/CallToAction/BannerCallToAction';
 import SiteNavigationContainer from '../../SiteNavigation/SiteNavigationContainer';
+import StrikeThroughHeader from '../../utilities/SectionHeader/StrikeThroughHeader';
+import NewsletterSubscriptionForm from '../../utilities/NewsletterSubscription/NewsletterSubscriptionForm';
 
 const ArticlesLandingPage = () => {
   return (
-    <>
+    <Fragment>
       <SiteNavigationContainer />
-      <main>Hello!</main>
+      <main>
+        <article data-testId="articles-page">
+          {/* Page Header */}
+          <header role="banner" className="bg-white">
+            <div
+              className="bg-gray-400"
+              css={css`
+                background-position: center center;
+                background-repeat: no-repeat;
+                background-size: cover;
+                height: 540px;
+
+                ${coverImageMediaQueryStyles(data.header.coverImage.url)}
+              `}
+            />
+
+            <div
+              className="base-12-grid"
+              css={css`
+                margin-top: -125px;
+              `}
+            >
+              <div
+                className="bg-blurple-500 grid-wide p-8 text-center"
+                css={css`
+                  min-height: 200px;
+                `}
+              >
+                <h1 className="font-league-gothic font-normal mb-0 text-5xl text-teal-500 uppercase">
+                  This will be the Header Title
+                </h1>
+
+                <LinkButton
+                  className="bg-yellow-400 hover:bg-yellow-100 mt-2 px-6 py-4 text-gray-900 hover:text-gray-900 text-lg"
+                  href="/authorize"
+                  text="Join Now"
+                />
+              </div>
+            </div>
+          </header>
+
+          {/* Introduction Section */}
+          <section className="base-12-grid bg-white py-12">
+            <Embed
+              className="col-span-4 md:col-span-8 lg:col-span-10 xl:col-span-4 lg:col-start-2 xl:col-start-8 xl:mt-12 xl:row-start-1 self-start"
+              url={data.introduction.media.url}
+            />
+
+            <div className="col-span-4 md:col-span-8 lg:col-span-10 xl:col-span-6 lg:col-start-2 xl:col-start-2 xl:row-start-1 mt-4 xl:mt-0">
+              <h2 className="mb-0 text-lg text-purple-400 uppercase">
+                About Us
+              </h2>
+
+              <h3 className="font-league-gothic font-normal mb-0 md:text-4xl mt-4 text-3xl uppercase">
+                {data.introduction.title}
+              </h3>
+
+              <p className="mt-8 text-lg">{data.introduction.copy}</p>
+            </div>
+          </section>
+
+          {/* Campaign Gallery Section */}
+          <section
+            className="base-12-grid bg-gray-100 py-12"
+            data-test="campaigns-section"
+          >
+            <StrikeThroughHeader title="Topic Gallery One" />
+
+            <div className="grid-wide text-center">
+              {/* //want to use gallery block in all the gallery sections */}
+              <CampaignGallery campaigns={data.campaignGallery.campaigns} />
+
+              <PrimaryButton
+                attributes={{ 'data-label': 'campaign_section_show_more' }}
+                className="mt-8 py-4 px-8 text-lg"
+                href="/us/campaigns"
+                text="See More Campaigns"
+              />
+            </div>
+          </section>
+
+          {/* Newsletter Signup Section */}
+          <section
+            className="base-12-grid bg-gray-100 py-12"
+            data-test="newsletter-section"
+          >
+            <StrikeThroughHeader title="Get Inspired. Get Entertained. Get Active." />
+
+            <div className="grid-wide text-center">
+              <NewsletterSubscriptionForm />
+            </div>
+          </section>
+
+          {/* Member Highlight Section */}
+          <section
+            className="base-12-grid bg-white py-12"
+            data-test="member-highlight-section"
+          >
+            <StrikeThroughHeader title={data.memberHighlights.title} />
+
+            <div className="grid-main">
+              <p className="text-lg">{data.memberHighlights.text}</p>
+            </div>
+
+            <div className="grid-wide">
+              <SpotlightGallery
+                type="memberSpotlight"
+                className="mt-8 text-center"
+                colors={{ background: tailwind('colors.purple.700') }}
+                items={data.memberHighlights.members}
+              />
+            </div>
+          </section>
+
+          {/* Scholarship Winners Section */}
+          <section
+            className="base-12-grid bg-white py-12"
+            data-test="scholarship-winners-section"
+          >
+            <StrikeThroughHeader title={data.scholarshipWinners.title} />
+
+            <div className="grid-wide text-center">
+              <SpotlightGallery
+                type="memberSpotlight"
+                colors={{
+                  background: tailwind('colors.blurple.500'),
+                  title: tailwind('colors.teal.500'),
+                }}
+                items={data.scholarshipWinners.members}
+              />
+            </div>
+          </section>
+
+          {/* Article Archive Call To Action Banner */}
+          <BannerCallToAction
+            text="An index of all articles and videos by DoSomething.org"
+            title="Article Archive"
+          >
+            <PrimaryButton
+              attributes={{ 'data-label': 'signup_cta_authorize' }}
+              className="mt-8 xl:m-0 py-4 px-16 text-lg xl:ml-auto"
+              href="/authorize"
+              text="View More Stories"
+            />
+          </BannerCallToAction>
+        </article>
+      </main>
       <SiteFooter />
-    </>
+    </Fragment>
   );
 };
 

--- a/resources/assets/components/pages/ArticlesPage/ArticlesPage.js
+++ b/resources/assets/components/pages/ArticlesPage/ArticlesPage.js
@@ -1,7 +1,16 @@
 import React from 'react';
 
+import SiteFooter from '../../utilities/SiteFooter/SiteFooter';
+import SiteNavigationContainer from '../../SiteNavigation/SiteNavigationContainer';
+
 const ArticlesLandingPage = () => {
-  return <div>Hello!</div>;
+  return (
+    <>
+      <SiteNavigationContainer />
+      <main>Hello!</main>
+      <SiteFooter />
+    </>
+  );
 };
 
 export default ArticlesLandingPage;

--- a/resources/assets/components/pages/ArticlesPage/ArticlesPage.js
+++ b/resources/assets/components/pages/ArticlesPage/ArticlesPage.js
@@ -1,0 +1,9 @@
+import React from 'react';
+
+const ArticlesLandingPage = () => (
+  <>
+    <div>Hello!</div>
+  </>
+);
+
+export default ArticlesLandingPage;

--- a/resources/assets/components/pages/ArticlesPage/ArticlesPage.js
+++ b/resources/assets/components/pages/ArticlesPage/ArticlesPage.js
@@ -7,6 +7,7 @@ import PageQuery from '../PageQuery';
 import LinkButton from '../../utilities/Button/LinkButton';
 import SiteFooter from '../../utilities/SiteFooter/SiteFooter';
 import PrimaryButton from '../../utilities/Button/PrimaryButton';
+import GalleryBlock from '../../blocks/GalleryBlock/GalleryBlock';
 import { pageCardFragment } from '../../utilities/PageCard/PageCard';
 import { coverImageMediaQueryStyles } from '../../../helpers/display';
 import BannerCallToAction from '../../utilities/CallToAction/BannerCallToAction';
@@ -118,7 +119,12 @@ const ArticlesLandingPage = ({
             <StrikeThroughHeader title={featuredArticlesGalleryTopTitle} />
 
             <div className="grid-wide text-center">
-              <CampaignGallery campaigns={data.campaignGallery.campaigns} />
+              <GalleryBlock
+                blocks={featuredArticlesGalleryTop || []}
+                galleryType="PAGE"
+                itemsPerRow={3}
+                imageAlignment="LEFT"
+              />
             </div>
           </section>
 
@@ -142,13 +148,11 @@ const ArticlesLandingPage = ({
             <StrikeThroughHeader title={topicArticlesGalleryOneTitle} />
 
             <div className="grid-wide text-center">
-              <CampaignGallery campaigns={data.campaignGallery.campaigns} />
-
-              <PrimaryButton
-                attributes={{ 'data-label': 'campaign_section_show_more' }}
-                className="mt-8 py-4 px-8 text-lg"
-                href="/us/campaigns"
-                text="See More Campaigns"
+              <GalleryBlock
+                blocks={topicArticlesGalleryOne || []}
+                galleryType="PAGE"
+                itemsPerRow={3}
+                imageAlignment="LEFT"
               />
             </div>
           </section>
@@ -161,13 +165,11 @@ const ArticlesLandingPage = ({
             <StrikeThroughHeader title={topicArticlesGalleryTwoTitle} />
 
             <div className="grid-wide text-center">
-              <CampaignGallery campaigns={data.campaignGallery.campaigns} />
-
-              <PrimaryButton
-                attributes={{ 'data-label': 'campaign_section_show_more' }}
-                className="mt-8 py-4 px-8 text-lg"
-                href="/us/campaigns"
-                text="See More Campaigns"
+              <GalleryBlock
+                blocks={topicArticlesGalleryTwo || []}
+                galleryType="PAGE"
+                itemsPerRow={3}
+                imageAlignment="LEFT"
               />
             </div>
           </section>
@@ -180,13 +182,11 @@ const ArticlesLandingPage = ({
             <StrikeThroughHeader title={featuredArticlesGalleryBottomTitle} />
 
             <div className="grid-wide text-center">
-              <CampaignGallery campaigns={data.campaignGallery.campaigns} />
-
-              <PrimaryButton
-                attributes={{ 'data-label': 'campaign_section_show_more' }}
-                className="mt-8 py-4 px-8 text-lg"
-                href="/us/campaigns"
-                text="See More Campaigns"
+              <GalleryBlock
+                blocks={featuredArticlesGalleryBottom || []}
+                galleryType="PAGE"
+                itemsPerRow={3}
+                imageAlignment="LEFT"
               />
             </div>
           </section>
@@ -214,9 +214,17 @@ ArticlesLandingPage.propTypes = {
   ctaButtonText: PropTypes.string,
   ctaText: PropTypes.string,
   ctaTitle: PropTypes.string,
+  featuredArticlesGalleryTopTitle: PropTypes.string.isRequired,
+  featuredArticlesGalleryTop: PropTypes.arrayOf(PropTypes.object).isRequired,
+  featuredArticlesGalleryBottomTitle: PropTypes.string,
+  featuredArticlesGalleryBottom: PropTypes.arrayOf(PropTypes.object),
   headerTitle: PropTypes.string,
   headerLinkUrl: PropTypes.string.isRequired,
   headerButtonText: PropTypes.string,
+  topicArticlesGalleryOneTitle: PropTypes.string,
+  topicArticlesGalleryOne: PropTypes.arrayOf(PropTypes.object),
+  topicArticlesGalleryTwoTitle: PropTypes.string,
+  topicArticlesGalleryTwo: PropTypes.arrayOf(PropTypes.object),
 };
 
 ArticlesLandingPage.defaultProps = {
@@ -224,8 +232,14 @@ ArticlesLandingPage.defaultProps = {
   ctaButtonText: 'View More Stories',
   ctaText: 'An index of all articles and videos by DoSomething.org',
   ctaTitle: 'Article Archive',
+  featuredArticlesGalleryBottomTitle: null,
+  featuredArticlesGalleryBottom: null,
   headerTitle: null,
   headerButtonText: 'Read More',
+  topicArticlesGalleryOne: null,
+  topicArticlesGalleryOneTitle: null,
+  topicArticlesGalleryTwo: null,
+  topicArticlesGalleryTwoTitle: null,
 };
 
 const ArticlesPage = () => (

--- a/resources/assets/components/pages/ArticlesPage/ArticlesPage.js
+++ b/resources/assets/components/pages/ArticlesPage/ArticlesPage.js
@@ -1,5 +1,5 @@
 import gql from 'graphql-tag';
-// import PropTypes from 'prop-types';
+import PropTypes from 'prop-types';
 import { css } from '@emotion/core';
 import React, { Fragment } from 'react';
 
@@ -8,6 +8,7 @@ import LinkButton from '../../utilities/Button/LinkButton';
 import SiteFooter from '../../utilities/SiteFooter/SiteFooter';
 import PrimaryButton from '../../utilities/Button/PrimaryButton';
 import { pageCardFragment } from '../../utilities/PageCard/PageCard';
+import { coverImageMediaQueryStyles } from '../../../helpers/display';
 import BannerCallToAction from '../../utilities/CallToAction/BannerCallToAction';
 import SiteNavigationContainer from '../../SiteNavigation/SiteNavigationContainer';
 import StrikeThroughHeader from '../../utilities/SectionHeader/StrikeThroughHeader';
@@ -48,15 +49,42 @@ const ARTICLES_PAGE_QUERY = gql`
   ${pageCardFragment}
 `;
 
-const ArticlesLandingPage = props => {
-  console.log(props);
+const ArticlesLandingPage = ({
+  coverImage,
+  headerTitle,
+  headerLinkUrl,
+  headerButtonText,
+  featuredArticlesGalleryTopTitle,
+  featuredArticlesGalleryTop,
+  topicArticlesGalleryOneTitle,
+  topicArticlesGalleryOne,
+  topicArticlesGalleryTwoTitle,
+  topicArticlesGalleryTwo,
+  featuredArticlesGalleryBottomTitle,
+  featuredArticlesGalleryBottom,
+  ctaTitle,
+  ctaText,
+  ctaButtonText,
+}) => {
   return (
     <Fragment>
       <SiteNavigationContainer />
       <main>
-        <article data-testId="articles-page">
+        <article data-test="articles-page">
           {/* Page Header */}
           <header role="banner" className="bg-white">
+            <div
+              className="bg-gray-400"
+              css={css`
+                background-position: center center;
+                background-repeat: no-repeat;
+                background-size: cover;
+                height: 540px;
+
+                ${coverImageMediaQueryStyles(coverImage.url)}
+              `}
+            />
+
             <div
               className="base-12-grid"
               css={css`
@@ -70,17 +98,29 @@ const ArticlesLandingPage = props => {
                 `}
               >
                 <h1 className="font-league-gothic font-normal mb-0 text-5xl text-teal-500 uppercase">
-                  This will be the Header Title
+                  {headerTitle}
                 </h1>
 
                 <LinkButton
                   className="bg-yellow-400 hover:bg-yellow-100 mt-2 px-6 py-4 text-gray-900 hover:text-gray-900 text-lg"
-                  href="/authorize"
-                  text="Join Now"
+                  href={headerLinkUrl}
+                  text={headerButtonText}
                 />
               </div>
             </div>
           </header>
+
+          {/* Featured Gallery Section Top */}
+          <section
+            className="base-12-grid bg-gray-100 py-12"
+            data-test="campaigns-section"
+          >
+            <StrikeThroughHeader title={featuredArticlesGalleryTopTitle} />
+
+            <div className="grid-wide text-center">
+              <CampaignGallery campaigns={data.campaignGallery.campaigns} />
+            </div>
+          </section>
 
           {/* Newsletter Signup Section */}
           <section
@@ -94,16 +134,70 @@ const ArticlesLandingPage = props => {
             </div>
           </section>
 
-          {/* Article Archive Call To Action Banner */}
-          <BannerCallToAction
-            text="An index of all articles and videos by DoSomething.org"
-            title="Article Archive"
+          {/* Topic Gallery Section One */}
+          <section
+            className="base-12-grid bg-gray-100 py-12"
+            data-test="campaigns-section"
           >
+            <StrikeThroughHeader title={topicArticlesGalleryOneTitle} />
+
+            <div className="grid-wide text-center">
+              <CampaignGallery campaigns={data.campaignGallery.campaigns} />
+
+              <PrimaryButton
+                attributes={{ 'data-label': 'campaign_section_show_more' }}
+                className="mt-8 py-4 px-8 text-lg"
+                href="/us/campaigns"
+                text="See More Campaigns"
+              />
+            </div>
+          </section>
+
+          {/* Topic Gallery Section Two */}
+          <section
+            className="base-12-grid bg-gray-100 py-12"
+            data-test="campaigns-section"
+          >
+            <StrikeThroughHeader title={topicArticlesGalleryTwoTitle} />
+
+            <div className="grid-wide text-center">
+              <CampaignGallery campaigns={data.campaignGallery.campaigns} />
+
+              <PrimaryButton
+                attributes={{ 'data-label': 'campaign_section_show_more' }}
+                className="mt-8 py-4 px-8 text-lg"
+                href="/us/campaigns"
+                text="See More Campaigns"
+              />
+            </div>
+          </section>
+
+          {/* Featured Gallery Section Bottom */}
+          <section
+            className="base-12-grid bg-gray-100 py-12"
+            data-test="campaigns-section"
+          >
+            <StrikeThroughHeader title={featuredArticlesGalleryBottomTitle} />
+
+            <div className="grid-wide text-center">
+              <CampaignGallery campaigns={data.campaignGallery.campaigns} />
+
+              <PrimaryButton
+                attributes={{ 'data-label': 'campaign_section_show_more' }}
+                className="mt-8 py-4 px-8 text-lg"
+                href="/us/campaigns"
+                text="See More Campaigns"
+              />
+            </div>
+          </section>
+
+          {/* Article Archive Call To Action Banner */}
+          <BannerCallToAction text={ctaText} title={ctaTitle}>
             <PrimaryButton
               attributes={{ 'data-label': 'signup_cta_authorize' }}
               className="mt-8 xl:m-0 py-4 px-16 text-lg xl:ml-auto"
-              href="/authorize"
-              text="View More Stories"
+              href="/us"
+              text={ctaButtonText}
             />
           </BannerCallToAction>
         </article>
@@ -113,9 +207,26 @@ const ArticlesLandingPage = props => {
   );
 };
 
-// ArticlesLandingPage.propTypes = {
-//   page: PropTypes.object.isRequired,
-// };
+ArticlesLandingPage.propTypes = {
+  coverImage: PropTypes.shape({
+    url: PropTypes.string.isRequired,
+  }),
+  ctaButtonText: PropTypes.string,
+  ctaText: PropTypes.string,
+  ctaTitle: PropTypes.string,
+  headerTitle: PropTypes.string,
+  headerLinkUrl: PropTypes.string.isRequired,
+  headerButtonText: PropTypes.string,
+};
+
+ArticlesLandingPage.defaultProps = {
+  coverImage: null,
+  ctaButtonText: 'View More Stories',
+  ctaText: 'An index of all articles and videos by DoSomething.org',
+  ctaTitle: 'Article Archive',
+  headerTitle: null,
+  headerButtonText: 'Read More',
+};
 
 const ArticlesPage = () => (
   <PageQuery query={ARTICLES_PAGE_QUERY}>

--- a/resources/assets/components/pages/ArticlesPage/ArticlesPage.js
+++ b/resources/assets/components/pages/ArticlesPage/ArticlesPage.js
@@ -192,7 +192,7 @@ const ArticlesLandingPage = ({
           </section>
 
           {/* Article Archive Call To Action Banner */}
-          <BannerCallToAction text={ctaText} title={ctaTitle}>
+          <BannerCallToAction text={ctaText} title={ctaTitle} stacked>
             <PrimaryButton
               attributes={{ 'data-label': 'signup_cta_authorize' }}
               className="mt-8 xl:m-0 py-4 px-16 text-lg xl:ml-auto"

--- a/resources/assets/components/pages/ArticlesPage/ArticlesPage.js
+++ b/resources/assets/components/pages/ArticlesPage/ArticlesPage.js
@@ -1,15 +1,55 @@
-import React, { Fragment } from 'react';
+import gql from 'graphql-tag';
+// import PropTypes from 'prop-types';
 import { css } from '@emotion/core';
+import React, { Fragment } from 'react';
 
+import PageQuery from '../PageQuery';
 import LinkButton from '../../utilities/Button/LinkButton';
 import SiteFooter from '../../utilities/SiteFooter/SiteFooter';
 import PrimaryButton from '../../utilities/Button/PrimaryButton';
+import { pageCardFragment } from '../../utilities/PageCard/PageCard';
 import BannerCallToAction from '../../utilities/CallToAction/BannerCallToAction';
 import SiteNavigationContainer from '../../SiteNavigation/SiteNavigationContainer';
 import StrikeThroughHeader from '../../utilities/SectionHeader/StrikeThroughHeader';
 import NewsletterSubscriptionForm from '../../utilities/NewsletterSubscription/NewsletterSubscriptionForm';
 
-const ArticlesLandingPage = () => {
+const ARTICLES_PAGE_QUERY = gql`
+  query ArticlesPageQuery($preview: Boolean) {
+    page: articlesPage(preview: $preview) {
+      id
+      coverImage {
+        url
+      }
+      headerTitle
+      headerLinkUrl
+      headerButtonText
+      featuredArticlesGalleryTopTitle
+      featuredArticlesGalleryTop {
+        ...PageCard
+      }
+      topicArticlesGalleryOneTitle
+      topicArticlesGalleryOne {
+        ...PageCard
+      }
+      topicArticlesGalleryTwoTitle
+      topicArticlesGalleryTwo {
+        ...PageCard
+      }
+      featuredArticlesGalleryBottomTitle
+      featuredArticlesGalleryBottom {
+        ...PageCard
+      }
+      ctaTitle
+      ctaText
+      ctaButtonText
+      additionalContent
+    }
+  }
+  ${pageCardFragment}
+`;
+
+const ArticlesLandingPage = props => {
+  console.log(props);
   return (
     <Fragment>
       <SiteNavigationContainer />
@@ -17,18 +57,6 @@ const ArticlesLandingPage = () => {
         <article data-testId="articles-page">
           {/* Page Header */}
           <header role="banner" className="bg-white">
-            <div
-              className="bg-gray-400"
-              css={css`
-                background-position: center center;
-                background-repeat: no-repeat;
-                background-size: cover;
-                height: 540px;
-
-                ${coverImageMediaQueryStyles(data.header.coverImage.url)}
-              `}
-            />
-
             <div
               className="base-12-grid"
               css={css`
@@ -54,46 +82,6 @@ const ArticlesLandingPage = () => {
             </div>
           </header>
 
-          {/* Introduction Section */}
-          <section className="base-12-grid bg-white py-12">
-            <Embed
-              className="col-span-4 md:col-span-8 lg:col-span-10 xl:col-span-4 lg:col-start-2 xl:col-start-8 xl:mt-12 xl:row-start-1 self-start"
-              url={data.introduction.media.url}
-            />
-
-            <div className="col-span-4 md:col-span-8 lg:col-span-10 xl:col-span-6 lg:col-start-2 xl:col-start-2 xl:row-start-1 mt-4 xl:mt-0">
-              <h2 className="mb-0 text-lg text-purple-400 uppercase">
-                About Us
-              </h2>
-
-              <h3 className="font-league-gothic font-normal mb-0 md:text-4xl mt-4 text-3xl uppercase">
-                {data.introduction.title}
-              </h3>
-
-              <p className="mt-8 text-lg">{data.introduction.copy}</p>
-            </div>
-          </section>
-
-          {/* Campaign Gallery Section */}
-          <section
-            className="base-12-grid bg-gray-100 py-12"
-            data-test="campaigns-section"
-          >
-            <StrikeThroughHeader title="Topic Gallery One" />
-
-            <div className="grid-wide text-center">
-              {/* //want to use gallery block in all the gallery sections */}
-              <CampaignGallery campaigns={data.campaignGallery.campaigns} />
-
-              <PrimaryButton
-                attributes={{ 'data-label': 'campaign_section_show_more' }}
-                className="mt-8 py-4 px-8 text-lg"
-                href="/us/campaigns"
-                text="See More Campaigns"
-              />
-            </div>
-          </section>
-
           {/* Newsletter Signup Section */}
           <section
             className="base-12-grid bg-gray-100 py-12"
@@ -103,46 +91,6 @@ const ArticlesLandingPage = () => {
 
             <div className="grid-wide text-center">
               <NewsletterSubscriptionForm />
-            </div>
-          </section>
-
-          {/* Member Highlight Section */}
-          <section
-            className="base-12-grid bg-white py-12"
-            data-test="member-highlight-section"
-          >
-            <StrikeThroughHeader title={data.memberHighlights.title} />
-
-            <div className="grid-main">
-              <p className="text-lg">{data.memberHighlights.text}</p>
-            </div>
-
-            <div className="grid-wide">
-              <SpotlightGallery
-                type="memberSpotlight"
-                className="mt-8 text-center"
-                colors={{ background: tailwind('colors.purple.700') }}
-                items={data.memberHighlights.members}
-              />
-            </div>
-          </section>
-
-          {/* Scholarship Winners Section */}
-          <section
-            className="base-12-grid bg-white py-12"
-            data-test="scholarship-winners-section"
-          >
-            <StrikeThroughHeader title={data.scholarshipWinners.title} />
-
-            <div className="grid-wide text-center">
-              <SpotlightGallery
-                type="memberSpotlight"
-                colors={{
-                  background: tailwind('colors.blurple.500'),
-                  title: tailwind('colors.teal.500'),
-                }}
-                items={data.scholarshipWinners.members}
-              />
             </div>
           </section>
 
@@ -165,4 +113,14 @@ const ArticlesLandingPage = () => {
   );
 };
 
-export default ArticlesLandingPage;
+// ArticlesLandingPage.propTypes = {
+//   page: PropTypes.object.isRequired,
+// };
+
+const ArticlesPage = () => (
+  <PageQuery query={ARTICLES_PAGE_QUERY}>
+    {page => <ArticlesLandingPage {...page} />}
+  </PageQuery>
+);
+
+export default ArticlesPage;

--- a/resources/assets/components/pages/ArticlesPage/ArticlesPage.js
+++ b/resources/assets/components/pages/ArticlesPage/ArticlesPage.js
@@ -1,9 +1,7 @@
 import React from 'react';
 
-const ArticlesLandingPage = () => (
-  <>
-    <div>Hello!</div>
-  </>
-);
+const ArticlesLandingPage = () => {
+  return <div>Hello!</div>;
+};
 
 export default ArticlesLandingPage;

--- a/routes/web.php
+++ b/routes/web.php
@@ -58,9 +58,11 @@ Route::get('search', function () {
 });
 
 // About pages
-
 Route::view('us/about', 'app');
 Route::view('us/about/{slug}', 'app');
+
+// Articles pages
+Route::view('us/articles', 'app');
 
 // Categorized Pages (articles, facts)
 $categories = 'articles|facts|stories';


### PR DESCRIPTION
### What's this PR do?

This pull request adds a new `/us/articles` route and an `ArticlesLandingPage` component. It follows a fairly similar pattern to the `About Page` but contains up to four galleries to display articles from.

### How should this be reviewed?

Sorry for all the broken images, I think dev has limited options of articles that are fully built out. 

Large Screen:
<img width="1388" alt="Screen Shot 2021-04-09 at 12 06 49 PM" src="https://user-images.githubusercontent.com/15236023/114209180-56467180-992c-11eb-919b-c03cffebfd79.png">

<img width="1391" alt="Screen Shot 2021-04-09 at 12 07 07 PM" src="https://user-images.githubusercontent.com/15236023/114209249-69594180-992c-11eb-8c46-8919960b5a6a.png">

<img width="1388" alt="Screen Shot 2021-04-09 at 12 07 15 PM" src="https://user-images.githubusercontent.com/15236023/114209315-7a09b780-992c-11eb-942e-9024cb2a70a2.png">

### Any background context you want to provide?

There will be follow up PRs to build out the correct Newsletter signup section and add some cypress tests!

### Relevant tickets

References [Pivotal #177518572](https://www.pivotaltracker.com/n/projects/2401401/stories/177518572).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [x] Added screenshots of front-end changes on small, medium, and large screens.
- [ ] Added appropriate feature/unit tests.
