### PR TITLE
Removes link text field and adds button text field

### DIFF
--- a/contentful/content-types/articlesPage.js
+++ b/contentful/content-types/articlesPage.js
@@ -64,8 +64,8 @@ module.exports = function(migration) {
     .omitted(false);
 
   articlesPage
-    .createField('headerLinkText')
-    .name('Header Link Text')
+    .createField('headerButtonText')
+    .name('Header Button Text')
     .type('Symbol')
     .localized(false)
     .required(false)
@@ -277,7 +277,7 @@ module.exports = function(migration) {
       'A valid URL e.g. https://dosomething.org, or a link to a valid US email e.g. http://email.dosomething.org/deliveries/dgPY8QPY8QMDAAF4ifqeOl6Y5gBsgx5ogGE=',
   });
 
-  articlesPage.changeFieldControl('headerLinkText', 'builtin', 'singleLine', {
+  articlesPage.changeFieldControl('headerButtonText', 'builtin', 'singleLine', {
     helpText: 'Add custom text for the article link ie. "Read More" etc.',
   });
 

--- a/docs/development/content-types/articles-page.md
+++ b/docs/development/content-types/articles-page.md
@@ -12,9 +12,9 @@ This content type is an in-house replacement for the page we formerly housed on 
 
 -   **Header Title**: Custom Title for the featured header article (alternative to headline in article page itself).
 
--   **Header Article**: Article that should be displayed and linked to at the top of the Articles page.
+-   **Header Link URL**: A link to the article that should be displayed and linked to at the top of the Articles page.
 
--   **Header Link Text**: Optional custom text for the link out to the header article.
+-   **Header Button Text**: Optional custom text for the link out to the header article.
 
 -   **Featured Articles Gallery Top Title**: The title above the first gallery of articles.
 


### PR DESCRIPTION
### What's this PR do?

This pull request updates the articles page content type with (hopefully) one last naming update! Feedback was to call the field to add custom text on the header article link `button text` vs `link text` since there will be a button visually shown on the page. 

### How should this be reviewed?

👀 

### Any background context you want to provide?

n/a

### Relevant tickets

References [Pivotal #177518391](https://www.pivotaltracker.com/story/show/177518391).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added screenshots of front-end changes on small, medium, and large screens.
- [ ] Added appropriate feature/unit tests.
