### PR TITLE
Ghost Inspector Deploy Hook

### DIFF
--- a/docs/installation-and-usage/usage.md
+++ b/docs/installation-and-usage/usage.md
@@ -44,10 +44,10 @@ We use [Prettier](https://prettier.io/) to format our code & [ESLint](http://esl
 
 They run in the following scenarios:
 
-- When using the `npm start` command, your files will be "watched" for changes, and when a change is detected, the JS code will be linted and only compiled if it passes.
-- Code will be automatically formatted when committing changes. You can also install an [editor plugin](https://prettier.io/docs/en/editors.html) to reformat code as you write it, or manually format the project with `npm run format`.
-- You can manually lint code by running `npm run lint -s`. The `-s` option lets you suppress the verbose NPM warnings that follows when there are linting errors.
-- Code linting also runs via [Wercker](http://www.wercker.com/), our continuous integration service, when a new pull request is made for the repository.
+-   When using the `npm start` command, your files will be "watched" for changes, and when a change is detected, the JS code will be linted and only compiled if it passes.
+-   Code will be automatically formatted when committing changes. You can also install an [editor plugin](https://prettier.io/docs/en/editors.html) to reformat code as you write it, or manually format the project with `npm run format`.
+-   You can manually lint code by running `npm run lint -s`. The `-s` option lets you suppress the verbose NPM warnings that follows when there are linting errors.
+-   Code linting also runs via [Wercker](http://www.wercker.com/), our continuous integration service, when a new pull request is made for the repository.
 
 We use [StyleCI](https://styleci.io/repos/75642790) service to lint our PHP code when a new pull request is made for the respository.
 
@@ -59,8 +59,8 @@ We use [StyleCI](https://styleci.io/repos/75642790) service to lint our PHP code
 
 There are a couple of other third-party services that you will want access to for development:
 
-- The [Dosomething Team](https://dashboard.heroku.com/teams/dosomething/overview) on [Heroku](https://www.heroku.com/) to access the Phoenix Pipeline, which includes Review Apps, Dev, QA and Production Phoenix deployments.
-- The [Dosomething Organization](https://app.wercker.com/dosomething) on [Wercker](https://app.wercker.com) to access and re-trigger auto builds for _pull requests_ in the Phoenix repository.
+-   The [Dosomething Team](https://dashboard.heroku.com/teams/dosomething/overview) on [Heroku](https://www.heroku.com/) to access the Phoenix Pipeline, which includes Review Apps, Dev, QA and Production Phoenix deployments.
+-   The [Dosomething Organization](https://app.wercker.com/dosomething) on [Wercker](https://app.wercker.com) to access and re-trigger auto builds for _pull requests_ in the Phoenix repository.
 
 ### Review Apps
 

--- a/docs/installation-and-usage/usage.md
+++ b/docs/installation-and-usage/usage.md
@@ -73,3 +73,9 @@ Once a _Pull Request_ is merged, a deploy to our _Development_ and _QA (staging)
 The Development environment can be accessed at [https://dev.dosomething.org](https://dev.dosomething.org).
 
 The QA environment can be accessed at [https://qa.dosomething.org](https://qa.dosomething.org).
+
+### Ghost Inspector
+
+We run automated tests against our website using [Ghost Inspector](https://app.ghostinspector.com/folders/5c4763450bb17c1d6e1f5e9d).
+
+Once a deploy is executed on our _QA (staging)_ and _Production_ environments, the respective QA or Production test suite is triggered to run via a [Heroku Deploy Hook integration](https://ghostinspector.com/docs/integration/heroku/).


### PR DESCRIPTION
### What's this PR do?

This pull request adds some quick documentation so I can test the [Ghost Inspector Heroku Deploy Hook](https://ghostinspector.com/docs/integration/heroku/) to trigger test runs after deploying to QA & Production.

### How should this be reviewed?
👀 

### Any background context you want to provide?
Using the deploy hook seems to be our quickest & easiest bet. 
Should this be codified via Terraform?


### Relevant tickets

References [Pivotal #170523172](https://www.pivotaltracker.com/n/projects/2328687/stories/170523172).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [x] Documentation added for new features/changed endpoints.
- [ ] Added screenshots of front-end changes on small, medium, and large screens.
- [ ] Added appropriate feature/unit tests.
