### PR TITLE
Survey the surveys

### DIFF
--- a/resources/assets/components/App.js
+++ b/resources/assets/components/App.js
@@ -47,7 +47,9 @@ const App = ({ store, history }) => {
             /* If we're in "chromeless" mode, open all links in new windows: */
             <base target="_blank" />
           ) : null}
+
           <PopoverDispatcher />
+
           {featureFlag('sitewide_nps_survey') ? (
             <TrafficDistribution percentage={5} feature="nps_survey">
               <DismissableElement

--- a/resources/assets/components/App.js
+++ b/resources/assets/components/App.js
@@ -14,6 +14,7 @@ import Modal from './utilities/Modal/Modal';
 import { initializeStore } from '../store/store';
 import HomePage from './pages/HomePage/HomePage';
 import { env, featureFlag } from '../helpers/env';
+import { isAuthenticated } from '../helpers/auth';
 import BlockPage from './pages/BlockPage/BlockPage';
 import CausePage from './pages/CausePage/CausePage';
 import AboutPage from './pages/AboutPage/AboutPage';
@@ -50,7 +51,7 @@ const App = ({ store, history }) => {
 
           <PopoverDispatcher />
 
-          {featureFlag('sitewide_nps_survey') ? (
+          {featureFlag('sitewide_nps_survey') && isAuthenticated() ? (
             <TrafficDistribution percentage={5} feature="nps_survey">
               <DismissableElement
                 name="nps_survey"

--- a/resources/assets/components/App.js
+++ b/resources/assets/components/App.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import { get } from 'lodash';
 import PropTypes from 'prop-types';
 import ErrorBoundary from 'react-error-boundary';
 import { ApolloProvider } from '@apollo/react-common';

--- a/resources/assets/components/App.js
+++ b/resources/assets/components/App.js
@@ -55,7 +55,7 @@ const App = ({ store, history }) => {
               <DismissableElement
                 name="nps_survey"
                 render={(handleClose, handleComplete) => (
-                  <DelayedElement delay={30}>
+                  <DelayedElement delay={60}>
                     <Modal onClose={handleClose} trackingId="SURVEY_MODAL">
                       <TypeFormEmbed
                         displayType="modal"

--- a/resources/assets/components/App.js
+++ b/resources/assets/components/App.js
@@ -14,11 +14,11 @@ import Modal from './utilities/Modal/Modal';
 import { initializeStore } from '../store/store';
 import HomePage from './pages/HomePage/HomePage';
 import { env, featureFlag } from '../helpers/env';
-import { isAuthenticated } from '../helpers/auth';
 import BlockPage from './pages/BlockPage/BlockPage';
 import CausePage from './pages/CausePage/CausePage';
 import AboutPage from './pages/AboutPage/AboutPage';
 import CompanyPage from './pages/CompanyPage/CompanyPage';
+import { isAuthenticated, getUserId } from '../helpers/auth';
 import CampaignContainer from './Campaign/CampaignContainer';
 import BetaReferralPage from './pages/ReferralPage/Beta/BetaPage';
 import CollectionPage from './pages/CollectionPage/CollectionPage';
@@ -62,7 +62,7 @@ const App = ({ store, history }) => {
                         displayType="modal"
                         typeformUrl="https://dosomething.typeform.com/to/Phi9pA"
                         queryParameters={{
-                          northstar_id: get(window.AUTH, 'id', null),
+                          northstar_id: getUserId(),
                           url: window.location.pathname,
                         }}
                         onSubmit={handleComplete}

--- a/resources/assets/components/App.js
+++ b/resources/assets/components/App.js
@@ -48,8 +48,7 @@ const App = ({ store, history }) => {
             <base target="_blank" />
           ) : null}
           <PopoverDispatcher />
-          {featureFlag('sitewide_nps_survey') &&
-          window.location.pathname !== '/us' ? (
+          {featureFlag('sitewide_nps_survey') ? (
             <TrafficDistribution percentage={5} feature="nps_survey">
               <DismissableElement
                 name="nps_survey"

--- a/resources/assets/components/pages/HomePage/HomePage.js
+++ b/resources/assets/components/pages/HomePage/HomePage.js
@@ -1,12 +1,9 @@
-import { get } from 'lodash';
 import gql from 'graphql-tag';
 import PropTypes from 'prop-types';
 import { css } from '@emotion/core';
 import { React, Fragment } from 'react';
 
 import PageQuery from '../PageQuery';
-import Modal from '../../utilities/Modal/Modal';
-import { featureFlag } from '../../../helpers/env';
 import * as NewsletterImages from './NewsletterImages';
 import { isAuthenticated } from '../../../helpers/auth';
 import HomePageArticleGallery from './HomePageArticleGallery';
@@ -15,16 +12,12 @@ import { contentfulImageUrl } from '../../../helpers/contentful';
 import PrimaryButton from '../../utilities/Button/PrimaryButton';
 import { pageCardFragment } from '../../utilities/PageCard/PageCard';
 import CampaignGallery from '../../utilities/Gallery/CampaignGallery';
-import TypeFormEmbed from '../../utilities/TypeFormEmbed/TypeFormEmbed';
-import DelayedElement from '../../utilities/DelayedElement/DelayedElement';
 import { coverImageMediaQueryStyles, tailwind } from '../../../helpers/display';
 import BannerCallToAction from '../../utilities/CallToAction/BannerCallToAction';
 import { campaignCardFragment } from '../../utilities/CampaignCard/CampaignCard';
 import StrikeThroughHeader from '../../utilities/SectionHeader/StrikeThroughHeader';
 import SiteNavigationContainer from '../../SiteNavigation/SiteNavigationContainer';
 import AnalyticsWaypoint from '../../utilities/AnalyticsWaypoint/AnalyticsWaypoint';
-import DismissableElement from '../../utilities/DismissableElement/DismissableElement';
-import TrafficDistribution from '../../utilities/TrafficDistribution/TrafficDistribution';
 import { campaignCardFeaturedFragment } from '../../utilities/CampaignCard/CampaignCardFeatured';
 
 const HOME_PAGE_QUERY = gql`
@@ -439,28 +432,6 @@ const HomePageTemplate = ({
             </BannerCallToAction>
           )}
         </article>
-
-        {featureFlag('nps_survey') ? (
-          <TrafficDistribution percentage={5} feature="homepage_nps_survey">
-            <DismissableElement
-              name="nps_survey"
-              render={(handleClose, handleComplete) => (
-                <DelayedElement delay={5}>
-                  <Modal onClose={handleClose} trackingId="SURVEY_MODAL">
-                    <TypeFormEmbed
-                      displayType="modal"
-                      typeformUrl="https://dosomething.typeform.com/to/iEdy7C"
-                      queryParameters={{
-                        northstar_id: get(window.AUTH, 'id', null),
-                      }}
-                      onSubmit={handleComplete}
-                    />
-                  </Modal>
-                </DelayedElement>
-              )}
-            />
-          </TrafficDistribution>
-        ) : null}
       </main>
 
       <SiteFooter />


### PR DESCRIPTION
### What's this PR do?

This pull request removes our Homepage specific NPS survey & updates our sitewide NPS survey to 
- display on the homepage as well (previously was excluded in favor of the homepage specific one)
- display only for authenticated users
- display after 60 seconds (updated from 30)

### How should this be reviewed?
👀 

### Any background context you want to provide?
We're all set with the Homepage survey. For sitewide - most of our negative sentiment came from unauthenticated users who were unfamiliar with our site or annoyed with the popover interference. (More deets in the report in the attached ticket + more work to come to make the survey less obtrusive)

### Relevant tickets

References [Pivotal #177063160](https://www.pivotaltracker.com/story/show/177063160).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added screenshots of front-end changes on small, medium, and large screens.
- [ ] Added appropriate feature/unit tests.
