### PR TITLE
Hours Spent Field - Assigned Zero Value Bug Fix

### DIFF
--- a/resources/assets/components/actions/PhotoSubmissionAction/HoursSpentField.js
+++ b/resources/assets/components/actions/PhotoSubmissionAction/HoursSpentField.js
@@ -21,6 +21,10 @@ const HoursSpentField = ({ actionId, hasError, onChange }) => {
   const [minutes, setMinutes] = useState('');
 
   useEffect(() => {
+    if (!hours && !minutes) {
+      return;
+    }
+
     onChange((Number(hours) * 60 + Number(minutes)) / 60);
   }, [hours, minutes]);
 


### PR DESCRIPTION
### What's this PR do?

This pull request fixes a bug where the `HoursSpentField` component would assign a `0` value event when there was no input! (Leading to non-volunteer credit Photo Submissions being rejected with invalid `hours_spent` 😱 )

### How should this be reviewed?
👀 

### Any background context you want to provide?
In #2606, we introduced this bug. 

Frustratingly, we didn't catch this in our [automated tests](https://app.ghostinspector.com/suites/56980f16812f6dd51bc172f2) because the Action we're testing against does not contain an Action ID (since it's an older database campaign, relying on our [roundabout way](https://github.com/DoSomething/northstar/blob/c54bf6e4edae47f22fd66f2b7c9176efc1f19a75/app/Repositories/PostRepository.php#L56-L65) of finding the 'default' Action through the Campaign ID in our Activity API). And as such, the `HoursSpentFIeld` would [not be rendered](https://github.com/DoSomething/phoenix-next/blob/19704dc6776c8ea934a0f7160a8c100e3ae531dd/resources/assets/components/actions/PhotoSubmissionAction/PhotoSubmissionAction.js#L469-L477) in the first place! (Since it requires the Action ID to determine if the Action gets Volunteer Credit).

Since our newer/updated high-profile campaigns receive the most traffic, I've added an. Action ID to the [Breakup Bash Photo Uploader](https://app.contentful.com/spaces/81iqaqpfd8fy/entries/2yOYXi3zos2YioGeSyc6Ik?previousEntries=1K7U7AGI4osOCEieCW0UOW) in Contentful so that we're testing against our primary flow.

### Relevant tickets
https://dosomething.slack.com/archives/C09ANFQLA/p1618365713056500

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added screenshots of front-end changes on small, medium, and large screens.
- [ ] Added appropriate feature/unit tests.
