### PR TITLE
Update validation minimum for hours_spent field

### DIFF
--- a/app/Http/Requests/PostRequest.php
+++ b/app/Http/Requests/PostRequest.php
@@ -65,7 +65,7 @@ class PostRequest extends FormRequest
                     'text' => 'required|min:4|max:60',
                     'why_participated' => 'required',
                     'number_of_participants' => 'integer|nullable',
-                    'hours_spent' => 'numeric|nullable|min:0.1|max:999999.99',
+                    'hours_spent' => 'numeric|nullable|min:0.01|max:999999.99',
                 ];
 
             case 'text':


### PR DESCRIPTION
### What's this PR do?

This pull request updates the validation on the `hours_spent` Post field to `0.01`

### How should this be reviewed?
👀 

### Any background context you want to provide?
Now that we accept minutes explicitly (#2606), it's possible to receive a value under `0.1` (anything under 5 minutes).

### Relevant tickets
https://dosomething.slack.com/archives/C09ANFQLA/p1618427752064900?thread_ts=1618365713.056500&cid=C09ANFQLA

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added screenshots of front-end changes on small, medium, and large screens.
- [ ] Added appropriate feature/unit tests.
