### PR TITLE
Update main nav links

### DIFF
--- a/resources/assets/components/SiteNavigation/SiteNavigation.js
+++ b/resources/assets/components/SiteNavigation/SiteNavigation.js
@@ -642,7 +642,7 @@ class SiteNavigation extends React.Component {
 
             <li className="menu-nav__item">
               <a
-                href="https://lets.dosomething.org"
+                href="/articles"
                 onClick={() =>
                   this.handleOnClickLink({
                     name: 'clicked_nav_link_articles',
@@ -658,7 +658,7 @@ class SiteNavigation extends React.Component {
 
             <li className="menu-nav__item">
               <a
-                href="https://join.dosomething.org/"
+                href="/about"
                 onClick={() =>
                   this.handleOnClickLink({
                     name: 'clicked_nav_link_about',

--- a/resources/assets/components/SiteNavigation/SiteNavigation.js
+++ b/resources/assets/components/SiteNavigation/SiteNavigation.js
@@ -642,7 +642,7 @@ class SiteNavigation extends React.Component {
 
             <li className="menu-nav__item">
               <a
-                href="/articles"
+                href="/us/articles"
                 onClick={() =>
                   this.handleOnClickLink({
                     name: 'clicked_nav_link_articles',
@@ -658,7 +658,7 @@ class SiteNavigation extends React.Component {
 
             <li className="menu-nav__item">
               <a
-                href="/about"
+                href="/us/about"
                 onClick={() =>
                   this.handleOnClickLink({
                     name: 'clicked_nav_link_about',

--- a/resources/assets/components/utilities/SiteFooter/SiteFooter.js
+++ b/resources/assets/components/utilities/SiteFooter/SiteFooter.js
@@ -110,7 +110,7 @@ const SiteFooter = () => {
             <li>
               <a
                 className="font-bold no-underline hover:underline"
-                href="https://join.dosomething.org/"
+                href="/us/about"
                 onClick={event =>
                   handleFooterTracking('who_we_are', event.target.href)
                 }
@@ -154,7 +154,7 @@ const SiteFooter = () => {
             <li>
               <a
                 className="font-bold no-underline hover:underline"
-                href="https://lets.dosomething.org/"
+                href="/us/articles"
                 onClick={event =>
                   handleFooterTracking('articles', event.target.href)
                 }

--- a/resources/views/partials/footer.blade.php
+++ b/resources/views/partials/footer.blade.php
@@ -28,11 +28,11 @@
     <div class="footer__column -links">
         <h4>Who We Are</h4>
         <ul>
-          <li><a href="https://join.dosomething.org/">What is DoSomething.org?</a></li>
+          <li><a href="{{ config('app.url') }}/us/about">What is DoSomething.org?</a></li>
           <li><a href="{{ config('app.url') }}/us/about/our-people">Our Team</a></li>
           <li><a href="{{ config('app.url') }}/us/about/our-financials">Our Financials</a></li>
           <li><a href="{{ config('app.url') }}/us/about/our-press">Press</a></li>
-          <li><a href="https://lets.dosomething.org/">Articles</a></li>
+          <li><a href="{{ config('app.url') }}/us/articles">Articles</a></li>
           <li><a href="{{ config('app.url') }}/us/about/contact-us">Contact Us</a></li>
          </ul>
     </div>


### PR DESCRIPTION
### What's this PR do?

This pull request updates the site nav and footer with the correct path to our new in house `articles` and `about` pages. We'll also want to update any references to `vote.dosomething.org` in contentful as well. We are hardcoding a link to `vote.dosomething.org` in the [VoterRegStatusBlock](https://github.com/DoSomething/phoenix-next/blob/b7e471aafad96557acc5f83cda928248032c495a/resources/assets/components/pages/AccountPage/VoterReg/VoterRegStatusBlock.js#L95-L105) that I'm guessing we'll need to update, but feels like we could do that in a small clean up ticket.

### How should this be reviewed?

👀 

### Any background context you want to provide?

Once we have turned the redirects from instapage to our site on and launch the about/articles pages, I think we'll be safe to merge this PR in!

### Relevant tickets

References [Pivotal #177651648](https://www.pivotaltracker.com/story/show/177651648).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added appropriate feature/unit tests.
