### PR TITLE
Add Analytics to the Articles Page

### DIFF
--- a/resources/assets/components/pages/ArticlesPage/ArticlesPage.js
+++ b/resources/assets/components/pages/ArticlesPage/ArticlesPage.js
@@ -145,7 +145,10 @@ const ArticlesLandingPage = ({
                 Sign up for weekly emails of news, videos, how-tos, advice, and
                 ways to transform your community.
               </p>
-              <SingleNewsletterSubscriptionForm emailSubscriptionTopic="lifestyle" />
+              <SingleNewsletterSubscriptionForm
+                emailSubscriptionTopic="lifestyle"
+                submissionSourceDetails="lifestyle_newsletter-cta_articles_page"
+              />
             </div>
           </section>
 

--- a/resources/assets/components/utilities/NewsletterSubscription/SingleNewsletterSubscriptionForm.js
+++ b/resources/assets/components/utilities/NewsletterSubscription/SingleNewsletterSubscriptionForm.js
@@ -30,8 +30,12 @@ const SingleNewsletterSubscriptionForm = ({ emailSubscriptionTopic }) => {
   const handleOnFocus = event => {
     event.preventDefault();
 
-    // @TODO: add analytics tracking
-    console.log('handling input focus...');
+    trackAnalyticsEvent('focused_call_to_action_popover_email', {
+      action: 'field_focused',
+      category: EVENT_CATEGORIES.siteAction,
+      label: 'call_to_action_popover',
+      context: { contextSource: `newsletter_${emailSubscriptionTopic}` },
+    });
   };
 
   const handleSubmit = event => {

--- a/resources/assets/components/utilities/NewsletterSubscription/SingleNewsletterSubscriptionForm.js
+++ b/resources/assets/components/utilities/NewsletterSubscription/SingleNewsletterSubscriptionForm.js
@@ -47,7 +47,7 @@ const SingleNewsletterSubscriptionForm = ({
     trackAnalyticsEvent('clicked_signup_newsletter', {
       action: 'button_clicked',
       category: EVENT_CATEGORIES.signup,
-      label: 'newsletter',
+      label: 'signup_newsletter',
       context: {
         contextSource: 'articles_page',
       },

--- a/resources/assets/components/utilities/NewsletterSubscription/SingleNewsletterSubscriptionForm.js
+++ b/resources/assets/components/utilities/NewsletterSubscription/SingleNewsletterSubscriptionForm.js
@@ -49,7 +49,7 @@ const SingleNewsletterSubscriptionForm = ({
       category: EVENT_CATEGORIES.signup,
       label: 'newsletter',
       context: {
-        url: window.location.href,
+        contextSource: 'articles_page',
       },
     });
 

--- a/resources/assets/components/utilities/NewsletterSubscription/SingleNewsletterSubscriptionForm.js
+++ b/resources/assets/components/utilities/NewsletterSubscription/SingleNewsletterSubscriptionForm.js
@@ -33,10 +33,10 @@ const SingleNewsletterSubscriptionForm = ({
   const handleOnFocus = event => {
     event.preventDefault();
 
-    trackAnalyticsEvent('focused_call_to_action_popover_email', {
+    trackAnalyticsEvent('focused_signup_newsletter', {
       action: 'field_focused',
       category: EVENT_CATEGORIES.siteAction,
-      label: 'call_to_action_popover',
+      label: 'signup_newsletter',
       context: { contextSource: `newsletter_${emailSubscriptionTopic}` },
     });
   };
@@ -65,10 +65,10 @@ const SingleNewsletterSubscriptionForm = ({
       .then(() => {
         setShowConfirmation(true);
 
-        trackAnalyticsEvent('submitted_call_to_action_popover', {
+        trackAnalyticsEvent('submitted_signup_newsletter', {
           action: 'form_submitted',
           category: EVENT_CATEGORIES.siteAction,
-          label: 'call_to_action_popover',
+          label: 'signup_newsletter',
           context: { contextSource: `newsletter_${emailSubscriptionTopic}` },
         });
       })
@@ -84,10 +84,10 @@ const SingleNewsletterSubscriptionForm = ({
           console.log('🚫 failed response? caught the error!', error);
         }
 
-        trackAnalyticsEvent('failed_call_to_action_popover', {
+        trackAnalyticsEvent('failed_signup_newsletter', {
           action: 'form_failed',
           category: EVENT_CATEGORIES.siteAction,
-          label: 'call_to_action_popover',
+          label: 'signup_newsletter',
           context: {
             contextSource: `newsletter_${emailSubscriptionTopic}`,
             error,

--- a/resources/assets/components/utilities/NewsletterSubscription/SingleNewsletterSubscriptionForm.js
+++ b/resources/assets/components/utilities/NewsletterSubscription/SingleNewsletterSubscriptionForm.js
@@ -9,6 +9,10 @@ import PrimaryButton from '../Button/PrimaryButton';
 import { tailwind } from '../../../helpers/display';
 import { report } from '../../../helpers/monitoring';
 import CheckIcon from '../../artifacts/CheckIcon/CheckIcon';
+import {
+  EVENT_CATEGORIES,
+  trackAnalyticsEvent,
+} from '../../../helpers/analytics';
 
 const SingleNewsletterSubscriptionForm = ({ emailSubscriptionTopic }) => {
   const [emailValue, setEmailValue] = useState('');
@@ -33,6 +37,15 @@ const SingleNewsletterSubscriptionForm = ({ emailSubscriptionTopic }) => {
   const handleSubmit = event => {
     event.preventDefault();
 
+    trackAnalyticsEvent('clicked_signup_newsletter', {
+      action: 'button_clicked',
+      category: EVENT_CATEGORIES.signup,
+      label: 'newsletter',
+      context: {
+        url: window.location.href,
+      },
+    });
+
     const client = new RestApiClient(`${env('NORTHSTAR_URL')}`);
 
     client
@@ -40,10 +53,17 @@ const SingleNewsletterSubscriptionForm = ({ emailSubscriptionTopic }) => {
         email: emailValue,
         email_subscription_topic: emailSubscriptionTopic,
         source: 'phoenix-next',
-        source_detail: 'lifestyle_newsletter_subscriptions-articles-page',
+        source_detail: 'lifestyle_newsletter-cta_articles_page',
       })
       .then(() => {
         setShowConfirmation(true);
+
+        trackAnalyticsEvent('submitted_call_to_action_popover', {
+          action: 'form_submitted',
+          category: EVENT_CATEGORIES.siteAction,
+          label: 'call_to_action_popover',
+          context: { contextSource: `newsletter_${emailSubscriptionTopic}` },
+        });
       })
       .catch(error => {
         report(error);
@@ -56,6 +76,17 @@ const SingleNewsletterSubscriptionForm = ({ emailSubscriptionTopic }) => {
         if (window.ENV.APP_ENV !== 'production') {
           console.log('🚫 failed response? caught the error!', error);
         }
+
+        trackAnalyticsEvent('failed_call_to_action_popover', {
+          action: 'form_failed',
+          category: EVENT_CATEGORIES.siteAction,
+          label: 'call_to_action_popover',
+          context: {
+            contextSource: `newsletter_${emailSubscriptionTopic}`,
+            error,
+            errorMessage,
+          },
+        });
       });
   };
 

--- a/resources/assets/components/utilities/NewsletterSubscription/SingleNewsletterSubscriptionForm.js
+++ b/resources/assets/components/utilities/NewsletterSubscription/SingleNewsletterSubscriptionForm.js
@@ -14,7 +14,10 @@ import {
   trackAnalyticsEvent,
 } from '../../../helpers/analytics';
 
-const SingleNewsletterSubscriptionForm = ({ emailSubscriptionTopic }) => {
+const SingleNewsletterSubscriptionForm = ({
+  emailSubscriptionTopic,
+  submissionSourceDetails,
+}) => {
   const [emailValue, setEmailValue] = useState('');
 
   const [errors, setErrors] = useState(null);
@@ -57,7 +60,7 @@ const SingleNewsletterSubscriptionForm = ({ emailSubscriptionTopic }) => {
         email: emailValue,
         email_subscription_topic: emailSubscriptionTopic,
         source: 'phoenix-next',
-        source_detail: 'lifestyle_newsletter-cta_articles_page',
+        source_detail: submissionSourceDetails,
       })
       .then(() => {
         setShowConfirmation(true);
@@ -149,6 +152,7 @@ const SingleNewsletterSubscriptionForm = ({ emailSubscriptionTopic }) => {
 
 SingleNewsletterSubscriptionForm.propTypes = {
   emailSubscriptionTopic: PropTypes.string.isRequired,
+  submissionSourceDetails: PropTypes.string.isRequired,
 };
 
 export default SingleNewsletterSubscriptionForm;


### PR DESCRIPTION
### What's this PR do?

This pull request adds analytics events for the newsletter section of the articles page, but sets it up so that if the newsletter component is used for other pages, these analytics events will work there as well! I also updated a source detail to match the expected syntax.

### How should this be reviewed?

👀 

### Any background context you want to provide?

Needed so we can track newsletter activity on this page!

### Relevant tickets

References [Pivotal #177518765](https://www.pivotaltracker.com/story/show/177518765).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added screenshots of front-end changes on small, medium, and large screens.
- [ ] Added appropriate feature/unit tests.
