### PR TITLE
Upgrade phpseclib to 2.0.31.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,9 +14,10 @@
     "fideloper/proxy": "^4.0",
     "huddledigital/zendesk-laravel": "^3.2",
     "laravel/framework": "^6.0",
+    "lcobucci/jwt": "~3.3.3",
+    "phpseclib/phpseclib": "^2.0.31",
     "predis/predis": "^1.1",
-    "seatgeek/sixpack-php": "^2.1",
-    "lcobucci/jwt": "~3.3.3"
+    "seatgeek/sixpack-php": "^2.1"
   },
   "require-dev": {
     "facade/ignition": "^1.4",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5eb9eeff99cb37baf409221451ee756e",
+    "content-hash": "bc25977f06a65577985b9cd0be7f1e1b",
     "packages": [
         {
             "name": "barryvdh/laravel-debugbar",
@@ -2852,16 +2852,16 @@
         },
         {
             "name": "phpseclib/phpseclib",
-            "version": "2.0.30",
+            "version": "2.0.31",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpseclib/phpseclib.git",
-                "reference": "136b9ca7eebef78be14abf90d65c5e57b6bc5d36"
+                "reference": "233a920cb38636a43b18d428f9a8db1f0a1a08f4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpseclib/phpseclib/zipball/136b9ca7eebef78be14abf90d65c5e57b6bc5d36",
-                "reference": "136b9ca7eebef78be14abf90d65c5e57b6bc5d36",
+                "url": "https://api.github.com/repos/phpseclib/phpseclib/zipball/233a920cb38636a43b18d428f9a8db1f0a1a08f4",
+                "reference": "233a920cb38636a43b18d428f9a8db1f0a1a08f4",
                 "shasum": ""
             },
             "require": {
@@ -2939,6 +2939,10 @@
                 "x.509",
                 "x509"
             ],
+            "support": {
+                "issues": "https://github.com/phpseclib/phpseclib/issues",
+                "source": "https://github.com/phpseclib/phpseclib/tree/2.0.31"
+            },
             "funding": [
                 {
                     "url": "https://github.com/terrafrost",
@@ -2953,7 +2957,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-12-17T05:42:04+00:00"
+            "time": "2021-04-06T13:56:45+00:00"
         },
         {
             "name": "predis/predis",
@@ -8404,5 +8408,5 @@
         "ext-newrelic": "*"
     },
     "platform-dev": [],
-    "plugin-api-version": "1.1.0"
+    "plugin-api-version": "2.0.0"
 }


### PR DESCRIPTION
### What's this PR do?

This pull request upgrades phpseclib to 2.0.31 (following #2601, which caused issues in production & had to be [reverted](https://github.com/DoSomething/phoenix-next/pull/2613)).

### How should this be reviewed?

This time, I've _only_ updated this one dependency to try to isolate the issue.

I deployed this branch to QA & confirmed that it works! That narrows down the culprit a bit...

### Any background context you want to provide?

See prior deploys & [this incident](https://dosomething.pagerduty.com/incidents/PTSWT3F?utm_source=slack&utm_campaign=channel) for context.

### Relevant tickets

References [Pivotal #177823411](https://www.pivotaltracker.com/story/show/177823411).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added screenshots of front-end changes on small, medium, and large screens.
- [ ] Added appropriate feature/unit tests.
