### PR TITLE
Adds a Content Type for Affirmation and Removes unneeded CTA fields

### DIFF
--- a/contentful/content-types/affirmation.js
+++ b/contentful/content-types/affirmation.js
@@ -1,0 +1,80 @@
+module.exports = function(migration) {
+  const affirmation = migration
+    .createContentType('affirmation')
+    .name('Affirmation')
+    .description('What the user sees post-signup!')
+    .displayField('header');
+  affirmation
+    .createField('internalTitle')
+    .name('Internal Title')
+    .type('Symbol')
+    .localized(false)
+    .required(false)
+    .validations([])
+    .disabled(false)
+    .omitted(false);
+  affirmation
+    .createField('header')
+    .name('Header')
+    .type('Symbol')
+    .localized(false)
+    .required(true)
+    .validations([])
+    .disabled(false)
+    .omitted(false);
+  affirmation
+    .createField('photo')
+    .name('Photo')
+    .type('Link')
+    .localized(false)
+    .required(true)
+    .validations([])
+    .disabled(true)
+    .omitted(false)
+    .linkType('Asset');
+  affirmation
+    .createField('quote')
+    .name('Quote')
+    .type('Text')
+    .localized(false)
+    .required(true)
+    .validations([])
+    .disabled(false)
+    .omitted(false);
+
+  affirmation
+    .createField('newAuthor')
+    .name('Author')
+    .type('Link')
+    .localized(false)
+    .required(true)
+    .validations([
+      {
+        linkContentType: ['person'],
+      },
+    ])
+    .disabled(false)
+    .omitted(false)
+    .linkType('Entry');
+
+  affirmation
+    .createField('author')
+    .name('Legacy Author')
+    .type('Symbol')
+    .localized(false)
+    .required(true)
+    .validations([])
+    .disabled(true)
+    .omitted(false);
+
+  affirmation.changeFieldControl('internalTitle', 'builtin', 'singleLine', {
+    helpText:
+      'This title is used internally to help find this content in the CMS. It will not be displayed anywhere on the website.',
+  });
+
+  affirmation.changeFieldControl('header', 'builtin', 'singleLine', {});
+  affirmation.changeFieldControl('photo', 'builtin', 'assetLinkEditor', {});
+  affirmation.changeFieldControl('quote', 'builtin', 'markdown', {});
+  affirmation.changeFieldControl('newAuthor', 'builtin', 'entryLinkEditor', {});
+  affirmation.changeFieldControl('author', 'builtin', 'singleLine', {});
+};

--- a/docs/development/content-types/affirmation.md
+++ b/docs/development/content-types/affirmation.md
@@ -1,0 +1,21 @@
+# Affirmation (Post/Signup Conifmration)
+
+## Overview
+
+This content type is where we populate content that users see after they successfully complete an action on Phoenix (ie. signup, reportback).
+
+## Content Type Fields
+
+-   **Internal Title**: This is for our internal Contentful organization and will be how the affirmation shows up in search results, etc.
+
+-   **Header**: Text added to the top of the card that is displayed.
+
+-   **Photo**: This field is disabled in the GUI for editing.
+
+-   **Quote**: An optional field to add a quote in the card displayed.
+
+-   **Author**: The author associated with the campaign and who's name and photo will be displayed.
+
+## Additional Information
+
+We previously displayed a share button, and some call to action text but have removed that now that we no longer have a share button featured in this content type.

--- a/docs/development/content-types/affirmation.md
+++ b/docs/development/content-types/affirmation.md
@@ -1,4 +1,4 @@
-# Affirmation (Post/Signup Conifmration)
+# Affirmation (Post/Signup Confirmation)
 
 ## Overview
 


### PR DESCRIPTION
### What's this PR do?

This pull request updates the affirmation to no longer include the cta fields since they aren't being used and are causing confusion.

### How should this be reviewed?

👀 

### Any background context you want to provide?

As part of cleanup, we are removing these to help make the campaign process more clear!

### Relevant tickets

References [Pivotal #174150633](https://www.pivotaltracker.com/story/show/174150633).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added screenshots of front-end changes on small, medium, and large screens.
- [ ] Added appropriate feature/unit tests.
