### PR TITLE
Removing CTA Header/Description from the Affirmation Content Type

### DIFF
--- a/resources/assets/components/Affirmation/Affirmation.js
+++ b/resources/assets/components/Affirmation/Affirmation.js
@@ -21,8 +21,6 @@ export const AffirmationBlockFragment = gql`
     id
     header
     quote
-    callToActionHeader
-    callToActionDescription
     author {
       name
       jobTitle
@@ -46,14 +44,7 @@ const USER_QUERY = gql`
 // We seem to have removed the content "photo" from being used in the actual output.
 // Also it would be nice to be able to default to the Campaign Lead attached to the
 // campaign if no author is provided!
-const Affirmation = ({
-  author,
-  callToActionDescription,
-  callToActionHeader,
-  header,
-  onClose,
-  quote,
-}) => (
+const Affirmation = ({ author, header, onClose, quote }) => (
   <Card className="affirmation rounded" title={header}>
     {quote ? <TextContent className="pt-3 px-3">{quote}</TextContent> : null}
 
@@ -76,11 +67,6 @@ const Affirmation = ({
                 </p>
               </Badge>
             ) : null}
-
-            <div className="affirmation__cta p-3">
-              <h3>{callToActionHeader}</h3>
-              <p>{callToActionDescription}</p>
-            </div>
 
             {author ? (
               <Byline
@@ -123,8 +109,6 @@ const Affirmation = ({
 
 Affirmation.propTypes = {
   author: PropTypes.object,
-  callToActionDescription: PropTypes.string,
-  callToActionHeader: PropTypes.string,
   header: PropTypes.string,
   onClose: PropTypes.func.isRequired,
   quote: PropTypes.string,
@@ -132,11 +116,9 @@ Affirmation.propTypes = {
 
 Affirmation.defaultProps = {
   author: null,
-  callToActionDescription: "Let's Do This.",
   header: 'Thanks for joining us!',
   quote:
     "By joining this campaign, you've teamed up with millions of other members who are making an impact on the causes affecting your world. As a DoSomething.org member, you're part of something bigger. You're part of a global movement for good.",
-  callToActionHeader: "Woohoo! You're signed up.",
 };
 
 export default Affirmation;

--- a/resources/assets/components/Affirmation/affirmation.scss
+++ b/resources/assets/components/Affirmation/affirmation.scss
@@ -1,18 +1,12 @@
 @import '../../scss/next-toolbox.scss';
 
 .affirmation {
-  .markdown {
-    color: theme('colors.gray.900');
-  }
-
-  .affirmation__cta {
-    h3 {
-      font-weight: 800;
+    .markdown {
+        color: theme('colors.gray.900');
     }
-  }
 
-  .close-button {
-    color: $blue;
-    cursor: pointer;
-  }
+    .close-button {
+        color: $blue;
+        cursor: pointer;
+    }
 }


### PR DESCRIPTION
### What's this PR do?

This pull request is removing references to the CTA header and description in the Affirmation modal since we have removed it from the content model!

### How should this be reviewed?

👀 

### Any background context you want to provide?

We wanted to remove the default props, as well as the display of the CTA itself since we no longer have a share button on the affirmation.

### Relevant tickets

References [Pivotal #174150633](https://www.pivotaltracker.com/story/show/174150633).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [x] Documentation added for new features/changed endpoints.
- [ ] Added screenshots of front-end changes on small, medium, and large screens.
- [ ] Added appropriate feature/unit tests.
