### PR TITLE
Appending UTM Params on Refer Friends Link

### DIFF
--- a/resources/assets/components/pages/AccountPage/ReferFriends/ReferFriendsTab.js
+++ b/resources/assets/components/pages/AccountPage/ReferFriends/ReferFriendsTab.js
@@ -12,7 +12,7 @@ import SignupReferralsBlock from '../../../blocks/SignupReferralsBlock/SignupRef
 
 const ReferFriendsTab = () => {
   const referralIncentive = featureFlag('refer_friends_incentive');
-  const referFriendsLink = getReferFriendsLink();
+  const referFriendsLink = getReferFriendsLink('member_profile');
 
   if (!referFriendsLink) {
     return (

--- a/resources/assets/helpers/refer-friends.js
+++ b/resources/assets/helpers/refer-friends.js
@@ -18,12 +18,16 @@ export function getReferralCampaignId() {
  * @return {String|Undefined}
  */
 export function getReferFriendsLink() {
+  const pathname = window.location.pathname;
   const userId = getUserId();
   const referralCampaignId = getReferralCampaignId();
+  const utmCampaignValue = pathname.includes('/account')
+    ? 'member_profile'
+    : referralCampaignId;
 
   if (!userId || !referralCampaignId) {
     return undefined;
   }
 
-  return `${PHOENIX_URL}/us/join?user_id=${userId}&campaign_id=${referralCampaignId}`;
+  return `${PHOENIX_URL}/us/join?user_id=${userId}&campaign_id=${referralCampaignId}&utm_campaign=${utmCampaignValue}&utm_medium=referral&utm_source=ds-refer-friends`;
 }

--- a/resources/assets/helpers/refer-friends.js
+++ b/resources/assets/helpers/refer-friends.js
@@ -17,13 +17,10 @@ export function getReferralCampaignId() {
  *
  * @return {String|Undefined}
  */
-export function getReferFriendsLink() {
-  const pathname = window.location.pathname;
+export function getReferFriendsLink(utmCampaign) {
   const userId = getUserId();
   const referralCampaignId = getReferralCampaignId();
-  const utmCampaignValue = pathname.includes('/account')
-    ? 'member_profile'
-    : referralCampaignId;
+  const utmCampaignValue = utmCampaign || referralCampaignId;
 
   if (!userId || !referralCampaignId) {
     return undefined;

--- a/resources/assets/helpers/refer-friends.test.js
+++ b/resources/assets/helpers/refer-friends.test.js
@@ -21,7 +21,7 @@ describe('getReferFriendsLink', () => {
   /** @test */
   it('returns referral link when user is authenticated & campaign ID query param is present', () => {
     expect(getReferFriendsLink()).toEqual(
-      `${referralUrl}&campaign_id=${referralCampaignId}`,
+      `${referralUrl}&campaign_id=${referralCampaignId}&utm_campaign=456&utm_medium=referral&utm_source=ds-refer-friends`,
     );
   });
 
@@ -34,7 +34,7 @@ describe('getReferFriendsLink', () => {
     };
 
     expect(getReferFriendsLink()).toEqual(
-      `${referralUrl}&campaign_id=${defaultReferralCampaignId}`,
+      `${referralUrl}&campaign_id=${defaultReferralCampaignId}&utm_campaign=789&utm_medium=referral&utm_source=ds-refer-friends`,
     );
   });
 

--- a/resources/assets/helpers/refer-friends.test.js
+++ b/resources/assets/helpers/refer-friends.test.js
@@ -51,4 +51,11 @@ describe('getReferFriendsLink', () => {
 
     expect(getReferFriendsLink()).toEqual(undefined);
   });
+
+  /** @test */
+  it('returns referral link when a custom utm_campaign is provided', () => {
+    expect(getReferFriendsLink('custom-campaign')).toEqual(
+      `${referralUrl}&campaign_id=${referralCampaignId}&utm_campaign=custom-campaign&utm_medium=referral&utm_source=ds-refer-friends`,
+    );
+  });
 });


### PR DESCRIPTION
### What's this PR do?

This pull request appends some utm params to the refer friends link helper! Two are static, and one is based on whether we are coming from a member profile page or a campaign.

### How should this be reviewed?

Should there be anything more specific added to the check on the `utmCampaignValue`? 

### Any background context you want to provide?

Request from the data team!

### Relevant tickets

References [Pivotal #176470707](https://www.pivotaltracker.com/story/show/176470707).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added screenshots of front-end changes on small, medium, and large screens.
- [ ] Added appropriate feature/unit tests.
