### PR TITLE
Remove Photo Caption

### DIFF
--- a/cypress/integration/account-campaigns-tab.js
+++ b/cypress/integration/account-campaigns-tab.js
@@ -63,23 +63,6 @@ describe('User Account Campaigns Tab', () => {
   });
 
   /** @test */
-  it('Displays the caption of a photo post under the photo', () => {
-    const user = userFactory();
-
-    cy.mockGraphqlOp('UserPostsQuery', {
-      postsByUserId: [
-        {
-          type: 'photo',
-        },
-      ],
-    });
-
-    cy.login(user);
-    cy.visit(`/us/account/campaigns`);
-    cy.findByTestId('photo-post-caption').should('have.length', 1);
-  });
-
-  /** @test */
   it('Displays the caption of a text post at the top of the Postcard', () => {
     const user = userFactory();
 

--- a/cypress/integration/campaign-post.js
+++ b/cypress/integration/campaign-post.js
@@ -122,7 +122,6 @@ describe('Campaign Post', () => {
       cy.get('input[type="file"]').attachFile('upload.jpg');
 
       // Fill out other fields:
-      cy.get('[name="caption"]').type("Let's do this!");
       cy.get('[name="quantity"]').type('1');
       cy.get('[name="whyParticipated"]').type('Testing');
 
@@ -169,7 +168,6 @@ describe('Campaign Post', () => {
       cy.get('input[type="file"]').attachFile('upload.jpg');
 
       // Fill out other fields:
-      cy.get('[name="caption"]').type("Let's do this!");
       cy.get('[name="quantity"]').type('1');
       cy.get('[name="whyParticipated"]').type('Testing');
 
@@ -231,7 +229,6 @@ describe('Campaign Post', () => {
         cy.get('input[type="file"]').attachFile('upload.jpg');
 
         // Fill out other fields:
-        cy.get('[name="caption"]').type("Let's do this!");
         cy.get('[name="quantity"]').type('1');
         cy.get('[name="hours"]').type('1');
         cy.get('[name="minutes"]').type('30');
@@ -285,7 +282,6 @@ describe('Campaign Post', () => {
         cy.get('input[type="file"]').attachFile('upload.jpg');
 
         // Fill out other fields:
-        cy.get('[name="caption"]').type("Let's do this!");
         cy.get('[name="quantity"]').type('1');
         cy.get('[name="whyParticipated"]').type('Testing');
 
@@ -375,7 +371,6 @@ describe('Campaign Post', () => {
         cy.get('input[type="file"]').attachFile('upload.jpg');
 
         // Fill out other fields:
-        cy.get('[name="caption"]').type("Let's do this!");
         cy.get('[name="quantity"]').type('1');
         cy.get('[name="whyParticipated"]').type('Testing');
 

--- a/cypress/integration/campaign-post.js
+++ b/cypress/integration/campaign-post.js
@@ -1,6 +1,5 @@
 /// <reference types="Cypress" />
 
-import { MockList } from 'graphql-tools';
 import { userFactory } from '../fixtures/user';
 import { campaignId, POSTS_API } from '../fixtures/constants';
 import { newTextPost, newPhotoPost } from '../fixtures/posts';

--- a/resources/assets/components/actions/PhotoSubmissionAction/PhotoSubmissionAction.js
+++ b/resources/assets/components/actions/PhotoSubmissionAction/PhotoSubmissionAction.js
@@ -365,7 +365,7 @@ class PhotoSubmissionAction extends PostForm {
               >
                 <div className="wrapper">
                   <div className="form-section md:pr-3">
-                    <div className="wrapper pb-3">
+                    <div className="wrapper">
                       <MediaUploader
                         label="Add your photo here"
                         media={this.state.mediaValue}

--- a/resources/assets/components/actions/PhotoSubmissionAction/PhotoSubmissionAction.js
+++ b/resources/assets/components/actions/PhotoSubmissionAction/PhotoSubmissionAction.js
@@ -18,7 +18,6 @@ import FormValidation from '../../utilities/Form/FormValidation';
 import PrimaryButton from '../../utilities/Button/PrimaryButton';
 import { withoutUndefined, withoutNulls } from '../../../helpers/data';
 import MediaUploader from '../../utilities/MediaUploader/MediaUploader';
-import CharacterLimit from '../../utilities/CharacterLimit/CharacterLimit';
 import PrivacyLanguage from '../../utilities/PrivacyLanguage/PrivacyLanguage';
 import AnalyticsWaypoint from '../../utilities/AnalyticsWaypoint/AnalyticsWaypoint';
 import {
@@ -38,8 +37,6 @@ export const PhotoSubmissionBlockFragment = gql`
   fragment PhotoSubmissionBlockFragment on PhotoSubmissionBlock {
     actionId
     title
-    captionFieldLabel
-    captionFieldPlaceholderMessage
     showQuantityField
     quantityFieldLabel
     quantityFieldPlaceholder
@@ -52,8 +49,6 @@ export const PhotoSubmissionBlockFragment = gql`
     affirmationContent
   }
 `;
-
-const CAPTION_CHARACTER_LIMIT = 60;
 
 class PhotoSubmissionAction extends PostForm {
   /**
@@ -102,7 +97,6 @@ class PhotoSubmissionAction extends PostForm {
     };
 
     this.state = {
-      captionValue: '',
       mediaValue: this.defaultMediaState,
       numberOfParticipantsValue: '',
       quantityValue: '',
@@ -154,7 +148,6 @@ class PhotoSubmissionAction extends PostForm {
   fields = () => {
     const items = {
       file: 'media',
-      text: 'caption',
       why_participated: 'whyParticipated',
       hours_spent: 'hoursSpent',
     };
@@ -286,7 +279,6 @@ class PhotoSubmissionAction extends PostForm {
     );
 
     this.setState({
-      captionValue: '',
       mediaValue: this.defaultMediaState,
       quantityValue: '',
       shouldResetForm: false,
@@ -380,37 +372,6 @@ class PhotoSubmissionAction extends PostForm {
                         onChange={this.handleFileUpload}
                         hasError={has(errors, 'media')}
                       />
-
-                      <div className="form-item">
-                        <label
-                          className={classnames('field-label', {
-                            'has-error': has(errors, 'caption'),
-                          })}
-                          htmlFor="caption"
-                        >
-                          {this.props.captionFieldLabel}
-                        </label>
-
-                        <input
-                          className={classnames('text-field', {
-                            'has-error shake': has(errors, 'caption'),
-                          })}
-                          type="text"
-                          id="caption"
-                          name="caption"
-                          placeholder={this.props.captionFieldPlaceholder}
-                          value={this.state.captionValue}
-                          onChange={this.handleChange}
-                          required
-                          maxLength={CAPTION_CHARACTER_LIMIT}
-                        />
-
-                        <CharacterLimit
-                          className="pt-1"
-                          limit={CAPTION_CHARACTER_LIMIT}
-                          text={this.state.captionValue}
-                        />
-                      </div>
                     </div>
                   </div>
 
@@ -576,8 +537,6 @@ PhotoSubmissionAction.propTypes = {
   affirmationContent: PropTypes.string,
   buttonText: PropTypes.string,
   campaignId: PropTypes.string,
-  captionFieldLabel: PropTypes.string,
-  captionFieldPlaceholder: PropTypes.string,
   className: PropTypes.string,
   id: PropTypes.string.isRequired, // @TODO: rename property to blockId
   informationContent: PropTypes.string,
@@ -605,8 +564,6 @@ PhotoSubmissionAction.defaultProps = {
     "Thanks for joining the movement, and submitting your photo! After we review your submission, we'll add it to the public gallery alongside submissions from all the other members taking action in this campaign.",
   buttonText: 'Submit a new photo',
   campaignId: null,
-  captionFieldLabel: 'Add a title to your photo.',
-  captionFieldPlaceholder: '60 characters or less',
   className: null,
   informationContent:
     'A DoSomething staffer will review and approve your photo.',

--- a/resources/assets/components/actions/PostCreatedModal.js
+++ b/resources/assets/components/actions/PostCreatedModal.js
@@ -22,7 +22,7 @@ const PostCreatedModal = ({ affirmationContent, onClose, title, userId }) => (
           {postData => {
             const count = postData.postsCount;
 
-            if (count > 3) {
+            if (!count || count > 3) {
               return null;
             }
 

--- a/resources/assets/components/blocks/PostGalleryBlock/PostGalleryBlockQuery.js
+++ b/resources/assets/components/blocks/PostGalleryBlock/PostGalleryBlockQuery.js
@@ -167,7 +167,6 @@ class PostGalleryBlockQuery extends React.Component {
       campaignId,
       className,
       count,
-      hideCaption,
       hideQuantity,
       hideReactions,
       id,
@@ -210,7 +209,6 @@ class PostGalleryBlockQuery extends React.Component {
             <PostGallery
               id={id}
               className={classnames(className)}
-              hideCaption={hideCaption}
               hideQuantity={hideQuantity}
               hideReactions={hideReactions}
               itemsPerRow={itemsPerRow}
@@ -234,7 +232,6 @@ PostGalleryBlockQuery.propTypes = {
   className: PropTypes.string,
   count: PropTypes.number,
   filterType: PropTypes.string,
-  hideCaption: PropTypes.bool,
   hideQuantity: PropTypes.bool,
   hideReactions: PropTypes.bool,
   id: PropTypes.string,
@@ -250,7 +247,6 @@ PostGalleryBlockQuery.defaultProps = {
   className: null,
   count: 9,
   filterType: null,
-  hideCaption: false,
   hideQuantity: false,
   hideReactions: false,
   id: null,

--- a/resources/assets/components/utilities/MediaUploader/MediaUploader.js
+++ b/resources/assets/components/utilities/MediaUploader/MediaUploader.js
@@ -57,7 +57,7 @@ const MediaUploader = ({ label, onChange, hasError, media }) => {
       data-testid="media-uploader"
       htmlFor="media-uploader"
       className={classnames(
-        'cursor-pointer block h-0 overflow-hidden relative bg-gray-200 text-gray-600 mb-3 w-full hover:bg-gray-300 focus:bg-gray-300',
+        'cursor-pointer block h-0 overflow-hidden relative bg-gray-200 text-gray-600 my-auto w-full hover:bg-gray-300 focus:bg-gray-300',
         {
           'border border-solid border-red-500 shake': hasError || internalError,
         },
@@ -68,7 +68,7 @@ const MediaUploader = ({ label, onChange, hasError, media }) => {
     >
       <div
         className={classnames(
-          'items-center flex h-full justify-center left-0 absolute top-0 w-full',
+          'items-center flex h-full justify-center left-0 absolute top-0 w-full align-middle',
           {
             'bg-gray-100': filePreviewUrl,
             'flex-col': !filePreviewUrl,

--- a/resources/assets/components/utilities/PostCard/PostCard.js
+++ b/resources/assets/components/utilities/PostCard/PostCard.js
@@ -36,7 +36,7 @@ export const postCardFragment = gql`
   }
 `;
 
-const PostCard = ({ post, hideCaption, hideQuantity, hideReactions }) => {
+const PostCard = ({ post, hideQuantity, hideReactions }) => {
   const isAnonymous = post.actionDetails.anonymous;
 
   // If this post is for an anonymous action, label it with the state (if available).
@@ -114,12 +114,6 @@ const PostCard = ({ post, hideCaption, hideQuantity, hideReactions }) => {
           {post.impact && !hideQuantity ? (
             <p className="mt-1 text-gray-600 text-sm">{post.impact}</p>
           ) : null}
-
-          {post.type !== 'text' && post.text && !hideCaption ? (
-            <p data-testid="photo-post-caption" className="text-gray-600 mt-3">
-              {post.text}
-            </p>
-          ) : null}
         </div>
       </div>
     </Card>
@@ -127,14 +121,12 @@ const PostCard = ({ post, hideCaption, hideQuantity, hideReactions }) => {
 };
 
 PostCard.propTypes = {
-  hideCaption: PropTypes.bool,
   hideQuantity: PropTypes.bool,
   hideReactions: PropTypes.bool,
   post: propType(postCardFragment).isRequired,
 };
 
 PostCard.defaultProps = {
-  hideCaption: false,
   hideQuantity: false,
   hideReactions: false,
 };

--- a/resources/assets/components/utilities/PostGallery/PostGallery.js
+++ b/resources/assets/components/utilities/PostGallery/PostGallery.js
@@ -27,7 +27,6 @@ const PostGallery = props => {
   const {
     id,
     className,
-    hideCaption,
     hideQuantity,
     hideReactions,
     itemsPerRow,
@@ -58,7 +57,6 @@ const PostGallery = props => {
           <PostCard
             key={post.id}
             post={post}
-            hideCaption={hideCaption}
             hideQuantity={hideQuantity}
             hideReactions={hideReactions}
           />
@@ -91,7 +89,6 @@ const PostGallery = props => {
 
 PostGallery.propTypes = {
   className: PropTypes.string,
-  hideCaption: PropTypes.bool,
   hideQuantity: PropTypes.bool,
   hideReactions: PropTypes.bool,
   id: PropTypes.string,
@@ -106,7 +103,6 @@ PostGallery.propTypes = {
 
 PostGallery.defaultProps = {
   className: null,
-  hideCaption: false,
   hideQuantity: false,
   hideReactions: false,
   id: null,

--- a/schema.json
+++ b/schema.json
@@ -12420,8 +12420,8 @@
               "name": "String",
               "ofType": null
             },
-            "isDeprecated": false,
-            "deprecationReason": null
+            "isDeprecated": true,
+            "deprecationReason": "No longer displaying in the block"
           },
           {
             "name": "callToActionDescription",
@@ -12432,8 +12432,8 @@
               "name": "String",
               "ofType": null
             },
-            "isDeprecated": false,
-            "deprecationReason": null
+            "isDeprecated": true,
+            "deprecationReason": "No longer displaying in the block"
           },
           {
             "name": "internalTitle",


### PR DESCRIPTION
### What's this PR do?

This pull request removes the photo caption from the submission form and some associated props for that field. It also removes the caption from displaying in the reportback gallery.

### How should this be reviewed?

Old Photo Submission:
![Screen Shot 2021-04-22 at 12 35 05 PM](https://user-images.githubusercontent.com/15236023/115751465-3620a480-a367-11eb-9fb8-fab098a43565.png)

New Photo Submission:
![Screen Shot 2021-04-22 at 12 33 44 PM](https://user-images.githubusercontent.com/15236023/115751491-3c168580-a367-11eb-9d21-f37b66bd7575.png)

Old Photo Gallery:
![Screen Shot 2021-04-22 at 12 34 30 PM](https://user-images.githubusercontent.com/15236023/115752147-d37bd880-a367-11eb-85c9-1dbd912a1772.png)

New Photo Gallery:
![Screen Shot 2021-04-22 at 12 34 37 PM](https://user-images.githubusercontent.com/15236023/115752179-d971b980-a367-11eb-9e37-a22e8e6e996e.png)


### Any background context you want to provide?

We are no longer having this as a requirement for members to upload photos!

### Relevant tickets

References [Pivotal #176179265](https://www.pivotaltracker.com/story/show/176179265).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [x] Added screenshots of front-end changes on small, medium, and large screens.
- [ ] Added appropriate feature/unit tests.
