### PR TITLE
Removes caption fields from Photo Submission Action in Contentful Type

### DIFF
--- a/contentful/content-types/photoSubmissionAction.js
+++ b/contentful/content-types/photoSubmissionAction.js
@@ -38,24 +38,6 @@ module.exports = function(migration) {
     .disabled(false)
     .omitted(false);
   photoSubmissionAction
-    .createField('captionFieldLabel')
-    .name('Caption Field Label')
-    .type('Symbol')
-    .localized(true)
-    .required(false)
-    .validations([])
-    .disabled(false)
-    .omitted(false);
-  photoSubmissionAction
-    .createField('captionFieldPlaceholder')
-    .name('Caption Field Placeholder')
-    .type('Symbol')
-    .localized(true)
-    .required(false)
-    .validations([])
-    .disabled(false)
-    .omitted(false);
-  photoSubmissionAction
     .createField('showQuantityField')
     .name('Show Quantity Field')
     .type('Boolean')
@@ -155,47 +137,45 @@ module.exports = function(migration) {
     .disabled(false)
     .omitted(false);
 
-  photoSubmissionAction.changeEditorInterface('internalTitle', 'singleLine', {
-    helpText:
-      '(Example: "Teens for Jeans 2017 Photo Submission Action") Use the campaign title, year and append "Photo Submission Action".',
-  });
+  photoSubmissionAction.changeFieldControl(
+    'internalTitle',
+    'builtin',
+    'singleLine',
+    {
+      helpText:
+        '(Example: "Teens for Jeans 2017 Photo Submission Action") Use the campaign title, year and append "Photo Submission Action".',
+    },
+  );
 
-  photoSubmissionAction.changeEditorInterface('actionId', 'numberEditor', {
-    helpText: 'The Action ID associated with this action in Rogue',
-  });
+  photoSubmissionAction.changeFieldControl(
+    'actionId',
+    'builtin',
+    'numberEditor',
+    {
+      helpText: 'The Action ID associated with this action in Rogue',
+    },
+  );
 
-  photoSubmissionAction.changeEditorInterface('title', 'singleLine', {
+  photoSubmissionAction.changeFieldControl('title', 'builtin', 'singleLine', {
     helpText:
       'Title to display for this block (defaults to "Submit your photo").',
   });
 
-  photoSubmissionAction.changeEditorInterface(
-    'captionFieldLabel',
-    'singleLine',
+  photoSubmissionAction.changeFieldControl(
+    'showQuantityField',
+    'builtin',
+    'boolean',
     {
       helpText:
-        'The label for the caption field (defaults to "Add a caption to your photo.").',
+        "Should the form ask for the quantity of items in member's photo submission?",
+      trueLabel: 'Yes',
+      falseLabel: 'No',
     },
   );
 
-  photoSubmissionAction.changeEditorInterface(
-    'captionFieldPlaceholder',
-    'singleLine',
-    {
-      helpText:
-        'The placeholder for the caption field (defaults to "60 characters or less").',
-    },
-  );
-
-  photoSubmissionAction.changeEditorInterface('showQuantityField', 'boolean', {
-    helpText:
-      "Should the form ask for the quantity of items in member's photo submission?",
-    trueLabel: 'Yes',
-    falseLabel: 'No',
-  });
-
-  photoSubmissionAction.changeEditorInterface(
+  photoSubmissionAction.changeFieldControl(
     'quantityFieldLabel',
+    'builtin',
     'singleLine',
     {
       helpText:
@@ -203,8 +183,9 @@ module.exports = function(migration) {
     },
   );
 
-  photoSubmissionAction.changeEditorInterface(
+  photoSubmissionAction.changeFieldControl(
     'quantityFieldPlaceholder',
+    'builtin',
     'singleLine',
     {
       helpText:
@@ -212,8 +193,9 @@ module.exports = function(migration) {
     },
   );
 
-  photoSubmissionAction.changeEditorInterface(
+  photoSubmissionAction.changeFieldControl(
     'whyParticipatedFieldLabel',
+    'builtin',
     'singleLine',
     {
       helpText:
@@ -221,8 +203,9 @@ module.exports = function(migration) {
     },
   );
 
-  photoSubmissionAction.changeEditorInterface(
+  photoSubmissionAction.changeFieldControl(
     'whyParticipatedFieldPlaceholder',
+    'builtin',
     'singleLine',
     {
       helpText:
@@ -230,13 +213,19 @@ module.exports = function(migration) {
     },
   );
 
-  photoSubmissionAction.changeEditorInterface('buttonText', 'singleLine', {
-    helpText:
-      'The text to show for the submit button (defaults to "Submit a new photo").',
-  });
+  photoSubmissionAction.changeFieldControl(
+    'buttonText',
+    'builtin',
+    'singleLine',
+    {
+      helpText:
+        'The text to show for the submit button (defaults to "Submit a new photo").',
+    },
+  );
 
-  photoSubmissionAction.changeEditorInterface(
+  photoSubmissionAction.changeFieldControl(
     'informationTitle',
+    'builtin',
     'singleLine',
     {
       helpText:
@@ -244,8 +233,9 @@ module.exports = function(migration) {
     },
   );
 
-  photoSubmissionAction.changeEditorInterface(
+  photoSubmissionAction.changeFieldControl(
     'informationContent',
+    'builtin',
     'markdown',
     {
       helpText:
@@ -253,8 +243,9 @@ module.exports = function(migration) {
     },
   );
 
-  photoSubmissionAction.changeEditorInterface(
+  photoSubmissionAction.changeFieldControl(
     'affirmationContent',
+    'builtin',
     'markdown',
     {
       helpText:
@@ -262,14 +253,16 @@ module.exports = function(migration) {
     },
   );
 
-  photoSubmissionAction.changeEditorInterface(
+  photoSubmissionAction.changeFieldControl(
     'additionalContent',
+    'builtin',
     'objectEditor',
     {},
   );
 
-  photoSubmissionAction.changeEditorInterface(
+  photoSubmissionAction.changeFieldControl(
     'numberOfParticipantsFieldLabel',
+    'builtin',
     'singleLine',
     {
       helpText:


### PR DESCRIPTION
### What's this PR do?

This pull request deletes two fields from the `Photo Submission Action` content type because we are no longer displaying these as a part of the photo submission form.

### How should this be reviewed?

👀 

### Any background context you want to provide?

n/a

### Relevant tickets

References [Pivotal #176179265](https://www.pivotaltracker.com/story/show/176179265).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added screenshots of front-end changes on small, medium, and large screens.
- [ ] Added appropriate feature/unit tests.
