### PR TITLE
Remove caption required from Post Request

### DIFF
--- a/app/Http/Requests/PostRequest.php
+++ b/app/Http/Requests/PostRequest.php
@@ -30,6 +30,8 @@ class PostRequest extends FormRequest
                     'file.required' => 'An uploaded photo is required.',
                     'quantity.required_if' => 'The quantity field is required.',
                     'quantity.min' => $this->setMinQuantityMessage(),
+                    'text.max' => 'The caption field may not be greater than :max characters.',
+                    'text.min' => 'The caption field may not be less than :min characters.',
                     'number_of_participants.integer' => 'The number of participants must be a number.',
                     'hours_spent.numeric' => 'The hours must be a number',
                 ];
@@ -59,7 +61,7 @@ class PostRequest extends FormRequest
                     'file' => 'required|file|image',
                     'quantity' => 'required_if:show_quantity,1|integer|min:1',
                     'show_quantity' => 'required|boolean',
-                    'text' => 'required|min:4|max:60',
+                    'text' => 'min:4|max:60',
                     'why_participated' => 'required',
                     'number_of_participants' => 'integer|nullable',
                     'hours_spent' => 'numeric|nullable|min:0.01|max:999999.99',

--- a/app/Http/Requests/PostRequest.php
+++ b/app/Http/Requests/PostRequest.php
@@ -30,9 +30,6 @@ class PostRequest extends FormRequest
                     'file.required' => 'An uploaded photo is required.',
                     'quantity.required_if' => 'The quantity field is required.',
                     'quantity.min' => $this->setMinQuantityMessage(),
-                    'text.max' => 'The caption field may not be greater than :max characters.',
-                    'text.min' => 'The caption field may not be less than :min characters.',
-                    'text.required' => 'The caption field for your photo is required.',
                     'number_of_participants.integer' => 'The number of participants must be a number.',
                     'hours_spent.numeric' => 'The hours must be a number',
                 ];

--- a/app/Http/Requests/PostRequest.php
+++ b/app/Http/Requests/PostRequest.php
@@ -30,8 +30,6 @@ class PostRequest extends FormRequest
                     'file.required' => 'An uploaded photo is required.',
                     'quantity.required_if' => 'The quantity field is required.',
                     'quantity.min' => $this->setMinQuantityMessage(),
-                    'text.max' => 'The caption field may not be greater than :max characters.',
-                    'text.min' => 'The caption field may not be less than :min characters.',
                     'number_of_participants.integer' => 'The number of participants must be a number.',
                     'hours_spent.numeric' => 'The hours must be a number',
                 ];
@@ -61,7 +59,6 @@ class PostRequest extends FormRequest
                     'file' => 'required|file|image',
                     'quantity' => 'required_if:show_quantity,1|integer|min:1',
                     'show_quantity' => 'required|boolean',
-                    'text' => 'min:4|max:60',
                     'why_participated' => 'required',
                     'number_of_participants' => 'integer|nullable',
                     'hours_spent' => 'numeric|nullable|min:0.01|max:999999.99',

--- a/tests/Feature/StorePhotoReportbackPostTest.php
+++ b/tests/Feature/StorePhotoReportbackPostTest.php
@@ -27,47 +27,6 @@ class StorePhotoReportbackPostTest extends BrowserKitTestCase
     }
 
     /** @test */
-    public function text_caption_is_required_to_submit_photo_post()
-    {
-        $this->storePhotoPost([
-            'type' => 'photo',
-            'quantity' => '30',
-            'file' => 'not-a-file-upload',
-            'why_participated' => 'Because testing is very important.',
-        ]);
-
-        $this->assertValidationError('text');
-    }
-
-    /** @test */
-    public function text_caption_must_be_4_characters_or_longer_to_submit_photo_post()
-    {
-        $this->storePhotoPost([
-            'type' => 'photo',
-            'text' => 'duh',
-            'quantity' => '30',
-            'file' => 'not-a-file-upload',
-            'why_participated' => 'Because testing is very important.',
-        ]);
-
-        $this->assertValidationError('text');
-    }
-
-    /** @test */
-    public function text_caption_must_be_60_characters_or_shorter_to_submit_photo_post()
-    {
-        $this->storePhotoPost([
-            'type' => 'photo',
-            'text' => 'This text caption is way longer than 60 characters and thus should fail!',
-            'quantity' => '30',
-            'file' => 'not-a-file-upload',
-            'why_participated' => 'Because testing is very important.',
-        ]);
-
-        $this->assertValidationError('text');
-    }
-
-    /** @test */
     public function quantity_is_required_if_field_is_displayed_to_submit_photo_post()
     {
         $this->storePhotoPost([


### PR DESCRIPTION
### What's this PR do?

This pull request removes the `required` rule and error message handling from the Post request since we no longer have a field for that...

### How should this be reviewed?

👀 

### Any background context you want to provide?

This came up in QA Ghosty Testing, hooray 👻 

### Relevant tickets

References [Pivotal #176179265](https://www.pivotaltracker.com/n/projects/2401401/stories/176179265).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added screenshots of front-end changes on small, medium, and large screens.
- [ ] Added appropriate feature/unit tests.
