### PR TITLE
Ensure we report Errors to New Relic

### DIFF
--- a/resources/assets/helpers/monitoring.js
+++ b/resources/assets/helpers/monitoring.js
@@ -11,7 +11,7 @@ import Debug from '../services/Debug';
  * @param {Object} customAttributes
  */
 export function report(error, customAttributes = null) {
-  let errorInstance;
+  let errorInstance = error;
 
   // Print to the console for devs:
   console.error(`[report] ${error}`);


### PR DESCRIPTION
### What's this PR do?

This pull request defaults the reported new relic error (on the browser side) to the `error` parameter.

### How should this be reviewed?
👀 

### Any background context you want to provide?
I think we may have inadvertently defaulted this to `null` this ignoring any standard `Error`s passed in to our `report` helper. I've been wondering for a while at the lack of errors in the [New Relic Browser explorer], particularly when trying to dig into https://www.pivotaltracker.com/n/projects/2401401/stories/177951493. I'm favoring this fix over the one detailed in the ticket for now.

### Relevant tickets

References [Pivotal #177951493](https://www.pivotaltracker.com/story/show/177951493).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added screenshots of front-end changes on small, medium, and large screens.
- [ ] Added appropriate feature/unit tests.
