### PR TITLE
Boost Email Popover

### DIFF
--- a/resources/assets/components/utilities/PopoverDispatcher/CtaPopover/CtaPopoverEmailForm.js
+++ b/resources/assets/components/utilities/PopoverDispatcher/CtaPopover/CtaPopoverEmailForm.js
@@ -12,7 +12,11 @@ import {
   trackAnalyticsEvent,
 } from '../../../../helpers/analytics';
 
-const CtaPopoverEmailForm = ({ handleComplete }) => {
+const CtaPopoverEmailForm = ({
+  emailSubscriptionTopic,
+  handleComplete,
+  submissionSourceDetails,
+}) => {
   const [emailValue, setEmailValue] = useState('');
   const [errorResponse, setErrorResponse] = useState(null);
   const [showAffirmation, setShowAffirmation] = useState(false);
@@ -23,7 +27,7 @@ const CtaPopoverEmailForm = ({ handleComplete }) => {
       action: 'field_focused',
       category: EVENT_CATEGORIES.siteAction,
       label: 'call_to_action_popover',
-      context: { contextSource: 'newsletter_scholarships' },
+      context: { contextSource: `newsletter_${emailSubscriptionTopic}` },
     });
   };
 
@@ -34,7 +38,7 @@ const CtaPopoverEmailForm = ({ handleComplete }) => {
       action: 'form_submitted',
       category: EVENT_CATEGORIES.siteAction,
       label: 'call_to_action_popover',
-      context: { contextSource: 'newsletter_scholarships' },
+      context: { contextSource: `newsletter_${emailSubscriptionTopic}` },
     });
 
     const client = new RestApiClient(`${env('NORTHSTAR_URL')}`);
@@ -42,9 +46,9 @@ const CtaPopoverEmailForm = ({ handleComplete }) => {
     client
       .post('/v2/subscriptions', {
         email: emailValue,
-        email_subscription_topic: 'scholarships',
+        email_subscription_topic: emailSubscriptionTopic,
         source: 'phoenix-next',
-        source_detail: 'scholarship_newsletter-cta_scholarship-page',
+        source_detail: submissionSourceDetails,
       })
       .then(response => {
         setShowAffirmation(true);
@@ -129,7 +133,9 @@ const CtaPopoverEmailForm = ({ handleComplete }) => {
 };
 
 CtaPopoverEmailForm.propTypes = {
+  emailSubscriptionTopic: PropTypes.string.isRequired,
   handleComplete: PropTypes.func.isRequired,
+  submissionSourceDetails: PropTypes.string.isRequired,
 };
 
 export default CtaPopoverEmailForm;

--- a/resources/assets/components/utilities/PopoverDispatcher/CtaPopover/CtaPopoverEmailForm.js
+++ b/resources/assets/components/utilities/PopoverDispatcher/CtaPopover/CtaPopoverEmailForm.js
@@ -74,7 +74,7 @@ const CtaPopoverEmailForm = ({
           category: EVENT_CATEGORIES.siteAction,
           label: 'call_to_action_popover',
           context: {
-            contextSource: 'newsletter_scholarships',
+            contextSource: `newsletter_${emailSubscriptionTopic}`,
             error,
             errorMessage,
           },

--- a/resources/assets/components/utilities/PopoverDispatcher/CtaPopover/CtaPopoverEmailForm.js
+++ b/resources/assets/components/utilities/PopoverDispatcher/CtaPopover/CtaPopoverEmailForm.js
@@ -133,7 +133,12 @@ const CtaPopoverEmailForm = ({
 };
 
 CtaPopoverEmailForm.propTypes = {
-  emailSubscriptionTopic: PropTypes.string.isRequired,
+  emailSubscriptionTopic: PropTypes.oneOf([
+    'lifestyle',
+    'scholarships',
+    'news',
+    'community',
+  ]).isRequired,
   handleComplete: PropTypes.func.isRequired,
   submissionSourceDetails: PropTypes.string.isRequired,
 };

--- a/resources/assets/components/utilities/PopoverDispatcher/PopoverDispatcher.js
+++ b/resources/assets/components/utilities/PopoverDispatcher/PopoverDispatcher.js
@@ -9,7 +9,11 @@ import { getUserId } from '../../../helpers/auth';
 import { getCampaign } from '../../../helpers/campaign';
 import SitewideBanner from './SitewideBanner/SitewideBanner';
 import DelayedElement from '../DelayedElement/DelayedElement';
-import { isCurrentPathInPaths, query } from '../../../helpers/url';
+import {
+  isCurrentPathInPaths,
+  popoverSourceDetailPathCheck,
+  query,
+} from '../../../helpers/url';
 import CtaPopoverEmailForm from './CtaPopover/CtaPopoverEmailForm';
 import DismissableElement from '../DismissableElement/DismissableElement';
 import {
@@ -71,7 +75,7 @@ const PopoverDispatcher = () => {
               <CtaPopoverEmailForm
                 handleComplete={handleComplete}
                 emailSubscriptionTopic="lifestyle"
-                submissionSourceDetails="lifestyle_newsletter-cta_"
+                submissionSourceDetails={`lifestyle_newsletter-cta_${popoverSourceDetailPathCheck()}`}
               />
             </CtaPopover>
           </DelayedElement>

--- a/resources/assets/components/utilities/PopoverDispatcher/PopoverDispatcher.js
+++ b/resources/assets/components/utilities/PopoverDispatcher/PopoverDispatcher.js
@@ -13,6 +13,7 @@ import { isCurrentPathInPaths, query } from '../../../helpers/url';
 import CtaPopoverEmailForm from './CtaPopover/CtaPopoverEmailForm';
 import DismissableElement from '../DismissableElement/DismissableElement';
 import {
+  lifestyleNewsletterPaths,
   sitewideBannerExcludedPaths,
   scholarshipsNewsletterPaths,
 } from './config';
@@ -51,7 +52,33 @@ const PopoverDispatcher = () => {
   const target = usePortal('popover-portal');
   const hiddenAttributeDataTestId = 'sitewide-banner-hidden';
 
-  // Check if this path is to scholarships page or specified article pages to display the popover instead of site wide banner.
+  // Check if this path is to 11 facts page or article pages to display the lifestyle newsletter popover instead of site wide banner.
+  if (
+    isCurrentPathInPaths(lifestyleNewsletterPaths) &&
+    !isCurrentPathInPaths(scholarshipsNewsletterPaths)
+  ) {
+    return createPortal(
+      <DismissableElement
+        name="cta_popover_scholarship_email"
+        context={{ contextSource: 'newsletter_scholarships' }}
+        render={(handleClose, handleComplete) => (
+          <DelayedElement delay={3}>
+            <CtaPopover
+              title="Pays To Do Good"
+              content="Want to earn easy scholarships for volunteering?
+              Subscribe to DoSomething's monthly scholarship email."
+              handleClose={handleClose}
+            >
+              <CtaPopoverEmailForm handleComplete={handleComplete} />
+            </CtaPopover>
+          </DelayedElement>
+        )}
+      />,
+      target,
+    );
+  }
+
+  // Check if this path is to scholarships page or specified article pages to display the scholarship newsletter popover instead of site wide banner.
   if (isCurrentPathInPaths(scholarshipsNewsletterPaths)) {
     return createPortal(
       <DismissableElement

--- a/resources/assets/components/utilities/PopoverDispatcher/PopoverDispatcher.js
+++ b/resources/assets/components/utilities/PopoverDispatcher/PopoverDispatcher.js
@@ -60,16 +60,19 @@ const PopoverDispatcher = () => {
     return createPortal(
       <DismissableElement
         name="cta_popover_scholarship_email"
-        context={{ contextSource: 'newsletter_scholarships' }}
+        context={{ contextSource: 'newsletter_lifestyle' }}
         render={(handleClose, handleComplete) => (
           <DelayedElement delay={3}>
             <CtaPopover
-              title="Pays To Do Good"
-              content="Want to earn easy scholarships for volunteering?
-              Subscribe to DoSomething's monthly scholarship email."
+              title="The Boost"
+              content="Sign up for our weekly newsletter of stories of incredible young people and actionable how-tos."
               handleClose={handleClose}
             >
-              <CtaPopoverEmailForm handleComplete={handleComplete} />
+              <CtaPopoverEmailForm
+                handleComplete={handleComplete}
+                emailSubscriptionTopic="lifestyle"
+                submissionSourceDetails="lifestyle_newsletter-cta_"
+              />
             </CtaPopover>
           </DelayedElement>
         )}
@@ -92,7 +95,11 @@ const PopoverDispatcher = () => {
             Subscribe to DoSomething's monthly scholarship email."
               handleClose={handleClose}
             >
-              <CtaPopoverEmailForm handleComplete={handleComplete} />
+              <CtaPopoverEmailForm
+                handleComplete={handleComplete}
+                emailSubscriptionTopic="scholarships"
+                submissionSourceDetails="scholarship_newsletter-cta_scholarship-page"
+              />
             </CtaPopover>
           </DelayedElement>
         )}

--- a/resources/assets/components/utilities/PopoverDispatcher/config.js
+++ b/resources/assets/components/utilities/PopoverDispatcher/config.js
@@ -22,3 +22,8 @@ export const scholarshipsNewsletterPaths = [
   '/us/articles/how-to-apply-for-scholarships-like-a-pro',
   '/us/articles/scholarship-winners',
 ];
+
+/**
+ * Paths to check for when we want to display the boost newsletter popover
+ */
+export const lifestyleNewsletterPaths = ['/us/facts/*', '/us/articles/*'];

--- a/resources/assets/helpers/url.js
+++ b/resources/assets/helpers/url.js
@@ -54,6 +54,20 @@ export const isCurrentPathInPaths = paths => {
 };
 
 /**
+ * Checks if current path matches an item in given paths array.
+ *
+ * @return {String}
+ */
+export const popoverSourceDetailPathCheck = () => {
+  const pathname = window.location.pathname;
+
+  if (pathname.includes('/facts/')) {
+    return '11_facts';
+  }
+  return 'articles';
+};
+
+/**
  * Return a boolean indicating whether the provided URL is external to the site.
  *
  * @param  {String} url


### PR DESCRIPTION
### What's this PR do?

This pull request updates the `ctaPopoverEmailForm` to work for more than just the scholarships newsletter and updates our `popoverDispatcher` to display the ctaPopover on 11 facts and ~ most ~ articles pages!

### How should this be reviewed?

Let me know if you think the helper is overkill, but I wanted to be consistent with how we are checking paths in other places in the popoverDispatcher component.

Large Screen:
![Screen Shot 2021-05-03 at 2 58 37 PM](https://user-images.githubusercontent.com/15236023/116921393-ec1aa700-ac21-11eb-82d7-0f7b93f68975.png)

Small Screen:
![Screen Shot 2021-05-03 at 2 58 51 PM](https://user-images.githubusercontent.com/15236023/116921402-f0df5b00-ac21-11eb-8d7b-7a1eae5a4e62.png)

Medium Screen:
![Screen Shot 2021-05-03 at 2 59 02 PM](https://user-images.githubusercontent.com/15236023/116921429-f89eff80-ac21-11eb-83fa-7802640f4ab7.png)

### Any background context you want to provide?

We are expanding our newsletter popovers to continue acquisition success we've seen from the scholarships popover.

### Relevant tickets

References [Pivotal #175377416](https://www.pivotaltracker.com/story/show/175377416).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [x] Added screenshots of front-end changes on small, medium, and large screens.
- [ ] Added appropriate feature/unit tests.
