### PR TITLE
Site Navigation Profile Dropdown Menu - Logged In

### DIFF
--- a/cypress/integration/site-navigation.js
+++ b/cypress/integration/site-navigation.js
@@ -1,5 +1,6 @@
 /// <reference types="Cypress" />
 
+import { userFactory } from '../fixtures/user';
 import { tailwind } from '../../resources/assets/helpers/display';
 import exampleFactPage from '../fixtures/contentful/exampleFactPage';
 
@@ -146,6 +147,22 @@ describe('Site Navigation', () => {
       // Assert the Benefits subnav is not still rendered on page:
       cy.get('.main-subnav').should('not.exist');
     });
+
+    it('does not render the profile dropdown when hovering over the profile icon', () => {
+      const user = userFactory();
+
+      // Set the viewport:
+      cy.viewport(size.width, size.height);
+
+      // Log the user in.
+      cy.login(user)
+        .withState(exampleFactPage)
+        .visit('/us/facts/test-11-facts-about-testing');
+
+      cy.findByTestId('account-profile-nav').trigger('mouseover');
+
+      cy.findByTestId('profile-dropdown').should('have.length', 0);
+    });
   });
 
   largeSizes.forEach(size => {
@@ -177,6 +194,28 @@ describe('Site Navigation', () => {
       cy.get('#main-nav__benefits')
         .should('have.attr', 'href')
         .and('include', '/us/about/benefits');
+    });
+
+    it('toggles the profile dropdown when hovering over the profile icon', () => {
+      const user = userFactory();
+
+      // Set the viewport:
+      cy.viewport(size.width, size.height);
+
+      // Log the user in.
+      cy.login(user)
+        .withState(exampleFactPage)
+        .visit('/us/facts/test-11-facts-about-testing');
+
+      cy.findByTestId('account-profile-nav').trigger('mouseover');
+
+      cy.findByTestId('profile-dropdown').within(() => {
+        cy.findAllByTestId('profile-dropdown-link').should('have.length', 7);
+      });
+
+      cy.findByTestId('account-profile-nav').trigger('mouseout');
+
+      cy.findByTestId('profile-dropdown').should('have.length', 0);
     });
   });
 });

--- a/resources/assets/components/SiteNavigation/SiteNavigationProfile.js
+++ b/resources/assets/components/SiteNavigation/SiteNavigationProfile.js
@@ -45,11 +45,6 @@ const SiteNavigationProfile = () => {
               context: getPageContext(),
             })
           }
-          css={css`
-            @media (min-width: ${tailwind('screens.lg')}) {
-              padding-right: 3px;
-            }
-          `}
         >
           <ProfileIcon />
         </a>

--- a/resources/assets/components/SiteNavigation/SiteNavigationProfile.js
+++ b/resources/assets/components/SiteNavigation/SiteNavigationProfile.js
@@ -32,6 +32,7 @@ const SiteNavigationProfile = () => {
         className="utility-nav__account-profile menu-nav__item flex"
         onMouseEnter={() => setIsDropdownActive(true)}
         onMouseLeave={() => setIsDropdownActive(false)}
+        data-testid="account-profile-nav"
       >
         <a
           id="utility-nav__account-profile"
@@ -62,6 +63,7 @@ const SiteNavigationProfile = () => {
                 css={css`
                   top: 75px;
                 `}
+                data-testid="profile-dropdown"
               >
                 {/* Top partial-border for dropdown. */}
                 <span
@@ -75,6 +77,7 @@ const SiteNavigationProfile = () => {
                   {dropdownList.map(({ copy, slug }) => (
                     <li key={slug}>
                       <a
+                        data-testid="profile-dropdown-link"
                         className="text-black no-underline hover:text-black hover:underline"
                         href={`/us/account/${slug}`}
                         css={css`

--- a/resources/assets/components/SiteNavigation/SiteNavigationProfile.js
+++ b/resources/assets/components/SiteNavigation/SiteNavigationProfile.js
@@ -1,4 +1,3 @@
-import tw from 'twin.macro';
 import Media from 'react-media';
 import { css } from '@emotion/core';
 import React, { useState } from 'react';
@@ -52,10 +51,7 @@ const SiteNavigationProfile = () => {
 
         <Media query={{ minWidth: tailwind('screens.lg') }}>
           <>
-            <MenuCarat
-              cssStyles={isDropdownActive ? tw`transform rotate-180` : null}
-              className="cursor-pointer"
-            />
+            <MenuCarat flipped={isDropdownActive} className="cursor-pointer" />
 
             {isDropdownActive ? (
               <div

--- a/resources/assets/components/SiteNavigation/SiteNavigationProfile.js
+++ b/resources/assets/components/SiteNavigation/SiteNavigationProfile.js
@@ -1,5 +1,10 @@
-import React from 'react';
+import tw from 'twin.macro';
+import Media from 'react-media';
+import { css } from '@emotion/core';
+import React, { useState } from 'react';
 
+import { tailwind } from '../../helpers/display';
+import MenuCarat from '../artifacts/MenuCarat/MenuCarat';
 import ProfileIcon from '../artifacts/ProfileIcon/ProfileIcon';
 import { isAuthenticated, buildAuthRedirectUrl } from '../../helpers/auth';
 import {
@@ -8,10 +13,26 @@ import {
   getPageContext,
 } from '../../helpers/analytics';
 
+const dropdownList = [
+  { copy: 'My Campaigns', slug: 'campaigns' },
+  { copy: 'My Rewards', slug: 'rewards' },
+  { copy: 'Volunteer Credits', slug: 'credits' },
+  { copy: 'Refer A Friend', slug: 'refer-friends' },
+  { copy: 'My Interests', slug: 'interests' },
+  { copy: 'My Subscriptions', slug: 'subscriptions' },
+  { copy: 'My Profile', slug: '' },
+];
+
 const SiteNavigationProfile = () => {
+  const [isDropdownActive, setIsDropdownActive] = useState(false);
+
   return isAuthenticated() ? (
     <>
-      <li className="utility-nav__account-profile menu-nav__item flex">
+      <li
+        className="utility-nav__account-profile menu-nav__item flex"
+        onMouseEnter={() => setIsDropdownActive(true)}
+        onMouseLeave={() => setIsDropdownActive(false)}
+      >
         <a
           id="utility-nav__account-profile"
           href="/us/account"
@@ -24,9 +45,53 @@ const SiteNavigationProfile = () => {
               context: getPageContext(),
             })
           }
+          css={css`
+            @media (min-width: ${tailwind('screens.lg')}) {
+              padding-right: 3px;
+            }
+          `}
         >
           <ProfileIcon />
         </a>
+
+        <Media query={{ minWidth: tailwind('screens.lg') }}>
+          <>
+            <MenuCarat
+              cssStyles={isDropdownActive ? tw`transform rotate-180` : null}
+              className="cursor-pointer"
+            />
+
+            {isDropdownActive ? (
+              <div
+                className="bg-white absolute p-6 border-l border-solid border-gray-300 w-48 right-0"
+                css={css`
+                  top: 75px;
+                `}
+              >
+                {/* Top partial-border for dropdown. */}
+                <span
+                  className="absolute top-0 left-0 border-t border-solid border-gray-300"
+                  css={css`
+                    width: 72px;
+                  `}
+                />
+
+                <ul>
+                  {dropdownList.map(({ copy, slug }) => (
+                    <li key={slug}>
+                      <a
+                        className="text-black no-underline hover:text-black hover:underline"
+                        href={`/us/account/${slug}`}
+                      >
+                        {copy}
+                      </a>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            ) : null}
+          </>
+        </Media>
       </li>
     </>
   ) : (

--- a/resources/assets/components/SiteNavigation/SiteNavigationProfile.js
+++ b/resources/assets/components/SiteNavigation/SiteNavigationProfile.js
@@ -8,8 +8,8 @@ import {
   getPageContext,
 } from '../../helpers/analytics';
 
-const SiteNavigationProfile = () =>
-  isAuthenticated() ? (
+const SiteNavigationProfile = () => {
+  return isAuthenticated() ? (
     <>
       <li className="utility-nav__account-profile menu-nav__item flex">
         <a
@@ -66,5 +66,6 @@ const SiteNavigationProfile = () =>
       </li>
     </>
   );
+};
 
 export default SiteNavigationProfile;

--- a/resources/assets/components/SiteNavigation/SiteNavigationProfile.js
+++ b/resources/assets/components/SiteNavigation/SiteNavigationProfile.js
@@ -82,6 +82,11 @@ const SiteNavigationProfile = () => {
                       <a
                         className="text-black no-underline hover:text-black hover:underline"
                         href={`/us/account/${slug}`}
+                        css={css`
+                          :hover {
+                            text-decoration-color: ${tailwind('colors.black')};
+                          }
+                        `}
                       >
                         {copy}
                       </a>

--- a/resources/assets/components/SiteNavigation/site-navigation.scss
+++ b/resources/assets/components/SiteNavigation/site-navigation.scss
@@ -354,7 +354,7 @@ $extraSmall: '(min-width: 360px)';
     padding: 12px $spacing_1x 12px;
 
     @include media($large) {
-        padding: 12px $spacing_1x 14px;
+        padding: 12px 3px 14px $spacing_1x;
     }
 
     > img {

--- a/resources/assets/components/artifacts/MenuCarat/MenuCarat.js
+++ b/resources/assets/components/artifacts/MenuCarat/MenuCarat.js
@@ -3,14 +3,14 @@ import PropTypes from 'prop-types';
 import { css } from '@emotion/core';
 import classNames from 'classnames';
 
-const MenuCarat = ({ className, color, cssStyles, height, width }) => (
+const MenuCarat = ({ className, color, height, flipped, width }) => (
   <div className={classNames('menu-carat pl-2 my-auto', className)}>
     <svg
       css={css`
         pointerevents: 'none';
         height: ${height};
         width: ${width};
-        ${cssStyles};
+        ${flipped ? 'transform: rotate(180deg);' : ''}
       `}
       // adding the props here gives us the ability to pass another
       // css prop to the component if there are one off cases we need to define
@@ -29,7 +29,7 @@ const MenuCarat = ({ className, color, cssStyles, height, width }) => (
 MenuCarat.propTypes = {
   className: PropTypes.string,
   color: PropTypes.string,
-  cssStyles: PropTypes.object,
+  flipped: PropTypes.bool,
   width: PropTypes.string,
   height: PropTypes.string,
 };
@@ -37,7 +37,7 @@ MenuCarat.propTypes = {
 MenuCarat.defaultProps = {
   className: null,
   color: '#202020',
-  cssStyles: null,
+  flipped: false,
   width: '16px',
   height: '9px',
 };

--- a/resources/assets/components/artifacts/MenuCarat/MenuCarat.js
+++ b/resources/assets/components/artifacts/MenuCarat/MenuCarat.js
@@ -1,9 +1,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { css } from '@emotion/core';
+import classNames from 'classnames';
 
-const MenuCarat = ({ color, cssStyles, height, width }) => (
-  <div className="menu-carat pl-2 my-auto">
+const MenuCarat = ({ className, color, cssStyles, height, width }) => (
+  <div className={classNames('menu-carat pl-2 my-auto', className)}>
     <svg
       css={css`
         pointerevents: 'none';
@@ -26,6 +27,7 @@ const MenuCarat = ({ color, cssStyles, height, width }) => (
 );
 
 MenuCarat.propTypes = {
+  className: PropTypes.string,
   color: PropTypes.string,
   cssStyles: PropTypes.object,
   width: PropTypes.string,
@@ -33,6 +35,7 @@ MenuCarat.propTypes = {
 };
 
 MenuCarat.defaultProps = {
+  className: null,
   color: '#202020',
   cssStyles: null,
   width: '16px',

--- a/resources/assets/components/blocks/ScholarshipInfoBlock/ScholarshipInfoBlock.js
+++ b/resources/assets/components/blocks/ScholarshipInfoBlock/ScholarshipInfoBlock.js
@@ -241,15 +241,7 @@ const ScholarshipInfoBlock = ({
               onClick={toggleHiddenInfo}
             >
               <p className="text-sm font-bold">{`${detailsLabel} Details`}</p>
-              <MenuCarat
-                cssStyles={
-                  drawerOpen
-                    ? css`
-                        transform: rotate(180deg);
-                      `
-                    : null
-                }
-              />
+              <MenuCarat flipped={drawerOpen} />
             </button>
           </div>
         </div>

--- a/resources/assets/components/pages/CampaignsPage/FilterNavigation/FilterNavigation.js
+++ b/resources/assets/components/pages/CampaignsPage/FilterNavigation/FilterNavigation.js
@@ -1,7 +1,6 @@
 import pluralize from 'pluralize';
 import PropTypes from 'prop-types';
 import { startCase } from 'lodash';
-import { css } from '@emotion/core';
 import React, { useState } from 'react';
 
 import {
@@ -18,10 +17,6 @@ const FilterNavigation = ({ filters, setFilters }) => {
   const filterCategoryNames = Object.keys(filters).map(filter =>
     pluralize.singular(filter),
   );
-
-  const caratToggle = css`
-    transform: rotate(180deg);
-  `;
 
   const handleMenuToggle = event => {
     const selectedFilter = event.target.dataset.filter;
@@ -50,10 +45,7 @@ const FilterNavigation = ({ filters, setFilters }) => {
             attributes={{ 'data-filter': name }}
             className="mr-4 lg:mr-8"
             decoration={
-              <MenuCarat
-                color="#322baa"
-                cssStyles={activeFilter === name ? caratToggle : null}
-              />
+              <MenuCarat color="#322baa" flipped={activeFilter === name} />
             }
             isActive={activeFilter === name}
             key={`${name}_button`}


### PR DESCRIPTION
### What's this PR do?

This pull request adds a dropdown menu activated by hovering over the account icon (and new menu carat) in the site navigation for authenticated users on large screens.

(For funsies - since this is the third time we're using custom rotation logic to 'flip' the `MenuCarat`, we abstract this logic into a `flipped` prop on the component directly in https://github.com/DoSomething/phoenix-next/pull/2650/commits/02fa1e3d6fad075bdf119b41dff5b6313a1fdc44. (I don't know if `flipped` is the best verbiage here but it sounds fun)).

### How should this be reviewed?
👀 

### Any background context you want to provide?
Turns out dropdowns are challenging! (at least to me...) I'm not the world's biggest fan of a statically assigned `72px` wide border, but when it comes to absolute positioning and semi-borders, I couldn't figure out a better way to do this.

We deviate a touch from the design in omitting to fill in the left side border of the account icon when the dropdown is active. This didn't seem necessary enough to justify finessing across the top padding with another pseudo-element of negative margining. I'll confirm with Design that this is OK!

### Relevant tickets

References [Pivotal #177932848](https://www.pivotaltracker.com/story/show/177932848).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [x] Added screenshots of front-end changes on small, medium, and large screens.
- [x] Added appropriate feature/unit tests.

![Kapture 2021-05-13 at 10 42 56](https://user-images.githubusercontent.com/12417657/118142090-0d288800-b3d8-11eb-87fb-2ff19ee787f7.gif)

- [Active](https://user-images.githubusercontent.com/12417657/118141580-81aef700-b3d7-11eb-9979-05b0a72b5608.png)
- [Inactive](https://user-images.githubusercontent.com/12417657/118141593-85427e00-b3d7-11eb-83a7-3dc94e16770a.png)

