### PR TITLE
Add Space Between Profile Dropdown List Items

### DIFF
--- a/resources/assets/components/SiteNavigation/SiteNavigationProfile.js
+++ b/resources/assets/components/SiteNavigation/SiteNavigationProfile.js
@@ -1,6 +1,5 @@
 import Media from 'react-media';
 import { css } from '@emotion/core';
-import classNames from 'classnames';
 import React, { useState } from 'react';
 
 import { tailwind } from '../../helpers/display';
@@ -56,7 +55,7 @@ const SiteNavigationProfile = () => {
 
             {isDropdownActive ? (
               <div
-                className="bg-white absolute p-6 border-l border-solid border-gray-300 w-48 right-0"
+                className="bg-white absolute border-l border-solid border-gray-300 w-48 right-0"
                 css={css`
                   top: 75px;
                 `}
@@ -70,12 +69,9 @@ const SiteNavigationProfile = () => {
                   `}
                 />
 
-                <ul>
-                  {dropdownList.map(({ copy, slug }, index) => (
-                    <li
-                      key={slug}
-                      className={classNames({ 'pt-3': index !== 0 })}
-                    >
+                <ul className="px-6 py-4">
+                  {dropdownList.map(({ copy, slug }) => (
+                    <li key={slug} className="py-2">
                       <a
                         data-testid="profile-dropdown-link"
                         className="text-black no-underline hover:text-black hover:underline"

--- a/resources/assets/components/SiteNavigation/SiteNavigationProfile.js
+++ b/resources/assets/components/SiteNavigation/SiteNavigationProfile.js
@@ -71,10 +71,10 @@ const SiteNavigationProfile = () => {
 
                 <ul className="px-6 py-4">
                   {dropdownList.map(({ copy, slug }) => (
-                    <li key={slug} className="py-2">
+                    <li key={slug}>
                       <a
                         data-testid="profile-dropdown-link"
-                        className="text-black no-underline hover:text-black hover:underline"
+                        className="block py-2 text-black no-underline hover:text-black hover:underline"
                         href={`/us/account/${slug}`}
                         css={css`
                           :hover {

--- a/resources/assets/components/SiteNavigation/SiteNavigationProfile.js
+++ b/resources/assets/components/SiteNavigation/SiteNavigationProfile.js
@@ -1,5 +1,6 @@
 import Media from 'react-media';
 import { css } from '@emotion/core';
+import classNames from 'classnames';
 import React, { useState } from 'react';
 
 import { tailwind } from '../../helpers/display';
@@ -70,8 +71,11 @@ const SiteNavigationProfile = () => {
                 />
 
                 <ul>
-                  {dropdownList.map(({ copy, slug }) => (
-                    <li key={slug}>
+                  {dropdownList.map(({ copy, slug }, index) => (
+                    <li
+                      key={slug}
+                      className={classNames({ 'pt-3': index !== 0 })}
+                    >
                       <a
                         data-testid="profile-dropdown-link"
                         className="text-black no-underline hover:text-black hover:underline"


### PR DESCRIPTION
### What's this PR do?

This pull request adds some padding between the links in the profile dropdown menu.

### How should this be reviewed?
👀 

### Any background context you want to provide?
Follow up on #2650 per [design QA feedback](https://www.pivotaltracker.com/story/show/177932848/comments/224186504).

### Relevant tickets

References [Pivotal #177932848](https://www.pivotaltracker.com/story/show/177932848).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [x] Added screenshots of front-end changes on small, medium, and large screens.
- [ ] Added appropriate feature/unit tests.


**Before**
![image](https://user-images.githubusercontent.com/12417657/118169261-be3e1b00-b3f6-11eb-8da8-c0eaeaa84187.png)
**After**
![image](https://user-images.githubusercontent.com/12417657/118169232-b7170d00-b3f6-11eb-894f-fc0d0237796b.png)
