### PR TITLE
Site Navigation Login link dropdown menu

### DIFF
--- a/cypress/integration/site-navigation.js
+++ b/cypress/integration/site-navigation.js
@@ -148,11 +148,17 @@ describe('Site Navigation', () => {
       cy.get('.main-subnav').should('not.exist');
     });
 
-    it('does not render the profile dropdown when hovering over the profile icon', () => {
+    it('does not render the profile dropdown when hovering over the profile icon or login link', () => {
       const user = userFactory();
 
       // Set the viewport:
       cy.viewport(size.width, size.height);
+
+      cy.visit('/us/facts/test-11-facts-about-testing');
+
+      cy.findByTestId('login-nav').trigger('mouseover');
+
+      cy.findByTestId('profile-dropdown').should('have.length', 0);
 
       // Log the user in.
       cy.login(user)
@@ -214,6 +220,25 @@ describe('Site Navigation', () => {
       });
 
       cy.findByTestId('account-profile-nav').trigger('mouseout');
+
+      cy.findByTestId('profile-dropdown').should('have.length', 0);
+    });
+
+    it.only('toggles the profile dropdown when hovering over the login icon', () => {
+      const user = userFactory();
+
+      // Set the viewport:
+      cy.viewport(size.width, size.height);
+
+      cy.visit('/us/facts/test-11-facts-about-testing');
+
+      cy.findByTestId('login-nav').trigger('mouseover');
+
+      cy.findByTestId('profile-dropdown').within(() => {
+        cy.findAllByTestId('profile-dropdown-link').should('have.length', 8);
+      });
+
+      cy.findByTestId('login-nav').trigger('mouseout');
 
       cy.findByTestId('profile-dropdown').should('have.length', 0);
     });

--- a/cypress/integration/site-navigation.js
+++ b/cypress/integration/site-navigation.js
@@ -224,7 +224,7 @@ describe('Site Navigation', () => {
       cy.findByTestId('profile-dropdown').should('have.length', 0);
     });
 
-    it.only('toggles the profile dropdown when hovering over the login icon', () => {
+    it.only('toggles the profile dropdown when hovering over the login link', () => {
       const user = userFactory();
 
       // Set the viewport:

--- a/resources/assets/components/SiteNavigation/SiteNavigationProfile.js
+++ b/resources/assets/components/SiteNavigation/SiteNavigationProfile.js
@@ -43,12 +43,12 @@ const DropdownMenu = () => (
       `}
     />
 
-    <ul className="px-6 py-4">
+    <ul className="py-4">
       {dropdownList.map(({ copy, slug }) => (
         <li key={slug}>
           <a
             data-testid="profile-dropdown-link"
-            className="block py-2 text-black no-underline hover:text-black hover:underline"
+            className="block px-6 py-2 text-black no-underline hover:text-black hover:underline"
             href={`/us/account/${slug}`}
             css={css`
               :hover {
@@ -65,7 +65,7 @@ const DropdownMenu = () => (
         <li>
           <a
             data-testid="profile-dropdown-link"
-            className="block py-2 text-black no-underline hover:text-black hover:underline"
+            className="block px-6 py-2 text-black no-underline hover:text-black hover:underline"
             href={buildAuthRedirectUrl({ mode: 'login' })}
             css={css`
               :hover {
@@ -82,7 +82,7 @@ const DropdownMenu = () => (
 );
 
 const SiteNavigationProfile = () => {
-  const [isDropdownActive, setIsDropdownActive] = useState(false);
+  const [isDropdownActive, setIsDropdownActive] = useState(true);
 
   return isAuthenticated() ? (
     <>
@@ -125,7 +125,7 @@ const SiteNavigationProfile = () => {
           { 'border-gray-300': isDropdownActive },
         )}
         onMouseEnter={() => setIsDropdownActive(true)}
-        onMouseLeave={() => setIsDropdownActive(false)}
+        // onMouseLeave={() => setIsDropdownActive(false)}
         data-testid="login-nav"
       >
         <a

--- a/resources/assets/components/SiteNavigation/SiteNavigationProfile.js
+++ b/resources/assets/components/SiteNavigation/SiteNavigationProfile.js
@@ -126,6 +126,7 @@ const SiteNavigationProfile = () => {
         )}
         onMouseEnter={() => setIsDropdownActive(true)}
         onMouseLeave={() => setIsDropdownActive(false)}
+        data-testid="login-nav"
       >
         <a
           id="utility-nav__auth"

--- a/resources/assets/components/SiteNavigation/SiteNavigationProfile.js
+++ b/resources/assets/components/SiteNavigation/SiteNavigationProfile.js
@@ -129,6 +129,7 @@ const SiteNavigationProfile = () => {
         data-testid="login-nav"
       >
         <a
+          className="whitespace-no-wrap"
           id="utility-nav__auth"
           href={buildAuthRedirectUrl({ mode: 'login' })}
           onClick={() =>
@@ -154,6 +155,7 @@ const SiteNavigationProfile = () => {
 
       <li className="utility-nav__join menu-nav__item">
         <a
+          className="whitespace-no-wrap"
           id="utility-nav__join"
           href={buildAuthRedirectUrl()}
           onClick={() =>

--- a/resources/assets/components/SiteNavigation/SiteNavigationProfile.js
+++ b/resources/assets/components/SiteNavigation/SiteNavigationProfile.js
@@ -82,7 +82,7 @@ const DropdownMenu = () => (
 );
 
 const SiteNavigationProfile = () => {
-  const [isDropdownActive, setIsDropdownActive] = useState(true);
+  const [isDropdownActive, setIsDropdownActive] = useState(false);
 
   return isAuthenticated() ? (
     <>
@@ -125,7 +125,7 @@ const SiteNavigationProfile = () => {
           { 'border-gray-300': isDropdownActive },
         )}
         onMouseEnter={() => setIsDropdownActive(true)}
-        // onMouseLeave={() => setIsDropdownActive(false)}
+        onMouseLeave={() => setIsDropdownActive(false)}
         data-testid="login-nav"
       >
         <a

--- a/resources/assets/components/SiteNavigation/SiteNavigationProfile.js
+++ b/resources/assets/components/SiteNavigation/SiteNavigationProfile.js
@@ -121,8 +121,8 @@ const SiteNavigationProfile = () => {
     <>
       <li
         className={classNames(
-          'utility-nav__auth menu-nav__item flex lg:pr-3 lg:mr-1 relative',
-          { 'border-r border-solid border-gray-300': isDropdownActive },
+          'utility-nav__auth menu-nav__item flex lg:pr-3 lg:mr-1 relative border-r border-solid border-white',
+          { 'border-gray-300': isDropdownActive },
         )}
         onMouseEnter={() => setIsDropdownActive(true)}
         onMouseLeave={() => setIsDropdownActive(false)}
@@ -139,10 +139,6 @@ const SiteNavigationProfile = () => {
               context: getPageContext(),
             })
           }
-          // Prevent the log-in link from shifting when we activate the right hand border for the dropdown.
-          css={css`
-            ${isDropdownActive ? 'margin-right: -1px;' : ''}
-          `}
         >
           Log In
         </a>

--- a/resources/assets/components/SiteNavigation/SiteNavigationProfile.js
+++ b/resources/assets/components/SiteNavigation/SiteNavigationProfile.js
@@ -39,7 +39,7 @@ const DropdownMenu = () => (
     <span
       className="absolute top-0 left-0 border-t border-solid border-gray-300"
       css={css`
-        width: ${isAuthenticated() ? '72' : '86'}px;
+        width: ${isAuthenticated() ? '72' : '87'}px;
       `}
     />
 
@@ -138,6 +138,10 @@ const SiteNavigationProfile = () => {
               context: getPageContext(),
             })
           }
+          // Prevent the log-in link from shifting when we activate the right hand border for the dropdown.
+          css={css`
+            ${isDropdownActive ? 'margin-right: -1px;' : ''}
+          `}
         >
           Log In
         </a>

--- a/resources/assets/components/SiteNavigation/SiteNavigationProfile.js
+++ b/resources/assets/components/SiteNavigation/SiteNavigationProfile.js
@@ -1,5 +1,6 @@
 import Media from 'react-media';
 import { css } from '@emotion/core';
+import classNames from 'classnames';
 import React, { useState } from 'react';
 
 import { tailwind } from '../../helpers/display';
@@ -95,7 +96,14 @@ const SiteNavigationProfile = () => {
     </>
   ) : (
     <>
-      <li className="utility-nav__auth menu-nav__item">
+      <li
+        className={classNames(
+          'utility-nav__auth menu-nav__item flex lg:pr-3 lg:mr-1 relative',
+          { 'border-r border-solid border-gray-300': isDropdownActive },
+        )}
+        onMouseEnter={() => setIsDropdownActive(true)}
+        onMouseLeave={() => setIsDropdownActive(false)}
+      >
         <a
           id="utility-nav__auth"
           href={buildAuthRedirectUrl({ mode: 'login' })}
@@ -110,6 +118,65 @@ const SiteNavigationProfile = () => {
         >
           Log In
         </a>
+
+        <Media query={{ minWidth: tailwind('screens.lg') }}>
+          <>
+            <MenuCarat flipped={isDropdownActive} className="cursor-pointer" />
+
+            {isDropdownActive ? (
+              <div
+                className="bg-white absolute border-l border-r border-solid border-gray-300 w-48"
+                css={css`
+                  top: 53px;
+                  right: -1px;
+                `}
+                data-testid="profile-dropdown"
+              >
+                {/* Top partial-border for dropdown. */}
+                <span
+                  className="absolute top-0 left-0 border-t border-solid border-gray-300"
+                  css={css`
+                    width: 86px;
+                  `}
+                />
+
+                <ul className="px-6 py-4">
+                  {dropdownList.map(({ copy, slug }) => (
+                    <li key={slug}>
+                      <a
+                        data-testid="profile-dropdown-link"
+                        className="block py-2 text-black no-underline hover:text-black hover:underline"
+                        href={`/us/account/${slug}`}
+                        css={css`
+                          :hover {
+                            text-decoration-color: ${tailwind('colors.black')};
+                          }
+                        `}
+                      >
+                        {copy}
+                      </a>
+                    </li>
+                  ))}
+
+                  <li>
+                    <a
+                      data-testid="profile-dropdown-link"
+                      className="block py-2 text-black no-underline hover:text-black hover:underline"
+                      href={buildAuthRedirectUrl({ mode: 'login' })}
+                      css={css`
+                        :hover {
+                          text-decoration-color: ${tailwind('colors.black')};
+                        }
+                      `}
+                    >
+                      Log In
+                    </a>
+                  </li>
+                </ul>
+              </div>
+            ) : null}
+          </>
+        </Media>
       </li>
 
       <li className="utility-nav__join menu-nav__item">

--- a/resources/assets/components/SiteNavigation/SiteNavigationProfile.js
+++ b/resources/assets/components/SiteNavigation/SiteNavigationProfile.js
@@ -23,6 +23,64 @@ const dropdownList = [
   { copy: 'My Profile', slug: '' },
 ];
 
+const DropdownMenu = () => (
+  <div
+    className={classNames(
+      'bg-white absolute border-l border-solid border-gray-300 w-48 right-0',
+      { 'border-r': !isAuthenticated() },
+    )}
+    css={css`
+      top: ${isAuthenticated() ? '75' : '53'}px;
+      ${!isAuthenticated() ? 'right: -1px;' : ''}
+    `}
+    data-testid="profile-dropdown"
+  >
+    {/* Top partial-border for dropdown. */}
+    <span
+      className="absolute top-0 left-0 border-t border-solid border-gray-300"
+      css={css`
+        width: ${isAuthenticated() ? '72' : '86'}px;
+      `}
+    />
+
+    <ul className="px-6 py-4">
+      {dropdownList.map(({ copy, slug }) => (
+        <li key={slug}>
+          <a
+            data-testid="profile-dropdown-link"
+            className="block py-2 text-black no-underline hover:text-black hover:underline"
+            href={`/us/account/${slug}`}
+            css={css`
+              :hover {
+                text-decoration-color: ${tailwind('colors.black')};
+              }
+            `}
+          >
+            {copy}
+          </a>
+        </li>
+      ))}
+
+      {!isAuthenticated() ? (
+        <li>
+          <a
+            data-testid="profile-dropdown-link"
+            className="block py-2 text-black no-underline hover:text-black hover:underline"
+            href={buildAuthRedirectUrl({ mode: 'login' })}
+            css={css`
+              :hover {
+                text-decoration-color: ${tailwind('colors.black')};
+              }
+            `}
+          >
+            Log In
+          </a>
+        </li>
+      ) : null}
+    </ul>
+  </div>
+);
+
 const SiteNavigationProfile = () => {
   const [isDropdownActive, setIsDropdownActive] = useState(false);
 
@@ -54,42 +112,7 @@ const SiteNavigationProfile = () => {
           <>
             <MenuCarat flipped={isDropdownActive} className="cursor-pointer" />
 
-            {isDropdownActive ? (
-              <div
-                className="bg-white absolute border-l border-solid border-gray-300 w-48 right-0"
-                css={css`
-                  top: 75px;
-                `}
-                data-testid="profile-dropdown"
-              >
-                {/* Top partial-border for dropdown. */}
-                <span
-                  className="absolute top-0 left-0 border-t border-solid border-gray-300"
-                  css={css`
-                    width: 72px;
-                  `}
-                />
-
-                <ul className="px-6 py-4">
-                  {dropdownList.map(({ copy, slug }) => (
-                    <li key={slug}>
-                      <a
-                        data-testid="profile-dropdown-link"
-                        className="block py-2 text-black no-underline hover:text-black hover:underline"
-                        href={`/us/account/${slug}`}
-                        css={css`
-                          :hover {
-                            text-decoration-color: ${tailwind('colors.black')};
-                          }
-                        `}
-                      >
-                        {copy}
-                      </a>
-                    </li>
-                  ))}
-                </ul>
-              </div>
-            ) : null}
+            {isDropdownActive ? <DropdownMenu /> : null}
           </>
         </Media>
       </li>
@@ -123,58 +146,7 @@ const SiteNavigationProfile = () => {
           <>
             <MenuCarat flipped={isDropdownActive} className="cursor-pointer" />
 
-            {isDropdownActive ? (
-              <div
-                className="bg-white absolute border-l border-r border-solid border-gray-300 w-48"
-                css={css`
-                  top: 53px;
-                  right: -1px;
-                `}
-                data-testid="profile-dropdown"
-              >
-                {/* Top partial-border for dropdown. */}
-                <span
-                  className="absolute top-0 left-0 border-t border-solid border-gray-300"
-                  css={css`
-                    width: 86px;
-                  `}
-                />
-
-                <ul className="px-6 py-4">
-                  {dropdownList.map(({ copy, slug }) => (
-                    <li key={slug}>
-                      <a
-                        data-testid="profile-dropdown-link"
-                        className="block py-2 text-black no-underline hover:text-black hover:underline"
-                        href={`/us/account/${slug}`}
-                        css={css`
-                          :hover {
-                            text-decoration-color: ${tailwind('colors.black')};
-                          }
-                        `}
-                      >
-                        {copy}
-                      </a>
-                    </li>
-                  ))}
-
-                  <li>
-                    <a
-                      data-testid="profile-dropdown-link"
-                      className="block py-2 text-black no-underline hover:text-black hover:underline"
-                      href={buildAuthRedirectUrl({ mode: 'login' })}
-                      css={css`
-                        :hover {
-                          text-decoration-color: ${tailwind('colors.black')};
-                        }
-                      `}
-                    >
-                      Log In
-                    </a>
-                  </li>
-                </ul>
-              </div>
-            ) : null}
+            {isDropdownActive ? <DropdownMenu /> : null}
           </>
         </Media>
       </li>

--- a/resources/assets/components/SiteNavigation/site-navigation.scss
+++ b/resources/assets/components/SiteNavigation/site-navigation.scss
@@ -332,6 +332,10 @@ $extraSmall: '(min-width: 360px)';
 
     > a {
         padding: $spacing_1x;
+
+        @include media($large) {
+            padding-right: 3px;
+        }
     }
 }
 


### PR DESCRIPTION
### What's this PR do?

This pull request adds the profile dropdown menu when hovering over the login link (unauthed users) on large screens

### How should this be reviewed?
👁️ 

commit-by-commit would allow spotting the newer additions a bit easier per the refactor in https://github.com/DoSomething/phoenix-next/pull/2652/commits/cf22b0fd57fb3b7c8d0bf7b182d341b4cfd54ac2

### Any background context you want to provide?
A little bit of finessing was necessary to add the right-hand border when the dropdown is activated without nudging the whole element to the left. 

It also arguably felt like a good idea to extract the menu dropdown itself with the subtle differences between auth/non-auth state toggled by the `isAuthenticated()` boolean.

### Relevant tickets

References [Pivotal #177933072](https://www.pivotaltracker.com/story/show/177933072).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [x] Added screenshots of front-end changes on small, medium, and large screens.
- [x] Added appropriate feature/unit tests.


![image](https://user-images.githubusercontent.com/12417657/118325177-13e6f600-b4d1-11eb-8a38-aef3feba8fbe.png)

![image](https://user-images.githubusercontent.com/12417657/118325159-10536f00-b4d1-11eb-95d4-577cfe24c5fd.png)
