### PR TITLE
Adds padding beneath partner logo for marketing page

### DIFF
--- a/resources/assets/components/pages/VoterRegistrationMarketingPage/VoterRegistrationMarketingPage.js
+++ b/resources/assets/components/pages/VoterRegistrationMarketingPage/VoterRegistrationMarketingPage.js
@@ -90,7 +90,7 @@ const VoterRegistrationMarketingPageTemplate = ({
             {logo.url ? (
               <img
                 data-testid="vr-marketing-page-banner-logo"
-                className="m-auto"
+                className="m-auto pb-3"
                 src={contentfulImageUrl(logo.url, '250', '60')}
                 alt={logo.description || ''}
               />


### PR DESCRIPTION
### What's this PR do?

This pull request adds a small amount of padding below the partner logo on our VR marketing pages.

### How should this be reviewed?

Original:
![Screen Shot 2021-05-20 at 11 51 51 AM](https://user-images.githubusercontent.com/15236023/119011112-b801ee80-b962-11eb-88dc-33acc4bbcceb.png)

New:
![Screen Shot 2021-05-20 at 11 52 01 AM](https://user-images.githubusercontent.com/15236023/119011131-bcc6a280-b962-11eb-9d87-b1d966140f38.png)

### Any background context you want to provide?

Request for the marketing team!

### Relevant tickets

References [Pivotal #178096390](https://www.pivotaltracker.com/story/show/178096390).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [x] Added screenshots of front-end changes on small, medium, and large screens.
- [ ] Added appropriate feature/unit tests.
