### PR TITLE
Swap articles for donate in nav

### DIFF
--- a/resources/assets/components/SiteNavigation/SiteNavigation.js
+++ b/resources/assets/components/SiteNavigation/SiteNavigation.js
@@ -337,7 +337,7 @@ class SiteNavigation extends React.Component {
 
             <li className="menu-nav__item">
               <a
-                href="us/about/donate"
+                href="/us/about/donate"
                 onClick={() =>
                   this.handleOnClickLink({
                     name: 'clicked_nav_link_donate',

--- a/resources/assets/components/SiteNavigation/SiteNavigation.js
+++ b/resources/assets/components/SiteNavigation/SiteNavigation.js
@@ -337,17 +337,17 @@ class SiteNavigation extends React.Component {
 
             <li className="menu-nav__item">
               <a
-                href="/us/articles"
+                href="us/about/donate"
                 onClick={() =>
                   this.handleOnClickLink({
-                    name: 'clicked_nav_link_articles',
+                    name: 'clicked_nav_link_donate',
                     action: 'link_clicked',
                     category: EVENT_CATEGORIES.navigation,
-                    label: 'articles',
+                    label: 'donate',
                   })
                 }
               >
-                Articles
+                Donate
               </a>
             </li>
 


### PR DESCRIPTION
### What's this PR do?

This pull request removes articles from the nav and replaces it with a link to the donate page. The idea is that down the road some of the nav categories will be re-worked and articles will be re-introduced.

<img width="793" alt="image" src="https://user-images.githubusercontent.com/4240292/119015521-d3aeca00-b94d-11eb-87d2-4d4a8f0816c4.png">


Analytics events upon click:
<img width="409" alt="image" src="https://user-images.githubusercontent.com/4240292/119015375-b2e67480-b94d-11eb-8efd-37403fea10e0.png">


### How should this be reviewed?

Analytics look good? Anything else I missed?

### Any background context you want to provide?

All above and in ticket!

### Relevant tickets

References [Pivotal #178201214](https://www.pivotaltracker.com/n/projects/2401401/stories/178201214).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Added screenshots of front-end changes on small, medium, and large screens.
- [ ] Added appropriate feature/unit tests.
