### PR TITLE
Profile Dropdown Analytics

### DIFF
--- a/resources/assets/components/SiteNavigation/SiteNavigationProfile.js
+++ b/resources/assets/components/SiteNavigation/SiteNavigationProfile.js
@@ -1,4 +1,5 @@
 import Media from 'react-media';
+import PropTypes from 'prop-types';
 import { css } from '@emotion/core';
 import classNames from 'classnames';
 import React, { useState } from 'react';
@@ -23,6 +24,26 @@ const dropdownList = [
   { copy: 'My Profile', slug: '' },
 ];
 
+const DropdownLink = ({ href, copy }) => (
+  <a
+    data-testid="profile-dropdown-link"
+    className="block px-6 py-2 text-black no-underline hover:text-black hover:underline"
+    href={href}
+    css={css`
+      :hover {
+        text-decoration-color: ${tailwind('colors.black')};
+      }
+    `}
+  >
+    {copy}
+  </a>
+);
+
+DropdownLink.propTypes = {
+  href: PropTypes.string.isRequired,
+  copy: PropTypes.string.isRequired,
+};
+
 const DropdownMenu = () => (
   <div
     className={classNames(
@@ -46,35 +67,16 @@ const DropdownMenu = () => (
     <ul className="py-4">
       {dropdownList.map(({ copy, slug }) => (
         <li key={slug}>
-          <a
-            data-testid="profile-dropdown-link"
-            className="block px-6 py-2 text-black no-underline hover:text-black hover:underline"
-            href={`/us/account/${slug}`}
-            css={css`
-              :hover {
-                text-decoration-color: ${tailwind('colors.black')};
-              }
-            `}
-          >
-            {copy}
-          </a>
+          <DropdownLink href={`/us/account/${slug}`} copy={copy} />
         </li>
       ))}
 
       {!isAuthenticated() ? (
         <li>
-          <a
-            data-testid="profile-dropdown-link"
-            className="block px-6 py-2 text-black no-underline hover:text-black hover:underline"
+          <DropdownLink
             href={buildAuthRedirectUrl({ mode: 'login' })}
-            css={css`
-              :hover {
-                text-decoration-color: ${tailwind('colors.black')};
-              }
-            `}
-          >
-            Log In
-          </a>
+            copy="Log In"
+          />
         </li>
       ) : null}
     </ul>

--- a/resources/assets/components/SiteNavigation/SiteNavigationProfile.js
+++ b/resources/assets/components/SiteNavigation/SiteNavigationProfile.js
@@ -34,6 +34,14 @@ const DropdownLink = ({ href, copy }) => (
         text-decoration-color: ${tailwind('colors.black')};
       }
     `}
+    onClick={() =>
+      trackAnalyticsEvent(`clicked_subnav_link_profile_${copy}`, {
+        action: 'link_clicked',
+        category: EVENT_CATEGORIES.navigation,
+        label: `profile_${copy}`,
+        context: getPageContext(),
+      })
+    }
   >
     {copy}
   </a>

--- a/resources/assets/components/SiteNavigation/SiteNavigationProfile.js
+++ b/resources/assets/components/SiteNavigation/SiteNavigationProfile.js
@@ -47,7 +47,7 @@ DropdownLink.propTypes = {
 const DropdownMenu = () => (
   <div
     className={classNames(
-      'bg-white absolute border-l border-solid border-gray-300 w-48 right-0',
+      'bg-white absolute border-l border-b border-solid border-gray-300 w-48 right-0',
       { 'border-r': !isAuthenticated() },
     )}
     css={css`


### PR DESCRIPTION
### What's this PR do?

This pull request adds analytics events to the profile dropdown menu links

### How should this be reviewed?
- https://github.com/DoSomething/phoenix-next/commit/b3f8e70e0a579d9d2b42a4ead71fcfe553cb1039 extracts the link markup into a sub-component so we don't have to keep repeating ourselves
- https://github.com/DoSomething/phoenix-next/commit/86fa62d0ec713649ac3b5b9383f68759bc4601c7 adds a missing `border-bottom` to the dropdown menu
- https://github.com/DoSomething/phoenix-next/commit/cb711e5c05c93b3f139e139ed76b8e6144edf2a3 adds the analytics event

### Any background context you want to provide?
The card outlines a separately named event for the login menu but in Sprint Planning we discussed simplifying it to one name and using the auth status as the differentiator.

### Relevant tickets

References [Pivotal #177935008](https://www.pivotaltracker.com/story/show/177935008).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added screenshots of front-end changes on small, medium, and large screens.
- [ ] Added appropriate feature/unit tests.

![image](https://user-images.githubusercontent.com/12417657/119365978-7e8cf400-bc7e-11eb-8890-bb8ca24faff8.png)
