### PR TITLE
Adds a check for if the impact quantity is 0 or null

### DIFF
--- a/cypress/integration/campaign-progress-bar.js
+++ b/cypress/integration/campaign-progress-bar.js
@@ -110,7 +110,7 @@ describe('Campaign Progress Bar', () => {
   });
 
   /** @test */
-  it('Displays default goal of 1000 with 0 current impact quantity', () => {
+  it('Does not display if progress quantity is 0 or null', () => {
     cy.mockGraphqlOp('CampaignBannerQuery', {
       campaign: (root, { campaignId }) => ({
         id: campaignId,
@@ -126,10 +126,7 @@ describe('Campaign Progress Bar', () => {
 
     cy.anonVisitCampaign(exampleCampaign);
 
-    cy.findByTestId('campaign-progress-bar-container').within(() => {
-      cy.contains('0 petitions signed.');
-      cy.contains('Help us get to 1,000!');
-    });
+    cy.findByTestId('campaign-progress-bar-container').should('have.length', 0);
   });
 
   /** @test */

--- a/resources/assets/components/CampaignBanner/CampaignBanner.js
+++ b/resources/assets/components/CampaignBanner/CampaignBanner.js
@@ -42,6 +42,7 @@ const CAMPAIGN_BANNER_QUERY = gql`
         id
         actionLabel
         postType
+        currentImpactQuantity
         timeCommitmentLabel
         scholarshipEntry
         reportback
@@ -112,6 +113,10 @@ const CampaignBanner = ({
     }
   }
 
+  const showProgressBar =
+    actionItem &&
+    actionItem.postType === 'photo' &&
+    actionItem.currentImpactQuantity;
   return (
     <>
       <CoverImage coverImage={coverImage} />
@@ -133,7 +138,7 @@ const CampaignBanner = ({
             data-testid="campaign-banner-primary-content"
             className="grid-wide-7/10 mb-6"
           >
-            {!loading && actionItem && actionItem.postType === 'photo' ? (
+            {!loading && showProgressBar ? (
               <CampaignProgressBar actionId={actionItem.id} />
             ) : null}
             <TextContent>{content}</TextContent>


### PR DESCRIPTION
### What's this PR do?

This pull request adds a check for if the impact quantity is a falsey value before displaying the progress bar. This check is so that we avoid posting a progress bar that will never progress past 0!

### How should this be reviewed?

👀 

### Any background context you want to provide?

We discovered this 🐛 on a specific campaign we are currently running.

### Relevant tickets

References [Pivotal #178274595](https://www.pivotaltracker.com/story/show/178274595).

### Checklist

- [ x This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added screenshots of front-end changes on small, medium, and large screens.
- [x] Added appropriate feature/unit tests.
