### PR TITLE
Move Quantity Check to Progress Bar Component

### DIFF
--- a/resources/assets/components/CampaignBanner/CampaignBanner.js
+++ b/resources/assets/components/CampaignBanner/CampaignBanner.js
@@ -42,7 +42,6 @@ const CAMPAIGN_BANNER_QUERY = gql`
         id
         actionLabel
         postType
-        currentImpactQuantity
         timeCommitmentLabel
         scholarshipEntry
         reportback
@@ -113,10 +112,7 @@ const CampaignBanner = ({
     }
   }
 
-  const showProgressBar =
-    actionItem &&
-    actionItem.postType === 'photo' &&
-    actionItem.currentImpactQuantity;
+  const showProgressBar = actionItem && actionItem.postType === 'photo';
   return (
     <>
       <CoverImage coverImage={coverImage} />

--- a/resources/assets/components/utilities/CampaignProgressBar/CampaignProgressBar.js
+++ b/resources/assets/components/utilities/CampaignProgressBar/CampaignProgressBar.js
@@ -57,11 +57,9 @@ const CampaignProgressBar = ({ actionId }) => {
     currentImpactTotal,
   );
 
-  return (
+  const ProgressBarDisplay = () => (
     <>
-      {loading ? (
-        <Spinner className="flex justify-center p-6" />
-      ) : (
+      {currentImpactTotal ? (
         <div className="mb-6" data-testid="campaign-progress-bar-container">
           <ProgressBar percentage={percentage} />
           <p className="text-lg">
@@ -71,6 +69,16 @@ const CampaignProgressBar = ({ actionId }) => {
             {` `}Help us get to {`${goal.toLocaleString()}`}!
           </p>
         </div>
+      ) : null}
+    </>
+  );
+
+  return (
+    <>
+      {loading ? (
+        <Spinner className="flex justify-center p-6" />
+      ) : (
+        <ProgressBarDisplay />
       )}
     </>
   );


### PR DESCRIPTION
### What's this PR do?

This pull request moves a check for the impactTotal to the progress bar itself vs the campaignBanner due to how expensive a calculation it is to pull that number for all actions on all photo campaigns. 

### How should this be reviewed?

👀 

### Any background context you want to provide?

Was seeing a bunch of errors in ghost inspector and papertrail after deploying the initial changes.

### Relevant tickets

References [Pivotal #178274595](https://www.pivotaltracker.com/story/show/178274595).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added screenshots of front-end changes on small, medium, and large screens.
- [ ] Added appropriate feature/unit tests.
