### PR TITLE
Update Login Profile Dropdown Links

### DIFF
--- a/app/Http/Controllers/AuthController.php
+++ b/app/Http/Controllers/AuthController.php
@@ -137,9 +137,9 @@ class AuthController extends Controller
         // "Log In" in the top navigation), or to the path defined in the $redirectTo property.
         $defaultIntended = is_same_domain(url()->previous()) ? url()->previous() : $this->redirectTo;
 
-        // The post-login redirect will be to the intended page (if logging in to view a page
-        // protected by the 'auth' middleware), or to the default path determined above.
-        $intended = session()->pull('url.intended', $defaultIntended);
+        // The post-login redirect will be to the custom 'destination', or the intended page (if logging in
+        // to view a page protected by the 'auth' middleware), or to the default path determined above.
+        $intended = Arr::get($queryParams, 'destination') ?: session()->pull('url.intended', $defaultIntended);
 
         session(['login.intended' => $intended]);
 

--- a/app/Http/Controllers/AuthController.php
+++ b/app/Http/Controllers/AuthController.php
@@ -122,6 +122,21 @@ class AuthController extends Controller
     }
 
     /**
+     * Get custom destination URL (redirect for post authentication) from query params, and parse out
+     * the relative path to avoid melicious redirects.
+     *
+     * @param array $queryParams
+     * @return string|null
+     *
+     */
+     protected function getCustomDestination($queryParams = [])
+     {
+        $customDestination = Arr::get($queryParams, 'destination');
+
+        return $customDestination ? parse_url($customDestination, PHP_URL_PATH) : null;
+     }
+
+    /**
      * Set session data used post-login and once user returns, redirected back to intended page.
      *
      * @param array $queryParams
@@ -139,7 +154,7 @@ class AuthController extends Controller
 
         // The post-login redirect will be to the custom 'destination', or the intended page (if logging in
         // to view a page protected by the 'auth' middleware), or to the default path determined above.
-        $intended = Arr::get($queryParams, 'destination') ?: session()->pull('url.intended', $defaultIntended);
+        $intended = $this->getCustomDestination($queryParams) ?: session()->pull('url.intended', $defaultIntended);
 
         session(['login.intended' => $intended]);
 

--- a/app/Http/Controllers/AuthController.php
+++ b/app/Http/Controllers/AuthController.php
@@ -133,7 +133,14 @@ class AuthController extends Controller
      {
         $customDestination = Arr::get($queryParams, 'destination');
 
-        return $customDestination ? parse_url($customDestination, PHP_URL_PATH) : null;
+        if (! $customDestination) {
+            return null;
+        }
+
+        $path = parse_url($customDestination, PHP_URL_PATH);
+        $query = parse_url($customDestination, PHP_URL_QUERY);
+
+        return $path . (!empty($query) ? '?' . $query : '');
      }
 
     /**

--- a/app/Http/Controllers/AuthController.php
+++ b/app/Http/Controllers/AuthController.php
@@ -127,10 +127,9 @@ class AuthController extends Controller
      *
      * @param array $queryParams
      * @return string|null
-     *
      */
-     protected function getCustomDestination($queryParams = [])
-     {
+    protected function getCustomDestination($queryParams = [])
+    {
         $customDestination = Arr::get($queryParams, 'destination');
 
         if (! $customDestination) {
@@ -140,8 +139,8 @@ class AuthController extends Controller
         $path = parse_url($customDestination, PHP_URL_PATH);
         $query = parse_url($customDestination, PHP_URL_QUERY);
 
-        return $path . (!empty($query) ? '?' . $query : '');
-     }
+        return $path . (! empty($query) ? '?' . $query : '');
+    }
 
     /**
      * Set session data used post-login and once user returns, redirected back to intended page.

--- a/resources/assets/components/SiteNavigation/SiteNavigationProfile.js
+++ b/resources/assets/components/SiteNavigation/SiteNavigationProfile.js
@@ -82,7 +82,7 @@ const DropdownMenu = () => (
       {!isAuthenticated() ? (
         <li>
           <DropdownLink
-            href={buildAuthRedirectUrl({ mode: 'login' })}
+            href={buildAuthRedirectUrl({ options: { mode: 'login' } })}
             copy="Log In"
           />
         </li>
@@ -141,7 +141,7 @@ const SiteNavigationProfile = () => {
         <a
           className="whitespace-no-wrap"
           id="utility-nav__auth"
-          href={buildAuthRedirectUrl({ mode: 'login' })}
+          href={buildAuthRedirectUrl({ options: { mode: 'login' } })}
           onClick={() =>
             trackAnalyticsEvent('clicked_nav_link_log_in', {
               action: 'link_clicked',

--- a/resources/assets/components/SiteNavigation/SiteNavigationProfile.js
+++ b/resources/assets/components/SiteNavigation/SiteNavigationProfile.js
@@ -75,7 +75,17 @@ const DropdownMenu = () => (
     <ul className="py-4">
       {dropdownList.map(({ copy, slug }) => (
         <li key={slug}>
-          <DropdownLink href={`/us/account/${slug}`} copy={copy} />
+          <DropdownLink
+            href={
+              isAuthenticated()
+                ? `/us/account/${slug}`
+                : buildAuthRedirectUrl({
+                    options: { mode: 'login' },
+                    destination: `/us/account/${slug}`,
+                  })
+            }
+            copy={copy}
+          />
         </li>
       ))}
 

--- a/resources/assets/helpers/auth.js
+++ b/resources/assets/helpers/auth.js
@@ -83,13 +83,15 @@ export function getDataForAuthRedirect() {
  *
  * @param  {Undefined|Object} options
  * @param  {Undefined|String} actionId
+ * @param  {Undefined|String} destination
  * @return {String}
  */
-export function buildAuthRedirectUrl({ options, actionId } = {}) {
+export function buildAuthRedirectUrl({ options, actionId, destination } = {}) {
   const params = queryString.stringify(
     withoutValueless({
       actionId,
       options: JSON.stringify({ ...getDataForAuthRedirect(), ...options }),
+      destination,
     }),
   );
 

--- a/resources/assets/helpers/auth.js
+++ b/resources/assets/helpers/auth.js
@@ -81,11 +81,11 @@ export function getDataForAuthRedirect() {
 /**
  * Build authentication redirect URL with optional context data.
  *
- * @param  {Null|Object} options
- * @param  {Null|String} actionId
+ * @param  {Undefined|Object} options
+ * @param  {Undefined|String} actionId
  * @return {String}
  */
-export function buildAuthRedirectUrl(options = null, actionId = null) {
+export function buildAuthRedirectUrl({ options, actionId } = {}) {
   const params = queryString.stringify(
     withoutValueless({
       actionId,

--- a/resources/assets/helpers/auth.test.js
+++ b/resources/assets/helpers/auth.test.js
@@ -1,0 +1,25 @@
+import { buildAuthRedirectUrl } from './auth';
+
+describe('buildAuthRedirectUrl', () => {
+  it('Builds an authentication redirect URL using custom parameters', () => {
+    const actionId = '123';
+    const destination = '/us/about';
+    const options = { contentful__id: '456' };
+
+    expect(buildAuthRedirectUrl({ actionId, destination, options })).toEqual(
+      `http://localhost/authorize?actionId=123&destination=%2Fus%2Fabout&options=%7B%22contentful__id%22%3A%22456%22%7D`,
+    );
+  });
+
+  it('Works without the parameter', () => {
+    expect(buildAuthRedirectUrl({ actionsId: null })).toEqual(
+      'http://localhost/authorize?options=%7B%7D',
+    );
+  });
+
+  it('Ignores undefined parameter values', () => {
+    expect(buildAuthRedirectUrl({ actionsId: null })).toEqual(
+      'http://localhost/authorize?options=%7B%7D',
+    );
+  });
+});

--- a/resources/assets/middleware/requiresAuthentication.js
+++ b/resources/assets/middleware/requiresAuthentication.js
@@ -17,7 +17,7 @@ const requiresAuthenticationMiddleware = () => next => action => {
     const actionId = `auth:${Date.now()}`;
 
     localforage.setItem(actionId, action).then(() => {
-      const redirectUrl = buildAuthRedirectUrl(null, actionId);
+      const redirectUrl = buildAuthRedirectUrl({ actionId });
       redirect(redirectUrl);
     });
 


### PR DESCRIPTION
### What's this PR do?

This pull request updates and uses the `buildAuthRedirectUrl` helper method for the "Log In" profile dropdown links on the site navigation bar to redirect users to their account pages via the Northstar login page for authentication instead of registration.

### How should this be reviewed?
- https://github.com/DoSomething/phoenix-next/commit/d47b16aaf7ab8e5c50357760243a13b86f767823 swaps the helper to use a single object parameter, this allows us to more flexibly add & use options.
- https://github.com/DoSomething/phoenix-next/commit/6b8bdc22ddb0607327d8339161c6e8822f3c1a23 & https://github.com/DoSomething/phoenix-next/commit/7d72256b9fbff650f7286cb7e8c942bd92051af4 add the new `destination` option to allow customizing the user's redirect post-authentication. (In our use case, we want to redirect users to a specific account tab after logging in.)
- https://github.com/DoSomething/phoenix-next/commit/3eab724e0da29e8acdc0e86a5d35fdda4caa5a1c adds some tests
- https://github.com/DoSomething/phoenix-next/commit/67e8ad84116bbc5b8a4c2a4f9ee8f151150a18b8 does the work to use this new `destination` param for the 'Login' profile dropdown

### Any background context you want to provide?
Previously, we made use of the 'Authentication gate' surrounding the account pages to simply link users to the respective account pages. Leah [pointed out](https://www.pivotaltracker.com/story/show/177933072/comments/224415285) in QA that this was redirecting users to _register_ instead of the desired UX to _login_. 

### Relevant tickets

References [Pivotal #177933072](https://www.pivotaltracker.com/story/show/177933072).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added screenshots of front-end changes on small, medium, and large screens.
- [x] Added appropriate feature/unit tests.
