### PR TITLE
Account Landing Page Navigation

### DIFF
--- a/resources/assets/components/App.js
+++ b/resources/assets/components/App.js
@@ -84,6 +84,7 @@ const App = ({ store, history }) => {
               ) : null}
 
               <Route
+                exact={featureFlag('account_landing_page')}
                 path="/us/account"
                 render={() => (
                   <AuthGate>
@@ -95,6 +96,10 @@ const App = ({ store, history }) => {
                   </AuthGate>
                 )}
               />
+
+              {featureFlag('account_landing_page') ? (
+                <Route path="/us/account/:slug" component={AccountQuery} />
+              ) : null}
 
               <Route path="/us/blocks/:id" component={BlockPage} />
 

--- a/resources/assets/components/pages/AccountLandingPage/AccountLandingPage.js
+++ b/resources/assets/components/pages/AccountLandingPage/AccountLandingPage.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import gql from 'graphql-tag';
 import { css } from '@emotion/core';
+import { Link } from 'react-router-dom';
 
 import Query from '../../Query';
 import letsDoThis from './lets-do-this.png';
@@ -88,11 +89,11 @@ const AccountLandingPage = () => (
             </Query>
 
             {accountLinks.map(({ title, subTitle, slug, icon }) => (
-              <a
+              <Link
                 data-testid="account-landing-page-navigation-link"
                 key={title}
                 className="my-1 p-4 rounded bg-white border border-solid border-gray-300 hover:border-blurple-500 no-underline hover:no-underline flex items-center"
-                href={`/us/account/${slug}`}
+                to={`/us/account/${slug}`}
                 css={css`
                   :hover {
                     > svg {
@@ -110,7 +111,7 @@ const AccountLandingPage = () => (
                     <div className="text-sm text-gray-500">{subTitle}</div>
                   ) : null}
                 </div>
-              </a>
+              </Link>
             ))}
 
             <a

--- a/resources/assets/components/pages/AccountPage/Account/Account.js
+++ b/resources/assets/components/pages/AccountPage/Account/Account.js
@@ -41,7 +41,7 @@ const Account = props => (
                 to="/us/account"
                 className="font-bold no-underline hover:no-underline"
               >
-                My Profile
+                My Account
               </Link>{' '}
               <span className="font-bold">/</span>
             </div>

--- a/resources/assets/components/pages/AccountPage/Account/Account.js
+++ b/resources/assets/components/pages/AccountPage/Account/Account.js
@@ -34,6 +34,19 @@ const Account = props => (
             'bg-white': !featureFlag('account_landing_page'),
           })}
         >
+          {/* Account landing page breadcrumb link: */}
+          {featureFlag('account_landing_page') ? (
+            <div className="grid-wide-2/3 pb-1">
+              <Link
+                to="/us/account"
+                className="font-bold no-underline hover:no-underline"
+              >
+                My Profile
+              </Link>{' '}
+              <span className="font-bold">/</span>
+            </div>
+          ) : null}
+
           <AccountRoute {...props} />
         </div>
       </article>

--- a/resources/assets/components/pages/AccountPage/Account/Account.js
+++ b/resources/assets/components/pages/AccountPage/Account/Account.js
@@ -1,8 +1,11 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import classNames from 'classnames';
+import { Link } from 'react-router-dom';
 
 import AccountRoute from './AccountRoute';
 import AccountNavigation from './AccountNavigation';
+import { featureFlag } from '../../../../helpers/env';
 import SiteFooter from '../../../utilities/SiteFooter/SiteFooter';
 import SiteNavigation from '../../../SiteNavigation/SiteNavigation';
 
@@ -12,16 +15,25 @@ const Account = props => (
 
     <main>
       <article className="account-page">
-        <header className="base-12-grid bg-gray-100 py-3 md:py-6">
-          <div className="grid-wide pt-12">
-            <h1 className="font-league-gothic font-normal text-4xl md:text-5xl uppercase">
-              Welcome, {props.user.firstName}!
-            </h1>
-          </div>
-        </header>
-        <AccountNavigation {...props} />
+        {!featureFlag('account_landing_page') ? (
+          <header className="base-12-grid bg-gray-100 py-3 md:py-6">
+            <div className="grid-wide pt-12">
+              <h1 className="font-league-gothic font-normal text-4xl md:text-5xl uppercase">
+                Welcome, {props.user.firstName}!
+              </h1>
+            </div>
+          </header>
+        ) : null}
 
-        <div className="base-12-grid bg-white py-3 md:py-6">
+        {!featureFlag('account_landing_page') ? (
+          <AccountNavigation {...props} />
+        ) : null}
+
+        <div
+          className={classNames('base-12-grid py-3 md:py-6', {
+            'bg-white': !featureFlag('account_landing_page'),
+          })}
+        >
           <AccountRoute {...props} />
         </div>
       </article>

--- a/resources/assets/components/pages/AccountPage/Account/AccountNavigation.js
+++ b/resources/assets/components/pages/AccountPage/Account/AccountNavigation.js
@@ -19,8 +19,12 @@ const AccountNavigation = () => (
   <nav className="base-12-grid page-navigation py-3 md:py-6 -no-fade">
     <div className="grid-wide nav-items -mx-3">
       <NavigationLink
-        exact
-        to="/us/account"
+        exact={!featureFlag('account_landing_page')}
+        to={
+          featureFlag('account_landing_page')
+            ? '/us/account/profile'
+            : '/us/account'
+        }
         onClick={() => handleAccountNavTabClick('account')}
       >
         Account

--- a/resources/assets/components/pages/AccountPage/Account/AccountRoute.js
+++ b/resources/assets/components/pages/AccountPage/Account/AccountRoute.js
@@ -47,7 +47,14 @@ const AccountRoute = props => (
 
     <Route path="/us/account/refer-friends" component={ReferFriendsTab} />
 
-    <Route path="/us/account" render={() => <Profile {...props} />} />
+    <Route
+      path={
+        featureFlag('account_landing_page')
+          ? '/us/account'
+          : '/us/account/profile'
+      }
+      render={() => <Profile {...props} />}
+    />
   </Switch>
 );
 

--- a/resources/assets/components/pages/AccountPage/Account/AccountRoute.js
+++ b/resources/assets/components/pages/AccountPage/Account/AccountRoute.js
@@ -49,9 +49,9 @@ const AccountRoute = props => (
 
     <Route
       path={
-        !featureFlag('account_landing_page')
-          ? '/us/account'
-          : '/us/account/profile'
+        featureFlag('account_landing_page')
+          ? '/us/account/profile'
+          : '/us/account'
       }
       render={() => <Profile {...props} />}
     />

--- a/resources/assets/components/pages/AccountPage/Account/AccountRoute.js
+++ b/resources/assets/components/pages/AccountPage/Account/AccountRoute.js
@@ -49,7 +49,7 @@ const AccountRoute = props => (
 
     <Route
       path={
-        featureFlag('account_landing_page')
+        !featureFlag('account_landing_page')
           ? '/us/account'
           : '/us/account/profile'
       }

--- a/resources/assets/components/pages/AccountPage/Profile/Profile.js
+++ b/resources/assets/components/pages/AccountPage/Profile/Profile.js
@@ -15,7 +15,7 @@ import {
 const Profile = props => (
   <React.Fragment>
     <div className="grid-wide">
-      <h1 className="text-xl">Account</h1>
+      <h1 className="text-xl">Profile</h1>
       <p className="text-gray-600">
         Update your personal information and manage your account.
       </p>


### PR DESCRIPTION
### What's this PR do?

This pull request 
- updates the `AccountLandingPage` to navigate to the account sub-pages
- adjusts the current profile sub-page to `/account/profile` 
- updates the account sub-page headers 
- adds a navigation breadcrumb link back to the landing page on sub-pages

### How should this be reviewed?
👀 

### Any background context you want to provide?
This is all still feature flagged, but we're -technically- good to flip the switch!

### Relevant tickets

References [Pivotal #176615026](https://www.pivotaltracker.com/story/show/176615026).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [x] Added screenshots of front-end changes on small, medium, and large screens.
- [ ] Added appropriate feature/unit tests.

📸 

- [Before](https://user-images.githubusercontent.com/12417657/120520033-564d7580-c3a1-11eb-8610-380727b5b23e.png)

- [After](https://user-images.githubusercontent.com/12417657/120520071-62393780-c3a1-11eb-87f0-b311ddfaf261.png)

- [After (Small)](https://user-images.githubusercontent.com/12417657/120520040-58afcf80-c3a1-11eb-8cc1-53e30e3c8a39.png)

![Screen Shot 2021-06-03 at 12 26 14](https://user-images.githubusercontent.com/12417657/120520155-77ae6180-c3a1-11eb-9fdd-61c72ae683bc.png)

