### PR TITLE
Remove margin from VC signature

### DIFF
--- a/resources/assets/components/pages/AccountPage/Credits/CertificateTemplate.js
+++ b/resources/assets/components/pages/AccountPage/Credits/CertificateTemplate.js
@@ -253,10 +253,7 @@ const CertificateTemplate = ({ certificatePost }) => {
           <View style={{ fontSize: 10, marginTop: 20, lineHeight: 1.1 }}>
             <View style={styles.flex}>
               <View style={{ width: '50%' }}>
-                <Image
-                  src={signature}
-                  style={{ width: 100, marginVertical: -12 }}
-                />
+                <Image src={signature} style={{ width: 100 }} />
               </View>
 
               <View style={{ width: '50%' }}>


### PR DESCRIPTION
### What's this PR do?

This pull request removes the margin on the VC signature so it gets positioned closer to the name below it. I think there's something different about this image and it looks better with no margin.

With margin (old):
<img width="416" alt="image" src="https://user-images.githubusercontent.com/4240292/121375804-dcb00d00-c8f5-11eb-972f-ed6bcabe9444.png">

Without margin (new):
<img width="366" alt="image" src="https://user-images.githubusercontent.com/4240292/121375848-e5a0de80-c8f5-11eb-9b3b-6657e140d450.png">


### How should this be reviewed?

Any consequences of removing the margin that I'm missing?

### Any background context you want to provide?

All above!

### Relevant tickets

References [Pivotal #178386171](https://www.pivotaltracker.com/story/show/178386171).

### Checklist

- [ ] This PR has been added to the relevant Pivotal card.
