### PR TITLE
Update HolaBar copy

### DIFF
--- a/resources/assets/components/utilities/PopoverDispatcher/PopoverDispatcher.js
+++ b/resources/assets/components/utilities/PopoverDispatcher/PopoverDispatcher.js
@@ -179,7 +179,7 @@ const PopoverDispatcher = () => {
           contextSource="volunteer_hours"
           cta="Get Started"
           link="/us/about/volunteer-hours"
-          description="Earn verified volunteer hours and the chance to win a $1,000 scholarship!"
+          description="Sign up for these campaigns and earn verified volunteer hours (and a signed certificate!)"
           handleClose={handleClose}
           handleComplete={handleComplete}
         />


### PR DESCRIPTION
### What's this PR do?

This pull request updates the HolaBar copy since we don't currently have any VC campaigns with a scholarship attached.

New copy:
<img width="1209" alt="Screen Shot 2021-06-21 at 2 33 23 PM" src="https://user-images.githubusercontent.com/4240292/122810868-b474c680-d284-11eb-8195-7725925262bd.png">

<img width="798" alt="image" src="https://user-images.githubusercontent.com/4240292/122811233-0fa6b900-d285-11eb-8067-286a740c8eef.png">

<img width="383" alt="image" src="https://user-images.githubusercontent.com/4240292/122811157-fb62bc00-d284-11eb-9f9c-553e379c274e.png">


### How should this be reviewed?

That copy look right?

### Any background context you want to provide?

Nope!

### Relevant tickets

References [Pivotal #178606543](https://www.pivotaltracker.com/story/show/178606543).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [x] Added screenshots of front-end changes on small, medium, and large screens.
