### PR TITLE
Update Boost references to be biweekly

### DIFF
--- a/resources/assets/components/utilities/EmailSubscription/config.js
+++ b/resources/assets/components/utilities/EmailSubscription/config.js
@@ -34,7 +34,7 @@ export const EMAIL_SUBSCRIPTION_TEXT = {
       'A roundup of photos, writing, and stories of impact from the DoSomething community and members like you.',
   },
   [EMAIL_SUBSCRIPTION_TOPICS.lifestyle]: {
-    subtitle: 'Sent every Thursday',
+    subtitle: 'Sent every other Thursday',
     title: 'The Boost',
     description:
       'Stories of incredible young people, actionable how-tos, inspirational playlists, and other content to live your best life and help others do the same.',

--- a/resources/assets/components/utilities/PopoverDispatcher/PopoverDispatcher.js
+++ b/resources/assets/components/utilities/PopoverDispatcher/PopoverDispatcher.js
@@ -69,7 +69,7 @@ const PopoverDispatcher = () => {
           <DelayedElement delay={3}>
             <CtaPopover
               title="The Boost"
-              content="Sign up for our weekly newsletter of stories of incredible young people and actionable how-tos."
+              content="Sign up for our biweekly newsletter of stories of incredible young people and actionable how-tos."
               handleClose={handleClose}
             >
               <CtaPopoverEmailForm


### PR DESCRIPTION
### What's this PR do?

This pull request updates the two spots in Phoenix where we reference The Boost cadence to be biweekly.

Popover:
<img width="410" alt="image" src="https://user-images.githubusercontent.com/4240292/122950490-581bb080-d331-11eb-9996-91e742eb166b.png">

Profile and wherever else the subscriptions topics live:
<img width="460" alt="image" src="https://user-images.githubusercontent.com/4240292/122950660-7c778d00-d331-11eb-8ac8-cd9c195aa24e.png">

### How should this be reviewed?

Did I miss any places where we reference the cadence of this newsletter?

### Any background context you want to provide?

Nope!

### Relevant tickets

References [Pivotal #178369775](https://www.pivotaltracker.com/story/show/178369775).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.