### PR TITLE
New User Campaigns Tab

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -79,6 +79,7 @@ DS_ENABLE_REFER_FRIENDS_INCENTIVE=
 DS_ENABLE_SITEWIDE_NPS_SURVEY=
 DS_ENABLE_POST_CONFIRMATION_PAGE=
 DS_ENABLE_NEW_ARTICLES_PAGE=
+DS_ENABLE_USER_CAMPAIGNS=
 
 # ==============================================================================
 # Site Config

--- a/config/feature-flags.php
+++ b/config/feature-flags.php
@@ -23,4 +23,5 @@ return [
     'sitewide_nps_survey' => env('DS_ENABLE_SITEWIDE_NPS_SURVEY', false),
     'rewards_levels' => env('DS_ENABLE_REWARDS_LEVELS', false),
     'new_articles_page' => env('DS_ENABLE_NEW_ARTICLES_PAGE', false),
+    'user_campaigns' => env('DS_ENABLE_USER_CAMPAIGNS', false),
 ];

--- a/resources/assets/components/pages/AccountPage/Account/AccountRoute.js
+++ b/resources/assets/components/pages/AccountPage/Account/AccountRoute.js
@@ -8,6 +8,7 @@ import NotFound from '../../../NotFound';
 import RewardsTab from '../Rewards/RewardsTab';
 import Interests from '../Interests/Interests';
 import { featureFlag } from '../../../../helpers/env';
+import UserCampaigns from '../Campaigns/UserCampaigns';
 import UserPostsQuery from '../Campaigns/UserPostsQuery';
 import DeleteAccountTab from '../Profile/DeleteAccountTab';
 import Subscriptions from '../Subscriptions/Subscriptions';
@@ -16,9 +17,14 @@ import ReferFriendsTab from '../ReferFriends/ReferFriendsTab';
 const AccountRoute = props => (
   <Switch>
     <Route
-      exact
       path="/us/account/campaigns"
-      render={() => <UserPostsQuery userId={props.userId} />}
+      render={() =>
+        featureFlag('user_campaigns') ? (
+          <UserCampaigns />
+        ) : (
+          <UserPostsQuery userId={props.userId} />
+        )
+      }
     />
     {featureFlag('rewards_levels') ? (
       <Redirect from="/us/account/badges" to="/us/account/rewards" />

--- a/resources/assets/components/pages/AccountPage/Campaigns/UserCampaigns.js
+++ b/resources/assets/components/pages/AccountPage/Campaigns/UserCampaigns.js
@@ -88,15 +88,20 @@ const UserCampaigns = () => (
           return (
             <>
               <nav
-                className="page-navigation pt-3 md:pt-6 -no-fade"
+                className="base-12-grid page-navigation pt-3 md:pt-6 -no-fade"
                 css={css`
                   border-bottom-width: 2px;
                   // offset some assigned styles for the .page-navigation class:
                   background-color: ${tailwind('colors.gray.100')};
                   border-top: 0;
+                  padding-left: 0;
+                  padding-right: 0;
                 `}
               >
-                <div className="nav-items -mx-3" style={{ float: 'none' }}>
+                <div
+                  className="grid-wide md:col-start-1 nav-items -mx-3"
+                  style={{ float: 'none' }}
+                >
                   <NavigationLink to="/us/account/campaigns/incomplete">
                     Incomplete ({get(groupedSignups, 'incomplete', []).length})
                   </NavigationLink>

--- a/resources/assets/components/pages/AccountPage/Campaigns/UserCampaigns.js
+++ b/resources/assets/components/pages/AccountPage/Campaigns/UserCampaigns.js
@@ -74,11 +74,9 @@ UserCampaignsGallery.defaultProps = {
 
 const UserCampaigns = () => (
   <>
-    <div className="grid-wide pb-3">
-      <SectionHeader title="Campaigns" />
-    </div>
-
     <div className="grid-wide">
+      <SectionHeader title="Campaigns" />
+
       <Query query={USER_CAMPAIGNS_QUERY} variables={{ userId: getUserId() }}>
         {({ paginatedSignups }) => {
           const groupedSignups = groupUserCampaignSignups(

--- a/resources/assets/components/pages/AccountPage/Campaigns/UserCampaigns.js
+++ b/resources/assets/components/pages/AccountPage/Campaigns/UserCampaigns.js
@@ -1,0 +1,163 @@
+import React from 'react';
+import { get } from 'lodash';
+import gql from 'graphql-tag';
+import PropTypes from 'prop-types';
+import { css } from '@emotion/core';
+import { Switch, Route, Redirect } from 'react-router-dom';
+
+import Query from '../../../Query';
+import { getUserId } from '../../../../helpers/auth';
+import { tailwind } from '../../../../helpers/display';
+import { groupUserCampaignSignups } from '../../../../helpers/campaign';
+import SectionHeader from '../../../utilities/SectionHeader/SectionHeader';
+import NavigationLink from '../../../utilities/NavigationLink/NavigationLink';
+import CampaignCard, {
+  campaignCardFragment,
+} from '../../../utilities/CampaignCard/CampaignCard';
+
+const USER_CAMPAIGNS_QUERY = gql`
+  query UserCampaignsQuery($userId: String!) {
+    paginatedSignups(userId: $userId, first: 100) {
+      edges {
+        node {
+          id
+          createdAt
+          campaign {
+            id
+            endDate
+            campaignWebsite {
+              ...CampaignCard
+            }
+            actions {
+              id
+              scholarshipEntry
+              reportback
+            }
+          }
+          posts {
+            id
+            status
+            createdAt
+            actionDetails {
+              id
+              scholarshipEntry
+              reportback
+            }
+          }
+        }
+      }
+    }
+  }
+
+  ${campaignCardFragment}
+`;
+
+const UserCampaignsGallery = ({ signups }) => (
+  <div className="grid-wide py-3">
+    <ul className="gap-8 grid grid-cols-1 md:grid-cols-2 xxl:grid-cols-3">
+      {signups.map(signup => (
+        <li key={signup.id}>
+          <CampaignCard campaign={signup.campaign.campaignWebsite} />
+        </li>
+      ))}
+    </ul>
+  </div>
+);
+
+UserCampaignsGallery.propTypes = {
+  signups: PropTypes.arrayOf(PropTypes.object),
+};
+
+UserCampaignsGallery.defaultProps = {
+  signups: [],
+};
+
+const UserCampaigns = () => (
+  <>
+    <div className="grid-wide pb-3">
+      <SectionHeader title="Campaigns" />
+    </div>
+
+    <div className="grid-wide">
+      <Query query={USER_CAMPAIGNS_QUERY} variables={{ userId: getUserId() }}>
+        {({ paginatedSignups }) => {
+          const groupedSignups = groupUserCampaignSignups(
+            paginatedSignups.edges.map(edge => edge.node),
+          );
+
+          return (
+            <>
+              <nav
+                className="page-navigation pt-3 md:pt-6 -no-fade"
+                css={css`
+                  border-bottom-width: 2px;
+                  // offset some assigned styles for the .page-navigation class:
+                  background-color: ${tailwind('colors.gray.100')};
+                  border-top: 0;
+                `}
+              >
+                <div className="nav-items -mx-3" style={{ float: 'none' }}>
+                  <NavigationLink to="/us/account/campaigns/incomplete">
+                    Incomplete ({get(groupedSignups, 'incomplete', []).length})
+                  </NavigationLink>
+
+                  <NavigationLink to="/us/account/campaigns/complete">
+                    Complete ({get(groupedSignups, 'complete', []).length})
+                  </NavigationLink>
+
+                  {groupedSignups.expired ? (
+                    <NavigationLink to="/us/account/campaigns/expired">
+                      Expired ({groupedSignups.expired.length})
+                    </NavigationLink>
+                  ) : null}
+                </div>
+              </nav>
+
+              <Switch>
+                <Route
+                  path="/us/account/campaigns/incomplete"
+                  render={() => (
+                    <UserCampaignsGallery signups={groupedSignups.incomplete} />
+                  )}
+                />
+
+                <Route
+                  exact
+                  path="/us/account/campaigns"
+                  render={() => (
+                    <Redirect to="/us/account/campaigns/incomplete" />
+                  )}
+                />
+
+                <Route
+                  path="/us/account/campaigns/complete"
+                  render={() => (
+                    <UserCampaignsGallery
+                      // Sort signups by most recently submitted post.
+                      signups={get(groupedSignups, 'complete', []).sort(
+                        (signupA, signupB) =>
+                          Date.parse(signupB.posts[0]) -
+                          Date.parse(signupA.posts[0]),
+                      )}
+                    />
+                  )}
+                />
+
+                {groupedSignups.expired ? (
+                  <Route
+                    path="/us/account/campaigns/expired"
+                    render={() => (
+                      <UserCampaignsGallery signups={groupedSignups.expired} />
+                    )}
+                  />
+                ) : null}
+              </Switch>
+            </>
+          );
+        }}
+      </Query>
+    </div>
+  </>
+);
+
+export default UserCampaigns;


### PR DESCRIPTION
### What's this PR do?

This pull request adds a first pass of the new user account campaigns tab (feature flagged).

### How should this be reviewed?
There's a helper (https://github.com/DoSomething/phoenix-next/commit/97b59c794553de3a154f82e06bbba38d4455e08a) to parse the user's campaign signups into the tabbed categories for this page which is the chunk of the complexity. 

The markup & styling in the new component (https://github.com/DoSomething/phoenix-next/commit/ea35c77c987490d7eda88f9c26a50b6931c006ab, https://github.com/DoSomething/phoenix-next/commit/d03f48f817f0dbac947c4113209e53bb3471f76a) is a bit finessed since these designs call for a variation on the styles assigned for the `.page-navigation`. It would be nice to abstract these a bit for more elegant sharing between our various navs in some follow-up!

### Any background context you want to provide?
We're still missing the tab-specific copy, tab-specific campaign cards (or at least the narrowed-down versions we're scoped for this build), and of course tests & documentation for follow-up PRs!

### Relevant tickets

References [Pivotal #178248537](https://www.pivotaltracker.com/story/show/178248537).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [x] Added screenshots of front-end changes on small, medium, and large screens.
- [ ] Added appropriate feature/unit tests.


📸 
- [Small](https://user-images.githubusercontent.com/12417657/122984293-d779a600-d36a-11eb-80d7-a03ed007c4f6.png)
- [Medium](https://user-images.githubusercontent.com/12417657/122984302-d9dc0000-d36a-11eb-9ec4-810348306bc6.png)
![Screen Shot 2021-06-22 at 16 27 43](https://user-images.githubusercontent.com/12417657/122984306-da749680-d36a-11eb-9b85-eff3291ffed1.png)
