### PR TITLE
Switch back to regular logo

### DIFF
--- a/resources/assets/components/SiteNavigation/SiteNavigation.js
+++ b/resources/assets/components/SiteNavigation/SiteNavigation.js
@@ -13,7 +13,7 @@ import SearchIcon from '../artifacts/SearchIcon/SearchIcon';
 import SiteNavigationFeature from './SiteNavigationFeature';
 import CloseButton from '../artifacts/CloseButton/CloseButton';
 import BenefitsGallery from './BenefitsGallery/BenefitsGallery';
-import DoSomethingLogo from '../utilities/DoSomethingLogo/DoSomethingPrideLogo'; // @TODO: Change back to DoSomethingLogo after Pride month.
+import DoSomethingLogo from '../utilities/DoSomethingLogo/DoSomethingLogo';
 import { query } from '../../helpers/url';
 import {
   EVENT_CATEGORIES,


### PR DESCRIPTION
### What's this PR do?

This pull request sadly removes the pride logo and takes us back to our regular logo!

<img width="386" alt="image" src="https://user-images.githubusercontent.com/4240292/123991540-a9eeb700-d97f-11eb-8b7c-a0ef290954c5.png">

### How should this be reviewed?

Do you see a rainbow in the above screenshot?

### Any background context you want to provide?

July starts tomorrow!

### Relevant tickets

References [Pivotal #178300523](https://www.pivotaltracker.com/story/show/178300523).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Added screenshots of front-end changes on small, medium, and large screens.
