### PR TITLE
Add analytics event to log-out link on account landing page

### DIFF
--- a/resources/assets/components/pages/AccountLandingPage/AccountLandingPage.js
+++ b/resources/assets/components/pages/AccountLandingPage/AccountLandingPage.js
@@ -128,6 +128,13 @@ const AccountLandingPage = () => (
             <a
               className="block mt-5 text-black mb-10 md:mb-0"
               href="/deauthorize"
+              onClick={() =>
+                trackAnalyticsEvent(`clicked_account_nav_link_log_out`, {
+                  action: 'link_clicked',
+                  category: EVENT_CATEGORIES.navigation,
+                  label: 'account_log_out',
+                })
+              }
             >
               Log Out
             </a>


### PR DESCRIPTION
### What's this PR do?

This pull request adds a custom analytics event to the 'log out' link on the account landing page.

### How should this be reviewed?
👀 

### Any background context you want to provide?
I forgot this when tackling the analytics events for this page!

### Relevant tickets
References [Pivotal #178363894](https://www.pivotaltracker.com/story/show/178363894/comments/225466758).

### Checklist

- [x] This PR has been added to the relevant Pivotal card.
- [ ] Documentation added for new features/changed endpoints.
- [ ] Added screenshots of front-end changes on small, medium, and large screens.
- [ ] Added appropriate feature/unit tests.
